### PR TITLE
libobs: Add transition duration functions

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -1308,6 +1308,12 @@ Functions used by transitions
 
 ---------------------
 
+.. function:: uint64_t obs_transition_get_duration_ms(obs_source_t *transition)
+
+   :return: The duration of the transition in milliseconds
+
+---------------------
+
 .. function:: void obs_transition_video_render(obs_source_t *transition, obs_transition_video_render_callback_t callback)
 
    Helper function used for rendering transitions.  This function will

--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -1314,6 +1314,12 @@ Functions used by transitions
 
 ---------------------
 
+.. function:: uint64_t obs_transition_get_duration_frames(obs_source_t *transition)
+
+   :return: The duration of the transition in frames
+
+---------------------
+
 .. function:: void obs_transition_video_render(obs_source_t *transition, obs_transition_video_render_callback_t callback)
 
    Helper function used for rendering transitions.  This function will

--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -454,6 +454,11 @@ float obs_transition_get_time(obs_source_t *transition)
 	return get_video_time(transition);
 }
 
+uint64_t obs_transition_get_duration_ms(obs_source_t *transition)
+{
+	return transition ? transition->transition_duration : 0;
+}
+
 static inline gs_texture_t *get_texture(obs_source_t *transition,
 		enum obs_transition_target target)
 {

--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -459,6 +459,17 @@ uint64_t obs_transition_get_duration_ms(obs_source_t *transition)
 	return transition ? transition->transition_duration : 0;
 }
 
+uint64_t obs_transition_get_duration_frames(obs_source_t *transition)
+{
+	struct obs_video_info info;
+	obs_get_video_info(&info);
+	if (info.fps_den == 0)
+		return UINT64_MAX;
+	else
+		return transition ? (transition->transition_duration *
+			info.fps_num) / (info.fps_den * 1000): 0;
+}
+
 static inline gs_texture_t *get_texture(obs_source_t *transition,
 		enum obs_transition_target target)
 {

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1300,7 +1300,8 @@ typedef void (*obs_transition_video_render_callback_t)(void *data,
 typedef float (*obs_transition_audio_mix_callback_t)(void *data, float t);
 
 EXPORT float obs_transition_get_time(obs_source_t *transition);
-EXPORT float obs_transition_get_duration_ms(obs_source_t *transition);
+EXPORT uint64_t obs_transition_get_duration_ms(obs_source_t *transition);
+EXPORT uint64_t obs_transition_get_duration_frames(obs_source_t *transition);
 
 EXPORT void obs_transition_video_render(obs_source_t *transition,
 		obs_transition_video_render_callback_t callback);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1300,6 +1300,7 @@ typedef void (*obs_transition_video_render_callback_t)(void *data,
 typedef float (*obs_transition_audio_mix_callback_t)(void *data, float t);
 
 EXPORT float obs_transition_get_time(obs_source_t *transition);
+EXPORT float obs_transition_get_duration_ms(obs_source_t *transition);
 
 EXPORT void obs_transition_video_render(obs_source_t *transition,
 		obs_transition_video_render_callback_t callback);


### PR DESCRIPTION
Adds functions to return the duration of a transition.