### PR TITLE
libobs: Unload modules first, then destroy context info

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -916,6 +916,14 @@ void obs_shutdown(void)
 
 #undef FREE_REGISTERED_TYPES
 
+	module = obs->first_module;
+	while (module) {
+		struct obs_module *next = module->next;
+		free_module(module);
+		module = next;
+	}
+	obs->first_module = NULL;
+
 	da_free(obs->input_types);
 	da_free(obs->filter_types);
 	da_free(obs->transition_types);
@@ -935,14 +943,6 @@ void obs_shutdown(void)
 
 	core = obs;
 	obs = NULL;
-
-	module = core->first_module;
-	while (module) {
-		struct obs_module *next = module->next;
-		free_module(module);
-		module = next;
-	}
-	core->first_module = NULL;
 
 	for (size_t i = 0; i < core->module_paths.num; i++)
 		free_module_path(core->module_paths.array+i);


### PR DESCRIPTION
Allow modules to do their own deallocation and freeing of obs related information in the unload callback, instead of taking away the ability from plugins. This fixes crashes in plugins which keep track of everything that was ever created in their code, for example through std::unique_ptr and std::shared_ptr.

Testing revealed no obvious crashes and no heap corruption with included plugins. External plugins might actually work better this way as they have a chance to undo their changes first and store any global/user-specific information that may be stored in obs structures.