### PR TITLE
UI: Add Search to Hotkeys settings menu

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -780,6 +780,7 @@ Basic.AdvAudio.AudioTracks="Tracks"
 # basic mode 'hotkeys' settings
 Basic.Settings.Hotkeys="Hotkeys"
 Basic.Settings.Hotkeys.Pair="Key combinations shared with '%1' act as toggles"
+Basic.Settings.Hotkeys.Filter="Filter"
 
 # basic mode hotkeys
 Basic.Hotkeys.SelectScene="Switch to scene"

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2414,6 +2414,47 @@ void OBSBasicSettings::LoadHotkeySettings(obs_hotkey_id ignoreKey)
 	widget->setLayout(layout);
 	ui->hotkeyPage->setWidget(widget);
 
+	auto filterLayout = new QGridLayout();
+	auto filterWidget = new QWidget();
+	filterWidget->setLayout(filterLayout);
+
+	auto filterLabel = new QLabel(QTStr("Basic.Settings.Hotkeys.Filter"));
+	auto filter = new QLineEdit();
+
+	auto setRowVisible = [=](int row, bool visible, QLayoutItem *label) {
+		label->widget()->setVisible(visible);
+
+		auto field = layout->itemAt(row, QFormLayout::FieldRole);
+		if (field)
+			field->widget()->setVisible(visible);
+	};
+
+	auto searchFunction = [=](const QString &text) {
+		for (int i = 0; i < layout->rowCount(); i++) {
+			auto label = layout->itemAt(i, QFormLayout::LabelRole);
+			if (label) {
+				OBSHotkeyLabel *item =
+					qobject_cast<OBSHotkeyLabel*>(
+					label->widget());
+				if(item) {
+					if (item->text().toLower()
+						.contains(text.toLower()))
+						setRowVisible(i, true, label);
+					else
+						setRowVisible(i, false, label);
+				}
+			}
+		}
+	};
+
+	connect(filter, &QLineEdit::textChanged,
+		this, searchFunction);
+
+	filterLayout->addWidget(filterLabel, 0, 0);
+	filterLayout->addWidget(filter, 0, 1);
+
+	layout->addRow(filterWidget);
+
 	using namespace std;
 	using encoders_elem_t =
 		tuple<OBSEncoder, QPointer<QLabel>, QPointer<QWidget>>;


### PR DESCRIPTION
This commit adds a search bar to the top of the hotkeys settings menu,
with it set to look for matches anywhere in the string label for that
hotkey.

It currently has issues when clearing a search, since setVisible(true)
or show() on a widget will recompute the styles, making it a slow
operation. There doesn't seem to be a way around this without
implementing pagination or some other means of displaying the data
first.