### PR TITLE
libobs: Fix circlebuf_pop_back returning front

### DIFF
--- a/libobs/util/circlebuf.h
+++ b/libobs/util/circlebuf.h
@@ -292,7 +292,7 @@ static inline void circlebuf_pop_front(struct circlebuf *cb, void *data,
 static inline void circlebuf_pop_back(struct circlebuf *cb, void *data,
 		size_t size)
 {
-	circlebuf_peek_front(cb, data, size);
+	circlebuf_peek_back(cb, data, size);
 
 	cb->size -= size;
 	if (!cb->size) {


### PR DESCRIPTION
The only time circlebuf_pop_back is used in obs self is with data set to NULL so this change should not break anything.