### PR TITLE
libobs: Fix 7ch speakers layout for monitoring

### DIFF
--- a/libobs/audio-monitoring/win32/wasapi-output.c
+++ b/libobs/audio-monitoring/win32/wasapi-output.c
@@ -233,7 +233,7 @@ static enum speaker_layout convert_speaker_layout(DWORD layout, WORD channels)
 	case KSAUDIO_SPEAKER_SURROUND:         return SPEAKERS_4POINT0;
 	case KSAUDIO_SPEAKER_4POINT1:          return SPEAKERS_4POINT1;
 	case KSAUDIO_SPEAKER_5POINT1:          return SPEAKERS_5POINT1;
-	case KSAUDIO_SPEAKER_7POINT1:          return SPEAKERS_7POINT1;
+	case KSAUDIO_SPEAKER_7POINT1_SURROUND: return SPEAKERS_7POINT1;
 	}
 
 	return (enum speaker_layout)channels;


### PR DESCRIPTION
The mentioned previously KSAUDIO_SPEAKER_7POINT1 has two speakers:

- SPEAKER_FRONT_LEFT_OF_CENTER (0x40)
- SPEAKER_FRONT_RIGHT_OF_CENTER (0x80)

while proposed the KSAUDIO_SPEAKER_7POINT1_SURROUND has different speakers:

- SPEAKER_SIDE_LEFT (0x200)
- SPEAKER_SIDE_RIGHT (0x400)

in accordance with the FFmpeg layout AV_CH_LAYOUT_7POINT1 it has exactly these "SIDE" speakers (0x200 and 0x400) and this layout used in OBS Studio for the SPEAKERS_7POINT1.

Links:
https://github.com/obsproject/obs-studio/pull/1182
https://github.com/obsproject/obs-studio/pull/1163