### PR TITLE
UI: Remove warning when using separate QSV encoders

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -622,7 +622,6 @@ Basic.Settings.Output.Simple.Warn.Encoder="Warning: Recording with a software en
 Basic.Settings.Output.Simple.Warn.Lossless="Warning: Lossless quality generates tremendously large file sizes!  Lossless quality can use upward of 7 gigabytes of disk space per minute at high resolutions and framerates.  Lossless is not recommended for long recordings unless you have a very large amount of disk space available."
 Basic.Settings.Output.Simple.Warn.Lossless.Msg="Are you sure you want to use lossless quality?"
 Basic.Settings.Output.Simple.Warn.Lossless.Title="Lossless quality warning!"
-Basic.Settings.Output.Simple.Warn.MultipleQSV="Warning: You cannot use multiple separate QSV encoders when streaming and recording at the same time.  If you want to stream and record at the same time, please change either the recording encoder or the stream encoder."
 Basic.Settings.Output.Simple.Encoder.Software="Software (x264)"
 Basic.Settings.Output.Simple.Encoder.Hardware.QSV="Hardware (QSV)"
 Basic.Settings.Output.Simple.Encoder.Hardware.AMD="Hardware (AMD)"

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4319,12 +4319,6 @@ void OBSBasicSettings::SimpleRecordingEncoderChanged()
 				warning += "\n\n";
 			warning += SIMPLE_OUTPUT_WARNING("Encoder");
 		}
-
-		if (streamEnc == enc && enc == SIMPLE_ENCODER_QSV) {
-			if (!warning.isEmpty())
-				warning += "\n\n";
-			warning += SIMPLE_OUTPUT_WARNING("MultipleQSV");
-		}
 	}
 
 	if (ui->simpleOutRecFormat->currentText().compare("mp4") == 0) {


### PR DESCRIPTION
The ability to use multiple separate QSV encoders was added in Pull Request #1341 (commit 3a08e858a68aeecaf6499973b55988db5a903ae5). This error message was left in place, so let's remove it now.

I've compiled and tested this on Windows 10 64-bit.  As always, feedback or reviews are appreciated.