### PR TITLE
enc-amf: Update to 2.5.0.1 and update repository address

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/palana/Syphon-Framework.git
 [submodule "plugins/enc-amf"]
 	path = plugins/enc-amf
-	url = https://github.com/Xaymar/obs-studio_amf-encoder-plugin.git
+	url = https://github.com/obsproject/obs-amd-encoder.git
 [submodule "plugins/obs-browser"]
 	path = plugins/obs-browser
 	url = https://github.com/obsproject/obs-browser.git


### PR DESCRIPTION
See #1498 for patch notes, this simply restores compatibility with cmake 3.7 and earlier.