### PR TITLE
text-freetype2: Add alignment setting

### DIFF
--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -131,14 +131,14 @@ static obs_properties_t *ft2_source_properties(void *unused)
 		obs_module_text("Text"), OBS_TEXT_MULTILINE);
 
 	obs_property_t *alignmentProp = obs_properties_add_list(props,
-	                "alignment", obs_module_text("Alignment"),
-	                OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+			"alignment", obs_module_text("Alignment"),
+			OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
 	obs_property_list_add_int(alignmentProp, "Left",
-	                TEXT_ALIGNMENT_LEFT);
+			TEXT_ALIGNMENT_LEFT);
 	obs_property_list_add_int(alignmentProp, "Center",
-	                TEXT_ALIGNMENT_CENTER);
+			TEXT_ALIGNMENT_CENTER);
 	obs_property_list_add_int(alignmentProp, "Right",
-	                TEXT_ALIGNMENT_RIGHT);
+			TEXT_ALIGNMENT_RIGHT);
 
 	obs_properties_add_bool(props, "from_file",
 		obs_module_text("ReadFromFile"));

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -140,6 +140,11 @@ static obs_properties_t *ft2_source_properties(void *unused)
 	obs_property_list_add_int(alignmentProp, "Right",
 			TEXT_ALIGNMENT_RIGHT);
 
+	obs_properties_add_int(props,
+		"additional_char_spacing", obs_module_text("Additional char spacing"), -1000, 1000, 1);
+	obs_properties_add_int(props,
+		"additional_line_spacing", obs_module_text("Additional line spacing"), -1000, 1000, 1);
+
 	obs_properties_add_bool(props, "from_file",
 		obs_module_text("ReadFromFile"));
 
@@ -307,6 +312,8 @@ static void ft2_source_update(void *data, obs_data_t *settings)
 	srcdata->drop_shadow = obs_data_get_bool(settings, "drop_shadow");
 	srcdata->outline_text = obs_data_get_bool(settings, "outline");
 	srcdata->alignment = obs_data_get_int(settings, "alignment");
+	srcdata->additional_char_spacing = obs_data_get_int(settings, "additional_char_spacing");
+	srcdata->additional_line_spacing = obs_data_get_int(settings, "additional_line_spacing");
 	word_wrap = obs_data_get_bool(settings, "word_wrap");
 
 	color[0] = (uint32_t)obs_data_get_int(settings, "color1");
@@ -493,6 +500,8 @@ static void *ft2_source_create(obs_data_t *settings, obs_source_t *source)
 	obs_data_set_default_int(settings, "color2", 0xFFFFFFFF);
 
 	obs_data_set_default_int(settings, "alignment", TEXT_ALIGNMENT_LEFT);
+	obs_data_set_default_int(settings, "additional_char_spacing", 0);
+	obs_data_set_default_int(settings, "additional_line_spacing", 0);
 
 	ft2_source_update(srcdata, settings);
 

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -130,6 +130,16 @@ static obs_properties_t *ft2_source_properties(void *unused)
 	obs_properties_add_text(props, "text",
 		obs_module_text("Text"), OBS_TEXT_MULTILINE);
 
+	obs_property_t *alignmentProp = obs_properties_add_list(props,
+	                "alignment", obs_module_text("Alignment"),
+	                OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+	obs_property_list_add_int(alignmentProp, "Left",
+	                TEXT_ALIGNMENT_LEFT);
+	obs_property_list_add_int(alignmentProp, "Center",
+	                TEXT_ALIGNMENT_CENTER);
+	obs_property_list_add_int(alignmentProp, "Right",
+	                TEXT_ALIGNMENT_RIGHT);
+
 	obs_properties_add_bool(props, "from_file",
 		obs_module_text("ReadFromFile"));
 
@@ -296,6 +306,7 @@ static void ft2_source_update(void *data, obs_data_t *settings)
 
 	srcdata->drop_shadow = obs_data_get_bool(settings, "drop_shadow");
 	srcdata->outline_text = obs_data_get_bool(settings, "outline");
+	srcdata->alignment = obs_data_get_int(settings, "alignment");
 	word_wrap = obs_data_get_bool(settings, "word_wrap");
 
 	color[0] = (uint32_t)obs_data_get_int(settings, "color1");
@@ -480,6 +491,8 @@ static void *ft2_source_create(obs_data_t *settings, obs_source_t *source)
 
 	obs_data_set_default_int(settings, "color1", 0xFFFFFFFF);
 	obs_data_set_default_int(settings, "color2", 0xFFFFFFFF);
+
+	obs_data_set_default_int(settings, "alignment", TEXT_ALIGNMENT_LEFT);
 
 	ft2_source_update(srcdata, settings);
 

--- a/plugins/text-freetype2/text-freetype2.h
+++ b/plugins/text-freetype2/text-freetype2.h
@@ -21,10 +21,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define num_cache_slots 65535
 #define src_glyph srcdata->cacheglyphs[glyph_index]
 
+#define max_aligned_lines 256
+
 struct glyph_info {
 	float u, v, u2, v2;
 	int32_t w, h, xoff, yoff;
 	int32_t xadv;
+};
+
+enum text_alignment {
+	TEXT_ALIGNMENT_LEFT,
+	TEXT_ALIGNMENT_CENTER,
+	TEXT_ALIGNMENT_RIGHT,
 };
 
 struct ft2_source {
@@ -41,6 +49,11 @@ struct ft2_source {
 	bool update_file;
 	uint64_t last_checked;
 
+	// in pixels
+	uint32_t lines_width[max_aligned_lines];
+	uint32_t max_line_width;
+
+	enum text_alignment alignment;
 	uint32_t cx, cy, max_h, custom_width;
 	uint32_t texbuf_x, texbuf_y;
 	uint32_t color[2];

--- a/plugins/text-freetype2/text-freetype2.h
+++ b/plugins/text-freetype2/text-freetype2.h
@@ -54,6 +54,7 @@ struct ft2_source {
 	uint32_t max_line_width;
 
 	enum text_alignment alignment;
+	int32_t additional_char_spacing, additional_line_spacing;
 	uint32_t cx, cy, max_h, custom_width;
 	uint32_t texbuf_x, texbuf_y;
 	uint32_t color[2];

--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -146,19 +146,19 @@ skip_word_wrap:;
 	len = wcslen(srcdata->text);
 	uint32_t current_line_width = 0;
 	uint32_t current_line_index = 0;
-	if (srcdata->custom_width < 100) {
+	if (srcdata->custom_width < 100)
 		srcdata->max_line_width = 0;
-	} else {
+	else
 		srcdata->max_line_width = srcdata->custom_width;
-	}
+
 	for (uint32_t i = 0; i <= len; i++) {
 		if (srcdata->text[i] == L'\n' || i == len) {
-			if (current_line_width > srcdata->max_line_width) {
+			if (current_line_width > srcdata->max_line_width)
 				srcdata->max_line_width = current_line_width;
-			}
+
 			if (current_line_index < max_aligned_lines) {
 				srcdata->lines_width[current_line_index] =
-				        current_line_width;
+					current_line_width;
 				current_line_index++;
 			}
 			current_line_width = 0;
@@ -175,17 +175,16 @@ skip_word_wrap:;
 
 uint32_t get_dx_for_line(struct ft2_source *srcdata, int line_index)
 {
-	if (line_index >= max_aligned_lines) {
+	if (line_index >= max_aligned_lines)
 		return 0;
-	}
 
 	switch (srcdata->alignment) {
 	case TEXT_ALIGNMENT_CENTER:
 		return (srcdata->max_line_width -
-		        srcdata->lines_width[line_index]) / 2;
+			srcdata->lines_width[line_index]) / 2;
 	case TEXT_ALIGNMENT_RIGHT:
 		return srcdata->max_line_width -
-		        srcdata->lines_width[line_index];
+			srcdata->lines_width[line_index];
 	default:
 		return 0;
 	}
@@ -203,7 +202,8 @@ void fill_vertex_buffer(struct ft2_source *srcdata)
 
 	uint32_t current_line_index = 0;
 	uint32_t dx = get_dx_for_line(srcdata, 0);
-	uint32_t dy = srcdata->max_h, max_y = dy;
+	uint32_t dy = srcdata->max_h;
+	uint32_t max_y = dy;
 	uint32_t cur_glyph = 0;
 	size_t len = wcslen(srcdata->text);
 

--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -136,7 +136,7 @@ void set_up_vertex_buffer(struct ft2_source *srcdata)
 	next_char:;
 		glyph_index = FT_Get_Char_Index(srcdata->font_face,
 			srcdata->text[i]);
-		word_width += src_glyph->xadv;
+		word_width += src_glyph->xadv + srcdata->additional_char_spacing;
 	eos_skip:;
 	}
 
@@ -165,7 +165,7 @@ skip_word_wrap:;
 		} else {
 			glyph_index = FT_Get_Char_Index(srcdata->font_face,
 				srcdata->text[i]);
-			current_line_width += src_glyph->xadv;
+			current_line_width += src_glyph->xadv + srcdata->additional_char_spacing;
 		}
 	}
 
@@ -222,7 +222,7 @@ void fill_vertex_buffer(struct ft2_source *srcdata)
 		current_line_index++;
 		dx = get_dx_for_line(srcdata, current_line_index);
 		i++;
-		dy += srcdata->max_h + 4;
+		dy += srcdata->max_h + 4 + srcdata->additional_line_spacing;
 		if (i == wcslen(srcdata->text)) goto skip_glyph;
 		if (srcdata->text[i] == L'\n') goto add_linebreak;
 	draw_glyph:;
@@ -236,9 +236,9 @@ void fill_vertex_buffer(struct ft2_source *srcdata)
 
 		if (srcdata->custom_width < 100) goto skip_custom_width;
 
-		if (dx + src_glyph->xadv > srcdata->custom_width) {
+		if (dx + src_glyph->xadv + srcdata->additional_char_spacing > srcdata->custom_width) {
 			dx = 0;
-			dy += srcdata->max_h + 4;
+			dy += srcdata->max_h + 4 + srcdata->additional_line_spacing;
 		}
 
 	skip_custom_width:;
@@ -256,7 +256,7 @@ void fill_vertex_buffer(struct ft2_source *srcdata)
 		set_rect_colors2(col + (cur_glyph * 6),
 			srcdata->color[0],
 			srcdata->color[1]);
-		dx += src_glyph->xadv;
+		dx += src_glyph->xadv + srcdata->additional_char_spacing;
 		if (dy - (float)src_glyph->yoff + src_glyph->h > max_y)
 			max_y = dy - src_glyph->yoff + src_glyph->h;
 		cur_glyph++;


### PR DESCRIPTION
Alignment can be used:
- without custom_width when text has many lines (there is no reason in alignment in one-line text)
- with custom_width and word_wrap

There is issue in non-left alignment in source with custom_width and without word_wrap.