### PR TITLE
Separate crash handler from libobs startup

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1887,6 +1887,7 @@ int main(int argc, char *argv[])
 #endif
 
 #ifdef _WIN32
+	obs_init_win32_crash_handler();
 	SetErrorMode(SEM_FAILCRITICALERRORS);
 	load_debug_privilege();
 	base_set_crash_handler(main_crash_handler, nullptr);

--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -788,6 +788,13 @@ void reset_win32_symbol_paths(void)
 	da_free(paths);
 }
 
+extern void initialize_crash_handler(void);
+
+void obs_init_win32_crash_handler(void)
+{
+	initialize_crash_handler();
+}
+
 void initialize_com(void)
 {
 	CoInitializeEx(0, COINIT_MULTITHREADED);

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -776,7 +776,6 @@ static bool obs_init(const char *locale, const char *module_config_path,
 }
 
 #ifdef _WIN32
-extern void initialize_crash_handler(void);
 extern void initialize_com(void);
 extern void uninitialize_com(void);
 #endif
@@ -795,7 +794,6 @@ bool obs_startup(const char *locale, const char *module_config_path,
 	}
 
 #ifdef _WIN32
-	initialize_crash_handler();
 	initialize_com();
 #endif
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -276,6 +276,12 @@ EXPORT void obs_set_locale(const char *locale);
 /** @return the current locale */
 EXPORT const char *obs_get_locale(void);
 
+/** Initialize the Windows-specific crash handler */
+
+#ifdef _WIN32
+EXPORT void obs_init_win32_crash_handler(void);
+#endif
+
 /**
  * Returns the profiler name store (see util/profiler.h) used by OBS, which is
  * either a name store passed to obs_startup, an internal name store, or NULL


### PR DESCRIPTION
This separates the crash handler from libobs startup. The problem with starting the crash handler at all times is anything using libobs and its own signal handler immediately turns into a conflict. To avoid this, the separation given here allows us to opt-out of the crash handler. 

In particular, the recent PR for CMocka unit-tests has this issue since it catches segmentation faults and similar via a well-featured signal handler. We can now opt-out of the crash handler and let CMocka do that for us, at least while running the tests.

The Streamlabs OBS UI also has a conflict with this since they use Electron which uses Crashpad. Crashpad catches signals via an external process but it still seems to conflict. As a result, the Streamlabs OBS fork required explicitly removing the crash handler. It would no longer be required with this and instead, the crash handler initialization function would simply not be called.