### PR TITLE
UI: Theme fixes

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -43,6 +43,7 @@ QWidget {
 	font-family: "Open Sans", "Tahoma", "Arial", sans-serif;
 	font-size: 12px;
 	padding: 4px;
+	overflow: auto;
 }
 
 #menubar {
@@ -77,6 +78,14 @@ QSizeGrip {
 
 QWidget::disabled {
 	color: #484848;
+}
+
+* [themeID="error"] {
+	color: #d91740;
+}
+
+* [themeID="warning"] {
+	color: #d9af17;
 }
 
 /* Dropdown menus, Scenes box, Sources box */
@@ -502,10 +511,12 @@ QPushButton {
 
 QPushButton::flat {
 	background-color: rgb(24,24,25);
+	border: none;
 }
 
 QPushButton:checked {
-	background-color: #202b52;
+	background-color: #581624;
+	border-color: #84162d;
 }
 
 QPushButton:hover {
@@ -520,6 +531,11 @@ QPushButton:pressed {
 QPushButton:disabled {
 	border: 1px solid #232426;
 	background-color: #1a1a1b;
+}
+
+QPushButton::flat:hover,
+QPushButton::flat:disabled {
+	border: none;
 }
 
 /* Progress Bar */
@@ -833,13 +849,6 @@ OBSBasicProperties,
 
 FocusList::item {
 	padding: 0px 2px;
-}
-
-#transitionsContainer QPushButton,
-#mixerDock QPushButton,
-#effectWidget QPushButton,
-#asyncWidget QPushButton {
-	border: none;
 }
 
 #fpsTypes {

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -50,8 +50,8 @@ OBSTheme {
     highlight: rgb(42,130,218); /* blue */
     highlightText: rgb(0,0,0);
 
-    link: rgb(42,130,218); /* blue */
-    linkVisited: rgb(42,130,218); /* blue */
+    link: rgb(114, 162, 255); /* OBS blue */
+    linkVisited: rgb(114, 162, 255); /* OBS blue */
 }
 
 OBSTheme::disabled {

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -45,38 +45,70 @@
 /************************/
 
 OBSTheme {
-    window: rgb(49, 54, 59); /* Blue-gray */
-    windowText: rgb(239, 240, 241); /* White */
-    base: rgb(0, 139, 163); /* Dark Cyan (Primary Dark) */
-    alternateBase: rgb(186, 45, 101); /* Dark Pink (Secondary Dark) */
-    text: rgb(239, 240, 241); /* White */
-    button: rgb(0, 188, 212); /* Cyan (Primary) */
-    buttonText: rgb(239, 240, 241); /* White */
-    brightText: rgb(255, 148, 194); /* Light Pink (Secondary Light) */
+	window: rgb(49, 54, 59); /* Blue-gray */
+	windowText: rgb(239, 240, 241); /* White */
+	base: rgb(0, 139, 163); /* Dark Cyan (Primary Dark) */
+	alternateBase: rgb(186, 45, 101); /* Dark Pink (Secondary Dark) */
+	text: rgb(239, 240, 241); /* White */
+	button: rgb(0, 188, 212); /* Cyan (Primary) */
+	buttonText: rgb(239, 240, 241); /* White */
+	brightText: rgb(255, 148, 194); /* Light Pink (Secondary Light) */
 
-    light: rgb(162, 161, 162); /* Lighter Gray */
-    mid: rgb(118, 121, 124); /* Light Grey */
-    dark: rgb(84, 87, 91); /* Gray */
-    shadow: rgb(35, 38, 41); /* Dark Gray */
+	light: rgb(162, 161, 162); /* Lighter Gray */
+	mid: rgb(118, 121, 124); /* Light Grey */
+	dark: rgb(84, 87, 91); /* Gray */
+	shadow: rgb(35, 38, 41); /* Dark Gray */
 
-    highlight: rgb(98, 238, 255); /* Light Cyan (Primary Light) */
-    highlightText: rgb(0,0,0);
+	highlight: rgb(98, 238, 255); /* Light Cyan (Primary Light) */
+	highlightText: rgb(0,0,0);
 
-    link: rgb(98, 238, 255); /* Light Cyan (Primary Light) */
-    linkVisited: rgb(98, 238, 255); /* Light Cyan (Primary Light) */
+	link: rgb(98, 238, 255); /* Light Cyan (Primary Light) */
+	linkVisited: rgb(98, 238, 255); /* Light Cyan (Primary Light) */
 }
 
 OBSTheme::disabled {
-    text: rgb(255, 148, 194); /* Light Pink (Secondary Light) */
-    buttonText: rgb(255, 148, 194); /* Light Pink (Secondary Light) */
-    brightText: rgb(255, 148, 194); /* Light Pink (Secondary Light) */
+	text: rgb(118, 121, 124); /* Light Gray */
+	buttonText: rgb(118, 121, 124); /* Light Gray */
+	brightText: rgb(118, 121, 124); /* Light Gray */
 }
 
 OBSTheme::inactive {
-    highlight: rgb(0, 188, 212); /* Cyan (Primary) */
-    highlightText: rgb(239, 240, 241); /* White */
+	highlight: rgb(0, 188, 212); /* Cyan (Primary) */
+	highlightText: rgb(239, 240, 241); /* White */
 }
 
+
+/************************/
+/* ---- SourceTree ---- */
+/************************/
+
+SourceTree::item:selected:!active {
+	color: rgb(239, 240, 241); /* White */
+	background-color: rgba(255, 148, 194, 0.25); /* Light Pink (Secondary Light) */
+	border: none;
+}
+
+SourceTree::item:selected {
+	background-color: rgba(240, 98, 146, 0.5); /* Pink (Secondary) */
+	border: none;
+}
+
+SourceTree::item:hover,
+SourceTree::item:disabled:hover,
+SourceTree::item:hover:!active {
+	background-color: rgb(0, 188, 212); /* Cyan (Primary) */
+	color: rgb(239, 240, 241); /* White */
+	border: none;
+}
+
+SourceTree QLineEdit {
+	padding-top: 0;
+	padding-bottom: 0;
+	padding-right: 0;
+	padding-left: 2px;
+	border: none;
+	border-radius: none;
+}
 
 /*************************/
 /* --- General style --- */
@@ -573,16 +605,6 @@ QLineEdit {
 	color: rgb(239, 240, 241); /* White */
 }
 
-QListWidget QLineEdit {
-	padding-top: 0;
-	padding-bottom: 0;
-	padding-right: 0;
-	padding-left: 2px;
-	border: none;
-	border-radius: none;
-}
-
-
 /**********************/
 /* --- Checkboxes --- */
 /**********************/
@@ -744,23 +766,23 @@ MuteCheckBox::indicator:unchecked:disabled {
 /****************************/
 
 SourceTreeSubItemCheckBox {
-    background: transparent;
-    outline: none;
+	background: transparent;
+	outline: none;
 }
 
 SourceTreeSubItemCheckBox::indicator {
-    width: 10px;
-    height: 10px;
+	width: 10px;
+	height: 10px;
 }
 
 SourceTreeSubItemCheckBox::indicator:checked,
 SourceTreeSubItemCheckBox::indicator:checked:hover {
-    image: url(./Dark/expand.png);
+	image: url(./Dark/expand.png);
 }
 
 SourceTreeSubItemCheckBox::indicator:unchecked,
 SourceTreeSubItemCheckBox::indicator:unchecked:hover {
-    image: url(./Dark/collapse.png);
+	image: url(./Dark/collapse.png);
 }
 
 /*************************/
@@ -837,10 +859,10 @@ QPushButton:disabled {
 }
 
 QPushButton::menu-indicator {
-    image: url(./Rachni/down_arrow.png);
-    subcontrol-position: right;
-    subcontrol-origin: padding;
-    width: 25px;
+	image: url(./Rachni/down_arrow.png);
+	subcontrol-position: right;
+	subcontrol-origin: padding;
+	width: 25px;
 }
 
 /******************************/
@@ -1171,6 +1193,14 @@ QFrame[frameShape="0"] {
 
 
 /* Misc style tweaks for dark themes */
+* [themeID="error"] {
+	color: rgb(255, 89, 76); /* Red Error */
+}
+
+* [themeID="warning"] {
+	color: rgb(255, 148, 194); /* Light Pink (Secondary Light) */
+}
+
 QStatusBar::item {
 	border: none;
 }


### PR DESCRIPTION
This PR has two commits (feel free to squash, I kept them separate because they're for two different theme files).

The first is updates to the Rachni theme to fix a few issues with the new SourceTree widget, and some minor tweaks to colors. This also includes some white-space fixes that were introduced in 8b6d437

The second is an update to the link color used with the dark theme, as the default blue was essentially unreadable.