### PR TITLE
UI: Disable Transition button while transitioning 

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -174,6 +174,7 @@ private:
 
 	QPointer<QMenu> startStreamMenu;
 
+	QPointer<QPushButton> transitionButton;
 	QPointer<QPushButton> replayBufferButton;
 
 	QPointer<QSystemTrayIcon> trayIcon;


### PR DESCRIPTION
Per request ID 1238 on Mantis 
"To prevent operator error, it should probably not be possible to start a
transition while another transition is already active."

This was achieved through making the transitionButton
previously just created in CreateProgramSettings() and then stored
in a QWidget, into a member variable in OBSBasic class.
(Similar to replayBufferButton)

Signals were amended so that TransitionStopped() would
enable the button, and TransitionClicked() would disable it.
(TransitionStopped() and TransitionClicked() are  both called
upon receiving corresponding signals)

These are functions contained within OBSBasic class, so the functions
have access to the transitionButton member variable, and are thus
able to enable/disable.