### PR TITLE
Various Changes to OpenGL intialization

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,7 @@ WX_CONFIG_CHECK(
 		is in LD_LIBRARY_PATH or equivalent variable and
 		wxWidgets version is $wxVersion or above.
 		]) ],
-	[core], )
+	[core], [--version=2.9])
 
 CPPFLAGS="$CPPFLAGS $WX_CPPFLAGS"
 CXXFLAGS="$CXXFLAGS $WX_CXXFLAGS_ONLY"

--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -97,11 +97,6 @@ static NSOpenGLContext *gl_context_create(struct gs_init_data *info)
 	return context;
 }
 
-static inline void required_extension_error(const char *extension)
-{
-	blog(LOG_ERROR, "OpenGL extension %s is required", extension);
-}
-
 static bool gl_init_extensions(device_t device)
 {
 	glewExperimental=true;
@@ -111,27 +106,6 @@ static bool gl_init_extensions(device_t device)
 			       glewGetErrorString(error));
 	       return false;
 	}
-
-	if(!GLEW_VERSION_2_1) {
-	       blog(LOG_ERROR, "OpenGL 2.1 minimum required by the graphics "
-	                       "adapter");
-	       return false;
-	}
-
-	if(!GLEW_ARB_framebuffer_object) {
-		required_extension_error("GL_ARB_framebuffer_object");
-		return false;
-	}
-
-	if(!GLEW_ARB_separate_shader_objects) {
-		required_extension_error("GL_ARB_separate_shader_objects");
-		return false;
-	}
-
-	//something inside glew produces error code 1280 (invalid enum)
-	glGetError();
-
-	device->copy_type = COPY_TYPE_FBO_BLIT;
 
 	return true;
 }

--- a/libobs-opengl/gl-x11.c
+++ b/libobs-opengl/gl-x11.c
@@ -105,23 +105,13 @@ static void print_info_stuff(struct gs_init_data *info)
 struct gl_platform *gl_platform_create(device_t device,
 		struct gs_init_data *info)
 {	
-	/* X11 */
 	int num_configs = 0;
 	int error_base = 0, event_base = 0;
 	Display *display = XOpenDisplay(NULL); /* Open default screen */
-	
-	/* OBS */
 	struct gl_platform *plat = bmalloc(sizeof(struct gl_platform));
-	
-	/* GLX */
 	GLXFBConfig* configs;
 	
 	print_info_stuff(info);
-	
-	if (!plat) { 
-		blog(LOG_ERROR, "Out of memory");
-		return NULL;
-	}
 	
 	memset(plat, 0, sizeof(struct gl_platform));
 	
@@ -144,7 +134,7 @@ struct gl_platform *gl_platform_create(device_t device,
 		
 		glXQueryVersion(display, &major, &minor);
 		if (major < 1 || minor < 4) {
-			blog(LOG_ERROR, "GLX version isn't high enough.");
+			blog(LOG_ERROR, "GLX version found: %i.%i\nRequired: 1.4", major, minor);
 			goto fail0;
 		}
 	}


### PR DESCRIPTION
I removed all extension checking code to gl-subsystem.c as it needs to be called on all platforms and does not change given a platform. 
I added a function and tables to handle OpenGL debug and error messages via the ARB_debug_output extension or via the GL 4.0 API if available. 
I removed the hardcoded request for a 3.2 context on Linux and Windows. It will now give the latest context given it fits our requirements (which is just a core profile and debug context if _DEBUG is set currently). 

Snuck in was a change to autoconf that allows autoconf to correctly find wxWidgets 2.9 (or greater) with wx-config (not just wx-config-2.9) without user interaction.
