### PR TITLE
appveyor: Build jansson with dynamic crt

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,9 @@ install:
   - set build_config=RelWithDebInfo
   - mkdir build build32 build64
   - cd ./build32
-  - cmake -G "Visual Studio 15 2017" -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DCOMPILE_D3D12_HOOK=true ..
+  - cmake -G "Visual Studio 15 2017" -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DJANSSON_STATIC_CRT=false -DCOMPILE_D3D12_HOOK=true ..
   - cd ../build64
-  - cmake -G "Visual Studio 15 2017 Win64" -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DCOMPILE_D3D12_HOOK=true ..
+  - cmake -G "Visual Studio 15 2017 Win64" -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DJANSSON_STATIC_CRT=false -DCOMPILE_D3D12_HOOK=true ..
 
 build_script:
   - call msbuild /m /p:Configuration=%build_config% C:\projects\obs-studio\build32\obs-studio.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"


### PR DESCRIPTION
Jansson is built with static crt by default which provides us a warning and mismatch when compiling with the UI. This is meant to correct that. 