### PR TITLE
libobs: Handle 'in', 'out', and 'inout' keywords in shader parsers

### DIFF
--- a/libobs-opengl/gl-shaderparser.c
+++ b/libobs-opengl/gl-shaderparser.c
@@ -108,6 +108,10 @@ static void gl_write_var(struct gl_shader_parser *glsp, struct shader_var *var)
 		dstr_cat(&glsp->gl_string, "uniform ");
 	else if (var->var_type == SHADER_VAR_CONST)
 		dstr_cat(&glsp->gl_string, "const ");
+	else if (var->var_type == SHADER_VAR_INOUT)
+		dstr_cat(&glsp->gl_string, "inout ");
+	else if (var->var_type == SHADER_VAR_OUT)
+		dstr_cat(&glsp->gl_string, "out ");
 
 	gl_write_type(glsp, var->type);
 	dstr_cat(&glsp->gl_string, " ");

--- a/libobs/graphics/effect-parser.h
+++ b/libobs/graphics/effect-parser.h
@@ -37,9 +37,17 @@ struct dstr;
 /* ------------------------------------------------------------------------- */
 /* effect parser var data */
 
+enum ep_var_type {
+	EP_VAR_NONE,
+	EP_VAR_IN = EP_VAR_NONE,
+	EP_VAR_INOUT,
+	EP_VAR_OUT,
+	EP_VAR_UNIFORM
+};
+
 struct ep_var {
 	char *type, *name, *mapping;
-	bool uniform;
+	enum ep_var_type var_type;
 };
 
 static inline void ep_var_init(struct ep_var *epv)

--- a/libobs/graphics/shader-parser.c
+++ b/libobs/graphics/shader-parser.c
@@ -334,16 +334,40 @@ static inline int sp_parse_func_param(struct shader_parser *sp,
 		struct shader_var *var)
 {
 	int code;
-	bool is_uniform = false;
+	bool var_type_keyword = false;
 
 	if (!cf_next_valid_token(&sp->cfp))
 		return PARSE_EOF;
 
-	code = sp_check_for_keyword(sp, "uniform", &is_uniform);
+	code = sp_check_for_keyword(sp, "in", &var_type_keyword);
 	if (code == PARSE_EOF)
 		return PARSE_EOF;
+	else if (var_type_keyword)
+		var->var_type = SHADER_VAR_IN;
 
-	var->var_type = is_uniform ? SHADER_VAR_UNIFORM : SHADER_VAR_NONE;
+	if (!var_type_keyword) {
+		code = sp_check_for_keyword(sp, "inout", &var_type_keyword);
+		if (code == PARSE_EOF)
+			return PARSE_EOF;
+		else if (var_type_keyword)
+			var->var_type = SHADER_VAR_INOUT;
+	}
+
+	if (!var_type_keyword) {
+		code = sp_check_for_keyword(sp, "out", &var_type_keyword);
+		if (code == PARSE_EOF)
+			return PARSE_EOF;
+		else if (var_type_keyword)
+			var->var_type = SHADER_VAR_OUT;
+	}
+
+	if (!var_type_keyword) {
+		code = sp_check_for_keyword(sp, "uniform", &var_type_keyword);
+		if (code == PARSE_EOF)
+			return PARSE_EOF;
+		else if (var_type_keyword)
+			var->var_type = SHADER_VAR_UNIFORM;
+	}
 
 	code = cf_get_name(&sp->cfp, &var->type, "type", ")");
 	if (code != PARSE_SUCCESS)

--- a/libobs/graphics/shader-parser.h
+++ b/libobs/graphics/shader-parser.h
@@ -38,6 +38,9 @@ EXPORT enum gs_address_mode get_address_mode(const char *address_mode);
 
 enum shader_var_type {
 	SHADER_VAR_NONE,
+	SHADER_VAR_IN = SHADER_VAR_NONE,
+	SHADER_VAR_INOUT,
+	SHADER_VAR_OUT,
 	SHADER_VAR_UNIFORM,
 	SHADER_VAR_CONST
 };


### PR DESCRIPTION
This adds support for the "in", "out" and "inout" keywords in function signatures in both effect-parser.c and shader-parser.c. This attempts to address [Mantis issue 001239](https://obsproject.com/mantis/view.php?id=1239). 