### PR TITLE
Build on PPC64LE using x86 Intrinsic Compat Shims

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,10 @@ if(${CMAKE_C_COMPILER_ID} MATCHES "Clang" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "C
 	set(CMAKE_COMPILER_IS_CLANG TRUE)
 endif()
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64le")
+	add_compile_definitions(NO_WARN_X86_INTRINSICS)
+endif()
+
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
 	set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wvla -Wno-unused-function -Werror-implicit-function-declaration -Wno-missing-field-initializers ${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
 	set(CMAKE_C_FLAGS "-Wall -Wextra -Wvla -Wno-unused-function -Werror-implicit-function-declaration -Wno-missing-braces -Wno-missing-field-initializers ${CMAKE_C_FLAGS} -std=gnu99 -fno-strict-aliasing")

--- a/deps/media-playback/CMakeLists.txt
+++ b/deps/media-playback/CMakeLists.txt
@@ -22,7 +22,12 @@ add_library(media-playback STATIC
 	${media-playback_SOURCES}
 	)
 
-if(NOT MSVC)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64le")
+	target_compile_options(media-playback
+			PUBLIC
+			-mvsx)
+	add_compile_definitions(NO_WARN_X86_INTRINSICS)
+elseif(NOT MSVC)
 	target_compile_options(media-playback
 		PUBLIC
 			-mmmx

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -464,7 +464,12 @@ target_compile_definitions(libobs
 	PUBLIC
 		HAVE_OBSCONFIG_H)
 
-if(NOT MSVC)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64le")
+	target_compile_options(libobs
+		PUBLIC
+			-mvsx)
+	add_compile_definitions(NO_WARN_X86_INTRINSICS)
+elseif(NOT MSVC)
 	target_compile_options(libobs
 		PUBLIC
 			-mmmx


### PR DESCRIPTION
As currently used and configured, x86 intrinsics (defined in  `xmmintrin` and `emmintrin` etc) prevent building on PowerPC64 LE systems. Defining the flag `NO_WARN_X86_INTRINSICS` permits the GCC 8+ provided compatibility shims to supply suitable implementations for _MMX_/_(SSE/2)_ as used in OBS. This is in preparation for a direct port to AltiVec/native vector acceleration.

Specifically this is to enable livestreaming on Raptor Computing Systems Talos 2 workstation systems (fully open source firmware/software fully documented OpenPOWER PPC64 systems) - https://www.raptorcs.com/content/base/products.html