### PR TITLE
UI: Make Windowed Projectors accept always_on_top

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -142,7 +142,7 @@ void OBSProjector::Init(int monitor, bool window, QString title,
 
 	bool alwaysOnTop = config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "ProjectorAlwaysOnTop");
-	if (alwaysOnTop && !window)
+	if (alwaysOnTop)
 		SetAlwaysOnTop(this, true);
 
 	if (window)


### PR DESCRIPTION
Make Windowed Projectors accept Settings>Make projectors always on top
user's setting.

Projectors not affected by application's main menu File>Always On Top
setting, but Windowed Projectors may be always on top too.

Each Windowed Projector can be minimized if required.

request: https://obsproject.com/mantis/view.php?id=1167