### PR TITLE
UI: Dark theme padding and alignment fixes

### DIFF
--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -86,7 +86,7 @@ QWidget::disabled {
     color: 2px solid rgb(200,199,200); /* lighter */
 }
 
-QAbstractItemView {
+QAbstractItemView, QStackedWidget#stackedMixerArea QWidget {
     background-color: rgb(31,30,31); /* veryDark */
 }
 
@@ -148,10 +148,7 @@ QGroupBox {
 }
 
 QScrollBar:vertical {
-    background-color: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0,
-        stop: 0 rgb(31,30,31), /* veryDark */
-        stop: 0.75 rgb(54, 53, 54),
-        stop: 1 rgb(58,57,58)); /* dark */
+    background-color: rgb(58,57,58); /* dark */
     width: 14px;
 }
 
@@ -179,10 +176,7 @@ QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical, QScrollBar::add-
 }
 
 QScrollBar:horizontal {
-    background-color: QLinearGradient(x1: 0, y1: 0, x2: 0, y2: 1,
-        stop: 0 rgb(31,30,31), /* veryDark */
-        stop: 0.75 rgb(54, 53, 54),
-        stop: 1 rgb(58,57,58)); /* dark */
+    background-color: rgb(58,57,58); /* dark */
     height: 14px;
 }
 
@@ -319,6 +313,13 @@ QComboBox {
     padding-left: 10px;
 }
 
+QComboBox:hover {
+    background-color: QLinearGradient(x1: 0, y1: 0, x2: 0, y2: 1,
+        stop: 0 rgb(111, 110, 101),
+        stop: 0.25 rgb(100, 99, 100),
+        stop: 1 rgb(88,87,88)); 
+}
+
 QComboBox::drop-down {
     border:none;
     border-left: 1px solid rgba(31,30,31,155); /* veryDark */
@@ -357,7 +358,12 @@ QComboBox::down-arrow:editable {
 QLineEdit, QTextEdit, QPlainTextEdit {
     background-color: rgb(31,30,31); /* veryDark */
     border: none;
-    padding-left: 2px;
+    border-radius: 3px;
+    padding: 2px 2px 3px 7px;
+}
+
+OBSHotkeyWidget QLineEdit {
+    margin: 0px 3px 0px 0px;
 }
 
 
@@ -366,9 +372,9 @@ QLineEdit, QTextEdit, QPlainTextEdit {
 QSpinBox, QDoubleSpinBox {
     background-color: rgb(31,30,31); /* veryDark */
     border: none;
-    padding-left: 2px;
-    padding-right: 15px;
-    margin-right: 10px;
+    border-radius: 3px;
+    margin: 0px 3px 0px 0px;
+    padding: 2px 2px 3px 7px;
 }
 
 QSpinBox::up-button, QDoubleSpinBox::up-button {
@@ -456,6 +462,10 @@ QPushButton::menu-indicator {
     subcontrol-position: right;
     subcontrol-origin: padding;
     width: 25px;
+}
+
+QPushButton[themeID="hotkeyButtons"] {
+    margin: 1px  2px;
 }
 
 /* Sliders */


### PR DESCRIPTION
Newer themes like Acri and Rachni have consistent sizing and padding on buttons and inputs. This brings the default Dark theme in line with them.

Changes in this PR:
* Added Spacing between Hotkey buttons 
* Aligned height of inputs with hotkey buttons
* aligned left inner edge of text inputs and rounding with other inputs (like dropdowns)
* ~~Aligned dock headings with dock contents~~ Removed per Jim's request
* Coloured the Mixer with the same background as Scenes/Sources
* Added a hover color for dropdown menus similar to buttons
* Removed gradient behind the scrollbar

Hotkey inputs & buttons:
![2018-08-25_16-43-52](https://user-images.githubusercontent.com/941350/44615838-e7a16c00-a886-11e8-9a72-753e94ffe527.png)
![2018-08-25_16-44-30](https://user-images.githubusercontent.com/941350/44615842-ebcd8980-a886-11e8-89fa-66ebcc0a694b.png)

Input alignment:
![2018-08-25_16-47-38](https://user-images.githubusercontent.com/941350/44615851-00118680-a887-11e8-9a84-bccfcdc47926.png)
![2018-08-25_16-48-00](https://user-images.githubusercontent.com/941350/44615852-03a50d80-a887-11e8-8648-747ad67746c4.png)

Mixer background:
![2018-08-25_20-27-43](https://user-images.githubusercontent.com/941350/44617456-d4ea5f80-a8a5-11e8-85ae-55a2af0db73a.png)
![2018-08-25_20-27-53](https://user-images.githubusercontent.com/941350/44617458-d74cb980-a8a5-11e8-8d17-c37376e148c7.png)

Dropdown hover:
![2018-08-25_20-30-52](https://user-images.githubusercontent.com/941350/44617459-dd429a80-a8a5-11e8-880a-5019d35a747e.png)

Scrollbar:
![2018-09-10_19-11-08](https://user-images.githubusercontent.com/941350/45288189-68ba5d80-b52d-11e8-85e2-6d89111315d5.png)
![2018-09-10_19-11-00](https://user-images.githubusercontent.com/941350/45288196-6f48d500-b52d-11e8-9da3-32aa11c08b19.png)
