### PR TITLE
win-mf: Initialize member variable

### DIFF
--- a/plugins/win-mf/mf-h264-encoder.cpp
+++ b/plugins/win-mf/mf-h264-encoder.cpp
@@ -66,7 +66,8 @@ H264Encoder::H264Encoder(const obs_encoder_t *encoder,
 	framerateNum(framerateNum),
 	framerateDen(framerateDen),
 	initialBitrate(bitrate),
-	profile(profile)
+	profile(profile),
+	createOutputSample(false)
 {}
 
 H264Encoder::~H264Encoder()


### PR DESCRIPTION
This was found with Cppcheck. A member variable of built-in type is left uninitialized in the class constructor.