### PR TITLE
Initial pass at pkg-config support

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -446,6 +446,22 @@ if(BUILD_CAPTIONS)
 endif()
 
 add_library(libobs SHARED ${libobs_SOURCES} ${libobs_HEADERS})
+if(UNIX)
+	if (NOT APPLE)
+		set(DEST_DIR "${CMAKE_INSTALL_PREFIX}")
+		foreach(LIB "obs" "rt")
+			set(PRIVATE_LIBS "${PRIVATE_LIBS} -l${LIB}")
+		endforeach()
+		if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+			set(LIBDATA "libdata")
+		else()
+			set(LIBDATA "share/libdata")
+		endif()
+		CONFIGURE_FILE("libobs.pc.in" "libobs.pc" @ONLY)
+		set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/${LIBDATA}/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
+		install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libobs.pc" DESTINATION "${INSTALL_PKGCONFIG_DIR}")
+	endif()
+endif()
 
 set_target_properties(libobs PROPERTIES
 	OUTPUT_NAME obs

--- a/libobs/libobs.pc.in
+++ b/libobs/libobs.pc.in
@@ -1,0 +1,11 @@
+prefix=@DEST_DIR@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libobs
+Description: OBS Studio Library
+Version: @OBS_VERSION@
+Requires: x11
+Cflags: -I${includedir}
+Libs: -L${libdir} @PRIVATE_LIBS@


### PR DESCRIPTION
Based on:

http://dailycommit.blogspot.com/2016/10/how-to-generate-pkg-config-file-with.html
https://people.freedesktop.org/~dbn/pkg-config-guide.html

Should allow third party plugins to find and use libobs more easily.

I'm sure this is not perfect yet, but thought it would serve as a good starting point for discussion.