### PR TITLE
CI: Build Browser Source on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,22 +3,29 @@ environment:
   CURL_VERSION: 7.56.1
 
 install:
+  - set CEF_VERSION=3.3440.1805.gbe070f9
   - git submodule update --init --recursive
   - if exist dependencies2017.zip (curl -kLO https://obsproject.com/downloads/dependencies2017.zip -f --retry 5 -z dependencies2017.zip) else (curl -kLO https://obsproject.com/downloads/dependencies2017.zip -f --retry 5 -C -)
   - if exist vlc.zip (curl -kLO https://obsproject.com/downloads/vlc.zip -f --retry 5 -z vlc.zip) else (curl -kLO https://obsproject.com/downloads/vlc.zip -f --retry 5 -C -)
+  - if exist cef_binary_%CEF_VERSION%_windows32.zip (curl -kLO https://obsproject.com/downloads/cef_binary_%CEF_VERSION%_windows32.zip -f --retry 5 -z cef_binary_%CEF_VERSION%_windows32.zip) else (curl -kLO https://obsproject.com/downloads/cef_binary_%CEF_VERSION%_windows32.zip -f --retry 5 -C -)
+  - if exist cef_binary_%CEF_VERSION%_windows64.zip (curl -kLO https://obsproject.com/downloads/cef_binary_%CEF_VERSION%_windows64.zip -f --retry 5 -z cef_binary_%CEF_VERSION%_windows64.zip) else (curl -kLO https://obsproject.com/downloads/cef_binary_%CEF_VERSION%_windows64.zip -f --retry 5 -C -)
   - 7z x dependencies2017.zip -odependencies2017
   - 7z x vlc.zip -ovlc
+  - 7z x cef_binary_%CEF_VERSION%_windows32.zip -oCEF_32
+  - 7z x cef_binary_%CEF_VERSION%_windows64.zip -oCEF_64
   - set DepsPath32=%CD%\dependencies2017\win32
   - set DepsPath64=%CD%\dependencies2017\win64
   - set VLCPath=%CD%\vlc
   - set QTDIR32=C:\Qt\5.11.1\msvc2015
   - set QTDIR64=C:\Qt\5.11.1\msvc2017_64
+  - set CEF_32=%CD%\CEF_32\cef_binary_%CEF_VERSION%_windows32
+  - set CEF_64=%CD%\CEF_64\cef_binary_%CEF_VERSION%_windows64
   - set build_config=RelWithDebInfo
   - mkdir build build32 build64
   - cd ./build32
-  - cmake -G "Visual Studio 15 2017" -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DCOMPILE_D3D12_HOOK=true ..
+  - cmake -G "Visual Studio 15 2017" -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DCOMPILE_D3D12_HOOK=true -DBUILD_BROWSER=true -DCEF_ROOT_DIR=%CEF_32% ..
   - cd ../build64
-  - cmake -G "Visual Studio 15 2017 Win64" -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DCOMPILE_D3D12_HOOK=true ..
+  - cmake -G "Visual Studio 15 2017 Win64" -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DCOMPILE_D3D12_HOOK=true -DBUILD_BROWSER=true -DCEF_ROOT_DIR=%CEF_64% ..
 
 build_script:
   - call msbuild /m /p:Configuration=%build_config% C:\projects\obs-studio\build32\obs-studio.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
@@ -35,6 +42,8 @@ test: off
 cache:
   - dependencies2017.zip
   - vlc.zip
+  - cef_binary_3.3440.1805.gbe070f9_windows32.zip
+  - cef_binary_3.3440.1805.gbe070f9_windows64.zip
 
 notifications:
   - provider: Webhook


### PR DESCRIPTION
This adds the Browser Source to the Windows AppVeyor build.

**Please let this finish building for testing purposes before merge.**