### PR TITLE
UI: Fix path for File > Show Recordings

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3596,9 +3596,13 @@ void OBSBasic::changeEvent(QEvent *event)
 void OBSBasic::on_actionShow_Recordings_triggered()
 {
 	const char *mode = config_get_string(basicConfig, "Output", "Mode");
+	const char *type = config_get_string(basicConfig, "AdvOut", "RecType");
+	const char *adv_path = strcmp(type, "Standard") ?
+			config_get_string(basicConfig, "AdvOut", "FFFilePath") :
+			config_get_string(basicConfig, "AdvOut", "RecFilePath");
 	const char *path = strcmp(mode, "Advanced") ?
-		config_get_string(basicConfig, "SimpleOutput", "FilePath") :
-		config_get_string(basicConfig, "AdvOut", "RecFilePath");
+			config_get_string(basicConfig, "SimpleOutput", "FilePath") :
+			adv_path;
 	QDesktopServices::openUrl(QUrl::fromLocalFile(path));
 }
 


### PR DESCRIPTION
In main menu, File > Show Recordings does not show the path for ffmpeg
custom output when it is selected in Settings.
This fixes the issue.
(Bug found by EposVox)