### PR TITLE
linux-v4l2: Improve properties

### DIFF
--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -495,8 +495,10 @@ static bool device_selected(obs_properties_t *props, obs_property_t *p,
 
 	obs_property_t *prop = obs_properties_get(props, "input");
 	v4l2_input_list(dev, prop);
-	obs_property_modified(prop, settings);
 	v4l2_close(dev);
+
+	obs_property_modified(prop, settings);
+
 	return true;
 }
 
@@ -514,8 +516,10 @@ static bool input_selected(obs_properties_t *props, obs_property_t *p,
 
 	obs_property_t *prop = obs_properties_get(props, "pixelformat");
 	v4l2_format_list(dev, prop);
-	obs_property_modified(prop, settings);
 	v4l2_close(dev);
+
+	obs_property_modified(prop, settings);
+
 	return true;
 }
 
@@ -534,8 +538,10 @@ static bool format_selected(obs_properties_t *props, obs_property_t *p,
 	obs_property_t *prop = obs_properties_get(props, "resolution");
 	v4l2_resolution_list(dev, obs_data_get_int(settings, "pixelformat"),
 			prop);
-	obs_property_modified(prop, settings);
 	v4l2_close(dev);
+
+	obs_property_modified(prop, settings);
+
 	return true;
 }
 
@@ -557,8 +563,10 @@ static bool resolution_selected(obs_properties_t *props, obs_property_t *p,
 				"resolution"));
 	v4l2_framerate_list(dev, obs_data_get_int(settings, "pixelformat"),
 			width, height, prop);
-	obs_property_modified(prop, settings);
 	v4l2_close(dev);
+
+	obs_property_modified(prop, settings);
+
 	return true;
 }
 


### PR DESCRIPTION
This patchset improves the property handling for disconnected/reconnected devices, and disables properties when the device isn't active
