### PR TITLE
UI: Fix a series of mem leaks

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2131,6 +2131,8 @@ OBSBasic::~OBSBasic()
 		updateCheckThread->wait();
 
 	delete multiviewProjectorMenu;
+	delete previewProjector;
+	delete studioProgramProjector;
 	delete trayMenu;
 	delete programOptions;
 	delete program;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2133,6 +2133,8 @@ OBSBasic::~OBSBasic()
 	delete multiviewProjectorMenu;
 	delete previewProjector;
 	delete studioProgramProjector;
+	delete previewProjectorSource;
+	delete previewProjectorMain;
 	delete sourceProjector;
 	delete scaleFilteringMenu;
 	delete trayMenu;
@@ -4143,7 +4145,7 @@ QMenu *OBSBasic::AddBackgroundColorMenu(obs_sceneitem_t *item)
 void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 {
 	QMenu popup(this);
-	QPointer<QMenu> previewProjector;
+	delete previewProjectorSource;
 	delete sourceProjector;
 	delete scaleFilteringMenu;
 
@@ -4160,11 +4162,11 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		popup.addAction(ui->actionLockPreview);
 		popup.addMenu(ui->scalingMenu);
 
-		previewProjector = new QMenu(QTStr("PreviewProjector"));
-		AddProjectorMenuMonitors(previewProjector, this,
+		previewProjectorSource = new QMenu(QTStr("PreviewProjector"));
+		AddProjectorMenuMonitors(previewProjectorSource, this,
 				SLOT(OpenPreviewProjector()));
 
-		popup.addMenu(previewProjector);
+		popup.addMenu(previewProjectorSource);
 
 		QAction *previewWindow = popup.addAction(
 				QTStr("PreviewWindow"),
@@ -5476,7 +5478,7 @@ void OBSBasic::on_previewDisabledLabel_customContextMenuRequested(
 		const QPoint &pos)
 {
 	QMenu popup(this);
-	QPointer<QMenu> previewProjector;
+	delete previewProjectorMain;
 
 	QAction *action = popup.addAction(
 			QTStr("Basic.Main.PreviewConextMenu.Enable"),
@@ -5484,15 +5486,15 @@ void OBSBasic::on_previewDisabledLabel_customContextMenuRequested(
 	action->setCheckable(true);
 	action->setChecked(obs_display_enabled(ui->preview->GetDisplay()));
 
-	previewProjector = new QMenu(QTStr("PreviewProjector"));
-	AddProjectorMenuMonitors(previewProjector, this,
+	previewProjectorMain = new QMenu(QTStr("PreviewProjector"));
+	AddProjectorMenuMonitors(previewProjectorMain, this,
 			SLOT(OpenPreviewProjector()));
 
 	QAction *previewWindow = popup.addAction(
 			QTStr("PreviewWindow"),
 			this, SLOT(OpenPreviewWindow()));
 
-	popup.addMenu(previewProjector);
+	popup.addMenu(previewProjectorMain);
 	popup.addAction(previewWindow);
 	popup.exec(QCursor::pos());
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -222,7 +222,9 @@ OBSBasic::OBSBasic(QWidget *parent)
 	connect(windowHandle(), &QWindow::screenChanged, displayResize);
 	connect(ui->preview, &OBSQTDisplay::DisplayResized, displayResize);
 
-	installEventFilter(CreateShortcutFilter());
+	delete shortcutFilter;
+	shortcutFilter = CreateShortcutFilter();
+	installEventFilter(shortcutFilter);
 
 	stringstream name;
 	name << "OBS " << App()->GetVersionString();
@@ -2142,6 +2144,7 @@ OBSBasic::~OBSBasic()
 	delete colorSelect;
 	delete deinterlaceMenu;
 	delete perSceneTransitionMenu;
+	delete shortcutFilter;
 	delete trayMenu;
 	delete programOptions;
 	delete program;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2135,6 +2135,7 @@ OBSBasic::~OBSBasic()
 	delete previewProjectorSource;
 	delete previewProjectorMain;
 	delete sourceProjector;
+	delete sceneProjectorMenu;
 	delete scaleFilteringMenu;
 	delete colorMenu;
 	delete colorWidgetAction;
@@ -3808,7 +3809,6 @@ static void AddProjectorMenuMonitors(QMenu *parent, QObject *target,
 void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 {
 	QListWidgetItem *item = ui->scenes->itemAt(pos);
-	QPointer<QMenu> sceneProjectorMenu;
 
 	QMenu popup(this);
 	QMenu order(QTStr("Basic.MainMenu.Edit.Order"), this);
@@ -3838,6 +3838,7 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 
 		popup.addSeparator();
 
+		delete sceneProjectorMenu;
 		sceneProjectorMenu = new QMenu(QTStr("SceneProjector"));
 		AddProjectorMenuMonitors(sceneProjectorMenu, this,
 				SLOT(OpenSceneProjector()));

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2133,6 +2133,7 @@ OBSBasic::~OBSBasic()
 	delete multiviewProjectorMenu;
 	delete previewProjector;
 	delete studioProgramProjector;
+	delete scaleFilteringMenu;
 	delete trayMenu;
 	delete programOptions;
 	delete program;
@@ -4059,9 +4060,8 @@ void OBSBasic::SetScaleFilter()
 	obs_sceneitem_set_scale_filter(sceneItem, mode);
 }
 
-QMenu *OBSBasic::AddScaleFilteringMenu(obs_sceneitem_t *item)
+QMenu *OBSBasic::AddScaleFilteringMenu(QMenu *menu, obs_sceneitem_t *item)
 {
-	QMenu *menu = new QMenu(QTStr("ScaleFiltering"));
 	obs_scale_type scaleFilter = obs_sceneitem_get_scale_filter(item);
 	QAction *action;
 
@@ -4144,6 +4144,7 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 	QMenu popup(this);
 	QPointer<QMenu> previewProjector;
 	QPointer<QMenu> sourceProjector;
+	delete scaleFilteringMenu;
 
 	if (preview) {
 		QAction *action = popup.addAction(
@@ -4264,7 +4265,8 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		if (width == 0 || height == 0)
 			resizeOutput->setEnabled(false);
 
-		popup.addMenu(AddScaleFilteringMenu(sceneItem));
+		scaleFilteringMenu = new QMenu(QTStr("ScaleFiltering"));
+		popup.addMenu(AddScaleFilteringMenu(scaleFilteringMenu, sceneItem));
 		popup.addSeparator();
 
 		popup.addMenu(sourceProjector);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -27,7 +27,6 @@
 #include <QDesktopWidget>
 #include <QScreen>
 #include <QColorDialog>
-#include <QWidgetAction>
 #include <QSizePolicy>
 
 #include <util/dstr.h>
@@ -2137,6 +2136,9 @@ OBSBasic::~OBSBasic()
 	delete previewProjectorMain;
 	delete sourceProjector;
 	delete scaleFilteringMenu;
+	delete colorMenu;
+	delete colorWidgetAction;
+	delete colorSelect;
 	delete trayMenu;
 	delete programOptions;
 	delete program;
@@ -4085,9 +4087,9 @@ QMenu *OBSBasic::AddScaleFilteringMenu(QMenu *menu, obs_sceneitem_t *item)
 	return menu;
 }
 
-QMenu *OBSBasic::AddBackgroundColorMenu(obs_sceneitem_t *item)
+QMenu *OBSBasic::AddBackgroundColorMenu(QMenu *menu, QWidgetAction *widgetAction,
+		ColorSelect *select, obs_sceneitem_t *item)
 {
-	QMenu *menu = new QMenu(QTStr("ChangeBG"));
 	QAction *action;
 
 	menu->setStyleSheet(QString(
@@ -4120,8 +4122,6 @@ QMenu *OBSBasic::AddBackgroundColorMenu(obs_sceneitem_t *item)
 
 	menu->addSeparator();
 
-	QWidgetAction *widgetAction = new QWidgetAction(menu);
-	ColorSelect *select = new ColorSelect(menu);
 	widgetAction->setDefaultWidget(select);
 
 	for (int i = 1; i < 9; i++) {
@@ -4142,12 +4142,22 @@ QMenu *OBSBasic::AddBackgroundColorMenu(obs_sceneitem_t *item)
 	return menu;
 }
 
+ColorSelect::ColorSelect(QWidget *parent)
+	: QWidget(parent),
+	ui(new Ui::ColorSelect)
+{
+	ui->setupUi(this);
+}
+
 void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 {
 	QMenu popup(this);
 	delete previewProjectorSource;
 	delete sourceProjector;
 	delete scaleFilteringMenu;
+	delete colorMenu;
+	delete colorWidgetAction;
+	delete colorSelect;
 
 	if (preview) {
 		QAction *action = popup.addAction(
@@ -4219,7 +4229,11 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 			OBS_SOURCE_AUDIO;
 		QAction *action;
 
-		popup.addMenu(AddBackgroundColorMenu(sceneItem));
+		colorMenu = new QMenu(QTStr("ChangeBG"));
+		colorWidgetAction = new QWidgetAction(colorMenu);
+		colorSelect = new ColorSelect(colorMenu);
+		popup.addMenu(AddBackgroundColorMenu(colorMenu,
+				colorWidgetAction, colorSelect, sceneItem));
 		popup.addAction(QTStr("Rename"), this,
 				SLOT(EditSceneItemName()));
 		popup.addAction(QTStr("Remove"), this,
@@ -6829,11 +6843,4 @@ void OBSBasic::ResizeOutputSizeOfSource()
 
 	ResetVideo();
 	on_actionFitToScreen_triggered();
-}
-
-ColorSelect::ColorSelect(QWidget *parent)
-	: QWidget(parent),
-	  ui(new Ui::ColorSelect)
-{
-	ui->setupUi(this);
 }

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2139,6 +2139,7 @@ OBSBasic::~OBSBasic()
 	delete colorMenu;
 	delete colorWidgetAction;
 	delete colorSelect;
+	delete deinterlaceMenu;
 	delete trayMenu;
 	delete programOptions;
 	delete program;
@@ -4013,9 +4014,8 @@ void OBSBasic::SetDeinterlacingOrder()
 	obs_source_set_deinterlace_field_order(source, order);
 }
 
-QMenu *OBSBasic::AddDeinterlacingMenu(obs_source_t *source)
+QMenu *OBSBasic::AddDeinterlacingMenu(QMenu *menu, obs_source_t *source)
 {
-	QMenu *menu = new QMenu(QTStr("Deinterlacing"));
 	obs_deinterlace_mode deinterlaceMode =
 		obs_source_get_deinterlace_mode(source);
 	obs_deinterlace_field_order deinterlaceOrder =
@@ -4158,6 +4158,7 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 	delete colorMenu;
 	delete colorWidgetAction;
 	delete colorSelect;
+	delete deinterlaceMenu;
 
 	if (preview) {
 		QAction *action = popup.addAction(
@@ -4263,7 +4264,8 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		}
 
 		if (isAsyncVideo) {
-			popup.addMenu(AddDeinterlacingMenu(source));
+			deinterlaceMenu = new QMenu(QTStr("Deinterlacing"));
+			popup.addMenu(AddDeinterlacingMenu(deinterlaceMenu, source));
 			popup.addSeparator();
 		}
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2133,6 +2133,7 @@ OBSBasic::~OBSBasic()
 	delete multiviewProjectorMenu;
 	delete previewProjector;
 	delete studioProgramProjector;
+	delete sourceProjector;
 	delete scaleFilteringMenu;
 	delete trayMenu;
 	delete programOptions;
@@ -4143,7 +4144,7 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 {
 	QMenu popup(this);
 	QPointer<QMenu> previewProjector;
-	QPointer<QMenu> sourceProjector;
+	delete sourceProjector;
 	delete scaleFilteringMenu;
 
 	if (preview) {

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2140,6 +2140,7 @@ OBSBasic::~OBSBasic()
 	delete colorWidgetAction;
 	delete colorSelect;
 	delete deinterlaceMenu;
+	delete perSceneTransitionMenu;
 	delete trayMenu;
 	delete programOptions;
 	delete program;
@@ -3853,8 +3854,9 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 
 		popup.addSeparator();
 
-		QMenu *transitionMenu = CreatePerSceneTransitionMenu();
-		popup.addMenu(transitionMenu);
+		delete perSceneTransitionMenu;
+		perSceneTransitionMenu = CreatePerSceneTransitionMenu();
+		popup.addMenu(perSceneTransitionMenu);
 
 		/* ---------------------- */
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -217,6 +217,7 @@ private:
 	QPointer<QWidgetAction>   colorWidgetAction;
 	QPointer<ColorSelect>     colorSelect;
 	QPointer<QMenu>           deinterlaceMenu;
+	QPointer<QMenu>           perSceneTransitionMenu;
 
 	void          UpdateMultiviewProjectorMenu();
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -199,6 +199,7 @@ private:
 	QPointer<QMenu>           previewProjector;
 	QPointer<QMenu>           studioProgramProjector;
 	QPointer<QMenu>           multiviewProjectorMenu;
+	QPointer<QMenu>           sourceProjector;
 	QPointer<QMenu>           scaleFilteringMenu;
 
 	void          UpdateMultiviewProjectorMenu();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -199,6 +199,7 @@ private:
 	QPointer<QMenu>           previewProjector;
 	QPointer<QMenu>           studioProgramProjector;
 	QPointer<QMenu>           multiviewProjectorMenu;
+	QPointer<QMenu>           scaleFilteringMenu;
 
 	void          UpdateMultiviewProjectorMenu();
 
@@ -579,7 +580,7 @@ public:
 	}
 
 	QMenu *AddDeinterlacingMenu(obs_source_t *source);
-	QMenu *AddScaleFilteringMenu(obs_sceneitem_t *item);
+	QMenu *AddScaleFilteringMenu(QMenu *menu, obs_sceneitem_t *item);
 	QMenu *AddBackgroundColorMenu(obs_sceneitem_t *item);
 	void CreateSourcePopupMenu(int idx, bool preview);
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -211,6 +211,7 @@ private:
 	QPointer<QMenu>           multiviewProjectorMenu;
 	QPointer<QMenu>           previewProjectorSource;
 	QPointer<QMenu>           previewProjectorMain;
+	QPointer<QMenu>           sceneProjectorMenu;
 	QPointer<QMenu>           sourceProjector;
 	QPointer<QMenu>           scaleFilteringMenu;
 	QPointer<QMenu>           colorMenu;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -216,6 +216,7 @@ private:
 	QPointer<QMenu>           colorMenu;
 	QPointer<QWidgetAction>   colorWidgetAction;
 	QPointer<ColorSelect>     colorSelect;
+	QPointer<QMenu>           deinterlaceMenu;
 
 	void          UpdateMultiviewProjectorMenu();
 
@@ -595,7 +596,7 @@ public:
 		}
 	}
 
-	QMenu *AddDeinterlacingMenu(obs_source_t *source);
+	QMenu *AddDeinterlacingMenu(QMenu *menu, obs_source_t *source);
 	QMenu *AddScaleFilteringMenu(QMenu *menu, obs_sceneitem_t *item);
 	QMenu *AddBackgroundColorMenu(QMenu *menu, QWidgetAction *widgetAction,
 			ColorSelect *select, obs_sceneitem_t *item);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -19,6 +19,7 @@
 
 #include <QBuffer>
 #include <QAction>
+#include <QWidgetAction>
 #include <QSystemTrayIcon>
 #include <obs.hpp>
 #include <vector>
@@ -97,6 +98,15 @@ struct QuickTransition {
 private:
 	static void SourceRenamed(void *param, calldata_t *data);
 	std::shared_ptr<OBSSignal> renamedSignal;
+};
+
+class ColorSelect : public QWidget {
+
+public:
+	explicit ColorSelect(QWidget *parent = 0);
+
+private:
+	std::unique_ptr<Ui::ColorSelect> ui;
 };
 
 class OBSBasic : public OBSMainWindow {
@@ -203,6 +213,9 @@ private:
 	QPointer<QMenu>           previewProjectorMain;
 	QPointer<QMenu>           sourceProjector;
 	QPointer<QMenu>           scaleFilteringMenu;
+	QPointer<QMenu>           colorMenu;
+	QPointer<QWidgetAction>   colorWidgetAction;
+	QPointer<ColorSelect>     colorSelect;
 
 	void          UpdateMultiviewProjectorMenu();
 
@@ -584,7 +597,8 @@ public:
 
 	QMenu *AddDeinterlacingMenu(obs_source_t *source);
 	QMenu *AddScaleFilteringMenu(QMenu *menu, obs_sceneitem_t *item);
-	QMenu *AddBackgroundColorMenu(obs_sceneitem_t *item);
+	QMenu *AddBackgroundColorMenu(QMenu *menu, QWidgetAction *widgetAction,
+			ColorSelect *select, obs_sceneitem_t *item);
 	void CreateSourcePopupMenu(int idx, bool preview);
 
 	void UpdateTitleBar();
@@ -769,13 +783,4 @@ public:
 
 private:
 	std::unique_ptr<Ui::OBSBasic> ui;
-};
-
-class ColorSelect : public QWidget {
-
-public:
-	explicit ColorSelect(QWidget *parent = 0);
-
-private:
-	std::unique_ptr<Ui::ColorSelect> ui;
 };

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -199,6 +199,8 @@ private:
 	QPointer<QMenu>           previewProjector;
 	QPointer<QMenu>           studioProgramProjector;
 	QPointer<QMenu>           multiviewProjectorMenu;
+	QPointer<QMenu>           previewProjectorSource;
+	QPointer<QMenu>           previewProjectorMain;
 	QPointer<QMenu>           sourceProjector;
 	QPointer<QMenu>           scaleFilteringMenu;
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -219,6 +219,7 @@ private:
 	QPointer<ColorSelect>     colorSelect;
 	QPointer<QMenu>           deinterlaceMenu;
 	QPointer<QMenu>           perSceneTransitionMenu;
+	QPointer<QObject>         shortcutFilter;
 
 	void          UpdateMultiviewProjectorMenu();
 

--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -132,7 +132,9 @@ OBSBasicStats::OBSBasicStats(QWidget *parent, bool closeable)
 				[this] () {close();});
 	connect(resetButton, &QPushButton::clicked, [this] () {Reset();});
 
-	installEventFilter(CreateShortcutFilter());
+	delete shortcutFilter;
+	shortcutFilter = CreateShortcutFilter();
+	installEventFilter(shortcutFilter);
 
 	resize(800, 280);
 
@@ -181,6 +183,7 @@ void OBSBasicStats::closeEvent(QCloseEvent *event)
 
 OBSBasicStats::~OBSBasicStats()
 {
+	delete shortcutFilter;
 	os_cpu_usage_info_destroy(cpu_info);
 }
 

--- a/UI/window-basic-stats.hpp
+++ b/UI/window-basic-stats.hpp
@@ -59,4 +59,6 @@ public:
 	~OBSBasicStats();
 
 	static void InitializeValues();
+private:
+	QPointer<QObject> shortcutFilter;
 };


### PR DESCRIPTION
Fixes leaks with:
- projector menus (in source, main preview, scenes),
- background color menu
- deinterlace menu,
- scene transition override,
- filter shortcuts (in Main and stats).

There are more leaks with filter shortcuts (see https://github.com/obsproject/obs-studio/pull/1366 ) but I didn't fix them out of laziness ...