### PR TITLE
win-capture: Start user-facing monitor count at 1

### DIFF
--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -271,7 +271,7 @@ static bool get_monitor_props(obs_property_t *monitor_list, int monitor_idx)
 		return false;
 
 	dstr_catf(&monitor_desc, "%s %d: %ldx%ld @ %ld,%ld",
-			TEXT_MONITOR, monitor_idx,
+			TEXT_MONITOR, monitor_idx + 1,
 			info.cx, info.cy, info.x, info.y);
 
 	obs_property_list_add_int(monitor_list, monitor_desc.array,

--- a/plugins/win-capture/monitor-capture.c
+++ b/plugins/win-capture/monitor-capture.c
@@ -198,7 +198,7 @@ static BOOL CALLBACK enum_monitor_props(HMONITOR handle, HDC hdc, LPRECT rect,
 	dstr_catf(&monitor_desc,
 		format_string.array,
 		TEXT_MONITOR,
-		monitor_id,
+		monitor_id + 1,
 		resolution.array);
 
 	obs_property_list_add_int(monitor_list,


### PR DESCRIPTION
Operating systems don't report monitors from 0, so OBS shouldn't either. This avoids user confusion when display capture doesn't work, or when the user uses "Identify" systems which overlay monitor indexes.
This does not change monitor count internally.



Let me know if I've missed any display capture plugins, I modified the two I could find. Tested on Windows 10.