### PR TITLE
UI: Change monitoring device on profile change

### DIFF
--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -346,6 +346,19 @@ void OBSBasic::ResetProfileData()
 	ResetOutputs();
 	ClearHotkeys();
 	CreateHotkeys();
+
+	/* load audio monitoring */
+#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
+	const char *device_name = config_get_string(basicConfig, "Audio",
+			"MonitoringDeviceName");
+	const char *device_id = config_get_string(basicConfig, "Audio",
+			"MonitoringDeviceId");
+
+	obs_set_audio_monitoring_device(device_name, device_id);
+
+	blog(LOG_INFO, "Audio monitoring device:\n\tname: %s\n\tid: %s",
+			device_name, device_id);
+#endif
 }
 
 void OBSBasic::on_actionNewProfile_triggered()


### PR DESCRIPTION
When profile gets changed, will result in the audio monitoring device being reinitialized with that profiles selected device.

Fixes [https://obsproject.com/mantis/view.php?id=1216](https://obsproject.com/mantis/view.php?id=1216)