### PR TITLE
UI: Draw peak-audio-meter correctly when clipping

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -740,11 +740,18 @@ void VolumeMeter::paintMeter(QPainter &painter, int x, int y,
 			backgroundErrorColor);
 
 	} else {
-		qreal end = errorLength + warningLength + nominalLength;
 		painter.fillRect(
 			minimumPosition, y,
-			end, height,
-			QBrush(foregroundErrorColor));
+			nominalLength, height,
+			foregroundNominalColor);
+		painter.fillRect(
+			warningPosition, y,
+			warningLength, height,
+			foregroundWarningColor);
+		painter.fillRect(
+			errorPosition, y,
+			maximumPosition - errorPosition, height,
+			foregroundErrorColor);
 	}
 
 	if (peakHoldPosition - 3 < minimumPosition) {


### PR DESCRIPTION
The peak meter was drawn with a single red draw call when clipping,
which causes the meter to look like it was flashing. In this fix
the peak-meter is drawn normally (with three seperate green, yellow and red
sections) when clipping.