### PR TITLE
libobs: Expose source save/load signal

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -696,9 +696,6 @@ extern bool obs_source_init_context(struct obs_source *source,
 		obs_data_t *settings, const char *name,
 		obs_data_t *hotkey_data, bool private);
 
-extern void obs_source_save(obs_source_t *source);
-extern void obs_source_load(obs_source_t *source);
-
 extern bool obs_transition_init(obs_source_t *transition);
 extern void obs_transition_free(obs_source_t *transition);
 extern void obs_transition_tick(obs_source_t *transition);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -576,6 +576,12 @@ EXPORT obs_data_t *obs_save_source(obs_source_t *source);
 /** Loads a source from settings data */
 EXPORT obs_source_t *obs_load_source(obs_data_t *data);
 
+/** Send a save signal to sources */
+EXPORT void obs_source_save(obs_source_t *source);
+
+/** Send a load signal to sources */
+EXPORT void obs_source_load(obs_source_t *source);
+
 typedef void (*obs_load_source_cb)(void *private_data, obs_source_t *source);
 
 /** Loads sources from a data array */


### PR DESCRIPTION
Streamlabs uses this since they opted out of using obs_save_source and there's no other way to tell a source to save before caching its settings. The only plugin that currently uses the save feature is obs-vst. No plugin, to my knowledge, uses the load functionality. I don't see any possible side effect of exposing the functionality as well. 