### PR TITLE
UI: Fix mixer context menu toggling layout on kde

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2656,7 +2656,7 @@ void OBSBasic::VolControlContextMenu()
 
 	/* ------------------- */
 
-	QMenu popup(this);
+	QMenu popup;
 	popup.addAction(&unhideAllAction);
 	popup.addAction(&hideAction);
 	popup.addAction(&mixerRenameAction);
@@ -2708,7 +2708,7 @@ void OBSBasic::StackedMixerAreaContextMenuRequested()
 
 	/* ------------------- */
 
-	QMenu popup(this);
+	QMenu popup;
 	popup.addAction(&unhideAllAction);
 	popup.addSeparator();
 	popup.addAction(&toggleControlLayoutAction);


### PR DESCRIPTION
This is a weird one. On KDE just clicking in the options or right
clicking the empty space areas of the mixer dock would trigger a layout
change.

This fixes mantis #1256