### PR TITLE
rtmp-services: Update recommended parameters for Nood.tv

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 80,
+	"version": 81,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 80
+			"version": 81
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -797,7 +797,8 @@
             "recommended": {
                 "keyint": 2,
                 "max video bitrate": 25000,
-                "max audio bitrate": 192
+                "max audio bitrate": 192,
+                "x264opts": "scenecut=0"
             }
         },
         {


### PR DESCRIPTION
we need "x264opts": "scenecut=0" otherwise we have big problems