### PR TITLE
rtmp-services: update Periscope settings

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 87,
+	"version": 88,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 87
+			"version": 88
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1140,9 +1140,9 @@
                 }
             ],
             "recommended": {
-                "keyint": 2,
-                "max video bitrate": 800,
-                "max audio bitrate": 96
+                "keyint": 3,
+                "max video bitrate": 4000,
+                "max audio bitrate": 128
             }
         },
         {


### PR DESCRIPTION
Periscope's recommended ingest settings were recently updated:
     
> Input Key Settings (make sure to input these accurately)
>
>    - Video bitrate & codec: 2500 kbps (recommended), 4000 kbps (max), H.264
>    - Audio bitrate & codec: 128 kbps AAC-LC 
>    - Framerate: 30 fps 
>    - Resolution: 1280 x 720
>    - Keyframe interval: Every 3 seconds (OBS) or keyframe every 90 frames (Wirecast)

Source: https://help.pscp.tv/customer/en/portal/articles/2600293-what-is-periscope-producer