### PR TITLE
UI: add a default black background to the PGM output of the multiview

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -589,6 +589,9 @@ void OBSProjector::OBSRenderMultiview(void *data, uint32_t cx, uint32_t cy)
 	window->offset = labelOffset(programLabel, window->pvwprgCX);
 	calcPreviewProgram(true);
 
+	paintAreaWithColor(window->sourceX, window->sourceY, window->ppiCX,
+		window->ppiCY, backgroundColor);
+
 	// Scale and Draw the program
 	gs_matrix_push();
 	gs_matrix_translate3f(window->sourceX, window->sourceY, 0.0f);


### PR DESCRIPTION
Scenes have a transparent background by default. In the multiview, this is handled correctly for individual scenes and the preview output, but not for the program output. This PR aims to fix this behaviour.

Current behaviour:
![obs64_2019-02-02_15-27-55](https://user-images.githubusercontent.com/1812130/52165477-a51b6f80-2701-11e9-963b-3e26e13af815.png)

Expected behaviour:
![obs64_2019-02-02_15-41-45](https://user-images.githubusercontent.com/1812130/52165476-9e8cf800-2701-11e9-983e-d8d98c19b8f3.png)
