### PR TITLE
Fix small bug in timestamp smoothing for audio sources

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -730,11 +730,11 @@ static void source_output_audio_line(obs_source_t *source,
 			(source->next_audio_ts_min - in.timestamp) :
 			(in.timestamp - source->next_audio_ts_min);
 
-		/* smooth audio if lower or within threshold */
+		/* smooth audio if within threshold */
 		if (diff > MAX_TIMESTAMP_JUMP)
 			handle_ts_jump(source, source->next_audio_ts_min,
 					in.timestamp, diff);
-		else if (ts_under || diff < TS_SMOOTHING_THRESHOLD)
+		else if (diff < TS_SMOOTHING_THRESHOLD)
 			in.timestamp = source->next_audio_ts_min;
 	}
 


### PR DESCRIPTION
Due to a small error in the timestamp smoothing code the timestamp of
audio packages that were too early was always set to the next expected
timestamp, even if the difference was bigger than the smoothing threshold.

This would cause obs to simply append all audio data to the buffer even if
the real timestamp was way smaller than the latest in the buffer.

This should reduce corruption problems with for example the pulseaudio
plugin, which resends data under certain conditions.
