### PR TITLE
remove PSAPI_VERSION=1 (compatibility for XP, Vista)

### DIFF
--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -14,7 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#define PSAPI_VERSION 1
 #include <windows.h>
 #include <mmsystem.h>
 #include <shellapi.h>

--- a/plugins/win-capture/window-helpers.c
+++ b/plugins/win-capture/window-helpers.c
@@ -1,4 +1,3 @@
-#define PSAPI_VERSION 1
 #include <obs.h>
 #include <util/dstr.h>
 


### PR DESCRIPTION
We support Win7+ now.