### PR TITLE
UI: Return compatibility with old VS2013

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -119,10 +119,25 @@ if(MSVC)
 		)
 endif()
 
+# compatibility with MS VS2013, no Browser Source
+if(MSVC)
+	if(BROWSER_AVAILABLE_INTERNAL)
+		set(obs_C11_SOURCES
+			../deps/json11/json11.cpp)
+		set(obs_C11_HEADERS
+			../deps/json11/json11.hpp)
+	endif()
+else()
+	set(obs_C11_SOURCES
+		../deps/json11/json11.cpp)
+	set(obs_C11_HEADERS
+		../deps/json11/json11.hpp)
+endif()
+
 set(obs_SOURCES
 	${obs_PLATFORM_SOURCES}
 	${obs_libffutil_SOURCES}
-	../deps/json11/json11.cpp
+	${obs_C11_SOURCES}
 	obs-app.cpp
 	api-interface.cpp
 	window-basic-main.cpp
@@ -174,7 +189,7 @@ set(obs_SOURCES
 set(obs_HEADERS
 	${obs_PLATFORM_HEADERS}
 	${obs_libffutil_HEADERS}
-	../deps/json11/json11.hpp
+	${obs_C11_HEADERS}
 	obs-app.hpp
 	platform.hpp
 	window-main.hpp

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -70,9 +70,11 @@
 #include <QScreen>
 #include <QWindow>
 
+#if defined(BROWSER_AVAILABLE)
 #include <json11.hpp>
-
 using namespace json11;
+#endif
+
 using namespace std;
 
 #if defined(_WIN32) && defined(BROWSER_AVAILABLE)


### PR DESCRIPTION
VS2013 is still mentioned in:
https://github.com/obsproject/obs-studio/wiki/Install-Instructions#windows-build-directions
and it is hard to build the OBS Studio from the source using legacy software by following instructions for the Windows platform.

Of course, Qt has its own limitations and I tested only precompiled 5.8.0 for Windows.
Let's see if machine's building will succeed for all platforms...