### PR TITLE
linux-capture: Add randr support

### DIFF
--- a/CI/install-dependencies-linux-ubuntu16.sh
+++ b/CI/install-dependencies-linux-ubuntu16.sh
@@ -30,6 +30,7 @@ sudo apt-get install -y \
         libvlc-dev \
         libx11-dev \
         libx264-dev \
+        libxcb-randr0-dev \
         libxcb-shm0-dev \
         libxcb-xinerama0-dev \
         libxcomposite-dev \

--- a/CI/install-dependencies-linux.sh
+++ b/CI/install-dependencies-linux.sh
@@ -33,6 +33,7 @@ sudo apt-get install -y \
         libvlc-dev \
         libx11-dev \
         libx264-dev \
+        libxcb-randr0-dev \
         libxcb-shm0-dev \
         libxcb-xinerama0-dev \
         libxcomposite-dev \

--- a/plugins/linux-capture/CMakeLists.txt
+++ b/plugins/linux-capture/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT X11_Xcomposite_FOUND)
 	return()
 endif()
 
-find_package(XCB COMPONENTS XCB SHM XFIXES XINERAMA REQUIRED)
+find_package(XCB COMPONENTS XCB RANDR SHM XFIXES XINERAMA REQUIRED)
 find_package(X11_XCB REQUIRED)
 
 include_directories(SYSTEM

--- a/plugins/linux-capture/xhelpers.h
+++ b/plugins/linux-capture/xhelpers.h
@@ -65,6 +65,39 @@ int xinerama_screen_geo(xcb_connection_t *xcb, int_fast32_t screen,
 		int_fast32_t *w, int_fast32_t *h);
 
 /**
+ * Check for Randr extension
+ *
+ * @return true if randr is available which means it's active.
+ */
+bool randr_is_active(xcb_connection_t *xcb);
+
+/**
+ * Get the number of Randr screens
+ *
+ * @return number of screens
+ */
+int randr_screen_count(xcb_connection_t *xcb);
+
+/**
+ * Get screen geometry for a Rand crtc (screen)
+ *
+ * @note On error the passed coordinates/sizes will be set to 0.
+ *
+ * @param xcb xcb connection
+ * @param screen screen number to get geometry for
+ * @param x x-coordinate of the screen
+ * @param y y-coordinate of the screen
+ * @param w width of the screen
+ * @param h height of the screen
+ *
+ * @return < 0 on error
+ */
+int randr_screen_geo(xcb_connection_t *xcb, int_fast32_t screen,
+		int_fast32_t *x, int_fast32_t *y,
+		int_fast32_t *w, int_fast32_t *h,
+		xcb_screen_t **rscreen);
+
+/**
  * Get screen geometry for a X11 screen
  *
  * @note On error the passed sizes will be set to 0.


### PR DESCRIPTION
I just reworked my monitor setup and the xinerama support in linux-capture's xshm plugin was not able to capture the monitor I needed it to.  So this adds xcb-randr as a dependency and then uses it to determine the location of the screens which the rest of the xshm plugin will happily use.

I haven't done a lot of testing here yet, but everything does seem to be working fine so far.