### PR TITLE
Compilation fails with wxWidgets below version 2.9.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ esac
 
 # checks for wx
 AM_OPTIONS_WXCONFIG
-reqwx=2.4.0
+reqwx=2.9.0
 AM_PATH_WXCONFIG($reqwx, wxWin=1)
 if test "$wxWin" != 1; then
 	AC_MSG_ERROR([


### PR DESCRIPTION
Trying to compile OBS with a wxWidgets version below 2.9.0 causes the following error:

```
window-subclass.cpp: In member function 'virtual wxSize ListCtrlFixed::DoGetBestClientSize() const':
window-subclass.cpp:70:10: error: 'DoGetBestClientSize' is not a member of 'wxControl'
```

According to the wxWidgets API documentation wxWindow::DoGetBestClientSize() was added in version 2.9.0: http://docs.wxwidgets.org/trunk/classwx_window.html#afe8447cb5975584ee3d4a03e3d02ee89

The configure script should probably check for the correct required version and not allow compilation if the required version is not available.
