### PR TITLE
UI: Remove unused "Beta" texts

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -123,12 +123,10 @@ BandwidthTest.Region.Other="Other"
 
 # first time startup
 Basic.FirstStartup.RunWizard="Would you like to run the auto-configuration wizard?  You can also manually configure your settings by clicking the Settings button in the main window."
-Basic.FirstStartup.RunWizard.BetaWarning="(Note: The auto-configuration wizard is currently in beta)"
 Basic.FirstStartup.RunWizard.NoClicked="If you change your mind, you can run the auto-configuration wizard any time again from the Tools menu."
 
 # auto config wizard
 Basic.AutoConfig="Auto-Configuration Wizard"
-Basic.AutoConfig.Beta="Auto-Configuration Wizard (Beta)"
 Basic.AutoConfig.ApplySettings="Apply Settings"
 Basic.AutoConfig.StartPage="Usage Information"
 Basic.AutoConfig.StartPage.SubTitle="Specify what you want to use the program for"


### PR DESCRIPTION
Release 22.0.2: - Removed the "Beta" warning from the Auto-Configuration tool
The texts that the Auto-Configuration tool is in beta remained.