### PR TITLE
libobs/UI/docs: Add dial property to api

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -152,6 +152,7 @@ set(obs_SOURCES
 	properties-view.cpp
 	focus-list.cpp
 	menu-button.cpp
+	double-dial.cpp
 	double-slider.cpp
 	volume-control.cpp
 	adv-audio-control.cpp
@@ -201,6 +202,7 @@ set(obs_HEADERS
 	properties-view.moc.hpp
 	display-helpers.hpp
 	balance-slider.hpp
+	double-dial.hpp
 	double-slider.hpp
 	focus-list.hpp
 	menu-button.hpp

--- a/UI/double-dial.cpp
+++ b/UI/double-dial.cpp
@@ -1,0 +1,35 @@
+#include "double-dial.hpp"
+
+#include <cmath>
+
+DoubleDial::DoubleDial(QWidget *parent) : QDial(parent)
+{
+	connect(this, SIGNAL(valueChanged(int)),
+			this, SLOT(intValChanged(int)));
+}
+
+void DoubleDial::setDoubleConstraints(double newMin, double newMax,
+		double newStep, double val)
+{
+	minVal = newMin;
+	maxVal = newMax;
+	minStep = newStep;
+
+	double total = maxVal - minVal;
+	int intMax = int(total / minStep);
+
+	setMinimum(0);
+	setMaximum(intMax);
+	setSingleStep(1);
+	setDoubleVal(val);
+}
+
+void DoubleDial::intValChanged(int val)
+{
+	emit doubleValChanged((minVal/minStep + val) * minStep);
+}
+
+void DoubleDial::setDoubleVal(double val)
+{
+	setValue(lround((val - minVal) / minStep));
+}

--- a/UI/double-dial.hpp
+++ b/UI/double-dial.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QDial>
+
+class DoubleDial : public QDial {
+	Q_OBJECT
+
+	double minVal, maxVal, minStep;
+
+public:
+	DoubleDial(QWidget *parent = nullptr);
+
+	void setDoubleConstraints(double newMin, double newMax,
+			double newStep, double val);
+
+signals:
+	void doubleValChanged(double val);
+
+public slots:
+	void intValChanged(int val);
+	void setDoubleVal(double val);
+};

--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -28,6 +28,7 @@ set(frontend-tools_HEADERS
 	../../horizontal-scroll-area.hpp
 	../../vertical-scroll-area.hpp
 	../../double-slider.hpp
+	../../double-dial.hpp
 	)
 set(frontend-tools_SOURCES
 	${frontend-tools_SOURCES}
@@ -38,6 +39,7 @@ set(frontend-tools_SOURCES
 	../../horizontal-scroll-area.cpp
 	../../vertical-scroll-area.cpp
 	../../double-slider.cpp
+	../../double-dial.cpp
 	)
 set(frontend-tools_UI
 	${frontend-tools_UI}

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -7,6 +7,7 @@
 #include <QLineEdit>
 #include <QSpinBox>
 #include <QSlider>
+#include <QDial>
 #include <QDoubleSpinBox>
 #include <QComboBox>
 #include <QListWidget>
@@ -19,6 +20,7 @@
 #include <QMenu>
 #include <QStackedWidget>
 #include "double-slider.hpp"
+#include "double-dial.hpp"
 #include "qt-wrappers.hpp"
 #include "properties-view.hpp"
 #include "properties-view.moc.hpp"
@@ -351,6 +353,18 @@ void OBSPropertiesView::AddInt(obs_property_t *prop, QFormLayout *layout,
 				spin, SLOT(setValue(int)));
 		connect(spin, SIGNAL(valueChanged(int)),
 				slider, SLOT(setValue(int)));
+	} else if (type == OBS_NUMBER_DIAL) {
+		QDial *dial = new QDial();
+		dial->setMinimum(minVal);
+		dial->setMaximum(maxVal);
+		dial->setPageStep(stepVal);
+		dial->setValue(val);
+		subLayout->addWidget(dial);
+
+		connect(dial, SIGNAL(valueChanged(int)),
+			spin, SLOT(setValue(int)));
+		connect(spin, SIGNAL(valueChanged(int)),
+			dial, SLOT(setValue(int)));
 	}
 
 	connect(spin, SIGNAL(valueChanged(int)), info, SLOT(ControlChanged()));
@@ -397,6 +411,15 @@ void OBSPropertiesView::AddFloat(obs_property_t *prop, QFormLayout *layout,
 				spin, SLOT(setValue(double)));
 		connect(spin, SIGNAL(valueChanged(double)),
 				slider, SLOT(setDoubleVal(double)));
+	} else if (type == OBS_NUMBER_DIAL) {
+		DoubleDial *dial = new DoubleDial();
+		dial->setDoubleConstraints(minVal, maxVal, stepVal, val);
+		subLayout->addWidget(dial);
+
+		connect(dial, SIGNAL(doubleValChanged(double)),
+			spin, SLOT(setValue(double)));
+		connect(spin, SIGNAL(valueChanged(double)),
+			dial, SLOT(setDoubleVal(double)));
 	}
 
 	connect(spin, SIGNAL(valueChanged(double)), info,

--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -131,6 +131,28 @@ Property Object Functions
 
 ---------------------
 
+.. function:: obs_property_t *obs_properties_add_int_dial(obs_properties_t *props, const char *name, const char *description, int min, int max, int step)
+
+   :param    name:        Setting identifier string
+   :param    description: Localized name shown to user
+   :param    min:         Minimum value
+   :param    max:         Maximum value
+   :param    step:        Step value
+   :return:               The property
+
+---------------------
+
+.. function:: obs_property_t *obs_properties_add_float_dial(obs_properties_t *props, const char *name, const char *description, double min, double max, double step)
+
+   :param    name:        Setting identifier string
+   :param    description: Localized name shown to user
+   :param    min:         Minimum value
+   :param    max:         Maximum value
+   :param    step:        Step value
+   :return:               The property
+
+---------------------
+
 .. function:: obs_property_t *obs_properties_add_text(obs_properties_t *props, const char *name, const char *description, enum obs_text_type type)
 
    :param    name:        Setting identifier string

--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -432,6 +432,19 @@ obs_property_t *obs_properties_add_float_slider(obs_properties_t *props,
 	return add_flt(props, name, desc, min, max, step, OBS_NUMBER_SLIDER);
 }
 
+obs_property_t *obs_properties_add_int_dial(obs_properties_t *props,
+	const char *name, const char *desc, int min, int max, int step)
+{
+	return add_int(props, name, desc, min, max, step, OBS_NUMBER_DIAL);
+}
+
+obs_property_t *obs_properties_add_float_dial(obs_properties_t *props,
+	const char *name, const char *desc,
+	double min, double max, double step)
+{
+	return add_flt(props, name, desc, min, max, step, OBS_NUMBER_DIAL);
+}
+
 obs_property_t *obs_properties_add_text(obs_properties_t *props,
 		const char *name, const char *desc, enum obs_text_type type)
 {

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -90,7 +90,8 @@ enum obs_text_type {
 
 enum obs_number_type {
 	OBS_NUMBER_SCROLLER,
-	OBS_NUMBER_SLIDER
+	OBS_NUMBER_SLIDER,
+	OBS_NUMBER_DIAL
 };
 
 #define OBS_FONT_BOLD      (1<<0)
@@ -155,6 +156,14 @@ EXPORT obs_property_t *obs_properties_add_int_slider(obs_properties_t *props,
 		int min, int max, int step);
 
 EXPORT obs_property_t *obs_properties_add_float_slider(obs_properties_t *props,
+		const char *name, const char *description,
+		double min, double max, double step);
+
+EXPORT obs_property_t *obs_properties_add_int_dial(obs_properties_t *props,
+		const char *name, const char *description,
+		int min, int max, int step);
+
+EXPORT obs_property_t *obs_properties_add_float_dial(obs_properties_t *props,
 		const char *name, const char *description,
 		double min, double max, double step);
 


### PR DESCRIPTION
Adds obs_properties_add_int_dial and obs_properties_add_float_dial to
api.
![2019-01-02_21-13-53](https://user-images.githubusercontent.com/25020235/50624283-6b253680-0ed3-11e9-947d-1560dfd90545.gif)
