### PR TITLE
win-capture: Change text for memory capture

### DIFF
--- a/plugins/win-capture/monitor-capture.c
+++ b/plugins/win-capture/monitor-capture.c
@@ -3,7 +3,7 @@
 
 #define TEXT_MONITOR_CAPTURE obs_module_text("MonitorCapture")
 #define TEXT_CAPTURE_CURSOR  obs_module_text("CaptureCursor")
-#define TEXT_COMPATIBILITY   obs_module_text("Compatibility")
+#define TEXT_COMPATIBILITY   obs_module_text("SLIFix")
 #define TEXT_MONITOR         obs_module_text("Monitor")
 #define TEXT_PRIMARY_MONITOR obs_module_text("PrimaryMonitor")
 


### PR DESCRIPTION
To reflect https://github.com/obsproject/obs-studio/commit/10b27723a3ded5d750c483d1da58fc775993b7d3 changes.
It modifies only name of the option for 'Display Capture' source.