### PR TITLE
UI: If group's name exist, start it from 2

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -640,15 +640,15 @@ Qt::DropActions SourceTreeModel::supportedDropActions() const
 QString SourceTreeModel::GetNewGroupName()
 {
 	OBSScene scene = GetCurrentScene();
-	QString name;
+	QString name = QTStr("Group");
 
-	int i = 1;
+	int i = 2;
 	for (;;) {
-		name = QTStr("Basic.Main.Group").arg(QString::number(i++));
 		obs_sceneitem_t *group = obs_scene_get_group(scene,
 				QT_TO_UTF8(name));
 		if (!group)
 			break;
+		name = QTStr("Basic.Main.Group").arg(QString::number(i++));
 	}
 
 	return name;


### PR DESCRIPTION
Currently if you making a new group it named "Group 1" by default
instead of just "Group". This fixes it. The second group will be
named "Group 2".

In accordance with 133fa04