### PR TITLE
Fix several mem leaks

### DIFF
--- a/UI/slider-absoluteset-style.hpp
+++ b/UI/slider-absoluteset-style.hpp
@@ -6,7 +6,7 @@ class SliderAbsoluteSetStyle : public QProxyStyle
 {
 public:
 	SliderAbsoluteSetStyle(const QString& baseStyle);
-	SliderAbsoluteSetStyle(QStyle* baseStyle);
+	SliderAbsoluteSetStyle(QStyle* baseStyle = Q_NULLPTR);
 	int styleHint(QStyle::StyleHint hint, const QStyleOption* option,
 		const QWidget* widget, QStyleHintReturn* returnData) const;
 };

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -9,6 +9,7 @@
 #include <QSlider>
 #include <QLabel>
 #include <QPainter>
+#include <QStyleFactory>
 
 using namespace std;
 
@@ -246,7 +247,17 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 	obs_fader_attach_source(obs_fader, source);
 	obs_volmeter_attach_source(obs_volmeter, source);
 
-	slider->setStyle(new SliderAbsoluteSetStyle(slider->style()));
+	QString styleName = slider->style()->objectName();
+	QStyle *style;
+	style = QStyleFactory::create(styleName);
+	if (!style) {
+		style = new SliderAbsoluteSetStyle();
+	} else {
+		style = new SliderAbsoluteSetStyle(style);
+	}
+
+	style->setParent(slider);
+	slider->setStyle(style);
 
 	/* Call volume changed once to init the slider position and label */
 	VolumeChanged();

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -531,6 +531,7 @@ VolumeMeter::VolumeMeter(QWidget *parent, obs_volmeter_t *obs_volmeter,
 VolumeMeter::~VolumeMeter()
 {
 	updateTimerRef->RemoveVolControl(this);
+	delete tickPaintCache;
 }
 
 void VolumeMeter::setLevels(const float magnitude[MAX_AUDIO_CHANNELS],

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1857,6 +1857,7 @@ OBSBasic::~OBSBasic()
 	if (updateCheckThread && updateCheckThread->isRunning())
 		updateCheckThread->wait();
 
+	delete trayMenu;
 	delete programOptions;
 	delete program;
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1857,6 +1857,7 @@ OBSBasic::~OBSBasic()
 	if (updateCheckThread && updateCheckThread->isRunning())
 		updateCheckThread->wait();
 
+	delete multiviewProjectorMenu;
 	delete trayMenu;
 	delete programOptions;
 	delete program;

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -714,7 +714,7 @@ OBSBasicSettings::~OBSBasicSettings()
 {
 	bool disableHotkeysInFocus = config_get_bool(App()->GlobalConfig(),
 			"General", "DisableHotkeysInFocus");
-
+	delete ui->filenameFormatting->completer();
 	main->EnableOutputs(true);
 	App()->EnableInFocusHotkeys(!disableHotkeysInFocus);
 }

--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -4288,14 +4288,14 @@ RTMP_Close(RTMP *r)
     r->m_customSendParam = NULL;
 
 #if defined(CRYPTO) || defined(USE_ONLY_MD5)
+    for (int idx = 0; idx < r->Link.nStreams; idx++)
+    {
+        free(r->Link.streams[idx].playpath.av_val);
+        r->Link.streams[idx].playpath.av_val = NULL;
+    }
+
     if (!(r->Link.protocol & RTMP_FEATURE_WRITE) || (r->Link.pFlags & RTMP_PUB_CLEAN))
     {
-        for (int idx = 0; idx < r->Link.nStreams; idx++)
-        {
-            free(r->Link.streams[idx].playpath.av_val);
-            r->Link.streams[idx].playpath.av_val = NULL;
-        }
-
         r->Link.curStreamIdx = 0;
         r->Link.nStreams = 0;
     }


### PR DESCRIPTION
This PR fixes ~~5~~ 6 memory leaks, mostly in UI.    

I found two other leaks but didn't manage to fix;  I leave the info here for further reference.    
(i) UI: volume-control.cpp: line 213 in VolControl()    
slider->setStyle(new SliderAbsoluteSetStyle(slider->style()));     
There seems to be an ownership issue with slider because delete slider->style() does not work.    
See this : https://stackoverflow.com/questions/37786568/qstyle-ownership?rq=1     
However being too ignorant about QT, I could not make anything out of this stackoverflow discussion.    

edit: fixed in craftwar commit (included in this PR)

(ii) UI: window-basic-main.cpp: OBSBasic( ...) line 184 installEventFilter(CreateShortcutFilter());
The CreateShortcutFilter function returns a new OBSEventFilter .    
Elsewhere in the code , installEventFilter(CreateShortcutFilter()) does not create leaks.  So I don't know why it does here.   

**NB :** leak in plugins/obs-outputs/librtmp/parseurl.c : streamname in RTMP_ParsePlaypath is not freed    
Following discussion with palana it should not be freed in RTMP_ParsePlaypath so I reverted my initial commit.

**Update 05/13:**
librtmp memory leak bisected to [1682d77df](https://github.com/obsproject/obs-studio/commit/1682d77df34a5c98ab24f41a273b29dd52e4f59e)
Fixed in a new commit.

