### PR TITLE
libobs: Fix pasting filters crash when missing sources

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -427,6 +427,11 @@ static void duplicate_filters(obs_source_t *dst, obs_source_t *src,
 
 void obs_source_copy_filters(obs_source_t *dst, obs_source_t *src)
 {
+	if (!obs_source_valid(dst, "obs_source_copy_filters"))
+		return;
+	if (!obs_source_valid(src, "obs_source_copy_filters"))
+		return;
+
 	duplicate_filters(dst, src, dst->context.private);
 }
 


### PR DESCRIPTION
libobs: Fix crash when no destination for pasting filter

Solves https://obsproject.com/mantis/view.php?id=1220