### PR TITLE
Mark windows changed on Expose

### DIFF
--- a/plugins/linux-capture/xcompcap-helper.cpp
+++ b/plugins/linux-capture/xcompcap-helper.cpp
@@ -186,6 +186,9 @@ namespace XCompcap
 			if (ev.type == MapNotify)
 				changedWindows.insert(ev.xmap.event);
 
+			if (ev.type == Expose)
+				changedWindows.insert(ev.xexpose.window);
+
 			if (ev.type == DestroyNotify)
 				changedWindows.insert(ev.xdestroywindow.event);
 		}

--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -296,7 +296,7 @@ void XCompcapMain::updateSettings(obs_data_t *settings)
 		return;
 	}
 
-	XSelectInput(xdisp, p->win, StructureNotifyMask);
+	XSelectInput(xdisp, p->win, StructureNotifyMask | ExposureMask);
 	XSync(xdisp, 0);
 
 	XWindowAttributes attr;


### PR DESCRIPTION
On i3wm, windows aren't unmapped when switching away from a window's
workspace, but it does cause OBS to lose the capture. Because
switching back will not trigger a MapNotify, the capture fails to
restart unless you resize or move the window (ConfigureNotify). An
Expose event is fired by the wm, however, so catching this correctly
restarts the capture.
