### PR TITLE
obs-ffmpeg: Add option to use b-frames as reference

### DIFF
--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -23,6 +23,8 @@ NVENC.LookAhead.ToolTip="Enables dynamic B-frames.\n\nIf disabled, the encoder w
 NVENC.PsychoVisualTuning="Psycho Visual Tuning"
 NVENC.PsychoVisualTuning.ToolTip="Enables encoder settings that optimize the use of bitrate for increased perceived visual quality,\nespecially in situations with high motion, at the cost of increased GPU utilization."
 NVENC.CQLevel="CQ Level"
+NVENC.BFramesAsRef="Use B-Frames as Reference"
+NVENC.BFramesAsRef.ToolTip="Using B-Frames as a reference improves quality with negligible performance impact.\n\nIt is strongly recommended to enable this feature when using multiple B-Frames."
 
 FFmpegSource="Media Source"
 LocalFile="Local File"

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -318,6 +318,7 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 	const char *profile = obs_data_get_string(settings, "profile");
 	bool psycho_aq = obs_data_get_bool(settings, "psycho_aq");
 	bool lookahead = obs_data_get_bool(settings, "lookahead");
+	bool bframes_as_ref = obs_data_get_bool(settings, "bframes_as_ref");
 	int bf = (int)obs_data_get_int(settings, "bf");
 	bool vbr = astrcmpi(rc, "VBR") == 0;
 	NVENCSTATUS err;
@@ -434,6 +435,11 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 		config->rcParams.enableAQ = psycho_aq;
 		config->rcParams.enableTemporalAQ = psycho_aq;
 	}
+
+	/* b-frames as reference */
+	if (bf >= 1 && bframes_as_ref &&
+	    nv_get_cap(enc, NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE))
+		h264_config->useBFramesAsRef = NV_ENC_BFRAME_REF_MODE_MIDDLE;
 
 	/* -------------------------- */
 	/* rate control               */

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -404,6 +404,7 @@ void nvenc_defaults(obs_data_t *settings)
 	obs_data_set_default_string(settings, "preset", "hq");
 	obs_data_set_default_string(settings, "profile", "high");
 	obs_data_set_default_bool(settings, "psycho_aq", true);
+	obs_data_set_default_bool(settings, "bframes_as_ref", true);
 	obs_data_set_default_int(settings, "gpu", 0);
 	obs_data_set_default_int(settings, "bf", 2);
 }
@@ -497,6 +498,10 @@ obs_properties_t *nvenc_properties_internal(bool ffmpeg)
 				obs_module_text("NVENC.PsychoVisualTuning"));
 		obs_property_set_long_description(p,
 				obs_module_text("NVENC.PsychoVisualTuning.ToolTip"));
+		p = obs_properties_add_bool(props, "bframes_as_ref",
+				obs_module_text("NVENC.BFramesAsRef"));
+		obs_property_set_long_description(p,
+				obs_module_text("NVENC.BFramesAsRef.ToolTip"));
 	}
 
 	obs_properties_add_int(props, "gpu", obs_module_text("GPU"), 0, 8, 1);


### PR DESCRIPTION
(Variation on #1650 with it being a property, enabled by default).

According to nvidia documentation using b-frames as reference results in a slight quality improvement with no/negligible performance impact and is recommended to be enabled when using multiple b-frames.

Because of nvidia's recommendations I made this enabled by default but kept it configurable in case it causes issues.