### PR TITLE
Updated INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -133,23 +133,23 @@ Linux
     - If you are building ffmpeg from source, than you will need to install a
 			few packages.
 			
-          Aptitiude-based Distros (Debian, Ubuntu, etc):
-            apt-get install autoconf build-essential checkinstall git
-            libass-dev libtheora-dev libtool libva-dev libvdpau-dev
-            libvorbis-dev libx11-dev libxext-dev libxfixes-dev pkg-config
-            texi2html zlib1g-dev libpulse-dev libv4l-dev libudev-dev
+        Aptitiude-based Distros (Debian, Ubuntu, etc):
+          apt-get install autoconf build-essential checkinstall git
+          libass-dev libtheora-dev libtool libva-dev libvdpau-dev
+          libvorbis-dev libx11-dev libxext-dev libxfixes-dev pkg-config
+          texi2html zlib1g-dev libpulse-dev libv4l-dev libudev-dev
         
-          RPM-based distros (RHEL, Fedora, OpenSUSE, etc):
-            yum groupinstall "Development Tools" "Development Libraries"
-            yum install git libass-devel libtheora-devel libtool-ltdl-devel
-            libva-devel libvdpau-devel libvorbis-devel libX11-devel
-            libXext-devel libXfixes-devel pkgconfig texi2html zlib-devel
-            pulseaudio-libs-devel libv4l-devel libudev-devel
+        RPM-based distros (RHEL, Fedora, OpenSUSE, etc):
+          yum groupinstall "Development Tools" "Development Libraries"
+          yum install git libass-devel libtheora-devel libtool-ltdl-devel
+          libva-devel libvdpau-devel libvorbis-devel libX11-devel
+          libXext-devel libXfixes-devel pkgconfig texi2html zlib-devel
+          pulseaudio-libs-devel libv4l-devel libudev-devel
             
-            Checkinstall is not available for RPM-based distros, so you can
-            compile it from source, or you can substitute all checkinstall
-            commands with:
-              sudo make install
+          Checkinstall is not available for RPM-based distros, so you can
+          compile it from source, or you can substitute all checkinstall
+          commands with:
+            sudo make install
 
 
     - Building the software


### PR DESCRIPTION
- Added more detailed instructions for compiling on Linux.
- Removed markdown, and reverted to plain text
- Column width at 80 max (except for single command in Mac section, which existed prior to my editing)
- Removed references to build support for opus, webm, and vpx
- Noted FDK-AAC as optional to install
- Added instructions to install from PPA
- Added package list for RPM-based distros
- Moved source directory from /build to ~/source
