### PR TITLE
Enable high DPI support

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1646,6 +1646,7 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 
 	ScopeProfiler prof{run_program_init};
 
+	QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 	QCoreApplication::addLibraryPath(".");
 
 	OBSApp program(argc, argv, profilerNameStore.get());


### PR DESCRIPTION
Enable high DPI support. Makes using OBS much more pleasant on 4K monitors with high scaling factor enabled in the Windows display control panel.