### PR TITLE
UI: Fix disabled items in Dark theme being too light

### DIFF
--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -55,9 +55,9 @@ OBSTheme {
 }
 
 OBSTheme::disabled {
-    text: rgb(200,199,200); /* lighter */
-    buttonText: rgb(200,199,200); /* lighter */
-    brightText: rgb(200,199,200); /* lighter */
+    text: rgb(122,121,122); /* light */
+    buttonText: rgb(122,121,122); /* light */
+    brightText: rgb(122,121,122); /* light */
 }
 
 OBSTheme::inactive {


### PR DESCRIPTION
In the Dark theme, disabled UI elements had text that was too close in color to enabled UI elements. This commit switches them to use the "light" palette color instead of the "lighter" palette color.

This issue seems to have been introduced in https://github.com/obsproject/obs-studio/commit/e1ab9a0fc4ce3d442f12bdcc1c7a2cf5e1f52ae4.  I've tested this on Windows 10 64-bit.  As always, feedback and reviews are welcome.

Before:
![2018-07-31 12_16_14-](https://user-images.githubusercontent.com/624931/43472676-1066472a-94bc-11e8-80cb-5680713be592.png)
![2018-07-31 12_16_30-settings](https://user-images.githubusercontent.com/624931/43472682-167877c8-94bc-11e8-9f82-8f66cd7c8558.png)


After:
![2018-07-31 12_17_47-](https://user-images.githubusercontent.com/624931/43472690-1bf3a97a-94bc-11e8-8032-afa0cef67858.png)
![2018-07-31 12_17_58-settings](https://user-images.githubusercontent.com/624931/43472691-1d1cc656-94bc-11e8-8b8a-21d07d3f2414.png)
