### PR TITLE
CI: Create AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,14 +27,14 @@ matrix:
       before_install: "./CI/install-dependencies-osx.sh"
       before_script: "./CI/before-script-osx.sh"
       before_deploy: "./CI/before-deploy-osx.sh"
-
+      script: cd ./build && make -j4 && cd -
+      
     - os: linux
       dist: trusty
       sudo: required
       before_install: "./CI/install-dependencies-linux.sh"
       before_script: "./CI/before-script-linux.sh"
-
-script: cd ./build && make -j4 && cd -
+      script: "./CI/script-linux.sh"
 
 deploy:
   provider: s3

--- a/AUTHORS
+++ b/AUTHORS
@@ -159,6 +159,7 @@ Seung-Woo Kim
 Shamun
 Shaolin
 Simon
+Simon Peter
 SoraYuki
 Teemu Kauhanen
 thekrzos

--- a/CI/before-script-linux.sh
+++ b/CI/before-script-linux.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -ex
 
+export LD_LIBRARY_PATH=/opt/qt59/lib/x86_64-linux-gnu:/opt/qt59/lib:$LD_LIBRARY_PATH
+export PKG_CONFIG_PATH=/opt/qt59/lib/pkgconfig:$PKG_CONFIG_PATH
+export PATH=/opt/qt59/bin:$PATH
+
 ccache -s || echo "CCache is not available."
 mkdir build && cd build
-cmake ..
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr

--- a/CI/install-dependencies-linux.sh
+++ b/CI/install-dependencies-linux.sh
@@ -2,6 +2,7 @@
 set -ex
 
 sudo add-apt-repository ppa:jonathonf/ffmpeg-3 -y
+sudo add-apt-repository ppa:beineri/opt-qt593-trusty -y
 sudo apt-get -qq update
 sudo apt-get install -y \
         build-essential \
@@ -22,7 +23,7 @@ sudo apt-get install -y \
         libjansson-dev \
         libluajit-5.1-dev \
         libpulse-dev \
-        libqt5x11extras5-dev \
+        libpython3.4-stdlib \
         libspeexdsp-dev \
         libswresample-dev \
         libswscale-dev \
@@ -38,5 +39,6 @@ sudo apt-get install -y \
         libxinerama-dev \
         pkg-config \
         python3-dev \
-        qtbase5-dev \
+        qt59base \
+        qt59x11extras \
         swig

--- a/CI/install/AppDir/AppRun
+++ b/CI/install/AppDir/AppRun
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# libobs.so.0 loads its resources relative to the user's current working directory (cwd).
+# Hence we need to cd to usr/ inside the AppDir before executing the application.
+# A proper fix would be to make libobs.so.0 load its resources from a path relative to itself.
+# But seemingly OBS on the Mac works the same, so we can live with this for now.
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+export PYTHONHOME="${HERE}/usr/"
+cd "${HERE}/usr/"
+exec ./bin/obs "$@"

--- a/CI/script-linux.sh
+++ b/CI/script-linux.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -ex
+
+# Compile and install to an AppDir
+export LD_LIBRARY_PATH=/opt/qt59/lib/x86_64-linux-gnu:/opt/qt59/lib:$LD_LIBRARY_PATH
+export PKG_CONFIG_PATH=/opt/qt59/lib/pkgconfig:$PKG_CONFIG_PATH
+export PATH=/opt/qt59/bin:$PATH
+cd ./build
+make -j$(nproc)
+make DESTDIR=appdir -j$(nproc) install ; find appdir/
+( cd appdir/usr ; ln -s lib/obs-scripting/* . ) # FIXME: https://github.com/obsproject/obs-studio/pull/1565#issuecomment-448754477
+find appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+
+# Finalize the AppDir and convert it to AppImage
+wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
+# The libraries passed in with -executable are loaded by obs with dlopen(), so linuxdeployqt can't know about them
+./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -bundle-non-qt-libs \
+-executable=appdir/usr/lib/obs-plugins/frontend-tools.so \
+-executable=appdir/usr/lib/obs-plugins/image-source.so \
+-executable=appdir/usr/lib/obs-plugins/linux-alsa.so \
+-executable=appdir/usr/lib/obs-plugins/linux-capture.so \
+-executable=appdir/usr/lib/obs-plugins/linux-decklink.so \
+-executable=appdir/usr/lib/obs-plugins/linux-jack.so \
+-executable=appdir/usr/lib/obs-plugins/linux-pulseaudio.so \
+-executable=appdir/usr/lib/obs-plugins/linux-v4l2.so \
+-executable=appdir/usr/lib/obs-plugins/obs-ffmpeg.so \
+-executable=appdir/usr/lib/obs-plugins/obs-filters.so \
+-executable=appdir/usr/lib/obs-plugins/obs-libfdk.so \
+-executable=appdir/usr/lib/obs-plugins/obs-outputs.so \
+-executable=appdir/usr/lib/obs-plugins/obs-transitions.so \
+-executable=appdir/usr/lib/obs-plugins/obs-x264.so \
+-executable=appdir/usr/lib/obs-plugins/rtmp-services.so \
+-executable=appdir/usr/lib/obs-plugins/text-freetype2.so \
+-executable=appdir/usr/lib/obs-plugins/vlc-video.so \
+-executable=appdir/usr/lib/libobs-opengl.so.0 \
+-executable=appdir/usr/share/obs/obs-plugins/obs-ffmpeg/ffmpeg-mux
+
+# Also deploy the Python standard library
+( cd appdir ; dpkg -x /var/cache/apt/archives/libpython3.4-minimal*.deb . )
+( cd appdir ; dpkg -x /var/cache/apt/archives/libpython3.4-stdlib*.deb . )
+
+# libobs.so.0 loads resources from a path relative to cwd that only works
+# when -DUNIX_STRUCTURE=0 is used at configure time, which we are not using;
+# hence patching it to load resources relative to cwd = usr/
+sed -i -e 's|../../obs-plugins/64bit|././././lib/obs-plugins|g' appdir/usr/lib/libobs.so.0
+
+rm appdir/AppRun ; cp ../CI/install/AppDir/AppRun appdir/AppRun ; chmod +x appdir/AppRun # custom AppRun
+./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage
+
+# TODO: The next line should be replaced by a native upload mechanism defined in .travis.yml,
+# e.g., using https://github.com/probonopd/uploadtool
+curl --upload-file OBS*.AppImage https://transfer.sh/OBS-git.$(git rev-parse --short HEAD)-x86_64.AppImage


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/).

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/apps) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.