### PR TITLE
libobs: Add obs_app_text() function

### DIFF
--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -492,6 +492,50 @@ cleanup:
 	return lookup;
 }
 
+lookup_t *obs_app_load_locale(obs_module_t *module, const char *default_locale,
+		const char *locale)
+{
+	struct dstr str    = {0};
+	lookup_t    *lookup = NULL;
+
+	if (!default_locale || !locale) {
+		blog(LOG_WARNING, "obs_app_load_locale: Invalid parameters");
+		return NULL;
+	}
+
+	const char *m_file = module ? module->file : "(NONE)";
+
+	dstr_copy(&str, OBS_DATA_PATH);
+	dstr_cat(&str, "/obs-studio/locale/");
+	dstr_cat(&str, default_locale);
+	dstr_cat(&str, ".ini");
+
+	if (os_file_exists(str.array))
+		lookup = text_lookup_create(str.array);
+
+	if (!lookup) {
+		blog(LOG_WARNING, "Failed to load '%s' text for app: %s",
+				default_locale, m_file);
+		goto cleanup;
+	}
+
+	if (astrcmpi(locale, default_locale) == 0)
+		goto cleanup;
+
+	dstr_copy(&str, OBS_DATA_PATH);
+	dstr_cat(&str, "/obs-studio/locale/");
+	dstr_cat(&str, locale);
+	dstr_cat(&str, ".ini");
+
+	if (!(os_file_exists(str.array) && text_lookup_add(lookup, str.array)))
+		blog(LOG_WARNING, "Failed to load '%s' text for app: %s",
+				locale, m_file);
+
+cleanup:
+	dstr_free(&str);
+	return lookup;
+}
+
 #define REGISTER_OBS_DEF(size_var, structure, dest, info)                 \
 	do {                                                              \
 		struct structure data = {0};                              \

--- a/libobs/obs-module.h
+++ b/libobs/obs-module.h
@@ -109,15 +109,26 @@ MODULE_EXPORT void obs_module_free_locale(void);
 /** Optional: Use this macro in a module to use default locale handling. */
 #define OBS_MODULE_USE_DEFAULT_LOCALE(module_name, default_locale) \
 	lookup_t *obs_module_lookup = NULL; \
+	lookup_t *obs_app_lookup = NULL; \
 	const char *obs_module_text(const char *val) \
 	{ \
 		const char *out = val; \
 		text_lookup_getstr(obs_module_lookup, val, &out); \
 		return out; \
 	} \
+	const char *obs_app_text(const char * val) \
+	{ \
+		const char *out = val; \
+		text_lookup_getstr(obs_app_lookup, val, &out); \
+		return out; \
+	} \
 	bool obs_module_get_string(const char *val, const char **out) \
 	{ \
 		return text_lookup_getstr(obs_module_lookup, val, out); \
+	} \
+	bool obs_app_get_string(const char *val, const char **out) \
+	{ \
+		return text_lookup_getstr(obs_app_lookup, val, out); \
 	} \
 	void obs_module_set_locale(const char *locale) \
 	{ \
@@ -125,14 +136,22 @@ MODULE_EXPORT void obs_module_free_locale(void);
 		obs_module_lookup = obs_module_load_locale( \
 				obs_current_module(), \
 				default_locale, locale); \
+		if (obs_app_lookup) text_lookup_destroy(obs_app_lookup); \
+		obs_app_lookup = obs_app_load_locale( \
+				obs_current_module(), \
+				default_locale, locale); \
 	} \
 	void obs_module_free_locale(void) \
 	{ \
 		text_lookup_destroy(obs_module_lookup); \
+		text_lookup_destroy(obs_app_lookup); \
 	}
 
 /** Helper function for looking up locale if default locale handler was used */
 MODULE_EXTERN const char *obs_module_text(const char *lookup_string);
+
+/** Helper function for looking up qt strings */
+MODULE_EXTERN const char *obs_app_text(const char *lookup_string);
 
 /** Helper function for looking up locale if default locale handler was used,
  * returns true if text found, otherwise false */

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -437,6 +437,12 @@ EXPORT void obs_enum_modules(obs_enum_module_callback_t callback, void *param);
 EXPORT lookup_t *obs_module_load_locale(obs_module_t *module,
 		const char *default_locale, const char *locale);
 
+/** Helper function for using default app locale
+* @param  module  The module this function was run from (optional)
+*/
+EXPORT lookup_t *obs_app_load_locale(obs_module_t *module,
+		const char *default_locale, const char *locale);
+
 /**
  * Returns the location of a plugin module data file.
  *


### PR DESCRIPTION
Searches OBS's .ini files for existing text.