### PR TITLE
libobs: Fix utf-8 bom is not properly skipped

### DIFF
--- a/libobs/util/utf8.c
+++ b/libobs/util/utf8.c
@@ -41,7 +41,7 @@ size_t utf8_to_wchar(const char *in, size_t insize, wchar_t *out,
 	if (has_utf8_bom(in)) {
 		if (i_insize >= 3) {
 			in += 3;
-			insize -= 3;
+			i_insize -= 3;
 		}
 	}
 


### PR DESCRIPTION
I think this is typo, "insize" should be "i_insize".
Or line 48 will read over 3 bytes.
`ret = MultiByteToWideChar(CP_UTF8, 0, in, i_insize, out, (int)outsize);`