### PR TITLE
UI: Remove scrollbar line controls for Dark theme

### DIFF
--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -168,6 +168,7 @@ QScrollBar::handle:vertical {
 QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
     border: none;
     background: none;
+    height: 0px;
 }
 
 QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical, QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
@@ -197,6 +198,7 @@ QScrollBar::handle:horizontal {
 QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {
     border: none;
     background: none;
+    width: 0px;
 }
 
 QScrollBar::left-arrow:horizontal, QScrollBar::right-arrow:horizontal, QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal {


### PR DESCRIPTION
Fixes an issue when it's hard to perform drag-by-mouse move of the
scrollbar while handle is at corner and has minimum size.

Info: the handle minimum size styled as 20px, while add/sub-line is
14px, thus only 6px left for mouse drag when handle resides at corner.

While handle styled to cover whole bar, including subcontrol elements,
it is better to remove invisible subcontrols completely.