### PR TITLE
win-capture: Change text for memory capture

### DIFF
--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -10,7 +10,7 @@
 #define TEXT_MATCH_CLASS    obs_module_text("WindowCapture.Priority.Class")
 #define TEXT_MATCH_EXE      obs_module_text("WindowCapture.Priority.Exe")
 #define TEXT_CAPTURE_CURSOR obs_module_text("CaptureCursor")
-#define TEXT_COMPATIBILITY  obs_module_text("Compatibility")
+#define TEXT_COMPATIBILITY  obs_module_text("SLIFix")
 
 struct window_capture {
 	obs_source_t         *source;


### PR DESCRIPTION
To reflect https://github.com/obsproject/obs-studio/commit/10b27723a3ded5d750c483d1da58fc775993b7d3 changes.
It modifies only name of the option for the 'Window Capture' source.