### PR TITLE
window-remux: Change dialog to non-modal

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3394,7 +3394,7 @@ void OBSBasic::on_actionRemux_triggered()
 		config_get_string(basicConfig, "SimpleOutput", "FilePath") :
 		config_get_string(basicConfig, "AdvOut", "RecFilePath");
 	OBSRemux remux(path, this);
-	remux.exec();
+	remux.Init();
 }
 
 void OBSBasic::on_action_Settings_triggered()

--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -37,6 +37,9 @@ OBSRemux::OBSRemux(const char *path, QWidget *parent)
 	  ui      (new Ui::OBSRemux),
 	  recPath (path)
 {
+	setModal(false);
+	setSizeGripEnabled(true);
+
 	ui->setupUi(this);
 
 	ui->progressBar->setVisible(false);
@@ -97,6 +100,14 @@ bool OBSRemux::Stop()
 	}
 
 	return false;
+}
+
+void OBSRemux::Init()
+{
+	show();
+	raise();
+	activateWindow();
+	exec();
 }
 
 OBSRemux::~OBSRemux()

--- a/UI/window-remux.hpp
+++ b/UI/window-remux.hpp
@@ -51,6 +51,8 @@ public:
 
 	using job_t = std::shared_ptr<struct media_remux_job>;
 
+	void Init();
+
 private slots:
 	void inputChanged(const QString &str);
 


### PR DESCRIPTION
Pro Tip: You can now open multiple dialog boxes and remux multiple files at the same time.