### PR TITLE
Changed names of slots so that they mach the signals

### DIFF
--- a/obs/window-basic-main.cpp
+++ b/obs/window-basic-main.cpp
@@ -403,11 +403,11 @@ void OBSBasic::on_actionSceneProperties_triggered()
 {
 }
 
-void OBSBasic::on_actionSceneUp_triggered()
+void OBSBasic::on_actionSceneMoveUp_triggered()
 {
 }
 
-void OBSBasic::on_actionSceneDown_triggered()
+void OBSBasic::on_actionSceneMoveDown_triggered()
 {
 }
 
@@ -511,11 +511,11 @@ void OBSBasic::on_actionSourceProperties_triggered()
 {
 }
 
-void OBSBasic::on_actionSourceUp_triggered()
+void OBSBasic::on_actionSourceMoveUp_triggered()
 {
 }
 
-void OBSBasic::on_actionSourceDown_triggered()
+void OBSBasic::on_actionSourceMoveDown_triggered()
 {
 }
 

--- a/obs/window-basic-main.hpp
+++ b/obs/window-basic-main.hpp
@@ -73,15 +73,15 @@ private slots:
 	void on_actionAddScene_triggered();
 	void on_actionRemoveScene_triggered();
 	void on_actionSceneProperties_triggered();
-	void on_actionSceneUp_triggered();
-	void on_actionSceneDown_triggered();
+	void on_actionSceneMoveUp_triggered();
+	void on_actionSceneMoveDown_triggered();
 	void on_sources_itemChanged(QListWidgetItem *item);
 	void on_sources_customContextMenuRequested(const QPoint &pos);
 	void on_actionAddSource_triggered();
 	void on_actionRemoveSource_triggered();
 	void on_actionSourceProperties_triggered();
-	void on_actionSourceUp_triggered();
-	void on_actionSourceDown_triggered();
+	void on_actionSourceMoveUp_triggered();
+	void on_actionSourceMoveDown_triggered();
 	void on_settingsButton_clicked();
 
 public:


### PR DESCRIPTION
> QMetaObject::connectSlotsByName: No matching signal for on_actionSceneUp_triggered()
> QMetaObject::connectSlotsByName: No matching signal for on_actionSceneDown_triggered()
> QMetaObject::connectSlotsByName: No matching signal for on_actionSourceUp_triggered()
> QMetaObject::connectSlotsByName: No matching signal for on_actionSourceDown_triggered()

That is caused by not matching signals and slots.
I hope that is right, if not ignore and close this.
