### PR TITLE
libobs: windows: Allow env variable for data path

### DIFF
--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -64,6 +64,33 @@ char *find_libobs_data_file(const char *file)
 	struct dstr path;
 	dstr_init(&path);
 
+	WCHAR *env_path = 0;
+	DWORD env_path_sz = 
+		GetEnvironmentVariableW(L"OBS_DATA_PATH", NULL, 0);
+
+	env_path = bmalloc(env_path_sz * sizeof(WCHAR));
+
+	if (env_path_sz) {
+		GetEnvironmentVariableW(
+		    L"OBS_DATA_PATH",
+		    env_path, env_path_sz);
+	}
+
+	if (env_path) {
+		char *env_path_utf8 = 0;
+		struct dstr data_path;
+
+		os_wcs_to_utf8_ptr(env_path, env_path_sz, &env_path_utf8);
+		dstr_init_copy(&data_path, env_path_utf8);
+		dstr_cat(&data_path, "/libobs/");
+
+		if (check_path(file, data_path.array, &path)) {
+			return path.array;
+		}
+
+		bfree(env_path_utf8);
+	}
+
 	if (check_path(file, "data/libobs/", &path))
 		return path.array;
 
@@ -71,6 +98,8 @@ char *find_libobs_data_file(const char *file)
 		return path.array;
 
 	dstr_free(&path);
+
+	bfree(env_path);
 	return NULL;
 }
 


### PR DESCRIPTION
OBS_DATA_PATH on Windows is currently hard coded. This makes distribution difficult if libobs sits in a path that doesn't pertain to the hard-coded paths. This change allows an environment to specify the location of that data path.

Current Qt OBS wouldn't require any changes but if there was a need or want to move libobs data or libobs itself into a different directory, it could potentially be useful.