### PR TITLE
libobs: Add obs_enum_scenes for enumerating scenes

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1404,6 +1404,31 @@ void obs_enum_services(bool (*enum_proc)(void*, obs_service_t*), void *param)
 			enum_proc, param);
 }
 
+void obs_enum_scenes(bool(*enum_proc)(void*, obs_source_t*), void *param)
+{
+	obs_source_t *source;
+
+	if (!obs) return;
+
+	pthread_mutex_lock(&obs->data.sources_mutex);
+	source = obs->data.first_source;
+
+	while (source) {
+		obs_source_t *next_source =
+			(obs_source_t*)source->context.next;
+
+		if (source->info.type == OBS_SOURCE_TYPE_SCENE &&
+			!source->context.private &&
+			!enum_proc(param, source)) {
+			break;
+		}
+
+		source = next_source;
+	}
+
+	pthread_mutex_unlock(&obs->data.sources_mutex);
+}
+
 static inline void *get_context_by_name(void *vfirst, const char *name,
 		pthread_mutex_t *mutex, void *(*addref)(void*))
 {

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -568,6 +568,10 @@ EXPORT void obs_enum_encoders(bool (*enum_proc)(void*, obs_encoder_t*),
 EXPORT void obs_enum_services(bool (*enum_proc)(void*, obs_service_t*),
 		void *param);
 
+/** Enumerates scenes */
+EXPORT void obs_enum_scenes(bool(*enum_proc)(void*, obs_source_t*),
+	void *param);
+
 /**
  * Gets a source by its name.
  *


### PR DESCRIPTION
Add obs_enum_scenes which only enumerates scenes, so that all source types are covered by obs_enum_ functions. obs_enum_sources is not modified to keep backwards compatibility.