### PR TITLE
frontend-tools: Call modified prop callbacks on script load/reload

### DIFF
--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -230,6 +230,14 @@ void ScriptsTool::ReloadScript(const char *path)
 		const char *script_path = obs_script_get_path(script);
 		if (strcmp(script_path, path) == 0) {
 			obs_script_reload(script);
+
+			OBSData settings = obs_data_create();
+			obs_data_release(settings);
+
+			obs_properties_t *prop =
+				obs_script_get_properties(script);
+			obs_properties_apply_settings(prop, settings);
+
 			break;
 		}
 	}
@@ -317,6 +325,13 @@ void ScriptsTool::on_addScripts_clicked()
 			QListWidgetItem *item = new QListWidgetItem(script_file);
 			item->setData(Qt::UserRole, QString(file));
 			ui->scripts->addItem(item);
+
+			OBSData settings = obs_data_create();
+			obs_data_release(settings);
+
+			obs_properties_t *prop =
+				obs_script_get_properties(script);
+			obs_properties_apply_settings(prop, settings);
 		}
 	}
 }


### PR DESCRIPTION
This change means that the modified callback for a scripts properties is
always called when first loaded or on a reload. This behavior matches
the properties view for sources, where all modified callbacks are called
when the window opens. This change therefore treats reloading as
equivalent to reopening.