### PR TITLE
UI: Align Settings labels to left (& Properties labels)

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -843,6 +843,12 @@ QLabel#errorLabel {
 	font-weight: bold;
 }
 
+/* Obs source label */
+
+OBSSourceLabel {
+	font-weight: bold;
+}
+
 /* Settings Menu */
 
 #buttonBox {

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -147,8 +147,9 @@ QGroupBox {
     border: 1px solid rgb(31,30,31); /* veryDark */;
     border-radius: 5px;
     padding-top: 16px;
+    font-weight: bold;
+    margin-top: 20px;
 }
-
 
 /* ScrollBars */
 
@@ -645,7 +646,6 @@ SourceTreeSubItemCheckBox::indicator:unchecked {
     image: url(./Dark/collapse.png);
 }
 
-
 /* Label warning/error */
 
 QLabel#warningLabel {
@@ -655,6 +655,12 @@ QLabel#warningLabel {
 
 QLabel#errorLabel {
     color: rgb(192, 0, 0);
+    font-weight: bold;
+}
+
+/* Obs source label */
+
+OBSSourceLabel {
     font-weight: bold;
 }
 

--- a/UI/data/themes/Default.qss
+++ b/UI/data/themes/Default.qss
@@ -101,6 +101,12 @@ QLabel#errorLabel {
     font-weight: bold;
 }
 
+/* Obs source label */
+
+OBSSourceLabel {
+    font-weight: bold;
+}
+
 * [themeID="warning"] {
     color: rgb(192, 128, 0);
     font-weight: bold;
@@ -160,4 +166,8 @@ OBSBasicSettings {
     qproperty-videoIcon: url(:settings/images/settings/video.svg);
     qproperty-hotkeysIcon: url(:settings/images/settings/hotkeys.svg);
     qproperty-advancedIcon: url(:settings/images/settings/advanced.svg);
+}
+/* groupbox titles */
+QGroupBox {
+    font-weight: bold;
 }

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -226,6 +226,7 @@ QGroupBox {
 	border-radius: 2px;
 	padding-top: 16px;
 	margin-top: 20px;
+	font-weight: bold;
 }
 
 QGroupBox::title {
@@ -1049,6 +1050,12 @@ QLabel#warningLabel {
 
 QLabel#errorLabel {
 	color: rgb(186, 45, 101); /* Dark Pink (Secondary Dark) */
+	font-weight: bold;
+}
+
+/* Obs source label */
+
+OBSSourceLabel {
 	font-weight: bold;
 }
 

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -175,7 +175,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -343,7 +343,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -602,7 +602,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -657,7 +657,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -1195,7 +1195,7 @@
                    <string>Basic.Settings.Output.Mode</string>
                   </property>
                   <property name="alignment">
-                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                   <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                   </property>
                   <property name="buddy">
                    <cstring>outputMode</cstring>
@@ -1273,7 +1273,7 @@
                      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                     </property>
                     <property name="labelAlignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                     </property>
                     <item row="0" column="0">
                      <widget class="QLabel" name="label_19">
@@ -1287,7 +1287,7 @@
                        <string>Basic.Settings.Output.VideoBitrate</string>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                       <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                       </property>
                       <property name="buddy">
                        <cstring>simpleOutputVBitrate</cstring>
@@ -1457,7 +1457,7 @@
                      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                     </property>
                     <property name="labelAlignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                     </property>
                     <item row="0" column="0">
                      <widget class="QLabel" name="label_18">
@@ -1471,7 +1471,7 @@
                        <string>Basic.Settings.Output.Simple.SavePath</string>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                       <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                       </property>
                       <property name="buddy">
                        <cstring>simpleOutputPath</cstring>
@@ -1615,7 +1615,7 @@
                      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                     </property>
                     <property name="labelAlignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                     </property>
                     <item row="0" column="0">
                      <widget class="QLabel" name="label_35">
@@ -1799,7 +1799,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="1" column="0">
                             <widget class="QLabel" name="label_28">
@@ -1813,7 +1813,7 @@
                               <string>Basic.Settings.Output.Adv.AudioTrack</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                             </widget>
                            </item>
@@ -1910,20 +1910,43 @@
                             </widget>
                            </item>
                            <item row="4" column="0">
-                            <widget class="QCheckBox" name="advOutUseRescale">
-                             <property name="sizePolicy">
-                              <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                               <horstretch>0</horstretch>
-                               <verstretch>0</verstretch>
-                              </sizepolicy>
+                            <layout class="QHBoxLayout" name="horizontalLayout_123">
+                             <property name="spacing">
+                              <number>3</number>
                              </property>
-                             <property name="layoutDirection">
-                              <enum>Qt::RightToLeft</enum>
+                             <property name="leftMargin">
+                              <number>0</number>
                              </property>
-                             <property name="text">
-                              <string>Basic.Settings.Output.Adv.Rescale</string>
+                             <property name="topMargin">
+                              <number>0</number>
                              </property>
+                             <property name="rightMargin">
+                              <number>0</number>
+                             </property>
+                             <property name="bottomMargin">
+                              <number>0</number>
+                             </property>
+                             <item>
+                              <widget class="QLabel" name="label_rescale_str">
+                               <property name="text">
+                                <string>Basic.Settings.Output.Adv.Rescale</string>
+                               </property>
+                               <property name="buddy">
+                                <cstring>advOutUseRescale</cstring>
+                               </property>
+                              </widget>
+                             </item>
+                             <item>
+                              <widget class="QCheckBox" name="advOutUseRescale">
+                               <property name="sizePolicy">
+                                <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                                 <horstretch>0</horstretch>
+                                 <verstretch>0</verstretch>
+                                </sizepolicy>
+                               </property>
                             </widget>
+                             </item>
+                             </layout>
                            </item>
                            <item row="4" column="1">
                             <widget class="QComboBox" name="advOutRescale">
@@ -1967,7 +1990,7 @@
                          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                         </property>
                         <property name="labelAlignment">
-                         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                         <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                         </property>
                         <property name="topMargin">
                          <number>0</number>
@@ -1987,7 +2010,7 @@
                            <string>Basic.Settings.Output.Adv.Recording.Type</string>
                           </property>
                           <property name="alignment">
-                           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                           </property>
                           <property name="buddy">
                            <cstring>advOutRecType</cstring>
@@ -2050,7 +2073,7 @@
                              <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                             </property>
                             <property name="labelAlignment">
-                             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                             <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                             </property>
                             <property name="topMargin">
                              <number>0</number>
@@ -2073,7 +2096,7 @@
                                <string>Basic.Settings.Output.Simple.SavePath</string>
                               </property>
                               <property name="alignment">
-                               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                               <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                               </property>
                               <property name="buddy">
                                <cstring>advOutRecPath</cstring>
@@ -2242,20 +2265,43 @@
                              <widget class="QComboBox" name="advOutRecEncoder"/>
                             </item>
                             <item row="5" column="0">
-                             <widget class="QCheckBox" name="advOutRecUseRescale">
-                              <property name="sizePolicy">
-                               <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                                <horstretch>0</horstretch>
-                                <verstretch>0</verstretch>
-                               </sizepolicy>
+                             <layout class="QHBoxLayout" name="horizontalLayout_122">
+                              <property name="spacing">
+                               <number>3</number>
                               </property>
-                              <property name="layoutDirection">
-                               <enum>Qt::RightToLeft</enum>
+                              <property name="leftMargin">
+                               <number>0</number>
                               </property>
-                              <property name="text">
-                               <string>Basic.Settings.Output.Adv.Rescale</string>
+                              <property name="topMargin">
+                               <number>0</number>
                               </property>
-                             </widget>
+                              <property name="rightMargin">
+                               <number>0</number>
+                              </property>
+                              <property name="bottomMargin">
+                               <number>0</number>
+                              </property>
+                              <item>
+                               <widget class="QLabel" name="label_rescale_std">
+                                <property name="text">
+                                 <string>Basic.Settings.Output.Adv.Rescale</string>
+                                </property>
+                                <property name="buddy">
+                                 <cstring>advOutRecUseRescale</cstring>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <widget class="QCheckBox" name="advOutRecUseRescale">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                               </widget>
+			      </item>
+			     </layout>
                             </item>
                             <item row="5" column="1">
                              <widget class="QWidget" name="advOutRecRescaleContainer" native="true">
@@ -2327,7 +2373,7 @@
                           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                          </property>
                          <property name="labelAlignment">
-                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                          <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                          </property>
                          <property name="topMargin">
                           <number>0</number>
@@ -2350,7 +2396,7 @@
                             <string>Basic.Settings.Output.Adv.FFmpeg.SavePathURL</string>
                            </property>
                            <property name="alignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                           </widget>
                          </item>
@@ -2491,20 +2537,43 @@
                           </widget>
                          </item>
                          <item row="9" column="0">
-                          <widget class="QCheckBox" name="advOutFFUseRescale">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
+                          <layout class="QHBoxLayout" name="horizontalLayout_121">
+                           <property name="spacing">
+                            <number>3</number>
                            </property>
-                           <property name="layoutDirection">
-                            <enum>Qt::RightToLeft</enum>
+                           <property name="leftMargin">
+                            <number>0</number>
                            </property>
-                           <property name="text">
-                            <string>Basic.Settings.Output.Adv.Rescale</string>
+                           <property name="topMargin">
+                            <number>0</number>
                            </property>
-                          </widget>
+                           <property name="rightMargin">
+                            <number>0</number>
+                           </property>
+                           <property name="bottomMargin">
+                            <number>0</number>
+                           </property>
+                           <item>
+                            <widget class="QLabel" name="label_rescale">
+                             <property name="text">
+                              <string>Basic.Settings.Output.Adv.Rescale</string>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutFFUseRescale</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item>
+                            <widget class="QCheckBox" name="advOutFFUseRescale">
+                             <property name="sizePolicy">
+                              <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                               <horstretch>0</horstretch>
+                               <verstretch>0</verstretch>
+                              </sizepolicy>
+                             </property>
+                            </widget>
+                           </item>
+                          </layout>
                          </item>
                          <item row="9" column="1">
                           <widget class="QComboBox" name="advOutFFRescale">
@@ -2695,7 +2764,7 @@
                             <string>Basic.Settings.Output.Adv.FFmpeg.Type</string>
                            </property>
                            <property name="alignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <property name="buddy">
                             <cstring>advOutFFType</cstring>
@@ -2787,7 +2856,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="0" column="1">
                             <widget class="QComboBox" name="advOutTrack1Bitrate">
@@ -2863,7 +2932,7 @@
                               <string>Basic.Settings.Output.AudioBitrate</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                              <property name="buddy">
                               <cstring>advOutTrack1Bitrate</cstring>
@@ -2902,7 +2971,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="0" column="0">
                             <widget class="QLabel" name="label_49">
@@ -2916,7 +2985,7 @@
                               <string>Basic.Settings.Output.AudioBitrate</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                              <property name="buddy">
                               <cstring>advOutTrack2Bitrate</cstring>
@@ -3017,7 +3086,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="0" column="0">
                             <widget class="QLabel" name="label_51">
@@ -3031,7 +3100,7 @@
                               <string>Basic.Settings.Output.AudioBitrate</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                              <property name="buddy">
                               <cstring>advOutTrack3Bitrate</cstring>
@@ -3132,7 +3201,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="0" column="0">
                             <widget class="QLabel" name="label_53">
@@ -3146,7 +3215,7 @@
                               <string>Basic.Settings.Output.AudioBitrate</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                              <property name="buddy">
                               <cstring>advOutTrack4Bitrate</cstring>
@@ -3247,7 +3316,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="0" column="0">
                             <widget class="QLabel" name="label_59">
@@ -3261,7 +3330,7 @@
                               <string>Basic.Settings.Output.AudioBitrate</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                              <property name="buddy">
                               <cstring>advOutTrack5Bitrate</cstring>
@@ -3362,7 +3431,7 @@
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                            </property>
                            <item row="0" column="0">
                             <widget class="QLabel" name="label_61">
@@ -3376,7 +3445,7 @@
                               <string>Basic.Settings.Output.AudioBitrate</string>
                              </property>
                              <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                              </property>
                              <property name="buddy">
                               <cstring>advOutTrack6Bitrate</cstring>
@@ -3599,7 +3668,7 @@
           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
          </property>
          <property name="labelAlignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
          </property>
          <item row="0" column="0">
           <widget class="QLabel" name="label_14">
@@ -3698,7 +3767,7 @@
             <string>Basic.Settings.Audio.DesktopDevice</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
            </property>
            <property name="buddy">
             <cstring>desktopAudioDevice1</cstring>
@@ -3718,7 +3787,7 @@
             <string>Basic.Settings.Audio.DesktopDevice2</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
            </property>
            <property name="buddy">
             <cstring>desktopAudioDevice2</cstring>
@@ -3926,7 +3995,7 @@
           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
          </property>
          <property name="labelAlignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
          </property>
          <item row="0" column="0">
           <widget class="QLabel" name="label_8">
@@ -3940,7 +4009,7 @@
             <string>Basic.Settings.Video.BaseResolution</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
            </property>
            <property name="buddy">
             <cstring>baseResolution</cstring>
@@ -4147,7 +4216,7 @@
               <enum>QFormLayout::ExpandingFieldsGrow</enum>
              </property>
              <property name="labelAlignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
              </property>
              <property name="leftMargin">
               <number>0</number>
@@ -4241,7 +4310,7 @@
            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
           </property>
           <property name="labelAlignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
           </property>
           <property name="verticalSpacing">
            <number>0</number>
@@ -4309,7 +4378,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -4353,7 +4422,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -4381,7 +4450,7 @@
                       <string>Basic.Settings.Video.Adapter</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                      <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                      </property>
                      <property name="buddy">
                       <cstring>adapter</cstring>
@@ -4410,7 +4479,7 @@
                       <string>Basic.Settings.Advanced.Video.ColorFormat</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                      <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                      </property>
                      <property name="buddy">
                       <cstring>colorFormat</cstring>
@@ -4556,7 +4625,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -4607,7 +4676,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -4720,7 +4789,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -4837,7 +4906,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>
@@ -4937,7 +5006,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    <set>Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter</set>
                    </property>
                    <property name="topMargin">
                     <number>2</number>

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -122,7 +122,7 @@ void OBSPropertiesView::RefreshProperties()
 	QSizePolicy policy(QSizePolicy::Preferred, QSizePolicy::Preferred);
 	//widget->setSizePolicy(policy);
 
-	layout->setLabelAlignment(Qt::AlignRight);
+	layout->setLabelAlignment(Qt::AlignLeft);
 
 	obs_property_t *property = obs_properties_first(properties.get());
 	bool hasNoProperties = !property;
@@ -1392,7 +1392,7 @@ void OBSPropertiesView::AddProperty(obs_property_t *property,
 
 	if (label && minSize) {
 		label->setMinimumWidth(minSize);
-		label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+		label->setAlignment(Qt::AlignLeft|Qt::AlignLeading|Qt::AlignVCenter);
 	}
 
 	if (label && !obs_property_enabled(property))

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2405,7 +2405,7 @@ void OBSBasicSettings::LoadHotkeySettings(obs_hotkey_id ignoreKey)
 	layout->setVerticalSpacing(0);
 	layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
 	layout->setLabelAlignment(
-			Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter);
+			Qt::AlignLeft |Qt::AlignLeading|Qt::AlignVCenter);
 
 	auto widget = new QWidget();
 	widget->setLayout(layout);
@@ -2420,7 +2420,6 @@ void OBSBasicSettings::LoadHotkeySettings(obs_hotkey_id ignoreKey)
 
 	auto setRowVisible = [=](int row, bool visible, QLayoutItem *label) {
 		label->widget()->setVisible(visible);
-
 		auto field = layout->itemAt(row, QFormLayout::FieldRole);
 		if (field)
 			field->widget()->setVisible(visible);


### PR DESCRIPTION
Following a request by our chief-designer Warchamp, this patch aligns Settings labels to the left.
Headers have been boldened to distinguish them from the sublabels.
This has required to align also labels in Properties (ex: source property window).

Before:
![obs64_2019-01-10_22-53-43](https://user-images.githubusercontent.com/9283407/51003625-e0c67d80-1537-11e9-9e6c-c87f4e2b8aed.png)

After:
![obs64_2019-01-10_22-54-42](https://user-images.githubusercontent.com/9283407/51003640-eb811280-1537-11e9-8308-5827c0505a92.png)

Before:
![obs64_2019-01-10_22-54-14](https://user-images.githubusercontent.com/9283407/51003660-f76cd480-1537-11e9-9d12-e596352be54b.png)

After:
![obs64_2019-01-11_00-30-37](https://user-images.githubusercontent.com/9283407/51003718-25eaaf80-1538-11e9-81d8-a7b9c4302e77.png)

Before (browser source):
![obs64_2019-01-11_00-31-45](https://user-images.githubusercontent.com/9283407/51003755-49adf580-1538-11e9-9d91-9f0378af5f77.png)

After:
![obs64_2019-01-10_22-59-59](https://user-images.githubusercontent.com/9283407/51003761-50d50380-1538-11e9-9a57-3c41549c0e47.png)
