### PR TITLE
libobs-d3d11: Remove excessive code

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -1787,7 +1787,6 @@ bool gs_texture_map(gs_texture_t *tex, uint8_t **ptr, uint32_t *linesize)
 	gs_texture_2d *tex2d = static_cast<gs_texture_2d*>(tex);
 
 	D3D11_MAPPED_SUBRESOURCE map;
-	ZeroMemory(&map, sizeof(D3D11_MAPPED_SUBRESOURCE));
 	hr = tex2d->device->context->Map(tex2d->texture, 0,
 			D3D11_MAP_WRITE_DISCARD, 0, &map);
 	if (FAILED(hr))


### PR DESCRIPTION
This reverts https://github.com/obsproject/obs-studio/commit/671b6032e22fd3f714f7875b7b596a516468fb18

It seems that this code do nothing useful.
The structure should be fully overwritten internally (inside the Map).