### PR TITLE
UI: Correct custom property implementation

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -904,8 +904,8 @@ FocusList::item {
 
 /* Preview background color */
 
-* [themeID="displayBackgroundColor"] {
-    qproperty-displayBackgroundColor: #28282A;
+OBSQTDisplay {
+	qproperty-displayBackgroundColor: #28282A;
 }
 
 /* Preview/Program labels */

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -695,8 +695,8 @@ QLabel#errorLabel {
 
 /* Preview background color */
 
-* [themeID="displayBackgroundColor"] {
-    qproperty-displayBackgroundColor: rgb(76, 76, 76);
+OBSQTDisplay {
+	qproperty-displayBackgroundColor: rgb(76, 76, 76);
 }
 
 /* Preview/Program labels */

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -1260,8 +1260,8 @@ QToolTip {
 
 /* Preview background color */
 
-* [themeID="displayBackgroundColor"] {
-    qproperty-displayBackgroundColor: rgb(35, 38, 41);
+OBSQTDisplay {
+	qproperty-displayBackgroundColor: rgb(35, 38, 41);
 }
 
 /* Preview/Program labels */

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -138,8 +138,8 @@ QLabel#errorLabel {
 
 /* Preview background color */
 
-* [themeID="displayBackgroundColor"] {
-    qproperty-displayBackgroundColor: rgb(76, 76, 76);
+OBSQTDisplay {
+	qproperty-displayBackgroundColor: rgb(76, 76, 76);
 }
 
 /* Preview/Program labels */

--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -19,6 +19,13 @@ static inline long long color_to_int(QColor color)
 		shift(color.alpha(), 24);
 }
 
+static inline QColor rgba_to_color(uint32_t rgba)
+{
+	return QColor::fromRgb(rgba & 0xFF,
+	                       (rgba >> 8) & 0xFF,
+	                       (rgba >> 16) & 0xFF,
+	                       (rgba >> 24) & 0xFF);
+}
 
 OBSQTDisplay::OBSQTDisplay(QWidget *parent, Qt::WindowFlags flags)
 	: QWidget(parent, flags)
@@ -53,13 +60,25 @@ OBSQTDisplay::OBSQTDisplay(QWidget *parent, Qt::WindowFlags flags)
 
 	connect(windowHandle(), &QWindow::visibleChanged, windowVisible);
 	connect(windowHandle(), &QWindow::screenChanged, sizeChanged);
+}
 
-	this->setProperty("themeID", "displayBackgroundColor");
+QColor OBSQTDisplay::GetDisplayBackgroundColor() const
+{
+	return rgba_to_color(backgroundColor);
 }
 
 void OBSQTDisplay::SetDisplayBackgroundColor(const QColor &color)
 {
-	backgroundColor = (uint32_t)color_to_int(color);
+	uint32_t newBackgroundColor = (uint32_t)color_to_int(color);
+
+	if (newBackgroundColor != backgroundColor) {
+		backgroundColor = newBackgroundColor;
+		UpdateDisplayBackgroundColor();
+	}
+}
+
+void OBSQTDisplay::UpdateDisplayBackgroundColor()
+{
 	obs_display_set_background_color(display, backgroundColor);
 }
 

--- a/UI/qt-display.hpp
+++ b/UI/qt-display.hpp
@@ -8,6 +8,7 @@
 class OBSQTDisplay : public QWidget {
 	Q_OBJECT
 	Q_PROPERTY(QColor displayBackgroundColor MEMBER backgroundColor
+			READ GetDisplayBackgroundColor
 			WRITE SetDisplayBackgroundColor)
 
 	OBSDisplay display;
@@ -31,6 +32,7 @@ public:
 
 	uint32_t backgroundColor = GREY_COLOR_BACKGROUND;
 
-private slots:
+	QColor GetDisplayBackgroundColor() const;
 	void SetDisplayBackgroundColor(const QColor &color);
+	void UpdateDisplayBackgroundColor();
 };

--- a/UI/qt-display.hpp
+++ b/UI/qt-display.hpp
@@ -3,6 +3,8 @@
 #include <QWidget>
 #include <obs.hpp>
 
+#define GREY_COLOR_BACKGROUND 0xFF4C4C4C
+
 class OBSQTDisplay : public QWidget {
 	Q_OBJECT
 	Q_PROPERTY(QColor displayBackgroundColor MEMBER backgroundColor
@@ -27,7 +29,7 @@ public:
 
 	inline obs_display_t *GetDisplay() const {return display;}
 
-	uint32_t backgroundColor;
+	uint32_t backgroundColor = GREY_COLOR_BACKGROUND;
 
 private slots:
 	void SetDisplayBackgroundColor(const QColor &color);

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -67,7 +67,6 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 		obs_display_add_draw_callback(GetDisplay(),
 				isMultiview ? OBSRenderMultiview : OBSRender,
 				this);
-		obs_display_set_background_color(GetDisplay(), 0x000000);
 	};
 
 	connect(this, &OBSQTDisplay::DisplayCreated, addDrawCallback);


### PR DESCRIPTION
1. Fixes an issue when custom theme has no info about the preview
background color, the preview's display background may be rendered
with random color.
2. Adds Projector display background color customization instead of
hardcoded black. Now if source larger than the display's height or
width, the remaining space for the Fullscreen Projector filled with
the preview's display background color from the theme.

The Projector's background, if it defer from the Display's background
color may be specified via:
```
OBSProjector {
qproperty-displayBackgroundColor: ... ;
}
```
record that is placed after the `OBSQTDisplay` section in the theme
file (qss).

3. The usage of the `* [themeID="..."]` in themes was not versatile - 
this is selector _for any child object that has `themeID` property_.
In obs, all Projectors (see https://github.com/obsproject/obs-studio/commit/ea851b13512ca5420b2ce46aff3fa01cbc56a869 ) has no parent and thus the property
never applies to projectors despite it derived from the display class.

More versatile usage is
`*[themeID="..."]` (no space specified)
like _for any object that has `themeID` property_.

This also fixes it.

4. Adding one more property dynamically ('themeID') to the OBSQTDisplay
class not required because another property already set in the header
file (`displayBackgroundColor`). Unneeded overheat removed.