### PR TITLE
UI: Use AlwaysOnTop option for windowed projectors

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -36,6 +36,9 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 		windowedProjectors.push_back(this);
 
 		resize(480, 270);
+
+		SetAlwaysOnTop(this, config_get_bool(GetGlobalConfig(),
+				"BasicWindow", "ProjectorAlwaysOnTop"));
 	} else {
 		setWindowFlags(Qt::FramelessWindowHint |
 				Qt::X11BypassWindowManagerHint);
@@ -48,6 +51,8 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 		addAction(action);
 		connect(action, SIGNAL(triggered()), this,
 				SLOT(EscapeTriggered()));
+
+		SetAlwaysOnTop(this, true);
 	}
 
 	setAttribute(Qt::WA_DeleteOnClose, true);
@@ -67,11 +72,6 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 	};
 
 	connect(this, &OBSQTDisplay::DisplayCreated, addDrawCallback);
-
-	bool alwaysOnTop = config_get_bool(GetGlobalConfig(), "BasicWindow",
-			"ProjectorAlwaysOnTop");
-	if (alwaysOnTop && !isWindow)
-		SetAlwaysOnTop(this, true);
 
 	bool hideCursor = config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "HideProjectorCursor");


### PR DESCRIPTION
This fixes mantis issue # [1279](https://obsproject.com/mantis/view.php?id=1279)