### PR TITLE
Use selected color in color property label

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -638,9 +638,14 @@ void OBSPropertiesView::AddColor(obs_property_t *prop, QFormLayout *layout,
 	button->setText(QTStr("Basic.PropertiesWindow.SelectColor"));
 	button->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 
+	QPalette palette = QPalette(color);
 	colorLabel->setFrameStyle(QFrame::Sunken | QFrame::Panel);
 	colorLabel->setText(color.name(QColor::HexArgb));
-	colorLabel->setPalette(QPalette(color));
+	colorLabel->setPalette(palette);
+	colorLabel->setStyleSheet(
+		QString("background-color :%1; color: %2;")
+			.arg(palette.color(QPalette::Window).name(QColor::HexArgb))
+			.arg(palette.color(QPalette::WindowText).name(QColor::HexArgb)));
 	colorLabel->setAutoFillBackground(true);
 	colorLabel->setAlignment(Qt::AlignCenter);
 	colorLabel->setToolTip(QT_UTF8(obs_property_long_description(prop)));
@@ -1636,7 +1641,12 @@ bool WidgetInfo::ColorChanged(const char *setting)
 
 	QLabel *label = static_cast<QLabel*>(widget);
 	label->setText(color.name(QColor::HexArgb));
-	label->setPalette(QPalette(color));
+	QPalette palette = QPalette(color);
+	label->setPalette(palette);
+	label->setStyleSheet(
+		QString("background-color :%1; color: %2;")
+			.arg(palette.color(QPalette::Window).name(QColor::HexArgb))
+			.arg(palette.color(QPalette::WindowText).name(QColor::HexArgb)));
 
 	obs_data_set_int(view->settings, setting, color_to_int(color));
 

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -1,4 +1,5 @@
 #include <QFormLayout>
+#include <QStackedLayout>
 #include <QScrollBar>
 #include <QLabel>
 #include <QCheckBox>
@@ -650,10 +651,26 @@ void OBSPropertiesView::AddColor(obs_property_t *prop, QFormLayout *layout,
 	colorLabel->setAlignment(Qt::AlignCenter);
 	colorLabel->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 
+	QFrame *backdrop = new QLabel;
+	backdrop->setFrameStyle(QFrame::Sunken | QFrame::Panel);
+	backdrop->setPalette(palette);
+	backdrop->setStyleSheet(
+		"background: qlineargradient(x1:0, y1:0, x2:1, y2:1,"
+			"stop:0 #cccccc, stop:0.45 #cccccc,"
+			"stop:0.55 #444444, stop:1 #444444)");
+	backdrop->setAutoFillBackground(true);
+
+	QStackedLayout *stackLayout = new QStackedLayout;
+	stackLayout->setContentsMargins(0, 0, 0, 0);
+	stackLayout->setStackingMode(QStackedLayout::StackAll);
+
+	stackLayout->addWidget(backdrop);
+	stackLayout->addWidget(colorLabel);
+
 	QHBoxLayout *subLayout = new QHBoxLayout;
 	subLayout->setContentsMargins(0, 0, 0, 0);
 
-	subLayout->addWidget(colorLabel);
+	subLayout->addItem(stackLayout);
 	subLayout->addWidget(button);
 
 	WidgetInfo *info = new WidgetInfo(this, prop, colorLabel);


### PR DESCRIPTION
Originally wanted to do a separate color swatch, but was stymied by the single widget reference in WidgetInfo. Using QPalette values achieves basic white/black text for contrast, though it is still possible to select a color with poor contrast.