### PR TITLE
obs-filters: Add panic hotkeys to delay filters

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -275,6 +275,22 @@ obs_hotkey_id obs_hotkey_register_source(obs_source_t *source, const char *name,
 	return id;
 }
 
+obs_hotkey_id obs_hotkey_register_filter(obs_source_t *filter, const char *name,
+	const char *description, obs_hotkey_func func, void *data)
+{
+	if (!filter || !filter->context.private || !lock())
+		return OBS_INVALID_HOTKEY_ID;
+
+	obs_hotkey_id id = obs_hotkey_register_internal(
+			OBS_HOTKEY_REGISTERER_SOURCE,
+			obs_source_get_weak_source(filter),
+			&filter->context, name, description,
+			func, data);
+
+	unlock();
+	return id;
+}
+
 static inline void fixup_pair_pointers(void);
 
 static obs_hotkey_pair_t *create_hotkey_pair(struct obs_context_data *context,

--- a/libobs/obs-hotkey.h
+++ b/libobs/obs-hotkey.h
@@ -172,6 +172,10 @@ EXPORT obs_hotkey_id obs_hotkey_register_source(obs_source_t *source,
 		const char *name, const char *description,
 		obs_hotkey_func func, void *data);
 
+EXPORT obs_hotkey_id obs_hotkey_register_filter(obs_source_t *filter,
+	const char *name, const char *description,
+	obs_hotkey_func func, void *data);
+
 typedef bool (*obs_hotkey_active_func)(void *data,
 		obs_hotkey_pair_id id, obs_hotkey_t *hotkey, bool pressed);
 

--- a/plugins/obs-filters/async-delay-filter.c
+++ b/plugins/obs-filters/async-delay-filter.c
@@ -31,6 +31,8 @@ struct async_delay_data {
 	bool                           audio_delay_reached;
 	bool                           reset_video;
 	bool                           reset_audio;
+
+	obs_hotkey_id                  panic;
 };
 
 static const char *async_delay_filter_name(void *unused)
@@ -85,6 +87,20 @@ static void async_delay_filter_update(void *data, obs_data_t *settings)
 	filter->audio_delay_reached = false;
 }
 
+static bool dump_frames(void *data, obs_hotkey_pair_id id, obs_hotkey_t *key,
+	bool pressed)
+{
+	UNUSED_PARAMETER(id);
+	UNUSED_PARAMETER(key);
+
+	struct async_delay_data *filter = (struct gpu_delay_filter_data *)data;
+
+	filter->reset_audio = true;
+	filter->reset_video = true;
+	filter->video_delay_reached = false;
+	filter->audio_delay_reached = false;
+}
+
 static void *async_delay_filter_create(obs_data_t *settings,
 		obs_source_t *context)
 {
@@ -96,6 +112,9 @@ static void *async_delay_filter_create(obs_data_t *settings,
 
 	obs_get_audio_info(&oai);
 	filter->samplerate = oai.samples_per_sec;
+
+	filter->panic = obs_hotkey_register_filter(filter->context, "panic",
+			obs_module_text("Panic"), dump_frames, filter);
 
 	return filter;
 }


### PR DESCRIPTION
Adds a panic hotkey to async and gpu delay filters.