### PR TITLE
rtmp-services: Add Piczel.TV server

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 85,
+	"version": 86,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 85
+			"version": 86
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1312,6 +1312,18 @@
                 "max video bitrate": 8000,
                 "max audio bitrate": 192
             }
+        },
+        {
+            "name": "Piczel.tv",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://piczel.tv:1935/live"
+                }
+            ],
+            "recommended": {
+                "max video bitrate": 5000
+            }
         }
     ]
 }


### PR DESCRIPTION
Piczel.TV is a streaming and art gallery website - https://piczel.tv