### PR TITLE
libobs: Tell filters that we want to load

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1823,6 +1823,12 @@ void obs_load_sources(obs_data_array_t *array, obs_load_source_cb cb,
 			if (source->info.type == OBS_SOURCE_TYPE_TRANSITION)
 				obs_transition_load(source, source_data);
 			obs_source_load(source);
+			if (source->filters.num) {
+				for (size_t i = source->filters.num; i > 0; i--) {
+					obs_source_t *filter = source->filters.array[i - 1];
+					obs_source_load(filter);
+				}
+			}
 			if (cb)
 				cb(private_data, source);
 		}


### PR DESCRIPTION
Previously only sources would receive a load signal, but sources and filters would receive a save signal. This meant that filters that had a save signal to store something on disk would never receive a load signal to load it from disk.

With this both sources and filters will now receive save and load signals, allowing both to work the same way.