### PR TITLE
obs-x264: Specify x264 color space for BT.601

### DIFF
--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -363,7 +363,7 @@ static inline const char *get_x264_colorspace_name(enum video_colorspace cs)
 	switch (cs) {
 	case VIDEO_CS_DEFAULT:
 	case VIDEO_CS_601:
-		return "undef";
+		return "bt470bg";
 	case VIDEO_CS_709:;
 	}
 


### PR DESCRIPTION
Back in an older commit, the default YUV colorspace was changed to 601
in order to ensure correct playback in video players that ignore the
contents of the H264 header.
x264's "undef" is unfortunately not what players that don't ignore the
header expect for BT.601, resulting in incorrect colors when played
back. Setting it to "bt470bg", similar to what is specified in ffmpeg
outputs, remedies this issue.