### PR TITLE
UI: Name parameters in definition same as in declaration

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -515,20 +515,20 @@ void OBSBasicFilters::OBSSourceReordered(void *param, calldata_t *data)
 	UNUSED_PARAMETER(data);
 }
 
-void OBSBasicFilters::SourceRemoved(void *data, calldata_t *params)
+void OBSBasicFilters::SourceRemoved(void *param, calldata_t *data)
 {
-	UNUSED_PARAMETER(params);
+	UNUSED_PARAMETER(data);
 
-	QMetaObject::invokeMethod(static_cast<OBSBasicFilters*>(data),
+	QMetaObject::invokeMethod(static_cast<OBSBasicFilters*>(param),
 	                "close");
 }
 
-void OBSBasicFilters::SourceRenamed(void *data, calldata_t *params)
+void OBSBasicFilters::SourceRenamed(void *param, calldata_t *data)
 {
-	const char *name = calldata_string(params, "new_name");
+	const char *name = calldata_string(data, "new_name");
 	QString title = QTStr("Basic.Filters.Title").arg(QT_UTF8(name));
 
-	QMetaObject::invokeMethod(static_cast<OBSBasicFilters*>(data),
+	QMetaObject::invokeMethod(static_cast<OBSBasicFilters*>(param),
 	                "setWindowTitle", Q_ARG(QString, title));
 }
 


### PR DESCRIPTION
This was found with Cppcheck. These two member functions declarations have "param, data" parameters list but their definition have "data, params" parameters instead. Parameters order should match for better maintainability.