### PR TITLE
Save Windowed Projectors on exit

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1480,8 +1480,6 @@ void OBSBasic::OBSInit()
 
 	SystemTray(true);
 
-	OpenSavedProjectors();
-
 	if (windowState().testFlag(Qt::WindowFullScreen))
 		fullscreenInterface = true;
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5715,42 +5715,42 @@ void OBSBasic::OpenSavedProjectors()
 	bool projectorSave = config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "SaveProjectors");
 
-	if (projectorSave) {
-		for (size_t i = 0; i < projectorArray.size(); i++) {
-			if (projectorArray.at(i).empty() == false) {
-				OBSSource source = obs_get_source_by_name(
-					projectorArray.at(i).c_str());
+	if (!projectorSave)
+		return;
 
-				if (!source) {
-					RemoveSavedProjectors((int)i);
-					obs_source_release(source);
-					continue;
-				}
+	for (size_t i = 0; i < projectorArray.size(); i++) {
+		if (projectorArray.at(i).empty() == false) {
+			OBSSource source = obs_get_source_by_name(
+				projectorArray.at(i).c_str());
 
-				OpenProjector(source, (int)i, false);
-				obs_source_release(source);
+			if (!source) {
+				RemoveSavedProjectors((int)i);
+				continue;
 			}
+
+			OpenProjector(source, (int)i, false);
+			obs_source_release(source);
 		}
+	}
 
-		for (size_t i = 0; i < studioProgramProjectorArray.size(); i++) {
-			if (studioProgramProjectorArray.at(i) == 1) {
-				OpenProjector(nullptr, (int)i, false, nullptr,
-						ProjectorType::StudioProgram);
-			}
+	for (size_t i = 0; i < studioProgramProjectorArray.size(); i++) {
+		if (studioProgramProjectorArray.at(i) == 1) {
+			OpenProjector(nullptr, (int)i, false, nullptr,
+					ProjectorType::StudioProgram);
 		}
+	}
 
-		for (size_t i = 0; i < previewProjectorArray.size(); i++) {
-			if (previewProjectorArray.at(i) == 1) {
-				OpenProjector(nullptr, (int)i, false, nullptr,
-						ProjectorType::Preview);
-			}
+	for (size_t i = 0; i < previewProjectorArray.size(); i++) {
+		if (previewProjectorArray.at(i) == 1) {
+			OpenProjector(nullptr, (int)i, false, nullptr,
+					ProjectorType::Preview);
 		}
+	}
 
-		for (size_t i = 0; i < multiviewProjectorArray.size(); i++) {
-			if (multiviewProjectorArray.at(i) == 1) {
-				OpenProjector(nullptr, (int)i, false, nullptr,
-						ProjectorType::Multiview);
-			}
+	for (size_t i = 0; i < multiviewProjectorArray.size(); i++) {
+		if (multiviewProjectorArray.at(i) == 1) {
+			OpenProjector(nullptr, (int)i, false, nullptr,
+					ProjectorType::Multiview);
 		}
 	}
 }

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5692,7 +5692,7 @@ void OBSBasic::OpenSourceWindow()
 void OBSBasic::OpenMultiviewWindow()
 {
 	int monitor = sender()->property("monitor").toInt();
-	OpenProjector(nullptr, monitor, true, "Multiview",
+	OpenProjector(nullptr, monitor, true, QTStr("MultiviewWindowed"),
 			ProjectorType::Multiview);
 }
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -834,47 +834,6 @@ void OBSBasic::Load(const char *file)
 	ui->transitionDuration->setValue(newDuration);
 	SetTransition(curTransition);
 
-	/* ------------------- */
-
-	obs_data_array_t *savedProjectors = obs_data_get_array(data,
-			"saved_projectors");
-
-	if (savedProjectors)
-		LoadSavedProjectors(savedProjectors);
-
-	obs_data_array_release(savedProjectors);
-
-	/* ------------------- */
-
-	obs_data_array_t *savedPreviewProjectors = obs_data_get_array(data,
-			"saved_preview_projectors");
-
-	if (savedPreviewProjectors)
-		LoadSavedPreviewProjectors(savedPreviewProjectors);
-
-	obs_data_array_release(savedPreviewProjectors);
-
-	/* ------------------- */
-
-	obs_data_array_t *savedStudioProgramProjectors = obs_data_get_array(data,
-			"saved_studio_preview_projectors");
-
-	if (savedStudioProgramProjectors)
-		LoadSavedStudioProgramProjectors(savedStudioProgramProjectors);
-
-	obs_data_array_release(savedStudioProgramProjectors);
-
-	/* ------------------- */
-
-	obs_data_array_t *savedMultiviewProjectors = obs_data_get_array(data,
-			"saved_multiview_projectors");
-
-	if (savedMultiviewProjectors)
-		LoadSavedMultiviewProjectors(savedMultiviewProjectors);
-
-	obs_data_array_release(savedMultiviewProjectors);
-
-
 retryScene:
 	curScene = obs_get_source_by_name(sceneName);
 	curProgramScene = obs_get_source_by_name(programSceneName);
@@ -904,6 +863,49 @@ retryScene:
 
 	obs_data_array_release(sources);
 	obs_data_array_release(sceneOrder);
+
+	/* ------------------- */
+
+	bool projectorSave = config_get_bool(GetGlobalConfig(), "BasicWindow",
+			"SaveProjectors");
+
+	if (projectorSave) {
+		obs_data_array_t *savedProjectors = obs_data_get_array(data,
+				"saved_projectors");
+
+		if (savedProjectors)
+			LoadSavedProjectors(savedProjectors);
+
+		obs_data_array_release(savedProjectors);
+
+		obs_data_array_t *savedPreviewProjectors = obs_data_get_array(
+				data, "saved_preview_projectors");
+
+		if (savedPreviewProjectors)
+			LoadSavedPreviewProjectors(savedPreviewProjectors);
+
+		obs_data_array_release(savedPreviewProjectors);
+
+		obs_data_array_t *savedStudioProgramProjectors;
+		savedStudioProgramProjectors = obs_data_get_array(data,
+				"saved_studio_preview_projectors");
+
+		if (savedStudioProgramProjectors)
+			LoadSavedStudioProgramProjectors(
+					savedStudioProgramProjectors);
+
+		obs_data_array_release(savedStudioProgramProjectors);
+
+		obs_data_array_t *savedMultiviewProjectors = obs_data_get_array(
+				data, "saved_multiview_projectors");
+
+		if (savedMultiviewProjectors)
+			LoadSavedMultiviewProjectors(savedMultiviewProjectors);
+
+		obs_data_array_release(savedMultiviewProjectors);
+	}
+
+	/* ------------------- */
 
 	std::string file_base = strrchr(file, '/') + 1;
 	file_base.erase(file_base.size() - 5, 5);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5585,31 +5585,10 @@ void OBSBasic::OpenProjector(obs_source_t *source, int monitor, bool window,
 	if (monitor > 9 || monitor > QGuiApplication::screens().size() - 1)
 		return;
 
-	if (!window) {
-		delete projectors[monitor];
-		projectors[monitor].clear();
-		RemoveSavedProjectors(monitor);
-	}
-
 	OBSProjector *projector = new OBSProjector(nullptr, source, !!window);
 	const char *name = obs_source_get_name(source);
 
-	if (!window) {
-		if (type == ProjectorType::StudioProgram) {
-			studioProgramProjectorArray.at((size_t)monitor) = 1;
-		} else if (type == ProjectorType::Preview) {
-			previewProjectorArray.at((size_t)monitor) = 1;
-		} else if (type == ProjectorType::Multiview) {
-			multiviewProjectorArray.at((size_t)monitor) = 1;
-		} else {
-			projectorArray.at((size_t)monitor) = name;
-		}
-	}
-
-	if (!window) {
-		projector->Init(monitor, false, nullptr, type);
-		projectors[monitor] = projector;
-	} else {
+	if (window) {
 		projector->Init(monitor, true, title, type);
 
 		for (auto &projPtr : windowProjectors) {
@@ -5621,6 +5600,23 @@ void OBSBasic::OpenProjector(obs_source_t *source, int monitor, bool window,
 
 		if (projector)
 			windowProjectors.push_back(projector);
+	} else {
+		delete projectors[monitor];
+		projectors[monitor].clear();
+		RemoveSavedProjectors(monitor);
+
+		if (type == ProjectorType::StudioProgram) {
+			studioProgramProjectorArray.at((size_t)monitor) = 1;
+		} else if (type == ProjectorType::Preview) {
+			previewProjectorArray.at((size_t)monitor) = 1;
+		} else if (type == ProjectorType::Multiview) {
+			multiviewProjectorArray.at((size_t)monitor) = 1;
+		} else {
+			projectorArray.at((size_t)monitor) = name;
+		}
+
+		projector->Init(monitor, false, nullptr, type);
+		projectors[monitor] = projector;
 	}
 }
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5679,13 +5679,12 @@ void OBSBasic::OpenSourceWindow()
 {
 	int monitor = sender()->property("monitor").toInt();
 	OBSSceneItem item = GetCurrentSceneItem();
-	OBSSource source = obs_sceneitem_get_source(item);
-	QString text = QString::fromUtf8(obs_source_get_name(source));
-
-	QString title = QTStr("SourceWindow") + " - " + text;
-
 	if (!item)
 		return;
+
+	OBSSource source = obs_sceneitem_get_source(item);
+	QString text = QString::fromUtf8(obs_source_get_name(source));
+	QString title = QTStr("SourceWindow") + " - " + text;
 
 	OpenProjector(obs_sceneitem_get_source(item), monitor, true, title);
 }
@@ -5701,13 +5700,12 @@ void OBSBasic::OpenSceneWindow()
 {
 	int monitor = sender()->property("monitor").toInt();
 	OBSScene scene = GetCurrentScene();
-	OBSSource source = obs_scene_get_source(scene);
-	QString text = QString::fromUtf8(obs_source_get_name(source));
-
-	QString title = QTStr("SceneWindow") + " - " + text;
-
 	if (!scene)
 		return;
+
+	OBSSource source = obs_scene_get_source(scene);
+	QString text = QString::fromUtf8(obs_source_get_name(source));
+	QString title = QTStr("SceneWindow") + " - " + text;
 
 	OpenProjector(obs_scene_get_source(scene), monitor, true, title);
 }

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2204,6 +2204,8 @@ void OBSBasic::RenameSources(OBSSource source, QString newName,
 			volumes[i]->SetName(newName);
 	}
 
+	OBSProjector::RenameProjector(prevName, newName);
+
 	SaveProject();
 
 	obs_scene_t *scene = obs_scene_from_source(source);
@@ -5538,9 +5540,7 @@ void OBSBasic::OpenSourceWindow()
 		return;
 
 	OBSSource source = obs_sceneitem_get_source(item);
-	QString text = QString::fromUtf8(obs_source_get_name(source));
-	QString title = QTStr("SourceWindow") + " - " + text;
-
+	QString title = QString::fromUtf8(obs_source_get_name(source));
 	OpenProjector(obs_sceneitem_get_source(item), monitor, title);
 }
 
@@ -5559,9 +5559,7 @@ void OBSBasic::OpenSceneWindow()
 		return;
 
 	OBSSource source = obs_scene_get_source(scene);
-	QString text = QString::fromUtf8(obs_source_get_name(source));
-	QString title = QTStr("SceneWindow") + " - " + text;
-
+	QString title = QString::fromUtf8(obs_source_get_name(source));
 	OpenProjector(obs_scene_get_source(scene), monitor, title);
 }
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -250,9 +250,8 @@ private:
 
 	void Nudge(int dist, MoveDir dir);
 
-	void OpenProjector(obs_source_t *source, int monitor,
-			QString title = nullptr,
-			ProjectorType type = ProjectorType::Source);
+	OBSProjector *OpenProjector(obs_source_t *source, int monitor,
+			QString title, ProjectorType type);
 
 	void GetAudioSourceFilters();
 	void GetAudioSourceProperties();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -29,6 +29,7 @@
 #include "window-basic-transform.hpp"
 #include "window-basic-adv-audio.hpp"
 #include "window-basic-filters.hpp"
+#include "window-projector.hpp"
 
 #include <obs-frontend-internal.hpp>
 
@@ -65,13 +66,6 @@ struct BasicOutputHandler;
 enum class QtDataRole {
 	OBSRef = Qt::UserRole,
 	OBSSignals,
-};
-
-enum class ProjectorType {
-	Source,
-	Preview,
-	StudioProgram,
-	Multiview
 };
 
 struct QuickTransition {

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -68,6 +68,13 @@ enum class QtDataRole {
 	OBSSignals,
 };
 
+struct SavedProjectorInfo {
+	ProjectorType type;
+	int monitor;
+	std::string geometry;
+	std::string name;
+};
+
 struct QuickTransition {
 	QPushButton *button = nullptr;
 	OBSSource source;
@@ -114,11 +121,6 @@ private:
 
 	std::vector<OBSSignal> signalHandlers;
 
-	std::vector<std::string> projectorArray;
-	std::vector<int> studioProgramProjectorArray;
-	std::vector<int> multiviewProjectorArray;
-	std::vector<int> previewProjectorArray;
-
 	bool loaded = false;
 	long disableSaving = 1;
 	bool projectChanged = false;
@@ -163,6 +165,7 @@ private:
 
 	ConfigFile    basicConfig;
 
+	std::vector<SavedProjectorInfo*> savedProjectorsArray;
 	QPointer<QWidget> projectors[10];
 	QList<QPointer<QWidget>> windowProjectors;
 
@@ -246,7 +249,8 @@ private:
 	void ClearSceneData();
 
 	void Nudge(int dist, MoveDir dir);
-	void OpenProjector(obs_source_t *source, int monitor, bool window,
+
+	void OpenProjector(obs_source_t *source, int monitor,
 			QString title = nullptr,
 			ProjectorType type = ProjectorType::Source);
 
@@ -360,18 +364,6 @@ private:
 
 	obs_data_array_t *SaveProjectors();
 	void LoadSavedProjectors(obs_data_array_t *savedProjectors);
-
-	obs_data_array_t *SavePreviewProjectors();
-	void LoadSavedPreviewProjectors(
-		obs_data_array_t *savedPreviewProjectors);
-
-	obs_data_array_t *SaveStudioProgramProjectors();
-	void LoadSavedStudioProgramProjectors(
-		obs_data_array_t *savedStudioProgramProjectors);
-
-	obs_data_array_t *SaveMultiviewProjectors();
-	void LoadSavedMultiviewProjectors(
-		obs_data_array_t *savedMultiviewProjectors);
 
 public slots:
 	void StartStreaming();
@@ -562,7 +554,6 @@ public:
 	void SystemTray(bool firstStarted);
 
 	void OpenSavedProjectors();
-	void RemoveSavedProjectors(int monitor);
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -135,25 +135,19 @@ static OBSSource CreateLabel(const char *name, size_t h)
 void OBSProjector::Init(int monitor, bool window, QString title,
 		ProjectorType type_)
 {
-	QScreen *screen = QGuiApplication::screens()[monitor];
-
-	if (!window)
-		setGeometry(screen->geometry());
-
 	bool alwaysOnTop = config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "ProjectorAlwaysOnTop");
 	if (alwaysOnTop && !window)
 		SetAlwaysOnTop(this, true);
 
-	if (window)
-		setWindowTitle(title);
-
 	show();
 
-	if (source)
-		obs_source_inc_showing(source);
+	if (window) {
+		setWindowTitle(title);
+	} else {
+		QScreen *screen = QGuiApplication::screens()[monitor];
+		setGeometry(screen->geometry());
 
-	if (!window) {
 		QAction *action = new QAction(this);
 		action->setShortcut(Qt::Key_Escape);
 		addAction(action);
@@ -161,6 +155,9 @@ void OBSProjector::Init(int monitor, bool window, QString title,
 				SLOT(EscapeTriggered()));
 		activateWindow();
 	}
+
+	if (source)
+		obs_source_inc_showing(source);
 
 	savedMonitor = monitor;
 	isWindow     = window;

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -3,7 +3,7 @@
 #include <QMouseEvent>
 #include <QMenu>
 #include <QScreen>
-#include "window-projector.hpp"
+#include "window-basic-main.hpp"
 #include "display-helpers.hpp"
 #include "qt-wrappers.hpp"
 #include "platform.hpp"

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -857,6 +857,21 @@ void OBSProjector::UpdateMultiview()
 		multiviewLayout = HORIZONTAL_TOP;
 }
 
+OBSSource OBSProjector::GetSource()
+{
+	return source;
+}
+
+ProjectorType OBSProjector::GetProjectorType()
+{
+	return type;
+}
+
+int OBSProjector::GetMonitor()
+{
+	return savedMonitor;
+}
+
 void OBSProjector::UpdateMultiviewProjectors()
 {
 	obs_enter_graphics();

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -588,6 +588,7 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 		return;
 
 	OBSBasic *main = reinterpret_cast<OBSBasic*>(App()->GetMainWindow());
+	OBSSource source = window->source;
 
 	uint32_t targetCX;
 	uint32_t targetCY;
@@ -595,9 +596,9 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 	int      newCX, newCY;
 	float    scale;
 
-	if (window->source) {
-		targetCX = std::max(obs_source_get_width(window->source), 1u);
-		targetCY = std::max(obs_source_get_height(window->source), 1u);
+	if (source) {
+		targetCX = std::max(obs_source_get_width(source), 1u);
+		targetCY = std::max(obs_source_get_height(source), 1u);
 	} else {
 		struct obs_video_info ovi;
 		obs_get_video_info(&ovi);
@@ -615,14 +616,12 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 	gs_ortho(0.0f, float(targetCX), 0.0f, float(targetCY), -100.0f, 100.0f);
 	gs_set_viewport(x, y, newCX, newCY);
 
-	OBSSource source = window->source;
-
 	if (window->type == ProjectorType::Preview &&
 	    main->IsPreviewProgramMode()) {
 		OBSSource curSource = main->GetCurrentSceneSource();
 
-		if (window->source != curSource) {
-			obs_source_dec_showing(window->source);
+		if (source != curSource) {
+			obs_source_dec_showing(source);
 			obs_source_inc_showing(curSource);
 			source = curSource;
 		}

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -792,11 +792,6 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 
 void OBSProjector::EscapeTriggered()
 {
-	if (!isWindow) {
-		OBSBasic *main = (OBSBasic*)obs_frontend_get_main_window();
-		main->RemoveSavedProjectors(savedMonitor);
-	}
-
 	deleteLater();
 }
 

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -27,8 +27,8 @@ private:
 	void mousePressEvent(QMouseEvent *event) override;
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
 
-	int savedMonitor = 0;
-	bool isWindow = false;
+	int savedMonitor;
+	bool isWindow;
 	QString projectorTitle;
 	ProjectorType type = ProjectorType::Source;
 	OBSWeakSource multiviewScenes[8];
@@ -49,11 +49,11 @@ private slots:
 	void EscapeTriggered();
 
 public:
-	OBSProjector(QWidget *parent, obs_source_t *source, bool window);
+	OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
+			QString title, ProjectorType type_);
 	~OBSProjector();
 
-	void Init(int monitor, bool window, QString title,
-			ProjectorType type = ProjectorType::Source);
+	void Init();
 
 	OBSSource GetSource();
 	ProjectorType GetProjectorType();

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -5,6 +5,7 @@
 
 enum class ProjectorType {
 	Source,
+	Scene,
 	Preview,
 	StudioProgram,
 	Multiview

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -53,5 +53,8 @@ public:
 	void Init(int monitor, bool window, QString title,
 			ProjectorType type = ProjectorType::Source);
 
+	OBSSource GetSource();
+	ProjectorType GetProjectorType();
+	int GetMonitor();
 	static void UpdateMultiviewProjectors();
 };

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -2,7 +2,13 @@
 
 #include <obs.hpp>
 #include "qt-display.hpp"
-#include "window-basic-main.hpp"
+
+enum class ProjectorType {
+	Source,
+	Preview,
+	StudioProgram,
+	Multiview
+};
 
 class QMouseEvent;
 

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -29,6 +29,7 @@ private:
 
 	int savedMonitor = 0;
 	bool isWindow = false;
+	QString projectorTitle;
 	ProjectorType type = ProjectorType::Source;
 	OBSWeakSource multiviewScenes[8];
 	OBSSource     multiviewLabels[10];
@@ -42,6 +43,7 @@ private:
 	bool ready = false;
 
 	void UpdateMultiview();
+	void UpdateProjectorTitle(QString name);
 
 private slots:
 	void EscapeTriggered();
@@ -57,4 +59,5 @@ public:
 	ProjectorType GetProjectorType();
 	int GetMonitor();
 	static void UpdateMultiviewProjectors();
+	static void RenameProjector(QString oldName, QString newName);
 };


### PR DESCRIPTION
This expands the original work to save fullscreen projectors by changing a bit how it works in the background. Instead of creating an array of saved projectors by type, now it stores it all on a single array accounting for its type and monitor id.

Users with saved fullscreen projectors, just on the first load after this change, will have to reopen the projectors so obs generates the new save data on the new format on exit.

I haven't squashed the refactor commit because i don't know if i should. This way we can squash later if needed.