### PR TITLE
UI: Revert default tab in Settings > Output: Advanced tab to Stream tab

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -1389,7 +1389,7 @@
                  <item>
                   <widget class="QTabWidget" name="advOutTabs">
                    <property name="currentIndex">
-                    <number>1</number>
+                    <number>0</number>
                    </property>
                    <property name="usesScrollButtons">
                     <bool>true</bool>


### PR DESCRIPTION
Commit 2fedcab9872 changed the default index for widget "advOutTabs"
in OBSBasicSettings.ui; revert to index 0 (stream tab).