### PR TITLE
CI: Update to Qt 5.11.1

### DIFF
--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -24,7 +24,7 @@ sudo installer -pkg ./Packages.pkg -target /
 brew update
 
 #Base OBS Deps and ccache
-brew install qt5 jack speexdsp ccache swig
+brew install qt@5.11 jack speexdsp ccache swig
 
 export PATH=/usr/local/opt/ccache/libexec:$PATH
 ccache -s || echo "CCache is not available."

--- a/UI/frontend-plugins/frontend-tools/captions.cpp
+++ b/UI/frontend-plugins/frontend-tools/captions.cpp
@@ -1,4 +1,5 @@
 #include <QMessageBox>
+#include <QAction>
 
 #include <windows.h>
 #include <obs-frontend-api.h>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ install:
   - set DepsPath32=%CD%\dependencies2017\win32
   - set DepsPath64=%CD%\dependencies2017\win64
   - set VLCPath=%CD%\vlc
-  - set QTDIR32=C:\Qt\5.10.1\msvc2015
-  - set QTDIR64=C:\Qt\5.10.1\msvc2017_64
+  - set QTDIR32=C:\Qt\5.11.1\msvc2015
+  - set QTDIR64=C:\Qt\5.11.1\msvc2017_64
   - set build_config=RelWithDebInfo
   - mkdir build build32 build64
   - cd ./build32


### PR DESCRIPTION
This PR contains three commits, which can probably be squashed down to two (or one) if needed.  The first commit is for compatibility/compliance with Qt 5.11 includes.  QAction was previously implicitly included, but this is no longer done as of Qt 5.11.  The second and third commits switch AppVeyor Windows and Travis macOS builds to Qt 5.11.1, respectively.  Brew does not let us specify a patch release of Qt, so we can only specify Qt 5.11 in general.  Travis Linux builds on Ubuntu 14.04 don't have easy access to Qt 5.11.

Updating to Qt 5.11 does come with a few caveats.  First, Qt 5.11 dropped support for Microsoft Visual Studio 2013.  OBS Studio will probably not compile on VS2013 after this update.  Second, I'm also pretty sure that Qt 5.11 fully dropped support for OS X (macOS) 10.10.  We'd already made this change on the website some time ago, so this is probably a non-issue.

Qt 5.10 won't be receiving any new updates, so Qt 5.11 is our only path for Qt bug fixes and improvements.  Qt 5.11.2 isn't due until early September, and then the next release would likely be Qt 5.12, then next LTS.  In light of those timeframes, I felt now was a good time to submit this PR.  Some of Qt 5.11's touted benefits are: better support for high-DPI displays, better support for accessibility software on Windows, improved QML performance, and some Qt Widgets improvements.

I've built this on CI and locally on Windows 10 64-bit.  Seems to run as expected.  As always, feedback and more testing is appreciated.