### PR TITLE
libobs: Use FFmpeg for image loading by default

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT ImageMagick_MagickCore_FOUND AND NOT FFMPEG_AVCODEC_FOUND)
 	message(FATAL_ERROR "Either MagickCore or Libavcodec is required, but both were not found")
 endif()
 
-option(LIBOBS_PREFER_IMAGEMAGICK "Prefer ImageMagick over ffmpeg for image loading" ON)
+option(LIBOBS_PREFER_IMAGEMAGICK "Prefer ImageMagick over ffmpeg for image loading" OFF)
 
 if(NOT FFMPEG_AVCODEC_FOUND OR (ImageMagick_MagickCore_FOUND AND LIBOBS_PREFER_IMAGEMAGICK))
 	message(STATUS "Using ImageMagick for image loading in libobs")


### PR DESCRIPTION
As discussed in #307, this should be a better default option as ffmpeg is currently required anyway and unlike ImageMagick not buggy on some distributions.

All this PR does is switch the prefer imagemagick option to "off" as default value.
