### PR TITLE
Fix crash in obs_get_video_info when video_output_get_info returns NULL

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -714,6 +714,8 @@ bool obs_get_video_info(struct obs_video_info *ovi)
 		return false;
 
 	info = video_output_get_info(video->video);
+	if (!info)
+		return false;
 
 	memset(ovi, 0, sizeof(struct obs_video_info));
 	ovi->base_width    = video->base_width;


### PR DESCRIPTION
video_output_get_info can return NULL, if the input parameter is NULL, obs_get_video_info does not check this and uses the returned pointer, which leads to a crash, if the video could not be initialized correctly.
