### PR TITLE
enc-amf: Update to 2.5.0 and update repository address

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/palana/Syphon-Framework.git
 [submodule "plugins/enc-amf"]
 	path = plugins/enc-amf
-	url = https://github.com/Xaymar/obs-studio_amf-encoder-plugin.git
+	url = https://github.com/obsproject/obs-amd-encoder.git
 [submodule "plugins/obs-browser"]
 	path = plugins/obs-browser
 	url = https://github.com/obsproject/obs-browser.git


### PR DESCRIPTION
This PR corrects the submodule address to point to the obsproject copy instead of my fork of it. Additionally it updates the plugin to Version 2.5.0, changelog follows (important changes in bold):

* **Updated AMF to 1.4.9.0.**
* Updated english locale text for Pre-Pass to include encoding cost.
* Fixed various erroneous usages of short codes for printf in log text.
* Added support for Git commit detection to CMake.
* Added support for clang-format.
* Added support for CppCheck to CMake. (Thanks to Streamlabs for this one)