### PR TITLE
Unset cached variables on failure in Jansson find module

### DIFF
--- a/cmake/Modules/FindJansson.cmake
+++ b/cmake/Modules/FindJansson.cmake
@@ -59,5 +59,10 @@ else()
 		REQUIRED_VARS Jansson_LIB Jansson_INCLUDE_DIR
 		VERSION_VAR JANSSON_VERSION)
 	mark_as_advanced(Jansson_INCLUDE_DIR Jansson_LIB)
+
+	if(NOT JANSSON_FOUND)
+		unset(JANSSON_INCLUDE_DIRS CACHE)
+		unset(JANSSON_LIBRARIES CACHE)
+	endif()
 endif()
 


### PR DESCRIPTION
Prevents confusion on following cmake runs
