### PR TITLE
win-capture: Avoid segfault when retrieve size

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -1757,13 +1757,13 @@ static void game_capture_render(void *data, gs_effect_t *effect)
 static uint32_t game_capture_width(void *data)
 {
 	struct game_capture *gc = data;
-	return gc->active ? gc->global_hook_info->cx : 0;
+	return gc->active ? gc->cx : 0;
 }
 
 static uint32_t game_capture_height(void *data)
 {
 	struct game_capture *gc = data;
-	return gc->active ? gc->global_hook_info->cy : 0;
+	return gc->active ? gc->cy : 0;
 }
 
 static const char *game_capture_name(void *unused)


### PR DESCRIPTION
When changing size of a game-capture scene item in preview window, 
if the capture target window closed, it may crash.

In stop_capture function, it first release the global_hook_info member,
and then set the active member to false.
But while in game_capture_width/height function, it first checks the
active member to decide if get the value of cx from global_hook_info.

It will causes the game_capture_width function to read cx member from
a global_hook_info structure with nullptr value, thus crashes the obs.

game_capture_width/height function will be called in UI thread while
resizing scene item while the stop_capture called in a different thread
(graphic thread), so stop_capture may be executing concurrently.

I see that game_capture::cx/cy will be updated when the target resized,
so I change it to fetch cx/cy from game_capture instead of hook_info.