### PR TITLE
libobs: Add function to invoke hotkey function

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -1207,6 +1207,15 @@ static inline bool is_pressed(obs_key_t key)
 			key);
 }
 
+void obs_hotkey_func_invoke(const obs_hotkey_t *hotkey, bool pressed)
+{
+	if (!obs->hotkeys.reroute_hotkeys)
+		hotkey->func(hotkey->data, hotkey->id, hotkey, pressed);
+	else if (obs->hotkeys.router_func)
+		obs->hotkeys.router_func(obs->hotkeys.router_func_data,
+				hotkey->id, pressed);
+}
+
 static inline void press_released_binding(obs_hotkey_binding_t *binding)
 {
 	binding->pressed = true;
@@ -1215,11 +1224,7 @@ static inline void press_released_binding(obs_hotkey_binding_t *binding)
 	if (hotkey->pressed++)
 		return;
 
-	if (!obs->hotkeys.reroute_hotkeys)
-		hotkey->func(hotkey->data, hotkey->id, hotkey, true);
-	else if (obs->hotkeys.router_func)
-		obs->hotkeys.router_func(obs->hotkeys.router_func_data,
-				hotkey->id, true);
+	obs_hotkey_func_invoke(hotkey, true);
 }
 
 static inline void release_pressed_binding(obs_hotkey_binding_t *binding)
@@ -1230,11 +1235,7 @@ static inline void release_pressed_binding(obs_hotkey_binding_t *binding)
 	if (--hotkey->pressed)
 		return;
 
-	if (!obs->hotkeys.reroute_hotkeys)
-		hotkey->func(hotkey->data, hotkey->id, hotkey, false);
-	else if (obs->hotkeys.router_func)
-		obs->hotkeys.router_func(obs->hotkeys.router_func_data,
-				hotkey->id, false);
+	obs_hotkey_func_invoke(hotkey, false);
 }
 
 static inline void handle_binding(obs_hotkey_binding_t *binding,

--- a/libobs/obs-hotkey.h
+++ b/libobs/obs-hotkey.h
@@ -267,6 +267,8 @@ EXPORT void obs_enum_hotkey_bindings(obs_hotkey_binding_enum_func func,
 
 EXPORT void obs_hotkey_inject_event(obs_key_combination_t hotkey, bool pressed);
 
+EXPORT void obs_hotkey_func_invoke(const obs_hotkey_t *key, bool pressed);
+
 EXPORT void obs_hotkey_enable_background_press(bool enable);
 
 EXPORT void obs_hotkey_enable_strict_modifiers(bool enable);


### PR DESCRIPTION
Allow invoking hotkey functions without binding.
To be able to invoke hotkey functions from plugins like start and stop vlc without having to bind the hotkey.