### PR TITLE
cmake: Prevent policy CMP0072 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 2.8.12)
 
+if (UNIX AND POLICY CMP0072)
+	# In case of both legacy and glvnd OpenGL libraries found. Prefer GLVND
+	cmake_policy(SET CMP0072 NEW)
+endif()
+
 project(obs-studio)
 
 option(BUILD_CAPTIONS "Build captions" FALSE)


### PR DESCRIPTION
This policy was introduced in CMake version 3.11.

The FindOpenGL module provides an OpenGL::GL target and an
OPENGL_LIBRARIES variable for projects to use for legacy GL interfaces.
When both a legacy GL library (e.g. libGL.so) and GLVND libraries for
OpenGL and GLX (e.g. libOpenGL.so and libGLX.so) are available, the
module must choose between them. It documents an OpenGL_GL_PREFERENCE
variable that can be used to specify an explicit preference. When no
such preference is set, the module must choose a default preference.

The default behavior is to default to legacy (OLD) and is deprecated.

https://cmake.org/cmake/help/v3.11/policy/CMP0072.html
https://github.com/NVIDIA/libglvnd