### PR TITLE
Don't close module if opening failed during graphics initialization

### DIFF
--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -159,7 +159,8 @@ void gs_destroy(graphics_t graphics)
 	pthread_mutex_destroy(&graphics->mutex);
 	da_free(graphics->matrix_stack);
 	da_free(graphics->viewport_stack);
-	os_dlclose(graphics->module);
+	if (graphics->module)
+		os_dlclose(graphics->module);
 	bfree(graphics);
 }
 


### PR DESCRIPTION
If os_dlopen() fails in gs_create() the error handling is executed which calls gs_destroy(). gs_destroy() always tries to close graphics->module even if no module was loaded in gs_create(). If os_dlclose() is called with NULL on Linux it causes a segmentation fault.
