### PR TITLE
obs-ffmpeg: Fix NVENC settings

### DIFF
--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -19,6 +19,7 @@ NVENC.Preset.llhq="Low-Latency Quality"
 NVENC.Preset.llhp="Low-Latency Performance"
 NVENC.LookAhead="Look-ahead"
 NVENC.PsychoVisualTuning="Psycho Visual Tuning"
+NVENC.CQLevel="CQ Level"
 
 FFmpegSource="Media Source"
 LocalFile="Local File"


### PR DESCRIPTION
- Fix NVENC settings
- Add VBR rate control
- Remove lossless support and deprecated presets