### PR TITLE
libobs: Let filters register hotkeys

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -262,7 +262,7 @@ obs_hotkey_id obs_hotkey_register_service(obs_service_t *service,
 obs_hotkey_id obs_hotkey_register_source(obs_source_t *source, const char *name,
 		const char *description, obs_hotkey_func func, void *data)
 {
-	if (!source || source->context.private || !lock())
+	if (!source || !lock())
 		return OBS_INVALID_HOTKEY_ID;
 
 	obs_hotkey_id id = obs_hotkey_register_internal(


### PR DESCRIPTION
Removes check for whether a source is private (filters are private).

Would allow plugin developers to give users direct control of filters.

Note: Current UI does display these and is functional. May need work.

Creating a second api function specifically for filters is another idea #1372