### PR TITLE
Fix unencoded, non-RTMP output/service

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -685,28 +685,37 @@ bool SimpleOutput::StartStreaming(obs_service_t *service)
 				obs_output_get_signal_handler(streamOutput),
 				"stop", OBSStopStreaming, this);
 
-		const char *codec =
-			obs_output_get_supported_audio_codecs(streamOutput);
-		if (!codec) {
-			return false;
-		}
+		bool isEncoded = obs_output_get_flags(streamOutput)
+			& OBS_OUTPUT_ENCODED;
 
-		if (strcmp(codec, "aac") != 0) {
-			const char *id = FindAudioEncoderFromCodec(codec);
-			int audioBitrate = GetAudioBitrate();
-			obs_data_t *settings = obs_data_create();
-			obs_data_set_int(settings, "bitrate", audioBitrate);
-
-			aacStreaming = obs_audio_encoder_create(id,
-					"alt_audio_enc", nullptr, 0, nullptr);
-			obs_encoder_release(aacStreaming);
-			if (!aacStreaming)
+		if (isEncoded) {
+			const char *codec =
+				obs_output_get_supported_audio_codecs(
+					streamOutput);
+			if (!codec) {
 				return false;
+			}
 
-			obs_encoder_update(aacStreaming, settings);
-			obs_encoder_set_audio(aacStreaming, obs_get_audio());
+			if (strcmp(codec, "aac") != 0) {
+				const char *id = FindAudioEncoderFromCodec(
+					codec);
+				int audioBitrate = GetAudioBitrate();
+				obs_data_t *settings = obs_data_create();
+				obs_data_set_int(settings, "bitrate",
+					audioBitrate);
 
-			obs_data_release(settings);
+				aacStreaming = obs_audio_encoder_create(id,
+					"alt_audio_enc", nullptr, 0, nullptr);
+				obs_encoder_release(aacStreaming);
+				if (!aacStreaming)
+					return false;
+
+				obs_encoder_update(aacStreaming, settings);
+				obs_encoder_set_audio(aacStreaming,
+					obs_get_audio());
+
+				obs_data_release(settings);
+			}
 		}
 
 		outputType = type;

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -255,9 +255,14 @@ bool obs_output_actual_start(obs_output_t *output)
 bool obs_output_start(obs_output_t *output)
 {
 	bool encoded;
+	bool has_service;
 	if (!obs_output_valid(output, "obs_output_start"))
 		return false;
 	if (!output->context.data)
+		return false;
+
+	has_service = (output->info.flags & OBS_OUTPUT_SERVICE) != 0;
+	if (has_service && !obs_service_initialize(output->service, output))
 		return false;
 
 	encoded = (output->info.flags & OBS_OUTPUT_ENCODED) != 0;
@@ -1745,8 +1750,6 @@ bool obs_output_initialize_encoders(obs_output_t *output, uint32_t flags)
 			&has_service);
 
 	if (!encoded)
-		return false;
-	if (has_service && !obs_service_initialize(output->service, output))
 		return false;
 	if (has_video && !obs_encoder_initialize(output->video_encoder))
 		return false;


### PR DESCRIPTION
Because WebRTC handles encoding under the hood, the Caffeine output is not encoded. There are a couple parts of OBS that assumed outputs are always encoded and failed to start the stream/service properly.

1. SimpleOutput::StartStreaming would fail if encoded_audio_codecs was NULL
2. The service would never be initialized

obs-output.h says encoded_audio_codecs are only required for encoded outputs, and obs-service.h says initialize will be called before the output is started. This PR fixes the truth of those comments.