### PR TITLE
UI: Add left click context menu on empty scenes

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -960,6 +960,15 @@ void SourceTree::mouseDoubleClickEvent(QMouseEvent *event)
 		QListView::mouseDoubleClickEvent(event);
 }
 
+void SourceTree::mousePressEvent(QMouseEvent *event)
+{
+	SourceTreeModel *stm = GetStm();
+	if (event->button() == Qt::LeftButton && !stm->items.count())
+		emit noSourceLeftClick(event->pos());
+	else
+		QListView::mousePressEvent(event);
+}
+
 void SourceTree::dropEvent(QDropEvent *event)
 {
 	if (event->source() != this) {

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -168,9 +168,12 @@ public slots:
 	void UngroupSelectedGroups();
 	void AddGroup();
 	void Edit(int idx);
+signals:
+	void noSourceLeftClick(const QPoint &pos);
 
 protected:
 	virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
+	virtual void mousePressEvent(QMouseEvent *event) override;
 	virtual void dropEvent(QDropEvent *event) override;
 
 	virtual void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -216,8 +216,13 @@ OBSBasic::OBSBasic(QWidget *parent)
 			ResizePreview(ovi.base_width, ovi.base_height);
 	};
 
+	auto noSourceClick = [this](const QPoint &pos) {
+		on_sources_customContextMenuRequested(pos);
+	};
+
 	connect(windowHandle(), &QWindow::screenChanged, displayResize);
 	connect(ui->preview, &OBSQTDisplay::DisplayResized, displayResize);
+	connect(ui->sources, &SourceTree::noSourceLeftClick, noSourceClick);
 
 	installEventFilter(CreateShortcutFilter());
 


### PR DESCRIPTION
Suggested by warchamp, left clicks on empty scenes should show an add
source dialog. This approach opens the right click context menu.