### PR TITLE
obs-ffmpeg: fill in more fields on audio frames

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
@@ -132,6 +132,10 @@ static bool initialize_codec(struct enc_encoder *enc)
 		warn("Failed to open AAC codec: %s", av_err2str(ret));
 		return false;
 	}
+	enc->aframe->format = enc->context->sample_fmt;
+	enc->aframe->channels = enc->context->channels;
+	enc->aframe->channel_layout = enc->context->channel_layout;
+	enc->aframe->sample_rate = enc->context->sample_rate;
 
 	enc->frame_size = enc->context->frame_size;
 	if (!enc->frame_size)

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -290,6 +290,11 @@ static bool open_audio_codec(struct ffmpeg_data *data)
 		return false;
 	}
 
+	data->aframe->format = context->sample_fmt;
+	data->aframe->channels = context->channels;
+	data->aframe->channel_layout = context->channel_layout;
+	data->aframe->sample_rate = context->sample_rate;
+
 	context->strict_std_compliance = -2;
 
 	ret = avcodec_open2(context, data->acodec, NULL);


### PR DESCRIPTION
After you call av_frame_alloc(), ffmpeg expects you to fill in certain
fields on the frame, depending on whether it's an audio or video frame.
obs-ffmpeg did this in the two places where it allocates video frames,
but not where it allocates audio frames.  On my system, using trunk
ffmpeg and the Opus codec, this causes OBS to crash while calling
avcodec_send_frame, ultimately because av_frame_copy fails due to
'dst->format < 0' (as 'format' stays at the default of -1), causing a
null pointer to be added to a buffer queue, which later gets
dereferenced.

Oddly, the fields in question can just be copied directly from
corresponding fields in the AVCodecContext, but I don't see any ffmpeg
API to automatically copy all relevant fields, and all the examples I've
seen do it by hand.  So this patch does the same.