### PR TITLE
Add GPL Cooperation Commitment to base directory

### DIFF
--- a/COMMITMENT
+++ b/COMMITMENT
@@ -1,0 +1,46 @@
+GPL Cooperation Commitment
+Version 1.0
+
+Before filing or continuing to prosecute any legal proceeding or claim
+(other than a Defensive Action) arising from termination of a Covered
+License, we commit to extend to the person or entity ('you') accused
+of violating the Covered License the following provisions regarding
+cure and reinstatement, taken from GPL version 3. As used here, the
+term 'this License' refers to the specific Covered License being
+enforced.
+
+    However, if you cease all violation of this License, then your
+    license from a particular copyright holder is reinstated (a)
+    provisionally, unless and until the copyright holder explicitly
+    and finally terminates your license, and (b) permanently, if the
+    copyright holder fails to notify you of the violation by some
+    reasonable means prior to 60 days after the cessation.
+
+    Moreover, your license from a particular copyright holder is
+    reinstated permanently if the copyright holder notifies you of the
+    violation by some reasonable means, this is the first time you
+    have received notice of violation of this License (for any work)
+    from that copyright holder, and you cure the violation prior to 30
+    days after your receipt of the notice.
+
+We intend this Commitment to be irrevocable, and binding and
+enforceable against us and assignees of or successors to our
+copyrights.
+
+Definitions
+
+'Covered License' means the GNU General Public License, version 2
+(GPLv2), the GNU Lesser General Public License, version 2.1
+(LGPLv2.1), or the GNU Library General Public License, version 2
+(LGPLv2), all as published by the Free Software Foundation.
+
+'Defensive Action' means a legal proceeding or claim that We bring
+against you in response to a prior proceeding or claim initiated by
+you or your affiliate.
+
+'We' means each contributor to this repository as of the date of
+inclusion of this file, including subsidiaries of a corporate
+contributor.
+
+This work is available under a Creative Commons Attribution-ShareAlike
+4.0 International license (https://creativecommons.org/licenses/by-sa/4.0/).


### PR DESCRIPTION
Red Hat has been leading a campaign to encourage GPLv2 and LGPLv2.x projects to adopt the [GPL Cooperation Commitment](https://gplcc.github.io/gplcc/) (GPLCC). GPLCC supplements GPLv2 with the cure and repose provisions of GPLv3. GPLv2 by default features an "automatic termination" provision which is commonly seen as causing immediate termination of the license upon any noncompliance with no opportunity to correct the error. The cure and repose provisions of GPLv3 (1) give first-time violators 30 days to fix noncompliance and (2) automatically restore the license 60 days after the noncompliance stops, if no copyright holder notifies you of the violation during that time period. 

We believe GPLCC reduces opportunities for abusive enforcement tactics and promotes greater fairness and predictability in the enforcement of GPLv2 and LGPLv2.x licenses. This commit adds the project version of GPLCC to the repository. It operates prospectively, so it can be adopted by a project even if there are past GPLv2 contributors who have not agreed to it. 