### PR TITLE
Add support for external jansson

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,4 +1,17 @@
 
 add_subdirectory(w32-pthreads)
 add_subdirectory(glad)
-add_subdirectory(jansson)
+
+find_package(Jansson 2.5 QUIET)
+
+if(NOT JANSSON_FOUND)
+	message(STATUS "Jansson >=2.5 not found, building bundled version")
+	add_subdirectory(jansson)
+else()
+	message(STATUS "Using system Jansson library")
+	add_library(jansson UNKNOWN IMPORTED)
+	set_property(TARGET jansson PROPERTY
+		IMPORTED_LOCATION "${JANSSON_LIBRARIES}"
+		INTERFACE_INCLUDE_DIRECTORIES "${JANSSON_INCLUDE_DIRS}")
+endif()
+


### PR DESCRIPTION
Most linux distros come with jansson, most of them unfortunately with an outdated one.
This adds a versioned check for the system jansson, and uses it if it's new enough.
