### PR TITLE
obs-filters: Fix segfault in Compressor Filter

### DIFF
--- a/plugins/obs-filters/compressor-filter.c
+++ b/plugins/obs-filters/compressor-filter.c
@@ -442,6 +442,9 @@ static struct obs_audio_data *compressor_filter_audio(void *data,
 	struct compressor_data *cd = data;
 
 	const uint32_t num_samples = audio->frames;
+	if (num_samples == 0)
+		return audio;
+
 	float **samples = (float**)audio->data;
 
 	pthread_mutex_lock(&cd->sidechain_update_mutex);


### PR DESCRIPTION
obs_audio_data* sent to compressor_filter_audio had audio->frames == 0.
The analyze_envelope was trying to access an array at index -1 in result
of that. Just return if no samples are provided.

backtrace:

```Thread 13 "threaded-ml" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffa0c09700 (LWP 23257)]
0x00007fffa3f46cf4 in analyze_envelope (cd=0x5555564c80e0, samples=0x55555ace2ab8, num_samples=0) at 
/home/linus/Projects/c/obs-studio/plugins/obs-filters/compressor-filter.c:338
338		cd->envelope = cd->envelope_buf[num_samples - 1];
(gdb) bt full
#0  0x00007fffa3f46cf4 in analyze_envelope (cd=0x5555564c80e0, samples=0x55555ace2ab8, num_samples=0) at 
/home/linus/Projects/c/obs-studio/plugins/obs-filters/compressor-filter.c:338
        attack_gain = 0.99622786
        release_gain = 0.999622166
#1  0x00007fffa3f47241 in compressor_filter_audio (data=0x5555564c80e0, audio=0x55555ace2ab8) at 
/home/linus/Projects/c/obs-studio/plugins/obs-filters/compressor-filter.c:454
        cd = 0x5555564c80e0
        num_samples = 0
        samples = 0x55555ace2ab8
        weak_sidechain = 0x0
```

This fixes Mantis issue: [1261](https://obsproject.com/mantis/view.php?id=1261) (full backtrace and more info)