### PR TITLE
Use the correct name of the application

### DIFF
--- a/UI/dist/obs.desktop
+++ b/UI/dist/obs.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Version=1.0
-Name=OBS
+Name=OBS Studio
 GenericName=Streaming/Recording Software
 Comment=Free and Open Source Streaming/Recording Software
 Comment[ru]=Бесплатная программа с открытым кодом для записи/трансляции видео


### PR DESCRIPTION
According to https://obsproject.com/, the name of the application is "OBS Studio". This also helps avoid confusion with the Open Build Service (OBS) at https://openbuildservice.org/