### PR TITLE
libobs: Add minimum display duration to caption data

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -843,6 +843,7 @@ struct obs_weak_output {
 #define CAPTION_LINE_BYTES (4*CAPTION_LINE_CHARS)
 struct caption_text {
 	char text[CAPTION_LINE_BYTES+1];
+	double display_duration;
 	struct caption_text *next;
 };
 

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -1070,17 +1070,18 @@ static inline void send_interleaved(struct obs_output *output)
 		double frame_timestamp = (out.pts * out.timebase_num) /
 			(double)out.timebase_den;
 
-		/* TODO if output->caption_timestamp is more than 5 seconds
-		 * old, send empty frame */
 		if (output->caption_head &&
 		    output->caption_timestamp <= frame_timestamp) {
-			blog(LOG_INFO,"Sending caption: %f \"%s\"",
+			blog(LOG_DEBUG,"Sending caption: %f \"%s\"",
 					frame_timestamp,
 					&output->caption_head->text[0]);
 
+			double display_duration =
+				output->caption_head->display_duration;
+
 			if (add_caption(output, &out)) {
 				output->caption_timestamp =
-					frame_timestamp + 2.0;
+					frame_timestamp + display_duration;
 			}
 		}
 
@@ -2133,11 +2134,13 @@ const char *obs_output_get_id(const obs_output_t *output)
 
 #if BUILD_CAPTIONS
 static struct caption_text *caption_text_new(const char *text, size_t bytes,
-		struct caption_text *tail, struct caption_text **head)
+		struct caption_text *tail, struct caption_text **head,
+		double display_duration)
 {
 	struct caption_text *next = bzalloc(sizeof(struct caption_text));
 	snprintf(&next->text[0], CAPTION_LINE_BYTES + 1, "%.*s",
 			(int)bytes, text);
+	next->display_duration = display_duration;
 
 	if (!*head) {
 		*head = next;
@@ -2152,6 +2155,14 @@ void obs_output_output_caption_text1(obs_output_t *output, const char *text)
 {
 	if (!obs_output_valid(output, "obs_output_output_caption_text1"))
 		return;
+	obs_output_output_caption_text2(output, text, 2.0f);
+}
+
+void obs_output_output_caption_text2(obs_output_t *output, const char *text,
+		double display_duration)
+{
+	if (!obs_output_valid(output, "obs_output_output_caption_text2"))
+		return;
 	if (!active(output))
 		return;
 
@@ -2164,7 +2175,8 @@ void obs_output_output_caption_text1(obs_output_t *output, const char *text)
 	output->caption_tail = caption_text_new(
 			text, size,
 			output->caption_tail,
-			&output->caption_head);
+			&output->caption_head,
+			display_duration);
 
 	pthread_mutex_unlock(&output->caption_mutex);
 }

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1714,6 +1714,8 @@ EXPORT const char *obs_output_get_id(const obs_output_t *output);
 #if BUILD_CAPTIONS
 EXPORT void obs_output_output_caption_text1(obs_output_t *output,
 		const char *text);
+EXPORT void obs_output_output_caption_text2(obs_output_t *output,
+		const char *text, double display_duration);
 #endif
 
 EXPORT float obs_output_get_congestion(obs_output_t *output);


### PR DESCRIPTION
Adds `display_duration` declaring the minimum duration a caption text is not going to be overwritten by a new one.

To keep the functions backwards-compatible `obs_output_output_caption_text2` was added while
`obs_output_output_caption_text1` continues having a 2 second default.

Tested this with a newer version of my obs-websockets PR and it worked quite well when sending the results from Google's speech to text in real time to Twitch.