### PR TITLE
Removed unresolved EXPORT from previous revision of volume meter & modified locale not found error.

### DIFF
--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -525,9 +525,6 @@ EXPORT proc_handler_t obs_source_prochandler(obs_source_t source);
 /** Sets the user volume for a source that has audio output */
 EXPORT void obs_source_setvolume(obs_source_t source, float volume);
 
-/** Updates live volume for a source */
-EXPORT void obs_source_updatevolumelevel(obs_source_t source, int volume);
-
 /** Sets the presentation volume for a source */
 EXPORT void obs_source_set_present_volume(obs_source_t source, float volume);
 


### PR DESCRIPTION
Modified text of locale/blah.txt to be more consistent with other path errors, now shows full search path.
