### PR TITLE
UI: Fix array length computation

### DIFF
--- a/UI/frontend-plugins/frontend-tools/captions-mssapi-stream.cpp
+++ b/UI/frontend-plugins/frontend-tools/captions-mssapi-stream.cpp
@@ -249,8 +249,9 @@ STDMETHODIMP CaptionStream::Stat(STATSTG *stg, DWORD flag)
 	stg->cbSize.QuadPart = (ULONGLONG)buf->size;
 
 	if (flag == STATFLAG_DEFAULT) {
-		stg->pwcsName = (wchar_t*)CoTaskMemAlloc(sizeof(stat_name));
-		memcpy(stg->pwcsName, stat_name, sizeof(stat_name));
+		size_t byte_size = (wcslen(stat_name) + 1) * sizeof(wchar_t);
+		stg->pwcsName = (wchar_t*)CoTaskMemAlloc(byte_size);
+		memcpy(stg->pwcsName, stat_name, byte_size);
 	}
 
 	return S_OK;


### PR DESCRIPTION
This was found with Cppcheck. Code uses `sizeof()` applied to a pointer which yields `sizeof(void*)`. Actual length of string should be used instead.