### PR TITLE
libobs: Initialize handle in utility wrapper to proper value

### DIFF
--- a/libobs/util/windows/WinHandle.hpp
+++ b/libobs/util/windows/WinHandle.hpp
@@ -26,7 +26,7 @@ class WinHandle {
 	}
 
 public:
-	inline WinHandle()               : handle(NULL)    {}
+	inline WinHandle()               : handle(INVALID_HANDLE_VALUE) {}
 	inline WinHandle(HANDLE handle_) : handle(handle_) {}
 	inline ~WinHandle()                                {Clear();}
 


### PR DESCRIPTION
We appear to be setting handle to NULL which, technically speaking, is a valid handle value. In addition, we don't check for NULL in other places, we check for INVALID_HANDLE_VALUE.