### PR TITLE
UI: Add scenes in response to 'source_create' signal

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -121,6 +121,8 @@ private:
 
 	std::vector<OBSSignal> signalHandlers;
 
+	long m_isLoading = 0;
+
 	bool loaded = false;
 	long disableSaving = 1;
 	bool projectChanged = false;
@@ -469,6 +471,7 @@ private:
 	static void SceneItemDeselected(void *data, calldata_t *params);
 	static void SourceLoaded(void *data, obs_source_t *source);
 	static void SourceRemoved(void *data, calldata_t *params);
+	static void SourceCreated(void *data, calldata_t *params);
 	static void SourceActivated(void *data, calldata_t *params);
 	static void SourceDeactivated(void *data, calldata_t *params);
 	static void SourceRenamed(void *data, calldata_t *params);

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -347,10 +347,14 @@ static obs_source_t *obs_source_create_internal(const char *id,
 
 	blog(LOG_DEBUG, "%ssource '%s' (%s) created",
 			private ? "private " : "", name, id);
-	obs_source_dosignal(source, "source_create", NULL);
 
 	source->flags = source->default_flags;
 	source->enabled = true;
+
+	if (!private) {
+		obs_source_dosignal(source, "source_create", NULL);
+	}
+
 	return source;
 
 fail:


### PR DESCRIPTION
UI: update scene list on "source_create" signal
- update UI when "source_create" signal is fired
- remove redundant AddScene() calls
- libobs: don't fire "source_create" signal for private sources
- libobs: move "source_created" signal invocation after completing
  source setup disable "source_created" signal invocation for private sources

Split from and instead of
https://github.com/obsproject/obs-studio/pull/1221
