### PR TITLE
Require correct cmake version everywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-if(WIN32 OR APPLE)
-	cmake_minimum_required(VERSION 2.8.12)
-else()
-	cmake_minimum_required(VERSION 2.8.11)
-endif()
+cmake_minimum_required(VERSION 2.8.12)
 
 project(obs-studio)
 


### PR DESCRIPTION
Used 2.8.12 feature without realizing that 2.8.11 is still required on linux, so just bump the required version.
