### PR TITLE
libobs: Add keyer and transparent base effects

### DIFF
--- a/libobs/data/keyer.effect
+++ b/libobs/data/keyer.effect
@@ -1,0 +1,107 @@
+uniform float4x4 ViewProj;
+uniform float4x4 color_matrix;
+uniform float3 color_range_min = {0.0, 0.0, 0.0};
+uniform float3 color_range_max = {1.0, 1.0, 1.0};
+uniform texture2d image;
+uniform texture2d key_image;
+#define root3 (1.7320508075688772935274463415059)
+
+sampler_state def_sampler {
+	Filter   = Linear;
+	AddressU = Clamp;
+	AddressV = Clamp;
+};
+
+struct VertInOut {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+VertInOut VSDefault(VertInOut vert_in)
+{
+	VertInOut vert_out;
+	vert_out.pos = mul(float4(vert_in.pos.xyz, 1.0), ViewProj);
+	vert_out.uv  = vert_in.uv;
+	return vert_out;
+}
+
+/* thank you Xaymar https://www.xaymar.com/2017/07/06/how-to-converting-rgb-to-yuv-and-yuv-to-rgb/ */
+float4 RGBtoYUV(float4 rgba) {
+	float4 yuva;
+	yuva.r = rgba.r * 0.2126 + 0.7152 * rgba.g + 0.0722 * rgba.b;
+	yuva.g = (rgba.b - yuva.r) / 1.8556;
+	yuva.b = (rgba.r - yuva.r) / 1.5748;
+	yuva.a = rgba.a;
+	
+	yuva.gb += 0.5;
+	
+	return yuva;
+}
+
+float4 PSDrawBare(VertInOut vert_in) : TARGET
+{
+	float alpha = key_image.Sample(def_sampler, vert_in.uv).a;
+	return float4(image.Sample(def_sampler, vert_in.uv).rgb, alpha);
+}
+
+float4 PSDrawMatrix(VertInOut vert_in) : TARGET
+{
+	float alpha = key_image.Sample(def_sampler, vert_in.uv).a;
+	float4 yuv = image.Sample(def_sampler, vert_in.uv);
+	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max);
+	float4 rgba = saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+	return float4(rgba.rgb, alpha);
+}
+
+float4 PSDrawBareWhite(VertInOut vert_in) : TARGET
+{
+	float4 alpha = key_image.Sample(def_sampler, vert_in.uv);
+	return float4(image.Sample(def_sampler, vert_in.uv).rgb, distance(float3(0,0,0), RGBtoYUV(alpha).xyz) / root3);
+}
+
+float4 PSDrawMatrixWhite(VertInOut vert_in) : TARGET
+{
+	float4 alpha = key_image.Sample(def_sampler, vert_in.uv);
+	alpha.xyz = clamp(alpha.xyz, color_range_min, color_range_max);
+	
+	float4 yuv = image.Sample(def_sampler, vert_in.uv);
+	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max);
+	float4 rgba = saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+	return float4(rgba.rgb, distance(float3(0,0,0), alpha.xyz) / root3);
+}
+
+technique Draw
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawBare(vert_in);
+	}
+}
+
+technique DrawMatrix
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawMatrix(vert_in);
+	}
+}
+
+technique DrawWhiteKey
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawBareWhite(vert_in);
+	}
+}
+
+technique DrawMatrixWhiteKey
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawMatrixWhiteKey(vert_in);
+	}
+}

--- a/libobs/data/transparent.effect
+++ b/libobs/data/transparent.effect
@@ -1,0 +1,56 @@
+uniform float4x4 ViewProj;
+uniform float4x4 color_matrix;
+uniform float3 color_range_min = {0.0, 0.0, 0.0};
+uniform float3 color_range_max = {1.0, 1.0, 1.0};
+uniform texture2d image;
+uniform float alpha;
+
+sampler_state def_sampler {
+	Filter   = Linear;
+	AddressU = Clamp;
+	AddressV = Clamp;
+};
+
+struct VertInOut {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+VertInOut VSDefault(VertInOut vert_in)
+{
+	VertInOut vert_out;
+	vert_out.pos = mul(float4(vert_in.pos.xyz, 1.0), ViewProj);
+	vert_out.uv  = vert_in.uv;
+	return vert_out;
+}
+
+float4 PSDrawBare(VertInOut vert_in) : TARGET
+{
+	return float4(image.Sample(def_sampler, vert_in.uv).rgb, alpha);
+}
+
+float4 PSDrawMatrix(VertInOut vert_in) : TARGET
+{
+	float4 yuv = image.Sample(def_sampler, vert_in.uv);
+	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max);
+	float4 rgba = saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+	return float4(rgba.rgb, alpha);
+}
+
+technique Draw
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawBare(vert_in);
+	}
+}
+
+technique DrawMatrix
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawMatrix(vert_in);
+	}
+}

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -285,6 +285,9 @@ struct obs_core_video {
 	gs_effect_t                     *deinterlace_yadif_2x_effect;
 
 	struct obs_video_info           ovi;
+
+	gs_effect_t                     *transparent_effect;
+	gs_effect_t                     *keyer_effect;
 };
 
 struct audio_monitor;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -297,6 +297,16 @@ static int obs_init_graphics(struct obs_video_info *ovi)
 			NULL);
 	bfree(filename);
 
+	filename = obs_find_data_file("transparent.effect");
+	video->transparent_effect = gs_effect_create_from_file(filename,
+		NULL);
+	bfree(filename);
+
+	filename = obs_find_data_file("keyer.effect");
+	video->keyer_effect = gs_effect_create_from_file(filename,
+		NULL);
+	bfree(filename);
+
 	video->point_sampler = gs_samplerstate_create(&point_sampler);
 
 	obs->video.transparent_texture = gs_texture_create(2, 2, GS_RGBA, 1,
@@ -1524,6 +1534,10 @@ gs_effect_t *obs_get_base_effect(enum obs_base_effect effect)
 		return obs->video.bilinear_lowres_effect;
 	case OBS_EFFECT_PREMULTIPLIED_ALPHA:
 		return obs->video.premultiplied_alpha_effect;
+	case OBS_EFFECT_TRANSPARENT:
+		return obs->video.transparent_effect;
+	case OBS_EFFECT_KEYER:
+		return obs->video.keyer_effect;
 	}
 
 	return NULL;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -598,6 +598,8 @@ enum obs_base_effect {
 	OBS_EFFECT_LANCZOS,            /**< Lanczos downscale */
 	OBS_EFFECT_BILINEAR_LOWRES,    /**< Bilinear low resolution downscale */
 	OBS_EFFECT_PREMULTIPLIED_ALPHA,/**< Premultiplied alpha */
+	OBS_EFFECT_TRANSPARENT,        /**< RGB/YUV (alpha set via float) */
+	OBS_EFFECT_KEYER,              /**< RGB/YUV (alpha set via texture)*/
 };
 
 /** Returns a commonly used base effect */


### PR DESCRIPTION
Adds a transparent effect to render a texture w/ a set alpha value and a keyer
effect to render a texture in parts transparent via another input texture.

Note: current implemented techniques assumes keyer's texture matches the input
texture's format (yuv 709 or rgba) when using the key image based on color.