### PR TITLE
UI: Hides dock icon on Mac OSX when minimizing to tray

### DIFF
--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -168,3 +168,11 @@ void EnableOSXVSync(bool enable)
 		deferred_updates(enable ? 1 : 0);
 	}
 }
+
+void EnableOSXDockIcon(bool enable)
+{
+	if (enable)
+		[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+	else
+		[NSApp setActivationPolicy:NSApplicationActivationPolicyProhibited];
+}

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -63,4 +63,5 @@ RunOnceMutex GetRunOnceMutex(bool &already_running);
 
 #ifdef __APPLE__
 void EnableOSXVSync(bool enable);
+void EnableOSXDockIcon(bool enable);
 #endif


### PR DESCRIPTION
This hides the dock icon when minimizing OBS to the tray on OSX (including the icon in Command+Tab app switcher as well). This is how system tray applications work on mac (and matches the windows functionality).

This pull request also fixes existing issues with minimizing on startup (and hides the dock icon correctly in that case as well). Previously, when selecting "Minimize to system tray when started" on OSX, a blank contentless OBS window would display.