### PR TITLE
UI: Remove QNetworkReply from window-basic-main.hpp

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -42,7 +42,6 @@
 class QMessageBox;
 class QListWidgetItem;
 class VolControl;
-class QNetworkReply;
 class OBSBasicStats;
 
 #include "ui_OBSBasic.h"


### PR DESCRIPTION
QNetworkReply was added here in commit 5ba8b09c9c0ee3bd4cca7860e5892ee60d1f6cf6. Qt5Network was replaced in commits 13bed1a448e3726819778e5759bdf456556b6bf9 and 39d1cda4e9b276f1b0770027e211aec0d9ecb927, but this one line referring to QNetworkReply remained. Let's finally remove it.

This isn't a significant change.  Just removing a single unnecessary line.

Compiled and tested on Windows 10 64-bit.  As always, feedback and reviews are welcome.