### PR TITLE
UI: Fix Defaults button doesn't trigger UI

### DIFF
--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -189,7 +189,7 @@ void OBSBasicProperties::on_buttonBox_clicked(QAbstractButton *button)
 		if (!view->DeferUpdate())
 			obs_source_update(source, nullptr);
 
-		view->RefreshProperties();
+		view->ReloadProperties();
 	}
 }
 


### PR DESCRIPTION
Update all UI at default values when clicks "Defaults" button in the
source Properties.

This fixes mantis #1242