### PR TITLE
Updated CMake with new effect file locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,12 @@ tags
 *.ninja
 .ninja*
 .dirstamp
+
+#cmake
+cmake_install.cmake
+CMakeCache.txt
+CMakeFiles/
+CMakeScripts/
+
+#xcode
+*.xcodeproj/

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -72,5 +72,5 @@ target_link_libraries(libobs
 	${LIBAVUTIL_LIBRARIES}
 	${LIBSWRESAMPLE_LIBRARIES})
 
-file(COPY ${obs_SOURCE_DIR}/build/libobs/default.effect DESTINATION
-	${obs_BINARY_DIR}/libobs/)
+file(COPY ${obs_SOURCE_DIR}/build/data/libobs/default.effect DESTINATION
+	${obs_BINARY_DIR}/data/libobs/)

--- a/test/test-input/CMakeLists.txt
+++ b/test/test-input/CMakeLists.txt
@@ -9,6 +9,6 @@ target_link_libraries(test-input
 	libobs)
 
 file(COPY
-	${obs_SOURCE_DIR}/build/data/test-input/draw.effect
-	${obs_SOURCE_DIR}/build/data/test-input/test.effect
-	DESTINATION ${obs_BINARY_DIR}/data/test-input/)
+	${obs_SOURCE_DIR}/build/data/obs-plugins/test-input/draw.effect
+	${obs_SOURCE_DIR}/build/data/obs-plugins/test-input/test.effect
+	DESTINATION ${obs_BINARY_DIR}/data/obs-plugins/test-input/)


### PR DESCRIPTION
The new .effect file locations from 70290b8c2b52c8bf354dd801043eb16bc609b156 weren't added to the CMakeList files.
Also added some cmake & xcode files to gitignore
