### PR TITLE
Make V4L device strings unique

### DIFF
--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -329,7 +329,11 @@ static void v4l2_device_list(obs_property_t *prop, obs_data_t *settings)
 			continue;
 		}
 
-		obs_property_list_add_string(prop, (char *) video_cap.card,
+		/* make sure device names are unique */
+		char unique_device_name[68];
+		sprintf(unique_device_name, "%s (%s)", video_cap.card,
+				video_cap.bus_info);
+		obs_property_list_add_string(prop, unique_device_name,
 				device.array);
 		blog(LOG_INFO, "Found device '%s' at %s", video_cap.card,
 				device.array);


### PR DESCRIPTION
Addresses issue [0000702](https://obsproject.com/mantis/view.php?id=702) (multiple devices of the same model not being displayed in the device selection dropdown) by concatenating the v4l2_capability card and bus_info members as suggested in [relevant documentation](https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-querycap.html#c.v4l2_capability).