### PR TITLE
Fix pulse audio format conversion

### DIFF
--- a/plugins/linux-pulseaudio/pulse-input.c
+++ b/plugins/linux-pulseaudio/pulse-input.c
@@ -183,15 +183,24 @@ static void pulse_source_info(pa_context *c, const pa_source_info *i, int eol,
 	if (eol != 0)
 		goto skip;
 
-	data->format          = i->sample_spec.format;
+	blog(LOG_INFO, "Audio format: %s, %"PRIu32" Hz"
+		", %"PRIu8" channels",
+		pa_sample_format_to_string(i->sample_spec.format),
+		i->sample_spec.rate,
+		i->sample_spec.channels);
+
+	pa_sample_format_t format = i->sample_spec.format;
+	if (pulse_to_obs_audio_format(format) == AUDIO_FORMAT_UNKNOWN) {
+		format = PA_SAMPLE_S16LE;
+
+		blog(LOG_INFO, "Sample format %s not supported by OBS, using %s instead for recording",
+			pa_sample_format_to_string(i->sample_spec.format),
+			pa_sample_format_to_string(format));
+	}
+
+	data->format          = format;
 	data->samples_per_sec = i->sample_spec.rate;
 	data->channels        = i->sample_spec.channels;
-
-	blog(LOG_INFO, "Audio format: %s, %"PRIuFAST32" Hz"
-		", %"PRIuFAST8" channels",
-		pa_sample_format_to_string(data->format),
-		data->samples_per_sec,
-		data->channels);
 
 skip:
 	pulse_signal(0);


### PR DESCRIPTION
1. When I was recording from a PulseAudio source that uses the format s32le the output video only contained very distorted audio. The helper function in pulse-input.c only maps PA_SAMPLE_S24_32LE to AUDIO_FORMAT_32BIT, but according to the PulseAudio documentation PA_SAMPLE_S24_32LE is a 24 bit sample format, which doesn't seem to be right, so I changed that to PA_SAMPLE_S32LE which then allowed me to correctly record from the s32le source.
2. During the investigation of the first problem I noticed that recording from every PulseAudio source with a format that OBS does not support will result in the distorted audio, because OBS always handles it as AUDIO_FORMAT_UNKNOWN, which doesn't seem like a good idea. So I made the second change that forces PulseAudio to provide data in a sample format supported by OBS when the default format of the source is not supported. Like that I was able to record from a source with s24-32le sample format without problems.
