### PR TITLE
libobs/media-io: Fix mono upmix

### DIFF
--- a/libobs/media-io/audio-resampler-ffmpeg.c
+++ b/libobs/media-io/audio-resampler-ffmpeg.c
@@ -102,6 +102,21 @@ audio_resampler_t *audio_resampler_create(const struct resample_info *dst,
 		return NULL;
 	}
 
+	if (rs->input_layout == AV_CH_LAYOUT_MONO && rs->output_ch > 1) {
+		const double matrix[MAX_AUDIO_CHANNELS][MAX_AUDIO_CHANNELS] = {
+		{1},
+		{1, 1},
+		{1, 1, 0},
+		{1, 1, 1, 1},
+		{1, 1, 1, 0, 1},
+		{1, 1, 1, 1, 1, 1},
+		{1, 1, 1, 0, 1, 1, 1},
+		{1, 1, 1, 0, 1, 1, 1, 1},
+		};
+		if (swr_set_matrix(rs->context, matrix[rs->output_ch - 1], 1) < 0)
+			blog(LOG_DEBUG, "swr_set_matrix failed for mono upmix\n");
+	}
+
 	errcode = swr_init(rs->context);
 	if (errcode != 0) {
 		blog(LOG_ERROR, "avresample_open failed: error code %d",


### PR DESCRIPTION
Fixes Mantis issue 960.
A mono source is currently upmixed by swresampler in the following way:
- for stereo output, FL=FR=input/sqrt(2)
- for other speaker layouts of the outputs, FC=input, other channels
are zeroed.

In the case of stereo output, this leads to a 3dB level decrease which
users have issue with [1].
The obvious fix of adding a 3dB gain is reported to be adding distortions
on some setups [2].
Instead this commits changes the resampler options for mono input.

Note that the "Downmix to Mono" does not fix this upmix problem, since
it just makes all output channels identical by summing all input channels
and normalizing (by dividing by the number of output channels). This last
normalization step results in a level reduction for a mono input.

[1] https://obsproject.com/mantis/view.php?id=960.
[2] See also: https://obsproject.com/forum/threads/please-allow-for-mono-recording-of-microphones-ill-explain-why.84834