### PR TITLE
libobs/UI: Add Log Viewer

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -536,11 +536,15 @@ Basic.MainMenu.Help.Logs.ShowLogs="&Show Log Files"
 Basic.MainMenu.Help.Logs.UploadCurrentLog="Upload &Current Log File"
 Basic.MainMenu.Help.Logs.UploadLastLog="Upload &Last Log File"
 Basic.MainMenu.Help.Logs.ViewCurrentLog="&View Current Log"
+Basic.MainMenu.Help.Logs.TailLog="&Tail Log"
 Basic.MainMenu.Help.CheckForUpdates="Check For Updates"
 Basic.MainMenu.Help.CrashLogs="Crash &Reports"
 Basic.MainMenu.Help.CrashLogs.ShowLogs="&Show Crash Reports"
 Basic.MainMenu.Help.CrashLogs.UploadLastLog="Upload &Last Crash Report"
 Basic.MainMenu.Help.About="&About"
+
+# log viewer
+Basic.LogViewer.WholeFile="Whole File"
 
 # basic mode settings dialog
 Basic.Settings.ProgramRestart="The program must be restarted for these settings to take effect."

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -136,6 +136,7 @@
      <addaction name="actionUploadCurrentLog"/>
      <addaction name="actionUploadLastLog"/>
      <addaction name="actionViewCurrentLog"/>
+     <addaction name="actionViewTailLog"/>
     </widget>
     <widget class="QMenu" name="menuCrashLogs">
      <property name="title">
@@ -1673,6 +1674,11 @@
   <action name="actionShowAbout">
    <property name="text">
     <string>Basic.MainMenu.Help.About</string>
+   </property>
+  </action>
+  <action name="actionViewTailLog">
+   <property name="text">
+    <string>Basic.MainMenu.Help.Logs.TailLog</string>
    </property>
   </action>
  </widget>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4589,6 +4589,24 @@ static BPtr<char> ReadLogFile(const char *subdir, const char *log)
 	return file;
 }
 
+static BPtr<char> TailLogFile(const char *subdir, const char *log, uint32_t lines)
+{
+	//size_t os_fread_utf8_tail(FILE *file, char **pstr, uint32_t lines)
+	char logDir[512];
+	if (GetConfigPath(logDir, sizeof(logDir), subdir) <= 0)
+		return nullptr;
+
+	string path = (char*)logDir;
+	path += "/";
+	path += log;
+
+	BPtr<char> file = os_quick_tail_utf8_file(path.c_str(), 20);
+	if (!file)
+		blog(LOG_WARNING, "Failed to read log file %s", path.c_str());
+
+	return file;
+}
+
 void OBSBasic::UploadLog(const char *subdir, const char *file)
 {
 	BPtr<char> fileString{ReadLogFile(subdir, file)};
@@ -4639,6 +4657,23 @@ void OBSBasic::on_actionUploadCurrentLog_triggered()
 void OBSBasic::on_actionUploadLastLog_triggered()
 {
 	UploadLog("obs-studio/logs", App()->GetLastLog());
+}
+
+void OBSBasic::on_actionViewTailLog_triggered()
+{
+	char logDir[512];
+	if (GetConfigPath(logDir, sizeof(logDir), "obs-studio/logs") <= 0)
+		return;
+
+	const char* log = App()->GetCurrentLog();
+
+	string path = (char*)logDir;
+	path += "/";
+	path += log;
+
+	LogViewer *logView = new LogViewer(path.c_str());
+	logView->setAttribute(Qt::WA_DeleteOnClose, true);
+	logView->show();
 }
 
 void OBSBasic::on_actionViewCurrentLog_triggered()

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -45,9 +45,11 @@ EXPORT int64_t os_ftelli64(FILE *file);
 
 EXPORT size_t os_fread_mbs(FILE *file, char **pstr);
 EXPORT size_t os_fread_utf8(FILE *file, char **pstr);
+EXPORT size_t os_fread_utf8_tail(FILE *file, char **pstr, uint32_t lines);
 
 /* functions purely for convenience */
 EXPORT char *os_quick_read_utf8_file(const char *path);
+EXPORT char *os_quick_tail_utf8_file(const char *path, uint32_t lines);
 EXPORT bool os_quick_write_utf8_file(const char *path, const char *str,
 		size_t len, bool marker);
 EXPORT bool os_quick_write_utf8_file_safe(const char *path, const char *str,


### PR DESCRIPTION
Adds a log viewer widget to the tools menu, keeps track of a number of
lines and/or entire log file.
![2019-02-05_05-03-05](https://user-images.githubusercontent.com/25020235/52275082-65bc7100-2903-11e9-9be2-b5a048cc27d6.gif)
