### PR TITLE
obs-ffmpeg: Enable multiple audio tracks for FFmpeg output

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -2247,7 +2247,7 @@
                              <number>0</number>
                             </property>
                             <item>
-                             <widget class="QRadioButton" name="advOutFFTrack1">
+                             <widget class="QCheckBox" name="advOutFFTrack1">
                               <property name="text">
                                <string notr="true">1</string>
                               </property>
@@ -2257,35 +2257,35 @@
                              </widget>
                             </item>
                             <item>
-                             <widget class="QRadioButton" name="advOutFFTrack2">
+                             <widget class="QCheckBox" name="advOutFFTrack2">
                               <property name="text">
                                <string notr="true">2</string>
                               </property>
                              </widget>
                             </item>
                             <item>
-                             <widget class="QRadioButton" name="advOutFFTrack3">
+                             <widget class="QCheckBox" name="advOutFFTrack3">
                               <property name="text">
                                <string notr="true">3</string>
                               </property>
                              </widget>
                             </item>
                             <item>
-                             <widget class="QRadioButton" name="advOutFFTrack4">
+                             <widget class="QCheckBox" name="advOutFFTrack4">
                               <property name="text">
                                <string notr="true">4</string>
                               </property>
                              </widget>
                             </item>
                             <item>
-                             <widget class="QRadioButton" name="advOutFFTrack5">
+                             <widget class="QCheckBox" name="advOutFFTrack5">
                               <property name="text">
                                <string notr="true">5</string>
                               </property>
                              </widget>
                             </item>
                             <item>
-                             <widget class="QRadioButton" name="advOutFFTrack6">
+                             <widget class="QCheckBox" name="advOutFFTrack6">
                               <property name="text">
                                <string notr="true">6</string>
                               </property>

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1311,6 +1311,7 @@ inline void AdvancedOutput::SetupFFmpeg()
 	const char *aEncCustom = config_get_string(main->Config(), "AdvOut",
 			"FFACustom");
 	obs_data_t *settings = obs_data_create();
+	int number_mixes = 0;
 
 	obs_data_set_string(settings, "url", url);
 	obs_data_set_string(settings, "format_name", formatName);
@@ -1336,8 +1337,13 @@ inline void AdvancedOutput::SetupFFmpeg()
 			obs_data_set_int(settings, "scale_height", height);
 		}
 	}
-
-	obs_output_set_mixer(fileOutput, aTrack - 1);
+	for (int i = 0; i < MAX_AUDIO_MIXES; i++) {
+		if ((aTrack & (1 << i)) != 0)
+			number_mixes++;
+	}
+	obs_data_set_int(settings, "number_mixes", number_mixes);
+	// atrack is a bitmask storing the indexes of the mixes selected.
+	obs_data_set_int(settings, "audio_tracks", aTrack);
 	obs_output_set_media(fileOutput, obs_get_video(), obs_get_audio());
 	obs_output_update(fileOutput, settings);
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1800,14 +1800,12 @@ void OBSBasicSettings::LoadAdvOutputFFmpegSettings()
 	SelectEncoder(ui->advOutFFAEncoder, aEncoder, aEncoderId);
 	ui->advOutFFACfg->setText(aEncCustom);
 
-	switch (audioTrack) {
-	case 1: ui->advOutFFTrack1->setChecked(true); break;
-	case 2: ui->advOutFFTrack2->setChecked(true); break;
-	case 3: ui->advOutFFTrack3->setChecked(true); break;
-	case 4: ui->advOutFFTrack4->setChecked(true); break;
-	case 5: ui->advOutFFTrack5->setChecked(true); break;
-	case 6: ui->advOutFFTrack6->setChecked(true); break;
-	}
+	ui->advOutFFTrack1->setChecked(audioTrack & (1 << 0));
+	ui->advOutFFTrack2->setChecked(audioTrack & (1 << 1));
+	ui->advOutFFTrack3->setChecked(audioTrack & (1 << 2));
+	ui->advOutFFTrack4->setChecked(audioTrack & (1 << 3));
+	ui->advOutFFTrack5->setChecked(audioTrack & (1 << 4));
+	ui->advOutFFTrack6->setChecked(audioTrack & (1 << 5));
 }
 
 void OBSBasicSettings::LoadAdvOutputAudioSettings()
@@ -3128,11 +3126,13 @@ void OBSBasicSettings::SaveOutputSettings()
 	SaveSpinBox(ui->advOutFFABitrate, "AdvOut", "FFABitrate");
 	SaveEncoder(ui->advOutFFAEncoder, "AdvOut", "FFAEncoder");
 	SaveEdit(ui->advOutFFACfg, "AdvOut", "FFACustom");
-	SaveTrackIndex(main->Config(), "AdvOut", "FFAudioTrack",
-			ui->advOutFFTrack1, ui->advOutFFTrack2,
-			ui->advOutFFTrack3, ui->advOutFFTrack4,
-			ui->advOutFFTrack5, ui->advOutFFTrack6);
-
+	config_set_int(main->Config(), "AdvOut", "FFAudioTrack",
+			(ui->advOutFFTrack1->isChecked() ? (1 << 0) : 0) |
+			(ui->advOutFFTrack2->isChecked() ? (1 << 1) : 0) |
+			(ui->advOutFFTrack3->isChecked() ? (1 << 2) : 0) |
+			(ui->advOutFFTrack4->isChecked() ? (1 << 3) : 0) |
+			(ui->advOutFFTrack5->isChecked() ? (1 << 4) : 0) |
+			(ui->advOutFFTrack6->isChecked() ? (1 << 5) : 0));
 	SaveCombo(ui->advOutTrack1Bitrate, "AdvOut", "Track1Bitrate");
 	SaveCombo(ui->advOutTrack2Bitrate, "AdvOut", "Track2Bitrate");
 	SaveCombo(ui->advOutTrack3Bitrate, "AdvOut", "Track3Bitrate");

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -675,8 +675,12 @@ void obs_register_output_s(const struct obs_output_info *info, size_t size)
 			CHECK_REQUIRED_VAL_(info, raw_video,
 					obs_register_output);
 
-		if (info->flags & OBS_OUTPUT_AUDIO)
+		if (info->flags & OBS_OUTPUT_AUDIO && info->raw_audio)
 			CHECK_REQUIRED_VAL_(info, raw_audio,
+					obs_register_output);
+
+		if (info->flags & OBS_OUTPUT_AUDIO & OBS_OUTPUT_MULTI_TRACK)
+			CHECK_REQUIRED_VAL_(info, raw_audio2,
 					obs_register_output);
 	}
 #undef CHECK_REQUIRED_VAL_

--- a/libobs/obs-output.h
+++ b/libobs/obs-output.h
@@ -71,6 +71,8 @@ struct obs_output_info {
 	/* only used with encoded outputs, separated with semicolon */
 	const char *encoded_video_codecs;
 	const char *encoded_audio_codecs;
+	/* raw audio for ffmpeg multi track */
+	void (*raw_audio2)(void *data, int idx, struct audio_data *frames);
 };
 
 EXPORT void obs_register_output_s(const struct obs_output_info *info,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -45,6 +45,8 @@ struct ffmpeg_cfg {
 	int                audio_encoder_id;
 	const char         *video_settings;
 	const char         *audio_settings;
+	int                number_audio_mixes;
+	int                audio_tracks;
 	enum AVPixelFormat format;
 	enum AVColorRange  color_range;
 	enum AVColorSpace  color_space;
@@ -56,7 +58,7 @@ struct ffmpeg_cfg {
 
 struct ffmpeg_data {
 	AVStream           *video;
-	AVStream           *audio;
+	AVStream           **audio_streams;
 	AVCodec            *acodec;
 	AVCodec            *vcodec;
 	AVFormatContext    *output;
@@ -68,14 +70,17 @@ struct ffmpeg_data {
 
 	uint64_t           start_timestamp;
 
-	int64_t            total_samples;
+	int64_t            total_samples[MAX_AUDIO_MIXES];
 	uint32_t           audio_samplerate;
 	enum audio_format  audio_format;
 	size_t             audio_planes;
 	size_t             audio_size;
-	struct circlebuf   excess_frames[MAX_AV_PLANES];
-	uint8_t            *samples[MAX_AV_PLANES];
-	AVFrame            *aframe;
+	int                num_audio_streams;
+	//audio_tracks is a bitmask storing the indexes of the mixes selected.
+	int                audio_tracks;
+	struct circlebuf   excess_frames[MAX_AUDIO_MIXES][MAX_AV_PLANES];
+	uint8_t            *samples[MAX_AUDIO_MIXES][MAX_AV_PLANES];
+	AVFrame            *aframe[MAX_AUDIO_MIXES];
 
 	struct ffmpeg_cfg  config;
 
@@ -273,9 +278,9 @@ static bool create_video_stream(struct ffmpeg_data *data)
 	return true;
 }
 
-static bool open_audio_codec(struct ffmpeg_data *data)
+static bool open_audio_codec(struct ffmpeg_data *data, int idx)
 {
-	AVCodecContext *context = data->audio->codec;
+	AVCodecContext *context = data->audio_streams[idx]->codec;
 	char **opts = strlist_split(data->config.audio_settings, ' ', false);
 	int ret;
 
@@ -284,16 +289,16 @@ static bool open_audio_codec(struct ffmpeg_data *data)
 		strlist_free(opts);
 	}
 
-	data->aframe = av_frame_alloc();
-	if (!data->aframe) {
+	data->aframe[idx] = av_frame_alloc();
+	if (!data->aframe[idx]) {
 		blog(LOG_WARNING, "Failed to allocate audio frame");
 		return false;
 	}
 
-	data->aframe->format = context->sample_fmt;
-	data->aframe->channels = context->channels;
-	data->aframe->channel_layout = context->channel_layout;
-	data->aframe->sample_rate = context->sample_rate;
+	data->aframe[idx]->format = context->sample_fmt;
+	data->aframe[idx]->channels = context->channels;
+	data->aframe[idx]->channel_layout = context->channel_layout;
+	data->aframe[idx]->sample_rate = context->sample_rate;
 
 	context->strict_std_compliance = -2;
 
@@ -306,7 +311,7 @@ static bool open_audio_codec(struct ffmpeg_data *data)
 
 	data->frame_size = context->frame_size ? context->frame_size : 1024;
 
-	ret = av_samples_alloc(data->samples, NULL, context->channels,
+	ret = av_samples_alloc(data->samples[idx], NULL, context->channels,
 			data->frame_size, context->sample_fmt, 0);
 	if (ret < 0) {
 		blog(LOG_WARNING, "Failed to create audio buffer: %s",
@@ -317,9 +322,10 @@ static bool open_audio_codec(struct ffmpeg_data *data)
 	return true;
 }
 
-static bool create_audio_stream(struct ffmpeg_data *data)
+static bool create_audio_stream(struct ffmpeg_data *data, int idx)
 {
 	AVCodecContext *context;
+	AVStream *stream;
 	struct obs_audio_info aoi;
 
 	if (!obs_get_audio_info(&aoi)) {
@@ -327,17 +333,18 @@ static bool create_audio_stream(struct ffmpeg_data *data)
 		return false;
 	}
 
-	if (!new_stream(data, &data->audio, &data->acodec,
+	if (!new_stream(data, &stream, &data->acodec,
 				data->output->oformat->audio_codec,
 				data->config.audio_encoder))
 		return false;
 
-	context              = data->audio->codec;
-	context->bit_rate    = data->config.audio_bitrate * 1000;
-	context->time_base   = (AVRational){ 1, aoi.samples_per_sec };
-	context->channels    = get_audio_channels(aoi.speakers);
-	context->sample_rate = aoi.samples_per_sec;
-	context->channel_layout =
+	data->audio_streams[idx] = stream;
+	context                  = data->audio_streams[idx]->codec;
+	context->bit_rate        = data->config.audio_bitrate * 1000;
+	context->time_base       = (AVRational){ 1, aoi.samples_per_sec };
+	context->channels        = get_audio_channels(aoi.speakers);
+	context->sample_rate     = aoi.samples_per_sec;
+	context->channel_layout  =
 			av_get_default_channel_layout(context->channels);
 
 	//AVlib default channel layout for 5 channels is 5.0 ; fix for 4.1
@@ -347,7 +354,7 @@ static bool create_audio_stream(struct ffmpeg_data *data)
 	context->sample_fmt  = data->acodec->sample_fmts ?
 		data->acodec->sample_fmts[0] : AV_SAMPLE_FMT_FLTP;
 
-	data->audio->time_base = context->time_base;
+	data->audio_streams[idx]->time_base = context->time_base;
 
 	data->audio_samplerate = aoi.samples_per_sec;
 	data->audio_format = convert_ffmpeg_sample_format(context->sample_fmt);
@@ -357,7 +364,7 @@ static bool create_audio_stream(struct ffmpeg_data *data)
 	if (data->output->oformat->flags & AVFMT_GLOBALHEADER)
 		context->flags |= CODEC_FLAG_GLOBAL_H;
 
-	return open_audio_codec(data);
+	return open_audio_codec(data, idx);
 }
 
 static inline bool init_streams(struct ffmpeg_data *data)
@@ -368,9 +375,14 @@ static inline bool init_streams(struct ffmpeg_data *data)
 		if (!create_video_stream(data))
 			return false;
 
-	if (format->audio_codec != AV_CODEC_ID_NONE)
-		if (!create_audio_stream(data))
-			return false;
+	if (format->audio_codec != AV_CODEC_ID_NONE && data->num_audio_streams) {
+		data->audio_streams = calloc(1,
+				data->num_audio_streams * sizeof(void*));
+		for (int i = 0; i < data->num_audio_streams; i++) {
+			if (!create_audio_stream(data, i))
+				return false;
+		}
+	}
 
 	return true;
 }
@@ -457,12 +469,14 @@ static void close_video(struct ffmpeg_data *data)
 
 static void close_audio(struct ffmpeg_data *data)
 {
-	for (size_t i = 0; i < MAX_AV_PLANES; i++)
-		circlebuf_free(&data->excess_frames[i]);
+	for (int idx = 0; idx < data->num_audio_streams; idx++) {
+		for (size_t i = 0; i < MAX_AV_PLANES; i++)
+			circlebuf_free(&data->excess_frames[idx][i]);
 
-	av_freep(&data->samples[0]);
-	avcodec_close(data->audio->codec);
-	av_frame_free(&data->aframe);
+		av_freep(&data->samples[idx][0]);
+		avcodec_close(data->audio_streams[idx]->codec);
+		av_frame_free(&data->aframe[idx]);
+	}
 }
 
 static void ffmpeg_data_free(struct ffmpeg_data *data)
@@ -472,8 +486,11 @@ static void ffmpeg_data_free(struct ffmpeg_data *data)
 
 	if (data->video)
 		close_video(data);
-	if (data->audio)
+	if (data->audio_streams) {
 		close_audio(data);
+		free(data->audio_streams);
+		data->audio_streams = NULL;
+	}
 
 	if (data->output) {
 		if ((data->output->oformat->flags & AVFMT_NOFILE) == 0)
@@ -528,7 +545,8 @@ static bool ffmpeg_data_init(struct ffmpeg_data *data,
 
 	memset(data, 0, sizeof(struct ffmpeg_data));
 	data->config = *config;
-
+	data->num_audio_streams = config->number_audio_mixes;
+	data->audio_tracks = config->audio_tracks;
 	if (!config->url || !*config->url)
 		return false;
 
@@ -766,7 +784,7 @@ static void receive_video(void *param, struct video_data *frame)
 	data->total_frames++;
 }
 
-static void encode_audio(struct ffmpeg_output *output,
+static void encode_audio(struct ffmpeg_output *output, int idx,
 		struct AVCodecContext *context, size_t block_size)
 {
 	struct ffmpeg_data *data = &output->ff_data;
@@ -775,13 +793,13 @@ static void encode_audio(struct ffmpeg_output *output,
 	int ret, got_packet;
 	size_t total_size = data->frame_size * block_size * context->channels;
 
-	data->aframe->nb_samples = data->frame_size;
-	data->aframe->pts = av_rescale_q(data->total_samples,
+	data->aframe[idx]->nb_samples = data->frame_size;
+	data->aframe[idx]->pts = av_rescale_q(data->total_samples[idx],
 			(AVRational){1, context->sample_rate},
 			context->time_base);
 
-	ret = avcodec_fill_audio_frame(data->aframe, context->channels,
-			context->sample_fmt, data->samples[0],
+	ret = avcodec_fill_audio_frame(data->aframe[idx], context->channels,
+			context->sample_fmt, data->samples[idx][0],
 			(int)total_size, 1);
 	if (ret < 0) {
 		blog(LOG_WARNING, "encode_audio: avcodec_fill_audio_frame "
@@ -789,10 +807,10 @@ static void encode_audio(struct ffmpeg_output *output,
 		return;
 	}
 
-	data->total_samples += data->frame_size;
+	data->total_samples[idx] += data->frame_size;
 
 #if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 40, 101)
-	ret = avcodec_send_frame(context, data->aframe);
+	ret = avcodec_send_frame(context, data->aframe[idx]);
 	if (ret == 0)
 		ret = avcodec_receive_packet(context, &packet);
 
@@ -801,7 +819,7 @@ static void encode_audio(struct ffmpeg_output *output,
 	if (ret == AVERROR_EOF || ret == AVERROR(EAGAIN))
 		ret = 0;
 #else
-	ret = avcodec_encode_audio2(context, &packet, data->aframe,
+	ret = avcodec_encode_audio2(context, &packet, data->aframe[idx],
 			&got_packet);
 #endif
 	if (ret < 0) {
@@ -813,11 +831,13 @@ static void encode_audio(struct ffmpeg_output *output,
 	if (!got_packet)
 		return;
 
-	packet.pts = rescale_ts(packet.pts, context, data->audio->time_base);
-	packet.dts = rescale_ts(packet.dts, context, data->audio->time_base);
+	packet.pts = rescale_ts(packet.pts, context,
+			data->audio_streams[idx]->time_base);
+	packet.dts = rescale_ts(packet.dts, context,
+			data->audio_streams[idx]->time_base);
 	packet.duration = (int)av_rescale_q(packet.duration, context->time_base,
-			data->audio->time_base);
-	packet.stream_index = data->audio->index;
+			data->audio_streams[idx]->time_base);
+	packet.stream_index = data->audio_streams[idx]->index;
 
 	pthread_mutex_lock(&output->write_mutex);
 	da_push_back(output->packets, &packet);
@@ -853,18 +873,35 @@ static bool prepare_audio(struct ffmpeg_data *data,
 	return true;
 }
 
-static void receive_audio(void *param, struct audio_data *frame)
+/* Given a bitmask for the selected tracks and the mix index,
+ * this returns the stream index which will be passed to the muxer.
+ */
+int getTrackOrder(int track_config, int mix_index)
+{
+	int position = 0;
+	for (int i = 0; i < mix_index; i++) {
+		if (track_config & 1 << i)
+			position++;
+	}
+	return position;
+}
+
+static void receive_audio(void *param, int mix_idx, struct audio_data *frame)
 {
 	struct ffmpeg_output *output = param;
 	struct ffmpeg_data   *data   = &output->ff_data;
 	size_t frame_size_bytes;
 	struct audio_data in;
+	int track_order;
 
-	// codec doesn't support audio or none configured
-	if (!data->audio)
+	// check that the track was selected
+	if (!(data->audio_tracks & (1 << mix_idx )))
 		return;
 
-	AVCodecContext *context = data->audio->codec;
+	// get track order (first selected, etc ...)
+	track_order = getTrackOrder(data->audio_tracks, mix_idx);
+
+	AVCodecContext *context = data->audio_streams[track_order]->codec;
 
 	if (!data->start_timestamp)
 		return;
@@ -877,15 +914,16 @@ static void receive_audio(void *param, struct audio_data *frame)
 	frame_size_bytes = (size_t)data->frame_size * data->audio_size;
 
 	for (size_t i = 0; i < data->audio_planes; i++)
-		circlebuf_push_back(&data->excess_frames[i], in.data[i],
-				in.frames * data->audio_size);
+		circlebuf_push_back(&data->excess_frames[track_order][i],
+				in.data[i], in.frames * data->audio_size);
 
-	while (data->excess_frames[0].size >= frame_size_bytes) {
+	while (data->excess_frames[track_order][0].size >= frame_size_bytes) {
 		for (size_t i = 0; i < data->audio_planes; i++)
-			circlebuf_pop_front(&data->excess_frames[i],
-					data->samples[i], frame_size_bytes);
+			circlebuf_pop_front(&data->excess_frames[track_order][i],
+					data->samples[track_order][i],
+					frame_size_bytes);
 
-		encode_audio(output, context, data->audio_size);
+		encode_audio(output, track_order, context, data->audio_size);
 	}
 }
 
@@ -901,7 +939,7 @@ static uint64_t get_packet_sys_dts(struct ffmpeg_output *output,
 		time_base = data->video->time_base;
 		start_ts = output->video_start_ts;
 	} else {
-		time_base = data->audio->time_base;
+		time_base = data->audio_streams[0]->time_base;
 		start_ts = output->audio_start_ts;
 	}
 
@@ -1025,6 +1063,8 @@ static bool try_connect(struct ffmpeg_output *output)
 	config.height = (int)obs_output_get_height(output->output);
 	config.format = obs_to_ffmpeg_video_format(
 			video_output_get_format(video));
+	config.number_audio_mixes = (int)obs_data_get_int(settings, "number_mixes");
+	config.audio_tracks = (int)obs_data_get_int(settings, "audio_tracks");
 
 	if (format_is_yuv(voi->format)) {
 		config.color_range = voi->range == VIDEO_RANGE_FULL ?
@@ -1157,13 +1197,14 @@ static uint64_t ffmpeg_output_total_bytes(void *data)
 
 struct obs_output_info ffmpeg_output = {
 	.id        = "ffmpeg_output",
-	.flags     = OBS_OUTPUT_AUDIO | OBS_OUTPUT_VIDEO,
+	.flags     = OBS_OUTPUT_AUDIO | OBS_OUTPUT_VIDEO |
+			OBS_OUTPUT_MULTI_TRACK,
 	.get_name  = ffmpeg_output_getname,
 	.create    = ffmpeg_output_create,
 	.destroy   = ffmpeg_output_destroy,
 	.start     = ffmpeg_output_start,
 	.stop      = ffmpeg_output_stop,
 	.raw_video = receive_video,
-	.raw_audio = receive_audio,
+	.raw_audio2 = receive_audio,
 	.get_total_bytes = ffmpeg_output_total_bytes,
 };


### PR DESCRIPTION
Also changes UI, libobs/obs-output.
This allows multiple audio tracks as in Advanced (Standard) Recording modes.

![capture](https://user-images.githubusercontent.com/9283407/42185550-991b2eca-7e49-11e8-99ac-6f4cd6e2b3f4.PNG)
