### PR TITLE
rtmp-services: Remove dead servers/services

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 94,
+	"version": 95,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 94
+			"version": 95
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1333,39 +1333,6 @@
             }
         },
         {
-            "name": "DTube",
-            "servers": [
-                {
-                    "name": "Default",
-                    "url": "rtmp://stream.dtube.top/live/"
-                }
-            ]
-        },
-        {
-            "name": "STAGE TEN",
-            "servers": [
-                {
-                    "name": "STAGE TEN",
-                    "url": "rtmp://app-rtmp.stageten.tv/stageten"
-                }
-            ],
-            "recommended": {
-                "keyint": 2,
-                "profile": "baseline",
-                "max video bitrate": 4000,
-                "max audio bitrate": 128
-            }
-        },
-        {
-            "name": "Vimm.TV",
-            "servers": [
-                {
-                    "name": "Default",
-                    "url": "rtmp://www.vimm.tv/live"
-                }
-            ]
-        },
-        {
             "name": "DLive",
             "servers": [
                 {
@@ -1378,15 +1345,6 @@
                 "max video bitrate": 6000,
                 "max audio bitrate": 160
             }
-        },
-        {
-            "name": "Linkstream.live",
-            "servers": [
-                {
-                    "name": "Linkstream Live Ingest Point",
-                    "url": "rtmp://hadamard.streaming.linkstream.live:80/live"
-                }
-            ]
         },
         {
             "name": "Lightcast.com",


### PR DESCRIPTION
For cleaning purposes I wrote a script that attempts to connect to all servers within the services file.

Should the connection be rejected or not possible for any other reason during several runs of the script over a period of time, these servers (or services in case this applies to all listed servers) will be considered "dead" and shall be removed.

In the case of the services removed in this PR they are either dead (DTube) or instruct users to use other server urls that will be given out on demand in their web interface (StageTen, etc.). The server urls listed within OBS do no longer function.