### PR TITLE
obs-qsv11: Clear up the code

### DIFF
--- a/plugins/obs-qsv11/common_utils.h
+++ b/plugins/obs-qsv11/common_utils.h
@@ -20,7 +20,7 @@ Copyright(c) 2005-2014 Intel Corporation. All Rights Reserved.
 //  - mfxTime
 //  - MSDK_FOPEN
 //  - MSDK_SLEEP
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #include "bits/windows_defs.h"
 #elif defined(__linux__)
 #include "bits/linux_defs.h"


### PR DESCRIPTION
 _WIN32 is always defined for windows