### PR TITLE
linux-v4l2: Handle reconnection in properties

### DIFF
--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -581,6 +581,8 @@ static void device_added(const char *dev, void *vptr)
 {
 	V4L2_DATA(vptr);
 
+	obs_source_update_properties(data->source);
+
 	if (strcmp(data->device_id, dev))
 		return;
 
@@ -596,6 +598,8 @@ static void device_added(const char *dev, void *vptr)
 static void device_removed(const char *dev, void *vptr)
 {
 	V4L2_DATA(vptr);
+
+	obs_source_update_properties(data->source);
 
 	if (strcmp(data->device_id, dev))
 		return;


### PR DESCRIPTION
This updates device disconnection/reconnection, and will automatically disable the properties if a device isn't present.
