### PR TITLE
rtmp-services: Update ingest list for Restream.io

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 81,
+	"version": 82,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 81
+			"version": 82
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -662,6 +662,10 @@
                     "url": "rtmp://eu-luxembourg.restream.io/live"
                 },
                 {
+                    "name": "EU-West (Paris, FR)",
+                    "url": "rtmp://eu-paris.restream.io/live"
+                },
+                {
                     "name": "EU-Central (Frankfurt, DE)",
                     "url": "rtmp://eu-central.restream.io/live"
                 },


### PR DESCRIPTION
Update ingest list for Restream.io:
- add new Restream ingest: EU-West (Paris, FR)
- update rtmp-services version

Restream ingests could be checked at https://restream.io/api/ingests
