### PR TITLE
UI: Add Selected and Hidden Array Values

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -576,6 +576,8 @@ void OBSPropertiesView::AddEditableList(obs_property_t *prop,
 	for (size_t i = 0; i < count; i++) {
 		obs_data_t *item = obs_data_array_item(array, i);
 		list->addItem(QT_UTF8(obs_data_get_string(item, "value")));
+		list->setItemSelected(list->item(i), obs_data_get_bool(item, "selected"));
+		list->setItemHidden(list->item(i), obs_data_get_bool(item, "hidden"));
 		obs_data_release(item);
 	}
 
@@ -1690,7 +1692,10 @@ void WidgetInfo::EditableListChanged()
 		obs_data_t *arrayItem = obs_data_create();
 		obs_data_set_string(arrayItem, "value",
 				QT_TO_UTF8(item->text()));
-
+		obs_data_set_bool(arrayItem, "selected",
+			item->isSelected());
+		obs_data_set_bool(arrayItem, "hidden",
+			item->isHidden());
 		obs_data_array_push_back(array, arrayItem);
 		obs_data_release(arrayItem);
 	}


### PR DESCRIPTION
Add Selected and Hidden Array Values

Let developers get and set whether items in an editable list are hidden or
selected. May be useful in when editable lists are modified and handled in a
callback. Especially when edit button callbacks are used.