### PR TITLE
Supporting fixes for obs-browser web config UI

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -92,10 +92,10 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	void obs_frontend_set_current_scene(obs_source_t *scene) override
 	{
 		if (main->IsPreviewProgramMode()) {
-			QMetaObject::invokeMethod(main, "TransitionToScene",
+			QMetaObject::invokeMethod(main, "TransitionToScene", Qt::BlockingQueuedConnection,
 					Q_ARG(OBSSource, OBSSource(scene)));
 		} else {
-			QMetaObject::invokeMethod(main, "SetCurrentScene",
+			QMetaObject::invokeMethod(main, "SetCurrentScene", Qt::BlockingQueuedConnection,
 					Q_ARG(OBSSource, OBSSource(scene)),
 					Q_ARG(bool, false));
 		}

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -181,6 +181,11 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		}
 	}
 
+	bool obs_frontend_add_scene_collection(const char *name)
+	{
+		return main->AddSceneCollection(name);
+	}
+
 	void obs_frontend_get_profiles(
 			std::vector<std::string> &strings) override
 	{

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -92,12 +92,26 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	void obs_frontend_set_current_scene(obs_source_t *scene) override
 	{
 		if (main->IsPreviewProgramMode()) {
-			QMetaObject::invokeMethod(main, "TransitionToScene", Qt::BlockingQueuedConnection,
+			if (main->isQtGuiThread())
+			{
+				main->TransitionToScene(scene);
+			}
+			else
+			{
+				QMetaObject::invokeMethod(main, "TransitionToScene", Qt::BlockingQueuedConnection,
 					Q_ARG(OBSSource, OBSSource(scene)));
+			}
 		} else {
-			QMetaObject::invokeMethod(main, "SetCurrentScene", Qt::BlockingQueuedConnection,
+			if (main->isQtGuiThread())
+			{
+				main->SetCurrentScene(scene, false);
+			}
+			else
+			{
+				QMetaObject::invokeMethod(main, "SetCurrentScene", Qt::BlockingQueuedConnection,
 					Q_ARG(OBSSource, OBSSource(scene)),
 					Q_ARG(bool, false));
+			}
 		}
 	}
 

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -221,12 +221,12 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 
 	void obs_frontend_streaming_start(void) override
 	{
-		QMetaObject::invokeMethod(main, "StartStreaming");
+		QMetaObject::invokeMethod(main, "StartStreaming", Qt::QueuedConnection);
 	}
 
 	void obs_frontend_streaming_stop(void) override
 	{
-		QMetaObject::invokeMethod(main, "StopStreaming");
+		QMetaObject::invokeMethod(main, "StopStreaming", Qt::QueuedConnection);
 	}
 
 	bool obs_frontend_streaming_active(void) override

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -343,6 +343,16 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		main->SaveProject();
 	}
 
+	void obs_frontend_save_suspend(void) override
+	{
+		QMetaObject::invokeMethod(main, "SuspendSaving");
+	}
+
+	void obs_frontend_save_resume(void) override
+	{
+		QMetaObject::invokeMethod(main, "ResumeSaving");
+	}
+
 	void obs_frontend_add_save_callback(obs_frontend_save_cb callback,
 			void *private_data) override
 	{

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1839,8 +1839,33 @@ static void upgrade_settings(void)
 	os_closedir(dir);
 }
 
+// 
+// This is necessary for OBS to behave correctly on dual-monitor set-ups
+// with display DPIs over 96 (for example: 120)
+// More info here: https://bugreports.qt.io/browse/QTBUG-38993
+//
+#if defined(Q_OS_WIN32)
+#include "ShellScalingApi.h"
+#include <QLibrary>
+#endif
+
 int main(int argc, char *argv[])
 {
+// 
+// This is necessary for OBS to behave correctly on dual-monitor set-ups
+// with display DPIs over 96 (for example: 120)
+// More info here: https://bugreports.qt.io/browse/QTBUG-38993
+//
+#if defined(Q_OS_WIN32)
+	typedef BOOL(*SetProcessDpiAwarenessT)(PROCESS_DPI_AWARENESS value);
+	QLibrary user32("user32.dll", NULL);
+	SetProcessDpiAwarenessT SetProcessDpiAwarenessD = (SetProcessDpiAwarenessT)user32.resolve("SetProcessDpiAwarenessInternal");
+	if (SetProcessDpiAwarenessD)
+		SetProcessDpiAwarenessD(PROCESS_DPI_UNAWARE); //Process_DPI_Unaware
+#endif
+	//qputenv("QT_DEVICE_PIXEL_RATIO", QByteArray("1"));
+	//qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", QByteArray("0"));
+
 #ifndef _WIN32
 	signal(SIGPIPE, SIG_IGN);
 #endif

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1839,33 +1839,8 @@ static void upgrade_settings(void)
 	os_closedir(dir);
 }
 
-// 
-// This is necessary for OBS to behave correctly on dual-monitor set-ups
-// with display DPIs over 96 (for example: 120)
-// More info here: https://bugreports.qt.io/browse/QTBUG-38993
-//
-#if defined(Q_OS_WIN32)
-#include "ShellScalingApi.h"
-#include <QLibrary>
-#endif
-
 int main(int argc, char *argv[])
 {
-// 
-// This is necessary for OBS to behave correctly on dual-monitor set-ups
-// with display DPIs over 96 (for example: 120)
-// More info here: https://bugreports.qt.io/browse/QTBUG-38993
-//
-#if defined(Q_OS_WIN32)
-	typedef BOOL(*SetProcessDpiAwarenessT)(PROCESS_DPI_AWARENESS value);
-	QLibrary user32("user32.dll", NULL);
-	SetProcessDpiAwarenessT SetProcessDpiAwarenessD = (SetProcessDpiAwarenessT)user32.resolve("SetProcessDpiAwarenessInternal");
-	if (SetProcessDpiAwarenessD)
-		SetProcessDpiAwarenessD(PROCESS_DPI_UNAWARE); //Process_DPI_Unaware
-#endif
-	//qputenv("QT_DEVICE_PIXEL_RATIO", QByteArray("1"));
-	//qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", QByteArray("0"));
-
 #ifndef _WIN32
 	signal(SIGPIPE, SIG_IGN);
 #endif

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -148,6 +148,14 @@ void obs_frontend_set_current_scene_collection(const char *collection)
 		c->obs_frontend_set_current_scene_collection(collection);
 }
 
+bool obs_frontend_add_scene_collection(const char *name)
+{
+	if (!callbacks_valid())
+		return false;
+
+	return c->obs_frontend_add_scene_collection(name);
+}
+
 char **obs_frontend_get_profiles(void)
 {
 	if (!callbacks_valid())

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -291,6 +291,18 @@ config_t *obs_frontend_get_global_config(void)
 		: nullptr;
 }
 
+void obs_frontend_save_suspend(void)
+{
+	if (callbacks_valid())
+		c->obs_frontend_save_suspend();
+}
+
+void obs_frontend_save_resume(void)
+{
+	if (callbacks_valid())
+		c->obs_frontend_save_resume();
+}
+
 void obs_frontend_save(void)
 {
 	if (callbacks_valid())

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -95,6 +95,7 @@ EXPORT void obs_frontend_set_current_transition(obs_source_t *transition);
 EXPORT char **obs_frontend_get_scene_collections(void);
 EXPORT char *obs_frontend_get_current_scene_collection(void);
 EXPORT void obs_frontend_set_current_scene_collection(const char *collection);
+EXPORT bool obs_frontend_add_scene_collection(const char *name);
 
 EXPORT char **obs_frontend_get_profiles(void);
 EXPORT char *obs_frontend_get_current_profile(void);

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -150,6 +150,8 @@ EXPORT void obs_frontend_replay_buffer_stop(void);
 EXPORT bool obs_frontend_replay_buffer_active(void);
 
 EXPORT void obs_frontend_save(void);
+EXPORT void obs_frontend_save_suspend(void);
+EXPORT void obs_frontend_save_resume(void);
 
 EXPORT obs_output_t *obs_frontend_get_streaming_output(void);
 EXPORT obs_output_t *obs_frontend_get_recording_output(void);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -26,6 +26,7 @@ struct obs_frontend_callbacks {
 	virtual char *obs_frontend_get_current_scene_collection(void)=0;
 	virtual void obs_frontend_set_current_scene_collection(
 			const char *collection)=0;
+	virtual bool obs_frontend_add_scene_collection(const char *name)=0;
 
 	virtual void obs_frontend_get_profiles(
 			std::vector<std::string> &strings)=0;

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -61,7 +61,9 @@ struct obs_frontend_callbacks {
 	virtual config_t *obs_frontend_get_profile_config(void)=0;
 	virtual config_t *obs_frontend_get_global_config(void)=0;
 
-	virtual void obs_frontend_save(void)=0;
+	virtual void obs_frontend_save(void) = 0;
+	virtual void obs_frontend_save_suspend(void) = 0;
+	virtual void obs_frontend_save_resume(void) = 0;
 	virtual void obs_frontend_add_save_callback(
 			obs_frontend_save_cb callback, void *private_data)=0;
 	virtual void obs_frontend_remove_save_callback(

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -28,28 +28,6 @@
 
 using namespace std;
 
-bool ResolveSceneCollectionFilePath(const char* name, std::string& filePath)
-{
-	char queryPath[512];
-	snprintf(queryPath, sizeof(queryPath),
-		"obs-studio/basic/scenes/%s.json", name);
-
-	char path[512];
-	int ret = GetConfigPath(path, sizeof(path), queryPath);
-
-	if (ret <= 0) {
-		blog(LOG_WARNING, "Failed to get config path for scene collection");
-
-		return false;
-	}
-	else
-	{
-		filePath = path;
-
-		return true;
-	}
-}
-
 void EnumSceneCollections(std::function<bool (const char *, const char *)> &&cb)
 {
 	char path[512];

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -601,7 +601,6 @@ void OBSBasic::CreateDefaultScene(bool firstStart)
 	if (firstStart)
 		CreateFirstRunSources();
 
-	// AddScene(obs_scene_get_source(scene));
 	SetCurrentScene(scene, true);
 	obs_scene_release(scene);
 
@@ -2719,7 +2718,6 @@ void OBSBasic::DuplicateSelectedScene()
 		obs_scene_t *scene = obs_scene_duplicate(curScene,
 				name.c_str(), OBS_SCENE_DUP_REFS);
 		source = obs_scene_get_source(scene);
-		//AddScene(source);
 		SetCurrentScene(source, true);
 		obs_scene_release(scene);
 
@@ -3707,7 +3705,6 @@ void OBSBasic::on_actionAddScene_triggered()
 
 		obs_scene_t *scene = obs_scene_create(name.c_str());
 		source = obs_scene_get_source(scene);
-		// AddScene(source);
 		SetCurrentScene(source);
 		obs_scene_release(scene);
 	}

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1512,6 +1512,11 @@ void OBSBasic::OBSInit()
 	SET_VISIBILITY("ShowStatusBar", toggleStatusBar);
 #undef SET_VISIBILITY
 
+	// InitOBSCallbacks() MUST be positioned before Load(savePath) since audio devices appear in the
+	// mixer as a result of "source_activate" callback.
+	InitOBSCallbacks();
+	InitHotkeys();
+
 	{
 		ProfileScope("OBSBasic::Load");
 		disableSaving--;
@@ -1631,9 +1636,6 @@ void OBSBasic::OBSInit()
 
 	if (config_get_bool(basicConfig, "General", "OpenStatsOnStartup"))
 		on_stats_triggered();
-
-	InitOBSCallbacks();
-	InitHotkeys();
 
 	OBSBasicStats::InitializeValues();
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -994,6 +994,9 @@ void OBSBasic::SaveService()
 
 	obs_data_release(settings);
 	obs_data_release(data);
+
+	ResetVideo();
+	ResetOutputs();
 }
 
 bool OBSBasic::LoadService()
@@ -3069,7 +3072,12 @@ obs_service_t *OBSBasic::GetService()
 void OBSBasic::SetService(obs_service_t *newService)
 {
 	if (newService)
+	{
 		service = newService;
+
+		ResetVideo();
+		ResetOutputs();
+	}
 }
 
 bool OBSBasic::StreamingActive() const

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -258,8 +258,13 @@ private:
 	void GetAudioSourceProperties();
 	void VolControlContextMenu();
 
+	bool AddSceneCollection(const char* name);
 	void AddSceneCollection(bool create_new);
+
+private slots:
 	void RefreshSceneCollections();
+
+private:
 	void ChangeSceneCollection();
 	void LogScenes();
 
@@ -571,7 +576,10 @@ public:
 	QMenu *AddScaleFilteringMenu(obs_sceneitem_t *item);
 	void CreateSourcePopupMenu(QListWidgetItem *item, bool preview);
 
+public slots:
 	void UpdateTitleBar();
+
+public:
 	void UpdateSceneSelection(OBSSource source);
 
 	void SystemTrayInit();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -128,7 +128,7 @@ private:
 	long m_isLoading = 0;
 
 	bool loaded = false;
-	__declspec(align(64)) long disableSaving = 1; // Must be aligned for os_atomic_inc_long() and os_atomic_dec_long() to behave predictably
+	long disableSaving alignas(64) = 1; // Must be aligned for os_atomic_inc_long() and os_atomic_dec_long() to behave predictably
 	bool projectChanged = false;
 	bool previewEnabled = true;
 	bool fullscreenInterface = false;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -128,7 +128,7 @@ private:
 	long m_isLoading = 0;
 
 	bool loaded = false;
-	long disableSaving alignas(64) = 1; // Must be aligned for os_atomic_inc_long() and os_atomic_dec_long() to behave predictably
+	long disableSaving = 1;
 	bool projectChanged = false;
 	bool previewEnabled = true;
 	bool fullscreenInterface = false;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -475,6 +475,7 @@ private:
 	static void SceneItemDeselected(void *data, calldata_t *params);
 	static void SourceLoaded(void *data, obs_source_t *source);
 	static void SourceRemoved(void *data, calldata_t *params);
+	static void SourceCreated(void *data, calldata_t *params);
 	static void SourceActivated(void *data, calldata_t *params);
 	static void SourceDeactivated(void *data, calldata_t *params);
 	static void SourceRenamed(void *data, calldata_t *params);
@@ -726,6 +727,17 @@ public:
 
 	virtual int GetProfilePath(char *path, size_t size, const char *file)
 		const override;
+
+private:
+	// Detect whether we're running in QT GUI thread context
+	//
+	// This is used to determine whether to call QMetaObject::invokeMethod with
+	// Qt::AutoConnection or Qt::BlockingQueuedConnection
+	//
+	// If QMetaObject::invokeMethod is called with Qt::BlockingQueuedConnection on
+	// QT GUI thread, a dead lock will occur.
+	//
+	static bool isQtGuiThread();
 
 private:
 	std::unique_ptr<Ui::OBSBasic> ui;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -730,7 +730,7 @@ public:
 	virtual int GetProfilePath(char *path, size_t size, const char *file)
 		const override;
 
-private:
+public:
 	// Detect whether we're running in QT GUI thread context
 	//
 	// This is used to determine whether to call QMetaObject::invokeMethod with

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -125,6 +125,8 @@ private:
 	std::vector<int> multiviewProjectorArray;
 	std::vector<int> previewProjectorArray;
 
+	long m_isLoading = 0;
+
 	bool loaded = false;
 	long disableSaving = 1;
 	bool projectChanged = false;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -128,7 +128,7 @@ private:
 	long m_isLoading = 0;
 
 	bool loaded = false;
-	long disableSaving = 1;
+	__declspec(align(64)) long disableSaving = 1; // Must be aligned for os_atomic_inc_long() and os_atomic_dec_long() to behave predictably
 	bool projectChanged = false;
 	bool previewEnabled = true;
 	bool fullscreenInterface = false;
@@ -377,6 +377,18 @@ private:
 		obs_data_array_t *savedMultiviewProjectors);
 
 public slots:
+	void SuspendSaving() {
+		os_atomic_inc_long(&disableSaving);
+	}
+
+	void ResumeSaving() {
+		long result = os_atomic_dec_long(&disableSaving);
+
+		if (result == 0) {
+			SaveProject();
+		}
+	}
+
 	void StartStreaming();
 	void StopStreaming();
 	void ForceStopStreaming();

--- a/deps/jansson/CMakeLists.txt
+++ b/deps/jansson/CMakeLists.txt
@@ -104,10 +104,10 @@ include (CheckTypeSize)
 
 if (MSVC)
    # Turn off Microsofts "security" warnings.
-   add_definitions( "/W3 /D_CRT_SECURE_NO_WARNINGS /wd4005 /wd4996 /nologo" )
+   add_definitions( "/W3 /D_CRT_SECURE_NO_WARNINGS /wd4005 /wd4996 /nologo /MT" )
 
    # Disabled by OBS, options already set by top level CMakeLists
-   if (FALSE)
+   if (TRUE)
       if (JANSSON_STATIC_CRT)
          set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
          set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -348,11 +348,14 @@ static obs_source_t *obs_source_create_internal(const char *id,
 	blog(LOG_DEBUG, "%ssource '%s' (%s) created",
 			private ? "private " : "", name, id);
 
-	if (!private)
-		obs_source_dosignal(source, "source_create", NULL);
-
 	source->flags = source->default_flags;
 	source->enabled = true;
+
+	if (!private)
+	{
+		obs_source_dosignal(source, "source_create", NULL);
+	}
+
 	return source;
 
 fail:

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -347,7 +347,9 @@ static obs_source_t *obs_source_create_internal(const char *id,
 
 	blog(LOG_DEBUG, "%ssource '%s' (%s) created",
 			private ? "private " : "", name, id);
-	obs_source_dosignal(source, "source_create", NULL);
+
+	if (!private)
+		obs_source_dosignal(source, "source_create", NULL);
 
 	source->flags = source->default_flags;
 	source->enabled = true;


### PR DESCRIPTION
- do not fire source_created signal for private sources
- resolve sync issue in obs_frontend_set_current_scene()
- ui: update list of sources on source_created signal, remove redundant calls to AddScene()
- win-dshow: wait for Action::Activate to complete, this resolves a race condition
- jansson: build with /MT flag for Win32
- ui: detect if running on UI thread and use direct calls in those cases. this resolves some nasty race conditions.