### PR TITLE
Menu bar changes

### DIFF
--- a/obs/forms/OBSBasic.ui
+++ b/obs/forms/OBSBasic.ui
@@ -449,8 +449,8 @@
     <property name="title">
      <string>Basic.MainMenu.File</string>
     </property>
-    <addaction name="action_Save"/>
     <addaction name="action_Open"/>
+    <addaction name="action_Save"/>
     <addaction name="separator"/>
     <addaction name="action_Settings"/>
     <addaction name="separator"/>


### PR DESCRIPTION
Fixed two typos:  'actionE_xit' to 'action_Exit', and corrected Import and Export to call Open and Save. They were flip-flopped before.
