### PR TITLE
UI: Automatically generate Windows file description

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,16 @@ include(ObsHelpers)
 include(ObsCpack)
 include(GNUInstallDirs)
 
+if(WIN32)
+	string(REPLACE "-" ";" UI_VERSION_SPLIT ${OBS_VERSION})
+	list(GET UI_VERSION_SPLIT 0 UI_VERSION)
+	string(REPLACE "." ";" UI_VERSION_SEMANTIC ${UI_VERSION})
+	list(GET UI_VERSION_SEMANTIC 0 UI_VERSION_MAJOR)
+	list(GET UI_VERSION_SEMANTIC 1 UI_VERSION_MINOR)
+	list(GET UI_VERSION_SEMANTIC 2 UI_VERSION_PATCH)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/UI/obs.rc.in ${CMAKE_CURRENT_SOURCE_DIR}/UI/obs.rc)
+endif()
+
 # Must be a string in the format of "x.x.x-rcx"
 if(DEFINED RELEASE_CANDIDATE)
 	set(OBS_VERSION "${RELEASE_CANDIDATE}")

--- a/UI/obs.rc.in
+++ b/UI/obs.rc.in
@@ -1,0 +1,26 @@
+IDI_ICON1 ICON DISCARDABLE "../cmake/winrc/obs-studio.ico"
+
+1 VERSIONINFO
+FILEVERSION ${UI_VERSION_MAJOR},${UI_VERSION_MINOR},${UI_VERSION_PATCH},0
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904B0"
+    BEGIN
+      VALUE "CompanyName", "OBS"
+      VALUE "FileDescription", "OBS Studio"
+      VALUE "FileVersion", "${UI_VERSION}"
+      VALUE "InternalName", "obs"
+      VALUE "OriginalFilename", "obs"
+      VALUE "ProductName", "OBS Studio"
+      VALUE "ProductVersion", "${UI_VERSION}"
+      VALUE "Comments", "Free and open source software for video recording and live streaming"
+      VALUE "LegalCopyright", "(C) Hugh Bailey"
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x0409, 0x04B0
+  END
+END


### PR DESCRIPTION
This defines the main OBS Windows executable with a resource file, including a version number accessible externally and a File
description which appears in Windows Task Manager.

This is the first version, just looking to get feedback on what each of the fields should be populated with.

Originally I was going to put the cmakelist code within UI, but felt it could actually be used by other aspects (like libobs version?) so it's better if it's at the core.

Fields are defined here https://docs.microsoft.com/en-us/windows/desktop/menurc/stringfileinfo-block

### Current version:
![Descriptor](http://scr.wzd.li/scr/2019-01-29_20-19-27.png)
![Task Manager](http://scr.wzd.li/scr/2019-01-29_22-20-25.png)

## TO DO

- [ ] Look into ways to cut down the code in cmakelists, I feel there's too much written. Feedback here is helpful.
- [ ] Reuse the rc.in on OBS Browser, including icon but a custom internal name, filename, and **file description**. _Note: this may be exclusively done in the obs-browser repo separately._
![OBS Browser](http://scr.wzd.li/scr/2019-01-29_21-42-16.png)