### PR TITLE
UI: Make OBS bitness more specific in title bar and log

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1266,7 +1266,9 @@ string OBSApp::GetVersionString() const
 
 #ifdef _WIN32
 	if (sizeof(void*) == 8)
-		ver << "64bit, ";
+		ver << "64-bit, ";
+	else
+		ver << "32-bit, ";
 
 	ver << "windows)";
 #elif __APPLE__


### PR DESCRIPTION
This commit explicitly puts "32-bit" in the title bar and OBS log for 32-bit versions of OBS. It also changes "64bit" to "64-bit" to match the string used for Windows version info.

This is mostly a convenience for people providing support so they don't have to remember that "(windows)" in the OBS version string means that the OBS build is 32-bit.