### PR TITLE
Update crowdin url for translator instructions

### DIFF
--- a/obs/data/locale/en-US.ini
+++ b/obs/data/locale/en-US.ini
@@ -1,4 +1,4 @@
-# Note to translators: *DO NOT* translate this file directly. Instead, visit http://crowdin.net/project/obs-studio and submit your translations there.
+# Note to translators: *DO NOT* translate this file directly. Instead, visit http://crowdin.com/project/obs-studio and submit your translations there.
 # Pull requests for translations outside of CrowdIn will not be accepted.
 # Read this forum post for more instructions on submitting translations: https://obsproject.com/forum/threads/how-to-contribute-translations-for-obs.16327/
 


### PR DESCRIPTION
crowdin moved from .net to .com
