### PR TITLE
fix bug with show_in_multiview==false for some scenes

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -927,8 +927,9 @@ void OBSProjector::UpdateMultiview()
 	siScaleY  = (scenesCY - thicknessx2) / fh;
 
 	numSrcs = 0;
-	while (numSrcs < scenes.sources.num && numSrcs < maxSrcs) {
-		obs_source_t *src = scenes.sources.array[numSrcs];
+	int i = 0;
+	while (i < scenes.sources.num && numSrcs < maxSrcs) {
+		obs_source_t *src = scenes.sources.array[i++];
 		OBSData data = obs_source_get_private_settings(src);
 		obs_data_release(data);
 


### PR DESCRIPTION
Disabling a scene for multiview leads to hanging obs-studio when multiview is shown.

The iterators have to be seperated.