### PR TITLE
libobs/UI: Allow launch of custom "properties" window

### DIFF
--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -38,6 +38,7 @@ private:
 	std::unique_ptr<Ui::OBSBasicFilters> ui;
 	OBSSource source;
 	OBSPropertiesView *view = nullptr;
+	QWidget *customView = nullptr;
 
 	OBSSignal addSignal;
 	OBSSignal removeSignal;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -145,7 +145,7 @@ private:
 	QScopedPointer<QThread> logUploadThread;
 
 	QPointer<OBSBasicInteraction> interaction;
-	QPointer<OBSBasicProperties> properties;
+	QPointer<QWidget> properties;
 	QPointer<OBSBasicTransform> transformWindow;
 	QPointer<OBSBasicAdvAudio> advAudioWindow;
 	QPointer<OBSBasicFilters> filters;

--- a/libobs/obs-ui.h
+++ b/libobs/obs-ui.h
@@ -76,7 +76,9 @@ struct obs_modal_ui {
  *
  * @param  info  Pointer to the modal definition structure
  */
-EXPORT void obs_register_modal_ui(const struct obs_modal_ui *info);
+EXPORT void obs_register_modal_ui_s(const struct obs_modal_ui *info, size_t size);
+#define obs_register_modal_ui(info) \
+	obs_register_modal_ui_s(info, sizeof(struct obs_modal_ui))
 
 /* ------------------------------------------------------------------------- */
 
@@ -115,7 +117,9 @@ struct obs_modeless_ui {
  *
  * @param  info  Pointer to the modal definition structure
  */
-EXPORT void obs_register_modeless_ui(const struct obs_modeless_ui *info);
+EXPORT void obs_register_modeless_ui_s(const struct obs_modeless_ui *info, size_t size);
+#define obs_register_modeless_ui(info) \
+	obs_register_modeless_ui_s(info, sizeof(struct obs_modeless_ui))
 
 /* ------------------------------------------------------------------------- */
 


### PR DESCRIPTION
Makes use of obs_register_modeless_ui to create custom Qt elements

Currently assumes a target of "qt" or "qt dialog" and that id
matches the source id of the source to customize, and that the
task is "properties".

A create callback is used and is passed the source and parent
widget as parameters.

![image](https://user-images.githubusercontent.com/25020235/50890888-f01abf00-13af-11e9-80da-58083b6831f5.png)
![image](https://user-images.githubusercontent.com/25020235/50890912-fb6dea80-13af-11e9-9e72-28ef6534b495.png)
