### PR TITLE
win-ivcam: Remove and prohibit useless member functions

### DIFF
--- a/plugins/win-ivcam/seg_library/SegServerImpl.cpp
+++ b/plugins/win-ivcam/seg_library/SegServerImpl.cpp
@@ -36,7 +36,6 @@ SegServerImpl::SegServerImpl()
     m_sharedBuffer = NULL;
 }
 
-SegServerImpl::SegServerImpl(SegServerImpl const&) {};
 SegServerImpl::~SegServerImpl() 
 {
     if (m_server)
@@ -46,7 +45,6 @@ SegServerImpl::~SegServerImpl()
     }
     instance = nullptr;
 };
-SegServerImpl& SegServerImpl::operator=(const SegServerImpl &) { return *this; };
 
 SegServer* SegServerImpl::CreateServer()
 {

--- a/plugins/win-ivcam/seg_library/SegServerImpl.h
+++ b/plugins/win-ivcam/seg_library/SegServerImpl.h
@@ -56,8 +56,8 @@ private:
     LPCTSTR m_sharedBuffer;
 
     SegServerImpl();
-    SegServerImpl(SegServerImpl const& src);
-    SegServerImpl& operator=(const SegServerImpl & src);
+    SegServerImpl(SegServerImpl const& src) = delete;
+    SegServerImpl& operator=(const SegServerImpl & src) = delete;
 
 public:
     virtual ~SegServerImpl();


### PR DESCRIPTION
This was found with Cppcheck. Copy constructor and assignment operator do nothing and are declared private and are not actually used anywhere. It's clearer and more reliable to just prohibit them.