### PR TITLE
Remove ingest server live-ord.twitch.tv from services.json

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -51,10 +51,6 @@
                 "url": "rtmp://live-jfk.twitch.tv/app"
             },
             {
-                "name": "US Midwest: Chicago, IL",
-                "url": "rtmp://live-ord.twitch.tv/app"
-            },
-            {
                 "name": "US West: Los Angeles, CA",
                 "url": "rtmp://live-lax.twitch.tv/app"
             }


### PR DESCRIPTION
Server doesn't exist anymore
https://api.twitch.tv/kraken/ingests
http://blog.twitch.tv/2014/09/service-update-chicago-point-of-presence-closure/
