### PR TITLE
libobs-d3d11: Do not allow Alt+Enter interception

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -166,8 +166,8 @@ gs_swap_chain::gs_swap_chain(gs_device *device, const gs_init_data *data)
 	if (FAILED(hr))
 		throw HRError("Failed to create swap chain", hr);
 
-	const HRESULT res = device->factory->MakeWindowAssociation(hwnd,
-		DXGI_MWA_NO_ALT_ENTER);
+	//ignore Alt+Enter sequence for window
+	device->factory->MakeWindowAssociation(hwnd, DXGI_MWA_NO_ALT_ENTER);
 
 	Init();
 }

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -166,6 +166,9 @@ gs_swap_chain::gs_swap_chain(gs_device *device, const gs_init_data *data)
 	if (FAILED(hr))
 		throw HRError("Failed to create swap chain", hr);
 
+	const HRESULT res = device->factory->MakeWindowAssociation(hwnd,
+		DXGI_MWA_NO_ALT_ENTER);
+
 	Init();
 }
 


### PR DESCRIPTION
Prevent DXGI from responding to an Alt+Enter sequence.

Fixes: https://obsproject.com/mantis/view.php?id=1200