### PR TITLE
obs-filters: Use double-precision where viable

### DIFF
--- a/plugins/obs-filters/color-correction-filter.c
+++ b/plugins/obs-filters/color-correction-filter.c
@@ -351,16 +351,16 @@ static obs_properties_t *color_correction_filter_properties(void *data)
 	obs_properties_t *props = obs_properties_create();
 
 	obs_properties_add_float_slider(props, SETTING_GAMMA,
-			TEXT_GAMMA, -3.0f, 3.0f, 0.01f);
+			TEXT_GAMMA, -3.0, 3.0, 0.01);
 
 	obs_properties_add_float_slider(props, SETTING_CONTRAST,
-			TEXT_CONTRAST, -2.0f, 2.0f, 0.01f);
+			TEXT_CONTRAST, -2.0, 2.0, 0.01);
 	obs_properties_add_float_slider(props, SETTING_BRIGHTNESS,
-			TEXT_BRIGHTNESS, -1.0f, 1.0f, 0.01f);
+			TEXT_BRIGHTNESS, -1.0, 1.0, 0.01);
 	obs_properties_add_float_slider(props, SETTING_SATURATION,
-			TEXT_SATURATION, -1.0f, 5.0f, 0.01f);
+			TEXT_SATURATION, -1.0, 5.0, 0.01);
 	obs_properties_add_float_slider(props, SETTING_HUESHIFT,
-			TEXT_HUESHIFT, -180.0f, 180.0f, 0.01f);
+			TEXT_HUESHIFT, -180.0, 180.0, 0.01);
 	obs_properties_add_int_slider(props, SETTING_OPACITY,
 			TEXT_OPACITY, 0, 100, 1);
 

--- a/plugins/obs-filters/compressor-filter.c
+++ b/plugins/obs-filters/compressor-filter.c
@@ -40,12 +40,12 @@
 #define TEXT_OUTPUT_GAIN                MT_("Compressor.OutputGain")
 #define TEXT_SIDECHAIN_SOURCE           MT_("Compressor.SidechainSource")
 
-#define MIN_RATIO                       1.0f
-#define MAX_RATIO                       32.0f
-#define MIN_THRESHOLD_DB                -60.0f
+#define MIN_RATIO                       1.0
+#define MAX_RATIO                       32.0
+#define MIN_THRESHOLD_DB                -60.0
 #define MAX_THRESHOLD_DB                0.0f
-#define MIN_OUTPUT_GAIN_DB              -32.0f
-#define MAX_OUTPUT_GAIN_DB              32.0f
+#define MIN_OUTPUT_GAIN_DB              -32.0
+#define MAX_OUTPUT_GAIN_DB              32.0
 #define MIN_ATK_RLS_MS                  1
 #define MAX_RLS_MS                      1000
 #define MAX_ATK_MS                      500
@@ -497,15 +497,15 @@ static obs_properties_t *compressor_properties(void *data)
 		parent = obs_filter_get_parent(cd->context);
 
 	obs_properties_add_float_slider(props, S_RATIO,
-		TEXT_RATIO, MIN_RATIO, MAX_RATIO, 0.5f);
+		TEXT_RATIO, MIN_RATIO, MAX_RATIO, 0.5);
 	obs_properties_add_float_slider(props, S_THRESHOLD,
-		TEXT_THRESHOLD, MIN_THRESHOLD_DB, MAX_THRESHOLD_DB, 0.1f);
+		TEXT_THRESHOLD, MIN_THRESHOLD_DB, MAX_THRESHOLD_DB, 0.1);
 	obs_properties_add_int_slider(props, S_ATTACK_TIME,
 		TEXT_ATTACK_TIME, MIN_ATK_RLS_MS, MAX_ATK_MS, 1);
 	obs_properties_add_int_slider(props, S_RELEASE_TIME,
 		TEXT_RELEASE_TIME, MIN_ATK_RLS_MS, MAX_RLS_MS, 1);
 	obs_properties_add_float_slider(props, S_OUTPUT_GAIN,
-		TEXT_OUTPUT_GAIN, MIN_OUTPUT_GAIN_DB, MAX_OUTPUT_GAIN_DB, 0.1f);
+		TEXT_OUTPUT_GAIN, MIN_OUTPUT_GAIN_DB, MAX_OUTPUT_GAIN_DB, 0.1);
 
 	obs_property_t *sources = obs_properties_add_list(props,
 			S_SIDECHAIN_SOURCE, TEXT_SIDECHAIN_SOURCE,

--- a/plugins/obs-filters/noise-gate-filter.c
+++ b/plugins/obs-filters/noise-gate-filter.c
@@ -41,8 +41,8 @@ struct noise_gate_data {
 	float held_time;
 };
 
-#define VOL_MIN -96.0f
-#define VOL_MAX 0.0f
+#define VOL_MIN -96.0
+#define VOL_MAX 0.0
 
 static const char *noise_gate_name(void *unused)
 {
@@ -155,8 +155,8 @@ static struct obs_audio_data *noise_gate_filter_audio(void *data,
 
 static void noise_gate_defaults(obs_data_t *s)
 {
-	obs_data_set_default_double(s, S_OPEN_THRESHOLD, -26.0f);
-	obs_data_set_default_double(s, S_CLOSE_THRESHOLD, -32.0f);
+	obs_data_set_default_double(s, S_OPEN_THRESHOLD, -26.0);
+	obs_data_set_default_double(s, S_CLOSE_THRESHOLD, -32.0);
 	obs_data_set_default_int   (s, S_ATTACK_TIME, 25);
 	obs_data_set_default_int   (s, S_HOLD_TIME, 200);
 	obs_data_set_default_int   (s, S_RELEASE_TIME, 150);
@@ -167,9 +167,9 @@ static obs_properties_t *noise_gate_properties(void *data)
 	obs_properties_t *ppts = obs_properties_create();
 
 	obs_properties_add_float_slider(ppts, S_CLOSE_THRESHOLD,
-			TEXT_CLOSE_THRESHOLD, VOL_MIN, VOL_MAX, 1.0f);
+			TEXT_CLOSE_THRESHOLD, VOL_MIN, VOL_MAX, 1.0);
 	obs_properties_add_float_slider(ppts, S_OPEN_THRESHOLD,
-			TEXT_OPEN_THRESHOLD, VOL_MIN, VOL_MAX, 1.0f);
+			TEXT_OPEN_THRESHOLD, VOL_MIN, VOL_MAX, 1.0);
 	obs_properties_add_int(ppts, S_ATTACK_TIME, TEXT_ATTACK_TIME,
 			0, 10000, 1);
 	obs_properties_add_int(ppts, S_HOLD_TIME, TEXT_HOLD_TIME,

--- a/plugins/obs-filters/scroll-filter.c
+++ b/plugins/obs-filters/scroll-filter.c
@@ -121,10 +121,10 @@ static obs_properties_t *scroll_filter_properties(void *data)
 
 	obs_properties_add_float_slider(props, "speed_x",
 			obs_module_text("ScrollFilter.SpeedX"),
-			-500.0f, 500.0f, 1.0f);
+			-500.0, 500.0, 1.0);
 	obs_properties_add_float_slider(props, "speed_y",
 			obs_module_text("ScrollFilter.SpeedY"),
-			-500.0f, 500.0f, 1.0f);
+			-500.0, 500.0, 1.0);
 
 	p = obs_properties_add_bool(props, "limit_cx",
 			obs_module_text("ScrollFilter.LimitWidth"));

--- a/plugins/obs-filters/sharpness-filter.c
+++ b/plugins/obs-filters/sharpness-filter.c
@@ -101,7 +101,7 @@ static obs_properties_t *sharpness_properties(void *data)
 	obs_properties_t *props = obs_properties_create();
 
 	obs_properties_add_float_slider(props, "sharpness",
-		"Sharpness", 0.0f, 1.0f, 0.01f);
+		"Sharpness", 0.0, 1.0, 0.01);
 
 	UNUSED_PARAMETER(data);
 	return props;


### PR DESCRIPTION
We're expecting a variable with double precision. Since we don't read
the value of these doubles with a particular precision, it can often
lead to unpredictable results where the value set isn't the one
intended due to the loss of precision from float->double conversion.