### PR TITLE
UI: Change resize output text

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -870,5 +870,5 @@ About.Contribute="Want to contribute?"
 
 # Dynamic output size
 ResizeOutputSizeOfSource="Resize output (source size)"
-ResizeOutputSizeOfSource.Text="The base and canvas resolution will be resized to the size of the current source."
+ResizeOutputSizeOfSource.Text="The base and output resolution will be resized to the size of the current source."
 ResizeOutputSizeOfSource.Continue="Do you want to continue?"


### PR DESCRIPTION
The text for resizing the output based on source is inaccurate
because base and canvas are the same thing.