### PR TITLE
UI: Fix projector background color bug

### DIFF
--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -60,7 +60,7 @@ OBSQTDisplay::OBSQTDisplay(QWidget *parent, Qt::WindowFlags flags)
 void OBSQTDisplay::SetDisplayBackgroundColor(const QColor &color)
 {
 	backgroundColor = (uint32_t)color_to_int(color);
-	obs_display_set_background_color(display, backgroundColor);
+	obs_display_set_background_color(display, backgroundColor, false);
 }
 
 void OBSQTDisplay::CreateDisplay()

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -66,7 +66,7 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 		obs_display_add_draw_callback(GetDisplay(),
 				isMultiview ? OBSRenderMultiview : OBSRender,
 				this);
-		obs_display_set_background_color(GetDisplay(), 0x000000);
+		obs_display_set_background_color(GetDisplay(), 0x000000, true);
 	};
 
 	connect(this, &OBSQTDisplay::DisplayCreated, addDrawCallback);

--- a/libobs/obs-display.c
+++ b/libobs/obs-display.c
@@ -230,10 +230,11 @@ bool obs_display_enabled(obs_display_t *display)
 	return display ? display->enabled : false;
 }
 
-void obs_display_set_background_color(obs_display_t *display, uint32_t color)
+void obs_display_set_background_color(obs_display_t *display, uint32_t color,
+		bool projector)
 {
 	if (display) {
-		if (color)
+		if (color || projector)
 			display->background_color = color;
 		else
 			display->background_color = 0x4c4c4c;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -783,7 +783,7 @@ EXPORT void obs_display_set_enabled(obs_display_t *display, bool enable);
 EXPORT bool obs_display_enabled(obs_display_t *display);
 
 EXPORT void obs_display_set_background_color(obs_display_t *display,
-		uint32_t color);
+		uint32_t color, bool projector);
 
 
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
This fixes a bug where the background color of the projector would
be set to the same as the main window displays.