### PR TITLE
Slight modification of audio mixing function

### DIFF
--- a/libobs/media-io/audio-io.c
+++ b/libobs/media-io/audio-io.c
@@ -197,9 +197,16 @@ static void mix_float(uint8_t *mix_in, struct circlebuf *buf, size_t size)
 		circlebuf_pop_front(buf, vals, pop_count);
 		pop_count /= sizeof(float);
 
+		/* This sequence provides hints for MSVC to use packed SSE 
+		 * instructions addps, minps, maxps, etc. */
 		for (size_t i = 0; i < pop_count; i++) {
 			mix_val =  *mix + vals[i];
-			*(mix++) = CLAMP(mix_val, -1.0f, 1.0f);
+
+			/* clamp confuses the optimisation */
+			mix_val = (mix_val >  1.0f) ?  1.0f : mix_val; 
+			mix_val = (mix_val < -1.0f) ? -1.0f : mix_val;
+
+			*(mix++) = mix_val;
 		}
 	}
 }


### PR DESCRIPTION
Made a small modification to the mixing function. The use of clamp was resulting in the use of scalar SSE instructions instead of the packed versions. By hinting to the compiler, was able to correctly sequence the assembly code as needed (see far below).

Result was a 3.2x reduction in CPU ticks to execute the function.

Level   Number  Mean        Std Dev     Lower 95%   Upper 95%
mix ps  1081    1.96289     0.93642     1.9070      2.0188
mix ss  783     6.34622     2.69428     6.1572      6.5352

Also experimented with buffer size, but anything greater than 256 yielded no improvement and anything smaller saw a slower execution time.

Current ASM using MSVC 2013:

71ED28B0  movups      xmm0,xmmword ptr [edi]  
71ED28B3  add         ecx,4  
71ED28B6  movups      xmm2,xmmword ptr [eax]  
71ED28B9  add         eax,10h  
71ED28BC  movaps      xmm1,xmm3  
71ED28BF  addps       xmm2,xmm0  
71ED28C2  movaps      xmm0,xmm4  
71ED28C5  minps       xmm1,xmm2  
71ED28C8  maxps       xmm0,xmm1  
