### PR TITLE
Adding <linux/time.h> for CLOCK_REALTIME define.

### DIFF
--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -21,6 +21,9 @@
 #include <dlfcn.h>
 #include <unistd.h>
 #include <time.h>
+#if defined(__linux) || defined(__linux__) || defined(linux)
+#include <linux/time.h>
+#endif
 
 #include "dstr.h"
 #include "platform.h"


### PR DESCRIPTION
Adding <linux/time.h> to remove the error "CLOCK_REALTIME" not defined.
