### PR TITLE
UI: Hide preview for sources and filters where possible

### DIFF
--- a/UI/forms/OBSBasicFilters.ui
+++ b/UI/forms/OBSBasicFilters.ui
@@ -391,6 +391,19 @@
         </layout>
        </item>
        <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <property name="spacing">
           <number>4</number>

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -72,6 +72,8 @@ private:
 
 	bool isAsync;
 
+	int noPreviewMargin;
+
 private slots:
 	void AddFilter(OBSSource filter);
 	void RemoveFilter(OBSSource filter);

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -114,15 +114,19 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 		obs_display_add_draw_callback(preview->GetDisplay(),
 				OBSBasicProperties::DrawPreview, this);
 	};
-
 	enum obs_source_type type = obs_source_get_type(source);
 	uint32_t caps = obs_source_get_output_flags(source);
 	bool drawable_type = type == OBS_SOURCE_TYPE_INPUT ||
 		type == OBS_SOURCE_TYPE_SCENE;
+	bool drawable_preview = (caps & OBS_SOURCE_VIDEO) != 0;
 
-	if (drawable_type && (caps & OBS_SOURCE_VIDEO) != 0)
+	if (drawable_preview && drawable_type) {
+		preview->show();
 		connect(preview.data(), &OBSQTDisplay::DisplayCreated,
 				addDrawCallback);
+	} else {
+		preview->hide();
+	}
 }
 
 OBSBasicProperties::~OBSBasicProperties()


### PR DESCRIPTION
Hides the preview window for audio sources in the properties menu and
contextually in the filters menu to save on gui space.
![2018-06-14_19-06-18](https://user-images.githubusercontent.com/25020235/41446741-36d15092-7006-11e8-9c4d-88820ac76e0e.gif)

