### PR TITLE
decklink: Initialize member variable

### DIFF
--- a/plugins/decklink/decklink-device.hpp
+++ b/plugins/decklink/decklink-device.hpp
@@ -18,10 +18,10 @@ class DeckLinkDevice {
 	std::string                               name;
 	std::string                               displayName;
 	std::string                               hash;
-	int32_t                                   maxChannel;
-	decklink_bool_t                           supportsExternalKeyer;
-	decklink_bool_t                           supportsInternalKeyer;
-	int                                       keyerMode;
+	int32_t                                   maxChannel = 0;
+	decklink_bool_t                           supportsExternalKeyer = false;
+	decklink_bool_t                           supportsInternalKeyer = false;
+	int                                       keyerMode = 0;
 	volatile long                             refCount = 1;
 
 public:


### PR DESCRIPTION
This was found with Cppcheck. A member variable of built-in type is left uninitialized in the class constructor.