### PR TITLE
[win-capture] Modify log for sharedmem

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -727,7 +727,7 @@ static inline bool init_hook_info(struct game_capture *gc)
 
 	if (gc->config.force_shmem) {
 		warn("init_hook_info: user is forcing shared memory "
-			"(compatibility mode)");
+			"(multi-adapter compatibility mode)");
 	}
 
 	gc->global_hook_info->offsets = gc->process_is_64bit ?


### PR DESCRIPTION
Distinguish in the log that this is for shared-mem/mutli-adapter not anti-cheat.

Mostly so I don't have to open OBS and check to remember which one this means.