### PR TITLE
UI: Make stats dockable

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -293,6 +293,7 @@
      <addaction name="toggleMixer"/>
      <addaction name="toggleTransitions"/>
      <addaction name="toggleControls"/>
+     <addaction name="toggleStats"/>
     </widget>
     <action name="actionFullscreenInterface">
      <property name="text">
@@ -1098,6 +1099,21 @@
     </layout>
    </widget>
   </widget>
+  <widget class="QDockWidget" name="statsDock">
+   <property name="minimumSize">
+    <size>
+     <width>168</width>
+     <height>103</height>
+    </size>
+   </property>
+   <property name="windowTitle">
+    <string>Basic.Stats</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>2</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents"/>
+  </widget>
   <action name="actionAddScene">
    <property name="icon">
     <iconset resource="obs.qrc">
@@ -1654,6 +1670,17 @@
   <action name="actionDiscord">
    <property name="text">
     <string>Basic.MainMenu.Help.Discord</string>
+   </property>
+  </action>
+  <action name="toggleStats">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Basic.Stats</string>
    </property>
   </action>
  </widget>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -289,6 +289,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	assignDockToggle(ui->mixerDock, ui->toggleMixer);
 	assignDockToggle(ui->transitionsDock, ui->toggleTransitions);
 	assignDockToggle(ui->controlsDock, ui->toggleControls);
+	assignDockToggle(ui->statsDock, ui->toggleStats);
 
 	//hide all docking panes
 	ui->toggleScenes->setChecked(false);
@@ -296,6 +297,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	ui->toggleMixer->setChecked(false);
 	ui->toggleTransitions->setChecked(false);
 	ui->toggleControls->setChecked(false);
+	ui->toggleStats->setChecked(false);
 
 	//restore parent window geometry
 	const char *geometry = config_get_string(App()->GlobalConfig(),
@@ -1572,6 +1574,10 @@ void OBSBasic::OBSInit()
 #ifndef _WIN32
 	show();
 #endif
+
+	/* setup stats dock */
+	OBSBasicStats *statsDlg = new OBSBasicStats(ui->statsDock, false);
+	ui->statsDock->setWidget(statsDlg);
 
 	const char *dockStateStr = config_get_string(App()->GlobalConfig(),
 			"BasicWindow", "DockState");
@@ -6095,7 +6101,8 @@ void OBSBasic::on_resetUI_triggered()
 		ui->sourcesDock,
 		ui->mixerDock,
 		ui->transitionsDock,
-		ui->controlsDock
+		ui->controlsDock,
+		ui->statsDock
 	};
 
 	QList<int> sizes {
@@ -6111,6 +6118,7 @@ void OBSBasic::on_resetUI_triggered()
 	ui->mixerDock->setVisible(true);
 	ui->transitionsDock->setVisible(true);
 	ui->controlsDock->setVisible(true);
+	ui->statsDock->setVisible(true);
 
 	resizeDocks(docks, {cy, cy, cy, cy, cy}, Qt::Vertical);
 	resizeDocks(docks, sizes, Qt::Horizontal);
@@ -6128,6 +6136,7 @@ void OBSBasic::on_lockUI_toggled(bool lock)
 	ui->mixerDock->setFeatures(features);
 	ui->transitionsDock->setFeatures(features);
 	ui->controlsDock->setFeatures(features);
+	ui->statsDock->setFeatures(features);
 }
 
 void OBSBasic::on_toggleListboxToolbars_toggled(bool visible)

--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -28,7 +28,7 @@ static void setThemeID(QWidget *widget, const QString &themeID)
 	}
 }
 
-OBSBasicStats::OBSBasicStats(QWidget *parent)
+OBSBasicStats::OBSBasicStats(QWidget *parent, bool closeable)
 	: QWidget             (parent),
 	  cpu_info            (os_cpu_usage_info_start()),
 	  timer               (this)
@@ -75,13 +75,15 @@ OBSBasicStats::OBSBasicStats(QWidget *parent)
 	newStat("SkippedFrames", skippedFrames, 2);
 
 	/* --------------------------------------------- */
-
-	QPushButton *closeButton = new QPushButton(QTStr("Close"));
+	QPushButton *closeButton = nullptr;
+	if(closeable)
+		closeButton = new QPushButton(QTStr("Close"));
 	QPushButton *resetButton = new QPushButton(QTStr("Reset"));
 	QHBoxLayout *buttonLayout = new QHBoxLayout;
 	buttonLayout->addStretch();
 	buttonLayout->addWidget(resetButton);
-	buttonLayout->addWidget(closeButton);
+	if(closeable)
+		buttonLayout->addWidget(closeButton);
 
 	/* --------------------------------------------- */
 
@@ -125,16 +127,15 @@ OBSBasicStats::OBSBasicStats(QWidget *parent)
 	setLayout(mainLayout);
 
 	/* --------------------------------------------- */
-
-	connect(closeButton, &QPushButton::clicked, [this] () {close();});
+	if(closeable)
+		connect(closeButton, &QPushButton::clicked,
+				[this] () {close();});
 	connect(resetButton, &QPushButton::clicked, [this] () {Reset();});
 
 	installEventFilter(CreateShortcutFilter());
 
 	resize(800, 280);
-	setWindowFlags(Qt::Window |
-	               Qt::WindowMinimizeButtonHint |
-	               Qt::WindowCloseButtonHint);
+
 	setWindowTitle(QTStr("Basic.Stats"));
 	setWindowIcon(QIcon(":/res/images/obs.png"));
 	setWindowModality(Qt::NonModal);

--- a/UI/window-basic-stats.hpp
+++ b/UI/window-basic-stats.hpp
@@ -55,7 +55,7 @@ class OBSBasicStats : public QWidget {
 	virtual void closeEvent(QCloseEvent *event) override;
 
 public:
-	OBSBasicStats(QWidget *parent = nullptr);
+	OBSBasicStats(QWidget *parent = nullptr, bool closable = true);
 	~OBSBasicStats();
 
 	static void InitializeValues();


### PR DESCRIPTION
Adds a new dock out of the stats widget.

![image](https://user-images.githubusercontent.com/25020235/44730750-818b3380-aa96-11e8-97c8-5a8ed07a83eb.png)
