### PR TITLE
libobs/UI: Add volume meter track output styling

### DIFF
--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -563,6 +563,28 @@ VolumeMeter {
 }
 
 
+#mixerDock VScrollArea,
+#mixerDock HScrollArea {
+    background: rgb(31,30,31);
+}
+
+VolControl[streamSelected="true"][recordSelected="false"] QWidget{
+	background-color: rgb(42,105,43);
+}
+
+VolControl[streamSelected="true"][recordSelected="true"] QWidget{
+	background-color: rgb(42,105,43);
+}
+
+VolControl[recordSelected="true"] QWidget {
+	background-color: rgb(105,42,43);
+}
+
+VolControl QWidget{
+	background-color: rgb(41,40,41);
+}
+
+
 /* Status Bar */
 
 QStatusBar::item {

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -222,6 +222,18 @@ class MuteCheckBox;
 
 class VolControl : public QWidget {
 	Q_OBJECT
+	Q_PROPERTY(bool recordSelected
+		READ isRecordSelected
+		WRITE setRecordSelected
+		NOTIFY recordToggled
+		USER true
+		DESIGNABLE true)
+	Q_PROPERTY(bool streamSelected
+		READ isStreamSelected
+		WRITE setStreamSelected
+		NOTIFY streamToggled
+		USER true
+		DESIGNABLE true)
 
 private:
 	OBSSource source;
@@ -236,6 +248,8 @@ private:
 	obs_fader_t     *obs_fader;
 	obs_volmeter_t  *obs_volmeter;
 	bool            vertical;
+	bool            recordSelected;
+	bool            streamSelected;
 
 	static void OBSVolumeChanged(void *param, float db);
 	static void OBSVolumeLevel(void *data,
@@ -243,6 +257,7 @@ private:
 		const float peak[MAX_AUDIO_CHANNELS],
 		const float inputPeak[MAX_AUDIO_CHANNELS]);
 	static void OBSVolumeMuted(void *data, calldata_t *calldata);
+	static void OBSMixersChanged(void *data, calldata_t *calldata);
 
 	void EmitConfigClicked();
 
@@ -254,9 +269,14 @@ private slots:
 	void SliderChanged(int vol);
 	void updateText();
 
+	void setRecordSelected(bool selected);
+	void setStreamSelected(bool selected);
+
 signals:
 	void ConfigClicked();
 
+	void streamToggled(bool checked);
+	void recordToggled(bool checked);
 public:
 	explicit VolControl(OBSSource source, bool showConfig = false,
 			bool vertical = false);
@@ -269,4 +289,6 @@ public:
 
 	void SetMeterDecayRate(qreal q);
 	void setPeakMeterType(enum obs_peak_meter_type peakMeterType);
+	bool isRecordSelected() {return recordSelected;}
+	bool isStreamSelected() {return streamSelected;}
 };

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1426,6 +1426,17 @@ void OBSBasic::OBSInit()
 	if (!ResetAudio())
 		throw "Failed to initialize audio";
 
+	int trackIndex = config_get_int(basicConfig, "AdvOut",
+			"TrackIndex");
+	if (trackIndex >= 1 && trackIndex <= MAX_AUDIO_MIXES)
+		obs_set_stream_tracks(1 << (trackIndex - 1));
+	else
+		obs_set_stream_tracks(0);
+
+	int rec_tracks = config_get_int(basicConfig, "AdvOut",
+			"RecTracks");
+	obs_set_recording_tracks(rec_tracks);
+
 	ret = ResetVideo();
 
 	switch (ret) {

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2937,12 +2937,19 @@ static void SaveTrackIndex(config_t *config, const char *section,
 		QAbstractButton *check5,
 		QAbstractButton *check6)
 {
-	if (check1->isChecked()) config_set_int(config, section, name, 1);
-	else if (check2->isChecked()) config_set_int(config, section, name, 2);
-	else if (check3->isChecked()) config_set_int(config, section, name, 3);
-	else if (check4->isChecked()) config_set_int(config, section, name, 4);
-	else if (check5->isChecked()) config_set_int(config, section, name, 5);
-	else if (check6->isChecked()) config_set_int(config, section, name, 6);
+	int trackIndex = 0;
+	if (check1->isChecked()) trackIndex = 1;
+	else if (check2->isChecked()) trackIndex = 2;
+	else if (check3->isChecked()) trackIndex = 3;
+	else if (check4->isChecked()) trackIndex = 4;
+	else if (check5->isChecked()) trackIndex = 5;
+	else if (check6->isChecked()) trackIndex = 6;
+	config_set_int(config, section, name, trackIndex);
+
+	if (trackIndex >= 1 && trackIndex <= MAX_AUDIO_MIXES)
+		obs_set_stream_tracks(1 << (trackIndex - 1));
+	else
+		obs_set_stream_tracks(0);
 }
 
 void OBSBasicSettings::SaveFormat(QComboBox *combo)
@@ -2987,6 +2994,20 @@ void OBSBasicSettings::SaveEncoder(QComboBox *combo, const char *section,
 		config_set_string(main->Config(), section, value, cd.name);
 	else
 		config_set_string(main->Config(), section, value, nullptr);
+}
+
+static void UpdateAudioMixes(int streamTrack, uint32_t recTracks)
+{
+	if (streamTrack >= 1 && streamTrack <= MAX_AUDIO_MIXES)
+		obs_set_stream_tracks(1 << (streamTrack - 1));
+	else
+		obs_set_stream_tracks(0);
+
+	obs_set_recording_tracks(recTracks);
+	obs_enum_sources([](void *data, obs_source_t *source) {
+		obs_source_update_audio_mixers(source);
+		return true;
+	}, nullptr);
 }
 
 void OBSBasicSettings::SaveOutputSettings()
@@ -3047,13 +3068,13 @@ void OBSBasicSettings::SaveOutputSettings()
 	SaveCombo(ui->advOutRecRescale, "AdvOut", "RecRescaleRes");
 	SaveEdit(ui->advOutMuxCustom, "AdvOut", "RecMuxerCustom");
 
-	config_set_int(main->Config(), "AdvOut", "RecTracks",
-			(ui->advOutRecTrack1->isChecked() ? (1<<0) : 0) |
-			(ui->advOutRecTrack2->isChecked() ? (1<<1) : 0) |
-			(ui->advOutRecTrack3->isChecked() ? (1<<2) : 0) |
-			(ui->advOutRecTrack4->isChecked() ? (1<<3) : 0) |
-			(ui->advOutRecTrack5->isChecked() ? (1<<4) : 0) |
-			(ui->advOutRecTrack6->isChecked() ? (1<<5) : 0));
+	int recTracks = (ui->advOutRecTrack1->isChecked() ? (1 << 0) : 0) |
+			(ui->advOutRecTrack2->isChecked() ? (1 << 1) : 0) |
+			(ui->advOutRecTrack3->isChecked() ? (1 << 2) : 0) |
+			(ui->advOutRecTrack4->isChecked() ? (1 << 3) : 0) |
+			(ui->advOutRecTrack5->isChecked() ? (1 << 4) : 0) |
+			(ui->advOutRecTrack6->isChecked() ? (1 << 5) : 0);
+	config_set_int(main->Config(), "AdvOut", "RecTracks", recTracks);
 
 	config_set_bool(main->Config(), "AdvOut", "FFOutputToFile",
 			ui->advOutFFType->currentIndex() == 0 ? true : false);
@@ -3097,6 +3118,9 @@ void OBSBasicSettings::SaveOutputSettings()
 	WriteJsonData(streamEncoderProps, "streamEncoder.json");
 	WriteJsonData(recordEncoderProps, "recordEncoder.json");
 	main->ResetOutputs();
+
+	int trackIndex = config_get_int(main->Config(), "AdvOut", "TrackIndex");
+	UpdateAudioMixes(trackIndex, recTracks);
 }
 
 void OBSBasicSettings::SaveAudioSettings()

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -306,6 +306,8 @@ struct obs_core_audio {
 	DARRAY(struct audio_monitor*)   monitors;
 	char                            *monitoring_device_name;
 	char                            *monitoring_device_id;
+	uint32_t                        stream_tracks;
+	uint32_t                        recording_tracks;
 };
 
 /* user sources, output channels, and displays */

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3420,6 +3420,23 @@ void obs_source_set_audio_mixers(obs_source_t *source, uint32_t mixers)
 	source->audio_mixers = mixers;
 }
 
+void obs_source_update_audio_mixers(obs_source_t *source)
+{
+	struct calldata data;
+	uint8_t stack[128];
+
+	if (!obs_source_valid(source, "obs_source_set_audio_mixers"))
+		return;
+	if ((source->info.output_flags & OBS_SOURCE_AUDIO) == 0)
+		return;
+
+	calldata_init_fixed(&data, stack, sizeof(stack));
+	calldata_set_ptr(&data, "source", source);
+	calldata_set_int(&data, "mixers", source->audio_mixers);
+
+	signal_handler_signal(source->context.signals, "audio_mixers", &data);
+}
+
 uint32_t obs_source_get_audio_mixers(const obs_source_t *source)
 {
 	if (!obs_source_valid(source, "obs_source_get_audio_mixers"))

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1098,6 +1098,46 @@ bool obs_get_audio_info(struct obs_audio_info *oai)
 	return true;
 }
 
+bool obs_get_stream_tracks(uint32_t *tracks)
+{
+	struct obs_core_audio *audio = &obs->audio;
+	if (!obs)
+		return false;
+
+	*tracks = audio->stream_tracks;
+	return true;
+}
+
+bool obs_get_recording_tracks(uint32_t *tracks)
+{
+	struct obs_core_audio *audio = &obs->audio;
+	if (!obs)
+		return false;
+
+	*tracks = audio->recording_tracks;
+	return true;
+}
+
+bool obs_set_stream_tracks(uint32_t tracks)
+{
+	struct obs_core_audio *audio = &obs->audio;
+	if (!obs)
+		return false;
+
+	audio->stream_tracks = tracks;
+	return true;
+}
+
+bool obs_set_recording_tracks(uint32_t tracks)
+{
+	struct obs_core_audio *audio = &obs->audio;
+	if (!obs)
+		return false;
+
+	audio->recording_tracks = tracks;
+	return true;
+}
+
 bool obs_enum_source_types(size_t idx, const char **id)
 {
 	if (!obs) return false;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -346,6 +346,10 @@ EXPORT bool obs_get_video_info(struct obs_video_info *ovi);
 /** Gets the current audio settings, returns false if no audio */
 EXPORT bool obs_get_audio_info(struct obs_audio_info *oai);
 
+EXPORT bool obs_get_stream_tracks(uint32_t *tracks);
+EXPORT bool obs_get_recording_tracks(uint32_t *tracks);
+EXPORT bool obs_set_stream_tracks(uint32_t tracks);
+EXPORT bool obs_set_recording_tracks(uint32_t tracks);
 /**
  * Opens a plugin module directly from a specific path.
  *
@@ -933,6 +937,11 @@ EXPORT uint32_t obs_source_get_flags(const obs_source_t *source);
  * the source's audio should be applied to.
  */
 EXPORT void obs_source_set_audio_mixers(obs_source_t *source, uint32_t mixers);
+
+/**
+* Sends audio mixer update signal
+*/
+EXPORT void obs_source_update_audio_mixers(obs_source_t *source);
 
 /** Gets audio mixer flags */
 EXPORT uint32_t obs_source_get_audio_mixers(const obs_source_t *source);


### PR DESCRIPTION
Adds the ability to style volumeters based on which tracks they're
being sent to.

A helpful visual indicator to tell which sources are being streamed / recorded.
![2018-08-07_20-56-47](https://user-images.githubusercontent.com/25020235/43815916-f807e10e-9a86-11e8-869d-1c5738fd3621.gif)