### PR TITLE
win-dshow: Fix "Highest FPS" algorithm

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -78,7 +78,11 @@ static inline enum speaker_layout convert_speaker_layout(uint8_t channels)
 
 static inline enum video_colorspace convert_color_space(enum AVColorSpace s)
 {
-	return s == AVCOL_SPC_BT709 ? VIDEO_CS_709 : VIDEO_CS_DEFAULT;
+	switch (s) {
+	case AVCOL_SPC_BT709:     return VIDEO_CS_709;
+	case AVCOL_SPC_SMPTE170M: return VIDEO_CS_601;
+	}
+	return VIDEO_CS_DEFAULT;
 }
 
 static inline enum video_range_type convert_color_range(enum AVColorRange r)
@@ -344,6 +348,7 @@ static void mp_media_next_video(mp_media_t *m, bool preload)
 		bool success;
 
 		frame->format = new_format;
+		frame->colorspace = new_space;
 		frame->full_range = new_range == VIDEO_RANGE_FULL;
 
 		success = video_format_get_parameters(

--- a/libobs/data/bicubic_scale.effect
+++ b/libobs/data/bicubic_scale.effect
@@ -4,6 +4,8 @@
  * there.
  */
 
+#include "colorspace_helpers.effect"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 uniform float4x4 color_matrix;
@@ -81,64 +83,62 @@ float2 pixel_coord(float xpos, float ypos)
 	return float2(AspectUndistortU(xpos), ypos);
 }
 
-float4 pixel(float xpos, float ypos, bool undistort)
-{
-	if (undistort)
-		return image.Sample(textureSampler, pixel_coord(xpos, ypos));
-	else
-		return image.Sample(textureSampler, float2(xpos, ypos));
-}
-
-float4 get_line(float ypos, float4 xpos, float4 linetaps, bool undistort)
-{
-	return
-		pixel(xpos.r, ypos, undistort) * linetaps.r +
-		pixel(xpos.g, ypos, undistort) * linetaps.g +
-		pixel(xpos.b, ypos, undistort) * linetaps.b +
-		pixel(xpos.a, ypos, undistort) * linetaps.a;
-}
-
-float4 DrawBicubic(VertData v_in, bool undistort)
-{
-	float2 stepxy = base_dimension_i;
-	float2 pos = v_in.uv + stepxy * 0.5;
-	float2 f = frac(pos / stepxy);
-
-	float4 rowtaps = weight4(1.0 - f.x);
-	float4 coltaps = weight4(1.0 - f.y);
-
-	/* make sure all taps added together is exactly 1.0, otherwise some
- 	 * (very small) distortion can occur */
-	rowtaps /= rowtaps.r + rowtaps.g + rowtaps.b + rowtaps.a;
-	coltaps /= coltaps.r + coltaps.g + coltaps.b + coltaps.a;
-
-	float2 xystart = (-1.5 - f) * stepxy + pos;
-	float4 xpos = float4(
-		xystart.x,
-		xystart.x + stepxy.x,
-		xystart.x + stepxy.x * 2.0,
-		xystart.x + stepxy.x * 3.0
-	);
-
-	return
-		get_line(xystart.y                 , xpos, rowtaps, undistort) * coltaps.r +
-		get_line(xystart.y + stepxy.y      , xpos, rowtaps, undistort) * coltaps.g +
-		get_line(xystart.y + stepxy.y * 2.0, xpos, rowtaps, undistort) * coltaps.b +
-		get_line(xystart.y + stepxy.y * 3.0, xpos, rowtaps, undistort) * coltaps.a;
-}
+#include "bicubic_scale_impl.effect"
+#define MATRIX_FUNCTIONS 1
+#include "bicubic_scale_impl.effect"
+#undef MATRIX_FUNCTIONS
 
 float4 PSDrawBicubicRGBA(VertData v_in, bool undistort) : TARGET
 {
-	return DrawBicubic(v_in, undistort);
+	return DrawBicubic(v_in, undistort, false, false);
 }
 
-float4 PSDrawBicubicMatrix(VertData v_in) : TARGET
+float4 PSDrawBicubicRGBAFrom601(VertData v_in, bool undistort) : TARGET
 {
-	float4 rgba = DrawBicubic(v_in, false);
-	float4 yuv;
+	return DrawBicubic(v_in, false, true, false);
+}
 
-	yuv.xyz = clamp(rgba.xyz, color_range_min, color_range_max);
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+float4 PSDrawBicubicRGBATo601(VertData v_in, bool undistort) : TARGET
+{
+	const float4 color = DrawBicubic(v_in, false, false, false);
+	return float4(GammaSrgbToGamma601(color.rgb), color.a);
+}
+
+float4 PSDrawBicubicRGBAFrom709(VertData v_in, bool undistort) : TARGET
+{
+	return DrawBicubic(v_in, false, false, true);
+}
+
+float4 PSDrawBicubicRGBATo709(VertData v_in, bool undistort) : TARGET
+{
+	const float4 color = DrawBicubic(v_in, false, false, false);
+	return float4(GammaSrgbToGamma709(color.rgb), color.a);
+}
+
+float4 PSDrawBicubicMatrixFrom601(VertData v_in) : TARGET
+{
+	return DrawBicubicMatrix(v_in, false, true, false);
+}
+
+float4 PSDrawBicubicMatrixTo601(VertData v_in) : TARGET
+{
+	const float4 sample = DrawBicubic(v_in, false, false, false);
+	const float3 color = GammaSrgbToGamma601(sample.rgb);
+	const float3 clampedColor = clamp(color, color_range_min, color_range_max);
+	return saturate(mul(float4(clampedColor, 1.0), color_matrix));
+}
+
+float4 PSDrawBicubicMatrixFrom709(VertData v_in) : TARGET
+{
+	return DrawBicubicMatrix(v_in, false, false, true);
+}
+
+float4 PSDrawBicubicMatrixTo709(VertData v_in) : TARGET
+{
+	const float4 sample = DrawBicubic(v_in, false, false, false);
+	const float3 color = GammaSrgbToGamma709(sample.rgb);
+	const float3 clampedColor = clamp(color, color_range_min, color_range_max);
+	return saturate(mul(float4(clampedColor, 1.0), color_matrix));
 }
 
 technique Draw
@@ -147,6 +147,42 @@ technique Draw
 	{
 		vertex_shader = VSDefault(v_in);
 		pixel_shader  = PSDrawBicubicRGBA(v_in, false);
+	}
+}
+
+technique DrawFrom601
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawBicubicRGBAFrom601(v_in, false);
+	}
+}
+
+technique DrawTo601
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawBicubicRGBATo601(v_in, false);
+	}
+}
+
+technique DrawFrom709
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawBicubicRGBAFrom709(v_in, false);
+	}
+}
+
+technique DrawTo709
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawBicubicRGBATo709(v_in, false);
 	}
 }
 
@@ -159,11 +195,38 @@ technique DrawUndistort
 	}
 }
 
-technique DrawMatrix
+technique DrawMatrixFrom601
 {
 	pass
 	{
 		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSDrawBicubicMatrix(v_in);
+		pixel_shader  = PSDrawBicubicMatrixFrom601(v_in);
+	}
+}
+
+technique DrawMatrixTo601
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawBicubicMatrixTo601(v_in);
+	}
+}
+
+technique DrawMatrixFrom709
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawBicubicMatrixFrom709(v_in);
+	}
+}
+
+technique DrawMatrixTo709
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawBicubicMatrixTo709(v_in);
 	}
 }

--- a/libobs/data/bicubic_scale_impl.effect
+++ b/libobs/data/bicubic_scale_impl.effect
@@ -1,0 +1,74 @@
+#ifdef MATRIX_FUNCTIONS
+#define PIXEL_FUNC pixel_matrix
+#define GET_LINE_FUNC get_line_matrix
+#define DRAW_BICUBIC_FUNC DrawBicubicMatrix
+#else
+#define PIXEL_FUNC pixel
+#define GET_LINE_FUNC get_line
+#define DRAW_BICUBIC_FUNC DrawBicubic
+#endif
+
+float4 PIXEL_FUNC(float xpos, float ypos, bool undistort, bool from601, bool from709)
+{
+	float4 sample = undistort ?
+		image.Sample(textureSampler, pixel_coord(xpos, ypos)) :
+		image.Sample(textureSampler, float2(xpos, ypos));
+
+#ifdef MATRIX_FUNCTIONS
+	const float3 yuv = clamp(sample.xyz, color_range_min, color_range_max);
+	sample = saturate(mul(float4(yuv, 1.0), color_matrix));
+#endif
+
+	if (from601)
+	{
+		sample = float4(Gamma601ToGammaSrgb(sample.rgb), sample.a);
+	}
+	else if (from709)
+	{
+		sample = float4(Gamma709ToGammaSrgb(sample.rgb), sample.a);
+	}
+
+	return sample;
+}
+
+float4 GET_LINE_FUNC(float ypos, float4 xpos, float4 linetaps, bool undistort, bool from601, bool from709)
+{
+	return
+		PIXEL_FUNC(xpos.r, ypos, undistort, from601, from709) * linetaps.r +
+		PIXEL_FUNC(xpos.g, ypos, undistort, from601, from709) * linetaps.g +
+		PIXEL_FUNC(xpos.b, ypos, undistort, from601, from709) * linetaps.b +
+		PIXEL_FUNC(xpos.a, ypos, undistort, from601, from709) * linetaps.a;
+}
+
+float4 DRAW_BICUBIC_FUNC(VertData v_in, bool undistort, bool from601, bool from709)
+{
+	float2 stepxy = base_dimension_i;
+	float2 pos = v_in.uv + stepxy * 0.5;
+	float2 f = frac(pos / stepxy);
+
+	float4 rowtaps = weight4(1.0 - f.x);
+	float4 coltaps = weight4(1.0 - f.y);
+
+	/* make sure all taps added together is exactly 1.0, otherwise some
+ 	 * (very small) distortion can occur */
+	rowtaps /= rowtaps.r + rowtaps.g + rowtaps.b + rowtaps.a;
+	coltaps /= coltaps.r + coltaps.g + coltaps.b + coltaps.a;
+
+	float2 xystart = (-1.5 - f) * stepxy + pos;
+	float4 xpos = float4(
+		xystart.x,
+		xystart.x + stepxy.x,
+		xystart.x + stepxy.x * 2.0,
+		xystart.x + stepxy.x * 3.0
+	);
+
+	return
+		GET_LINE_FUNC(xystart.y                 , xpos, rowtaps, undistort, from601, from709) * coltaps.r +
+		GET_LINE_FUNC(xystart.y + stepxy.y      , xpos, rowtaps, undistort, from601, from709) * coltaps.g +
+		GET_LINE_FUNC(xystart.y + stepxy.y * 2.0, xpos, rowtaps, undistort, from601, from709) * coltaps.b +
+		GET_LINE_FUNC(xystart.y + stepxy.y * 3.0, xpos, rowtaps, undistort, from601, from709) * coltaps.a;
+}
+
+#undef PIXEL_FUNC
+#undef GET_LINE_FUNC
+#undef DRAW_BICUBIC_FUNC

--- a/libobs/data/bilinear_lowres_scale.effect
+++ b/libobs/data/bilinear_lowres_scale.effect
@@ -3,6 +3,8 @@
  * low resolution image below half size
  */
 
+#include "colorspace_helpers.effect"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 uniform float4x4 color_matrix;
@@ -29,39 +31,62 @@ VertData VSDefault(VertData v_in)
 	return vert_out;
 }
 
-float4 pixel(float2 uv)
-{
-	return image.Sample(textureSampler, uv);
-}
-
-float4 DrawLowresBilinear(VertData v_in)
-{
-	float2 stepxy = base_dimension_i;
-	float4 out_color;
-
-	out_color  = pixel(v_in.uv);
-	out_color += pixel(v_in.uv + float2(-stepxy.x, -stepxy.y));
-	out_color += pixel(v_in.uv + float2(-stepxy.x,       0.0));
-	out_color += pixel(v_in.uv + float2(-stepxy.x,  stepxy.y));
-	out_color += pixel(v_in.uv + float2(      0.0, -stepxy.y));
-	out_color += pixel(v_in.uv + float2(      0.0,  stepxy.y));
-	out_color += pixel(v_in.uv + float2( stepxy.x, -stepxy.y));
-	out_color += pixel(v_in.uv + float2( stepxy.x,       0.0));
-	out_color += pixel(v_in.uv + float2( stepxy.x,  stepxy.y));
-	return out_color / float4(9.0, 9.0, 9.0, 9.0);
-}
+#include "bilinear_lowres_scale_impl.effect"
+#define MATRIX_FUNCTIONS 1
+#include "bilinear_lowres_scale_impl.effect"
+#undef MATRIX_FUNCTIONS
 
 float4 PSDrawLowresBilinearRGBA(VertData v_in) : TARGET
 {
-	return DrawLowresBilinear(v_in);
+	return DrawLowresBilinear(v_in, false, false);
 }
 
-float4 PSDrawLowresBilinearMatrix(VertData v_in) : TARGET
+float4 PSDrawLowresBilinearRGBAFrom601(VertData v_in) : TARGET
 {
-	float4 yuv = DrawLowresBilinear(v_in);
+	return DrawLowresBilinear(v_in, true, false);
+}
 
-	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max);
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+float4 PSDrawLowresBilinearRGBATo601(VertData v_in) : TARGET
+{
+	const float4 color = DrawLowresBilinear(v_in, false, false);
+	return float4(GammaSrgbToGamma601(color.rgb), color.a);
+}
+
+float4 PSDrawLowresBilinearRGBAFrom709(VertData v_in) : TARGET
+{
+	return DrawLowresBilinear(v_in, false, true);
+}
+
+float4 PSDrawLowresBilinearRGBATo709(VertData v_in) : TARGET
+{
+	const float4 color = DrawLowresBilinear(v_in, false, false);
+	return float4(GammaSrgbToGamma709(color.rgb), color.a);
+}
+
+float4 PSDrawLowresBilinearMatrixFrom601(VertData v_in) : TARGET
+{
+	return DrawLowresBilinearMatrix(v_in, true, false);
+}
+
+float4 PSDrawLowresBilinearMatrixTo601(VertData v_in) : TARGET
+{
+	const float4 sample = DrawLowresBilinear(v_in, false, false);
+	const float3 color = GammaSrgbToGamma601(sample.rgb);
+	const float3 clampedColor = clamp(color, color_range_min, color_range_max);
+	return saturate(mul(float4(clampedColor, 1.0), color_matrix));
+}
+
+float4 PSDrawLowresBilinearMatrixFrom709(VertData v_in) : TARGET
+{
+	return DrawLowresBilinearMatrix(v_in, false, true);
+}
+
+float4 PSDrawLowresBilinearMatrixTo709(VertData v_in) : TARGET
+{
+	const float4 sample = DrawLowresBilinear(v_in, false, false);
+	const float3 color = GammaSrgbToGamma709(sample.rgb);
+	const float3 clampedColor = clamp(color, color_range_min, color_range_max);
+	return saturate(mul(float4(clampedColor, 1.0), color_matrix));
 }
 
 technique Draw
@@ -73,12 +98,74 @@ technique Draw
 	}
 }
 
-technique DrawMatrix
+technique DrawFrom601
 {
 	pass
 	{
 		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSDrawLowresBilinearMatrix(v_in);
+		pixel_shader  = PSDrawLowresBilinearRGBAFrom601(v_in);
 	}
 }
 
+technique DrawTo601
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLowresBilinearRGBATo601(v_in);
+	}
+}
+
+technique DrawFrom709
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLowresBilinearRGBAFrom709(v_in);
+	}
+}
+
+technique DrawTo709
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLowresBilinearRGBATo709(v_in);
+	}
+}
+
+technique DrawMatrixFrom601
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLowresBilinearMatrixFrom601(v_in);
+	}
+}
+
+technique DrawMatrixTo601
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLowresBilinearMatrixTo601(v_in);
+	}
+}
+
+technique DrawMatrixFrom709
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLowresBilinearMatrixFrom709(v_in);
+	}
+}
+
+technique DrawMatrixTo709
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLowresBilinearMatrixTo709(v_in);
+	}
+}

--- a/libobs/data/bilinear_lowres_scale_impl.effect
+++ b/libobs/data/bilinear_lowres_scale_impl.effect
@@ -1,0 +1,48 @@
+#ifdef MATRIX_FUNCTIONS
+#define PIXEL_FUNC pixel_matrix
+#define DRAW_LOWRES_BILINEAR_FUNC DrawLowresBilinearMatrix
+#else
+#define PIXEL_FUNC pixel
+#define DRAW_LOWRES_BILINEAR_FUNC DrawLowresBilinear
+#endif
+
+float4 PIXEL_FUNC(float2 uv, bool from601, bool from709)
+{
+	float4 sample = image.Sample(textureSampler, uv);
+
+#ifdef MATRIX_FUNCTIONS
+	const float3 yuv = clamp(sample.xyz, color_range_min, color_range_max);
+	sample = saturate(mul(float4(yuv, 1.0), color_matrix));
+#endif
+
+	if (from601)
+	{
+		sample = float4(Gamma601ToGammaSrgb(sample.rgb), sample.a);
+	}
+	else if (from709)
+	{
+		sample = float4(Gamma709ToGammaSrgb(sample.rgb), sample.a);
+	}
+
+	return sample;
+}
+
+float4 DRAW_LOWRES_BILINEAR_FUNC(VertData v_in, bool from601, bool from709)
+{
+	float2 stepxy = base_dimension_i;
+	float4 out_color;
+
+	out_color  = PIXEL_FUNC(v_in.uv, from601, from709);
+	out_color += PIXEL_FUNC(v_in.uv + float2(-stepxy.x, -stepxy.y), from601, from709);
+	out_color += PIXEL_FUNC(v_in.uv + float2(-stepxy.x,       0.0), from601, from709);
+	out_color += PIXEL_FUNC(v_in.uv + float2(-stepxy.x,  stepxy.y), from601, from709);
+	out_color += PIXEL_FUNC(v_in.uv + float2(      0.0, -stepxy.y), from601, from709);
+	out_color += PIXEL_FUNC(v_in.uv + float2(      0.0,  stepxy.y), from601, from709);
+	out_color += PIXEL_FUNC(v_in.uv + float2( stepxy.x, -stepxy.y), from601, from709);
+	out_color += PIXEL_FUNC(v_in.uv + float2( stepxy.x,       0.0), from601, from709);
+	out_color += PIXEL_FUNC(v_in.uv + float2( stepxy.x,  stepxy.y), from601, from709);
+	return out_color / float4(9.0, 9.0, 9.0, 9.0);
+}
+
+#undef PIXEL_FUNC
+#undef DRAW_LOWRES_BILINEAR_FUNC

--- a/libobs/data/colorspace_helpers.effect
+++ b/libobs/data/colorspace_helpers.effect
@@ -1,0 +1,117 @@
+float GammaToLinearSrgbChannel(float channel)
+{
+	return (channel < 0.04045) ? (channel / 12.92) : pow((channel + 0.055) / 1.055, 2.4);
+}
+
+float3 GammaToLinearSrgb(float3 color)
+{
+	return float3(GammaToLinearSrgbChannel(color.r), GammaToLinearSrgbChannel(color.g), GammaToLinearSrgbChannel(color.b));
+}
+
+float LinearToGammaChannelSrgb(float channel)
+{
+	return (channel < 0.0031308) ? (12.92 * channel) : ((1.055 * pow(channel, 1.0 / 2.4)) - 0.055);
+}
+
+float3 LinearToGammaSrgb(float3 color)
+{
+	return float3(LinearToGammaChannelSrgb(color.r), LinearToGammaChannelSrgb(color.g), LinearToGammaChannelSrgb(color.b));
+}
+
+float GammaToLinear601709Channel(float channel)
+{
+	return (channel < 0.081) ? (channel / 4.5) : pow((channel + 0.099) / 1.099, 1.0 / 0.45);
+}
+
+float3 GammaToLinear601709(float3 color)
+{
+	return float3(GammaToLinear601709Channel(color.r), GammaToLinear601709Channel(color.g), GammaToLinear601709Channel(color.b));
+}
+
+float LinearToGammaChannel601709(float channel)
+{
+	return (channel < 0.018) ? (4.5 * channel) : ((1.099 * pow(channel, 0.45)) - 0.099);
+}
+
+float3 LinearToGamma601709(float3 color)
+{
+	return float3(LinearToGammaChannel601709(color.r), LinearToGammaChannel601709(color.g), LinearToGammaChannel601709(color.b));
+}
+
+float3 LinearSrgbToXyz(float3 color)
+{
+	float3x3 transform =
+	{
+		0.4124564, 0.2126729, 0.0193339,
+		0.3575761, 0.7151522, 0.1191920,
+		0.1804375, 0.0721750, 0.9503041,
+	};
+	return mul(color, transform);
+}
+
+float3 XyzToLinearSrgb(float3 color)
+{
+	float3x3 transform =
+	{
+		 3.2404542, -0.9692660,  0.0556434,
+		-1.5371385,  1.8760108, -0.2040259,
+		-0.4985314,  0.0415560,  1.0572252,
+	};
+	color = mul(color, transform);
+	return saturate(color);
+}
+
+float3 XyzToLinear601(float3 color)
+{
+	float3x3 transform =
+	{
+		 3.5053960, -1.0690722,  0.0563200,
+		-1.7394894,  1.9778245, -0.1970226,
+		-0.5439640,  0.0351722,  1.0502026,
+	};
+	color = mul(color, transform);
+	return saturate(color);
+}
+
+float3 Linear601ToXyz(float3 color)
+{
+	float3x3 transform =
+	{
+		0.3935891, 0.2124132, 0.0187423,
+		0.3652497, 0.7010437, 0.1119313,
+		0.1916313, 0.0865432, 0.9581563,
+	};
+	return mul(color, transform);
+}
+
+float3 GammaSrgbToGamma601(float3 gammaSrgb)
+{
+	const float3 linearSrgb = GammaToLinearSrgb(gammaSrgb);
+	const float3 xyz = LinearSrgbToXyz(linearSrgb);
+	const float3 linear601 = XyzToLinear601(xyz);
+	const float3 gamma601 = LinearToGamma601709(linearSrgb);
+	return gamma601;
+}
+
+float3 GammaSrgbToGamma709(float3 gammaSrgb)
+{
+	const float3 linear709 = GammaToLinearSrgb(gammaSrgb); // Linear 709/sRGB are identical.
+	const float3 gamma709 = LinearToGamma601709(linear709);
+	return gamma709;
+}
+
+float3 Gamma601ToGammaSrgb(float3 gamma601)
+{
+	const float3 linear601 = GammaToLinear601709(gamma601);
+	const float3 xyz = Linear601ToXyz(linear601);
+	const float3 linearSrgb = XyzToLinearSrgb(xyz);
+	const float3 gammaSrgb = LinearToGammaSrgb(linearSrgb);
+	return gammaSrgb;
+}
+
+float3 Gamma709ToGammaSrgb(float3 gamma709)
+{
+	const float3 linearSrgb = GammaToLinear601709(gamma709); // Linear 709/sRGB are identical.
+	const float3 gammaSrgb = LinearToGammaSrgb(linearSrgb);
+	return gammaSrgb;
+}

--- a/libobs/data/default.effect
+++ b/libobs/data/default.effect
@@ -1,3 +1,5 @@
+#include "colorspace_helpers.effect"
+
 uniform float4x4 ViewProj;
 uniform float4x4 color_matrix;
 uniform float3 color_range_min = {0.0, 0.0, 0.0};
@@ -15,6 +17,18 @@ struct VertInOut {
 	float2 uv  : TEXCOORD0;
 };
 
+float4 GetColorBare(VertInOut vert_in)
+{
+	return image.Sample(def_sampler, vert_in.uv);
+}
+
+float4 GetYuvAsRgb(VertInOut vert_in)
+{
+	float4 yuv = image.Sample(def_sampler, vert_in.uv);
+	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max);
+	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+}
+
 VertInOut VSDefault(VertInOut vert_in)
 {
 	VertInOut vert_out;
@@ -25,14 +39,64 @@ VertInOut VSDefault(VertInOut vert_in)
 
 float4 PSDrawBare(VertInOut vert_in) : TARGET
 {
-	return image.Sample(def_sampler, vert_in.uv);
+	return GetColorBare(vert_in);
+}
+
+float4 PSDrawBareFrom601(VertInOut vert_in) : TARGET
+{
+	const float4 color = GetColorBare(vert_in);
+	return float4(Gamma601ToGammaSrgb(color.rgb), color.a);
+}
+
+float4 PSDrawBareTo601(VertInOut vert_in) : TARGET
+{
+	const float4 color = GetColorBare(vert_in);
+	return float4(GammaSrgbToGamma601(color.rgb), color.a);
+}
+
+float4 PSDrawBareFrom709(VertInOut vert_in) : TARGET
+{
+	const float4 color = GetColorBare(vert_in);
+	return float4(Gamma709ToGammaSrgb(color.rgb), color.a);
+}
+
+float4 PSDrawBareTo709(VertInOut vert_in) : TARGET
+{
+	const float4 color = GetColorBare(vert_in);
+	return float4(GammaSrgbToGamma709(color.rgb), color.a);
 }
 
 float4 PSDrawMatrix(VertInOut vert_in) : TARGET
 {
-	float4 yuv = image.Sample(def_sampler, vert_in.uv);
-	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max);
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+	return GetYuvAsRgb(vert_in);
+}
+
+float4 PSDrawMatrixFrom601(VertInOut vert_in) : TARGET
+{
+	const float4 color = GetYuvAsRgb(vert_in);
+	return float4(Gamma601ToGammaSrgb(color.rgb), color.a);
+}
+
+float4 PSDrawMatrixTo601(VertInOut vert_in) : TARGET
+{
+	const float4 sample = image.Sample(def_sampler, vert_in.uv);
+	const float3 color = GammaSrgbToGamma601(sample.rgb);
+	const float3 clampedColor = clamp(color, color_range_min, color_range_max);
+	return saturate(mul(float4(clampedColor, 1.0), color_matrix));
+}
+
+float4 PSDrawMatrixFrom709(VertInOut vert_in) : TARGET
+{
+	const float4 color = GetYuvAsRgb(vert_in);
+	return float4(Gamma709ToGammaSrgb(color.rgb), color.a);
+}
+
+float4 PSDrawMatrixTo709(VertInOut vert_in) : TARGET
+{
+	const float4 sample = image.Sample(def_sampler, vert_in.uv);
+	const float3 color = GammaSrgbToGamma709(sample.rgb);
+	const float3 clampedColor = clamp(color, color_range_min, color_range_max);
+	return saturate(mul(float4(clampedColor, 1.0), color_matrix));
 }
 
 technique Draw
@@ -44,11 +108,74 @@ technique Draw
 	}
 }
 
-technique DrawMatrix
+technique DrawFrom601
 {
 	pass
 	{
 		vertex_shader = VSDefault(vert_in);
-		pixel_shader  = PSDrawMatrix(vert_in);
+		pixel_shader  = PSDrawBareFrom601(vert_in);
+	}
+}
+
+technique DrawTo601
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawBareTo601(vert_in);
+	}
+}
+
+technique DrawFrom709
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawBareFrom709(vert_in);
+	}
+}
+
+technique DrawTo709
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawBareTo709(vert_in);
+	}
+}
+
+technique DrawMatrixFrom601
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawMatrixFrom601(vert_in);
+	}
+}
+
+technique DrawMatrixTo601
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawMatrixTo601(vert_in);
+	}
+}
+
+technique DrawMatrixFrom709
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawMatrixFrom709(vert_in);
+	}
+}
+
+technique DrawMatrixTo709
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawMatrixTo709(vert_in);
 	}
 }

--- a/libobs/data/deinterlace_base.effect
+++ b/libobs/data/deinterlace_base.effect
@@ -43,220 +43,134 @@ int3 select(int2 texel, int x, int y)
 	return int3(texel + int2(x, y), 0);
 }
 
-float4 load_at_prev(int2 texel, int x, int y)
-{
-	return previous_image.Load(select(texel, x, y));
-}
-
-float4 load_at_image(int2 texel, int x, int y)
-{
-	return image.Load(select(texel, x, y));
-}
-
-float4 load_at(int2 texel, int x, int y, int field)
-{
-	if(field == 0)
-		return load_at_image(texel, x, y);
-	else
-		return load_at_prev(texel, x, y);
-}
-
-#define YADIF_UPDATE(c, level) 	\
-	if(score.c < spatial_score.c) \
-	{ \
-		spatial_score.c = score.c; \
-		spatial_pred.c = (load_at(texel, level, -1, field) + load_at(texel, -level, 1, field)).c / 2; \
-
-#define YADIF_CHECK_ONE(level, c) \
-{ \
-	float4 score = abs(load_at(texel, -1 + level, 1, field) - load_at(texel, -1 - level, -1, field)) + \
-	               abs(load_at(texel, level,      1, field) - load_at(texel, -level,     -1, field)) + \
-	               abs(load_at(texel, 1 + level,  1, field) - load_at(texel, 1 - level,  -1, field)); \
-	YADIF_UPDATE(c, level) } \
-}
-
-#define YADIF_CHECK(level) \
-{ \
-	float4 score = abs(load_at(texel, -1 + level, 1, field) - load_at(texel, -1 - level, -1, field)) + \
-	               abs(load_at(texel, level,      1, field) - load_at(texel, -level,     -1, field)) + \
-	               abs(load_at(texel, 1 + level,  1, field) - load_at(texel, 1 - level,  -1, field)); \
-	YADIF_UPDATE(r, level) YADIF_CHECK_ONE(level * 2, r) } \
-	YADIF_UPDATE(g, level) YADIF_CHECK_ONE(level * 2, g) } \
-	YADIF_UPDATE(b, level) YADIF_CHECK_ONE(level * 2, b) } \
-	YADIF_UPDATE(a, level) YADIF_CHECK_ONE(level * 2, a) } \
-}
-
-float4 texel_at_yadif(int2 texel, int field, bool mode0)
-{
-	if((texel.y % 2) == field)
-		return load_at(texel, 0, 0, field);
-
-	#define YADIF_AVG(x_off, y_off) ((load_at_prev(texel, x_off, y_off) + load_at_image(texel, x_off, y_off))/2)
-	float4 c = load_at(texel, 0, 1, field),
-	       d = YADIF_AVG(0, 0),
-	       e = load_at(texel, 0, -1, field);
-
-	float4 temporal_diff0 = (abs(load_at_prev(texel,  0, 0)      -     load_at_image(texel, 0, 0)))      / 2,
-	       temporal_diff1 = (abs(load_at_prev(texel,  0, 1) - c) + abs(load_at_prev(texel,  0, -1) - e)) / 2,
-	       temporal_diff2 = (abs(load_at_image(texel, 0, 1) - c) + abs(load_at_image(texel, 0, -1) - e)) / 2,
-	       diff = max(temporal_diff0, max(temporal_diff1, temporal_diff2));
-
-	float4 spatial_pred = (c + e) / 2,
-	       spatial_score = abs(load_at(texel, -1, 1, field) - load_at(texel, -1, -1, field)) +
-	                       abs(c - e) +
-	                       abs(load_at(texel, 1,  1, field) - load_at(texel, 1,  -1, field)) - 1;
-
-	YADIF_CHECK(-1)
-	YADIF_CHECK(1)
-
-	if (mode0) {
-		float4 b = YADIF_AVG(0, 2),
-		       f = YADIF_AVG(0, -2);
-
-		float4 max_ = max(d - e, max(d - c, min(b - c, f - e))),
-		       min_ = min(d - e, min(d - c, max(b - c, f - e)));
-
-		diff = max(diff, max(min_, -max_));
-	} else {
-		diff = max(diff, max(min(d - e, d - c), -max(d - e, d - c)));
-	}
-
-#define YADIF_SPATIAL(c) \
-{ \
-	if(spatial_pred.c > d.c + diff.c) \
-		spatial_pred.c = d.c + diff.c; \
-	else if(spatial_pred.c < d.c - diff.c) \
-		spatial_pred.c = d.c - diff.c; \
-}
-
-	YADIF_SPATIAL(r)
-	YADIF_SPATIAL(g)
-	YADIF_SPATIAL(b)
-	YADIF_SPATIAL(a)
-
-	return spatial_pred;
-}
-
-float4 texel_at_yadif_2x(int2 texel, int field, bool mode0)
-{
-	field = frame2 ? (1 - field) : field;
-	return texel_at_yadif(texel, field, mode0);
-}
-
-float4 texel_at_discard(int2 texel, int field)
-{
-	texel.y = texel.y / 2 * 2;
-	return load_at_image(texel, 0, field);
-}
-
-float4 texel_at_discard_2x(int2 texel, int field)
-{
-	field = frame2 ? field : (1 - field);
-	return texel_at_discard(texel, field);
-}
-
-float4 texel_at_blend(int2 texel, int field)
-{
-	return (load_at_image(texel, 0, 0) + load_at_image(texel, 0, 1)) / 2;
-}
-
-float4 texel_at_blend_2x(int2 texel, int field)
-{
-	if (!frame2)
-		return (load_at_image(texel, 0, 0) +
-		        load_at_prev(texel, 0, 1)) / 2;
-	else
-		return (load_at_image(texel, 0, 0) +
-		        load_at_image(texel, 0, 1)) / 2;
-}
-
-float4 texel_at_linear(int2 texel, int field)
-{
-	if ((texel.y % 2) == field)
-		return load_at_image(texel, 0, 0);
-	return (load_at_image(texel, 0, -1) + load_at_image(texel, 0, 1)) / 2;
-}
-
-float4 texel_at_linear_2x(int2 texel, int field)
-{
-	field = frame2 ? field : (1 - field);
-	return texel_at_linear(texel, field);
-}
-
-float4 texel_at_yadif_discard(int2 texel, int field)
-{
-	return (texel_at_yadif(texel, field, true) + texel_at_discard(texel, field)) / 2;
-}
-
-float4 texel_at_yadif_discard_2x(int2 texel, int field)
-{
-	field = frame2 ? (1 - field) : field;
-	return (texel_at_yadif(texel, field, true) + texel_at_discard(texel, field)) / 2;
-}
+#include "deinterlace_impl.effect"
+#define MATRIX_FUNCTIONS 1
+#include "deinterlace_impl.effect"
+#undef MATRIX_FUNCTIONS
 
 int2 pixel_uv(float2 uv)
 {
 	return int2(uv * dimensions);
 }
 
-float4 PSYadifMode0RGBA(VertData v_in) : TARGET
+float4 PSYadifMode0RGBA(VertData v_in, bool from601, bool from709) : TARGET
 {
-	return texel_at_yadif(pixel_uv(v_in.uv), field_order, true);
+	return texel_at_yadif(pixel_uv(v_in.uv), field_order, true, from601, from709);
 }
 
-float4 PSYadifMode0RGBA_2x(VertData v_in) : TARGET
+float4 PSYadifMode0RGBA_2x(VertData v_in, bool from601, bool from709) : TARGET
 {
-	return texel_at_yadif_2x(pixel_uv(v_in.uv), field_order, true);
+	return texel_at_yadif_2x(pixel_uv(v_in.uv), field_order, true, from601, from709);
 }
 
-float4 PSYadifMode2RGBA(VertData v_in) : TARGET
+float4 PSYadifMode2RGBA(VertData v_in, bool from601, bool from709) : TARGET
 {
-	return texel_at_yadif(pixel_uv(v_in.uv), field_order, false);
+	return texel_at_yadif(pixel_uv(v_in.uv), field_order, false, from601, from709);
 }
 
-float4 PSYadifMode2RGBA_2x(VertData v_in) : TARGET
+float4 PSYadifMode2RGBA_2x(VertData v_in, bool from601, bool from709) : TARGET
 {
-	return texel_at_yadif_2x(pixel_uv(v_in.uv), field_order, false);
+	return texel_at_yadif_2x(pixel_uv(v_in.uv), field_order, false, from601, from709);
 }
 
-float4 PSYadifDiscardRGBA(VertData v_in) : TARGET
+float4 PSYadifDiscardRGBA(VertData v_in, bool from601, bool from709) : TARGET
 {
-	return texel_at_yadif_discard(pixel_uv(v_in.uv), field_order);
+	return texel_at_yadif_discard(pixel_uv(v_in.uv), field_order, from601, from709);
 }
 
-float4 PSYadifDiscardRGBA_2x(VertData v_in) : TARGET
+float4 PSYadifDiscardRGBA_2x(VertData v_in, bool from601, bool from709) : TARGET
 {
-	return texel_at_yadif_discard_2x(pixel_uv(v_in.uv), field_order);
+	return texel_at_yadif_discard_2x(pixel_uv(v_in.uv), field_order, from601, from709);
 }
 
-float4 PSLinearRGBA(VertData v_in) : TARGET
+float4 PSLinearRGBA(VertData v_in, bool from601, bool from709) : TARGET
 {
-	return texel_at_linear(pixel_uv(v_in.uv), field_order);
+	return texel_at_linear(pixel_uv(v_in.uv), field_order, from601, from709);
 }
 
-float4 PSLinearRGBA_2x(VertData v_in) : TARGET
+float4 PSLinearRGBA_2x(VertData v_in, bool from601, bool from709) : TARGET
 {
-	return texel_at_linear_2x(pixel_uv(v_in.uv), field_order);
+	return texel_at_linear_2x(pixel_uv(v_in.uv), field_order, from601, from709);
 }
 
-float4 PSDiscardRGBA(VertData v_in) : TARGET
+float4 PSDiscardRGBA(VertData v_in, bool from601, bool from709) : TARGET
 {
-	return texel_at_discard(pixel_uv(v_in.uv), field_order);
+	return texel_at_discard(pixel_uv(v_in.uv), field_order, from601, from709);
 }
 
-float4 PSDiscardRGBA_2x(VertData v_in) : TARGET
+float4 PSDiscardRGBA_2x(VertData v_in, bool from601, bool from709) : TARGET
 {
-	return texel_at_discard_2x(pixel_uv(v_in.uv), field_order);
+	return texel_at_discard_2x(pixel_uv(v_in.uv), field_order, from601, from709);
 }
 
-float4 PSBlendRGBA(VertData v_in) : TARGET
+float4 PSBlendRGBA(VertData v_in, bool from601, bool from709) : TARGET
 {
-	return texel_at_blend(pixel_uv(v_in.uv), field_order);
+	return texel_at_blend(pixel_uv(v_in.uv), field_order, from601, from709);
 }
 
-float4 PSBlendRGBA_2x(VertData v_in) : TARGET
+float4 PSBlendRGBA_2x(VertData v_in, bool from601, bool from709) : TARGET
 {
-	return texel_at_blend_2x(pixel_uv(v_in.uv), field_order);
+	return texel_at_blend_2x(pixel_uv(v_in.uv), field_order, from601, from709);
+}
+
+float4 PSYadifMode0Matrix(VertData v_in, bool from601, bool from709) : TARGET
+{
+	return texel_at_yadif_matrix(pixel_uv(v_in.uv), field_order, true, from601, from709);
+}
+
+float4 PSYadifMode0Matrix_2x(VertData v_in, bool from601, bool from709) : TARGET
+{
+	return texel_at_yadif_2x_matrix(pixel_uv(v_in.uv), field_order, true, from601, from709);
+}
+
+float4 PSYadifMode2Matrix(VertData v_in, bool from601, bool from709) : TARGET
+{
+	return texel_at_yadif_matrix(pixel_uv(v_in.uv), field_order, false, from601, from709);
+}
+
+float4 PSYadifMode2Matrix_2x(VertData v_in, bool from601, bool from709) : TARGET
+{
+	return texel_at_yadif_2x_matrix(pixel_uv(v_in.uv), field_order, false, from601, from709);
+}
+
+float4 PSYadifDiscardMatrix(VertData v_in, bool from601, bool from709) : TARGET
+{
+	return texel_at_yadif_discard_matrix(pixel_uv(v_in.uv), field_order, from601, from709);
+}
+
+float4 PSYadifDiscardMatrix_2x(VertData v_in, bool from601, bool from709) : TARGET
+{
+	return texel_at_yadif_discard_2x_matrix(pixel_uv(v_in.uv), field_order, from601, from709);
+}
+
+float4 PSLinearMatrix(VertData v_in, bool from601, bool from709) : TARGET
+{
+	return texel_at_linear_matrix(pixel_uv(v_in.uv), field_order, from601, from709);
+}
+
+float4 PSLinearxMatrixA_2x(VertData v_in, bool from601, bool from709) : TARGET
+{
+	return texel_at_linear_2x_matrix(pixel_uv(v_in.uv), field_order, from601, from709);
+}
+
+float4 PSDiscardMatrix(VertData v_in, bool from601, bool from709) : TARGET
+{
+	return texel_at_discard_matrix(pixel_uv(v_in.uv), field_order, from601, from709);
+}
+
+float4 PSDiscardMatrix_2x(VertData v_in, bool from601, bool from709) : TARGET
+{
+	return texel_at_discard_2x_matrix(pixel_uv(v_in.uv), field_order, from601, from709);
+}
+
+float4 PSBlendMatrix(VertData v_in, bool from601, bool from709) : TARGET
+{
+	return texel_at_blend_matrix(pixel_uv(v_in.uv), field_order, from601, from709);
+}
+
+float4 PSBlendMatrix_2x(VertData v_in, bool from601, bool from709) : TARGET
+{
+	return texel_at_blend_2x_matrix(pixel_uv(v_in.uv), field_order, from601, from709);
 }
 
 VertData VSDefault(VertData v_in)
@@ -267,27 +181,37 @@ VertData VSDefault(VertData v_in)
 	return vert_out;
 }
 
-#define TECHNIQUE(rgba_ps, matrix_ps) \
+#define TECHNIQUE(rgba_ps, matrix_ps, matrix_from_601_ps, matrix_from_709_ps) \
 technique Draw \
 { \
 	pass \
 	{ \
 		vertex_shader = VSDefault(v_in); \
-		pixel_shader  = rgba_ps(v_in); \
+		pixel_shader  = rgba_ps(v_in, false, false); \
 	} \
 } \
-float4 matrix_ps(VertData v_in) : TARGET \
+float4 matrix_from_601_ps(VertData v_in) : TARGET \
 { \
-	float4 yuv = rgba_ps(v_in); \
-	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max); \
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix)); \
+	return matrix_ps(v_in, true, false); \
+} \
+float4 matrix_from_709_ps(VertData v_in) : TARGET \
+{ \
+	return matrix_ps(v_in, false, true); \
 } \
 \
-technique DrawMatrix \
+technique DrawMatrixFrom601 \
 { \
 	pass \
 	{ \
 		vertex_shader = VSDefault(v_in); \
-		pixel_shader  = matrix_ps(v_in); \
+		pixel_shader  = matrix_from_601_ps(v_in); \
+	} \
+} \
+technique DrawMatrixFrom709 \
+{ \
+	pass \
+	{ \
+		vertex_shader = VSDefault(v_in); \
+		pixel_shader  = matrix_from_709_ps(v_in); \
 	} \
 }

--- a/libobs/data/deinterlace_blend.effect
+++ b/libobs/data/deinterlace_blend.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE( PSBlendRGBA, PSBlendMatrix);
+TECHNIQUE( PSBlendRGBA, PSBlendMatrix, PSBlendMatrixFrom601, PSBlendMatrixFrom709);

--- a/libobs/data/deinterlace_blend_2x.effect
+++ b/libobs/data/deinterlace_blend_2x.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSBlendRGBA_2x, PSBlendMatrix_2x);
+TECHNIQUE(PSBlendRGBA_2x, PSBlendMatrix_2x, PSBlendMatrixFrom601_2x, PSBlendMatrixFrom709_2x);

--- a/libobs/data/deinterlace_discard.effect
+++ b/libobs/data/deinterlace_discard.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSDiscardRGBA, PSDiscardMatrix);
+TECHNIQUE(PSDiscardRGBA, PSDiscardMatrix, PSDiscardMatrixFrom601, PSDiscardMatrixFrom709);

--- a/libobs/data/deinterlace_discard_2x.effect
+++ b/libobs/data/deinterlace_discard_2x.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSDiscardRGBA_2x, PSDiscardMatrix_2x);
+TECHNIQUE(PSDiscardRGBA_2x, PSDiscardMatrix_2x, PSDiscardMatrixFrom601_2x, PSDiscardMatrixFrom709_2x);

--- a/libobs/data/deinterlace_impl.effect
+++ b/libobs/data/deinterlace_impl.effect
@@ -1,0 +1,222 @@
+#include "colorspace_helpers.effect"
+
+#ifdef MATRIX_FUNCTIONS
+#define CONVERT_TO_SRGB_FUNC convert_to_srgb_matrix
+#define LOAD_AT_PREV_FUNC load_at_prev_matrix
+#define LOAD_AT_IMAGE_FUNC load_at_image_matrix
+#define LOAD_AT_FUNC load_at_matrix
+#define TEXEL_AT_YADIF_FUNC texel_at_yadif_matrix
+#define TEXEL_AT_YADIF_2X_FUNC texel_at_yadif_2x_matrix
+#define TEXEL_AT_DISCARD_FUNC texel_at_discard_matrix
+#define TEXEL_AT_DISCARD_2X_FUNC texel_at_discard_2x_matrix
+#define TEXEL_AT_BLEND_FUNC texel_at_blend_matrix
+#define TEXEL_AT_BLEND_2X_FUNC texel_at_blend_2x_matrix
+#define TEXEL_AT_LINEAR_FUNC texel_at_linear_matrix
+#define TEXEL_AT_LINEAR_2X_FUNC texel_at_linear_2x_matrix
+#define TEXEL_AT_YADIF_DISCARD_FUNC texel_at_yadif_discard_matrix
+#define TEXEL_AT_YADIF_DISCARD_2X_FUNC texel_at_yadif_discard_2x_matrix
+#else
+#define CONVERT_TO_SRGB_FUNC convert_to_srgb
+#define LOAD_AT_PREV_FUNC load_at_prev
+#define LOAD_AT_IMAGE_FUNC load_at_image
+#define LOAD_AT_FUNC load_at
+#define TEXEL_AT_YADIF_FUNC texel_at_yadif
+#define TEXEL_AT_YADIF_2X_FUNC texel_at_yadif_2x
+#define TEXEL_AT_DISCARD_FUNC texel_at_discard
+#define TEXEL_AT_DISCARD_2X_FUNC texel_at_discard_2x
+#define TEXEL_AT_BLEND_FUNC texel_at_blend
+#define TEXEL_AT_BLEND_2X_FUNC texel_at_blend_2x
+#define TEXEL_AT_LINEAR_FUNC texel_at_linear
+#define TEXEL_AT_LINEAR_2X_FUNC texel_at_linear_2x
+#define TEXEL_AT_YADIF_DISCARD_FUNC texel_at_yadif_discard
+#define TEXEL_AT_YADIF_DISCARD_2X_FUNC texel_at_yadif_discard_2x
+#endif
+
+float4 CONVERT_TO_SRGB_FUNC(float4 sample, bool from601, bool from709)
+{
+#ifdef MATRIX_FUNCTIONS
+	const float3 yuv = clamp(sample.xyz, color_range_min, color_range_max);
+	sample = saturate(mul(float4(yuv, 1.0), color_matrix));
+#endif
+
+	if (from601)
+	{
+		sample = float4(Gamma601ToGammaSrgb(sample.rgb), sample.a);
+	}
+	else if (from709)
+	{
+		sample = float4(Gamma709ToGammaSrgb(sample.rgb), sample.a);
+	}
+
+	return sample;
+}
+
+float4 LOAD_AT_PREV_FUNC(int2 texel, int x, int y, bool from601, bool from709)
+{
+	return CONVERT_TO_SRGB_FUNC(previous_image.Load(select(texel, x, y)), from601, from709);
+}
+
+float4 LOAD_AT_IMAGE_FUNC(int2 texel, int x, int y, bool from601, bool from709)
+{
+	return CONVERT_TO_SRGB_FUNC(image.Load(select(texel, x, y)), from601, from709);
+}
+
+float4 LOAD_AT_FUNC(int2 texel, int x, int y, int field, bool from601, bool from709)
+{
+	if(field == 0)
+		return LOAD_AT_IMAGE_FUNC(texel, x, y, from601, from709);
+	else
+		return LOAD_AT_PREV_FUNC(texel, x, y, from601, from709);
+}
+
+#define YADIF_UPDATE(c, level) 	\
+	if(score.c < spatial_score.c) \
+	{ \
+		spatial_score.c = score.c; \
+		spatial_pred.c = (LOAD_AT_FUNC(texel, level, -1, field, from601, from709) + LOAD_AT_FUNC(texel, -level, 1, field, from601, from709)).c / 2; \
+
+#define YADIF_CHECK_ONE(level, c) \
+{ \
+	float4 score = abs(LOAD_AT_FUNC(texel, -1 + level, 1, field, from601, from709) - LOAD_AT_FUNC(texel, -1 - level, -1, field, from601, from709)) + \
+	               abs(LOAD_AT_FUNC(texel, level,      1, field, from601, from709) - LOAD_AT_FUNC(texel, -level,     -1, field, from601, from709)) + \
+	               abs(LOAD_AT_FUNC(texel, 1 + level,  1, field, from601, from709) - LOAD_AT_FUNC(texel, 1 - level,  -1, field, from601, from709)); \
+	YADIF_UPDATE(c, level) } \
+}
+
+#define YADIF_CHECK(level) \
+{ \
+	float4 score = abs(LOAD_AT_FUNC(texel, -1 + level, 1, field, from601, from709) - LOAD_AT_FUNC(texel, -1 - level, -1, field, from601, from709)) + \
+	               abs(LOAD_AT_FUNC(texel, level,      1, field, from601, from709) - LOAD_AT_FUNC(texel, -level,     -1, field, from601, from709)) + \
+	               abs(LOAD_AT_FUNC(texel, 1 + level,  1, field, from601, from709) - LOAD_AT_FUNC(texel, 1 - level,  -1, field, from601, from709)); \
+	YADIF_UPDATE(r, level) YADIF_CHECK_ONE(level * 2, r) } \
+	YADIF_UPDATE(g, level) YADIF_CHECK_ONE(level * 2, g) } \
+	YADIF_UPDATE(b, level) YADIF_CHECK_ONE(level * 2, b) } \
+	YADIF_UPDATE(a, level) YADIF_CHECK_ONE(level * 2, a) } \
+}
+
+float4 TEXEL_AT_YADIF_FUNC(int2 texel, int field, bool mode0, bool from601, bool from709)
+{
+	if((texel.y % 2) == field)
+		return LOAD_AT_FUNC(texel, 0, 0, field, from601, from709);
+
+	#define YADIF_AVG(x_off, y_off) ((LOAD_AT_PREV_FUNC(texel, x_off, y_off, from601, from709) + LOAD_AT_IMAGE_FUNC(texel, x_off, y_off, from601, from709))/2)
+	float4 c = LOAD_AT_FUNC(texel, 0, 1, field, from601, from709),
+	       d = YADIF_AVG(0, 0),
+	       e = LOAD_AT_FUNC(texel, 0, -1, field, from601, from709);
+
+	float4 temporal_diff0 = (abs(LOAD_AT_PREV_FUNC(texel,  0, 0, from601, from709)      -     LOAD_AT_IMAGE_FUNC(texel, 0,  0, from601, from709)))      / 2,
+	       temporal_diff1 = (abs(LOAD_AT_PREV_FUNC(texel,  0, 1, from601, from709) - c) + abs(LOAD_AT_PREV_FUNC(texel,  0, -1, from601, from709) - e)) / 2,
+	       temporal_diff2 = (abs(LOAD_AT_IMAGE_FUNC(texel, 0, 1, from601, from709) - c) + abs(LOAD_AT_IMAGE_FUNC(texel, 0, -1, from601, from709) - e)) / 2,
+	       diff = max(temporal_diff0, max(temporal_diff1, temporal_diff2));
+
+	float4 spatial_pred = (c + e) / 2,
+	       spatial_score = abs(LOAD_AT_FUNC(texel, -1, 1, field, from601, from709) - LOAD_AT_FUNC(texel, -1, -1, field, from601, from709)) +
+	                       abs(c - e) +
+	                       abs(LOAD_AT_FUNC(texel, 1,  1, field, from601, from709) - LOAD_AT_FUNC(texel, 1,  -1, field, from601, from709)) - 1;
+
+	YADIF_CHECK(-1)
+	YADIF_CHECK(1)
+
+	if (mode0) {
+		float4 b = YADIF_AVG(0, 2),
+		       f = YADIF_AVG(0, -2);
+
+		float4 max_ = max(d - e, max(d - c, min(b - c, f - e))),
+		       min_ = min(d - e, min(d - c, max(b - c, f - e)));
+
+		diff = max(diff, max(min_, -max_));
+	} else {
+		diff = max(diff, max(min(d - e, d - c), -max(d - e, d - c)));
+	}
+
+#define YADIF_SPATIAL(c) \
+{ \
+	if(spatial_pred.c > d.c + diff.c) \
+		spatial_pred.c = d.c + diff.c; \
+	else if(spatial_pred.c < d.c - diff.c) \
+		spatial_pred.c = d.c - diff.c; \
+}
+
+	YADIF_SPATIAL(r)
+	YADIF_SPATIAL(g)
+	YADIF_SPATIAL(b)
+	YADIF_SPATIAL(a)
+
+	return spatial_pred;
+}
+
+float4 TEXEL_AT_YADIF_2X_FUNC(int2 texel, int field, bool mode0, bool from601, bool from709)
+{
+	field = frame2 ? (1 - field) : field;
+	return TEXEL_AT_YADIF_FUNC(texel, field, mode0, from601, from709);
+}
+
+float4 TEXEL_AT_DISCARD_FUNC(int2 texel, int field, bool from601, bool from709)
+{
+	texel.y = texel.y / 2 * 2;
+	return LOAD_AT_IMAGE_FUNC(texel, 0, field, from601, from709);
+}
+
+float4 TEXEL_AT_DISCARD_2X_FUNC(int2 texel, int field, bool from601, bool from709)
+{
+	field = frame2 ? field : (1 - field);
+	return TEXEL_AT_DISCARD_FUNC(texel, field, from601, from709);
+}
+
+float4 TEXEL_AT_BLEND_FUNC(int2 texel, int field, bool from601, bool from709)
+{
+	return (LOAD_AT_IMAGE_FUNC(texel, 0, 0, from601, from709) + LOAD_AT_IMAGE_FUNC(texel, 0, 1, from601, from709)) / 2;
+}
+
+float4 TEXEL_AT_BLEND_2X_FUNC(int2 texel, int field, bool from601, bool from709)
+{
+	if (!frame2)
+		return (LOAD_AT_IMAGE_FUNC(texel, 0, 0, from601, from709) +
+		        LOAD_AT_PREV_FUNC(texel, 0, 1, from601, from709)) / 2;
+	else
+		return (LOAD_AT_IMAGE_FUNC(texel, 0, 0, from601, from709) +
+		        LOAD_AT_IMAGE_FUNC(texel, 0, 1, from601, from709)) / 2;
+}
+
+float4 TEXEL_AT_LINEAR_FUNC(int2 texel, int field, bool from601, bool from709)
+{
+	if ((texel.y % 2) == field)
+		return LOAD_AT_IMAGE_FUNC(texel, 0, 0, from601, from709);
+	return (LOAD_AT_IMAGE_FUNC(texel, 0, -1, from601, from709) + LOAD_AT_IMAGE_FUNC(texel, 0, 1, from601, from709)) / 2;
+}
+
+float4 TEXEL_AT_LINEAR_2X_FUNC(int2 texel, int field, bool from601, bool from709)
+{
+	field = frame2 ? field : (1 - field);
+	return TEXEL_AT_LINEAR_FUNC(texel, field, from601, from709);
+}
+
+float4 TEXEL_AT_YADIF_DISCARD_FUNC(int2 texel, int field, bool from601, bool from709)
+{
+	return (TEXEL_AT_YADIF_FUNC(texel, field, true, from601, from709) + TEXEL_AT_DISCARD_FUNC(texel, field, from601, from709)) / 2;
+}
+
+float4 TEXEL_AT_YADIF_DISCARD_2X_FUNC(int2 texel, int field, bool from601, bool from709)
+{
+	field = frame2 ? (1 - field) : field;
+	return (TEXEL_AT_YADIF_FUNC(texel, field, true, from601, from709) + TEXEL_AT_DISCARD_FUNC(texel, field, from601, from709)) / 2;
+}
+
+#undef CONVERT_TO_SRGB_FUNC
+#undef LOAD_AT_PREV_FUNC
+#undef LOAD_AT_IMAGE_FUNC
+#undef LOAD_AT_FUNC
+#undef YADIF_UPDATE
+#undef YADIF_CHECK_ONE
+#undef YADIF_CHECK
+#undef TEXEL_AT_YADIF_FUNC
+#undef YADIF_SPATIAL
+#undef TEXEL_AT_YADIF_2X_FUNC
+#undef TEXEL_AT_DISCARD_FUNC
+#undef TEXEL_AT_DISCARD_2X_FUNC
+#undef TEXEL_AT_BLEND_FUNC
+#undef TEXEL_AT_BLEND_2X_FUNC
+#undef TEXEL_AT_LINEAR_FUNC
+#undef TEXEL_AT_LINEAR_2X_FUNC
+#undef TEXEL_AT_YADIF_DISCARD_FUNC
+#undef TEXEL_AT_YADIF_DISCARD_2X_FUNC

--- a/libobs/data/deinterlace_linear.effect
+++ b/libobs/data/deinterlace_linear.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSLinearRGBA, PSLinearMatrix);
+TECHNIQUE(PSLinearRGBA, PSLinearMatrix, PSLinearMatrixFrom601, PSLinearMatrixFrom709);

--- a/libobs/data/deinterlace_linear_2x.effect
+++ b/libobs/data/deinterlace_linear_2x.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSLinearRGBA_2x, PSLinearxMatrixA_2x);
+TECHNIQUE(PSLinearRGBA_2x, PSLinearxMatrixA_2x, PSLinearxMatrixAFrom601_2x, PSLinearxMatrixAFrom709_2x);

--- a/libobs/data/deinterlace_yadif.effect
+++ b/libobs/data/deinterlace_yadif.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSYadifMode0RGBA, PSYadifMode0Matrix);
+TECHNIQUE(PSYadifMode0RGBA, PSYadifMode0Matrix, PSYadifMode0MatrixFrom601, PSYadifMode0MatrixFrom709);

--- a/libobs/data/deinterlace_yadif_2x.effect
+++ b/libobs/data/deinterlace_yadif_2x.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSYadifMode0RGBA_2x, PSYadifMode0Matrix_2x);
+TECHNIQUE(PSYadifMode0RGBA_2x, PSYadifMode0Matrix_2x, PSYadifMode0MatrixFrom601_2x, PSYadifMode0MatrixFrom709_2x);

--- a/libobs/data/lanczos_scale.effect
+++ b/libobs/data/lanczos_scale.effect
@@ -4,6 +4,8 @@
  * there.
  */
 
+#include "colorspace_helpers.effect"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 uniform float4x4 color_matrix;
@@ -82,71 +84,72 @@ float2 pixel_coord(float xpos, float ypos)
 	return float2(AspectUndistortU(xpos), ypos);
 }
 
-float4 pixel(float xpos, float ypos, bool undistort)
+#include "lanczos_scale_impl.effect"
+#define MATRIX_FUNCTIONS 1
+#include "lanczos_scale_impl.effect"
+#undef MATRIX_FUNCTIONS
+
+float4 DrawLanczosRGBA(FragData v_in, bool undistort, bool from601, bool from709)
 {
-	if (undistort)
-		return image.Sample(textureSampler, pixel_coord(xpos, ypos));
-	else
-		return image.Sample(textureSampler, float2(xpos, ypos));
+	return draw_lanczos(v_in, undistort, from601, from709);
 }
 
-float4 get_line(float ypos, float3 xpos1, float3 xpos2, float3 rowtap1,
-		float3 rowtap2, bool undistort)
+float4 DrawLanczosMatrix(FragData v_in, bool from601, bool from709)
 {
-	return
-		pixel(xpos1.r, ypos, undistort) * rowtap1.r +
-		pixel(xpos1.g, ypos, undistort) * rowtap2.r +
-		pixel(xpos1.b, ypos, undistort) * rowtap1.g +
-		pixel(xpos2.r, ypos, undistort) * rowtap2.g +
-		pixel(xpos2.g, ypos, undistort) * rowtap1.b +
-		pixel(xpos2.b, ypos, undistort) * rowtap2.b;
-}
-
-float4 DrawLanczos(FragData v_in, bool undistort)
-{
-	float2 stepxy = base_dimension_i;
-	float2 pos = v_in.uv + stepxy * 0.5;
-	float2 f = frac(pos / stepxy);
-
-	float3 rowtap1 = weight3((1.0 - f.x) / 2.0,       v_in.scale.x);
-	float3 rowtap2 = weight3((1.0 - f.x) / 2.0 + 0.5, v_in.scale.x);
-	float3 coltap1 = weight3((1.0 - f.y) / 2.0,       v_in.scale.y);
-	float3 coltap2 = weight3((1.0 - f.y) / 2.0 + 0.5, v_in.scale.y);
-
-	/* make sure all taps added together is exactly 1.0, otherwise some
-         * (very small) distortion can occur */
-	float suml = rowtap1.r + rowtap1.g + rowtap1.b + rowtap2.r + rowtap2.g + rowtap2.b;
-	float sumc = coltap1.r + coltap1.g + coltap1.b + coltap2.r + coltap2.g + coltap2.b;
-	rowtap1 /= suml;
-	rowtap2 /= suml;
-	coltap1 /= sumc;
-	coltap2 /= sumc;
-
-	float2 xystart = (-2.5 - f) * stepxy + pos;
-	float3 xpos1 = float3(xystart.x                 , xystart.x + stepxy.x      , xystart.x + stepxy.x * 2.0);
-	float3 xpos2 = float3(xystart.x + stepxy.x * 3.0, xystart.x + stepxy.x * 4.0, xystart.x + stepxy.x * 5.0);
-
-	return
-		get_line(xystart.y                 , xpos1, xpos2, rowtap1, rowtap2, undistort) * coltap1.r +
-		get_line(xystart.y + stepxy.y      , xpos1, xpos2, rowtap1, rowtap2, undistort) * coltap2.r +
-		get_line(xystart.y + stepxy.y * 2.0, xpos1, xpos2, rowtap1, rowtap2, undistort) * coltap1.g +
-		get_line(xystart.y + stepxy.y * 3.0, xpos1, xpos2, rowtap1, rowtap2, undistort) * coltap2.g +
-		get_line(xystart.y + stepxy.y * 4.0, xpos1, xpos2, rowtap1, rowtap2, undistort) * coltap1.b +
-		get_line(xystart.y + stepxy.y * 5.0, xpos1, xpos2, rowtap1, rowtap2, undistort) * coltap2.b;
+	return draw_lanczos_matrix(v_in, false, from601, from709);
 }
 
 float4 PSDrawLanczosRGBA(FragData v_in, bool undistort) : TARGET
 {
-	return DrawLanczos(v_in, undistort);
+	return DrawLanczosRGBA(v_in, undistort, false, false);
 }
 
-float4 PSDrawLanczosMatrix(FragData v_in) : TARGET
+float4 PSDrawLanczosRGBAFrom601(FragData v_in) : TARGET
 {
-	float4 rgba = DrawLanczos(v_in, false);
-	float4 yuv;
+	return DrawLanczosRGBA(v_in, false, true, false);
+}
 
-	yuv.xyz = clamp(rgba.xyz, color_range_min, color_range_max);
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+float4 PSDrawLanczosRGBATo601(FragData v_in) : TARGET
+{
+	const float4 color = DrawLanczosRGBA(v_in, false, false, false);
+	return float4(GammaSrgbToGamma601(color.rgb), color.a);
+}
+
+float4 PSDrawLanczosRGBAFrom709(FragData v_in) : TARGET
+{
+	return DrawLanczosRGBA(v_in, false, false, true);
+}
+
+float4 PSDrawLanczosRGBATo709(FragData v_in) : TARGET
+{
+	const float4 color = DrawLanczosRGBA(v_in, false, false, false);
+	return float4(GammaSrgbToGamma709(color.rgb), color.a);
+}
+
+float4 PSDrawLanczosMatrixFrom601(FragData v_in) : TARGET
+{
+	return DrawLanczosMatrix(v_in, true, false);
+}
+
+float4 PSDrawLanczosMatrixTo601(FragData v_in) : TARGET
+{
+	const float4 sample = draw_lanczos(v_in, false, false, false);
+	const float3 color = GammaSrgbToGamma601(sample.rgb);
+	const float3 clampedColor = clamp(color, color_range_min, color_range_max);
+	return saturate(mul(float4(clampedColor, 1.0), color_matrix));
+}
+
+float4 PSDrawLanczosMatrixFrom709(FragData v_in) : TARGET
+{
+	return DrawLanczosMatrix(v_in, false, true);
+}
+
+float4 PSDrawLanczosMatrixTo709(FragData v_in) : TARGET
+{
+	const float4 sample = draw_lanczos(v_in, false, false, false);
+	const float3 color = GammaSrgbToGamma709(sample.rgb);
+	const float3 clampedColor = clamp(color, color_range_min, color_range_max);
+	return saturate(mul(float4(clampedColor, 1.0), color_matrix));
 }
 
 technique Draw
@@ -155,6 +158,42 @@ technique Draw
 	{
 		vertex_shader = VSDefault(v_in);
 		pixel_shader  = PSDrawLanczosRGBA(v_in, false);
+	}
+}
+
+technique DrawFrom601
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLanczosRGBAFrom601(v_in);
+	}
+}
+
+technique DrawTo601
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLanczosRGBATo601(v_in);
+	}
+}
+
+technique DrawFrom709
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLanczosRGBAFrom709(v_in);
+	}
+}
+
+technique DrawTo709
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLanczosRGBATo709(v_in);
 	}
 }
 
@@ -167,11 +206,38 @@ technique DrawUndistort
 	}
 }
 
-technique DrawMatrix
+technique DrawMatrixFrom601
 {
 	pass
 	{
 		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSDrawLanczosMatrix(v_in);
+		pixel_shader  = PSDrawLanczosMatrixFrom601(v_in);
+	}
+}
+
+technique DrawMatrixTo601
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLanczosMatrixTo601(v_in);
+	}
+}
+
+technique DrawMatrixFrom709
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLanczosMatrixFrom709(v_in);
+	}
+}
+
+technique DrawMatrixTo709
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLanczosMatrixTo709(v_in);
 	}
 }

--- a/libobs/data/lanczos_scale_impl.effect
+++ b/libobs/data/lanczos_scale_impl.effect
@@ -1,0 +1,81 @@
+#ifdef MATRIX_FUNCTIONS
+#define PIXEL_FUNC pixel_matrix
+#define GET_LINE_FUNC get_line_matrix
+#define DRAW_LANCZOS_FUNC draw_lanczos_matrix
+#else
+#define PIXEL_FUNC pixel
+#define GET_LINE_FUNC get_line
+#define DRAW_LANCZOS_FUNC draw_lanczos
+#endif
+
+float4 PIXEL_FUNC(float xpos, float ypos, bool undistort, bool from601, bool from709)
+{
+	float4 sample = undistort ?
+		image.Sample(textureSampler, pixel_coord(xpos, ypos)) :
+		image.Sample(textureSampler, float2(xpos, ypos));
+
+#ifdef MATRIX_FUNCTIONS
+	const float3 yuv = clamp(sample.xyz, color_range_min, color_range_max);
+	sample = saturate(mul(float4(yuv, 1.0), color_matrix));
+#endif
+
+	if (from601)
+	{
+		sample = float4(Gamma601ToGammaSrgb(sample.rgb), sample.a);
+	}
+	else if (from709)
+	{
+		sample = float4(Gamma709ToGammaSrgb(sample.rgb), sample.a);
+	}
+
+	return sample;
+}
+
+float4 GET_LINE_FUNC(float ypos, float3 xpos1, float3 xpos2, float3 rowtap1,
+		float3 rowtap2, bool undistort, bool from601, bool from709)
+{
+	return
+		PIXEL_FUNC(xpos1.r, ypos, undistort, from601, from709) * rowtap1.r +
+		PIXEL_FUNC(xpos1.g, ypos, undistort, from601, from709) * rowtap2.r +
+		PIXEL_FUNC(xpos1.b, ypos, undistort, from601, from709) * rowtap1.g +
+		PIXEL_FUNC(xpos2.r, ypos, undistort, from601, from709) * rowtap2.g +
+		PIXEL_FUNC(xpos2.g, ypos, undistort, from601, from709) * rowtap1.b +
+		PIXEL_FUNC(xpos2.b, ypos, undistort, from601, from709) * rowtap2.b;
+}
+
+float4 DRAW_LANCZOS_FUNC(FragData v_in, bool undistort, bool from601, bool from709)
+{
+	float2 stepxy = base_dimension_i;
+	float2 pos = v_in.uv + stepxy * 0.5;
+	float2 f = frac(pos / stepxy);
+
+	float3 rowtap1 = weight3((1.0 - f.x) / 2.0,       v_in.scale.x);
+	float3 rowtap2 = weight3((1.0 - f.x) / 2.0 + 0.5, v_in.scale.x);
+	float3 coltap1 = weight3((1.0 - f.y) / 2.0,       v_in.scale.y);
+	float3 coltap2 = weight3((1.0 - f.y) / 2.0 + 0.5, v_in.scale.y);
+
+	/* make sure all taps added together is exactly 1.0, otherwise some
+         * (very small) distortion can occur */
+	float suml = rowtap1.r + rowtap1.g + rowtap1.b + rowtap2.r + rowtap2.g + rowtap2.b;
+	float sumc = coltap1.r + coltap1.g + coltap1.b + coltap2.r + coltap2.g + coltap2.b;
+	rowtap1 /= suml;
+	rowtap2 /= suml;
+	coltap1 /= sumc;
+	coltap2 /= sumc;
+
+	float2 xystart = (-2.5 - f) * stepxy + pos;
+	float3 xpos1 = float3(xystart.x                 , xystart.x + stepxy.x      , xystart.x + stepxy.x * 2.0);
+	float3 xpos2 = float3(xystart.x + stepxy.x * 3.0, xystart.x + stepxy.x * 4.0, xystart.x + stepxy.x * 5.0);
+
+	return
+		GET_LINE_FUNC(xystart.y                 , xpos1, xpos2, rowtap1, rowtap2, undistort, from601, from709) * coltap1.r +
+		GET_LINE_FUNC(xystart.y + stepxy.y      , xpos1, xpos2, rowtap1, rowtap2, undistort, from601, from709) * coltap2.r +
+		GET_LINE_FUNC(xystart.y + stepxy.y * 2.0, xpos1, xpos2, rowtap1, rowtap2, undistort, from601, from709) * coltap1.g +
+		GET_LINE_FUNC(xystart.y + stepxy.y * 3.0, xpos1, xpos2, rowtap1, rowtap2, undistort, from601, from709) * coltap2.g +
+		GET_LINE_FUNC(xystart.y + stepxy.y * 4.0, xpos1, xpos2, rowtap1, rowtap2, undistort, from601, from709) * coltap1.b +
+		GET_LINE_FUNC(xystart.y + stepxy.y * 5.0, xpos1, xpos2, rowtap1, rowtap2, undistort, from601, from709) * coltap2.b;
+}
+
+#undef PIXEL_FUNC
+#undef GET_LINE_FUNC
+#undef DRAW_LANCZOS_FUNC

--- a/libobs/data/repeat.effect
+++ b/libobs/data/repeat.effect
@@ -1,3 +1,5 @@
+#include "colorspace_helpers.effect"
+
 uniform float4x4 ViewProj;
 uniform float4x4 color_matrix;
 uniform float3 color_range_min = {0.0, 0.0, 0.0};
@@ -16,6 +18,18 @@ struct VertInOut {
 	float2 uv  : TEXCOORD0;
 };
 
+float4 GetColorBare(VertInOut vert_in)
+{
+	return image.Sample(def_sampler, vert_in.uv);
+}
+
+float4 GetYuvAsRgb(VertInOut vert_in)
+{
+	float4 yuv = image.Sample(def_sampler, vert_in.uv);
+	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max);
+	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+}
+
 VertInOut VSDefault(VertInOut vert_in)
 {
 	VertInOut vert_out;
@@ -26,14 +40,64 @@ VertInOut VSDefault(VertInOut vert_in)
 
 float4 PSDrawBare(VertInOut vert_in) : TARGET
 {
-	return image.Sample(def_sampler, vert_in.uv);
+	return GetColorBare(vert_in);
+}
+
+float4 PSDrawBareFrom601(VertInOut vert_in) : TARGET
+{
+	const float4 color = GetColorBare(vert_in);
+	return float4(Gamma601ToGammaSrgb(color.rgb), color.a);
+}
+
+float4 PSDrawBareTo601(VertInOut vert_in) : TARGET
+{
+	const float4 color = GetColorBare(vert_in);
+	return float4(GammaSrgbToGamma601(color.rgb), color.a);
+}
+
+float4 PSDrawBareFrom709(VertInOut vert_in) : TARGET
+{
+	const float4 color = GetColorBare(vert_in);
+	return float4(Gamma709ToGammaSrgb(color.rgb), color.a);
+}
+
+float4 PSDrawBareTo709(VertInOut vert_in) : TARGET
+{
+	const float4 color = GetColorBare(vert_in);
+	return float4(GammaSrgbToGamma709(color.rgb), color.a);
 }
 
 float4 PSDrawMatrix(VertInOut vert_in) : TARGET
 {
-	float4 yuv = image.Sample(def_sampler, vert_in.uv);
-	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max);
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+	return GetYuvAsRgb(vert_in);
+}
+
+float4 PSDrawMatrixFrom601(VertInOut vert_in) : TARGET
+{
+	const float4 color = GetYuvAsRgb(vert_in);
+	return float4(Gamma601ToGammaSrgb(color.rgb), color.a);
+}
+
+float4 PSDrawMatrixTo601(VertInOut vert_in) : TARGET
+{
+	const float4 sample = image.Sample(def_sampler, vert_in.uv);
+	const float3 color = GammaSrgbToGamma601(sample.rgb);
+	const float3 clampedColor = clamp(color, color_range_min, color_range_max);
+	return saturate(mul(float4(clampedColor, 1.0), color_matrix));
+}
+
+float4 PSDrawMatrixFrom709(VertInOut vert_in) : TARGET
+{
+	const float4 color = GetYuvAsRgb(vert_in);
+	return float4(Gamma709ToGammaSrgb(color.rgb), color.a);
+}
+
+float4 PSDrawMatrixTo709(VertInOut vert_in) : TARGET
+{
+	const float4 sample = image.Sample(def_sampler, vert_in.uv);
+	const float3 color = GammaSrgbToGamma709(sample.rgb);
+	const float3 clampedColor = clamp(color, color_range_min, color_range_max);
+	return saturate(mul(float4(clampedColor, 1.0), color_matrix));
 }
 
 technique Draw
@@ -45,11 +109,74 @@ technique Draw
 	}
 }
 
-technique DrawMatrix
+technique DrawFrom601
 {
 	pass
 	{
 		vertex_shader = VSDefault(vert_in);
-		pixel_shader  = PSDrawMatrix(vert_in);
+		pixel_shader  = PSDrawBareFrom601(vert_in);
+	}
+}
+
+technique DrawTo601
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawBareTo601(vert_in);
+	}
+}
+
+technique DrawFrom709
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawBareFrom709(vert_in);
+	}
+}
+
+technique DrawTo709
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawBareTo709(vert_in);
+	}
+}
+
+technique DrawMatrixFrom601
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawMatrixFrom601(vert_in);
+	}
+}
+
+technique DrawMatrixTo601
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawMatrixTo601(vert_in);
+	}
+}
+
+technique DrawMatrixFrom709
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawMatrixFrom709(vert_in);
+	}
+}
+
+technique DrawMatrixTo709
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawMatrixTo709(vert_in);
 	}
 }

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -643,6 +643,7 @@ struct obs_source {
 	bool                            async_gpu_conversion;
 	enum video_format               async_format;
 	enum video_format               async_cache_format;
+	enum video_colorspace           async_colorspace;
 	enum gs_color_format            async_texture_format;
 	float                           async_color_matrix[16];
 	bool                            async_full_range;

--- a/libobs/obs-source-deinterlace.c
+++ b/libobs/obs-source-deinterlace.c
@@ -317,7 +317,7 @@ void deinterlace_render(obs_source_t *s)
 	struct vec2 size = {(float)s->async_width, (float)s->async_height};
 	bool yuv = format_is_yuv(s->async_format);
 	bool limited_range = yuv && !s->async_full_range;
-	const char *tech = yuv ? "DrawMatrix" : "Draw";
+	const char *tech = (s->async_colorspace == VIDEO_CS_709) ? (yuv ? "DrawMatrixFrom709" : "DrawFrom709") : (yuv ? "DrawMatrixFrom601" : "DrawFrom601");
 
 	gs_texture_t *cur_tex = s->async_texrender ?
 		gs_texrender_get_texture(s->async_texrender) :

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1597,6 +1597,7 @@ bool update_async_texture(struct obs_source *source,
 	uint8_t           *ptr;
 	uint32_t          linesize;
 
+	source->async_colorspace = frame->colorspace;
 	source->async_flip       = frame->flip;
 	source->async_full_range = frame->full_range;
 	memcpy(source->async_color_matrix, frame->color_matrix,
@@ -1678,7 +1679,7 @@ static void obs_source_draw_async_texture(struct obs_source *source)
 	gs_effect_t    *effect        = gs_get_effect();
 	bool           yuv           = format_is_yuv(source->async_format);
 	bool           limited_range = yuv && !source->async_full_range;
-	const char     *type         = yuv ? "DrawMatrix" : "Draw";
+	const char     *type         = (source->async_colorspace == VIDEO_CS_709) ? (yuv ? "DrawMatrixFrom709" : "DrawFrom709") : (yuv ? "DrawMatrixFrom601" : "DrawFrom601");
 	bool           def_draw      = (!effect);
 	gs_technique_t *tech          = NULL;
 

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -215,9 +215,13 @@ static inline void render_output_texture(struct obs_core_video *video,
 	gs_technique_t *tech;
 
 	if (video->ovi.output_format == VIDEO_FORMAT_RGBA) {
-		tech = gs_effect_get_technique(effect, "Draw");
+		tech = (video->ovi.colorspace == VIDEO_CS_709) ?
+			gs_effect_get_technique(effect, "DrawTo709") :
+			gs_effect_get_technique(effect, "DrawTo601");
 	} else {
-		tech = gs_effect_get_technique(effect, "DrawMatrix");
+		tech = (video->ovi.colorspace == VIDEO_CS_709) ?
+			gs_effect_get_technique(effect, "DrawMatrixTo709") :
+			gs_effect_get_technique(effect, "DrawMatrixTo601");
 	}
 
 	gs_eparam_t    *image   = gs_effect_get_param_by_name(effect, "image");

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -228,6 +228,7 @@ struct obs_source_frame {
 	uint64_t            timestamp;
 
 	enum video_format   format;
+	enum video_colorspace colorspace;
 	float               color_matrix[16];
 	bool                full_range;
 	float               color_range_min[3];

--- a/plugins/decklink/decklink-device-instance.cpp
+++ b/plugins/decklink/decklink-device-instance.cpp
@@ -176,6 +176,7 @@ void DeckLinkDeviceInstance::SetupVideoFormat(DeckLinkDeviceMode *mode_)
 	}
 
 	colorRange = static_cast<DeckLinkInput*>(decklink)->GetColorRange();
+	currentFrame.colorspace = activeColorSpace;
 	currentFrame.full_range = colorRange == VIDEO_RANGE_FULL;
 
 	video_format_get_parameters(activeColorSpace, colorRange,

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -415,11 +415,12 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 	config->frameIntervalP = 1 + bf;
 	h264_config->idrPeriod = gop_size;
 	vui_params->videoSignalTypePresentFlag = 1;
+	vui_params->videoFormat = 5; /* Unspecified */
 	vui_params->videoFullRangeFlag = (voi->range == VIDEO_RANGE_FULL);
 	vui_params->colourDescriptionPresentFlag = 1;
-	vui_params->colourMatrix = (voi->colorspace == VIDEO_CS_709) ? 1 : 5;
-	vui_params->colourPrimaries = 1;
-	vui_params->transferCharacteristics = 1;
+	vui_params->colourMatrix = (voi->colorspace == VIDEO_CS_709) ? 1 /* BT.709 */ : 6 /* BT.601 525 */;
+	vui_params->colourPrimaries = (voi->colorspace == VIDEO_CS_709) ? 1 /* BT.709 */ : 6 /* BT.601 525 */;
+	vui_params->transferCharacteristics = (voi->colorspace == VIDEO_CS_709) ? 1 /* BT.709 */ : 6 /* BT.601 */;
 
 	enc->bframes = bf > 0;
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -201,7 +201,7 @@ static bool nvenc_update(void *data, obs_data_t *settings)
 	enc->context->time_base = (AVRational){voi->fps_den, voi->fps_num};
 	enc->context->pix_fmt = obs_to_ffmpeg_video_format(info.format);
 	enc->context->colorspace = info.colorspace == VIDEO_CS_709 ?
-		AVCOL_SPC_BT709 : AVCOL_SPC_BT470BG;
+		AVCOL_SPC_BT709 : AVCOL_SPC_SMPTE170M;
 	enc->context->color_range = info.range == VIDEO_RANGE_FULL ?
 		AVCOL_RANGE_JPEG : AVCOL_RANGE_MPEG;
 	enc->context->max_b_frames = bf;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -1086,7 +1086,7 @@ static bool try_connect(struct ffmpeg_output *output)
 		config.color_range = voi->range == VIDEO_RANGE_FULL ?
 			AVCOL_RANGE_JPEG : AVCOL_RANGE_MPEG;
 		config.color_space = voi->colorspace == VIDEO_CS_709 ?
-			AVCOL_SPC_BT709 : AVCOL_SPC_BT470BG;
+			AVCOL_SPC_BT709 : AVCOL_SPC_SMPTE170M;
 	} else {
 		config.color_range = AVCOL_RANGE_UNSPECIFIED;
 		config.color_space = AVCOL_SPC_RGB;

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -362,8 +362,9 @@ static inline const char *get_x264_colorspace_name(enum video_colorspace cs)
 {
 	switch (cs) {
 	case VIDEO_CS_DEFAULT:
-	case VIDEO_CS_601:
 		return "undef";
+	case VIDEO_CS_601:
+		return "smpte170m";
 	case VIDEO_CS_709:;
 	}
 

--- a/plugins/win-dshow/ffmpeg-decode.c
+++ b/plugins/win-dshow/ffmpeg-decode.c
@@ -233,6 +233,7 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode,
 		enum video_range_type range;
 
 		frame->format = new_format;
+		frame->colorspace = VIDEO_CS_601;
 		frame->full_range =
 			decode->frame->color_range == AVCOL_RANGE_JPEG;
 

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -671,12 +671,12 @@ static inline bool CapsMatch(const VideoInfo &info, F&& f, Fs ... fs)
 template <typename ... F>
 static bool CapsMatch(const VideoDevice &dev, F ... fs)
 {
-	auto matcher = [&](const VideoInfo &info)
-	{
-		return CapsMatch(info, fs ...);
-	};
-
-	return any_of(begin(dev.caps), end(dev.caps), matcher);
+	// no early exit, trigger all side effects.
+	bool match = false;
+	for (const VideoInfo &info : dev.caps)
+		if (CapsMatch(info, fs ...))
+			match = true;
+	return match;
 }
 
 static inline bool MatcherMatchVideoFormat(VideoFormat format,

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -1042,6 +1042,7 @@ inline bool DShowInput::Activate(obs_data_t *settings)
 	enum video_colorspace cs = GetColorSpace(settings);
 
 	video_range_type range = GetColorRange(settings);
+	frame.colorspace = cs;
 	frame.full_range = range == VIDEO_RANGE_FULL;
 
 	if (device.Start() != Result::Success)


### PR DESCRIPTION
MatcherClosestFrameRateSelector updates best_match as a side effect of
visiting every VideoInfo instance, but CapsMatch uses std::any_of,
which will stop iterating prematurely on first match. This means that
the highest FPS is not selected.

This change switches to a for loop that doesn't exit early.