### PR TITLE
RFC: win-capture: Fix potential race condition with unload

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -527,13 +527,9 @@ static void game_capture_update(void *data, obs_data_t *settings)
 	}
 }
 
-extern void wait_for_hook_initialization(void);
-
 static void *game_capture_create(obs_data_t *settings, obs_source_t *source)
 {
 	struct game_capture *gc = bzalloc(sizeof(*gc));
-
-	wait_for_hook_initialization();
 
 	gc->source = source;
 	gc->initial_config = true;


### PR DESCRIPTION
This fixes a potential race condition if you shutdown libobs too fast and unload has been called before the init_hooks thread could finish. The init_hooks thread calls functions that relies on the global obs context to be intact. Since it's asynchronous and unload is called with the global obs context already nullified, if done too quickly, it will crash.

In other words, we have to make sure that initialization is done before unload is called. 

There are two ways of working around this: 
1. We start calling unload functions before we nullify the global obs context to make sure obs context is still usable.
2. We simply finish all of the initialization in the initialization function.  

I did some testing with moving the asynchronous code back into the initializing thread and it doesn't seem to actually take that long. This simplifies the code and removes the race condition as well. I haven't extensively tested this but it seems to work well enough for a simple change.