### PR TITLE
UI: Add rename scene/source shortcut

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -244,6 +244,11 @@ void SourceTreeItem::mouseDoubleClickEvent(QMouseEvent *event)
 	}
 }
 
+bool SourceTreeItem::IsEditing()
+{
+	return editor != nullptr;
+}
+
 void SourceTreeItem::EnterEditMode()
 {
 	setFocusPolicy(Qt::StrongFocus);
@@ -1279,10 +1284,14 @@ void SourceTree::Edit(int row)
 	if (row < 0 || row >= stm->items.count())
 		return;
 
-	QWidget *widget = indexWidget(stm->createIndex(row, 0));
+	QModelIndex index = stm->createIndex(row, 0);
+	QWidget *widget = indexWidget(index);
 	SourceTreeItem *itemWidget = reinterpret_cast<SourceTreeItem *>(widget);
+	if (itemWidget->IsEditing())
+		return;
+
 	itemWidget->EnterEditMode();
-	edit(stm->createIndex(row, 0));
+	edit(index);
 }
 
 bool SourceTree::MultipleBaseSelected() const

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -47,6 +47,7 @@ class SourceTreeItem : public QWidget {
 
 public:
 	explicit SourceTreeItem(SourceTree *tree, OBSSceneItem sceneitem);
+	bool IsEditing();
 
 private:
 	QSpacerItem *spacer = nullptr;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -241,12 +241,29 @@ OBSBasic::OBSBasic(QWidget *parent)
 			ui->statusbar, SLOT(UpdateCPUUsage()));
 	cpuUsageTimer->start(3000);
 
+	QAction *renameScene = new QAction(ui->scenesDock);
+	renameScene->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+	connect(renameScene, SIGNAL(triggered()), this, SLOT(EditSceneName()));
+	ui->scenesDock->addAction(renameScene);
+
+	QAction *renameSource = new QAction(ui->sourcesDock);
+	renameSource->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+	connect(renameSource, SIGNAL(triggered()), this,
+			SLOT(EditSceneItemName()));
+	ui->sourcesDock->addAction(renameSource);
+
 #ifdef __APPLE__
+	renameScene->setShortcut({Qt::Key_Return});
+	renameSource->setShortcut({Qt::Key_Return});
+
 	ui->actionRemoveSource->setShortcuts({Qt::Key_Backspace});
 	ui->actionRemoveScene->setShortcuts({Qt::Key_Backspace});
 
 	ui->action_Settings->setMenuRole(QAction::PreferencesRole);
 	ui->actionE_xit->setMenuRole(QAction::QuitRole);
+#else
+	renameScene->setShortcut({Qt::Key_F2});
+	renameSource->setShortcut({Qt::Key_F2});
 #endif
 
 	auto addNudge = [this](const QKeySequence &seq, const char *s)


### PR DESCRIPTION
This creates a hidden QAction in sceneDocks and sourceDocks so we can
assign a shortcut to perform the renaming action.

This finishes the work on PR #1212 as groupping was added to SourceTree