### PR TITLE
libobs: add obs_source_frame_copy

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2288,6 +2288,12 @@ static void copy_frame_data(struct obs_source_frame *dst,
 	}
 }
 
+void obs_source_frame_copy(obs_source_frame *dst,
+		const struct obs_source_frame *src)
+{
+	copy_frame_data(dst, src);
+}
+
 static inline bool async_texture_changed(struct obs_source *source,
 		const struct obs_source_frame *frame)
 {

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1991,6 +1991,8 @@ static inline void obs_source_frame_destroy(struct obs_source_frame *frame)
 	}
 }
 
+EXPORT void obs_source_frame_copy(struct obs_source_frame *dst,
+		const struct obs_source_frame *src);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
For a plugin I'm working on I need to copy frames. Now I have a full copy of the internal function copy_frame_data in my code but it would be nice to have an exported function to use in my plugin.

The plugin I'm working on is an in memory replay buffer. The frames of one source are buffered and can be shown in a replay source.