### PR TITLE
UI: Allow streamable file formats for Remux

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -284,6 +284,13 @@ Remux.FileExists="The following target files already exist. Do you want to repla
 Remux.ExitUnfinishedTitle="Remuxing in progress"
 Remux.ExitUnfinished="Remuxing is not finished, stopping now may render the target file unusable.\nAre you sure you want to stop remuxing?"
 Remux.HelpText="Drop files in this window to remux, or select an empty \"OBS Recording\" cell to browse for a file."
+Remux.StreamableFileFormat="Write to MP4/MOV using streamable file format"
+Remux.MP4notStreamable="Disabled"
+Remux.MP4withFastStart="Place index table to the beginning"
+Remux.MP4selfcontainedFragmented="Make selfcontained fragmented file"
+Remux.ToolTip.StreamableFileFormat="Files remuxed with any streamable option enabled, can be processed faster\nby web services. Like YouTube, that starts encoding right during uploading."
+Remux.ToolTip.MP4withFastStart="Runs a second pass moving the index ('moov' box) to the beginning of the file.\nRequire more disk operations to complete.\n\nFFmpeg: -movflags faststart"
+Remux.ToolTip.MP4selfcontainedFragmented="Writes the index table as fragments across the file. Creates fragments that at least 4 seconds long.\nRequires modern software for playback and edit.\n\nFFmpeg: -movflags frag_keyframe -min_frag_duration 4000000"
 
 # update dialog
 UpdateAvailable="New Update Available"

--- a/UI/forms/OBSRemux.ui
+++ b/UI/forms/OBSRemux.ui
@@ -21,20 +21,6 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Close|QDialogButtonBox::Ok|QDialogButtonBox::Reset|QDialogButtonBox::RestoreDefaults</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="1" column="0">
     <widget class="QTableView" name="tableView">
      <property name="selectionMode">
@@ -60,6 +46,78 @@
       <number>24</number>
      </property>
     </widget>
+   </item>
+  <item row="3" column="0">
+   <layout class="QFormLayout" name="RemuxOptionsFormLayout">
+    <item row="0" column="0">
+     <widget class="QLabel" name="streamableLabel">
+      <property name="text">
+       <string>Remux.StreamableFileFormat</string>
+      </property>
+      <property name="toolTip">
+       <string>Remux.ToolTip.StreamableFileFormat</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QComboBox" name="streamableOptions">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <item>
+       <property name="text">
+        <string>Remux.MP4notStreamable</string>
+       </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Remux.MP4withFastStart</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Remux.MP4selfcontainedFragmented</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0">
+    <spacer name="RemuxVerticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Minimum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Close|QDialogButtonBox::Ok|QDialogButtonBox::Reset|QDialogButtonBox::RestoreDefaults</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -699,6 +699,8 @@ OBSRemux::OBSRemux(const char *path, QWidget *parent, bool autoRemux_)
 			SIGNAL(clicked()), this, SLOT(clearAll()));
 	connect(ui->buttonBox->button(QDialogButtonBox::Close),
 			SIGNAL(clicked()), this, SLOT(close()));
+	connect(ui->streamableOptions, SIGNAL(currentIndexChanged(int)),
+			this, SLOT(muxOptChaged()));
 
 	worker->moveToThread(&remuxer);
 	remuxer.start();
@@ -960,6 +962,25 @@ void OBSRemux::clearAll()
 	queueModel->clearAll();
 }
 
+void OBSRemux::muxOptChaged()
+{
+	int remuxOpt = ui->streamableOptions->currentIndex();
+
+	switch (remuxOpt) {
+	case 1:
+		ui->streamableOptions->setToolTip(QTStr(
+				"Remux.ToolTip.MP4withFastStart"));
+		break;
+	case 2:
+		ui->streamableOptions->setToolTip(QTStr(
+				"Remux.ToolTip.MP4selfcontainedFragmented"));
+		break;
+	default:
+		ui->streamableOptions->setToolTip(QTStr(""));
+		break;
+	}
+}
+
 /**********************************************************
   Worker thread - Executes the libobs remux operation as a
                   background process.
@@ -997,8 +1018,10 @@ void RemuxWorker::remux(const QString &source, const QString &target)
 			QT_TO_UTF8(source),
 			QT_TO_UTF8(target))) {
 
+		int remuxOpt = 0;
+
 		success = media_remux_job_process(mr_job, callback,
-			this);
+				this, remuxOpt);
 
 		media_remux_job_destroy(mr_job);
 

--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -702,6 +702,11 @@ OBSRemux::OBSRemux(const char *path, QWidget *parent, bool autoRemux_)
 	connect(ui->streamableOptions, SIGNAL(currentIndexChanged(int)),
 			this, SLOT(muxOptChaged()));
 
+	// load last streamable file format selection
+	int curIdx = (int)config_get_int(App()->GlobalConfig(),
+			"Remux", "RemuxStreamableOpt");
+	ui->streamableOptions->setCurrentIndex(curIdx);
+
 	worker->moveToThread(&remuxer);
 	remuxer.start();
 
@@ -966,6 +971,10 @@ void OBSRemux::muxOptChaged()
 {
 	int remuxOpt = ui->streamableOptions->currentIndex();
 
+	// save current streamable file format selection
+	config_set_int(App()->GlobalConfig(),
+		"Remux", "RemuxStreamableOpt", remuxOpt);
+
 	switch (remuxOpt) {
 	case 1:
 		ui->streamableOptions->setToolTip(QTStr(
@@ -1018,7 +1027,12 @@ void RemuxWorker::remux(const QString &source, const QString &target)
 			QT_TO_UTF8(source),
 			QT_TO_UTF8(target))) {
 
-		int remuxOpt = 0;
+		// Use last saved streamable file format selection:
+		// 0 - Disabled
+		// 1 - FastStart
+		// 2 - Selfcontained Fragmented
+		int remuxOpt = (int)config_get_int(App()->GlobalConfig(),
+			"Remux", "RemuxStreamableOpt");
 
 		success = media_remux_job_process(mr_job, callback,
 				this, remuxOpt);

--- a/UI/window-remux.hpp
+++ b/UI/window-remux.hpp
@@ -84,6 +84,7 @@ public slots:
 	bool stopRemux();
 	void clearFinished();
 	void clearAll();
+	void muxOptChaged();
 
 signals:
 	void remux(const QString &source, const QString &target);

--- a/libobs/media-io/media-remux.c
+++ b/libobs/media-io/media-remux.c
@@ -265,7 +265,7 @@ bool media_remux_job_process(media_remux_job_t job,
 							%s", av_err2str(ret));
 				break;
 			}
-		}	
+		}
 	}
 
 	ret = avformat_write_header(job->ofmt_ctx, &dict);

--- a/libobs/media-io/media-remux.h
+++ b/libobs/media-io/media-remux.h
@@ -31,7 +31,7 @@ extern "C" {
 EXPORT bool media_remux_job_create(media_remux_job_t *job,
 		const char *in_filename, const char *out_filename);
 EXPORT bool media_remux_job_process(media_remux_job_t job,
-		media_remux_progress_callback callback, void *data);
+		media_remux_progress_callback callback, void *data, int opt);
 EXPORT void media_remux_job_destroy(media_remux_job_t job);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This also modifies libobs.

Adds new controls to Remux dialog that allow to write streamable file
formats for .mp4 and .mov files. YouTube can process this files faster,
by starting when uploading is not yet complete.