### PR TITLE
UI: Add support for Restream "Auto" server in auto-config

### DIFF
--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -219,6 +219,10 @@ void AutoConfigTestPage::TestBandwidthThread()
 		string_depad_key(key);
 		key += "?bandwidthtest";
 	}
+	else if(wiz->serviceName == "Restream.io" || wiz->serviceName == "Restream.io - RTMP") {
+		string_depad_key(key);
+		key += "?test=true";
+	}
 
 	obs_data_set_string(service_settings, "service",
 			wiz->serviceName.c_str());
@@ -246,8 +250,9 @@ void AutoConfigTestPage::TestBandwidthThread()
 		GetServers(servers);
 
 	/* just use the first server if it only has one alternate server,
-	 * or if using Mixer due to its "auto" server */
-	if (servers.size() < 3 || wiz->serviceName == "Mixer.com - FTL") {
+	 * or if using Mixer or Restream due to their "auto" servers */
+	if (servers.size() < 3 || wiz->serviceName == "Mixer.com - FTL" || 
+			wiz->serviceName.substr(0, 11)=="Restream.io") {
 		servers.resize(1);
 
 	} else if (wiz->service == AutoConfig::Service::Twitch &&


### PR DESCRIPTION
Uses the "Auto" server automatically for Restream rather than doing a region-based test on multiple servers.