### PR TITLE
obs-frontend-api: Ship the OBS frontend API header

### DIFF
--- a/UI/obs-frontend-api/CMakeLists.txt
+++ b/UI/obs-frontend-api/CMakeLists.txt
@@ -26,4 +26,5 @@ if(UNIX AND NOT APPLE)
 			)
 endif()
 
+install_obs_headers(obs-frontend-api.h)
 install_obs_core(obs-frontend-api)


### PR DESCRIPTION
This allows the building and packaging of externally maintained OBS frontend
plugins such as obs-ndi and obs-websocket for distribution in a Linux
distribution package repository.