### PR TITLE
UI: Add collapsible groups to hotkeys

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -886,3 +886,45 @@ FocusList::item {
 * [themeID="displayBackgroundColor"] {
     qproperty-displayBackgroundColor: #28282A;
 }
+
+/* Property groups */
+
+QFrame[themeID="propertyGroupContents"] {
+	border-bottom: 2px solid #2f2f2f;
+	margin-bottom: 3px;
+	background-image: url(./Acri/bot_hook.png);
+	background-origin: margin;
+	background-clip: margin;
+	background-position: bottom left;
+	background-repeat: none;
+}
+
+* [themeID="propertyGroupTitle"] {
+	border-bottom: 2px solid #2f2f2f;
+	margin-left: 5px;
+	margin-right: 5px;
+	padding-top: 0px;
+	padding-bottom: 6px;
+	text-align: left;
+	font-size: 14px;
+	font-weight: bold;
+	background-image: url(./Acri/top_hook.png);
+	background-origin: padding;
+	background-clip: padding;
+	background-position: bottom left;
+	background-repeat: none;
+}
+
+QCheckBox[themeID="propertyGroupTitle"]::indicator {
+	width: 16px;
+	height: 16px;
+}
+
+QCheckBox[themeID="propertyGroupTitle"]::indicator:checked {
+	image: url(./Dark/expand.png);
+}
+
+QCheckBox[themeID="propertyGroupTitle"]::indicator:unchecked {
+	image: url(./Dark/collapse.png);
+}
+

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -688,3 +688,33 @@ QLabel#errorLabel {
 * [themeID="displayBackgroundColor"] {
     qproperty-displayBackgroundColor: rgb(76, 76, 76);
 }
+
+* [themeID="propertyGroupContents"] {
+    border-width: 0px 2px 2px 2px;
+    border-style: solid;
+    border-color: rgb(70,69,70);
+    border-radius: 0px 0px 5px 5px;
+}
+
+* [themeID="propertyGroupTitle"] {
+    padding: 4px;
+    background-color: QLinearGradient(x1: 0, y1: 0, x2: 0, y2: 1,
+        stop: 0 rgb(86,85,86),
+        stop: 0.1 rgb(82,81,82),
+        stop: 0.5 rgb(78,77,78),
+        stop: 0.9 rgb(74,73,74),
+        stop: 1 rgb(70,69,70));
+}
+
+QCheckBox[themeID="propertyGroupTitle"]::indicator {
+    width: 16px;
+    height: 16px;
+}
+
+QCheckBox[themeID="propertyGroupTitle"]::indicator:checked {
+    image: url(./Dark/expand.png);
+}
+
+QCheckBox[themeID="propertyGroupTitle"]::indicator:unchecked {
+    image: url(./Dark/collapse.png);
+}

--- a/UI/data/themes/Default.qss
+++ b/UI/data/themes/Default.qss
@@ -141,3 +141,31 @@ QLabel#errorLabel {
 * [themeID="displayBackgroundColor"] {
     qproperty-displayBackgroundColor: rgb(76, 76, 76);
 }
+
+/* Property groups */
+
+* [themeID="propertyGroupContents"] {
+    border-width: 0px 1px 1px 1px;
+    border-color: palette(mid);
+    border-style: solid;
+}
+
+* [themeID="propertyGroupTitle"] {
+    padding: 4px;
+    background-color: palette(midlight);
+    border: 1px solid palette(mid);
+}
+
+QCheckBox[themeID="propertyGroupTitle"]::indicator {
+    width: 16px;
+    height: 16px;
+}
+
+QCheckBox[themeID="propertyGroupTitle"]::indicator:checked {
+    image: url(:/res/images/expand.png);
+}
+
+QCheckBox[themeID="propertyGroupTitle"]::indicator:unchecked {
+    image: url(:/res/images/collapse.png);
+}
+

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -1254,3 +1254,33 @@ QToolTip {
 * [themeID="displayBackgroundColor"] {
     qproperty-displayBackgroundColor: rgb(35, 38, 41);
 }
+
+/*******************/
+/* Property groups */
+/*******************/
+
+QFrame[themeID="propertyGroupContents"] {
+	border-width: 0px 1px 1px 1px;
+	border-style: solid;
+	border-color: palette(shadow);
+	border-radius: 0px;
+}
+
+* [themeID="propertyGroupTitle"] {
+	margin: 0px;
+	padding: 4px;
+	background: palette(shadow);
+}
+
+QCheckBox[themeID="propertyGroupTitle"]::indicator {
+	width: 16px;
+	height: 16px;
+}
+
+QCheckBox[themeID="propertyGroupTitle"]::indicator:checked {
+	image: url(./Dark/expand.png);
+}
+
+QCheckBox[themeID="propertyGroupTitle"]::indicator:unchecked {
+	image: url(./Dark/collapse.png);
+}


### PR DESCRIPTION
Adds collapsible groups to hotkey settings.

See (and thanks to) #1580

![2019-02-02_21-15-58](https://user-images.githubusercontent.com/25020235/52173259-e88fd100-2735-11e9-9de0-c028021ef3c0.gif)
![2019-02-02_22-00-33](https://user-images.githubusercontent.com/25020235/52173264-0826f980-2736-11e9-9588-7364ebcdd04c.gif)
![2019-02-02_22-01-28](https://user-images.githubusercontent.com/25020235/52173267-1d9c2380-2736-11e9-96e7-49439f8ac430.gif)
![2019-02-02_22-02-04](https://user-images.githubusercontent.com/25020235/52173272-3278b700-2736-11e9-9eb2-0f4ae6611097.gif)

