### PR TITLE
UI: Fix wrong filename building for Remux dialog

### DIFF
--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -482,7 +482,7 @@ void RemuxQueueModel::checkInputPath(int row)
 
 		if (entry.state == RemuxEntryState::Ready)
 			entry.targetPath = fileInfo.path() + QDir::separator()
-				+ fileInfo.baseName() + ".mp4";
+				+ fileInfo.completeBaseName() + ".mp4";
 	}
 
 	if (entry.state == RemuxEntryState::Ready && isProcessing)


### PR DESCRIPTION
If a file that is added to the Remux dialog has a `.` in it's filename, it's target path / target filename is being cut from that point onwards (say `example.video.mkv` => `example.mkv`)

This happens due to the usage of `QFileInfo::baseName()` instead of `QFileInfo::completeBaseName()`.
This is already correctly used in [`UI/window-basic-main.cpp`](https://github.com/obsproject/obs-studio/blob/01c78bffc5f19a270905d08cb0252a76b45ebef7/UI/window-basic-main.cpp#L5184).

This PR fixes up `UI/window-remux.cpp` to also use `completeBaseName()`.

![image](https://user-images.githubusercontent.com/1345036/53293377-1f0bb980-37d3-11e9-87fb-8c9db48dc598.png)