### PR TITLE
obs-ffmpeg: Set average framerate in video stream

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -316,6 +316,7 @@ static void create_video_stream(struct ffmpeg_mux *ffm)
 		(AVRational){ffm->params.fps_den, ffm->params.fps_num};
 
 	ffm->video_stream->time_base = context->time_base;
+	ffm->video_stream->avg_frame_rate = av_inv_q(context->time_base);
 
 	if (ffm->output->oformat->flags & AVFMT_GLOBALHEADER)
 		context->flags |= CODEC_FLAG_GLOBAL_H;


### PR DESCRIPTION
This commit fixes an issue where videos created with OBS will appear as having 1000 FPS in some media players (and FFmpeg as of the current Windows nightly).  Credit to @OsirisNL for pointing out the fix and where to apply it.

I did question whether remuxed videos should also apply this setting.  I briefly investigated this, and it seems that for 60 FPS videos, remuxing calculates a new avg_frame_rate that is within 60±0.01.  I'm not sure if this is preferable to specifying the avg_frame_rate (if the data is available), and I figure that could be left to a separate PR for later if needed.

I've built and tested this on Windows 10 64-bit.  As always, feedback, reviews, or more testing are welcomed.