### PR TITLE
Update mac-avcapture to use recent property and data changes

### DIFF
--- a/plugins/mac-avcapture/av-capture.m
+++ b/plugins/mac-avcapture/av-capture.m
@@ -522,27 +522,11 @@ static NSString *preset_names(NSString *preset)
 
 static void av_capture_defaults(obs_data_t settings)
 {
-	AVCaptureDevice *dev = [AVCaptureDevice
-		defaultDeviceWithMediaType:AVMediaTypeVideo];
-	if (!dev)
-		return;
-
-	NSString *highest = nil;
-	for (NSString *preset in presets()) {
-		if (![dev supportsAVCaptureSessionPreset:preset])
-			continue;
-		highest = preset;
-	}
-	if (!highest)
-		return;
-
-	obs_data_set_default_string(settings, "device",
-			dev.uniqueID.UTF8String);
-	obs_data_set_default_string(settings, "device_name",
-			dev.localizedName.UTF8String);
+	//TODO: localize
+	obs_data_set_default_string(settings, "device_name", "none");
 	obs_data_set_default_bool(settings, "use_preset", true);
-
-	obs_data_set_default_string(settings, "preset", highest.UTF8String);
+	obs_data_set_default_string(settings, "preset",
+			AVCaptureSessionPreset1280x720.UTF8String);
 }
 
 static bool update_device_list(obs_property_t list,


### PR DESCRIPTION
This continues the changes started by https://github.com/jp9000/obs-studio/pull/116, i.e. preserving user config if possible and exposing more internals to the UI. In particular, the device is no longer automatically selected and should be preserved even if the config dialog is opened while the selected device was never connected (during the current program run time) and the preset is automatically chosen if an incompatible preset is configured (due to switching devices or even editing the config manually).
