### PR TITLE
CI: Use HTTPS for downloading macOS deps package

### DIFF
--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -31,7 +31,7 @@ ccache -s || echo "CCache is not available."
 
 # Fetch and untar prebuilt OBS deps that are compatible with older versions of OSX
 hr "Downloading OBS deps"
-wget --quiet --retry-connrefused --waitretry=1 http://obs-nightly.s3.amazonaws.com/osx-deps-2018-08-09.tar.gz
+wget --quiet --retry-connrefused --waitretry=1 https://obs-nightly.s3.amazonaws.com/osx-deps-2018-08-09.tar.gz
 tar -xf ./osx-deps-2018-08-09.tar.gz -C /tmp
 
 # Fetch vlc codebase


### PR DESCRIPTION
Pull Request #1420 changed the URL for the macOS deps package. When it did that, it also changed the URL from HTTPS to HTTP. Since this asset is available over HTTPS, we should use that.

The certificate when using HTTPS is valid, and CI successfully compiled with this change.