### PR TITLE
UI: If group names exist, start from 2

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -640,15 +640,15 @@ Qt::DropActions SourceTreeModel::supportedDropActions() const
 QString SourceTreeModel::GetNewGroupName()
 {
 	OBSScene scene = GetCurrentScene();
-	QString name;
+	QString name = QTStr("Group");
 
-	int i = 1;
+	int i = 2;
 	for (;;) {
-		name = QTStr("Basic.Main.Group").arg(QString::number(i++));
 		obs_sceneitem_t *group = obs_scene_get_group(scene,
 				QT_TO_UTF8(name));
 		if (!group)
 			break;
+		name = QTStr("Basic.Main.Group").arg(QString::number(i++));
 	}
 
 	return name;


### PR DESCRIPTION
Currently if you have a group, "Group" for example, and you create
a new group, the dialog will pop up with a default name, but it'll
start with "Group 1" instead of "Group 2".  This fixes that to start
from 2 instead.