### PR TITLE
libobs/UI: Add Transition Previews

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -932,3 +932,5 @@ About.Contribute="Support the OBS Project"
 ResizeOutputSizeOfSource="Resize output (source size)"
 ResizeOutputSizeOfSource.Text="The base and output resolutions will be resized to the size of the current source."
 ResizeOutputSizeOfSource.Continue="Do you want to continue?"
+
+PreviewTransition="Preview Transition"

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -152,6 +152,8 @@ void OBSPropertiesView::RefreshProperties()
 		QLabel *noPropertiesLabel = new QLabel(NO_PROPERTIES_STRING);
 		layout->addWidget(noPropertiesLabel);
 	}
+
+	emit PropertiesRefreshed();
 }
 
 void OBSPropertiesView::SetScrollPos(int h, int v)

--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -121,6 +121,7 @@ public slots:
 signals:
 	void PropertiesResized();
 	void Changed();
+	void PropertiesRefreshed();
 
 public:
 	OBSPropertiesView(OBSData settings, void *obj,

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3423,6 +3423,11 @@ void OBSBasic::SetService(obs_service_t *newService)
 		service = newService;
 }
 
+int OBSBasic::GetTransitionDuration()
+{
+	return ui->transitionDuration->value();
+}
+
 bool OBSBasic::StreamingActive() const
 {
 	if (!outputHandler)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -577,6 +577,8 @@ public:
 	obs_service_t *GetService();
 	void          SetService(obs_service_t *service);
 
+	int GetTransitionDuration();
+
 	inline bool IsPreviewProgramMode() const
 	{
 		return os_atomic_load_bool(&previewProgramMode);

--- a/UI/window-basic-properties.hpp
+++ b/UI/window-basic-properties.hpp
@@ -45,16 +45,25 @@ private:
 	QDialogButtonBox *buttonBox;
 	QSplitter *windowSplitter;
 
+	OBSSource  sourceA;
+	OBSSource  sourceB;
+	OBSSource  sourceClone;
+	bool       direction = true;
+
 	static void SourceRemoved(void *data, calldata_t *params);
 	static void SourceRenamed(void *data, calldata_t *params);
 	static void UpdateProperties(void *data, calldata_t *params);
 	static void DrawPreview(void *data, uint32_t cx, uint32_t cy);
+	static void DrawTransitionPreview(void *data, uint32_t cx,
+		uint32_t cy);
+	void UpdateCallback(void *obj, obs_data_t *settings);
 	bool ConfirmQuit();
 	int  CheckSettings();
 	void Cleanup();
 
 private slots:
 	void on_buttonBox_clicked(QAbstractButton *button);
+	void AddPreviewButton();
 
 public:
 	OBSBasicProperties(QWidget *parent, OBSSource source_);

--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -665,6 +665,11 @@ static inline void handle_stop(obs_source_t *transition)
 			"transition_stop");
 }
 
+void obs_transition_force_stop(obs_source_t *transition)
+{
+	handle_stop(transition);
+}
+
 void obs_transition_video_render(obs_source_t *transition,
 		obs_transition_video_render_callback_t callback)
 {

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3674,11 +3674,24 @@ void obs_source_inc_showing(obs_source_t *source)
 		obs_source_activate(source, AUX_VIEW);
 }
 
+void obs_source_inc_active(obs_source_t *source)
+{
+	if (obs_source_valid(source, "obs_source_inc_active"))
+		obs_source_activate(source, MAIN_VIEW);
+}
+
 void obs_source_dec_showing(obs_source_t *source)
 {
 	if (obs_source_valid(source, "obs_source_dec_showing"))
 		obs_source_deactivate(source, AUX_VIEW);
 }
+
+void obs_source_dec_active(obs_source_t *source)
+{
+	if (obs_source_valid(source, "obs_source_dec_active"))
+		obs_source_deactivate(source, MAIN_VIEW);
+}
+
 
 void obs_source_enum_filters(obs_source_t *source,
 		obs_source_enum_proc_t callback, void *param)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1018,11 +1018,34 @@ EXPORT uint32_t obs_source_get_audio_mixers(const obs_source_t *source);
 EXPORT void obs_source_inc_showing(obs_source_t *source);
 
 /**
+ * Increments the 'active' reference counter to indicate that the source is
+ * fully active.  If the reference counter was 0, will call the 'activate'
+ * callback.
+ *
+ * Unlike obs_source_inc_showing, this will cause children of this source to be
+ * considered showing as well (currently used by transition previews to make
+ * the stinger transition show correctly).  obs_source_inc_showing should
+ * generally be used instead.
+ */
+EXPORT void obs_source_inc_active(obs_source_t *source);
+
+/**
  * Decrements the 'showing' reference counter to indicate that the source is
  * no longer being shown somewhere.  If the reference counter is set to 0,
  * will call the 'hide' callback
  */
 EXPORT void obs_source_dec_showing(obs_source_t *source);
+
+/**
+ * Decrements the 'active' reference counter to indicate that the source is no
+ * longer fully active.  If the reference counter is set to 0, will call the
+ * 'deactivate' callback
+ *
+ * Unlike obs_source_dec_showing, this will cause children of this source to be
+ * considered not showing as well.  obs_source_dec_showing should generally be
+ * used instead.
+ */
+EXPORT void obs_source_dec_active(obs_source_t *source);
 
 /** Enumerates filters assigned to the source */
 EXPORT void obs_source_enum_filters(obs_source_t *source,
@@ -1341,6 +1364,8 @@ typedef void (*obs_transition_video_render_callback_t)(void *data,
 typedef float (*obs_transition_audio_mix_callback_t)(void *data, float t);
 
 EXPORT float obs_transition_get_time(obs_source_t *transition);
+
+EXPORT void obs_transition_force_stop(obs_source_t *transition);
 
 EXPORT void obs_transition_video_render(obs_source_t *transition,
 		obs_transition_video_render_callback_t callback);


### PR DESCRIPTION
This PR adds a preview to the properties window for transitions. The preview will play back the transition at the global transition duration or the transitions fixed duration, between two private scenes with an A and B label, and different background colors.

![](https://i.imgur.com/RuUHxwK.gif)