### PR TITLE
UI: Fix bug when loading saved projectors

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6108,7 +6108,7 @@ void OBSBasic::OpenSavedProjectors()
 		}
 		}
 
-		if (projector && !info->geometry.empty()) {
+		if (projector && !info->geometry.empty() && info->monitor < 0) {
 			QByteArray byteArray = QByteArray::fromBase64(
 					QByteArray(info->geometry.c_str()));
 			projector->restoreGeometry(byteArray);


### PR DESCRIPTION
This fixes a bug on Linux where fullscreen projectors wouldn't
quite be fullscreen when loaded on start.