### PR TITLE
cmake: Fix pkg-config handling of libvlc

### DIFF
--- a/cmake/Modules/FindLibVLC.cmake
+++ b/cmake/Modules/FindLibVLC.cmake
@@ -10,7 +10,7 @@
 
 find_package(PkgConfig QUIET)
 if (PKG_CONFIG_FOUND)
-	pkg_check_modules(_VLC QUIET VLC)
+	pkg_check_modules(_VLC QUIET libvlc)
 endif()
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)


### PR DESCRIPTION
1. Changed `pkg-config` module name to `libvlc`
2.~~On UNIX, reference symlink `libvlc.so`, rather than
`libvlc.so.5`, which can change with `libvlc` version~~

Tested with VLC 3 installed via `libvlc-dev`, and also with VLC 4 with source install.