### PR TITLE
decklink: Add declaration file for integer types

### DIFF
--- a/plugins/decklink/decklink-device.hpp
+++ b/plugins/decklink/decklink-device.hpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 class DeckLinkDevice {
 	ComPtr<IDeckLink>                         device;


### PR DESCRIPTION
Another attempt to compile in VS 2013, without additional obs plugins, warns me that type _int32_t_ was unknown.