### PR TITLE
CI: Update Sparkle default base_url

### DIFF
--- a/CI/before-deploy-osx.sh
+++ b/CI/before-deploy-osx.sh
@@ -30,7 +30,7 @@ if [ -n "${TRAVIS_TAG}" ]; then
   STABLE=true
 fi
 
-sudo python ../CI/install/osx/build_app.py --public-key ../CI/install/osx/OBSPublicDSAKey.pem --sparkle-framework ../../sparkle/Sparkle.framework --base-url "https://obsproject.com/osx_update" --stable=$STABLE
+sudo python ../CI/install/osx/build_app.py --public-key ../CI/install/osx/OBSPublicDSAKey.pem --sparkle-framework ../../sparkle/Sparkle.framework --stable=$STABLE
 
 # Copy Chromium embedded framework to app Frameworks directory
 hr "Copying Chromium Embedded Framework.framework"

--- a/CI/install/osx/build_app.py
+++ b/CI/install/osx/build_app.py
@@ -45,7 +45,7 @@ parser.add_argument('-d', '--base-dir', dest='dir', default='rundir/RelWithDebIn
 parser.add_argument('-n', '--build-number', dest='build_number', default='0')
 parser.add_argument('-k', '--public-key', dest='public_key', default='OBSPublicDSAKey.pem')
 parser.add_argument('-f', '--sparkle-framework', dest='sparkle', default=None)
-parser.add_argument('-b', '--base-url', dest='base_url', default='https://builds.catchexception.org/obs-studio')
+parser.add_argument('-b', '--base-url', dest='base_url', default='https://obsproject.com/osx_update')
 parser.add_argument('-u', '--user', dest='user', default='jp9000')
 parser.add_argument('-c', '--channel', dest='channel', default='master')
 add_boolean_argument(parser, 'stable', default=False)


### PR DESCRIPTION
This updates the default base_url used to make Sparkle Update Feed URLs (`SUFeedURL`).  The current default hasn't worked in some time, so it doesn't make sense to have it remain the default.

@DDRBoxman Can you sanity check this please?  There are other aspects for Feed URLs that probably should be looked at (non-stable `SUFeedUrl`, `OBSFeedsURL`), but I wanted to keep this simple for now.