### PR TITLE
No need to subtract window position from translated coordinates

### DIFF
--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -306,7 +306,7 @@ void XCompcapMain::updateSettings(obs_data_t settings)
 
 		XTranslateCoordinates(xdisp, p->win, attr.root, 0, 0, &x, &y,
 				&child);
-		xcursor_offset(p->cursor, x - attr.x, y - attr.y);
+		xcursor_offset(p->cursor, x, y);
 	}
 
 	gs_color_format cf = GS_RGBA;


### PR DESCRIPTION
XTranslateCoordinates should already be doing this magic for us. By subtracting x.attr from x, the offset that Xlib gives us is skewed. It works on KDE because the result is probably 0 for both (although I haven't tested). For gnome however, it's slightly off giving the weird offset. 

This is just a guess. I had a hunch, took it, and it works. I would probably recommend further discussion. 
