### PR TITLE
fixed debian source install instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -179,7 +179,8 @@ Linux (Manually compiling on Debian-based distros)
 
         sudo apt-get install libx11-dev libgl-dev libpulse-dev libxcomposite-dev \
                 libxinerama-dev libv4l-dev libudev-dev libfreetype6-dev \
-                libfontconfig-dev qtbase5-dev libqt5x11extras5-dev
+                libfontconfig-dev qtbase5-dev libqt5x11extras5-dev libx264-dev \
+                libxcb-xinerama0-dev
 
   - Building and installing OBS:
 


### PR DESCRIPTION
There was a missing 'install' on line 180.
That same instruction was seemingly missing two dependencies, libxinerama0-dev and libx264-dev.

I found the issues on Xubuntu 14.10 when compiling c6ad237b4bffd9e8052f1398530ca2a5467b568e
