### PR TITLE
libobs: Allow filters to register hotkeys

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -262,7 +262,8 @@ obs_hotkey_id obs_hotkey_register_service(obs_service_t *service,
 obs_hotkey_id obs_hotkey_register_source(obs_source_t *source, const char *name,
 		const char *description, obs_hotkey_func func, void *data)
 {
-	if (!source || source->context.private || !lock())
+	if (!source || (source->context.private &&
+		source->info.type != OBS_SOURCE_TYPE_FILTER) || !lock())
 		return OBS_INVALID_HOTKEY_ID;
 
 	obs_hotkey_id id = obs_hotkey_register_internal(


### PR DESCRIPTION
Allows hotkeys to be registered for filters.

For use in combination w/ #1642