### PR TITLE
Fix calculation of physical memory on linux systems

### DIFF
--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -128,8 +128,8 @@ static void log_memory_info(void)
 	if (sysinfo(&info) < 0)
 		return;
 
-	blog(LOG_INFO, "Physical Memory: %luMB Total",
-		info.totalram / 1024 / 1024);
+	blog(LOG_INFO, "Physical Memory: %lluMB Total",
+		((unsigned long long) info.totalram) * info.mem_unit / 1024 / 1024);
 }
 
 static void log_kernel_version(void)


### PR DESCRIPTION
As stated in the sysinfo manpage the totalram field in the sysinfo
structure is in mem_unit sizes since Linux 2.3.23. To get the actual
memory in the system the totalram value has to be multiplied with the
mem_unit size.
