### PR TITLE
libobs: Allow const argument in obs_set_cmdline_args

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -854,7 +854,7 @@ bool obs_startup(const char *locale, const char *module_config_path,
 }
 
 static struct obs_cmdline_args cmdline_args = {0, NULL};
-void obs_set_cmdline_args(int argc, char **argv)
+void obs_set_cmdline_args(int argc, const char * const *argv)
 {
 	char *data;
 	size_t len;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -305,7 +305,7 @@ EXPORT const char *obs_get_version_string(void);
  * @param  argv  An array of command line arguments, copied from main() and ends
  *               with NULL.
  */
-EXPORT void obs_set_cmdline_args(int argc, char **argv);
+EXPORT void obs_set_cmdline_args(int argc, const char * const *argv);
 
 /**
  * Get the argc/argv used to start OBS


### PR DESCRIPTION
obs_set_cmdline_args copies the arguments passed to it. This means that
the array passed will never require it to be modified.