### PR TITLE
UI: Set preferHardware only when hw encoder is available

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -818,13 +818,13 @@ AutoConfig::AutoConfig(QWidget *parent)
 	if (!hardwareEncodingAvailable) {
 		delete streamPage->ui->preferHardware;
 		streamPage->ui->preferHardware = nullptr;
+	} else {
+		/* Newer generations of NVENC have a high enough quality to bitrate
+		* ratio that if NVENC is available, it makes sense to just always
+		* prefer hardware encoding by default */
+		bool preferHardware = nvencAvailable || os_get_physical_cores() <= 4;
+		streamPage->ui->preferHardware->setChecked(preferHardware);
 	}
-
-	/* Newer generations of NVENC have a high enough quality to bitrate
-	 * ratio that if NVENC is available, it makes sense to just always
-	 * prefer hardware encoding by default */
-	bool preferHardware = nvencAvailable || os_get_physical_cores() <= 4;
-	streamPage->ui->preferHardware->setChecked(preferHardware);
 
 	setOptions(0);
 	setButtonText(QWizard::FinishButton,


### PR DESCRIPTION
streamPage->ui->preferHardware doesn't exist if hw encoder is not available
This bug is found by @exeldro 