### PR TITLE
UI: sort audio controls by source name

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -155,20 +155,7 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *layout, obs_source_t *source_)
 	QWidget::connect(mixer6, SIGNAL(clicked(bool)),
 			this, SLOT(mixer6Changed(bool)));
 
-	int lastRow = layout->rowCount();
-
-	idx = 0;
-	layout->addWidget(nameLabel, lastRow, idx++);
-	layout->addWidget(volume, lastRow, idx++);
-	layout->addWidget(forceMonoContainer, lastRow, idx++);
-	layout->addWidget(panningContainer, lastRow, idx++);
-	layout->addWidget(syncOffset, lastRow, idx++);
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	layout->addWidget(monitoringType, lastRow, idx++);
-#endif
-	layout->addWidget(mixerContainer, lastRow, idx++);
-	layout->layout()->setAlignment(mixerContainer,
-			Qt::AlignHCenter | Qt::AlignVCenter);
+	setObjectName(sourceName);
 }
 
 OBSAdvAudioCtrl::~OBSAdvAudioCtrl()
@@ -182,6 +169,24 @@ OBSAdvAudioCtrl::~OBSAdvAudioCtrl()
 	monitoringType->deleteLater();
 #endif
 	mixerContainer->deleteLater();
+}
+
+void OBSAdvAudioCtrl::ShowAudioControl(QGridLayout *layout)
+{
+	int lastRow = layout->rowCount();
+	int idx = 0;
+
+	layout->addWidget(nameLabel, lastRow, idx++);
+	layout->addWidget(volume, lastRow, idx++);
+	layout->addWidget(forceMonoContainer, lastRow, idx++);
+	layout->addWidget(panningContainer, lastRow, idx++);
+	layout->addWidget(syncOffset, lastRow, idx++);
+#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
+	layout->addWidget(monitoringType, lastRow, idx++);
+#endif
+	layout->addWidget(mixerContainer, lastRow, idx++);
+	layout->layout()->setAlignment(mixerContainer,
+		Qt::AlignHCenter | Qt::AlignVCenter);
 }
 
 /* ------------------------------------------------------------------------- */

--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -51,6 +51,7 @@ public:
 	virtual ~OBSAdvAudioCtrl();
 
 	inline obs_source_t *GetSource() const {return source;}
+	void ShowAudioControl(QGridLayout *layout);
 
 public slots:
 	void SourceFlagsChanged(uint32_t flags);

--- a/UI/item-widget-helpers.hpp
+++ b/UI/item-widget-helpers.hpp
@@ -28,3 +28,15 @@ class QListWidgetItem;
 QListWidgetItem *TakeListItem(QListWidget *widget, int row);
 void DeleteListItem(QListWidget *widget, QListWidgetItem *item);
 void ClearListItems(QListWidget *widget);
+
+template<typename QObjectPtr>
+void InsertQObjectByName(std::vector<QObjectPtr> &controls, QObjectPtr control)
+{
+	QString name = control->objectName();
+	auto finder = [name](QObjectPtr elem) {
+		return elem->objectName() > name;
+	};
+	auto found_at = std::find_if(controls.begin(), controls.end(), finder);
+
+	controls.insert(found_at, control);
+}

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -136,6 +136,7 @@ VolControl::VolControl(OBSSource source_, bool showConfig)
 	font.setPointSize(font.pointSize()-1);
 
 	QString sourceName = obs_source_get_name(source);
+	setObjectName(sourceName);
 
 	nameLabel->setText(sourceName);
 	nameLabel->setFont(font);

--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -6,6 +6,7 @@
 #include <QLabel>
 #include "window-basic-adv-audio.hpp"
 #include "window-basic-main.hpp"
+#include "item-widget-helpers.hpp"
 #include "adv-audio-control.hpp"
 #include "obs-app.hpp"
 #include "qt-wrappers.hpp"
@@ -133,7 +134,12 @@ void OBSBasicAdvAudio::OBSSourceRemoved(void *param, calldata_t *calldata)
 inline void OBSBasicAdvAudio::AddAudioSource(obs_source_t *source)
 {
 	OBSAdvAudioCtrl *control = new OBSAdvAudioCtrl(mainLayout, source);
-	controls.push_back(control);
+
+	InsertQObjectByName(controls, control);
+
+	for (auto control : controls) {
+		control->ShowAudioControl(mainLayout);
+	}
 }
 
 void OBSBasicAdvAudio::SourceAdded(OBSSource source)

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2590,8 +2590,11 @@ void OBSBasic::ActivateAudioSource(OBSSource source)
 	connect(vol, &VolControl::ConfigClicked,
 			this, &OBSBasic::VolControlContextMenu);
 
-	volumes.push_back(vol);
-	ui->volumeWidgets->layout()->addWidget(vol);
+	InsertQObjectByName(volumes, vol);
+
+	for (auto volume : volumes) {
+		ui->volumeWidgets->layout()->addWidget(volume);
+	}
 }
 
 void OBSBasic::DeactivateAudioSource(OBSSource source)


### PR DESCRIPTION
Bug (Windows 8.1 x64): Audio controls in OBS Mixer and Advanced Audio Properties window are not sorted at all. Every time OBS is restarted they get shuffled. The order of these controls is not consistent between the mixer and the advanced properties window.

This commit introduces sorting audio controls by source name.

The user can rename audio sources to get desired order.

Before: 
![image](https://user-images.githubusercontent.com/108798/37567781-23dfa238-2ae5-11e8-9358-6594f3ae9ae5.png)

After: 
![image](https://user-images.githubusercontent.com/108798/37567789-2d5c3588-2ae5-11e8-94b2-a420a5f1b71b.png)

