### PR TITLE
win-capture: Draw cursor of actual size

### DIFF
--- a/plugins/win-capture/dc-capture.c
+++ b/plugins/win-capture/dc-capture.c
@@ -103,7 +103,9 @@ static void draw_cursor(struct dc_capture *capture, HDC hdc, HWND window)
 		pos.x = ci->ptScreenPos.x - (int)ii.xHotspot - win_pos.x;
 		pos.y = ci->ptScreenPos.y - (int)ii.yHotspot - win_pos.y;
 
-		DrawIcon(hdc, pos.x, pos.y, icon);
+		//draw cursor of original size
+		DrawIconEx(hdc, pos.x, pos.y, icon, 0, 0, 0, NULL,
+				DI_NORMAL);
 
 		DeleteObject(ii.hbmColor);
 		DeleteObject(ii.hbmMask);


### PR DESCRIPTION
When drawing cursor to window capture area - use actual resource width
and height instead of system metric values for icons.

Related issue: https://obsproject.com/forum/threads/cursor-capture.84507/