### PR TITLE
obs-ffmpeg: Fix constant QP mode in new NVENC

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -445,19 +445,14 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 		? NV_ENC_PARAMS_RC_VBR_HQ
 		: NV_ENC_PARAMS_RC_VBR;
 
-	if (astrcmpi(rc, "cqp") == 0) {
-		config->rcParams.targetQuality = cqp;
-		config->rcParams.averageBitRate = 0;
-		config->rcParams.maxBitRate = 0;
-		enc->can_change_bitrate = false;
+	if (astrcmpi(rc, "cqp") == 0 || astrcmpi(rc, "lossless") == 0) {
+		if (astrcmpi(rc, "lossless") == 0)
+			cqp = 0;
 
-	} else if (astrcmpi(rc, "lossless") == 0) {
 		config->rcParams.rateControlMode = NV_ENC_PARAMS_RC_CONSTQP;
-		config->rcParams.constQP.qpInterP = 0;
-		config->rcParams.constQP.qpInterB = 0;
-		config->rcParams.constQP.qpIntra = 0;
-		config->rcParams.averageBitRate = 0;
-		config->rcParams.maxBitRate = 0;
+		config->rcParams.constQP.qpInterP = cqp;
+		config->rcParams.constQP.qpInterB = cqp;
+		config->rcParams.constQP.qpIntra = cqp;
 		enc->can_change_bitrate = false;
 
 	} else if (astrcmpi(rc, "vbr") != 0) { /* CBR by default */


### PR DESCRIPTION
Right now selecting "CQP" in OBS will set Nvenc to what Nvidia calls "Target Quality" mode. This means VBR with a constant quality target instead of actual constant QP.
There also appears to be an issue wit `maxBitrate` set to 0 that limits bitrate to 128 Mbps in Target Quality mode. When properly setting CQP mode this does not happen.

This commit changes jim-nvenc so that the mode is properly set to `constQP` with the parameters set in identical fashion to what nvenc in ffmpeg would do. The result works as expected. I also removed setting `maxBitRate` and `averageBitRate` as these parameters don't do anything in CQP mode and combined lossless/cqp into a single if-clause.