### PR TITLE
Don't mix /MT and /MD flags

### DIFF
--- a/deps/blake2/CMakeLists.txt
+++ b/deps/blake2/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(
 
 if(WIN32)
 	if(MSVC)
-		add_compile_options("$<$<CONFIG:RelWithDebInfo>:/MT>")
+		add_compile_options($<IF:$<CONFIG:Debug>,/MTd,/MT> /Zl)
 	endif()
 	add_definitions(
 		-Dinline=_inline

--- a/deps/ipc-util/CMakeLists.txt
+++ b/deps/ipc-util/CMakeLists.txt
@@ -22,9 +22,12 @@ else()
 		ipc-util/pipe-posix.c)
 endif()
 
-if(MSVC)
-	add_compile_options("$<$<CONFIG:RelWithDebInfo>:/MT>")
-endif()
+# Omit default library names for object libraries
+# This is useful when we can't determine what type
+# of runtime the resulting binary is going to use.
+if (WIN32 AND MSVC)
+	add_compile_options($<IF:$<CONFIG:Debug>,/MTd,/MT> /Zl)
+endif ()
 
 add_library(ipc-util STATIC
 	${ipc-util_SOURCES}


### PR DESCRIPTION
There's a myriad of reasons to not mix these flags. This one in
particular is a little tricky to implement. In this change, I've changed
the ipc-util library to be an object library instead of a static
library since we don't distribute the library regardless. I then changed
the flags to include `/MT[d] /Zl`. What this does is links against the
basic required runtime VC++ requires practically everything to have to
compile at all, then omits the default library names. This is a common
practice for object libraries in general as it saves a bit of space but
in particular, it allows us to use those objects with a binary that use
either the dynamic or static runtimes. This way, we can compile both
graphics-hook and win-capture with the same objects without being given
a linker warning, telling us we have incompatible runtimes.