### PR TITLE
UI: Fix mixer dock widget minSize being too big

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -617,12 +617,6 @@
      <item>
       <widget class="QStackedWidget" name="stackedMixerArea">
        <widget class="VScrollArea" name="hMixerScrollArea">
-        <property name="minimumSize">
-         <size>
-          <width>175</width>
-          <height>220</height>
-         </size>
-        </property>
         <property name="contextMenuPolicy">
          <enum>Qt::CustomContextMenu</enum>
         </property>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1560,9 +1560,8 @@ void OBSBasic::OBSInit()
 		}
 	}
 
-	bool vertical = config_get_bool(App()->GlobalConfig(), "BasicWindow",
-			"VerticalVolControl");
-	ui->stackedMixerArea->setCurrentIndex(vertical);
+	ToggleMixerLayout(config_get_bool(App()->GlobalConfig(), "BasicWindow",
+			"VerticalVolControl"));
 
 	if (config_get_bool(basicConfig, "General", "OpenStatsOnStartup"))
 		on_stats_triggered();
@@ -2524,13 +2523,24 @@ void OBSBasic::StackedMixerAreaContextMenuRequested()
 	popup.exec(QCursor::pos());
 }
 
+void OBSBasic::ToggleMixerLayout(bool vertical)
+{
+	if (vertical) {
+		ui->stackedMixerArea->setMinimumSize(180, 220);
+		ui->stackedMixerArea->setCurrentIndex(1);
+	} else {
+		ui->stackedMixerArea->setMinimumSize(220, 0);
+		ui->stackedMixerArea->setCurrentIndex(0);
+	}
+}
+
 void OBSBasic::ToggleVolControlLayout()
 {
 	bool vertical = !config_get_bool(GetGlobalConfig(), "BasicWindow",
 			"VerticalVolControl");
 	config_set_bool(GetGlobalConfig(), "BasicWindow", "VerticalVolControl",
 			vertical);
-	ui->stackedMixerArea->setCurrentIndex(vertical);
+	ToggleMixerLayout(vertical);
 
 	// We need to store it so we can delete current and then add
 	// at the right order

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -252,6 +252,7 @@ private:
 	void GetAudioSourceProperties();
 	void VolControlContextMenu();
 	void ToggleVolControlLayout();
+	void ToggleMixerLayout(bool vertical);
 
 	void RefreshSceneCollections();
 	void ChangeSceneCollection();


### PR DESCRIPTION
When the vertical volume meter was introduced it set in the OBSBasic.ui
mixer dock definition a min width/height that was valid for both
widgets. QStackedWidget hints the minimum size as the higher w/h
of its children so this workaround is necessary.