### PR TITLE
libobs: Validate pointers before render

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3035,7 +3035,8 @@ void obs_source_process_filter_tech_end(obs_source_t *filter, gs_effect_t *effec
 	gs_texture_t *texture;
 	uint32_t     parent_flags;
 
-	if (!filter) return;
+	if (!obs_ptr_valid(filter, "obs_source_process_filter_tech_end"))
+		return;
 
 	target       = obs_filter_get_target(filter);
 	parent       = obs_filter_get_parent(filter);
@@ -3051,7 +3052,8 @@ void obs_source_process_filter_tech_end(obs_source_t *filter, gs_effect_t *effec
 		render_filter_bypass(target, effect, tech);
 	} else {
 		texture = gs_texrender_get_texture(filter->filter_texrender);
-		render_filter_tex(texture, effect, width, height, tech);
+		if (texture)
+			render_filter_tex(texture, effect, width, height, tech);
 	}
 }
 
@@ -3068,6 +3070,10 @@ void obs_source_process_filter_end(obs_source_t *filter, gs_effect_t *effect,
 
 	target       = obs_filter_get_target(filter);
 	parent       = obs_filter_get_parent(filter);
+	
+	if (!target || !parent)
+		return;
+	
 	parent_flags = parent->info.output_flags;
 
 	if (can_bypass(target, parent, parent_flags, filter->allow_direct)) {


### PR DESCRIPTION
Changes obs_source_process_filter_tech_end and
obs_source_process_filter_end to be functionally similar