### PR TITLE
rtmp-services: Update ingest list for Restream.io

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 78,
+	"version": 79,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 78
+			"version": 79
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -714,6 +714,10 @@
                     "url": "rtmp://seoul.restream.io/live"
                 },
                 {
+                    "name": "Asia (Tokyo, Japan)",
+                    "url": "rtmp://tokyo.restream.io/live"
+                },
+                {
                     "name": "Australia (Sydney)",
                     "url": "rtmp://au.restream.io/live"
                 }


### PR DESCRIPTION
Update ingest list for Restream.io:
- add new Restream ingest: Asia (Tokyo, Japan)
- update rtmp-services version

Restream ingests could be checked at: https://restream.io/ingests
