### PR TITLE
UI: Fix start up crash with saved projectors

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5692,7 +5692,7 @@ void OBSBasic::OpenSavedProjectors()
 		}
 		}
 
-		if (!info->geometry.empty()) {
+		if (projector && !info->geometry.empty()) {
 			QByteArray byteArray = QByteArray::fromBase64(
 					QByteArray(info->geometry.c_str()));
 			projector->restoreGeometry(byteArray);


### PR DESCRIPTION
This fixes a crash in case the user selected the option to save
projectors on exit and had multiple monitors at that time. Later on,
when obs is started again if the monitor list is lower now the open
projector code will return null when trying to create the saved
projector.

Just check if the returned projector pointer is valid before trying
to restore the saved geometry.