### PR TITLE
rtmp-services: Adding Castr.io ingests to service list

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 82,
+	"version": 83,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 82
+			"version": 83
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -806,6 +806,46 @@
             }
         },
         {
+            "name": "Castr.io",
+            "servers": [
+                {
+                    "name": "Chicago US",
+                    "url": "rtmp://cg.castr.io"
+                },
+                {
+                    "name": "Los Angeles US",
+                    "url": "rtmp://la.castr.io"
+                },
+                {
+                    "name": "Montreal CA",
+                    "url": "rtmp://qc.castr.io"
+                },
+                {
+                    "name": "London UK",
+                    "url": "rtmp://uk.castr.io"
+                },
+                {
+                    "name": "Frankfurt DE",
+                    "url": "rtmp://de.castr.io"
+                },
+                {
+                    "name": "Moscow RU",
+                    "url": "rtmp://ru.castr.io"
+                },
+                {
+                    "name": "Singapore",
+                    "url": "rtmp://sg.castr.io"
+                },
+                {
+                    "name": "Sydney AU",
+                    "url": "rtmp://au.castr.io"
+                }
+            ],
+            "recommended": {
+                "keyint": 2
+            }
+        },
+        {
             "name": "Boomstream",
             "servers": [
                 {


### PR DESCRIPTION
Added support for Castr.io to OBS:

- added castr.io ingests details/recommended confs to service list.
- incremented rtmp-services version.

[Castr.io RTMP Ingests](https://castr.io/ingests.json) gets updated periodically.