### PR TITLE
modernize header guards to #pragma once

### DIFF
--- a/libobs-d3d11/d3d11-exports.h
+++ b/libobs-d3d11/d3d11-exports.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef GS_D3D11EXPORTS_H
-#define GS_D3D11EXPORTS_H
+#pragma once
 
 #include "util/c99defs.h"
 
@@ -196,5 +195,3 @@ EXPORT void shader_setval(shader_t shader, sparam_t param, const void *val,
 EXPORT void shader_setdefault(shader_t shader, sparam_t param);
 
 }
-
-#endif

--- a/libobs-d3d11/mingw/dxgi.h
+++ b/libobs-d3d11/mingw/dxgi.h
@@ -12,8 +12,7 @@
 #include <ole2.h>
 #endif
 
-#ifndef __dxgi_h__
-#define __dxgi_h__
+#pragma once
 
 /* Forward declarations */
 
@@ -2709,5 +2708,3 @@ void __RPC_STUB IDXGIFactory1_IsCurrent_Stub(
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* __dxgi_h__ */

--- a/libobs-opengl/gl-helpers.h
+++ b/libobs-opengl/gl-helpers.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef GL_HELPERS_H
-#define GL_HELPERS_H
+#pragma once
 
 /*
  * Okay, so GL error handling is..  unclean to work with.  I don't want
@@ -128,5 +127,3 @@ extern bool gl_create_buffer(GLenum target, GLuint *buffer, GLsizeiptr size,
 
 extern bool update_buffer(GLenum target, GLuint buffer, void *data,
 		size_t size);
-
-#endif

--- a/libobs-opengl/gl-shaderparser.h
+++ b/libobs-opengl/gl-shaderparser.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef GL_SHADER_PARSER_H
-#define GL_SHADER_PARSER_H
+#pragma once
 
 /*
  *   Parses shaders into GLSL.  Shaders are almost identical to HLSL
@@ -67,5 +66,3 @@ static inline void gl_shader_parser_free(struct gl_shader_parser *glsp)
 
 extern bool gl_shader_parse(struct gl_shader_parser *glsp,
 		const char *shader_str, const char *file);
-
-#endif

--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef GL_SUBSYSTEM_H
-#define GL_SUBSYSTEM_H
+#pragma once
 
 #include "util/darray.h"
 #include "graphics/graphics.h"
@@ -459,7 +458,3 @@ extern void                  gl_platform_destroy(struct gl_platform *platform);
 
 extern struct gl_windowinfo *gl_windowinfo_create(struct gs_init_data *info);
 extern void                  gl_windowinfo_destroy(struct gl_windowinfo *wi);
-
-
-
-#endif

--- a/libobs-opengl/glew/auto/src/glew_utils.h
+++ b/libobs-opengl/glew/auto/src/glew_utils.h
@@ -29,8 +29,7 @@
 ** THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef __glew_utils_h__
-#define __glew_utils_h__
+#pragma once
 
 #include <GL/glew.h>
 #if defined(_WIN32)
@@ -97,5 +96,3 @@ extern GLboolean _glewStrSame (const GLubyte* a, const GLubyte* b, GLuint n);
 extern GLboolean _glewStrSame1 (GLubyte** a, GLuint* na, const GLubyte* b, GLuint nb);
 extern GLboolean _glewStrSame2 (GLubyte** a, GLuint* na, const GLubyte* b, GLuint nb);
 extern GLboolean _glewStrSame3 (GLubyte** a, GLuint* na, const GLubyte* b, GLuint nb)
-
-#endif /* __glew_utils_h__ */

--- a/libobs-opengl/glew/include/GL/glew.h
+++ b/libobs-opengl/glew/include/GL/glew.h
@@ -76,8 +76,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-#ifndef __glew_h__
-#define __glew_h__
+#pragma once
 #define __GLEW_H__
 
 #if defined(__gl_h_) || defined(__GL_H__) || defined(__X_GL_H)
@@ -17392,5 +17391,3 @@ GLEWAPI const GLubyte * GLEWAPIENTRY glewGetString (GLenum name);
 
 #undef GLAPI
 /* #undef GLEWAPI */
-
-#endif /* __glew_h__ */

--- a/libobs-opengl/glew/include/GL/glxew.h
+++ b/libobs-opengl/glew/include/GL/glxew.h
@@ -76,8 +76,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-#ifndef __glxew_h__
-#define __glxew_h__
+#pragma once
 #define __GLXEW_H__
 
 #ifdef __glxext_h_
@@ -1665,5 +1664,3 @@ GLEWAPI GLboolean GLEWAPIENTRY glxewGetExtension (const char *name);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* __glxew_h__ */

--- a/libobs-opengl/glew/include/GL/wglew.h
+++ b/libobs-opengl/glew/include/GL/wglew.h
@@ -52,8 +52,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-#ifndef __wglew_h__
-#define __wglew_h__
+#pragma once
 #define __WGLEW_H__
 
 #ifdef __wglext_h_
@@ -1417,5 +1416,3 @@ GLEWAPI GLboolean GLEWAPIENTRY wglewGetExtension (const char *name);
 #endif
 
 #undef GLEWAPI
-
-#endif /* __wglew_h__ */

--- a/libobs/graphics/axisang.h
+++ b/libobs/graphics/axisang.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef AXISANG_H
-#define AXISANG_H
+#pragma once
 
 #include "../util/c99defs.h"
 
@@ -62,6 +61,4 @@ EXPORT void axisang_from_quat(struct axisang *dst, const struct quat *q);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/graphics/bounds.h
+++ b/libobs/graphics/bounds.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef BOUNDS_H
-#define BOUNDS_H
+#pragma once
 
 #include "math-defs.h"
 #include "vec3.h"
@@ -130,6 +129,4 @@ EXPORT float bounds_min_dist(const struct bounds *b, const struct plane *p);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/graphics/effect-parser.h
+++ b/libobs/graphics/effect-parser.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef EFFECT_PARSER_H
-#define EFFECT_PARSER_H
+#pragma once
 
 #include "../util/darray.h"
 #include "../util/cf-parser.h"
@@ -281,6 +280,4 @@ extern bool ep_parse(struct effect_parser *ep, effect_t effect,
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/graphics/effect.h
+++ b/libobs/graphics/effect.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef EFFECT_H
-#define EFFECT_H
+#pragma once
 
 #include "effect-parser.h"
 #include "graphics.h"
@@ -176,6 +175,4 @@ EXPORT void effect_upload_shader_params(effect_t effect, shader_t shader,
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef GRAPHICS_INTERNAL_H
-#define GRAPHICS_INTERNAL_H
+#pragma once
 
 #include "../util/darray.h"
 #include "graphics.h"
@@ -225,5 +224,3 @@ struct graphics_subsystem {
 	DARRAY(uint32_t)       colors;
 	DARRAY(struct vec2)    texverts[16];
 };
-
-#endif

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef GRAPHICS_H
-#define GRAPHICS_H
+#pragma once
 
 #include "../util/bmem.h"
 #include "input.h"
@@ -705,6 +704,4 @@ static inline uint32_t gs_num_total_levels(uint32_t width, uint32_t height)
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/graphics/input.h
+++ b/libobs/graphics/input.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef INPUT_H
-#define INPUT_H
+#pragma once
 
 /* TODO: incomplete/may not be necessary */
 
@@ -150,6 +149,4 @@ EXPORT int input_getbuttonstate(input_t input, uint32_t button);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/graphics/math-extra.h
+++ b/libobs/graphics/math-extra.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef MATH_EXTRA_H
-#define MATH_EXTRA_H
+#pragma once
 
 #include "../util/c99defs.h"
 
@@ -61,6 +60,4 @@ EXPORT float rand_float(int positive_only);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/graphics/matrix3.h
+++ b/libobs/graphics/matrix3.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef MATRIX_H
-#define MATRIX_H
+#pragma once
 
 #include "vec3.h"
 
@@ -82,6 +81,4 @@ EXPORT void matrix3_mirrorv(struct matrix3 *dst, const struct matrix3 *m,
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/graphics/matrix4.h
+++ b/libobs/graphics/matrix4.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef MATRIX4_H
-#define MATRIX4_H
+#pragma once
 
 #include "vec4.h"
 
@@ -71,6 +70,4 @@ EXPORT void matrix4_perspective(struct matrix4 *dst, float angle,
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/graphics/plane.h
+++ b/libobs/graphics/plane.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef PLANE_H
-#define PLANE_H
+#pragma once
 
 #include "math-defs.h"
 #include "vec3.h"
@@ -96,6 +95,4 @@ static inline bool plane_coplanar(const struct plane *p1,
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/graphics/quat.h
+++ b/libobs/graphics/quat.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef QUAT_H
-#define QUAT_H
+#pragma once
 
 #include "../util/c99defs.h"
 #include "math-defs.h"
@@ -180,6 +179,4 @@ EXPORT void quat_interpolate_cubic(struct quat *dst, const struct quat *q1,
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/graphics/shader-parser.h
+++ b/libobs/graphics/shader-parser.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef SHADER_PARSER_H
-#define SHADER_PARSER_H
+#pragma once
 
 #include "../util/cf-parser.h"
 #include "graphics.h"
@@ -276,6 +275,4 @@ static inline struct shader_func *shader_parser_getfunc(
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/graphics/vec2.h
+++ b/libobs/graphics/vec2.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef VECT2_H
-#define VECT2_H
+#pragma once
 
 #include "../util/c99defs.h"
 #include <math.h>
@@ -167,5 +166,4 @@ EXPORT void vec2_norm(struct vec2 *dst, const struct vec2 *v);
 
 #ifdef __cplusplus
 }
-#endif
 #endif

--- a/libobs/graphics/vec3.h
+++ b/libobs/graphics/vec3.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef VECT_H
-#define VECT_H
+#pragma once
 
 #include "math-defs.h"
 #include <xmmintrin.h>
@@ -231,6 +230,4 @@ EXPORT void vec3_rand(struct vec3 *dst, int positive_only);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/graphics/vec4.h
+++ b/libobs/graphics/vec4.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef VECT4_H
-#define VECT4_H
+#pragma once
 
 #include "math-defs.h"
 #include <xmmintrin.h>
@@ -248,6 +247,4 @@ EXPORT void vec4_transform(struct vec4 *dst, const struct vec4 *v,
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/media-io/audio-io.h
+++ b/libobs/media-io/audio-io.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef AUDIO_IO_H
-#define AUDIO_IO_H
+#pragma once
 
 #include "../util/c99defs.h"
 #include "media-io.h"
@@ -86,6 +85,4 @@ EXPORT void audio_output_close(audio_t audio);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/media-io/media-io.h
+++ b/libobs/media-io/media-io.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef MEDIA_IO_H
-#define MEDIA_IO_H
+#pragma once
 
 /*
  * Media input/output components used for connecting media outputs/inputs
@@ -72,6 +71,4 @@ EXPORT void    media_close(media_t media);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef VIDEO_IO_H
-#define VIDEO_IO_H
+#pragma once
 
 #include "../util/c99defs.h"
 #include "media-io.h"
@@ -64,6 +63,4 @@ EXPORT void     video_output_close(video_t video);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/obs-data.h
+++ b/libobs/obs-data.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef OBS_DATA_H
-#define OBS_DATA_H
+#pragma once
 
 #include "util/darray.h"
 #include "util/threading.h"
@@ -79,5 +78,3 @@ struct obs_data {
 };
 
 extern void *obs_video_thread(void *param);
-
-#endif

--- a/libobs/obs-defs.h
+++ b/libobs/obs-defs.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef OBS_DEFS_H
-#define OBS_DEFS_H
+#pragma once
 
 #define MODULE_SUCCESS           0
 #define MODULE_ERROR            -1
@@ -26,5 +25,3 @@
 #define SOURCE_VIDEO (1<<0)
 #define SOURCE_AUDIO (1<<1)
 #define SOURCE_ASYNC (1<<2)
-
-#endif

--- a/libobs/obs-module.h
+++ b/libobs/obs-module.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef OBS_MODULE_H
-#define OBS_MODULE_H
+#pragma once
 
 #include "util/darray.h"
 
@@ -28,5 +27,3 @@ struct obs_module {
 extern void *load_module_subfunc(void *module, const char *module_name,
 		const char *name, const char *func, bool required);
 extern void free_module(struct obs_module *mod);
-
-#endif

--- a/libobs/obs-output.h
+++ b/libobs/obs-output.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef OBS_OUTPUT_H
-#define OBS_OUTPUT_H
+#pragma once
 
 #include "util/c99defs.h"
 #include "util/dstr.h"
@@ -115,5 +114,3 @@ struct obs_output {
 
 extern bool get_output_info(void *module, const char *module_name,
 		const char *output_name, struct output_info *info);
-
-#endif

--- a/libobs/obs-scene.h
+++ b/libobs/obs-scene.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef OBS_SCENE_H
-#define OBS_SCENE_H
+#pragma once
 
 #include "obs.h"
 #include "obs-source.h"
@@ -38,5 +37,3 @@ struct obs_scene {
 	source_t source;
 	DARRAY(struct obs_scene_item*) items;
 };
-
-#endif

--- a/libobs/obs-service.h
+++ b/libobs/obs-service.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef OBS_SERVICE_H
-#define OBS_SERVICE_H
+#pragma once
 
 struct service_data;
 
@@ -29,5 +28,3 @@ struct service_info {
 	/* get (viewers/etc) */
 	/* send (current game/title/activate commercial/etc) */
 };
-
-#endif

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef SOURCE_H
-#define SOURCE_H 
+#pragma once
 
 #include "util/c99defs.h"
 #include "util/darray.h"
@@ -204,5 +203,3 @@ extern void source_init(obs_t obs, struct obs_source *source);
 EXPORT void source_activate(source_t source);
 EXPORT void source_deactivate(source_t source);
 EXPORT void source_video_tick(source_t source, float seconds);
-
-#endif

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -15,8 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifndef LIBOBS_H
-#define LIBOBS_H
+#pragma once
 
 #include "util/c99defs.h"
 #include "graphics/graphics.h"
@@ -299,6 +298,4 @@ EXPORT void       output_save_settings(output_t output, const char *settings);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/util/base.h
+++ b/libobs/util/base.h
@@ -21,8 +21,7 @@
      distribution.
 ******************************************************************************/
 
-#ifndef BASE_H
-#define BASE_H
+#pragma once
 
 #include <wctype.h>
 #include <stdarg.h>
@@ -53,6 +52,4 @@ EXPORT void bcrash(const char *format, ...);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/util/bmem.h
+++ b/libobs/util/bmem.h
@@ -21,8 +21,7 @@
      distribution.
 ******************************************************************************/
 
-#ifndef BALLOC_H
-#define BALLOC_H
+#pragma once
 
 #include "c99defs.h"
 #include "base.h"
@@ -91,6 +90,4 @@ static inline wchar_t *bwstrdup(const wchar_t *str)
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/util/c99defs.h
+++ b/libobs/util/c99defs.h
@@ -21,8 +21,7 @@
      distribution.
 ******************************************************************************/
 
-#ifndef C99DEFS_H
-#define C99DEFS_H
+#pragma once
 
 /*
  * Contains hacks for getting some C99 stuff working in VC, things like
@@ -71,5 +70,3 @@ typedef long ssize_t;
 #include <sys/types.h>
 
 #endif /* _MSC_VER */
-
-#endif

--- a/libobs/util/cf-lexer.h
+++ b/libobs/util/cf-lexer.h
@@ -21,8 +21,7 @@
      distribution.
 ******************************************************************************/
 
-#ifndef CF_LEXER_H
-#define CF_LEXER_H
+#pragma once
 
 #include "lexer.h"
 
@@ -211,6 +210,4 @@ static inline struct cf_token *cf_preprocessor_gettokens(
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/util/cf-parser.h
+++ b/libobs/util/cf-parser.h
@@ -21,8 +21,7 @@
      distribution.
 ******************************************************************************/
 
-#ifndef CF_PARSER_H
-#define CF_PARSER_H
+#pragma once
 
 #include "cf-lexer.h"
 
@@ -279,6 +278,4 @@ static inline int next_name_ref(struct cf_parser *p, struct strref *dst,
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/util/config-file.h
+++ b/libobs/util/config-file.h
@@ -21,8 +21,7 @@
      distribution.
 ******************************************************************************/
 
-#ifndef CONFIG_FILE_H
-#define CONFIG_FILE_H
+#pragma once
 
 #include "c99defs.h"
 
@@ -82,6 +81,4 @@ EXPORT double config_get_double(config_t config, const char *section,
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/util/darray.h
+++ b/libobs/util/darray.h
@@ -21,8 +21,7 @@
      distribution.
 ******************************************************************************/
 
-#ifndef DARRAY_H
-#define DARRAY_H
+#pragma once
 
 #include "c99defs.h"
 #include <string.h>
@@ -540,6 +539,4 @@ static inline void darray_swap(const size_t element_size,
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/util/dstr.h
+++ b/libobs/util/dstr.h
@@ -21,8 +21,7 @@
      distribution.
 ******************************************************************************/
 
-#ifndef DSTR_H
-#define DSTR_H
+#pragma once
 
 #include <string.h>
 #include <stdarg.h>
@@ -305,6 +304,4 @@ static inline int dstr_ncmpi(const struct dstr *str1, const char *str2,
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/util/lexer.h
+++ b/libobs/util/lexer.h
@@ -21,8 +21,7 @@
      distribution.
 ******************************************************************************/
 
-#ifndef LEXER_H
-#define LEXER_H
+#pragma once
 
 #include "c99defs.h"
 #include "dstr.h"
@@ -289,6 +288,4 @@ EXPORT void lexer_getstroffset(const struct lexer *lex, const char *str,
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -21,8 +21,7 @@
      distribution.
 ******************************************************************************/
 
-#ifndef PLATFORM_H
-#define PLATFORM_H
+#pragma once
 
 #include <stdio.h>
 #include <wchar.h>
@@ -77,6 +76,4 @@ EXPORT off_t ftello(FILE *stream);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/util/serializer.h
+++ b/libobs/util/serializer.h
@@ -21,8 +21,7 @@
      distribution.
 ******************************************************************************/
 
-#ifndef SERIALIZER_H
-#define SERIALIZER_H
+#pragma once
 
 /*
  *   General programmable serialization functions.  (A shared interface to
@@ -123,6 +122,4 @@ static inline void serializer_write_double(struct serializer *s, double d)
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/util/text-lookup.h
+++ b/libobs/util/text-lookup.h
@@ -21,8 +21,7 @@
      distribution.
 ******************************************************************************/
 
-#ifndef TEXT_LOOKUP_H
-#define TEXT_LOOKUP_H
+#pragma once
 
 /*
  * Text Lookup interface
@@ -50,6 +49,4 @@ EXPORT bool text_lookup_getstr(lookup_t lookup, const char *lookup_val,
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/util/threading.h
+++ b/libobs/util/threading.h
@@ -21,8 +21,7 @@
      distribution.
 ******************************************************************************/
 
-#ifndef BASE_THREADING_H
-#define BASE_THREADING_H
+#pragma once
 
 /*
  *   Allows posix thread usage on windows as well as other operating systems.
@@ -128,6 +127,4 @@ static inline void event_reset(event_t *event)
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/libobs/util/utf8.h
+++ b/libobs/util/utf8.h
@@ -17,8 +17,7 @@
 /*
  * utf8: implementation of UTF-8 charset encoding (RFC3629).
  */
-#ifndef _UTF8_H_
-#define _UTF8_H_
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,5 +34,3 @@ size_t wchar_to_utf8(const wchar_t *in, size_t insize, char *out,
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* !_UTF8_H_ */

--- a/libobs/util/vc/stdbool.h
+++ b/libobs/util/vc/stdbool.h
@@ -1,5 +1,4 @@
-#ifndef _STDBOOL_H
-#define _STDBOOL_H
+#pragma once
 
 #if !defined(__cplusplus)
 typedef int8_t _Bool; 
@@ -7,6 +6,4 @@ typedef int8_t _Bool;
 #define true 1
 #define false 0
 #define __bool_true_false_are_defined 1
-#endif
-
 #endif

--- a/libobs/util/vc/stdint.h
+++ b/libobs/util/vc/stdint.h
@@ -16,8 +16,8 @@
  *  Date: 2000-12-02
  */
 
-#ifndef _STDINT_H
-#define _STDINT_H
+#pragma once
+
 #define __need_wint_t
 #define __need_wchar_t
 #include <stddef.h>
@@ -200,5 +200,3 @@ typedef unsigned __int64   uintmax_t;
 #define UINTMAX_C(val) (UINTMAX_MAX-UINTMAX_MAX+(val))
 
 #endif  /* !defined ( __cplusplus) || defined __STDC_CONSTANT_MACROS */
-
-#endif

--- a/test/test-input/test-filter.h
+++ b/test/test-input/test-filter.h
@@ -1,5 +1,4 @@
-#ifndef FILTER_TEST_H
-#define FILTER_TEST_H
+#pragma once
 
 #include "obs.h"
 
@@ -22,6 +21,4 @@ EXPORT void test_video_render(struct test_filter *rt);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/test/test-input/test-input-exports.h
+++ b/test/test-input/test-input-exports.h
@@ -1,5 +1,4 @@
-#ifndef OBS_CAPTURE_EXPORTS_H
-#define OBS_CAPTURE_EXPORTS_H
+#pragma once
 
 #include "util/c99defs.h"
 
@@ -12,6 +11,4 @@ EXPORT bool enum_filters(size_t idx, const char **name);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/test/test-input/test-random.h
+++ b/test/test-input/test-random.h
@@ -1,5 +1,4 @@
-#ifndef RANDOM_TEX_H
-#define RANDOM_TEX_H
+#pragma once
 
 #include "obs.h"
 
@@ -23,6 +22,4 @@ EXPORT int random_getheight(struct random_tex *rt);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/w32-pthreads/config.h
+++ b/w32-pthreads/config.h
@@ -1,7 +1,6 @@
 /* config.h  */
 
-#ifndef PTW32_CONFIG_H
-#define PTW32_CONFIG_H
+#pragma once
 
 /*********************************************************************
  * Defaults: see target specific redefinitions below.
@@ -146,8 +145,4 @@
 #if defined(__DMC__)
 #define HAVE_SIGNAL_H
 #define HAVE_C_INLINE
-#endif
-
-
-
 #endif

--- a/w32-pthreads/context.h
+++ b/w32-pthreads/context.h
@@ -34,8 +34,7 @@
  *      59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
  */
 
-#ifndef PTW32_CONTEXT_H
-#define PTW32_CONTEXT_H
+#pragma once
 
 #undef PTW32_PROGCTR
 
@@ -69,6 +68,4 @@
 
 #if !defined(PTW32_PROGCTR)
 #error Module contains CPU-specific code; modify and recompile.
-#endif
-
 #endif


### PR DESCRIPTION
I did not modify the files where it was not apparent where the end of the ifndef was (these were mostly the glew files)
This also means I modified the embedded libraries, which might not be wanted.

For more information:
http://en.wikipedia.org/wiki/Pragma_once
