### PR TITLE
obs-ffmpeg: Use b-frames as reference in nvenc

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -438,6 +438,10 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 		config->rcParams.enableTemporalAQ = psycho_aq;
 	}
 
+	/* b-frames as reference */
+	if (nv_get_cap(enc, NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE))
+		h264_config->useBFramesAsRef = NV_ENC_BFRAME_REF_MODE_MIDDLE;
+
 	/* -------------------------- */
 	/* rate control               */
 


### PR DESCRIPTION
quote from nvenc doc

Using B frame as a reference improves subjective and objective encoded quality with no performance impact. Hence the users enabling multiple B frames are strongly recommended to enable this feature.