### PR TITLE
Another attempt to fix ARB_debug_output, hopefully the last one.

### DIFF
--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -72,9 +72,10 @@ static void GLEW_TEMP_API gl_debug_proc(
 static void gl_enable_debug()
 {
 	 /* Perhaps we should create GLEW contexts? */
-
-	if (GLEW_ARB_debug_output)
+	if (GLEW_VERSION_4_3)
 		glDebugMessageCallback(gl_debug_proc, NULL);
+	if (GLEW_ARB_debug_output)
+		glDebugMessageCallbackARB(gl_debug_proc, NULL);
 	else {
 		blog(LOG_DEBUG, "Failed to set GL debug callback as it is "
 		                "not supported.");

--- a/libobs-opengl/gl-windows.c
+++ b/libobs-opengl/gl-windows.c
@@ -237,6 +237,7 @@ static inline void required_extension_error(const char *extension)
 
 static bool gl_init_extensions(device_t device)
 {
+	glewExperimental = true;
 	GLenum errorcode = glewInit();
 	if (errorcode != GLEW_OK) {
 		blog(LOG_ERROR, "glewInit failed, %u", errorcode);


### PR DESCRIPTION
Jim- was crashing with previous modifications in debug mode. I believe this is because of GLEW quirks and the need to set glewExperimental, which I fixed here. 
