### PR TITLE
decklink: Initialize member variable

### DIFF
--- a/plugins/decklink/decklink-device-instance.hpp
+++ b/plugins/decklink/decklink-device-instance.hpp
@@ -30,7 +30,7 @@ protected:
 	AudioRepacker           *audioRepacker = nullptr;
 	speaker_layout          channelFormat = SPEAKERS_STEREO;
 
-	IDeckLinkMutableVideoFrame *decklinkOutputFrame;
+	IDeckLinkMutableVideoFrame *decklinkOutputFrame = nullptr;
 
 	void FinalizeStream();
 	void SetupVideoFormat(DeckLinkDeviceMode *mode_);


### PR DESCRIPTION
This was found with Cppcheck. One of member variables of "raw pointer" type is left uninitialized in the class constructor.