### PR TITLE
libobs: Truncate thread names on Linux

### DIFF
--- a/libobs/util/threading-posix.c
+++ b/libobs/util/threading-posix.c
@@ -253,6 +253,12 @@ void os_set_thread_name(const char *name)
 #elif defined(__FreeBSD__)
 	pthread_set_name_np(pthread_self(), name);
 #elif defined(__GLIBC__) && !defined(__MINGW32__)
-	pthread_setname_np(pthread_self(), name);
+	if (strlen(name) <= 15) {
+		pthread_setname_np(pthread_self(), name);
+	} else {
+		char *thread_name = bstrdup_n(name, 15);
+		pthread_setname_np(pthread_self(), thread_name);
+		bfree(thread_name);
+	}
 #endif
 }


### PR DESCRIPTION
The pthread_setname_np manpage states:

The thread name is a meaningful C language string, whose length is restricted to 16 characters, including the terminating null byte ('\0').

Have not verified whether this is also the case for other POSIX based systems, so am making this change for Linux only.