### PR TITLE
win-dshow: Fix "Highest FPS" algorithm

### DIFF
--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -671,12 +671,12 @@ static inline bool CapsMatch(const VideoInfo &info, F&& f, Fs ... fs)
 template <typename ... F>
 static bool CapsMatch(const VideoDevice &dev, F ... fs)
 {
-	auto matcher = [&](const VideoInfo &info)
-	{
-		return CapsMatch(info, fs ...);
-	};
-
-	return any_of(begin(dev.caps), end(dev.caps), matcher);
+	// no early exit, trigger all side effects.
+	bool match = false;
+	for (const VideoInfo &info : dev.caps)
+		if (CapsMatch(info, fs ...))
+			match = true;
+	return match;
 }
 
 static inline bool MatcherMatchVideoFormat(VideoFormat format,


### PR DESCRIPTION
MatcherClosestFrameRateSelector updates best_match as a side effect of
visiting every VideoInfo instance, but CapsMatch uses std::any_of,
which will stop iterating prematurely on first match. This means that
the highest FPS is not selected.

This change switches to a for loop that doesn't exit early.