### PR TITLE
libobs: Replace fmaxf with inline comparison.

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -655,7 +655,7 @@ static void calc_volume_levels(struct obs_source *source, float *array,
 		float val_pow2 = val * val;
 
 		sum_val += val_pow2;
-		max_val  = fmaxf(max_val, val_pow2);
+		max_val  = (max_val > val_pow2) ? max_val : val_pow2;
 	}
 
 	/*


### PR DESCRIPTION
This replaces the call to fmaxf with the equivalent inline comparison
which is a bit faster (at least on linux).
