### PR TITLE
libobs: Rework code for checking Mac audio device capabilities for mo…

### DIFF
--- a/libobs/audio-monitoring/osx/coreaudio-enum-devices.c
+++ b/libobs/audio-monitoring/osx/coreaudio-enum-devices.c
@@ -25,16 +25,14 @@ static bool obs_enum_audio_monitoring_device(obs_enum_audio_device_cb cb,
 
 	AudioObjectPropertyAddress addr = {
 		kAudioDevicePropertyStreams,
-		kAudioDevicePropertyScopeInput,
+		kAudioDevicePropertyScopeOutput,
 		kAudioObjectPropertyElementMaster
 	};
 
-	/* check to see if it's a mac input device */
-	if (!allow_inputs) {
-		AudioObjectGetPropertyDataSize(id, &addr, 0, NULL, &size);
-		if (size)
-			return true;
-	}
+	/* Check if the device is capable of audio output. */
+	AudioObjectGetPropertyDataSize(id, &addr, 0, NULL, &size);
+	if (!allow_inputs && !size)
+		return true;
 
 	size = sizeof(CFStringRef);
 

--- a/libobs/audio-monitoring/osx/coreaudio-output.c
+++ b/libobs/audio-monitoring/osx/coreaudio-output.c
@@ -193,10 +193,10 @@ static bool audio_monitor_init(struct audio_monitor *monitor,
 	}
 
 	if (strcmp(uid, "default") != 0) {
-		CFStringRef cf_uid = CFStringCreateWithBytesNoCopy(NULL,
+		CFStringRef cf_uid = CFStringCreateWithBytes(NULL,
 				(const UInt8*)uid, strlen(uid),
 				kCFStringEncodingUTF8,
-				false, NULL);
+				false);
 
 		stat = AudioQueueSetProperty(monitor->queue,
 				kAudioQueueProperty_CurrentDevice,

--- a/libobs/audio-monitoring/osx/coreaudio-output.c
+++ b/libobs/audio-monitoring/osx/coreaudio-output.c
@@ -200,7 +200,7 @@ static bool audio_monitor_init(struct audio_monitor *monitor,
 
 		stat = AudioQueueSetProperty(monitor->queue,
 				kAudioQueueProperty_CurrentDevice,
-				cf_uid, sizeof(cf_uid));
+				&cf_uid, sizeof(cf_uid));
 		CFRelease(cf_uid);
 
 		if (!success(stat, "set current device")) {

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2016,7 +2016,7 @@ bool obs_set_audio_monitoring_device(const char *name, const char *id)
 	if (!obs || !name || !id || !*name || !*id)
 		return false;
 
-#if defined(_WIN32) || HAVE_PULSEAUDIO
+#if defined(_WIN32) || HAVE_PULSEAUDIO || defined(__APPLE__)
 	pthread_mutex_lock(&obs->audio.monitoring_mutex);
 
 	if (strcmp(id, obs->audio.monitoring_device_id) == 0) {


### PR DESCRIPTION
…nitoring

As of commit 2eb5a22, CoreAudio devices that use one device handle for both
input and output can no longer be used for audio monitoring. This commit
fixes that.

Tested with the built-in output, a Magewell XI100DUSB-HDMI which is input
only, and a MOTU UltraLite audio interface, which shows as output/input
capable.