### PR TITLE
libobs: Add type_data parameter for properties of encoders

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -282,8 +282,12 @@ void obs_encoder_set_name(obs_encoder_t *encoder, const char *name)
 static inline obs_data_t *get_defaults(const struct obs_encoder_info *info)
 {
 	obs_data_t *settings = obs_data_create();
-	if (info->get_defaults)
+	if (info->get_defaults2) {
+		info->get_defaults2(settings, info->type_data);
+	}
+	else if (info->get_defaults) {
 		info->get_defaults(settings);
+	}
 	return settings;
 }
 
@@ -304,11 +308,17 @@ obs_data_t *obs_encoder_get_defaults(const obs_encoder_t *encoder)
 obs_properties_t *obs_get_encoder_properties(const char *id)
 {
 	const struct obs_encoder_info *ei = find_encoder(id);
-	if (ei && ei->get_properties) {
+	if (ei && (ei->get_properties || ei->get_properties2)) {
 		obs_data_t       *defaults = get_defaults(ei);
 		obs_properties_t *properties;
 
-		properties = ei->get_properties(NULL);
+		if (ei->get_properties2) {
+			properties = ei->get_properties2(NULL, ei->type_data);
+		}
+		else if (ei->get_properties) {
+			properties = ei->get_properties(NULL);
+		}
+
 		obs_properties_apply_settings(properties, defaults);
 		obs_data_release(defaults);
 		return properties;
@@ -321,6 +331,12 @@ obs_properties_t *obs_encoder_properties(const obs_encoder_t *encoder)
 	if (!obs_encoder_valid(encoder, "obs_encoder_properties"))
 		return NULL;
 
+	if (encoder->info.get_properties2) {
+		obs_properties_t *props;
+		props = encoder->info.get_properties2(encoder->context.data, encoder->info.type_data);
+		obs_properties_apply_settings(props, encoder->context.settings);
+		return props;
+	}
 	if (encoder->info.get_properties) {
 		obs_properties_t *props;
 		props = encoder->info.get_properties(encoder->context.data);

--- a/libobs/obs-encoder.h
+++ b/libobs/obs-encoder.h
@@ -176,11 +176,29 @@ struct obs_encoder_info {
 	void (*get_defaults)(obs_data_t *settings);
 
 	/**
+	 * Gets the default settings for this encoder
+	 *
+	 * @param[out]  settings  Data to assign default settings to
+	 * @param[in]   typedata  Type Data
+	 */
+	void(*get_defaults2)(obs_data_t *settings, void *typedata);
+
+	/**
 	 * Gets the property information of this encoder
 	 *
+	 * @param[in]   data      Pointer from create (or null)
 	 * @return         The properties data
 	 */
 	obs_properties_t *(*get_properties)(void *data);
+
+	/**
+	 * Gets the property information of this encoder
+	 *
+	 * @param[in]   data      Pointer from create (or null)
+	 * @param[in]   typedata  Type Data
+	 * @return         The properties data
+	 */
+	obs_properties_t *(*get_properties2)(void *data, void *typedata);
 
 	/**
 	 * Updates the settings for this encoder (usually used for things like


### PR DESCRIPTION
Encoders can now re-use existing functions and as such be capable of registering many encoders using the same function implementation. This allows coders to reduce code duplication by simply using the stored type_data of an obs_encoder_info structure to store per-encoder information when registering them.

This PR is a re-do of the earlier PR #952, which was incorrectly closed at the time and did contain the change for encoders which wasn't added to obs. I have made sure that existing encoders keep working by adding a new function pointer instead of modifying the existing one.