### PR TITLE
UI: Reset replay buffer button on "stop" signal

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5399,6 +5399,7 @@ void OBSBasic::ReplayBufferStop(int code)
 		return;
 
 	replayBufferButton->setText(QTStr("Basic.Main.StartReplayBuffer"));
+	replayBufferButton->setChecked(false);
 
 	if (sysTrayReplayBuffer)
 		sysTrayReplayBuffer->setText(replayBufferButton->text());


### PR DESCRIPTION
Fixes an issue when Start Replay Button stays at checked state if stop
signal generated (hotkey event for example) instead of mouse click.

Mantis: https://obsproject.com/mantis/view.php?id=1343