### PR TITLE
win-mf: Add missing va_end() call

### DIFF
--- a/plugins/win-mf/mf-common.cpp
+++ b/plugins/win-mf/mf-common.cpp
@@ -24,6 +24,7 @@ static void DBGMSG(PCWSTR format, ...)
 		MF_LOG(LOG_INFO, "%s", cmsg);
 		bfree(cmsg);
 	}
+	va_end(args);
 }
 
 #ifndef IF_EQUAL_RETURN


### PR DESCRIPTION
This was found with Cppcheck. `va_start()` is not paired with `va_end()` which yields undefined behavior.