### PR TITLE
UI: async stop and start streaming API (Qt::QueuedConnection)

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -207,12 +207,14 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 
 	void obs_frontend_streaming_start(void) override
 	{
-		QMetaObject::invokeMethod(main, "StartStreaming");
+		QMetaObject::invokeMethod(main, "StartStreaming",
+			Qt::QueuedConnection);
 	}
 
 	void obs_frontend_streaming_stop(void) override
 	{
-		QMetaObject::invokeMethod(main, "StopStreaming");
+		QMetaObject::invokeMethod(main, "StopStreaming",
+			Qt::QueuedConnection);
 	}
 
 	bool obs_frontend_streaming_active(void) override


### PR DESCRIPTION
Default for QMetaObject::invokeMethod is Qt::AutoConnection
which uses direct calls when in QT UI thread.
This leads to a deadlock. Async calls resolve that.

Split from and instead of
https://github.com/obsproject/obs-studio/pull/1221
