### PR TITLE
UI: Part 3: bugfix: libobs: obs_frontend_set_current_scene() block until complete

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -92,10 +92,10 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	void obs_frontend_set_current_scene(obs_source_t *scene) override
 	{
 		if (main->IsPreviewProgramMode()) {
-			QMetaObject::invokeMethod(main, "TransitionToScene",
+			QMetaObject::invokeMethod(main, "TransitionToScene", Qt::BlockingQueuedConnection,
 					Q_ARG(OBSSource, OBSSource(scene)));
 		} else {
-			QMetaObject::invokeMethod(main, "SetCurrentScene",
+			QMetaObject::invokeMethod(main, "SetCurrentScene", Qt::BlockingQueuedConnection,
 					Q_ARG(OBSSource, OBSSource(scene)),
 					Q_ARG(bool, false));
 		}


### PR DESCRIPTION
invoke "TransitionToScene" and "SetCurrentScene" with Qt::BlockingQueuedConnection

This allows the caller to be sure that scene transition is complete
before the call returns. It is necessary for obs_frontend_get_current_scene()
call results to be consistent with previously executed
obs_frontend_set_current_scene() calls.