### PR TITLE
UI: Fix OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -639,12 +639,11 @@ void OBSBasic::SetCurrentScene(OBSSource scene, bool force, bool direct)
 				ui->scenes->blockSignals(true);
 				ui->scenes->setCurrentItem(item);
 				ui->scenes->blockSignals(false);
+				if (api)
+					api->on_event(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
 				break;
 			}
 		}
-
-		if (api && IsPreviewProgramMode())
-			api->on_event(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
 	}
 
 	UpdateSceneSelection(scene);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -900,8 +900,10 @@ retryScene:
 
 	disableSaving--;
 
-	if (api)
+	if (api) {
 		api->on_event(OBS_FRONTEND_EVENT_SCENE_CHANGED);
+		api->on_event(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
+	}
 }
 
 #define SERVICE_PATH "service.json"
@@ -2271,6 +2273,11 @@ void OBSBasic::UpdateSceneSelection(OBSSource source)
 			sceneChanging = false;
 
 			UpdateSources(scene);
+
+			OBSScene curScene =
+				GetOBSRef<OBSScene>(ui->scenes->currentItem());
+			if (api && scene != curScene)
+				api->on_event(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
 		}
 	}
 }
@@ -3507,6 +3514,9 @@ void OBSBasic::on_scenes_currentItemChanged(QListWidgetItem *current,
 	}
 
 	SetCurrentScene(source);
+
+	if (api)
+		api->on_event(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
 
 	UNUSED_PARAMETER(prev);
 }


### PR DESCRIPTION
@jp9000 I took the freedom to cherry-pick this commit from `jimtree` to a dedicated branch.

Description from original commit:
> OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED is supposed to be called
whenever the user changes the current preview scene -- it was almost
never being triggered.