### PR TITLE
UI: Add downstream keyer

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -942,3 +942,6 @@ ResizeOutputSizeOfSource.Text="The base and output resolutions will be resized t
 ResizeOutputSizeOfSource.Continue="Do you want to continue?"
 
 PreviewTransition="Preview Transition"
+
+# Downstream Keyer
+DownstreamKeyer="Downstream Keyer"

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -302,6 +302,7 @@
      <addaction name="resetUI"/>
      <addaction name="lockUI"/>
      <addaction name="separator"/>
+     <addaction name="toggleDSK"/>
      <addaction name="toggleScenes"/>
      <addaction name="toggleSources"/>
      <addaction name="toggleMixer"/>
@@ -341,7 +342,140 @@
    <addaction name="menuBasic_MainMenu_Help"/>
   </widget>
   <widget class="OBSBasicStatusBar" name="statusbar"/>
-  <widget class="OBSDock" name="scenesDock">
+  <widget class="QDockWidget" name="dskDock">
+   <property name="features">
+    <set>QDockWidget::AllDockWidgetFeatures</set>
+   </property>
+   <property name="windowTitle">
+    <string>DownstreamKeyer</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>8</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_6">
+    <layout class="QVBoxLayout" name="verticalLayout_5">
+     <property name="leftMargin">
+      <number>4</number>
+     </property>
+     <property name="topMargin">
+      <number>4</number>
+     </property>
+     <property name="rightMargin">
+      <number>4</number>
+     </property>
+     <property name="bottomMargin">
+      <number>4</number>
+     </property>
+     <item>
+      <widget class="QFrame" name="dskFrame">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>160</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Sunken</enum>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_17">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="SourceTree" name="dskWidget">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="contextMenuPolicy">
+           <enum>Qt::CustomContextMenu</enum>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="showDropIndicator" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="dragEnabled">
+           <bool>true</bool>
+          </property>
+          <property name="dragDropMode">
+           <enum>QAbstractItemView::InternalMove</enum>
+          </property>
+          <property name="defaultDropAction">
+           <enum>Qt::TargetMoveAction</enum>
+          </property>
+          <property name="selectionMode">
+           <enum>QAbstractItemView::ExtendedSelection</enum>
+          </property>
+          <addaction name="actionRemoveSource"/>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolBar" name="dskToolbar">
+          <property name="iconSize">
+           <size>
+            <width>16</width>
+            <height>16</height>
+           </size>
+          </property>
+          <property name="floatable">
+           <bool>false</bool>
+          </property>
+          <addaction name="actionDSKAddSource"/>
+          <addaction name="actionDSKRemoveSource"/>
+          <addaction name="actionDSKSourceProperties"/>
+          <addaction name="separator"/>
+          <addaction name="actionDSKSourceUp"/>
+          <addaction name="actionDSKSourceDown"/>
+         </widget>
+        </item>
+        <item>
+         <spacer name="dskFixedSizeHSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>150</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="scenesDock">
    <property name="features">
     <set>QDockWidget::AllDockWidgetFeatures</set>
    </property>
@@ -1125,6 +1259,18 @@
     <string notr="true">addIconSmall</string>
    </property>
   </action>
+   <action name="actionDSKAddSource">
+   <property name="icon">
+    <iconset resource="obs.qrc">
+     <normaloff>:/res/images/add.png</normaloff>:/res/images/add.png</iconset>
+   </property>
+   <property name="text">
+    <string>Add</string>
+   </property>
+   <property name="themeID" stdset="0">
+    <string notr="true">addIconSmall</string>
+   </property>
+  </action>
   <action name="actionAddSource">
    <property name="icon">
     <iconset resource="obs.qrc">
@@ -1155,7 +1301,7 @@
     <string notr="true">removeIconSmall</string>
    </property>
   </action>
-  <action name="actionRemoveSource">
+  <action name="actionDSKRemoveSource">
    <property name="icon">
     <iconset resource="obs.qrc">
      <normaloff>:/res/images/list_remove.png</normaloff>:/res/images/list_remove.png</iconset>
@@ -1188,7 +1334,70 @@
     <string notr="true">propertiesIconSmall</string>
    </property>
   </action>
+  <action name="actionRemoveSource">
+   <property name="icon">
+    <iconset resource="obs.qrc">
+     <normaloff>:/res/images/list_remove.png</normaloff>:/res/images/list_remove.png</iconset>
+   </property>
+   <property name="text">
+    <string>Remove</string>
+   </property>
+   <property name="shortcut">
+    <string>Del</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetWithChildrenShortcut</enum>
+   </property>
+   <property name="themeID" stdset="0">
+    <string notr="true">removeIconSmall</string>
+   </property>
+  </action>
+  <action name="actionDSKSourceProperties">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="obs.qrc">
+     <normaloff>:/res/images/properties.png</normaloff>:/res/images/properties.png</iconset>
+   </property>
+   <property name="text">
+    <string>Properties</string>
+   </property>
+   <property name="themeID" stdset="0">
+    <string notr="true">propertiesIconSmall</string>
+   </property>
+  </action>
+  <action name="actionDSKSourceProperties">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="obs.qrc">
+     <normaloff>:/res/images/properties.png</normaloff>:/res/images/properties.png</iconset>
+   </property>
+   <property name="text">
+    <string>Properties</string>
+   </property>
+   <property name="themeID" stdset="0">
+    <string notr="true">propertiesIconSmall</string>
+   </property>
+  </action>
   <action name="actionSceneUp">
+   <property name="icon">
+    <iconset resource="obs.qrc">
+     <normaloff>:/res/images/up.png</normaloff>:/res/images/up.png</iconset>
+   </property>
+   <property name="text">
+    <string>MoveUp</string>
+   </property>
+   <property name="themeID" stdset="0">
+    <string notr="true">upArrowIconSmall</string>
+   </property>
+  </action>
+  <action name="actionDSKSourceUp">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
    <property name="icon">
     <iconset resource="obs.qrc">
      <normaloff>:/res/images/up.png</normaloff>:/res/images/up.png</iconset>
@@ -1216,6 +1425,21 @@
    </property>
   </action>
   <action name="actionSceneDown">
+   <property name="icon">
+    <iconset resource="obs.qrc">
+     <normaloff>:/res/images/down.png</normaloff>:/res/images/down.png</iconset>
+   </property>
+   <property name="text">
+    <string>MoveDown</string>
+   </property>
+   <property name="themeID" stdset="0">
+    <string notr="true">downArrowIconSmall</string>
+   </property>
+  </action>
+  <action name="actionDSKSourceDown">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
    <property name="icon">
     <iconset resource="obs.qrc">
      <normaloff>:/res/images/down.png</normaloff>:/res/images/down.png</iconset>
@@ -1604,6 +1828,17 @@
    </property>
    <property name="text">
     <string>Basic.MainMenu.View.Docks.LockUI</string>
+   </property>
+  </action>
+  <action name="toggleDSK">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>DownstreamKeyer</string>
    </property>
   </action>
   <action name="toggleScenes">

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -535,7 +535,14 @@ static bool enumItem(obs_scene_t *, obs_sceneitem_t *item, void *ptr)
 
 void SourceTreeModel::SceneChanged()
 {
-	OBSScene scene = GetCurrentScene();
+	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+
+	OBSScene scene;
+
+	if (this->parent() == main->ui->dskWidget)
+		scene = main->GetDSKScene();
+	else
+		scene = main->GetCurrentScene(false);
 
 	beginResetModel();
 	items.clear();

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -448,8 +448,9 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 			return;
 		}
 
-		obs_source_t *filter =
-			obs_source_create(id, name.c_str(), nullptr, nullptr);
+		obs_source_t *filter = obs_source_create(
+			id, name.c_str(), nullptr, nullptr, false);
+
 		if (filter) {
 			const char *sourceName = obs_source_get_name(source);
 

--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -111,7 +111,7 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 		name = obs_source_get_display_name(type);
 	source = obs_source_create(type,
 				   GenerateSourceName(QT_TO_UTF8(name)).c_str(),
-				   settings, nullptr);
+				   settings, nullptr, false);
 	if (source) {
 		OBSScene scene = main->GetCurrentScene();
 		obs_scene_add(scene, source);

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -117,7 +117,7 @@ void OBSBasic::TriggerQuickTransition(int id)
 	QuickTransition *qt = GetQuickTransition(id);
 
 	if (qt && previewProgramMode) {
-		OBSScene scene = GetCurrentScene();
+		OBSScene scene = GetCurrentScene(false);
 		obs_source_t *source = obs_scene_get_source(scene);
 
 		ui->transitionDuration->setValue(qt->duration);
@@ -668,7 +668,7 @@ void OBSBasic::SetCurrentScene(OBSSource scene, bool force, bool direct)
 		}
 	}
 
-	if (obs_scene_get_source(GetCurrentScene()) != scene) {
+	if (obs_scene_get_source(GetCurrentScene(false)) != scene) {
 		for (int i = 0; i < ui->scenes->count(); i++) {
 			QListWidgetItem *item = ui->scenes->item(i);
 			OBSScene itemScene = GetOBSRef<OBSScene>(item);
@@ -728,7 +728,7 @@ void OBSBasic::CreateProgramDisplay()
 void OBSBasic::TransitionClicked()
 {
 	if (previewProgramMode)
-		TransitionToScene(GetCurrentScene());
+		TransitionToScene(GetCurrentScene(false));
 }
 
 void OBSBasic::CreateProgramOptions()
@@ -1205,7 +1205,7 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		CreateProgramDisplay();
 		CreateProgramOptions();
 
-		OBSScene curScene = GetCurrentScene();
+		OBSScene curScene = GetCurrentScene(false);
 
 		obs_scene_t *dup;
 		if (sceneDuplicationMode) {

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -192,6 +192,26 @@ extern void RegisterTwitchAuth();
 extern void RegisterMixerAuth();
 extern void RegisterRestreamAuth();
 
+static int CountDSKItems()
+{
+	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	int count = 0;
+
+	auto countItems = [](obs_scene_t *scene, obs_sceneitem_t *item,
+			     void *param) {
+		if (!item)
+			return true;
+
+		(*reinterpret_cast<int *>(param))++;
+
+		UNUSED_PARAMETER(scene);
+		return true;
+	};
+
+	obs_scene_enum_items(main->GetDSKScene(), countItems, &count);
+	return count;
+}
+
 OBSBasic::OBSBasic(QWidget *parent)
 	: OBSMainWindow(parent), ui(new Ui::OBSBasic)
 {
@@ -250,6 +270,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 
 	ui->scenes->setAttribute(Qt::WA_MacShowFocusRect, false);
 	ui->sources->setAttribute(Qt::WA_MacShowFocusRect, false);
+	ui->dskWidget->setAttribute(Qt::WA_MacShowFocusRect, false);
 
 	ui->scenes->setItemDelegate(new SceneRenameDelegate(ui->scenes));
 
@@ -325,6 +346,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	addNudge(Qt::Key_Left, SLOT(NudgeLeft()));
 	addNudge(Qt::Key_Right, SLOT(NudgeRight()));
 
+	assignDockToggle(ui->dskDock, ui->toggleDSK);
 	assignDockToggle(ui->scenesDock, ui->toggleScenes);
 	assignDockToggle(ui->sourcesDock, ui->toggleSources);
 	assignDockToggle(ui->mixerDock, ui->toggleMixer);
@@ -496,6 +518,14 @@ void OBSBasic::copyActionsDynamicProperties()
 			temp->setProperty(y, x->property(y));
 		}
 	}
+
+	for (QAction *x : ui->dskToolbar->actions()) {
+		QWidget *temp = ui->dskToolbar->widgetForAction(x);
+
+		for (QByteArray &y : x->dynamicPropertyNames()) {
+			temp->setProperty(y, x->property(y));
+		}
+	}
 }
 
 void OBSBasic::UpdateVolumeControlsDecayRate()
@@ -595,7 +625,7 @@ obs_data_array_t *OBSBasic::SaveProjectors()
 
 void OBSBasic::Save(const char *file)
 {
-	OBSScene scene = GetCurrentScene();
+	OBSScene scene = GetCurrentScene(false);
 	OBSSource curProgramScene = OBSGetStrongRef(programScene);
 	if (!curProgramScene)
 		curProgramScene = obs_scene_get_source(scene);
@@ -704,7 +734,7 @@ void OBSBasic::CreateDefaultScene(bool firstStart)
 	ui->transitionDuration->setValue(300);
 	SetTransition(fadeTransition);
 
-	obs_scene_t *scene = obs_scene_create(Str("Basic.Scene"));
+	obs_scene_t *scene = obs_scene_create(Str("Basic.Scene"), false);
 
 	if (firstStart)
 		CreateFirstRunSources();
@@ -848,6 +878,7 @@ void OBSBasic::Load(const char *file)
 		return;
 	}
 
+	usingDSK = false;
 	ClearSceneData();
 	InitDefaultTransitions();
 
@@ -1789,6 +1820,27 @@ void OBSBasic::OBSInit()
 	QMetaObject::invokeMethod(this, "DeferredSysTrayLoad",
 				  Qt::QueuedConnection, Q_ARG(int, 10));
 #endif
+
+	connect(ui->dskWidget, SIGNAL(clicked(const QModelIndex)), this,
+		SLOT(DownstreamKeyerClicked(QModelIndex)));
+	connect(ui->sources, SIGNAL(clicked(const QModelIndex)), this,
+		SLOT(SourceTreeClicked(QModelIndex)));
+}
+
+void OBSBasic::DownstreamKeyerClicked(QModelIndex index)
+{
+	usingDSK = true;
+	ui->sources->clearSelection();
+
+	UNUSED_PARAMETER(index);
+}
+
+void OBSBasic::SourceTreeClicked(QModelIndex index)
+{
+	usingDSK = false;
+	ui->dskWidget->clearSelection();
+
+	UNUSED_PARAMETER(index);
 }
 
 void OBSBasic::OnFirstLoad()
@@ -2353,8 +2405,31 @@ OBSSource OBSBasic::GetProgramSource()
 
 OBSScene OBSBasic::GetCurrentScene()
 {
-	QListWidgetItem *item = ui->scenes->currentItem();
-	return item ? GetOBSRef<OBSScene>(item) : nullptr;
+	if (!usingDSK) {
+		QListWidgetItem *item = ui->scenes->currentItem();
+		return item ? GetOBSRef<OBSScene>(item) : nullptr;
+	} else {
+		return GetDSKScene();
+	}
+}
+
+OBSScene OBSBasic::GetCurrentScene(bool dsk)
+{
+	if (!dsk) {
+		QListWidgetItem *item = ui->scenes->currentItem();
+		return item ? GetOBSRef<OBSScene>(item) : nullptr;
+	} else {
+		return GetDSKScene();
+	}
+}
+
+OBSScene OBSBasic::GetDSKScene()
+{
+	OBSSource source = obs_get_output_source(7);
+	OBSScene scene = obs_scene_from_source(source);
+	obs_source_release(source);
+
+	return scene;
 }
 
 OBSSceneItem OBSBasic::GetSceneItem(QListWidgetItem *item)
@@ -2364,7 +2439,10 @@ OBSSceneItem OBSBasic::GetSceneItem(QListWidgetItem *item)
 
 OBSSceneItem OBSBasic::GetCurrentSceneItem()
 {
-	return ui->sources->Get(GetTopSelectedSourceItem());
+	if (!usingDSK)
+		return ui->sources->Get(GetTopSelectedSourceItem());
+	else
+		return ui->dskWidget->Get(GetTopSelectedDSKSourceItem());
 }
 
 void OBSBasic::UpdatePreviewScalingMenu()
@@ -2418,32 +2496,70 @@ void OBSBasic::CreateFiltersWindow(obs_source_t *source)
 	filters->setAttribute(Qt::WA_DeleteOnClose, true);
 }
 
+static bool ShowSource(void *data, obs_hotkey_pair_id id, obs_hotkey_t *key,
+		       bool pressed)
+{
+	UNUSED_PARAMETER(id);
+	UNUSED_PARAMETER(key);
+	obs_source_t *source = static_cast<obs_source_t *>(data);
+	if (!pressed || obs_source_enabled(source) || !source)
+		return false;
+	obs_source_set_enabled(source, true);
+	return true;
+}
+
+static bool HideSource(void *data, obs_hotkey_pair_id id, obs_hotkey_t *key,
+		       bool pressed)
+{
+	UNUSED_PARAMETER(id);
+	UNUSED_PARAMETER(key);
+	obs_source_t *source = static_cast<obs_source_t *>(data);
+	if (!pressed || !obs_source_enabled(source) || !source)
+		return false;
+	obs_source_set_enabled(source, false);
+	return true;
+}
+
 /* Qt callbacks for invokeMethod */
 
 void OBSBasic::AddScene(OBSSource source)
 {
 	const char *name = obs_source_get_name(source);
 	obs_scene_t *scene = obs_scene_from_source(source);
+	bool dsk = obs_source_is_dsk(source);
+
+	if (dsk)
+		obs_set_output_source(7, source);
 
 	QListWidgetItem *item = new QListWidgetItem(QT_UTF8(name));
 	SetOBSRef(item, OBSScene(scene));
 	ui->scenes->addItem(item);
 
-	obs_hotkey_register_source(
-		source, "OBSBasic.SelectScene",
-		Str("Basic.Hotkeys.SelectScene"),
-		[](void *data, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
-			OBSBasic *main = reinterpret_cast<OBSBasic *>(
-				App()->GetMainWindow());
+	if (!dsk) {
+		obs_hotkey_register_source(
+			source, "OBSBasic.SelectScene",
+			Str("Basic.Hotkeys.SelectScene"),
+			[](void *data, obs_hotkey_id, obs_hotkey_t *,
+			   bool pressed) {
+				OBSBasic *main = reinterpret_cast<OBSBasic *>(
+					App()->GetMainWindow());
 
-			auto potential_source =
-				static_cast<obs_source_t *>(data);
-			auto source = obs_source_get_ref(potential_source);
-			if (source && pressed)
-				main->SetCurrentScene(source);
-			obs_source_release(source);
-		},
-		static_cast<obs_source_t *>(source));
+				auto potential_source =
+					static_cast<obs_source_t *>(data);
+
+				auto source =
+					obs_source_get_ref(potential_source);
+				if (source && pressed)
+					main->SetCurrentScene(source);
+				obs_source_release(source);
+			},
+			static_cast<obs_source_t *>(source));
+	} else {
+		obs_hotkey_pair_register_source(source, "OBSBasic.Show",
+						Str("Show"), "OBSBasic.Hide",
+						Str("Hide"), ShowSource,
+						HideSource, source, source);
+	}
 
 	signal_handler_t *handler = obs_source_get_signal_handler(source);
 
@@ -2480,6 +2596,8 @@ void OBSBasic::AddScene(OBSSource source)
 			return true;
 		},
 		&addSceneItem);
+
+	item->setHidden(dsk);
 
 	SaveProject();
 
@@ -2548,8 +2666,10 @@ void OBSBasic::AddSceneItem(OBSSceneItem item)
 {
 	obs_scene_t *scene = obs_sceneitem_get_scene(item);
 
-	if (GetCurrentScene() == scene)
+	if (GetCurrentScene(false) == scene)
 		ui->sources->Add(item);
+	else if (GetCurrentScene(true) == scene)
+		ui->dskWidget->Add(item);
 
 	SaveProject();
 
@@ -2617,18 +2737,26 @@ void OBSBasic::RenameSources(OBSSource source, QString newName,
 	SaveProject();
 
 	obs_scene_t *scene = obs_scene_from_source(source);
-	if (scene)
-		OBSProjector::UpdateMultiviewProjectors();
+	if (!scene)
+		return;
+
+	OBSProjector::UpdateMultiviewProjectors();
 }
 
 void OBSBasic::SelectSceneItem(OBSScene scene, OBSSceneItem item, bool select)
 {
-	SignalBlocker sourcesSignalBlocker(ui->sources);
+	if (!usingDSK)
+		SignalBlocker sourcesSignalBlocker(ui->sources);
+	else
+		SignalBlocker sourcesSignalBlocker(ui->dskWidget);
 
 	if (scene != GetCurrentScene() || ignoreSelectionUpdate)
 		return;
 
-	ui->sources->SelectItem(item, select);
+	if (!usingDSK)
+		ui->sources->SelectItem(item, select);
+	else
+		ui->dskWidget->SelectItem(item, select);
 }
 
 static inline bool SourceMixerHidden(obs_source_t *source)
@@ -3146,10 +3274,13 @@ void OBSBasic::RemoveSelectedSceneItem()
 
 void OBSBasic::ReorderSources(OBSScene scene)
 {
-	if (scene != GetCurrentScene() || ui->sources->IgnoreReorder())
-		return;
+	if (scene == GetCurrentScene() && !ui->sources->IgnoreReorder()) {
+		if (!usingDSK)
+			ui->sources->ReorderItems();
+		else
+			ui->dskWidget->ReorderItems();
+	}
 
-	ui->sources->ReorderItems();
 	SaveProject();
 }
 
@@ -3325,10 +3456,14 @@ void OBSBasic::RenderMain(void *data, uint32_t cx, uint32_t cy)
 	window->DrawBackdrop(float(ovi.base_width), float(ovi.base_height));
 
 	if (window->IsPreviewProgramMode()) {
-		OBSScene scene = window->GetCurrentScene();
+		OBSScene scene = window->GetCurrentScene(false);
+		OBSScene dskScene = window->GetCurrentScene(true);
 		obs_source_t *source = obs_scene_get_source(scene);
+		obs_source_t *dskSource = obs_scene_get_source(dskScene);
 		if (source)
 			obs_source_video_render(source);
+		if (dskSource)
+			obs_source_video_render(dskSource);
 	} else {
 		obs_render_main_texture();
 	}
@@ -3598,7 +3733,7 @@ void OBSBasic::ResetAudioDevice(const char *sourceId, const char *deviceId,
 		settings = obs_data_create();
 		obs_data_set_string(settings, "device_id", deviceId);
 		source = obs_source_create(sourceId, deviceDesc, settings,
-					   nullptr);
+					   nullptr, false);
 		obs_data_release(settings);
 
 		obs_set_output_source(channel, source);
@@ -3696,6 +3831,7 @@ void OBSBasic::ClearSceneData()
 	ClearVolumeControls();
 	ClearListItems(ui->scenes);
 	ui->sources->Clear();
+	ui->dskWidget->Clear();
 	ClearQuickTransitions();
 	ui->transitions->clear();
 
@@ -3705,6 +3841,8 @@ void OBSBasic::ClearSceneData()
 	obs_set_output_source(3, nullptr);
 	obs_set_output_source(4, nullptr);
 	obs_set_output_source(5, nullptr);
+	obs_set_output_source(6, nullptr);
+	obs_set_output_source(7, nullptr);
 	lastScene = nullptr;
 	swapScene = nullptr;
 	programScene = nullptr;
@@ -4067,7 +4205,7 @@ void OBSBasic::on_actionAddScene_triggered()
 			return;
 		}
 
-		obs_scene_t *scene = obs_scene_create(name.c_str());
+		obs_scene_t *scene = obs_scene_create(name.c_str(), false);
 		source = obs_scene_get_source(scene);
 		SetCurrentScene(source);
 		obs_scene_release(scene);
@@ -4290,7 +4428,7 @@ ColorSelect::ColorSelect(QWidget *parent)
 	ui->setupUi(this);
 }
 
-void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
+void OBSBasic::CreateSourcePopupMenu(int idx, bool preview, bool dsk)
 {
 	QMenu popup(this);
 	delete previewProjectorSource;
@@ -4336,15 +4474,32 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 	ui->actionCopyFilters->setEnabled(false);
 	ui->actionCopySource->setEnabled(false);
 
-	if (ui->sources->MultipleBaseSelected()) {
-		popup.addSeparator();
-		popup.addAction(QTStr("Basic.Main.GroupItems"), ui->sources,
-				SLOT(GroupSelectedItems()));
+	if (!dsk) {
+		if (ui->sources->MultipleBaseSelected()) {
+			popup.addSeparator();
+			popup.addAction(QTStr("Basic.Main.GroupItems"),
+					ui->sources,
+					SLOT(GroupSelectedItems()));
 
-	} else if (ui->sources->GroupsSelected()) {
-		popup.addSeparator();
-		popup.addAction(QTStr("Basic.Main.Ungroup"), ui->sources,
-				SLOT(UngroupSelectedGroups()));
+		} else if (ui->sources->GroupsSelected()) {
+			popup.addSeparator();
+			popup.addAction(QTStr("Basic.Main.Ungroup"),
+					ui->sources,
+					SLOT(UngroupSelectedGroups()));
+		}
+	} else {
+		if (ui->dskWidget->MultipleBaseSelected()) {
+			popup.addSeparator();
+			popup.addAction(QTStr("Basic.Main.GroupItems"),
+					ui->dskWidget,
+					SLOT(GroupSelectedItems()));
+
+		} else if (ui->dskWidget->GroupsSelected()) {
+			popup.addSeparator();
+			popup.addAction(QTStr("Basic.Main.Ungroup"),
+					ui->dskWidget,
+					SLOT(UngroupSelectedGroups()));
+		}
 	}
 
 	popup.addSeparator();
@@ -4362,7 +4517,13 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		if (addSourceMenu)
 			popup.addSeparator();
 
-		OBSSceneItem sceneItem = ui->sources->Get(idx);
+		OBSSceneItem sceneItem;
+
+		if (!dsk)
+			sceneItem = ui->sources->Get(idx);
+		else
+			sceneItem = ui->dskWidget->Get(idx);
+
 		obs_source_t *source = obs_sceneitem_get_source(sceneItem);
 		uint32_t flags = obs_source_get_output_flags(source);
 		bool isAsyncVideo = (flags & OBS_SOURCE_ASYNC_VIDEO) ==
@@ -4454,6 +4615,14 @@ void OBSBasic::on_sources_customContextMenuRequested(const QPoint &pos)
 	if (ui->scenes->count()) {
 		QModelIndex idx = ui->sources->indexAt(pos);
 		CreateSourcePopupMenu(idx.row(), false);
+	}
+}
+
+void OBSBasic::on_dskWidget_customContextMenuRequested(const QPoint &pos)
+{
+	if (ui->scenes->count()) {
+		QModelIndex idx = ui->dskWidget->indexAt(pos);
+		CreateSourcePopupMenu(idx.row(), false, true);
 	}
 }
 
@@ -4585,11 +4754,6 @@ void OBSBasic::AddSourcePopupMenu(const QPoint &pos)
 		popup->exec(pos);
 }
 
-void OBSBasic::on_actionAddSource_triggered()
-{
-	AddSourcePopupMenu(QCursor::pos());
-}
-
 static bool remove_items(obs_scene_t *, obs_sceneitem_t *item, void *param)
 {
 	vector<OBSSceneItem> &items =
@@ -4603,11 +4767,66 @@ static bool remove_items(obs_scene_t *, obs_sceneitem_t *item, void *param)
 	return true;
 };
 
+bool OBSBasic::IsDownstreamKeyerActive()
+{
+	return usingDSK;
+}
+
+void OBSBasic::RemoveDownstreamKeyer()
+{
+	if (CountDSKItems() == 0)
+		RemoveScene(obs_scene_get_source(GetDSKScene()));
+}
+
+void OBSBasic::on_actionDSKAddSource_triggered()
+{
+	usingDSK = true;
+
+	if (CountDSKItems() == 0) {
+		OBSScene scene = obs_scene_create(Str("DownstreamKeyer"), true);
+		obs_scene_release(scene);
+	}
+
+	AddSourcePopupMenu(QCursor::pos());
+}
+
+void OBSBasic::on_actionDSKRemoveSource_triggered()
+{
+	usingDSK = true;
+	on_actionRemoveSource_triggered();
+}
+
+void OBSBasic::on_actionDSKSourceProperties_triggered()
+{
+	usingDSK = true;
+	on_actionSourceProperties_triggered();
+}
+
+void OBSBasic::on_actionDSKSourceUp_triggered()
+{
+	usingDSK = true;
+	on_actionSourceUp_triggered();
+}
+
+void OBSBasic::on_actionDSKSourceDown_triggered()
+{
+	usingDSK = true;
+	on_actionSourceDown_triggered();
+}
+
+void OBSBasic::on_actionAddSource_triggered()
+{
+	usingDSK = false;
+	AddSourcePopupMenu(QCursor::pos());
+}
+
 void OBSBasic::on_actionRemoveSource_triggered()
 {
 	vector<OBSSceneItem> items;
 
-	obs_scene_enum_items(GetCurrentScene(), remove_items, &items);
+	OBSScene scene = GetCurrentScene();
+
+	obs_scene_enum_items(scene, remove_items, &items);
 
 	if (!items.size())
 		return;
@@ -4640,6 +4859,13 @@ void OBSBasic::on_actionRemoveSource_triggered()
 				obs_sceneitem_remove(item);
 		}
 	}
+
+	if (CountDSKItems() == 0 && usingDSK) {
+		RemoveScene(obs_scene_get_source(GetDSKScene()));
+		obs_set_output_source(7, nullptr);
+	}
+
+	usingDSK = false;
 }
 
 void OBSBasic::on_actionInteract_triggered()
@@ -4658,18 +4884,22 @@ void OBSBasic::on_actionSourceProperties_triggered()
 
 	if (source)
 		CreatePropertiesWindow(source);
+
+	usingDSK = false;
 }
 
 void OBSBasic::on_actionSourceUp_triggered()
 {
 	OBSSceneItem item = GetCurrentSceneItem();
 	obs_sceneitem_set_order(item, OBS_ORDER_MOVE_UP);
+	usingDSK = false;
 }
 
 void OBSBasic::on_actionSourceDown_triggered()
 {
 	OBSSceneItem item = GetCurrentSceneItem();
 	obs_sceneitem_set_order(item, OBS_ORDER_MOVE_DOWN);
+	usingDSK = false;
 }
 
 void OBSBasic::on_actionMoveUp_triggered()
@@ -5680,9 +5910,23 @@ int OBSBasic::GetTopSelectedSourceItem()
 	return selectedItems.count() ? selectedItems[0].row() : -1;
 }
 
+int OBSBasic::GetTopSelectedDSKSourceItem()
+{
+	QModelIndexList selectedItems =
+		ui->dskWidget->selectionModel()->selectedIndexes();
+	return selectedItems.count() ? selectedItems[0].row() : -1;
+}
+
 void OBSBasic::on_preview_customContextMenuRequested(const QPoint &pos)
 {
-	CreateSourcePopupMenu(GetTopSelectedSourceItem(), true);
+	int idx;
+
+	if (!usingDSK)
+		idx = GetTopSelectedSourceItem();
+	else
+		idx = GetTopSelectedDSKSourceItem();
+
+	CreateSourcePopupMenu(idx, true);
 
 	UNUSED_PARAMETER(pos);
 }
@@ -6543,12 +6787,13 @@ void OBSBasic::on_resetUI_triggered()
 
 	int mixerSize = cx - (cx22_5 * 2 + cx5 * 2);
 
-	QList<QDockWidget *> docks{ui->scenesDock, ui->sourcesDock,
-				   ui->mixerDock, ui->transitionsDock,
-				   ui->controlsDock};
+	QList<QDockWidget *> docks{ui->dskDock,         ui->scenesDock,
+				   ui->sourcesDock,     ui->mixerDock,
+				   ui->transitionsDock, ui->controlsDock};
 
 	QList<int> sizes{cx22_5, cx22_5, mixerSize, cx5, cx5};
 
+	ui->dskDock->setVisible(false);
 	ui->scenesDock->setVisible(true);
 	ui->sourcesDock->setVisible(true);
 	ui->mixerDock->setVisible(true);
@@ -6576,6 +6821,7 @@ void OBSBasic::on_lockUI_toggled(bool lock)
 	ui->mixerDock->setFeatures(mainFeatures);
 	ui->transitionsDock->setFeatures(mainFeatures);
 	ui->controlsDock->setFeatures(mainFeatures);
+	ui->dskDock->setFeatures(features);
 	statsDock->setFeatures(features);
 
 	for (int i = extraDocks.size() - 1; i >= 0; i--) {

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -184,7 +184,7 @@ bool AddNew(QWidget *parent, const char *id, const char *name,
 					   QTStr("NameExists.Text"));
 
 	} else {
-		source = obs_source_create(id, name, NULL, nullptr);
+		source = obs_source_create(id, name, NULL, nullptr, false);
 
 		if (source) {
 			AddSourceData data;
@@ -234,6 +234,11 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 
 void OBSBasicSourceSelect::on_buttonBox_rejected()
 {
+	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+
+	if (main->IsDownstreamKeyerActive())
+		main->RemoveDownstreamKeyer();
+
 	done(DialogCode::Rejected);
 }
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -716,6 +716,8 @@ struct obs_source {
 	enum obs_monitoring_type monitoring_type;
 
 	obs_data_t *private_settings;
+
+	bool is_dsk;
 };
 
 extern struct obs_source_info *get_source_info(const char *id);

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1180,9 +1180,10 @@ const struct obs_source_info group_info = {
 	.enum_active_sources = scene_enum_active_sources,
 	.enum_all_sources = scene_enum_all_sources};
 
-static inline obs_scene_t *create_id(const char *id, const char *name)
+static inline obs_scene_t *create_id(const char *id, const char *name, bool dsk)
 {
-	struct obs_source *source = obs_source_create(id, name, NULL, NULL);
+	struct obs_source *source =
+		obs_source_create(id, name, NULL, NULL, dsk);
 	return source->context.data;
 }
 
@@ -1192,9 +1193,9 @@ static inline obs_scene_t *create_private_id(const char *id, const char *name)
 	return source->context.data;
 }
 
-obs_scene_t *obs_scene_create(const char *name)
+obs_scene_t *obs_scene_create(const char *name, bool dsk)
 {
-	return create_id("scene", name);
+	return create_id("scene", name, dsk);
 }
 
 obs_scene_t *obs_scene_create_private(const char *name)
@@ -1330,7 +1331,7 @@ obs_scene_t *obs_scene_duplicate(obs_scene_t *scene, const char *name,
 
 	new_scene = make_private
 			    ? create_private_id(scene->source->info.id, name)
-			    : create_id(scene->source->info.id, name);
+			    : create_id(scene->source->info.id, name, false);
 
 	obs_source_copy_filters(new_scene->source, scene->source);
 
@@ -2521,7 +2522,7 @@ obs_sceneitem_t *obs_scene_insert_group(obs_scene_t *scene, const char *name,
 			return NULL;
 	}
 
-	obs_scene_t *sub_scene = create_id("group", name);
+	obs_scene_t *sub_scene = create_id("group", name, false);
 	obs_sceneitem_t *last_item = items ? items[count - 1] : NULL;
 
 	obs_sceneitem_t *item =

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -293,7 +293,7 @@ static obs_source_t *obs_source_create_internal(const char *id,
 						const char *name,
 						obs_data_t *settings,
 						obs_data_t *hotkey_data,
-						bool private)
+						bool private, bool dsk)
 {
 	struct obs_source *source = bzalloc(sizeof(struct obs_source));
 
@@ -351,6 +351,8 @@ static obs_source_t *obs_source_create_internal(const char *id,
 	source->flags = source->default_flags;
 	source->enabled = true;
 
+	source->is_dsk = dsk;
+
 	if (!private) {
 		obs_source_dosignal(source, "source_create", NULL);
 	}
@@ -364,16 +366,18 @@ fail:
 }
 
 obs_source_t *obs_source_create(const char *id, const char *name,
-				obs_data_t *settings, obs_data_t *hotkey_data)
+				obs_data_t *settings, obs_data_t *hotkey_data,
+				bool dsk)
 {
 	return obs_source_create_internal(id, name, settings, hotkey_data,
-					  false);
+					  false, dsk);
 }
 
 obs_source_t *obs_source_create_private(const char *id, const char *name,
 					obs_data_t *settings)
 {
-	return obs_source_create_internal(id, name, settings, NULL, true);
+	return obs_source_create_internal(id, name, settings, NULL, true,
+					  false);
 }
 
 static char *get_new_filter_name(obs_source_t *dst, const char *name)
@@ -477,7 +481,7 @@ obs_source_t *obs_source_duplicate(obs_source_t *source, const char *new_name,
 			     ? obs_source_create_private(source->info.id,
 							 new_name, settings)
 			     : obs_source_create(source->info.id, new_name,
-						 settings, NULL);
+						 settings, NULL, false);
 
 	new_source->audio_mixers = source->audio_mixers;
 	new_source->sync_offset = source->sync_offset;
@@ -4390,4 +4394,10 @@ float obs_source_get_balance_value(const obs_source_t *source)
 	return obs_source_valid(source, "obs_source_get_balance_value")
 		       ? source->balance
 		       : 0.5f;
+}
+
+bool obs_source_is_dsk(obs_source_t *source)
+{
+	return obs_source_valid(source, "obs_source_is_dsk") ? source->is_dsk
+							     : false;
 }

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1711,6 +1711,7 @@ static obs_source_t *obs_load_source_type(obs_data_t *source_data)
 {
 	obs_data_array_t *filters = obs_data_get_array(source_data, "filters");
 	obs_source_t *source;
+
 	const char *name = obs_data_get_string(source_data, "name");
 	const char *id = obs_data_get_string(source_data, "id");
 	obs_data_t *settings = obs_data_get_obj(source_data, "settings");
@@ -1723,8 +1724,9 @@ static obs_source_t *obs_load_source_type(obs_data_t *source_data)
 	int di_order;
 	int di_mode;
 	int monitoring_type;
+	bool dsk = obs_data_get_bool(source_data, "is_dsk");
 
-	source = obs_source_create(id, name, settings, hotkeys);
+	source = obs_source_create(id, name, settings, hotkeys, dsk);
 
 	obs_data_release(hotkeys);
 
@@ -1896,6 +1898,7 @@ obs_data_t *obs_save_source(obs_source_t *source)
 	int m_type = (int)obs_source_get_monitoring_type(source);
 	int di_mode = (int)obs_source_get_deinterlace_mode(source);
 	int di_order = (int)obs_source_get_deinterlace_field_order(source);
+	bool dsk = obs_source_is_dsk(source);
 
 	obs_source_save(source);
 	hotkeys = obs_hotkeys_save_source(source);
@@ -1924,6 +1927,7 @@ obs_data_t *obs_save_source(obs_source_t *source)
 	obs_data_set_int(source_data, "deinterlace_mode", di_mode);
 	obs_data_set_int(source_data, "deinterlace_field_order", di_order);
 	obs_data_set_int(source_data, "monitoring_type", m_type);
+	obs_data_set_bool(source_data, "is_dsk", dsk);
 
 	obs_data_set_obj(source_data, "private_settings",
 			 source->private_settings);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -823,7 +823,7 @@ EXPORT const char *obs_source_get_display_name(const char *id);
  */
 EXPORT obs_source_t *obs_source_create(const char *id, const char *name,
 				       obs_data_t *settings,
-				       obs_data_t *hotkey_data);
+				       obs_data_t *hotkey_data, bool dsk);
 
 EXPORT obs_source_t *obs_source_create_private(const char *id, const char *name,
 					       obs_data_t *settings);
@@ -1406,7 +1406,7 @@ EXPORT void obs_transition_swap_end(obs_source_t *tr_dest,
  *   A scene is a source which is a container of other sources with specific
  * display orientations.  Scenes can also be used like any other source.
  */
-EXPORT obs_scene_t *obs_scene_create(const char *name);
+EXPORT obs_scene_t *obs_scene_create(const char *name, bool dsk);
 
 EXPORT obs_scene_t *obs_scene_create_private(const char *name);
 
@@ -2149,6 +2149,8 @@ static inline void obs_source_frame_destroy(struct obs_source_frame *frame)
 
 EXPORT void obs_source_frame_copy(struct obs_source_frame *dst,
 				  const struct obs_source_frame *src);
+
+EXPORT bool obs_source_is_dsk(obs_source_t *source);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This adds the ability for a user to select a scene to be used
as a downstream keyer.

Current issues:
-~~the DSK scene is not always on top~~
-~~the DSK scene item shows up in sources list~~
-~~crash on exit~~