### PR TITLE
CI: Use latest Qt on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ install:
   - set DepsPath32=%CD%\dependencies2017\win32
   - set DepsPath64=%CD%\dependencies2017\win64
   - set VLCPath=%CD%\vlc
-  - set QTDIR32=C:\Qt\5.10.1\msvc2015
-  - set QTDIR64=C:\Qt\5.10.1\msvc2017_64
+  - set QTDIR32=C:\Qt\latest\msvc2015
+  - set QTDIR64=C:\Qt\latest\msvc2017_64
   - set build_config=RelWithDebInfo
   - mkdir build build32 build64
   - cd ./build32


### PR DESCRIPTION
We don't need change Qt version any more. It will use latest release on AppVeyor.