### PR TITLE
[OGL] Fix a possible null pointer dereference

### DIFF
--- a/libobs-opengl/gl-windows.c
+++ b/libobs-opengl/gl-windows.c
@@ -310,10 +310,10 @@ static int gl_choose_pixel_format(HDC hdc, struct gs_init_data *info)
 static inline bool gl_getpixelformat(HDC hdc, struct gs_init_data *info,
 		int *format, PIXELFORMATDESCRIPTOR *pfd)
 {
-	*format = gl_choose_pixel_format(hdc, info);
-
 	if (!format)
 		return false;
+
+	*format = gl_choose_pixel_format(hdc, info);
 
 	if (!DescribePixelFormat(hdc, *format, sizeof(*pfd), pfd)) {
 		blog(LOG_ERROR, "DescribePixelFormat failed, %u",


### PR DESCRIPTION
Note: Not sure if that was intended to check for null or literally check the retrieved value. 

If it was intended to check the value, then a \* is missing from the if statement (and I can fix it if that was the intent)
