### PR TITLE
UI: Disable paste filters unless a source is selected

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4024,6 +4024,8 @@ void OBSBasic::CreateSourcePopupMenu(QListWidgetItem *item, bool preview)
 
 		ui->actionCopyFilters->setEnabled(true);
 		ui->actionCopySource->setEnabled(true);
+	} else {
+		ui->actionPasteFilters->setEnabled(false);
 	}
 
 	popup.exec(QCursor::pos());


### PR DESCRIPTION
UI: Disable paste filters unless a source is selected
Fixes the paste filters right click option to behave like copy.

See: https://obsproject.com/mantis/view.php?id=1220 
and https://github.com/obsproject/obs-studio/pull/1261