### PR TITLE
rtmp-services: Remove LiveEdu from services

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 101,
+	"version": 102,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 101
+			"version": 102
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1154,24 +1154,6 @@
             }
         },
         {
-            "name": "LiveEdu.tv",
-            "common": true,
-            "servers": [
-                {
-                    "name": "US",
-                    "url": "rtmp://usmedia11.liveedu.tv/livecodingtv"
-                },
-                {
-                    "name": "EU",
-                    "url": "rtmp://eumedia8.liveedu.tv/livecodingtv"
-                },
-                {
-                    "name": "Asia",
-                    "url": "rtmp://apmedia1.liveedu.tv/livecodingtv"
-                }
-            ]
-        },
-        {
             "name": "Twitter / Periscope",
             "common": true,
             "servers": [


### PR DESCRIPTION
They now provide ingest URLs on demand in their panel.

The ones in our list point to random OVH IPs that are likely assigned to new customers by now and refuse the connection on TCP port 1935.