### PR TITLE
libobs/UI: Allow Access To argc/argv

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1981,6 +1981,8 @@ int main(int argc, char *argv[])
 	move_to_xdg();
 #endif
 
+	obs_set_cmdline_args(argc, argv);
+
 	for (int i = 1; i < argc; i++) {
 		if (arg_is(argv[i], "--portable", "-p")) {
 			portable_mode = true;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -239,6 +239,12 @@ struct obs_source_frame {
 	bool                prev_frame;
 };
 
+/** Access to the argc/argv used to start OBS. What you see is what you get. */
+struct obs_cmdline_args {
+	int argc;
+	char **argv;
+};
+
 /* ------------------------------------------------------------------------- */
 /* OBS context */
 
@@ -290,6 +296,24 @@ EXPORT uint32_t obs_get_version(void);
 
 /** @return The current core version string */
 EXPORT const char *obs_get_version_string(void);
+
+/**
+ * Sets things up for calls to obs_get_cmdline_args. Called onl yonce at startup
+ * and safely copies argv/argc from main(). Subsequent calls do nothing.
+ *
+ * @param  argc  The count of command line arguments, from main()
+ * @param  argv  An array of command line arguments, copied from main() and ends
+ *               with NULL.
+ */
+EXPORT void obs_set_cmdline_args(int argc, char **argv);
+
+/**
+ * Get the argc/argv used to start OBS
+ *
+ * @return  The command line arguments used for main(). Don't modify this or
+ *          you'll mess things up for other callers.
+ */
+EXPORT struct obs_cmdline_args obs_get_cmdline_args(void);
 
 /**
  * Sets a new locale to use for modules.  This will call obs_module_set_locale


### PR DESCRIPTION
This paves the way for plugins to have access to the argc/argv used when
spawning OBS. Notably, this will allow a patch to obs-browser that passes
through command line arguments on macOS to CEF.