### PR TITLE
Fix missing initialization

### DIFF
--- a/libobs/callback/calldata.c
+++ b/libobs/callback/calldata.c
@@ -181,7 +181,7 @@ bool calldata_getdata(calldata_t data, const char *name, void *out, size_t size)
 void calldata_setdata(calldata_t data, const char *name, const void *in,
 		size_t size)
 {
-	uint8_t *pos;
+	uint8_t *pos = NULL;
 
 	if (!data || !name || !*name)
 		return;


### PR DESCRIPTION
Fixes a missing initialization which caused a warning on at least gcc.
