### PR TITLE
UI: Add ability to make numbered recordings

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -645,6 +645,7 @@ Basic.Settings.Output.Adv.Recording.Type.FFmpegOutput="Custom Output (FFmpeg)"
 Basic.Settings.Output.Adv.Recording.UseStreamEncoder="(Use stream encoder)"
 Basic.Settings.Output.Adv.Recording.Filename="Filename Formatting"
 Basic.Settings.Output.Adv.Recording.OverwriteIfExists="Overwrite if file exists"
+Basic.Settings.Output.Adv.Recording.UseLocalCounter="Numbering per session"
 Basic.Settings.Output.Adv.FFmpeg.Type="FFmpeg Output Type"
 Basic.Settings.Output.Adv.FFmpeg.Type.URL="Output to URL"
 Basic.Settings.Output.Adv.FFmpeg.Type.RecordToFile="Output to File"
@@ -671,7 +672,8 @@ Basic.Settings.Output.Adv.FFmpeg.IgnoreCodecCompat="Show all codecs (even if pot
 FilenameFormatting.completer="%CCYY-%MM-%DD %hh-%mm-%ss\n%YY-%MM-%DD %hh-%mm-%ss\n%Y-%m-%d %H-%M-%S\n%y-%m-%d %H-%M-%S\n%a %Y-%m-%d %H-%M-%S\n%A %Y-%m-%d %H-%M-%S\n%Y-%b-%d %H-%M-%S\n%Y-%B-%d %H-%M-%S\n%Y-%m-%d %I-%M-%S-%p\n%Y-%m-%d %H-%M-%S-%z\n%Y-%m-%d %H-%M-%S-%Z"
 
 # basic mode 'output' settings - advanced section - recording subsection - TT
-FilenameFormatting.TT="%CCYY	Year, four digits\n%YY		Year, last two digits (00-99)\n%MM		Month as a decimal number (01-12)\n%DD		Day of the month, zero-padded (01-31)\n%hh		Hour in 24h format (00-23)\n%mm		Minute (00-59)\n%ss		Second (00-61)\n%%		A % sign\n%a		Abbreviated weekday name\n%A		Full weekday name\n%b		Abbreviated month name\n%B		Full month name\n%d		Day of the month, zero-padded (01-31)\n%H		Hour in 24h format (00-23)\n%I		Hour in 12h format (01-12)\n%m		Month as a decimal number (01-12)\n%M		Minute (00-59)\n%p		AM or PM designation\n%S		Second (00-61)\n%y		Year, last two digits (00-99)\n%Y		Year\n%z		ISO 8601 offset from UTC or timezone\n		name or abbreviation\n%Z		Timezone name or abbreviation\n"
+FilenameFormatting.TT="%CCYY	Year, four digits\n%YY		Year, last two digits (00-99)\n%MM		Month as a decimal number (01-12)\n%DD		Day of the month, zero-padded (01-31)\n%hh		Hour in 24h format (00-23)\n%mm		Minute (00-59)\n%ss		Second (00-61)\n%%		A % sign\n%a		Abbreviated weekday name\n%A		Full weekday name\n%b		Abbreviated month name\n%B		Full month name\n%d		Day of the month, zero-padded (01-31)\n%H		Hour in 24h format (00-23)\n%I		Hour in 12h format (01-12)\n%m		Month as a decimal number (01-12)\n%M		Minute (00-59)\n%p		AM or PM designation\n%S		Second (00-61)\n%y		Year, last two digits (00-99)\n%Y		Year\n%z		ISO 8601 offset from UTC or timezone\n		name or abbreviation\n%Z		Timezone name or abbreviation\n\n%%set[str1,...,strN]\n		User's set of the text strings\n		separated with ',' (comma)\n\n%%d		Decimal\n%%0nd	Decimal zero-padded, n = [0-9]\n"
+LocalCounter.TT="If checked, recording's counter resets each time the application starts.\n\nFor Replays, when not checked, the number is sum of the recording's number and current replay."
 
 # basic mode 'video' settings
 Basic.Settings.Video="Video"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -4081,11 +4081,22 @@
                     <widget class="QLineEdit" name="filenameFormatting"/>
                    </item>
                    <item row="1" column="1">
-                    <widget class="QCheckBox" name="overwriteIfExists">
-                     <property name="text">
-                      <string>Basic.Settings.Output.Adv.Recording.OverwriteIfExists</string>
-                     </property>
-                    </widget>
+                    <layout class="QHBoxLayout" name="horizontalLayoutWrLc">
+                     <item>
+                      <widget class="QCheckBox" name="overwriteIfExists">
+                       <property name="text">
+                        <string>Basic.Settings.Output.Adv.Recording.OverwriteIfExists</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QCheckBox" name="useLocalCounter">
+                       <property name="text">
+                        <string>Basic.Settings.Output.Adv.Recording.UseLocalCounter</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
                    </item>
                    <item row="2" column="1">
                     <layout class="QHBoxLayout" name="horizontalLayout_14">
@@ -4514,6 +4525,7 @@
   <tabstop>monitoringDevice</tabstop>
   <tabstop>filenameFormatting</tabstop>
   <tabstop>overwriteIfExists</tabstop>
+  <tabstop>useLocalCounter</tabstop>
   <tabstop>simpleRBPrefix</tabstop>
   <tabstop>simpleRBSuffix</tabstop>
   <tabstop>streamDelayEnable</tabstop>

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1205,6 +1205,14 @@ string GenerateTimeDateFilename(const char *extension, bool noSpace)
 	return string(file);
 }
 
+string GenerateNumberedString(const int32_t recType, int32_t number,
+		const char *format)
+{
+	BPtr<char> numname = os_numbered_string(recType, number, format);
+
+	return string(numname);
+}
+
 string GenerateSpecifiedFilename(const char *extension, bool noSpace,
 		const char *format)
 {

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -36,6 +36,8 @@
 std::string CurrentTimeString();
 std::string CurrentDateTimeString();
 std::string GenerateTimeDateFilename(const char *extension, bool noSpace=false);
+std::string GenerateNumberedString(const int32_t recType, int32_t number,
+					const char *format);
 std::string GenerateSpecifiedFilename(const char *extension, bool noSpace,
 					const char *format);
 QObject *CreateShortcutFilter();

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -8,6 +8,9 @@
 
 using namespace std;
 
+int64_t numRecGlob = 0; //global counter of recordings number
+int32_t numRec = 0; //per session counter of recordings
+
 static void OBSStreamStarting(void *data, calldata_t *params)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler*>(data);
@@ -835,6 +838,8 @@ bool SimpleOutput::ConfigureRecording(bool updateReplayBuffer)
 				"FilenameFormatting");
 	bool overwriteIfExists = config_get_bool(main->Config(), "Output",
 				"OverwriteIfExists");
+	bool useLocalCounter = config_get_bool(main->Config(), "Output",
+			"UseLocalCounter");
 	const char *rbPrefix = config_get_string(main->Config(), "SimpleOutput",
 				"RecRBPrefix");
 	const char *rbSuffix = config_get_string(main->Config(), "SimpleOutput",
@@ -859,6 +864,25 @@ bool SimpleOutput::ConfigureRecording(bool updateReplayBuffer)
 
 	os_closedir(dir);
 
+	int32_t numRecOut; //counter for numbered filenaming
+
+	numRecGlob = config_get_int(main->Config(), "Output",
+		"NumRecGlobal");
+
+	//count only recordings
+	if (!updateReplayBuffer) {
+		config_set_int(main->Config(), "Output",
+			"NumRecGlobal", ++numRecGlob);
+
+		++numRec;
+	}
+
+	//count recordings only per session
+	if (useLocalCounter)
+		numRecOut = numRec;
+	else
+		numRecOut = (int32_t)numRecGlob;
+
 	string strPath;
 	strPath += path;
 
@@ -866,8 +890,10 @@ bool SimpleOutput::ConfigureRecording(bool updateReplayBuffer)
 	if (lastChar != '/' && lastChar != '\\')
 		strPath += "/";
 
-	strPath += GenerateSpecifiedFilename(ffmpegOutput ? "avi" : format,
+	string sf = GenerateSpecifiedFilename(ffmpegOutput ? "avi" : format,
 			noSpace, filenameFormat);
+	strPath += GenerateNumberedString(updateReplayBuffer ? 0 : 1,
+			numRecOut, sf.c_str());
 	ensure_directory_exists(strPath);
 	if (!overwriteIfExists)
 		FindBestFilename(strPath, noSpace);
@@ -895,6 +921,7 @@ bool SimpleOutput::ConfigureRecording(bool updateReplayBuffer)
 		obs_data_set_string(settings, "directory", path);
 		obs_data_set_string(settings, "format", f.c_str());
 		obs_data_set_string(settings, "extension", format);
+		obs_data_set_int(settings, "recNumber", numRecOut);
 		obs_data_set_int(settings, "max_time_sec", rbTime);
 		obs_data_set_int(settings, "max_size_mb",
 				usingRecordingPreset ? rbSize : 0);
@@ -1539,6 +1566,7 @@ bool AdvancedOutput::StartRecording()
 	const char *filenameFormat;
 	bool noSpace = false;
 	bool overwriteIfExists = false;
+	bool useLocalCounter = false;
 
 	if (!useStreamEncoder) {
 		if (!ffmpegOutput) {
@@ -1562,6 +1590,8 @@ bool AdvancedOutput::StartRecording()
 				"FilenameFormatting");
 		overwriteIfExists = config_get_bool(main->Config(), "Output",
 				"OverwriteIfExists");
+		useLocalCounter = config_get_bool(main->Config(), "Output",
+				"UseLocalCounter");
 		noSpace = config_get_bool(main->Config(), "AdvOut",
 				ffmpegRecording ?
 				"FFFileNameWithoutSpace" :
@@ -1582,6 +1612,21 @@ bool AdvancedOutput::StartRecording()
 
 		os_closedir(dir);
 
+		int32_t numRecOut; //counter for numbered filenaming
+
+		numRecGlob = config_get_int(main->Config(), "Output",
+				"NumRecGlobal");
+		config_set_int(main->Config(), "Output",
+				"NumRecGlobal", ++numRecGlob);
+
+		++numRec;
+
+		//count recordings only per session
+		if (useLocalCounter)
+			numRecOut = numRec;
+		else
+			numRecOut = (int32_t)numRecGlob;
+
 		string strPath;
 		strPath += path;
 
@@ -1589,8 +1634,9 @@ bool AdvancedOutput::StartRecording()
 		if (lastChar != '/' && lastChar != '\\')
 			strPath += "/";
 
-		strPath += GenerateSpecifiedFilename(recFormat, noSpace,
-							filenameFormat);
+		string sf = GenerateSpecifiedFilename(recFormat, noSpace,
+				filenameFormat);
+		strPath += GenerateNumberedString(1, numRecOut, sf.c_str());
 		ensure_directory_exists(strPath);
 		if (!overwriteIfExists)
 			FindBestFilename(strPath, noSpace);
@@ -1628,6 +1674,7 @@ bool AdvancedOutput::StartReplayBuffer()
 	const char *filenameFormat;
 	bool noSpace = false;
 	bool overwriteIfExists = false;
+	bool useLocalCounter = false;
 	const char *rbPrefix;
 	const char *rbSuffix;
 	int rbTime;
@@ -1654,6 +1701,8 @@ bool AdvancedOutput::StartReplayBuffer()
 				"FilenameFormatting");
 		overwriteIfExists = config_get_bool(main->Config(), "Output",
 				"OverwriteIfExists");
+		useLocalCounter = config_get_bool(main->Config(), "Output",
+				"UseLocalCounter");
 		noSpace = config_get_bool(main->Config(), "AdvOut",
 				ffmpegRecording ?
 				"FFFileNameWithoutSpace" :
@@ -1682,6 +1731,17 @@ bool AdvancedOutput::StartReplayBuffer()
 
 		os_closedir(dir);
 
+		int32_t numRecOut; //counter for numbered filenaming
+
+		numRecGlob = config_get_int(main->Config(), "Output",
+				"NumRecGlobal");
+
+		//count recordings only per session
+		if (useLocalCounter)
+			numRecOut = numRec;
+		else
+			numRecOut = (int32_t)numRecGlob;
+
 		string strPath;
 		strPath += path;
 
@@ -1689,8 +1749,9 @@ bool AdvancedOutput::StartReplayBuffer()
 		if (lastChar != '/' && lastChar != '\\')
 			strPath += "/";
 
-		strPath += GenerateSpecifiedFilename(recFormat, noSpace,
+		string sf = GenerateSpecifiedFilename(recFormat, noSpace,
 				filenameFormat);
+		strPath += GenerateNumberedString(0, numRecOut, sf.c_str());
 		ensure_directory_exists(strPath);
 		if (!overwriteIfExists)
 			FindBestFilename(strPath, noSpace);
@@ -1717,6 +1778,7 @@ bool AdvancedOutput::StartReplayBuffer()
 		obs_data_set_string(settings, "directory", path);
 		obs_data_set_string(settings, "format", f.c_str());
 		obs_data_set_string(settings, "extension", recFormat);
+		obs_data_set_int(settings, "recNumber", numRecOut);
 		obs_data_set_int(settings, "max_time_sec", rbTime);
 		obs_data_set_int(settings, "max_size_mb",
 				usesBitrate ? 0 : rbSize);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -429,6 +429,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 #endif
 	HookWidget(ui->filenameFormatting,   EDIT_CHANGED,   ADV_CHANGED);
 	HookWidget(ui->overwriteIfExists,    CHECK_CHANGED,  ADV_CHANGED);
+	HookWidget(ui->useLocalCounter,      CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->simpleRBPrefix,       EDIT_CHANGED,   ADV_CHANGED);
 	HookWidget(ui->simpleRBSuffix,       EDIT_CHANGED,   ADV_CHANGED);
 	HookWidget(ui->streamDelayEnable,    CHECK_CHANGED,  ADV_CHANGED);
@@ -1550,6 +1551,7 @@ void OBSBasicSettings::LoadAdvOutputStreamingSettings()
 	specCompleter->setFilterMode(Qt::MatchContains);
 	ui->filenameFormatting->setCompleter(specCompleter);
 	ui->filenameFormatting->setToolTip(QTStr("FilenameFormatting.TT"));
+	ui->useLocalCounter->setToolTip(QTStr("LocalCounter.TT"));
 
 	switch (trackIndex) {
 	case 1: ui->advOutTrack1->setChecked(true); break;
@@ -2192,6 +2194,8 @@ void OBSBasicSettings::LoadAdvancedSettings()
 			"FilenameFormatting");
 	bool overwriteIfExists = config_get_bool(main->Config(), "Output",
 			"OverwriteIfExists");
+	bool useLocalCounter = config_get_bool(main->Config(), "Output",
+			"UseLocalCounter");
 	const char *bindIP = config_get_string(main->Config(), "Output",
 			"BindIP");
 	const char *rbPrefix = config_get_string(main->Config(), "SimpleOutput",
@@ -2216,6 +2220,7 @@ void OBSBasicSettings::LoadAdvancedSettings()
 
 	ui->filenameFormatting->setText(filename);
 	ui->overwriteIfExists->setChecked(overwriteIfExists);
+	ui->useLocalCounter->setChecked(useLocalCounter);
 	ui->simpleRBPrefix->setText(rbPrefix);
 	ui->simpleRBSuffix->setText(rbSuffix);
 
@@ -2815,6 +2820,7 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	SaveEdit(ui->simpleRBPrefix, "SimpleOutput", "RecRBPrefix");
 	SaveEdit(ui->simpleRBSuffix, "SimpleOutput", "RecRBSuffix");
 	SaveCheckBox(ui->overwriteIfExists, "Output", "OverwriteIfExists");
+	SaveCheckBox(ui->useLocalCounter, "Output", "UseLocalCounter");
 	SaveCheckBox(ui->streamDelayEnable, "Output", "DelayEnable");
 	SaveSpinBox(ui->streamDelaySec, "Output", "DelaySec");
 	SaveCheckBox(ui->streamDelayPreserve, "Output", "DelayPreserve");

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -169,6 +169,17 @@ EXPORT int os_safe_replace(const char *target_path, const char *from_path,
 EXPORT char *os_generate_formatted_filename(const char *extension, bool space,
 		const char *format);
 
+/*
+	recType bitfield definitions:
+	-----------------------------
+	0 - unknown type;
+	1 - local recording;
+	2 - replay save;
+	4... - reserved, same as 0;
+*/
+EXPORT char *os_numbered_string(const int32_t recType, int32_t number,
+		const char *format);
+
 struct os_inhibit_info;
 typedef struct os_inhibit_info os_inhibit_t;
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -759,9 +759,12 @@ static void replay_buffer_save(struct ffmpeg_muxer *stream)
 	const char *dir = obs_data_get_string(settings, "directory");
 	const char *fmt = obs_data_get_string(settings, "format");
 	const char *ext = obs_data_get_string(settings, "extension");
+	int64_t recNumber = obs_data_get_int(settings, "recNumber");
 	bool space = obs_data_get_bool(settings, "allow_spaces");
 
-	char *filename = os_generate_formatted_filename(ext, space, fmt);
+	char *filename2 = os_generate_formatted_filename(ext, space, fmt);
+	char *filename = os_numbered_string(2, (int32_t)recNumber,
+			filename2);
 
 	dstr_copy(&stream->path, dir);
 	dstr_replace(&stream->path, "\\", "/");
@@ -769,6 +772,7 @@ static void replay_buffer_save(struct ffmpeg_muxer *stream)
 		dstr_cat_ch(&stream->path, '/');
 	dstr_cat(&stream->path, filename);
 
+	bfree(filename2);
 	bfree(filename);
 	obs_data_release(settings);
 


### PR DESCRIPTION
Also, it modifies libobs, obs-ffmpeg.

- Add ability to make numbered files names for recordings.
- Add new Filename Formatting keys:

set of user's strings separated with comma
`%%set[str1,str2,...,strN]`

decimal
`%%d`

decimal zero-padded (n = 0-9, number of zeros)
`%%0nd`

The numbering based on global/local counter of the recordings.