### PR TITLE
obs-ffmpeg: Bind network buffer size in the UI

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -155,6 +155,10 @@ static obs_properties_t *ffmpeg_source_getproperties(void *data)
 	obs_properties_add_bool(props, "restart_on_activate",
 			obs_module_text("RestartWhenActivated"));
 
+	obs_properties_add_int_slider(props, "buffering_mb",
+			obs_module_text("BufferingMB"),
+			1, 16, 1);
+
 	obs_properties_add_text(props, "input",
 			obs_module_text("Input"), OBS_TEXT_DEFAULT);
 


### PR DESCRIPTION
Input buffer by default is set to 2MB - for some sources, for example streaming
RTSP input over UDP, this is not enough and causes significant playback issues
that are not present while playing back the same source under ffplay/mpv.

It looks like someone actually started working on this feature as there are
translated strings, properties and everything ready - only the control was
missing from the UI. This commit adds that control.

Currently, the range is set to 1-16MB, step 1MB. This is somewhat arbitrary,
so suggestions to tweak this range with more real-world use cases are welcome.