### PR TITLE
decklink: Remove redundant const qualifiers

### DIFF
--- a/plugins/decklink/decklink-device.cpp
+++ b/plugins/decklink/decklink-device.cpp
@@ -207,12 +207,12 @@ const std::vector<DeckLinkDeviceMode *>& DeckLinkDevice::GetOutputModes(void) co
 	return outputModes;
 }
 
-const bool DeckLinkDevice::GetSupportsExternalKeyer(void) const
+bool DeckLinkDevice::GetSupportsExternalKeyer(void) const
 {
 	return supportsExternalKeyer;
 }
 
-const bool DeckLinkDevice::GetSupportsInternalKeyer(void) const
+bool DeckLinkDevice::GetSupportsInternalKeyer(void) const
 {
 	return supportsInternalKeyer;
 }

--- a/plugins/decklink/decklink-device.hpp
+++ b/plugins/decklink/decklink-device.hpp
@@ -39,8 +39,8 @@ public:
 	const std::string& GetHash(void) const;
 	const std::vector<DeckLinkDeviceMode *>& GetInputModes(void) const;
 	const std::vector<DeckLinkDeviceMode *>& GetOutputModes(void) const;
-	const bool GetSupportsExternalKeyer(void) const;
-	const bool GetSupportsInternalKeyer(void) const;
+	bool GetSupportsExternalKeyer(void) const;
+	bool GetSupportsInternalKeyer(void) const;
 	int GetKeyerMode(void);
 	void SetKeyerMode(int newKeyerMode);
 	const std::string& GetName(void) const;


### PR DESCRIPTION
Recently added code contains redundant const qualifiers. They have no effect and compiler is not very happy emitting numerous messages like this:

    In file included from /Users/travis/build/obsproject/obs-studio/plugins/decklink/decklink-devices.hpp:3:
    /Users/travis/build/obsproject/obs-studio/plugins/decklink/decklink-device.hpp:42:2: warning:
     'const' type qualifier on return type has no effect [-Wignored-qualifiers]
       const bool GetSupportsExternalKeyer(void) const;