### PR TITLE
obs-qsv: enable High Profile for QSV h264

### DIFF
--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -142,7 +142,7 @@ static void obs_qsv_defaults(obs_data_t *settings)
 	obs_data_set_default_string(settings, "target_usage", "balanced");
 	obs_data_set_default_int(settings, "bitrate", 2500);
 	obs_data_set_default_int(settings, "max_bitrate", 3000);
-	obs_data_set_default_string(settings, "profile", "main");
+	obs_data_set_default_string(settings, "profile", "high");
 	obs_data_set_default_int(settings, "async_depth", 4);
 	obs_data_set_default_string(settings, "rate_control", "CBR");
 


### PR DESCRIPTION
- New QSV Default -> H264 High profile.  Previous Default -> H264 Main profile