### PR TITLE
UI: Add "(English)" warning to "Help &Portal"

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -555,7 +555,7 @@ Basic.MainMenu.Tools="&Tools"
 
 # basic mode help menu
 Basic.MainMenu.Help="&Help"
-Basic.MainMenu.Help.HelpPortal="Help &Portal"
+Basic.MainMenu.Help.HelpPortal="Help &Portal (English)"
 Basic.MainMenu.Help.Website="Visit &Website"
 Basic.MainMenu.Help.Discord="Join &Discord Server"
 Basic.MainMenu.Help.Logs="&Log Files"


### PR DESCRIPTION
I think this is needed because it's a warning for other language speakers that this site isn't in the language they speak.