### PR TITLE
cmake: Fix an error when SWIG isn't found

### DIFF
--- a/deps/obs-scripting/CMakeLists.txt
+++ b/deps/obs-scripting/CMakeLists.txt
@@ -62,10 +62,12 @@ find_package(SwigDeps QUIET 2)
 
 if(NOT SWIG_FOUND)
 	message(STATUS "Scripting: SWIG not found; scripting disabled")
+	return()
 endif()
 
 if(NOT PYTHONLIBS_FOUND AND NOT LUAJIT_FOUND)
 	message(STATUS "Scripting: Neither Python 3 nor Luajit was found; scripting plugin disabled")
+	return()
 endif()
 
 set(SCRIPTING_ENABLED ON CACHE BOOL "Interal global cmake variable" FORCE)


### PR DESCRIPTION
obs-scripting CMakeList.txt expects SWIG, Python3 or Luajit to enable
scripting so in case of not finding just return and don't abort
the configuration

Fix this [error](https://gist.github.com/admshao/bbcb1e12b04ec3a0ec9b51fc03da9434)