### PR TITLE
Add compiler checks to avoid VLA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,8 +67,8 @@ if(${CMAKE_C_COMPILER_ID} MATCHES "Clang" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "C
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
-	set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused-function -Werror-implicit-function-declaration -Wno-missing-field-initializers ${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
-	set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-unused-function -Werror-implicit-function-declaration -Wno-missing-braces -Wno-missing-field-initializers ${CMAKE_C_FLAGS} -std=gnu99 -fno-strict-aliasing")
+	set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wvla -Wno-unused-function -Werror-implicit-function-declaration -Wno-missing-field-initializers ${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
+	set(CMAKE_C_FLAGS "-Wall -Wextra -Wvla -Wno-unused-function -Werror-implicit-function-declaration -Wno-missing-braces -Wno-missing-field-initializers ${CMAKE_C_FLAGS} -std=gnu99 -fno-strict-aliasing")
 
 	option(USE_LIBC++ "Use libc++ instead of libstdc++" ${APPLE})
 	if(USE_LIBC++)

--- a/libobs/audio-monitoring/pulse/pulseaudio-wrapper.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-wrapper.c
@@ -307,14 +307,15 @@ int_fast32_t pulseaudio_connect_playback(pa_stream *s, const char *name,
 		return -1;
 
 	size_t dev_len = strlen(name) - 8;
-	char device[dev_len];
+	char *device = bzalloc(dev_len + 1);
 	memcpy(device, name, dev_len);
-	device[dev_len] = '\0';
 
 	pulseaudio_lock();
 	int_fast32_t ret = pa_stream_connect_playback(s, device, attr, flags,
 			NULL, NULL);
 	pulseaudio_unlock();
+
+	bfree(device);
 	return ret;
 }
 


### PR DESCRIPTION
There isn't any on Windows (maybe MSVC just doesn't allow/support it) but on Linux there were only 1 case of VLA and we should avoid it if possible.

Links:
lkml [here](https://lore.kernel.org/lkml/CA+55aFzCG-zNmZwX4A2FQpadafLfEzK6CC=qPXydAacU1RqZWA@mail.gmail.com/T/#u)
linux git [changes](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=02361bc77888)
linux securiy summit [pages 6, 7 and 8](https://outflux.net/slides/2018/lss/danger.pdf)