### PR TITLE
UI: Save scene collection before export

### DIFF
--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -439,6 +439,8 @@ void OBSBasic::on_actionImportSceneCollection_triggered()
 
 void OBSBasic::on_actionExportSceneCollection_triggered()
 {
+	SaveProjectNow();
+
 	char path[512];
 
 	QString home = QDir::homePath();


### PR DESCRIPTION
If someone were to make changes to a scene collection and go to export, the resulting export would not contain their changes, since the export just copies off of disk. This change makes sure that the scene collection is up to date first, before performing the export.