### PR TITLE
UI: Correct custom property implementation

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -883,6 +883,6 @@ FocusList::item {
 
 /* Preview background color */
 
-* [themeID="displayBackgroundColor"] {
-    qproperty-displayBackgroundColor: #28282A;
+OBSQTDisplay {
+	qproperty-displayBackgroundColor: #28282A;
 }

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -685,6 +685,6 @@ QLabel#errorLabel {
 
 /* Preview background color */
 
-* [themeID="displayBackgroundColor"] {
-    qproperty-displayBackgroundColor: rgb(76, 76, 76);
+OBSQTDisplay {
+	qproperty-displayBackgroundColor: rgb(76, 76, 76);
 }

--- a/UI/data/themes/Default.qss
+++ b/UI/data/themes/Default.qss
@@ -138,6 +138,6 @@ QLabel#errorLabel {
 
 /* Preview background color */
 
-* [themeID="displayBackgroundColor"] {
-    qproperty-displayBackgroundColor: rgb(76, 76, 76);
+OBSQTDisplay {
+	qproperty-displayBackgroundColor: rgb(76, 76, 76);
 }

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -1251,6 +1251,6 @@ QToolTip {
 
 /* Preview background color */
 
-* [themeID="displayBackgroundColor"] {
-    qproperty-displayBackgroundColor: rgb(35, 38, 41);
+OBSQTDisplay {
+	qproperty-displayBackgroundColor: rgb(35, 38, 41);
 }

--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -53,14 +53,26 @@ OBSQTDisplay::OBSQTDisplay(QWidget *parent, Qt::WindowFlags flags)
 
 	connect(windowHandle(), &QWindow::visibleChanged, windowVisible);
 	connect(windowHandle(), &QWindow::screenChanged, sizeChanged);
-
-	this->setProperty("themeID", "displayBackgroundColor");
 }
 
-void OBSQTDisplay::SetDisplayBackgroundColor(const QColor &color)
+QColor OBSQTDisplay::getDisplayGNDColor() const
 {
-	backgroundColor = (uint32_t)color_to_int(color);
-	obs_display_set_background_color(display, backgroundColor);
+	return m_displayGNDColor;
+}
+
+void OBSQTDisplay::setDisplayGNDColor(QColor color)
+{
+	// Only when color actually changed - apply it
+	if (color != m_displayGNDColor) {
+		m_displayGNDColor = color;
+		displayGNDColor = (uint32_t)color_to_int(m_displayGNDColor);
+		updateDisplayGNDColor();
+	}
+}
+
+void OBSQTDisplay::updateDisplayGNDColor()
+{
+	obs_display_set_background_color(display, displayGNDColor);
 }
 
 void OBSQTDisplay::CreateDisplay()

--- a/UI/qt-display.hpp
+++ b/UI/qt-display.hpp
@@ -3,6 +3,9 @@
 #include <QWidget>
 #include <obs.hpp>
 
+// Color format #AABBGGRR
+#define GREY_COLOR_BACKGROUND 0xFF4C4C4C
+
 class OBSQTDisplay : public QWidget {
 	Q_OBJECT
 	Q_PROPERTY(QColor displayBackgroundColor WRITE SetDisplayBackgroundColor
@@ -26,7 +29,7 @@ public:
 
 	inline obs_display_t *GetDisplay() const {return display;}
 
-	uint32_t backgroundColor;
+	uint32_t backgroundColor = GREY_COLOR_BACKGROUND;
 
 private slots:
 	void SetDisplayBackgroundColor(const QColor &color);

--- a/UI/qt-display.hpp
+++ b/UI/qt-display.hpp
@@ -8,8 +8,8 @@
 
 class OBSQTDisplay : public QWidget {
 	Q_OBJECT
-	Q_PROPERTY(QColor displayBackgroundColor WRITE SetDisplayBackgroundColor
-			NOTIFY SetDisplayBackgroundColor)
+	Q_PROPERTY(QColor displayBackgroudColor READ getDisplayGNDColor
+			WRITE setDisplayGNDColor)
 
 	OBSDisplay display;
 
@@ -29,8 +29,12 @@ public:
 
 	inline obs_display_t *GetDisplay() const {return display;}
 
-	uint32_t backgroundColor = GREY_COLOR_BACKGROUND;
+	uint32_t displayGNDColor = GREY_COLOR_BACKGROUND;
 
-private slots:
-	void SetDisplayBackgroundColor(const QColor &color);
+	QColor getDisplayGNDColor() const;
+	void setDisplayGNDColor(QColor color);
+	void updateDisplayGNDColor();
+
+private:
+	QColor m_displayGNDColor;
 };

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -66,7 +66,6 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 		obs_display_add_draw_callback(GetDisplay(),
 				isMultiview ? OBSRenderMultiview : OBSRender,
 				this);
-		obs_display_set_background_color(GetDisplay(), 0x000000);
 	};
 
 	connect(this, &OBSQTDisplay::DisplayCreated, addDrawCallback);

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -66,7 +66,7 @@ private:
 	// argb colors
 	static const uint32_t outerColor      = 0xFFD0D0D0;
 	static const uint32_t labelColor      = 0xD91F1F1F;
-	static const uint32_t backgroundColor = 0xFF000000;
+	static const uint32_t backgroundColor = 0xFF000000; // Scene's one
 	static const uint32_t previewColor    = 0xFF00D000;
 	static const uint32_t programColor    = 0xFFD00000;
 


### PR DESCRIPTION
1. Fixes an issue when custom theme has no info about the preview
background color, the preview's display background may be rendered
with random color.
2. Adds Projector display background color customization instead of
hardcoded black. Now if source larger than the display's height or
width, the remaining space for the Fullscreen Projector filled with
the preview's display background color from the theme.

The Projector's background, if it defer from the Display's background
color may be specified via:
```
OBSProjector {
qproperty-displayBackgroundColor: ... ;
}
```
record that is placed after the `OBSQTDisplay` section in the theme
file (qss).

3. The usage of the `* [themeID="..."]` in themes was not versatile - 
this is selector _for any child object that has `themeID` property_.
In obs, all Projectors (see https://github.com/obsproject/obs-studio/commit/ea851b13512ca5420b2ce46aff3fa01cbc56a869 ) has no parent and thus the property
never applies to projectors despite it derived from the display class.

More versatile usage is
`*[themeID="..."]` (no space specified)
like _for any object that has `themeID` property_.

This also fixes it.

4. Adding one more property dynamically ('themeID') to the OBSQTDisplay
class not required because another property already set in the header
file (`displayBackgroundColor`). Unneeded overheat removed.