### PR TITLE
libobs: Fix Monitoring devices showing input devices

### DIFF
--- a/libobs/audio-monitoring/osx/coreaudio-enum-devices.c
+++ b/libobs/audio-monitoring/osx/coreaudio-enum-devices.c
@@ -32,7 +32,7 @@ static bool obs_enum_audio_monitoring_device(obs_enum_audio_device_cb cb,
 	/* check to see if it's a mac input device */
 	if (!allow_inputs) {
 		AudioObjectGetPropertyDataSize(id, &addr, 0, NULL, &size);
-		if (!size)
+		if (size)
 			return true;
 	}
 

--- a/libobs/audio-monitoring/osx/coreaudio-enum-devices.c
+++ b/libobs/audio-monitoring/osx/coreaudio-enum-devices.c
@@ -41,7 +41,7 @@ static bool obs_enum_audio_monitoring_device(obs_enum_audio_device_cb cb,
 	addr.mSelector = kAudioDevicePropertyDeviceUID;
 	stat = AudioObjectGetPropertyData(id, &addr, 0, NULL, &size, &cf_uid);
 	if (!success(stat, "get audio device UID"))
-		return true;
+		goto fail;
 
 	addr.mSelector = kAudioDevicePropertyDeviceNameCFString;
 	stat = AudioObjectGetPropertyData(id, &addr, 0, NULL, &size, &cf_name);

--- a/libobs/audio-monitoring/osx/coreaudio-output.c
+++ b/libobs/audio-monitoring/osx/coreaudio-output.c
@@ -1,5 +1,5 @@
 #include <AudioUnit/AudioUnit.h>
-#include <AudioToolBox/AudioQueue.h>
+#include <AudioToolbox/AudioQueue.h>
 #include <CoreFoundation/CFString.h>
 #include <CoreAudio/CoreAudio.h>
 


### PR DESCRIPTION
The main bug fix is to show output devices in the Advanced Audio
Settings configuration, where currently on macOS it shows erroneously
input devices.

Second and third bugfixes are minor: after retrieving audio device UID
we then check for errors and return if we were not able to retrieve
the data. However cf_uid may already be allocated (since
AudioObjectGetPropertyData is OSX Api it may allocate then return
error. Checking for it being non-null and freeing if it is doesn't
hurt.

Last fix is the lowercase file not found error on coreaudio-output.c
file. Default MacOSX partitioning is case-insensitive, thus
by most developers. However, the actual dir name is AudioToolbox.
In other words, this bug is only exposed for developers compiling
on HFS case-sensitive based-storage.

#### TESTING #######

Main bug fix tested by using 2 output devices, one (now able to) selected as monitor
When selecting "Monitor and Output" or "Monitor only" it now routes audio to selected
device.
Manually able to compile OBS Project on case-sensitive file system, proving last fix
also works.