### PR TITLE
libobs, UI: reset hotkey description on target rename

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -26,6 +26,8 @@
 #include "menu-button.hpp"
 #include "qt-wrappers.hpp"
 
+#include "obs-hotkey.h"
+
 using namespace std;
 
 Q_DECLARE_METATYPE(OBSScene);
@@ -96,6 +98,18 @@ void OBSBasic::AddQuickTransitionHotkey(QuickTransition *qt)
 	qt->hotkey = obs_hotkey_register_frontend(hotkeyId->array,
 			QT_TO_UTF8(hotkeyName), quickTransition,
 			(void*)(uintptr_t)qt->id);
+}
+
+void QuickTransition::SourceRenamed(void *param, calldata_t *data)
+{
+	QuickTransition *qt = reinterpret_cast<QuickTransition*>(param);
+
+	QString hotkeyName = QTStr("QuickTransitions.HotkeyName")
+		.arg(MakeQuickTransitionText(qt));
+
+	obs_hotkey_set_description(qt->hotkey, QT_TO_UTF8(hotkeyName));
+
+	UNUSED_PARAMETER(data);
 }
 
 void OBSBasic::TriggerQuickTransition(int id)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -84,10 +84,17 @@ struct QuickTransition {
 
 	inline QuickTransition() {}
 	inline QuickTransition(OBSSource source_, int duration_, int id_)
-		: source   (source_),
-		  duration (duration_),
-		  id       (id_)
+		: source        (source_),
+		  duration      (duration_),
+		  id            (id_),
+		  renamedSignal (std::make_shared<OBSSignal>(
+					obs_source_get_signal_handler(source),
+					"rename", SourceRenamed, this))
 	{}
+
+private:
+	static void SourceRenamed(void *param, calldata_t *data);
+	std::shared_ptr<OBSSignal> renamedSignal;
 };
 
 class OBSBasic : public OBSMainWindow {

--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -79,6 +79,62 @@ obs_hotkey_t *obs_hotkey_binding_get_hotkey(obs_hotkey_binding_t *binding)
 	return binding->hotkey;
 }
 
+static inline bool find_id(obs_hotkey_id id, size_t *idx);
+void obs_hotkey_set_name(obs_hotkey_id id, const char *name)
+{
+	size_t idx;
+
+	if (!find_id(id, &idx))
+		return;
+
+	obs_hotkey_t *hotkey = &obs->hotkeys.hotkeys.array[idx];
+	bfree(hotkey->name);
+	hotkey->name = bstrdup(name);
+}
+
+void obs_hotkey_set_description(obs_hotkey_id id, const char *desc)
+{
+	size_t idx;
+
+	if (!find_id(id, &idx))
+		return;
+
+	obs_hotkey_t *hotkey = &obs->hotkeys.hotkeys.array[idx];
+	bfree(hotkey->description);
+	hotkey->description = bstrdup(desc);
+}
+
+static inline bool find_pair_id(obs_hotkey_pair_id id, size_t *idx);
+void obs_hotkey_pair_set_names(obs_hotkey_pair_id id,
+		const char *name0, const char *name1)
+{
+	size_t idx;
+	obs_hotkey_pair_t pair;
+
+	if (!find_pair_id(id, &idx))
+		return;
+
+	pair = obs->hotkeys.hotkey_pairs.array[idx];
+
+	obs_hotkey_set_name(pair.id[0], name0);
+	obs_hotkey_set_name(pair.id[1], name1);
+}
+
+void obs_hotkey_pair_set_descriptions(obs_hotkey_pair_id id,
+		const char *desc0, const char *desc1)
+{
+	size_t idx;
+	obs_hotkey_pair_t pair;
+
+	if (!find_pair_id(id, &idx))
+		return;
+
+	pair = obs->hotkeys.hotkey_pairs.array[idx];
+
+	obs_hotkey_set_description(pair.id[0], desc0);
+	obs_hotkey_set_description(pair.id[1], desc1);
+}
+
 static void hotkey_signal(const char *signal, obs_hotkey_t *hotkey)
 {
 	calldata_t data;

--- a/libobs/obs-hotkey.h
+++ b/libobs/obs-hotkey.h
@@ -60,6 +60,8 @@ enum obs_hotkey_registerer_type {
 };
 typedef enum obs_hotkey_registerer_type obs_hotkey_registerer_t;
 
+/* getter functions */
+
 EXPORT obs_hotkey_id obs_hotkey_get_id(const obs_hotkey_t *key);
 EXPORT const char *obs_hotkey_get_name(const obs_hotkey_t *key);
 EXPORT const char *obs_hotkey_get_description(const obs_hotkey_t *key);
@@ -75,6 +77,15 @@ EXPORT obs_hotkey_id obs_hotkey_binding_get_hotkey_id(
 		obs_hotkey_binding_t *binding);
 EXPORT obs_hotkey_t *obs_hotkey_binding_get_hotkey(
 		obs_hotkey_binding_t *binding);
+
+/* setter functions */
+
+EXPORT void obs_hotkey_set_name(obs_hotkey_id id, const char *name);
+EXPORT void obs_hotkey_set_description(obs_hotkey_id id, const char *desc);
+EXPORT void obs_hotkey_pair_set_names(obs_hotkey_pair_id id,
+		const char *name0, const char *name1);
+EXPORT void obs_hotkey_pair_set_descriptions(obs_hotkey_pair_id id,
+		const char *desc0, const char *desc1);
 
 #ifndef SWIG
 struct obs_hotkeys_translations {


### PR DESCRIPTION
Hotkey description and/or name should be reset each time its registerer's name (or similiar data) is changed.

Fixes [Hotkey of show & hide source never update description after renaming source](https://obsproject.com/mantis/view.php?id=1225).