### PR TITLE
[WIP] Show names of displays on Windows where possible

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -570,14 +570,26 @@ static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 			continue;
 
 		RECT rect = desc.DesktopCoordinates;
+
+		MONITORINFOEXA moninfo;
+		moninfo.cbSize = sizeof(MONITORINFOEXA);
+		GetMonitorInfoA(desc.Monitor, &moninfo);
+		DISPLAY_DEVICEA ddev;
+		ddev.cb = sizeof(ddev);
+		EnumDisplayDevicesA(moninfo.szDevice, 0, &ddev, 1);
+		DEVMODEA dmode;
+		EnumDisplaySettingsA(moninfo.szDevice, ENUM_CURRENT_SETTINGS, &dmode);
+
 		blog(LOG_INFO, "\t  output %u: "
 				"pos={%d, %d}, "
-				"size={%d, %d}, "
-				"attached=%s",
+				"size={%d, %d @ %d}, "
+				"attached=%s, "
+				"name=%s",
 				i,
 				rect.left, rect.top,
-				rect.right - rect.left, rect.bottom - rect.top,
-				desc.AttachedToDesktop ? "true" : "false");
+				rect.right - rect.left, rect.bottom - rect.top, dmode.dmDisplayFrequency,
+				desc.AttachedToDesktop ? "true" : "false",
+				ddev.DeviceString);
 	}
 }
 

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -175,6 +175,8 @@ struct gs_monitor_info {
 	long y;
 	long cx;
 	long cy;
+	char *monitor_name;
+	uint32_t flags;
 };
 
 struct gs_tvertarray {

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -117,6 +117,7 @@ static void reset_capture_data(struct duplicator_capture *capture)
 	capture->x = monitor_info.x;
 	capture->y = monitor_info.y;
 	capture->rot = monitor_info.rotation_degrees;
+	bfree(monitor_info.monitor_name);
 }
 
 static void free_capture_data(struct duplicator_capture *capture)
@@ -270,14 +271,35 @@ static bool get_monitor_props(obs_property_t *monitor_list, int monitor_idx)
 	if (!gs_get_duplicator_monitor_info(monitor_idx, &info))
 		return false;
 
-	dstr_catf(&monitor_desc, "%s %d: %ldx%ld @ %ld,%ld",
-			TEXT_MONITOR, monitor_idx + 1,
+	struct dstr format_str = { 0 };
+	dstr_copy(&format_str, "%s: %ldx%ld @ %ld,%ld");
+
+	struct dstr m = { 0 };
+	dstr_copy(&m, info.monitor_name);
+	if (dstr_cmp(&m, "Generic PnP Monitor") == 0 || dstr_is_empty(&m)) {
+		struct dstr d = { 0 };
+		dstr_catf(&d, "%s %d", TEXT_MONITOR, monitor_idx + 1);
+		dstr_free(&m);
+		dstr_copy_dstr(&m, &d);
+		dstr_free(&d);
+	} else {
+		dstr_replace(&m, "(", " (");
+	}
+
+	if (info.flags & MONITORINFOF_PRIMARY)
+		dstr_catf(&format_str, " (%s)", TEXT_PRIMARY_MONITOR);
+
+	dstr_catf(&monitor_desc, format_str.array,
+			m.array,
 			info.cx, info.cy, info.x, info.y);
 
 	obs_property_list_add_int(monitor_list, monitor_desc.array,
 			monitor_idx);
 
+	bfree(info.monitor_name);
 	dstr_free(&monitor_desc);
+	dstr_free(&format_str);
+	dstr_free(&m);
 
 	return true;
 }

--- a/plugins/win-capture/monitor-capture.c
+++ b/plugins/win-capture/monitor-capture.c
@@ -1,4 +1,5 @@
 #include <util/dstr.h>
+#include <util/platform.h>
 #include "dc-capture.h"
 
 #define TEXT_MONITOR_CAPTURE obs_module_text("MonitorCapture")
@@ -172,7 +173,7 @@ static BOOL CALLBACK enum_monitor_props(HMONITOR handle, HDC hdc, LPRECT rect,
 	UNUSED_PARAMETER(rect);
 
 	obs_property_t *monitor_list = (obs_property_t*)param;
-	MONITORINFO mi;
+	MONITORINFOEX mi;
 	size_t monitor_id = 0;
 	struct dstr monitor_desc = { 0 };
 	struct dstr resolution = { 0 };
@@ -183,6 +184,17 @@ static BOOL CALLBACK enum_monitor_props(HMONITOR handle, HDC hdc, LPRECT rect,
 	mi.cbSize = sizeof(mi);
 	GetMonitorInfo(handle, &mi);
 
+	DISPLAY_DEVICE ddev;
+	ddev.cb = sizeof(ddev);
+	EnumDisplayDevices(mi.szDevice, 0, &ddev, 1);
+
+	char *devname = NULL;
+#ifdef UNICODE
+	os_wcs_to_utf8_ptr(ddev.DeviceString, 128, &devname);
+#else
+	devname = (char*)bstrdup(ddev.DeviceString);
+#endif
+
 	dstr_catf(&resolution,
 		"%dx%d @ %d,%d",
 		mi.rcMonitor.right - mi.rcMonitor.left,
@@ -190,15 +202,27 @@ static BOOL CALLBACK enum_monitor_props(HMONITOR handle, HDC hdc, LPRECT rect,
 		mi.rcMonitor.left,
 		mi.rcMonitor.top);
 
-	dstr_copy(&format_string, "%s %d: %s");
+	dstr_copy(&format_string, "%s: %s");
 	if (mi.dwFlags == MONITORINFOF_PRIMARY) {
 		dstr_catf(&format_string, " (%s)", TEXT_PRIMARY_MONITOR);
 	}
 
+	struct dstr m = { 0 };
+	dstr_copy(&m, devname);
+	dstr_replace(&m, "(", " (");
+	if (dstr_cmp(&m, "Generic PnP Monitor") == 0 || dstr_is_empty(&m)) {
+		struct dstr d = { 0 };
+		dstr_catf(&d, "%s %d", TEXT_MONITOR, monitor_id + 1);
+		dstr_free(&m);
+		dstr_copy_dstr(&m, &d);
+		dstr_free(&d);
+	} else {
+		dstr_replace(&m, "(", " (");
+	}
+
 	dstr_catf(&monitor_desc,
 		format_string.array,
-		TEXT_MONITOR,
-		monitor_id + 1,
+		m.array,
 		resolution.array);
 
 	obs_property_list_add_int(monitor_list,
@@ -207,6 +231,7 @@ static BOOL CALLBACK enum_monitor_props(HMONITOR handle, HDC hdc, LPRECT rect,
 	dstr_free(&monitor_desc);
 	dstr_free(&resolution);
 	dstr_free(&format_string);
+	bfree(devname);
 
 	return TRUE;
 }


### PR DESCRIPTION
### **Feature 1**: Log display names and refresh rates on startup
```
Adapter 1: NVIDIA GeForce GTX 1080 Ti
  Dedicated VRAM: 3077570560
  Shared VRAM:    4263356416
  output 1: pos={0, 0}, size={3440, 1440 @ 60}, attached=true, name=Acer X34(DP)
  output 2: pos={-1200, -478}, size={1200, 1920 @ 59}, attached=true, name=Dell U2412M(Digital)
  output 3: pos={3440, 0}, size={1920, 1080 @ 60}, attached=true, name=Generic PnP Monitor
```

### **Feature 2**: Show names of displays in the Fullscreen Projectors list and Display Capture dropdown

![Projector List](https://i.imgur.com/9LGSa8l.png)
![Display Capture](https://i.imgur.com/eZj4Eps.png)

### **Feature 3**: Duplicator Display Capture now shows "Primary Monitor" just like non-duplicator (aka OpenGL)


--- 
I researched as much as I could into ways of grabbing the "Model" as fallback (in my examples, "Generic PnP Monitor" would appear as "SAMSUNG" if it was possible) but every method I tried ended up being a dead end. Instead, user-facing Generic displays will appear the old way, "Display X".

I tested this on macOS and Ubuntu to ensure nothing breaks. I might remove the `name = screens[i]->model();` as right now it'll always be blank, and to be honest we have no idea what Qt will decide to populate that field with at a future time.

### Feedback and suggestions are appreciated.

In collaboration with @Andersama (tbh he wrote most of the complex stuff).

## Still To Do:
- [ ] **In OpenGL mode, name displays in the Projector menu** 
- [ ] It'd probably be best to surround the obs_enter/leave_graphics in window-basic-main with an `#ifdef _WIN32`