### PR TITLE
libobs: Fix Projectors closing when toggling Always On Top

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5131,7 +5131,10 @@ void OBSBasic::on_previewDisabledLabel_customContextMenuRequested(
 
 void OBSBasic::on_actionAlwaysOnTop_triggered()
 {
-	CloseDialogs();
+	/* CloseDialogs()Commented out due to this closing all 
+	*  projectors when AlwaysOnTop is toggled.
+	*  No obvious problems are caused by this */
+	//CloseDialogs(); 
 
 	/* Make sure all dialogs are safely and successfully closed before
 	 * switching the always on top mode due to the fact that windows all


### PR DESCRIPTION
Pretty much my first PR ever to a project.

Please let me know of any suggestions or if there is a better way to fix. 

Was brought to my attention by bug 0001166 on the tracker.