### PR TITLE
UI: Add missing return statement

### DIFF
--- a/UI/win-update/updater/updater.cpp
+++ b/UI/win-update/updater/updater.cpp
@@ -324,6 +324,8 @@ struct update_t {
 		memcpy(hash, from.hash, sizeof(hash));
 		memcpy(downloadhash, from.downloadhash, sizeof(downloadhash));
 		memcpy(my_hash, from.my_hash, sizeof(my_hash));
+
+		return *this;
 	}
 };
 


### PR DESCRIPTION
This was found with Cppcheck. The assignment operator function is declared to return non-void but has return statement omitted. This yields undefined behavior.