### PR TITLE
win-capture: Avoid tex size mismatch for cursor

### DIFF
--- a/plugins/win-capture/cursor-capture.c
+++ b/plugins/win-capture/cursor-capture.c
@@ -166,7 +166,7 @@ static inline bool cursor_capture_icon(struct cursor_data *data, HICON icon)
 
 	bitmap = cursor_capture_icon_bitmap(&ii, &width, &height);
 	if (bitmap) {
-		if (data->last_cx != width && data->last_cy != height) {
+		if (data->last_cx != width || data->last_cy != height) {
 			data->texture = get_cached_texture(data, width, height);
 			data->last_cx = width;
 			data->last_cy = height;


### PR DESCRIPTION
Re-fetch texture when cursor's either width or height changed.

When the cursor icon changed and the new one has the same width or height,
it may not recreate the texture and thus cause memory access violation.