### PR TITLE
obs-text: faster read from file

### DIFF
--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -772,7 +772,7 @@ inline void TextSource::Tick(float seconds)
 
 	update_time_elapsed += seconds;
 
-	if (update_time_elapsed >= 1.0f) {
+	if (update_time_elapsed >= 0.016f) {
 		time_t t = get_modified_timestamp(file.c_str());
 		update_time_elapsed = 0.0f;
 

--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -773,19 +773,10 @@ inline void TextSource::Tick(float seconds)
 	update_time_elapsed += seconds;
 
 	if (update_time_elapsed >= 0.016f) {
-		time_t t = get_modified_timestamp(file.c_str());
 		update_time_elapsed = 0.0f;
 
-		if (update_file) {
-			LoadFileText();
-			RenderText();
-			update_file = false;
-		}
-
-		if (file_timestamp != t) {
-			file_timestamp = t;
-			update_file = true;
-		}
+		LoadFileText();
+		RenderText();
 	}
 }
 


### PR DESCRIPTION
If a text file changes multiple times per second, OBS doesn't draw the changes in between. With these changes, the text read is done every 16ms instead (roughly matches 60FPS). A small caveat is that I had to drop the file modified time check, as st_mtime is expressed in seconds of Unix time.

I'm not experienced in Qt, so I'm hoping someone could pick up from here and make the reading rate configurable per instance of the Text Source.