### PR TITLE
UI: Add option to save sources to clipboard as .json

### DIFF
--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -11,6 +11,10 @@
 
 using namespace std;
 
+static const char *sourceExtensions[] = {
+	"json", nullptr
+};
+
 static const char *textExtensions[] = {
 	"txt", "log", nullptr
 };
@@ -64,6 +68,7 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 {
 	OBSBasic *main = reinterpret_cast<OBSBasic*>(App()->GetMainWindow());
 	obs_data_t *settings = obs_data_create();
+	obs_data_t *json_settings = nullptr;
 	obs_source_t *source = nullptr;
 	const char *type = nullptr;
 	QString name;
@@ -105,10 +110,17 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 		name = QUrl::fromLocalFile(QString(data)).fileName();
 		type = "browser_source";
 		break;
+	case DropType_Source:
+		json_settings = obs_data_create_from_json_file(data);
+		settings = obs_data_get_obj(json_settings, "settings");
+		name = obs_data_get_string(json_settings, "name");
+		type = obs_data_get_string(json_settings, "id");
+		break;
 	}
 
 	if (!obs_source_get_display_name(type)) {
 		obs_data_release(settings);
+		obs_data_release(json_settings);
 		return;
 	}
 
@@ -124,6 +136,7 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 	}
 
 	obs_data_release(settings);
+	obs_data_release(json_settings);
 }
 
 void OBSBasic::dragEnterEvent(QDragEnterEvent *event)
@@ -181,6 +194,7 @@ if (found) \
 			CHECK_SUFFIX(htmlExtensions, DropType_Html);
 			CHECK_SUFFIX(imageExtensions, DropType_Image);
 			CHECK_SUFFIX(mediaExtensions, DropType_Media);
+			CHECK_SUFFIX(sourceExtensions, DropType_Source);
 
 #undef CHECK_SUFFIX
 		}

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2067,6 +2067,27 @@ void OBSBasic::InsertSceneItem(obs_sceneitem_t *item)
 	SetupVisibilityItem(ui->sources, listItem, item);
 }
 
+void OBSBasic::CreateSourceJson(obs_source_t *source)
+{
+	obs_data_t *json_output = obs_data_create();
+
+	const char *name = (char *)obs_source_get_name(source);
+	const char *id = (char *)obs_source_get_id(source);
+	obs_data_t *settings = obs_source_get_settings(source);
+
+	obs_data_set_obj(json_output, "settings", settings);
+	obs_data_set_string(json_output, "name", name);
+	obs_data_set_string(json_output, "id", id);
+
+	const char *json_text = (char *)obs_data_get_json(json_output);
+
+	QClipboard *clipboard = QApplication::clipboard();
+	clipboard->setText(json_text);
+
+	obs_data_release(json_output);
+	obs_data_release(settings);
+}
+
 void OBSBasic::CreateInteractionWindow(obs_source_t *source)
 {
 	if (interaction)
@@ -3963,6 +3984,9 @@ void OBSBasic::CreateSourcePopupMenu(QListWidgetItem *item, bool preview)
 		popup.addAction(sourceWindow);
 		popup.addSeparator();
 
+		popup.addAction(QTStr("Export"), this,
+			SLOT(on_actionSourceExport_triggered()));
+
 		action = popup.addAction(QTStr("Interact"), this,
 				SLOT(on_actionInteract_triggered()));
 
@@ -4174,6 +4198,15 @@ void OBSBasic::on_actionRemoveSource_triggered()
 				obs_sceneitem_remove(item);
 		}
 	}
+}
+
+void OBSBasic::on_actionSourceExport_triggered()
+{
+	OBSSceneItem item = GetCurrentSceneItem();
+	OBSSource source = obs_sceneitem_get_source(item);
+
+	if (source)
+		CreateSourceJson(source);
 }
 
 void OBSBasic::on_actionInteract_triggered()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -20,6 +20,7 @@
 #include <QBuffer>
 #include <QAction>
 #include <QSystemTrayIcon>
+#include <QClipboard>
 #include <obs.hpp>
 #include <vector>
 #include <memory>
@@ -244,6 +245,7 @@ private:
 	void TempStreamOutput(const char *url, const char *key,
 			int vBitrate, int aBitrate);
 
+	void CreateSourceJson(obs_source_t *source);
 	void CreateInteractionWindow(obs_source_t *source);
 	void CreatePropertiesWindow(obs_source_t *source);
 	void CreateFiltersWindow(obs_source_t *source);
@@ -610,6 +612,7 @@ private slots:
 	void on_scenes_itemDoubleClicked(QListWidgetItem *item);
 	void on_actionAddSource_triggered();
 	void on_actionRemoveSource_triggered();
+	void on_actionSourceExport_triggered();
 	void on_actionInteract_triggered();
 	void on_actionSourceProperties_triggered();
 	void on_actionSourceUp_triggered();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -111,7 +111,8 @@ class OBSBasic : public OBSMainWindow {
 		DropType_Text,
 		DropType_Image,
 		DropType_Media,
-		DropType_Html
+		DropType_Html,
+		DropType_Source
 	};
 
 private:


### PR DESCRIPTION
Adds a button to sources context menu to export the source as a .json file.
Intended to be used in conjunction w/ drag and drop source creation feature 
from pull request #1286 