### PR TITLE
frontend-tools: Fix memory leak when reloading scripts

### DIFF
--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -237,6 +237,7 @@ void ScriptsTool::ReloadScript(const char *path)
 			obs_properties_t *prop =
 				obs_script_get_properties(script);
 			obs_properties_apply_settings(prop, settings);
+			obs_properties_destroy(prop);
 
 			break;
 		}
@@ -332,6 +333,7 @@ void ScriptsTool::on_addScripts_clicked()
 			obs_properties_t *prop =
 				obs_script_get_properties(script);
 			obs_properties_apply_settings(prop, settings);
+			obs_properties_destroy(prop);
 		}
 	}
 }


### PR DESCRIPTION
Reloading any script will have a memory leak. Properties are received from a get function call, but not destroyed. This change makes sure they get destroyed.