### PR TITLE
libobs/UI: Add Property Grouping

### DIFF
--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -33,6 +33,7 @@ private:
 	void ListChanged(const char *setting);
 	bool ColorChanged(const char *setting);
 	bool FontChanged(const char *setting);
+	void GroupChanged(const char *setting);
 	void EditableListChanged();
 	void ButtonClicked();
 
@@ -102,6 +103,8 @@ private:
 	void AddFont(obs_property_t *prop, QFormLayout *layout, QLabel *&label);
 	void AddFrameRate(obs_property_t *prop, bool &warning,
 			QFormLayout *layout, QLabel *&label);
+
+	void AddGroup(obs_property_t *prop, QFormLayout *layout);
 
 	void AddProperty(obs_property_t *property, QFormLayout *layout);
 

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -55,6 +55,7 @@ enum obs_property_type {
 	OBS_PROPERTY_FONT,
 	OBS_PROPERTY_EDITABLE_LIST,
 	OBS_PROPERTY_FRAME_RATE,
+	OBS_PROPERTY_GROUP,
 };
 
 enum obs_combo_format {
@@ -93,6 +94,12 @@ enum obs_number_type {
 	OBS_NUMBER_SLIDER
 };
 
+enum obs_group_type {
+	OBS_COMBO_INVALID,
+	OBS_GROUP_NORMAL,
+	OBS_GROUP_CHECKABLE,
+};
+
 #define OBS_FONT_BOLD      (1<<0)
 #define OBS_FONT_ITALIC    (1<<1)
 #define OBS_FONT_UNDERLINE (1<<2)
@@ -121,6 +128,8 @@ EXPORT obs_property_t *obs_properties_first(obs_properties_t *props);
 
 EXPORT obs_property_t *obs_properties_get(obs_properties_t *props,
 		const char *property);
+
+EXPORT obs_properties_t *obs_properties_get_parent(obs_properties_t *props);
 
 /** Remove a property from a properties list.
  *
@@ -230,6 +239,11 @@ EXPORT obs_property_t *obs_properties_add_editable_list(obs_properties_t *props,
 
 EXPORT obs_property_t *obs_properties_add_frame_rate(obs_properties_t *props,
 		const char *name, const char *description);
+
+EXPORT obs_property_t *obs_properties_add_group(obs_properties_t *props,
+	const char *name, const char *description, enum obs_group_type type,
+	obs_properties_t *group);
+
 
 /* ------------------------------------------------------------------------- */
 
@@ -348,6 +362,9 @@ EXPORT struct media_frames_per_second obs_property_frame_rate_fps_range_min(
 		obs_property_t *p, size_t idx);
 EXPORT struct media_frames_per_second obs_property_frame_rate_fps_range_max(
 		obs_property_t *p, size_t idx);
+
+EXPORT enum obs_group_type obs_property_group_type(obs_property_t *p);
+EXPORT obs_properties_t *obs_property_group_content(obs_property_t *p);
 
 #ifndef SWIG
 DEPRECATED


### PR DESCRIPTION
The current OBS Studio properties UI does not have any visual indicators for things that belong together. This results in very cluttered UIs if you have a lot of options, something that does not necessarily have to be, but is currently a limitation of the way OBS Studio works.

This PR adds Property Groups which can be used to visually group properties together with additional context information, and optionally even allowing an entire group of properties to be disabled at the same time. They work using the same API as before and require a child property list, but do not allow recursion and correctly check for duplicated property names.

There are two types of groups:

- Normal: A normal group with just a name and content.
- Checkable: A checkable group with a checkbox, name and content.

In the UI these are implemented using QGroupBox, which automatically disables all child elements if the checkbox is unchecked.