### PR TITLE
Update macOS CI build image, target, and deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
 matrix:
   include:
     - os: osx
+      osx_image: xcode9.4
       env:
        - CMAKE_PREFIX_PATH=/usr/local/opt/qt5/lib/cmake
        - CEF_BUILD_VERSION=3.3282.1726.gc8368c8

--- a/CI/before-script-osx.sh
+++ b/CI/before-script-osx.sh
@@ -4,7 +4,7 @@ export PATH=/usr/local/opt/ccache/libexec:$PATH
 mkdir build
 cd build
 cmake -DENABLE_SPARKLE_UPDATER=ON \
--DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 \
+-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 \
 -DDepsPath=/tmp/obsdeps \
 -DVLCPath=$PWD/../../vlc-master \
 -DBUILD_BROWSER=ON \

--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -24,7 +24,7 @@ sudo installer -pkg ./Packages.pkg -target /
 brew update
 
 #Base OBS Deps and ccache
-brew install qt@5.11 jack speexdsp ccache swig
+brew install qt@5.11 jack speexdsp ccache swig mbedtls
 
 export PATH=/usr/local/opt/ccache/libexec:$PATH
 ccache -s || echo "CCache is not available."
@@ -41,7 +41,7 @@ unzip -q ./vlc-master.zip
 
 # Get sparkle
 hr "Downloading Sparkle framework"
-wget --quiet --retry-connrefused --waitretry=1 -O sparkle.tar.bz2 https://github.com/sparkle-project/Sparkle/releases/download/1.16.0/Sparkle-1.16.0.tar.bz2
+wget --quiet --retry-connrefused --waitretry=1 -O sparkle.tar.bz2 https://github.com/sparkle-project/Sparkle/releases/download/1.20.0/Sparkle-1.20.0.tar.bz2
 mkdir ./sparkle
 tar -xf ./sparkle.tar.bz2 -C ./sparkle
 sudo cp -R ./sparkle/Sparkle.framework /Library/Frameworks/Sparkle.framework

--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -55,7 +55,7 @@ cd ./cef_binary_${CEF_BUILD_VERSION}_macosx64
 sed -i '.orig' '/add_subdirectory(tests\/ceftests)/d' ./CMakeLists.txt
 mkdir build
 cd ./build
-cmake -DCMAKE_CXX_FLAGS="-std=c++11 -stdlib=libc++" -DCMAKE_EXE_LINKER_FLAGS="-std=c++11 -stdlib=libc++" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 ..
+cmake -DCMAKE_CXX_FLAGS="-std=c++11 -stdlib=libc++" -DCMAKE_EXE_LINKER_FLAGS="-std=c++11 -stdlib=libc++" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 ..
 make -j4
 mkdir libcef_dll
 cd ../../

--- a/CI/util/build-package-deps-osx.sh
+++ b/CI/util/build-package-deps-osx.sh
@@ -47,9 +47,9 @@ export MACOSX_DEPLOYMENT_TARGET=10.11
 # https://github.com/phracker/MacOSX-SDKs
 
 # libopus
-curl -L -O http://downloads.xiph.org/releases/opus/opus-1.1.3.tar.gz
-tar -xf opus-1.1.3.tar.gz
-cd ./opus-1.1.3
+curl -L -O https://ftp.osuosl.org/pub/xiph/releases/opus/opus-1.2.1.tar.gz
+tar -xf opus-1.2.1.tar.gz
+cd ./opus-1.2.1
 mkdir build
 cd ./build
 ../configure --disable-shared --enable-static --prefix="/tmp/obsdeps"
@@ -59,9 +59,9 @@ make install
 cd $WORK_DIR
 
 # libogg
-curl -L -O http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.gz
-tar -xf libogg-1.3.2.tar.gz
-cd ./libogg-1.3.2
+curl -L -O https://ftp.osuosl.org/pub/xiph/releases/ogg/libogg-1.3.3.tar.gz
+tar -xf libogg-1.3.3.tar.gz
+cd ./libogg-1.3.3
 mkdir build
 cd ./build
 ../configure --disable-shared --enable-static --prefix="/tmp/obsdeps"
@@ -71,9 +71,9 @@ make install
 cd $WORK_DIR
 
 # libvorbis
-curl -L -O http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.gz
-tar -xf libvorbis-1.3.5.tar.gz
-cd ./libvorbis-1.3.5
+curl -L -O https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-1.3.6.tar.gz
+tar -xf libvorbis-1.3.6.tar.gz
+cd ./libvorbis-1.3.6
 mkdir build
 cd ./build
 ../configure --disable-shared --enable-static --prefix="/tmp/obsdeps"
@@ -83,9 +83,9 @@ make install
 cd $WORK_DIR
 
 # libvpx
-curl -L -O http://storage.googleapis.com/downloads.webmproject.org/releases/webm/libvpx-1.6.0.tar.bz2
-tar -xf libvpx-1.6.0.tar.bz2
-cd ./libvpx-1.6.0
+curl -L -O https://chromium.googlesource.com/webm/libvpx/+archive/v1.7.0.tar.gz
+tar -xf libvpx-1.7.0.tar.gz
+cd ./libvpx-1.7.0
 mkdir build
 cd ./build
 ../configure --disable-shared --libdir="/tmp/obsdeps/bin"
@@ -113,9 +113,9 @@ rsync -avh --include="*/" --include="*.h" --exclude="*" ./* $DEPS_DEST/include/
 cd $WORK_DIR
 
 # janson
-curl -L -O http://www.digip.org/jansson/releases/jansson-2.9.tar.gz
-tar -xf jansson-2.9.tar.gz
-cd jansson-2.9
+curl -L -O http://www.digip.org/jansson/releases/jansson-2.11.tar.gz
+tar -xf jansson-2.11.tar.gz
+cd jansson-2.11
 mkdir build
 cd ./build
 ../configure --libdir="/tmp/obsdeps/bin" --enable-shared --disable-static
@@ -130,9 +130,9 @@ export LDFLAGS="-L/tmp/obsdeps/lib"
 export CFLAGS="-I/tmp/obsdeps/include"
 
 # FFMPEG
-curl -L -O https://github.com/FFmpeg/FFmpeg/archive/n3.2.2.zip
-unzip ./n3.2.2.zip
-cd ./FFmpeg-n3.2.2
+curl -L -O https://github.com/FFmpeg/FFmpeg/archive/n4.0.2.zip
+unzip ./n4.0.2.zip
+cd ./FFmpeg-n4.0.2
 mkdir build
 cd ./build
 ../configure --extra-ldflags="-mmacosx-version-min=10.11" --enable-shared --disable-static --shlibdir="/tmp/obsdeps/bin" --enable-gpl --disable-doc --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --disable-outdev=sdl

--- a/CI/util/build-package-deps-osx.sh
+++ b/CI/util/build-package-deps-osx.sh
@@ -41,7 +41,7 @@ mkdir $DEPS_DEST/include
 mkdir $DEPS_DEST/lib
 
 # OSX COMPAT
-export MACOSX_DEPLOYMENT_TARGET=10.9
+export MACOSX_DEPLOYMENT_TARGET=10.11
 
 # If you need an olders SDK and Xcode won't give it to you
 # https://github.com/phracker/MacOSX-SDKs
@@ -100,10 +100,10 @@ cd ./x264
 git checkout origin/stable
 mkdir build
 cd ./build
-../configure --extra-ldflags="-mmacosx-version-min=10.9" --enable-static --prefix="/tmp/obsdeps"
+../configure --extra-ldflags="-mmacosx-version-min=10.11" --enable-static --prefix="/tmp/obsdeps"
 make -j 12
 make install
-../configure --extra-ldflags="-mmacosx-version-min=10.9" --enable-shared --libdir="/tmp/obsdeps/bin" --prefix="/tmp/obsdeps"
+../configure --extra-ldflags="-mmacosx-version-min=10.11" --enable-shared --libdir="/tmp/obsdeps/bin" --prefix="/tmp/obsdeps"
 make -j 12
 ln -f -s libx264.*.dylib libx264.dylib
 find . -name \*.dylib -exec cp \{\} $DEPS_DEST/bin/ \;
@@ -135,7 +135,7 @@ unzip ./n3.2.2.zip
 cd ./FFmpeg-n3.2.2
 mkdir build
 cd ./build
-../configure --extra-ldflags="-mmacosx-version-min=10.9" --enable-shared --disable-static --shlibdir="/tmp/obsdeps/bin" --enable-gpl --disable-doc --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --disable-outdev=sdl
+../configure --extra-ldflags="-mmacosx-version-min=10.11" --enable-shared --disable-static --shlibdir="/tmp/obsdeps/bin" --enable-gpl --disable-doc --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --disable-outdev=sdl
 make -j 12
 find . -name \*.dylib -exec cp \{\} $DEPS_DEST/bin/ \;
 rsync -avh --include="*/" --include="*.h" --exclude="*" ../* $DEPS_DEST/include/


### PR DESCRIPTION
This PR does four things in three commits:

1. Update Travis CI builds for macOS to use the Xcode 9.4 image (macOS 10.13 w/ Xcode 9.4).
2. Update the Travis CI scripts to actually target macOS 10.11 as the minimum supported macOS version.
3. Update the build script that downloads the packages the macOS dependencies to target updated URLs for those dependencies.
4. Update the build script that downloads and packages the macOS dependencies to the latest stable versions of those dependencies.

The first change should be fairly safe to do.  Travis CI is [making the Xcode 9.4 image their default macOS build image on July 31, 2018](https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce).

The second change should also be fairly safe to do.  The OBS website has stated that current releases only support macOS 10.11+ for quite a while now, and other software packages are dropping support for OSX/macOS 10.9 and 10.10 (Google Chrome, Qt, and probably others).  CEF updated their build system to require Xcode 9.3.  This step will allow the compiler to optimize the releases for 10.11+.

The third change is tied to the fourth, so I'll just discuss the fourth change.  The fourth change updates all dependencies to their latest stable versions in the build script.  This does not directly update dependencies for macOS.  The build script must first be run to generate the dependencies package, and then that package must be uploaded somewhere for the build script to fetch them.

I don't have a Mac, so I cannot test these changes.  Since @DDRBoxman has a hand in the CI stuff (and a Mac), I'm pinging him on this.  I don't know Jim's thoughts on updating deps and when the best time is to do that, so hopefully he'll enlighten me a little here when he has time.  If the deps update needs to be split off from the other updates to make this more palatable, that's perfectly fine with me.

For what it's worth, Travis CI builds successfully with these changes.  Could probably produce a test build by setting up a temporary branch and providing a temporary package for updated deps.