### PR TITLE
UI: Let path text box edit paths

### DIFF
--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -47,6 +47,7 @@ public:
 public slots:
 
 	void ControlChanged();
+	void ControlChangedText();
 
 	/* editable list */
 	void EditListAdd();

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -79,7 +79,8 @@ enum obs_editable_list_type {
 enum obs_path_type {
 	OBS_PATH_FILE,
 	OBS_PATH_FILE_SAVE,
-	OBS_PATH_DIRECTORY
+	OBS_PATH_DIRECTORY,
+	OBS_PATH_EDITABLE = 4
 };
 
 enum obs_text_type {


### PR DESCRIPTION
Adds editable paths via the textbox. Return/Enter and loss of focus on
widget will update the value.

