### PR TITLE
UI: Add screenshot feature.

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -462,6 +462,9 @@ Basic.Main.ForceStopStreaming="Stop Streaming (discard delay)"
 Basic.Main.Group="Group %1"
 Basic.Main.GroupItems="Group Selected Items"
 Basic.Main.Ungroup="Ungroup"
+Basic.Main.TakeScreenshot="Capture Screenshot"
+Basic.Main.TakeScreenshot.ErrorTitle="Error"
+Basic.Main.TakeScreenshot.ErrorMessage="Unable to capture a screenshot due to an internal error. Please check the log file for additional details."
 
 # basic mode file menu
 Basic.MainMenu.File="&File"

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -314,6 +314,7 @@
      <string>Basic.MainMenu.Tools</string>
     </property>
     <addaction name="autoConfigure"/>
+    <addaction name="actionTakeScreenshot"/>
     <addaction name="separator"/>
    </widget>
    <addaction name="menu_File"/>
@@ -1654,6 +1655,14 @@
   <action name="actionUploadLastCrashLog">
    <property name="text">
     <string>Basic.MainMenu.Help.CrashLogs.UploadLastLog</string>
+   </property>
+  </action>
+  <action name="actionTakeScreenshot">
+   <property name="text">
+    <string>Basic.Main.TakeScreenshot</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+S</string>
    </property>
   </action>
  </widget>

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -663,6 +663,7 @@ private slots:
 	void on_modeSwitch_clicked();
 
 	void on_autoConfigure_triggered();
+	void on_actionTakeScreenshot_triggered();
 	void on_stats_triggered();
 
 	void on_resetUI_triggered();
@@ -705,6 +706,8 @@ private slots:
 	void OpenSourceWindow();
 	void OpenMultiviewWindow();
 	void OpenSceneWindow();
+
+	void TakeScreenshot();
 
 	void DeferredLoad(const QString &file, int requeueCount);
 

--- a/libobs/graphics/graphics-magick.c
+++ b/libobs/graphics/graphics-magick.c
@@ -67,3 +67,13 @@ uint8_t *gs_create_texture_file_data(const char *file,
 
 	return data;
 }
+
+uint32_t
+gs_texture_save_buffer_to_file(const char *buffer, int width,
+	int height, const char *file)
+{
+	blog(LOG_ERROR, "Saving textures to file is not currently"
+			"supported in the ImageMagick backend.");
+
+	return 0;
+}

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -523,6 +523,8 @@ EXPORT gs_texture_t *gs_texture_create_from_file(const char *file);
 EXPORT uint8_t *gs_create_texture_file_data(const char *file,
 		enum gs_color_format *format, uint32_t *cx, uint32_t *cy);
 
+EXPORT uint32_t gs_texture_save_to_file(gs_texture_t *texture, const char *file);
+
 #define GS_FLIP_U (1<<0)
 #define GS_FLIP_V (1<<1)
 


### PR DESCRIPTION
This adds an option to the main window to take a screenshot of the current
frame from the preview pane. The option is shown in the preview pane's
context menu and included in the Tools menu. The shortcut "Ctrl+Shift+S"
is also configured.

Images are saved to the same output directory as recordings, and are saved
only in .png format.

Existing features from libobs are used to capture the current texture into
a buffer. A new function is added to libobs to handle encoding and writing
an image file given a raw buffer.

This has been tested to work with both OpenGL and DX11 rendering backends.

The image encoding is currently only implemented when built with FFmpeg.
It will fail gracefully with an error message if ImageMagick is used
for the image handling backend.