### PR TITLE
Added qt5 as a dependent for Mac installation instructions.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -31,7 +31,7 @@ Windows:
 
 
 Mac OSX
-  - Use macports or homebrew and get FFmpeg, glew, qt5 and cmake.
+  - Use macports or homebrew and get FFmpeg, glew, cmake, and qt5.
 
   - In a terminal, go to the obs-studio directory create a cmbuild subdir
     and change to it, then to build, type: cmake .. && make


### PR DESCRIPTION
Per issue #80 and #73, I added qt5 as a dependency for Mac installations.

This doesn't address the qt installation directory issue addressed in #73, but I for example didn't have that issue as I installed qt5 through macports and everything worked fine.
