### PR TITLE
win-capture/graphics-hook: Fix try_lock_shmem_tex mutex  deadlock bug

### DIFF
--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -467,10 +467,15 @@ uint64_t os_gettime_ns(void)
 static inline int try_lock_shmem_tex(int id)
 {
 	int next = id == 0 ? 1 : 0;
+	DWORD wait_result = WAIT_FAILED;
 
-	if (WaitForSingleObject(tex_mutexes[id], 0) == WAIT_OBJECT_0) {
+	wait_result = WaitForSingleObject(tex_mutexes[id], 0);
+	if (wait_result == WAIT_OBJECT_0 || wait_result == WAIT_ABANDONED) {
 		return id;
-	} else if (WaitForSingleObject(tex_mutexes[next], 0) == WAIT_OBJECT_0) {
+	}
+
+	wait_result = WaitForSingleObject(tex_mutexes[next], 0);
+	if (wait_result == WAIT_OBJECT_0 || wait_result == WAIT_ABANDONED) {
 		return next;
 	}
 


### PR DESCRIPTION
… get two mutexes,eventually may cause deadlock

if obsstudio shutdown abnormal,tex_mutexes may not be released(ReleaseMutex),at that time if use WaitForSingleObject to get mutexe WaitForSingleObject will return WAIT_ABANDONED and get lock,but try_lock_shmem_tex will not return,it will continue wait next mutexe。eventually the return WAIT_ABANDONED will not release infinite。this commit will fix this bug。