### PR TITLE
libobs: memset() the correct buff size

### DIFF
--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -82,7 +82,7 @@ static void log_processor_info(void)
 	DWORD   size, speed;
 	LSTATUS status;
 
-	memset(data, 0, 1024);
+	memset(data, 0, sizeof(data));
 
 	status = RegOpenKeyW(HKEY_LOCAL_MACHINE,
 			L"HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
@@ -90,7 +90,7 @@ static void log_processor_info(void)
 	if (status != ERROR_SUCCESS)
 		return;
 
-	size = 1024;
+	size = sizeof(data);
 	status = RegQueryValueExW(key, L"ProcessorNameString", NULL, NULL,
 			(LPBYTE)data, &size);
 	if (status == ERROR_SUCCESS) {


### PR DESCRIPTION
Correctly initialize the data array. Calling `memset(data, 0, 1024)` only initializes the first 1024 bytes of the array. Since `sizeof(wchar_t)` is 2 bytes, then `sizeof(data)` is 2048 bytes long.

Also, `RegQueryValueExW` expects a byte pointer and was only getting half the bytes of the buffer since `size` was also being initialized to 1024.