### PR TITLE
UI: Fix display of mono audio source

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -1007,16 +1007,25 @@ void VolumeMeter::paintEvent(QPaintEvent *event)
 
 	for (int channelNr = 0; channelNr < displayNrAudioChannels;
 		channelNr++) {
+		int outputNrAudioChannels;
+		int channelNrFixed;
+		struct obs_audio_info audio_info;
+		if (obs_get_audio_info(&audio_info)) {
+			outputNrAudioChannels = get_audio_channels(audio_info.speakers);
+		} else {
+			outputNrAudioChannels = 2;
+		}
+		channelNrFixed = (displayNrAudioChannels == 1 &&  outputNrAudioChannels > 2 )? 2 : channelNr;
 		if (vertical)
 			paintVMeter(painter, channelNr * 4, 8, 3, height - 10,
-					displayMagnitude[channelNr],
-					displayPeak[channelNr],
-					displayPeakHold[channelNr]);
+					displayMagnitude[channelNrFixed],
+					displayPeak[channelNrFixed],
+					displayPeakHold[channelNrFixed]);
 		else
 			paintHMeter(painter, 5, channelNr * 4, width - 5, 3,
-					displayMagnitude[channelNr],
-					displayPeak[channelNr],
-					displayPeakHold[channelNr]);
+					displayMagnitude[channelNrFixed],
+					displayPeak[channelNrFixed],
+					displayPeakHold[channelNrFixed]);
 
 		if (idle)
 			continue;
@@ -1026,10 +1035,10 @@ void VolumeMeter::paintEvent(QPaintEvent *event)
 		// having too much visual impact.
 		if (vertical)
 			paintInputMeter(painter, channelNr * 4, 3, 3, 3,
-					displayInputPeakHold[channelNr]);
+					displayInputPeakHold[channelNrFixed]);
 		else
 			paintInputMeter(painter, 0, channelNr * 4, 3, 3,
-					displayInputPeakHold[channelNr]);
+					displayInputPeakHold[channelNrFixed]);
 	}
 
 	lastRedrawTime = ts;


### PR DESCRIPTION
 A mono input with surround output is upmixed by swresampler by routing
it to FC (front center) by default which corresponds to third channel
for 3.0, 4.0, 4.1, 5.0, 5.1, 7.1. (The other channels are muted.)
But the volume meters are set to show the first channel for mono sources.
Therefore although audio is processed, it would not show on the meter.
This fixes this display issue.
(Bug discovered by Fenrir who pointed me to it.)

**Additional comment:**
Another way to fix this display issue is to change the number of channels displayed.
At the moment only the number of input channels are shown; but actually what reaches
the volumeters are not the input channels because they have been upsampled to the number of
output channels by audio_resampler_resample function.
If one changes the meter to display a number of channels = nr_output_channels instead of nr_input_channels, one gets this for a mono source:
![obs64_2018-11-09_23-01-50](https://user-images.githubusercontent.com/9283407/48294722-5fdefd00-e486-11e8-8eeb-dce9eb793ed4.png)
This explains the display issue with current UI: the mono source is resampled by ffmpeg to third channel = FC ; while current UI displays only the first channel = FL.
Another solution would be then to change obs_volmeter_get_nr_channels function to return the number of output channels.
This would align to the fact that the audio that the input mixer shows is not that of the source directly but is post-resampling.
The main drawback is that in terms of UI the meters will occupy more room. 
I can implement this second solution if reviewers think it is the better one.
(I think it is the better one but I implemented the current solution in order to stick closer to current behaviour of the volumeter).
