### PR TITLE
UI: API: add obs_frontend_add_scene_collection(name)

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -167,6 +167,11 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		}
 	}
 
+	bool obs_frontend_add_scene_collection(const char *name)
+	{
+		return main->AddSceneCollection(name);
+	}
+
 	void obs_frontend_get_profiles(
 			std::vector<std::string> &strings) override
 	{

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -148,6 +148,14 @@ void obs_frontend_set_current_scene_collection(const char *collection)
 		c->obs_frontend_set_current_scene_collection(collection);
 }
 
+bool obs_frontend_add_scene_collection(const char *name)
+{
+	if (!callbacks_valid())
+		return false;
+
+	return c->obs_frontend_add_scene_collection(name);
+}
+
 char **obs_frontend_get_profiles(void)
 {
 	if (!callbacks_valid())

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -95,6 +95,7 @@ EXPORT void obs_frontend_set_current_transition(obs_source_t *transition);
 EXPORT char **obs_frontend_get_scene_collections(void);
 EXPORT char *obs_frontend_get_current_scene_collection(void);
 EXPORT void obs_frontend_set_current_scene_collection(const char *collection);
+EXPORT bool obs_frontend_add_scene_collection(const char *name);
 
 EXPORT char **obs_frontend_get_profiles(void);
 EXPORT char *obs_frontend_get_current_profile(void);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -26,6 +26,7 @@ struct obs_frontend_callbacks {
 	virtual char *obs_frontend_get_current_scene_collection(void)=0;
 	virtual void obs_frontend_set_current_scene_collection(
 			const char *collection)=0;
+	virtual bool obs_frontend_add_scene_collection(const char *name)=0;
 
 	virtual void obs_frontend_get_profiles(
 			std::vector<std::string> &strings)=0;

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -21,6 +21,7 @@
 #include <QVariant>
 #include <QFileDialog>
 #include <QStandardPaths>
+#include <QThread>
 #include "item-widget-helpers.hpp"
 #include "window-basic-main.hpp"
 #include "window-namedialog.hpp"
@@ -152,6 +153,54 @@ static bool GetSceneCollectionName(QWidget *parent, std::string &name,
 	file.erase(file.size() - 5, 5);
 	file.erase(0, file.size() - len);
 	return true;
+}
+
+bool OBSBasic::AddSceneCollection(const char* name)
+{
+	const bool isQtGuiThread =
+		QThread::currentThread() ==
+		QCoreApplication::instance()->thread();
+
+	// Check if scene collection exists
+	if (SceneCollectionExists(name))
+		return false;
+
+	// Save current scene collection
+	SaveProjectNow();
+
+	// Change current scene collection name and file path
+	config_set_string(App()->GlobalConfig(), "Basic", "SceneCollection",
+		name);
+	config_set_string(App()->GlobalConfig(), "Basic", "SceneCollectionFile",
+		name);
+
+	// Save new scene collection
+	SaveProjectNow();
+
+	// Refresh menu & title bar
+	if (isQtGuiThread) {
+		RefreshSceneCollections();
+
+		UpdateTitleBar();
+	} else {
+		QMetaObject::invokeMethod(this,
+			"RefreshSceneCollections",
+			Qt::BlockingQueuedConnection);
+
+		QMetaObject::invokeMethod(this,
+			"UpdateTitleBar",
+			Qt::BlockingQueuedConnection);
+	}
+
+	blog(LOG_INFO, "Added scene collection '%s' (clean, %s.json)",
+		name,
+		name);
+	blog(LOG_INFO, "------------------------------------------------");
+
+	if (api) {
+		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_LIST_CHANGED);
+		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED);
+	}
 }
 
 void OBSBasic::AddSceneCollection(bool create_new)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -258,8 +258,13 @@ private:
 	void GetAudioSourceProperties();
 	void VolControlContextMenu();
 
+	bool AddSceneCollection(const char* name);
 	void AddSceneCollection(bool create_new);
+
+private slots:
 	void RefreshSceneCollections();
+
+private:
 	void ChangeSceneCollection();
 	void LogScenes();
 
@@ -550,7 +555,10 @@ public:
 	QMenu *AddScaleFilteringMenu(obs_sceneitem_t *item);
 	void CreateSourcePopupMenu(QListWidgetItem *item, bool preview);
 
+public slots:
 	void UpdateTitleBar();
+
+public:
 	void UpdateSceneSelection(OBSSource source);
 
 	void SystemTrayInit();


### PR DESCRIPTION
Frontend API call to duplicate current scene collection
into a new one.

Depends on https://github.com/obsproject/obs-studio/pull/1226 for isQtGuiThread()

Split from and instead of
https://github.com/obsproject/obs-studio/pull/1221
