### PR TITLE
UI: Blacklist LockApp and Text Input from Game Capture

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -923,6 +923,8 @@ static const char *blacklisted_exes[] = {
 	"shellexperiencehost",
 	"winstore.app",
 	"searchui",
+	"lockapp",
+	"windowsinternal.composableshell.experiences.textinput.inputapp",
 	NULL
 };
 


### PR DESCRIPTION
Occasionally users accidentally select the following applications built
into Windows 10 using game capture, which cannot be captured.
This PR simply hides them from the game capture list.
The latter takes up 6 entries in the dropdown.

LockApp.exe - the lock screen which doesn't run in user space
WindowsInternal.ComposableShell.Experiences.TextInput.InputApp