### PR TITLE
UI: Reset replay buffer button if no save key set

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5320,6 +5320,7 @@ void OBSBasic::StartReplayBuffer()
 		OBSMessageBox::information(this,
 				RP_NO_HOTKEY_TITLE,
 				RP_NO_HOTKEY_TEXT);
+		replayBufferButton->setChecked(false);
 		return;
 	}
 


### PR DESCRIPTION
Fixes an issue when Start Replay Button stays at checked state if save
replay key was not specified and thus process actually not started.

Mantis: https://obsproject.com/mantis/view.php?id=1343