### PR TITLE
Add Bangalore, India server to Restream

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -692,6 +692,10 @@
                     "name": "Asia (Tokyo, Japan)",
                     "url": "rtmp://tokyo.restream.io/live"
                 },
+		{
+		    "name": "India (Bangalore),
+		    "url": "rtmp://india.restream.io/live"
+		},
                 {
                     "name": "Australia (Sydney)",
                     "url": "rtmp://au.restream.io/live"


### PR DESCRIPTION
This patch adds Indian server released by Restream to the list of predefined servers.