### PR TITLE
libobs: Copy metadata for tracks/streams when remuxing

### DIFF
--- a/libobs/media-io/media-remux.c
+++ b/libobs/media-io/media-remux.c
@@ -109,6 +109,8 @@ static inline bool init_output(media_remux_job_t job, const char *out_filename)
 		}
 		out_stream->time_base = out_stream->codec->time_base;
 
+		av_dict_copy(&out_stream->metadata, in_stream->metadata, 0);
+
 		out_stream->codec->codec_tag = 0;
 		if (job->ofmt_ctx->oformat->flags & AVFMT_GLOBALHEADER)
 			out_stream->codec->flags |= CODEC_FLAG_GLOBAL_H;


### PR DESCRIPTION
Currently, when a user remuxes a file, any audio tracks with custom names will have their names reset to default (e.g., Track 1, Track 2, Track 3, Track 4).  This PR enables the remux operation to copy metadata for audio and video tracks (called streams in FFmpeg), which preserves custom audio track names.  Since users are often instructed to remux files for various reasons, this PR will help users preserve track names they had set.

At first, I'd only enabled copying metadata for audio streams to preserve user-specified track names.  However, since video streams can also have similar metadata, and OBS users may try to use the remux feature on media files not directly generated by OBS, I thought we could copy all track metadata on remux.

This PR has been successfully built on the CI services, and I've built and tested it locally on Windows 10 1803 (17134.48) 64-bit.  As always, feedback, reviews, or more testing are welcomed.