### PR TITLE
UI: Fix memory leak when drag/dropping

### DIFF
--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -107,8 +107,10 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 		break;
 	}
 
-	if (!obs_source_get_display_name(type))
+	if (!obs_source_get_display_name(type)) {
+		obs_data_release(settings);
 		return;
+	}
 
 	if (name.isEmpty())
 		name = obs_source_get_display_name(type);


### PR DESCRIPTION
Patches a memory leak when a poorly matched type value is not handled by the case switch.