### PR TITLE
UI: Fix stream button checkable state

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4953,8 +4953,10 @@ void OBSBasic::on_streamButton_clicked()
 						QTStr("ConfirmStop.Title"),
 						QTStr("ConfirmStop.Text"));
 
-			if (button == QMessageBox::No)
+			if (button == QMessageBox::No) {
+				ui->streamButton->setChecked(true);
 				return;
+			}
 		}
 
 		StopStreaming();
@@ -4968,8 +4970,10 @@ void OBSBasic::on_streamButton_clicked()
 						QTStr("ConfirmStart.Title"),
 						QTStr("ConfirmStart.Text"));
 
-			if (button == QMessageBox::No)
+			if (button == QMessageBox::No) {
+				ui->streamButton->setChecked(false);
 				return;
+			}
 		}
 
 		StartStreaming();


### PR DESCRIPTION
This fixes an issue where the stream button would still be
checked when clicking no on the stream confirmation dialog.