### PR TITLE
libobs: Add output flag fetching functionality

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -419,6 +419,18 @@ bool obs_output_active(const obs_output_t *output)
 		(active(output) || reconnecting(output)) : false;
 }
 
+uint32_t obs_output_get_flags(const obs_output_t *output)
+{
+	return obs_output_valid(output, "obs_output_get_flags") ?
+		output->info.flags : 0;
+}
+
+uint32_t obs_output_flags(const char *id)
+{
+	const struct obs_output_info *info = find_output(id);
+	return info ? info->flags : 0;
+}
+
 static inline obs_data_t *get_defaults(const struct obs_output_info *info)
 {
 	obs_data_t *settings = obs_data_create();

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1440,6 +1440,12 @@ EXPORT void obs_output_force_stop(obs_output_t *output);
 /** Returns whether the output is active */
 EXPORT bool obs_output_active(const obs_output_t *output);
 
+/** Returns output capabilities in a bitmask. */
+EXPORT uint32_t obs_output_get_flags(const obs_output_t *output);
+
+/** Returns output capabilities in a bitmask based on id. */
+EXPORT uint32_t obs_output_flags(const char *id);
+
 /** Gets the default settings for an output type */
 EXPORT obs_data_t *obs_output_defaults(const char *id);
 


### PR DESCRIPTION
I don't see a use for this in the current iteration of the Qt UI but this allows you to fetch the capabilities of an output. In particular, it lets you test the output to see if it requires a service, an encoder, and if it allows for both video and audio. 