### PR TITLE
Add status badges to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 OBS Studio <https://obsproject.com>
 ===================================
 
+.. image:: https://travis-ci.org/obsproject/obs-studio.svg?branch=master
+   :alt: OBS Studio Build Status - Travis CI
+   :target: https://travis-ci.org/obsproject/obs-studio
+
 What is OBS Studio?
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,10 @@ OBS Studio <https://obsproject.com>
    :alt: OBS Studio Build Status - Travis CI
    :target: https://travis-ci.org/obsproject/obs-studio
 
+.. image:: https://ci.appveyor.com/api/projects/status/github/obsproject/obs-studio?branch=master&svg=true
+   :alt: OBS Studio Build Status - AppVeyor CI
+   :target: https://ci.appveyor.com/project/jp9000/obs-studio/branch/master
+
 What is OBS Studio?
 -------------------
 


### PR DESCRIPTION
This PR adds CI status badges to the README file for the master branch builds on Travis and AppVeyor.  These badges shows the current build status (success or failure) on the CI services of the master branch.