### PR TITLE
Add proper color space conversions

### DIFF
--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
@@ -217,7 +217,8 @@ void render_preview_source(void *param, uint32_t cx, uint32_t cy)
 
 	gs_texrender_reset(ctx->texrender);
 
-	if (gs_texrender_begin(ctx->texrender, width, height)) {
+	if (gs_texrender_begin(ctx->texrender, width, height,
+			       GS_CS_SRGB_NONLINEAR)) {
 		struct vec4 background;
 		vec4_zero(&background);
 

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -1424,13 +1424,22 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *scene,
 		{{{1.f, 1.f, 0.f}}},
 	};
 
+	vec4 red_srgb;
+	vec4 green_srgb;
+	vec4 blue_srgb;
+	vec4_set(&red_srgb, 1.0f, 0.0f, 0.0f, 1.0f);
+	vec4_set(&green_srgb, 0.0f, 1.0f, 0.0f, 1.0f);
+	vec4_set(&blue_srgb, 0.0f, 0.0f, 1.0f, 1.0f);
+
 	vec4 red;
 	vec4 green;
 	vec4 blue;
-
-	vec4_set(&red, 1.0f, 0.0f, 0.0f, 1.0f);
-	vec4_set(&green, 0.0f, 1.0f, 0.0f, 1.0f);
-	vec4_set(&blue, 0.0f, 0.5f, 1.0f, 1.0f);
+	gs_convert_colorspace(red_srgb, GS_CS_SRGB_NONLINEAR, GS_CS_ACESCG,
+			      &red);
+	gs_convert_colorspace(green_srgb, GS_CS_SRGB_NONLINEAR, GS_CS_ACESCG,
+			      &green);
+	gs_convert_colorspace(blue_srgb, GS_CS_SRGB_NONLINEAR, GS_CS_ACESCG,
+			      &blue);
 
 	bool visible = std::all_of(
 		std::begin(bounds), std::end(bounds), [&](const vec3 &b) {
@@ -1557,8 +1566,12 @@ void OBSBasicPreview::DrawSceneEditing()
 	gs_effect_t *solid = obs_get_base_effect(OBS_EFFECT_SOLID);
 	gs_technique_t *tech = gs_effect_get_technique(solid, "Solid");
 
+	vec4 color_srgb;
+	vec4_set(&color_srgb, 1.0f, 0.0f, 0.0f, 1.0f);
+
 	vec4 color;
-	vec4_set(&color, 1.0f, 0.0f, 0.0f, 1.0f);
+	gs_convert_colorspace(color_srgb, GS_CS_SRGB_NONLINEAR, GS_CS_ACESCG,
+			      &color);
 	gs_effect_set_vec4(gs_effect_get_param_by_name(solid, "color"), &color);
 
 	gs_technique_begin(tech);

--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -105,7 +105,11 @@ static inline enum speaker_layout convert_speaker_layout(uint8_t channels)
 
 static inline enum video_colorspace convert_color_space(enum AVColorSpace s)
 {
-	return s == AVCOL_SPC_BT709 ? VIDEO_CS_709 : VIDEO_CS_DEFAULT;
+	switch (s) {
+	case AVCOL_SPC_BT709:     return VIDEO_CS_709;
+	case AVCOL_SPC_SMPTE170M: return VIDEO_CS_601;
+	}
+	return VIDEO_CS_DEFAULT;
 }
 
 static inline enum video_range_type convert_color_range(enum AVColorRange r)
@@ -368,6 +372,7 @@ static void mp_media_next_video(mp_media_t *m, bool preload)
 		bool success;
 
 		frame->format = new_format;
+		frame->colorspace = new_space;
 		frame->full_range = new_range == VIDEO_RANGE_FULL;
 
 		success = video_format_get_parameters(new_space, new_range,

--- a/libobs/data/bicubic_scale.effect
+++ b/libobs/data/bicubic_scale.effect
@@ -4,9 +4,16 @@
  * there.
  */
 
+#include "colorspace.inc"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 uniform float4x4 color_matrix;
+uniform float3 color_rgb_matrix0;
+uniform float3 color_rgb_matrix1;
+uniform float3 color_rgb_matrix2;
+uniform float3 color_target_transfer_abc;
+uniform float3 color_target_transfer_def;
 uniform float2 base_dimension_i;
 uniform float undistort_factor = 1.0;
 
@@ -135,13 +142,19 @@ float4 PSDrawBicubicRGBADivide(VertData v_in) : TARGET
 	float4 rgba = DrawBicubic(v_in, false);
 	float alpha = rgba.a;
 	float multiplier = (alpha > 0.0) ? (1.0 / alpha) : 0.0;
-	return float4(rgba.rgb * multiplier, alpha);
+	float3 rgb = ConvertFromLinear(rgba.rgb * multiplier,
+			color_target_transfer_abc, color_target_transfer_def,
+			color_rgb_matrix0, color_rgb_matrix1, color_rgb_matrix2);
+	return float4(rgb, alpha);
 }
 
 float4 PSDrawBicubicMatrix(VertData v_in) : TARGET
 {
 	float3 rgb = DrawBicubic(v_in, false).rgb;
-	float3 yuv = mul(float4(saturate(rgb), 1.0), color_matrix).xyz;
+	float3 yuv = LinearToYuv(rgb,
+			color_target_transfer_abc, color_target_transfer_def,
+			color_matrix, color_rgb_matrix0, color_rgb_matrix1,
+			color_rgb_matrix2);
 	return float4(yuv, 1.0);
 }
 

--- a/libobs/data/bilinear_lowres_scale.effect
+++ b/libobs/data/bilinear_lowres_scale.effect
@@ -3,9 +3,16 @@
  * low resolution image below half size
  */
 
+#include "colorspace.inc"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 uniform float4x4 color_matrix;
+uniform float3 color_rgb_matrix0;
+uniform float3 color_rgb_matrix1;
+uniform float3 color_rgb_matrix2;
+uniform float3 color_target_transfer_abc;
+uniform float3 color_target_transfer_def;
 
 sampler_state textureSampler {
 	Filter    = Linear;
@@ -63,13 +70,19 @@ float4 PSDrawLowresBilinearRGBADivide(VertData v_in) : TARGET
 	float4 rgba = DrawLowresBilinear(v_in);
 	float alpha = rgba.a;
 	float multiplier = (alpha > 0.0) ? (1.0 / alpha) : 0.0;
-	return float4(rgba.rgb * multiplier, alpha);
+	float3 rgb = ConvertFromLinear(rgba.rgb * multiplier,
+			color_target_transfer_abc, color_target_transfer_def,
+			color_rgb_matrix0, color_rgb_matrix1, color_rgb_matrix2);
+	return float4(rgb, alpha);
 }
 
 float4 PSDrawLowresBilinearMatrix(VertData v_in) : TARGET
 {
 	float3 rgb = DrawLowresBilinear(v_in).rgb;
-	float3 yuv = mul(float4(saturate(rgb), 1.0), color_matrix).xyz;
+	float3 yuv = LinearToYuv(rgb,
+			color_target_transfer_abc, color_target_transfer_def,
+			color_matrix, color_rgb_matrix0, color_rgb_matrix1,
+			color_rgb_matrix2);
 	return float4(yuv, 1.0);
 }
 

--- a/libobs/data/colorspace.inc
+++ b/libobs/data/colorspace.inc
@@ -1,0 +1,79 @@
+// Keep in sync with file in plugins\obs-filters\data
+
+float GammaToLinearChannel(float v, float3 abc, float3 def)
+{
+	return (v < def.x) ? (abc.z * v) : (pow(abc.x * v + abc.y, def.z) + def.y);
+}
+
+float3 GammaToLinear(float3 color, float3 abc, float3 def)
+{
+	return float3(GammaToLinearChannel(color.r, abc, def), GammaToLinearChannel(color.g, abc, def), GammaToLinearChannel(color.b, abc, def));
+}
+
+float LinearToGammaChannel(float l, float3 abc, float3 def)
+{
+	return (l < def.x) ? (abc.z * l) : ((abc.x * pow(l + abc.y, def.z)) + def.y);
+}
+
+float3 LinearToGamma(float3 color, float3 abc, float3 def)
+{
+	return float3(LinearToGammaChannel(color.r, abc, def), LinearToGammaChannel(color.g, abc, def), LinearToGammaChannel(color.b, abc, def));
+}
+
+float3 YuvToRgb(float3 yuv, float3 range_min, float3 range_max, float4x4 yuv_matrix)
+{
+	yuv = clamp(yuv, range_min, range_max);
+	return saturate(mul(float4(yuv, 1.0), yuv_matrix).rgb);
+}
+
+float3 RgbToYuv(float3 rgb, float4x4 yuv_matrix)
+{
+	float3 yuv = mul(float4(rgb, 1.0), yuv_matrix).xyz;
+	return yuv;
+}
+
+float3 ConvertFromLinear(float3 rgb, float3 abc, float3 def, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	rgb = float3(dot(rgb, rgb_matrix0), dot(rgb, rgb_matrix1), dot(rgb, rgb_matrix2));
+	rgb = LinearToGamma(rgb, abc, def);
+	return rgb;
+}
+
+float3 ConvertToLinear(float3 rgb, float3 abc, float3 def, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	rgb = GammaToLinear(rgb, abc, def);
+	rgb = float3(dot(rgb, rgb_matrix0), dot(rgb, rgb_matrix1), dot(rgb, rgb_matrix2));
+	return rgb;
+}
+
+float3 TranslateColor(float3 rgb, float3 source_abc, float3 source_def, float3 target_abc, float3 target_def, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	rgb = GammaToLinear(rgb, source_abc, source_def);
+	rgb = float3(dot(rgb, rgb_matrix0), dot(rgb, rgb_matrix1), dot(rgb, rgb_matrix2));
+	rgb = LinearToGamma(rgb, target_abc, target_def);
+	return rgb;
+}
+
+float4 YuvToLinear(float3 yuv, float3 abc, float3 def, float3 range_min, float3 range_max, float4x4 yuv_matrix, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	return float4(ConvertToLinear(YuvToRgb(yuv, range_min, range_max, yuv_matrix), abc, def, rgb_matrix0, rgb_matrix1, rgb_matrix2), 1.0);
+}
+
+float3 LinearToYuv(float3 rgb, float3 abc, float3 def, float4x4 yuv_matrix, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	return RgbToYuv(ConvertFromLinear(rgb, abc, def, rgb_matrix0, rgb_matrix1, rgb_matrix2), yuv_matrix);
+}
+
+float3 TranslateMatrixColor(float3 yuv, float3 source_abc, float3 source_def, float3 target_abc, float3 target_def, float3 range_min, float3 range_max, float4x4 yuv_matrix, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	float3 source_rgb = YuvToRgb(yuv, range_min, range_max, yuv_matrix);
+	float3 target_rgb = TranslateColor(source_rgb, source_abc, source_def, target_abc, target_def, rgb_matrix0, rgb_matrix1, rgb_matrix2);
+	return target_rgb;
+}
+
+float3 TranslateMatrixColorReverse(float3 source_rgb, float3 source_abc, float3 source_def, float3 target_abc, float3 target_def, float4x4 yuv_matrix, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	float3 target_rgb = TranslateColor(source_rgb, source_abc, source_def, target_abc, target_def, rgb_matrix0, rgb_matrix1, rgb_matrix2);
+	float3 yuv = RgbToYuv(target_rgb, yuv_matrix);
+	return yuv;
+}

--- a/libobs/data/default.effect
+++ b/libobs/data/default.effect
@@ -1,5 +1,14 @@
+#include "colorspace.inc"
+
 uniform float4x4 ViewProj;
 uniform float4x4 color_matrix;
+uniform float3 color_rgb_matrix0;
+uniform float3 color_rgb_matrix1;
+uniform float3 color_rgb_matrix2;
+uniform float3 color_source_transfer_abc;
+uniform float3 color_source_transfer_def;
+uniform float3 color_target_transfer_abc;
+uniform float3 color_target_transfer_def;
 uniform texture2d image;
 
 sampler_state def_sampler {
@@ -26,18 +35,30 @@ float4 PSDrawBare(VertInOut vert_in) : TARGET
 	return image.Sample(def_sampler, vert_in.uv);
 }
 
+float4 PSDrawTranslate(VertInOut vert_in) : TARGET
+{
+	float4 color = image.Sample(def_sampler, vert_in.uv);
+	return float4(TranslateColor(color.rgb, color_source_transfer_abc, color_source_transfer_def, color_target_transfer_abc, color_target_transfer_def, color_rgb_matrix0, color_rgb_matrix1, color_rgb_matrix2), color.a);
+}
+
 float4 PSDrawAlphaDivide(VertInOut vert_in) : TARGET
 {
 	float4 rgba = image.Sample(def_sampler, vert_in.uv);
 	float alpha = rgba.a;
 	float multiplier = (alpha > 0.0) ? (1.0 / alpha) : 0.0;
-	return float4(rgba.rgb * multiplier, alpha);
+	float3 rgb = ConvertFromLinear(rgba.rgb * multiplier,
+			color_target_transfer_abc, color_target_transfer_def,
+			color_rgb_matrix0, color_rgb_matrix1, color_rgb_matrix2);
+	return float4(rgb, alpha);
 }
 
 float4 PSDrawMatrix(VertInOut vert_in) : TARGET
 {
 	float3 rgb = image.Sample(def_sampler, vert_in.uv).rgb;
-	float3 yuv = mul(float4(rgb, 1.0), color_matrix).xyz;
+	float3 yuv = LinearToYuv(rgb,
+			color_target_transfer_abc, color_target_transfer_def,
+			color_matrix, color_rgb_matrix0, color_rgb_matrix1,
+			color_rgb_matrix2);
 	return float4(yuv, 1.0);
 }
 
@@ -47,6 +68,15 @@ technique Draw
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawBare(vert_in);
+	}
+}
+
+technique DrawTranslate
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawTranslate(vert_in);
 	}
 }
 

--- a/libobs/data/deinterlace_base.effect
+++ b/libobs/data/deinterlace_base.effect
@@ -16,8 +16,17 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include "colorspace.inc"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
+uniform float3 color_rgb_matrix0;
+uniform float3 color_rgb_matrix1;
+uniform float3 color_rgb_matrix2;
+uniform float3 color_source_transfer_abc;
+uniform float3 color_source_transfer_def;
+uniform float3 color_target_transfer_abc;
+uniform float3 color_target_transfer_def;
 
 uniform texture2d previous_image;
 uniform float2 dimensions;
@@ -40,14 +49,19 @@ int3 select(int2 texel, int x, int y)
 	return int3(texel + int2(x, y), 0);
 }
 
+float4 convert_to_acescg(float4 sample)
+{
+	return float4(ConvertToLinear(sample.rgb, color_source_transfer_abc, color_source_transfer_def, color_rgb_matrix0, color_rgb_matrix1, color_rgb_matrix2), sample.a);
+}
+
 float4 load_at_prev(int2 texel, int x, int y)
 {
-	return previous_image.Load(select(texel, x, y));
+	return convert_to_acescg(previous_image.Load(select(texel, x, y)));
 }
 
 float4 load_at_image(int2 texel, int x, int y)
 {
-	return image.Load(select(texel, x, y));
+	return convert_to_acescg(image.Load(select(texel, x, y)));
 }
 
 float4 load_at(int2 texel, int x, int y, int field)
@@ -271,5 +285,19 @@ technique Draw \
 	{ \
 		vertex_shader = VSDefault(v_in); \
 		pixel_shader  = rgba_ps(v_in); \
+	} \
+} \
+\
+float4 draw_translate(VertData v_in) : TARGET \
+{ \
+	float4 color = rgba_ps(v_in); \
+	return float4(LinearToGamma(color.rgb, color_target_transfer_abc, color_target_transfer_def), color.a); \
+} \
+technique DrawTranslate \
+{ \
+	pass \
+	{ \
+		vertex_shader = VSDefault(v_in); \
+		pixel_shader  = draw_translate(v_in); \
 	} \
 }

--- a/libobs/data/lanczos_scale.effect
+++ b/libobs/data/lanczos_scale.effect
@@ -4,9 +4,16 @@
  * there.
  */
 
+#include "colorspace.inc"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 uniform float4x4 color_matrix;
+uniform float3 color_rgb_matrix0;
+uniform float3 color_rgb_matrix1;
+uniform float3 color_rgb_matrix2;
+uniform float3 color_target_transfer_abc;
+uniform float3 color_target_transfer_def;
 uniform float2 base_dimension_i;
 uniform float undistort_factor = 1.0;
 
@@ -143,13 +150,19 @@ float4 PSDrawLanczosRGBADivide(FragData v_in) : TARGET
 	float4 rgba = DrawLanczos(v_in, false);
 	float alpha = rgba.a;
 	float multiplier = (alpha > 0.0) ? (1.0 / alpha) : 0.0;
-	return float4(rgba.rgb * multiplier, alpha);
+	float3 rgb = ConvertFromLinear(rgba.rgb * multiplier,
+			color_target_transfer_abc, color_target_transfer_def,
+			color_rgb_matrix0, color_rgb_matrix1, color_rgb_matrix2);
+	return float4(rgb, alpha);
 }
 
 float4 PSDrawLanczosMatrix(FragData v_in) : TARGET
 {
 	float3 rgb = DrawLanczos(v_in, false).rgb;
-	float3 yuv = mul(float4(saturate(rgb), 1.0), color_matrix).xyz;
+	float3 yuv = LinearToYuv(rgb,
+			color_target_transfer_abc, color_target_transfer_def,
+			color_matrix, color_rgb_matrix0, color_rgb_matrix1,
+			color_rgb_matrix2);
 	return float4(yuv, 1.0);
 }
 

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -321,6 +321,9 @@ struct graphics_subsystem {
 	struct matrix4 projection;
 	struct gs_effect *cur_effect;
 
+	enum gs_colorspace cur_colorspace;
+	DARRAY(enum gs_colorspace) colorspace_stack;
+
 	gs_vertbuffer_t *sprite_buffer;
 
 	bool using_immediate;

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -83,6 +83,14 @@ enum gs_zstencil_format {
 	GS_Z32F_S8X24,
 };
 
+enum gs_colorspace {
+	GS_CS_SRGB_NONLINEAR,
+	GS_CS_SRGB_LINEAR, // Need GPU format support, but OpenGL is painful.
+	GS_CS_601,
+	GS_CS_709,
+	GS_CS_ACESCG,
+};
+
 enum gs_index_type {
 	GS_UNSIGNED_SHORT,
 	GS_UNSIGNED_LONG,
@@ -425,6 +433,10 @@ EXPORT void gs_effect_set_next_sampler(gs_eparam_t *param,
 
 EXPORT void gs_effect_set_color(gs_eparam_t *param, uint32_t argb);
 
+EXPORT void gs_effect_set_color_translate(const gs_effect_t *effect,
+					  enum gs_colorspace source_cs,
+					  enum gs_colorspace target_cs);
+
 /* ---------------------------------------------------
  * texture render helper functions
  * --------------------------------------------------- */
@@ -433,7 +445,7 @@ EXPORT gs_texrender_t *gs_texrender_create(enum gs_color_format format,
 					   enum gs_zstencil_format zsformat);
 EXPORT void gs_texrender_destroy(gs_texrender_t *texrender);
 EXPORT bool gs_texrender_begin(gs_texrender_t *texrender, uint32_t cx,
-			       uint32_t cy);
+			       uint32_t cy, enum gs_colorspace cs);
 EXPORT void gs_texrender_end(gs_texrender_t *texrender);
 EXPORT void gs_texrender_reset(gs_texrender_t *texrender);
 EXPORT gs_texture_t *gs_texrender_get_texture(const gs_texrender_t *texrender);
@@ -589,6 +601,9 @@ EXPORT void gs_blend_state_push(void);
 EXPORT void gs_blend_state_pop(void);
 EXPORT void gs_reset_blend_state(void);
 
+EXPORT void gs_colorspace_push(void);
+EXPORT void gs_colorspace_pop(void);
+
 /* -------------------------- */
 /* library-specific functions */
 
@@ -653,6 +668,9 @@ EXPORT gs_zstencil_t *gs_get_zstencil_target(void);
 EXPORT void gs_set_render_target(gs_texture_t *tex, gs_zstencil_t *zstencil);
 EXPORT void gs_set_cube_render_target(gs_texture_t *cubetex, int side,
 				      gs_zstencil_t *zstencil);
+
+EXPORT enum gs_colorspace gs_get_colorspace(void);
+EXPORT void gs_set_colorspace(enum gs_colorspace cs);
 
 EXPORT void gs_copy_texture(gs_texture_t *dst, gs_texture_t *src);
 EXPORT void gs_copy_texture_region(gs_texture_t *dst, uint32_t dst_x,
@@ -800,6 +818,11 @@ EXPORT void gs_debug_marker_begin(const float color[4], const char *markername);
 EXPORT void gs_debug_marker_begin_format(const float color[4],
 					 const char *format, ...);
 EXPORT void gs_debug_marker_end(void);
+
+EXPORT void gs_convert_colorspace(struct vec4 color,
+				  enum gs_colorspace source_cs,
+				  enum gs_colorspace target_cs,
+				  struct vec4 *target_color);
 
 #ifdef __APPLE__
 

--- a/libobs/graphics/texture-render.c
+++ b/libobs/graphics/texture-render.c
@@ -87,7 +87,8 @@ static bool texrender_resetbuffer(gs_texrender_t *texrender, uint32_t cx,
 	return true;
 }
 
-bool gs_texrender_begin(gs_texrender_t *texrender, uint32_t cx, uint32_t cy)
+bool gs_texrender_begin(gs_texrender_t *texrender, uint32_t cx, uint32_t cy,
+			enum gs_colorspace cs)
 {
 	if (!texrender || texrender->rendered)
 		return false;
@@ -106,10 +107,12 @@ bool gs_texrender_begin(gs_texrender_t *texrender, uint32_t cx, uint32_t cy)
 	gs_projection_push();
 	gs_matrix_push();
 	gs_matrix_identity();
+	gs_colorspace_push();
 
 	texrender->prev_target = gs_get_render_target();
 	texrender->prev_zs = gs_get_zstencil_target();
 	gs_set_render_target(texrender->target, texrender->zs);
+	gs_set_colorspace(cs);
 
 	gs_set_viewport(0, 0, texrender->cx, texrender->cy);
 
@@ -126,6 +129,7 @@ void gs_texrender_end(gs_texrender_t *texrender)
 	gs_matrix_pop();
 	gs_projection_pop();
 	gs_viewport_pop();
+	gs_colorspace_pop();
 
 	texrender->rendered = true;
 }

--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -59,6 +59,7 @@ enum video_colorspace {
 	VIDEO_CS_DEFAULT,
 	VIDEO_CS_601,
 	VIDEO_CS_709,
+	VIDEO_CS_SRGB,
 };
 
 enum video_range_type {
@@ -145,6 +146,8 @@ static inline const char *get_video_colorspace_name(enum video_colorspace cs)
 	switch (cs) {
 	case VIDEO_CS_709:
 		return "709";
+	case VIDEO_CS_SRGB:
+		return "sRGB";
 	case VIDEO_CS_601:
 	case VIDEO_CS_DEFAULT:;
 	}

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -202,6 +202,7 @@ struct obs_display {
 	bool enabled;
 	uint32_t cx, cy;
 	uint32_t background_color;
+	gs_texture_t *render_texture;
 	gs_swapchain_t *swap;
 	pthread_mutex_t draw_callbacks_mutex;
 	pthread_mutex_t draw_info_mutex;
@@ -638,6 +639,7 @@ struct obs_source {
 	bool async_full_range;
 	enum video_format async_cache_format;
 	bool async_cache_full_range;
+	enum gs_colorspace async_colorspace;
 	enum gs_color_format async_texture_format;
 	int async_plane_offset[2];
 	bool async_flip;
@@ -667,6 +669,10 @@ struct obs_source {
 	enum obs_deinterlace_mode deinterlace_mode;
 	bool deinterlace_top_first;
 	bool deinterlace_rendered;
+
+	/* input render-to-texture */
+	gs_texrender_t *input_texrender;
+	enum gs_colorspace input_colorspace;
 
 	/* filters */
 	struct obs_source *filter_parent;
@@ -780,6 +786,19 @@ convert_video_format(enum video_format format)
 		return GS_BGRA;
 
 	return GS_BGRX;
+}
+
+static inline enum gs_colorspace
+convert_video_colorspace(enum video_colorspace colorspace)
+{
+	switch (colorspace) {
+	case VIDEO_CS_709:
+		return GS_CS_709;
+	case VIDEO_CS_SRGB:
+		return GS_CS_SRGB_NONLINEAR;
+	default:
+		return GS_CS_601;
+	}
 }
 
 extern void obs_source_activate(obs_source_t *source, enum view_type type);

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -424,7 +424,7 @@ static void update_item_transform(struct obs_scene_item *item, bool update_tex)
 
 	} else if (!item->item_render && item_texture_enabled(item)) {
 		obs_enter_graphics();
-		item->item_render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+		item->item_render = gs_texrender_create(GS_RGBA16F, GS_ZS_NONE);
 		obs_leave_graphics();
 	}
 
@@ -544,7 +544,9 @@ static inline void render_item(struct obs_scene_item *item)
 		uint32_t cx = calc_cx(item, width);
 		uint32_t cy = calc_cy(item, height);
 
-		if (cx && cy && gs_texrender_begin(item->item_render, cx, cy)) {
+		if (cx && cy &&
+		    gs_texrender_begin(item->item_render, cx, cy,
+				       GS_CS_ACESCG)) {
 			float cx_scale = (float)width / (float)cx;
 			float cy_scale = (float)height / (float)cy;
 			struct vec4 clear_color;
@@ -792,7 +794,7 @@ static void scene_load_item(struct obs_scene *scene, obs_data_t *item_data)
 
 	} else if (!item->item_render && item_texture_enabled(item)) {
 		obs_enter_graphics();
-		item->item_render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+		item->item_render = gs_texrender_create(GS_RGBA16F, GS_ZS_NONE);
 		obs_leave_graphics();
 	}
 
@@ -1301,7 +1303,7 @@ static inline void duplicate_item_data(struct obs_scene_item *dst,
 		if (!dst->item_render && item_texture_enabled(dst)) {
 			obs_enter_graphics();
 			dst->item_render =
-				gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+				gs_texrender_create(GS_RGBA16F, GS_ZS_NONE);
 			obs_leave_graphics();
 		}
 	}
@@ -1672,7 +1674,7 @@ static obs_sceneitem_t *obs_scene_add_internal(obs_scene_t *scene,
 
 	if (item_texture_enabled(item)) {
 		obs_enter_graphics();
-		item->item_render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+		item->item_render = gs_texrender_create(GS_RGBA16F, GS_ZS_NONE);
 		obs_leave_graphics();
 	}
 

--- a/libobs/obs-source-deinterlace.c
+++ b/libobs/obs-source-deinterlace.c
@@ -336,12 +336,15 @@ void deinterlace_render(obs_source_t *s)
 	gs_effect_set_int(field, s->deinterlace_top_first);
 	gs_effect_set_vec2(dimensions, &size);
 
+	gs_effect_set_color_translate(effect, s->async_colorspace,
+				      gs_get_colorspace());
+
 	frame2_ts = s->deinterlace_frame_ts + s->deinterlace_offset +
 		    s->deinterlace_half_duration - TWOX_TOLERANCE;
 
 	gs_effect_set_bool(frame2, obs->video.video_time >= frame2_ts);
 
-	while (gs_effect_loop(effect, "Draw"))
+	while (gs_effect_loop(effect, "DrawTranslate"))
 		gs_draw_sprite(NULL, s->async_flip ? GS_FLIP_V : 0,
 			       s->async_width, s->async_height);
 }

--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -51,9 +51,9 @@ bool obs_transition_init(obs_source_t *transition)
 
 	transition->transition_alignment = OBS_ALIGN_LEFT | OBS_ALIGN_TOP;
 	transition->transition_texrender[0] =
-		gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+		gs_texrender_create(GS_RGBA16F, GS_ZS_NONE);
 	transition->transition_texrender[1] =
-		gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+		gs_texrender_create(GS_RGBA16F, GS_ZS_NONE);
 	transition->transition_source_active[0] = true;
 
 	return transition->transition_texrender[0] != NULL &&
@@ -630,7 +630,8 @@ static inline void render_child(obs_source_t *transition, obs_source_t *child,
 	if (!child)
 		return;
 
-	if (gs_texrender_begin(transition->transition_texrender[idx], cx, cy)) {
+	if (gs_texrender_begin(transition->transition_texrender[idx], cx, cy,
+			       GS_CS_ACESCG)) {
 		vec4_zero(&blank);
 		gs_clear(GS_CLEAR_COLOR, &blank, 0.0f, 0);
 		gs_ortho(0.0f, (float)cx, 0.0f, (float)cy, -100.0f, 100.0f);

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -123,9 +123,10 @@ static inline void render_main_texture(struct obs_core_video *video)
 			      render_main_texture_name);
 
 	struct vec4 clear_color;
-	vec4_set(&clear_color, 0.0f, 0.0f, 0.0f, 0.0f);
+	vec4_set(&clear_color, 0.0f, 0.0f, 0.0f, 1.0f);
 
 	gs_set_render_target(video->render_texture, NULL);
+	gs_set_colorspace(GS_CS_ACESCG);
 	gs_clear(GS_CLEAR_COLOR, &clear_color, 1.0f, 0);
 
 	set_render_size(video->base_width, video->base_height);
@@ -232,7 +233,11 @@ static inline void render_output_texture(struct obs_core_video *video)
 		gs_effect_get_param_by_name(effect, "base_dimension_i");
 	size_t passes, i;
 
+	const enum gs_colorspace target_cs =
+		convert_video_colorspace(video->ovi.colorspace);
+
 	gs_set_render_target(target, NULL);
+	gs_set_colorspace(target_cs);
 	set_render_size(width, height);
 
 	if (bres)
@@ -241,6 +246,7 @@ static inline void render_output_texture(struct obs_core_video *video)
 		gs_effect_set_vec2(bres_i, &base_i);
 
 	gs_effect_set_val(matrix, video->color_matrix, sizeof(float) * 16);
+	gs_effect_set_color_translate(effect, GS_CS_ACESCG, target_cs);
 	gs_effect_set_texture(image, texture);
 
 	gs_enable_blending(false);

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -232,8 +232,8 @@ static bool obs_init_textures(struct obs_video_info *ovi)
 	}
 
 	video->render_texture = gs_texture_create(ovi->base_width,
-						  ovi->base_height, GS_RGBA, 1,
-						  NULL, GS_RENDER_TARGET);
+						  ovi->base_height, GS_RGBA16F,
+						  1, NULL, GS_RENDER_TARGET);
 
 	if (!video->render_texture)
 		return false;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -233,6 +233,7 @@ struct obs_source_frame {
 	uint64_t timestamp;
 
 	enum video_format format;
+	enum video_colorspace colorspace;
 	float color_matrix[16];
 	bool full_range;
 	float color_range_min[3];
@@ -252,6 +253,7 @@ struct obs_source_frame2 {
 	uint64_t timestamp;
 
 	enum video_format format;
+	enum video_colorspace colorspace;
 	enum video_range_type range;
 	float color_matrix[16];
 	float color_range_min[3];

--- a/plugins/decklink/decklink-device-instance.cpp
+++ b/plugins/decklink/decklink-device-instance.cpp
@@ -181,6 +181,7 @@ void DeckLinkDeviceInstance::SetupVideoFormat(DeckLinkDeviceMode *mode_)
 	}
 
 	colorRange = static_cast<DeckLinkInput *>(decklink)->GetColorRange();
+	currentFrame.colorspace = activeColorSpace;
 	currentFrame.range = colorRange;
 
 	video_format_get_parameters(activeColorSpace, colorRange,

--- a/plugins/mac-avcapture/av-capture.mm
+++ b/plugins/mac-avcapture/av-capture.mm
@@ -491,6 +491,7 @@ static inline bool update_colorspace(av_capture *capture,
 		return true;
 	}
 
+	frame->colorspace = colorspace;
 	frame->full_range = full_range;
 
 	if (!video_format_get_parameters(colorspace, range, frame->color_matrix,

--- a/plugins/mac-capture/mac-window-capture.m
+++ b/plugins/mac-capture/mac-window-capture.m
@@ -69,6 +69,7 @@ static inline void capture_frame(struct window_capture *wc)
 
 	struct obs_source_frame frame = {
 		.format = VIDEO_FORMAT_BGRA,
+		.colorspace = VIDEO_CS_SRGB,
 		.width = width,
 		.height = height,
 		.data[0] = data,
@@ -103,7 +104,7 @@ static inline void *window_capture_create_internal(obs_data_t *settings,
 
 	wc->source = source;
 
-	wc->color_space = CGColorSpaceCreateDeviceRGB();
+	wc->color_space = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
 
 	da_init(wc->buffer);
 

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -434,11 +434,17 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 	config->frameIntervalP = 1 + bf;
 	h264_config->idrPeriod = gop_size;
 	vui_params->videoSignalTypePresentFlag = 1;
+	vui_params->videoFormat = 5; /* Unspecified */
 	vui_params->videoFullRangeFlag = (voi->range == VIDEO_RANGE_FULL);
 	vui_params->colourDescriptionPresentFlag = 1;
-	vui_params->colourMatrix = (voi->colorspace == VIDEO_CS_709) ? 1 : 5;
-	vui_params->colourPrimaries = 1;
-	vui_params->transferCharacteristics = 1;
+	vui_params->colourMatrix = (voi->colorspace == VIDEO_CS_709)
+					   ? 1 /* BT.709 */
+					   : 6 /* BT.601 525 */;
+	vui_params->colourPrimaries = (voi->colorspace == VIDEO_CS_709)
+					      ? 1 /* BT.709 */
+					      : 6 /* BT.601 525 */;
+	vui_params->transferCharacteristics =
+		(voi->colorspace == VIDEO_CS_709) ? 1 /* BT.709 */ : 6 /* BT.601 */;
 
 	enc->bframes = bf > 0;
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -195,7 +195,7 @@ static bool nvenc_update(void *data, obs_data_t *settings)
 	enc->context->pix_fmt = obs_to_ffmpeg_video_format(info.format);
 	enc->context->colorspace = info.colorspace == VIDEO_CS_709
 					   ? AVCOL_SPC_BT709
-					   : AVCOL_SPC_BT470BG;
+					   : AVCOL_SPC_SMPTE170M;
 	enc->context->color_range = info.range == VIDEO_RANGE_FULL
 					    ? AVCOL_RANGE_JPEG
 					    : AVCOL_RANGE_MPEG;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -1116,7 +1116,7 @@ static bool try_connect(struct ffmpeg_output *output)
 					     : AVCOL_RANGE_MPEG;
 		config.color_space = voi->colorspace == VIDEO_CS_709
 					     ? AVCOL_SPC_BT709
-					     : AVCOL_SPC_BT470BG;
+					     : AVCOL_SPC_SMPTE170M;
 	} else {
 		config.color_range = AVCOL_RANGE_UNSPECIFIED;
 		config.color_space = AVCOL_SPC_RGB;

--- a/plugins/obs-filters/data/chroma_key_filter.effect
+++ b/plugins/obs-filters/data/chroma_key_filter.effect
@@ -1,3 +1,5 @@
+#include "srgb_legacy.inc"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 
@@ -84,8 +86,10 @@ float4 ProcessChromaKey(float4 rgba, VertData v_in)
 
 float4 PSChromaKeyRGBA(VertData v_in) : TARGET
 {
-	float4 rgba = image.Sample(textureSampler, v_in.uv);
-	return ProcessChromaKey(rgba, v_in);
+	float4 sample = image.Sample(textureSampler, v_in.uv);
+	float4 rgba = float4(ConvertToSrgbNonlinear(sample.rgb), sample.a);
+	float4 keyed = ProcessChromaKey(rgba, v_in);
+	return float4(ConvertFromSrgbNonlinear(keyed.rgb), keyed.a);
 }
 
 technique Draw

--- a/plugins/obs-filters/data/color_correction_filter.effect
+++ b/plugins/obs-filters/data/color_correction_filter.effect
@@ -15,6 +15,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 *****************************************************************************/
 
+#include "srgb_legacy.inc"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 
@@ -47,6 +49,7 @@ float4 PSColorFilterRGBA(VertData vert_in) : TARGET
 {
 	/* Grab the current pixel to perform operations on. */
 	float4 currentPixel = image.Sample(textureSampler, vert_in.uv);
+	currentPixel = float4(ConvertToSrgbNonlinear(currentPixel.rgb), currentPixel.a);
 
 	/* Always address the gamma first. */
 	currentPixel.rgb = pow(currentPixel.rgb, gamma);
@@ -57,6 +60,7 @@ float4 PSColorFilterRGBA(VertData vert_in) : TARGET
 	 * https://docs.rainmeter.net/tips/colormatrix-guide/for more info.
 	 */
 	currentPixel = mul(color_matrix, currentPixel);
+	currentPixel.rgb = ConvertFromSrgbNonlinear(currentPixel.rgb);
 
 	return currentPixel;
 }

--- a/plugins/obs-filters/data/color_grade_filter.effect
+++ b/plugins/obs-filters/data/color_grade_filter.effect
@@ -1,3 +1,5 @@
+#include "srgb_legacy.inc"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 
@@ -31,6 +33,7 @@ VertDataOut VSDefault(VertDataIn v_in)
 float4 LUT(VertDataOut v_in) : TARGET
 {
 	float4 textureColor = image.Sample(textureSampler, v_in.uv);
+	textureColor = float4(ConvertToSrgbNonlinear(textureColor.rgb), textureColor.a);
 	float blueColor = textureColor.b * 63.0;
 
 	float2 quad1;
@@ -54,6 +57,7 @@ float4 LUT(VertDataOut v_in) : TARGET
 	float4 luttedColor = lerp(newColor1, newColor2, frac(blueColor));
 
 	float4 final_color = lerp(textureColor, luttedColor, clut_amount);
+	final_color.rgb = ConvertFromSrgbNonlinear(final_color.rgb);
 	return float4(final_color.rgb, textureColor.a);
 }
 

--- a/plugins/obs-filters/data/color_key_filter.effect
+++ b/plugins/obs-filters/data/color_key_filter.effect
@@ -1,3 +1,5 @@
+#include "srgb_legacy.inc"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 
@@ -39,18 +41,21 @@ float GetColorDist(float3 rgb)
 	return distance(key_color.rgb, rgb);
 }
 
-float4 ProcessColorKey(float4 rgba, VertData v_in)
+float4 ProcessColorKey(float4 rgba)
 {
 	float colorDist = GetColorDist(rgba.rgb);
-	rgba.a *= saturate(max(colorDist - similarity, 0.0) / smoothness);
+	rgba.a *= saturate((colorDist - similarity) / smoothness);
 
 	return CalcColor(rgba);
 }
 
 float4 PSColorKeyRGBA(VertData v_in) : TARGET
 {
-	float4 rgba = image.Sample(textureSampler, v_in.uv) * color;
-	return ProcessColorKey(rgba, v_in);
+	float4 sample = image.Sample(textureSampler, v_in.uv);
+	float4 sample_srgb = float4(ConvertToSrgbNonlinear(sample.rgb), sample.a);
+	float4 rgba = sample_srgb * color;
+	float4 keyed = ProcessColorKey(rgba);
+	return float4(ConvertFromSrgbNonlinear(keyed.rgb), keyed.a);
 }
 
 technique Draw

--- a/plugins/obs-filters/data/colorspace.inc
+++ b/plugins/obs-filters/data/colorspace.inc
@@ -1,0 +1,79 @@
+// Keep in sync with file in libobs\data
+
+float GammaToLinearChannel(float v, float3 abc, float3 def)
+{
+	return (v < def.x) ? (abc.z * v) : (pow(abc.x * v + abc.y, def.z) + def.y);
+}
+
+float3 GammaToLinear(float3 color, float3 abc, float3 def)
+{
+	return float3(GammaToLinearChannel(color.r, abc, def), GammaToLinearChannel(color.g, abc, def), GammaToLinearChannel(color.b, abc, def));
+}
+
+float LinearToGammaChannel(float l, float3 abc, float3 def)
+{
+	return (l < def.x) ? (abc.z * l) : ((abc.x * pow(l + abc.y, def.z)) + def.y);
+}
+
+float3 LinearToGamma(float3 color, float3 abc, float3 def)
+{
+	return float3(LinearToGammaChannel(color.r, abc, def), LinearToGammaChannel(color.g, abc, def), LinearToGammaChannel(color.b, abc, def));
+}
+
+float3 YuvToRgb(float3 yuv, float3 range_min, float3 range_max, float4x4 yuv_matrix)
+{
+	yuv = clamp(yuv, range_min, range_max);
+	return saturate(mul(float4(yuv, 1.0), yuv_matrix).rgb);
+}
+
+float3 RgbToYuv(float3 rgb, float4x4 yuv_matrix)
+{
+	float3 yuv = mul(float4(rgb, 1.0), yuv_matrix).xyz;
+	return yuv;
+}
+
+float3 ConvertFromLinear(float3 rgb, float3 abc, float3 def, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	rgb = float3(dot(rgb, rgb_matrix0), dot(rgb, rgb_matrix1), dot(rgb, rgb_matrix2));
+	rgb = LinearToGamma(rgb, abc, def);
+	return rgb;
+}
+
+float3 ConvertToLinear(float3 rgb, float3 abc, float3 def, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	rgb = GammaToLinear(rgb, abc, def);
+	rgb = float3(dot(rgb, rgb_matrix0), dot(rgb, rgb_matrix1), dot(rgb, rgb_matrix2));
+	return rgb;
+}
+
+float3 TranslateColor(float3 rgb, float3 source_abc, float3 source_def, float3 target_abc, float3 target_def, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	rgb = GammaToLinear(rgb, source_abc, source_def);
+	rgb = float3(dot(rgb, rgb_matrix0), dot(rgb, rgb_matrix1), dot(rgb, rgb_matrix2));
+	rgb = LinearToGamma(rgb, target_abc, target_def);
+	return rgb;
+}
+
+float4 YuvToLinear(float3 yuv, float3 abc, float3 def, float3 range_min, float3 range_max, float4x4 yuv_matrix, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	return float4(ConvertToLinear(YuvToRgb(yuv, range_min, range_max, yuv_matrix), abc, def, rgb_matrix0, rgb_matrix1, rgb_matrix2), 1.0);
+}
+
+float3 LinearToYuv(float3 rgb, float3 abc, float3 def, float4x4 yuv_matrix, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	return RgbToYuv(ConvertFromLinear(rgb, abc, def, rgb_matrix0, rgb_matrix1, rgb_matrix2), yuv_matrix);
+}
+
+float3 TranslateMatrixColor(float3 yuv, float3 source_abc, float3 source_def, float3 target_abc, float3 target_def, float3 range_min, float3 range_max, float4x4 yuv_matrix, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	float3 source_rgb = YuvToRgb(yuv, range_min, range_max, yuv_matrix);
+	float3 target_rgb = TranslateColor(source_rgb, source_abc, source_def, target_abc, target_def, rgb_matrix0, rgb_matrix1, rgb_matrix2);
+	return target_rgb;
+}
+
+float3 TranslateMatrixColorReverse(float3 source_rgb, float3 source_abc, float3 source_def, float3 target_abc, float3 target_def, float4x4 yuv_matrix, float3 rgb_matrix0, float3 rgb_matrix1, float3 rgb_matrix2)
+{
+	float3 target_rgb = TranslateColor(source_rgb, source_abc, source_def, target_abc, target_def, rgb_matrix0, rgb_matrix1, rgb_matrix2);
+	float3 yuv = RgbToYuv(target_rgb, yuv_matrix);
+	return yuv;
+}

--- a/plugins/obs-filters/data/mask_alpha_filter.effect
+++ b/plugins/obs-filters/data/mask_alpha_filter.effect
@@ -1,3 +1,5 @@
+#include "srgb_legacy.inc"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 
@@ -34,11 +36,13 @@ VertDataOut VSDefault(VertDataIn v_in)
 
 float4 PSAlphaMaskRGBA(VertDataOut v_in) : TARGET
 {
-	float4 rgba = image.Sample(textureSampler, v_in.uv) * color;
+	float4 sample = image.Sample(textureSampler, v_in.uv);
+	float4 sample_srgb = float4(ConvertToSrgbNonlinear(sample.rgb), sample.a);
+	float4 rgba = sample_srgb * color;
 
 	float4 targetRGB = target.Sample(textureSampler, v_in.uv2);
 	rgba.a *= targetRGB.a;
-	return rgba;
+	return float4(ConvertFromSrgbNonlinear(rgba.rgb), rgba.a);
 }
 
 technique Draw

--- a/plugins/obs-filters/data/mask_color_filter.effect
+++ b/plugins/obs-filters/data/mask_color_filter.effect
@@ -1,3 +1,5 @@
+#include "srgb_legacy.inc"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 
@@ -34,11 +36,13 @@ VertDataOut VSDefault(VertDataIn v_in)
 
 float4 PSColorMaskRGBA(VertDataOut v_in) : TARGET
 {
-	float4 rgba = image.Sample(textureSampler, v_in.uv) * color;
+	float4 sample = image.Sample(textureSampler, v_in.uv);
+	float4 sample_srgb = float4(ConvertToSrgbNonlinear(sample.rgb), sample.a);
+	float4 rgba = sample_srgb * color;
 
 	float4 targetRGB = target.Sample(textureSampler, v_in.uv2);
 	rgba.a *= (targetRGB.r + targetRGB.g + targetRGB.b) / 3.0;
-	return rgba;
+	return float4(ConvertFromSrgbNonlinear(rgba.rgb), rgba.a);
 }
 
 technique Draw

--- a/plugins/obs-filters/data/srgb_legacy.inc
+++ b/plugins/obs-filters/data/srgb_legacy.inc
@@ -1,0 +1,22 @@
+#include "colorspace.inc"
+
+float3 ConvertToSrgbNonlinear(float3 rgb)
+{
+	float3 rgb_matrix0 = float3(2.02579975, -0.798917055, -0.159652337);
+	float3 rgb_matrix1 = float3(0.231922448, 0.835083961, -0.0509763733);
+	float3 rgb_matrix2 = float3(0.0342020467, -0.189897582, 1.07084787);
+	rgb = float3(dot(rgb, rgb_matrix0), dot(rgb, rgb_matrix1), dot(rgb, rgb_matrix2));
+	rgb = saturate(rgb);
+	rgb = LinearToGamma(rgb, float3(1.055, 0.0, 12.92), float3(0.0031308, -0.055, 1.0 / 2.4));
+	return rgb;
+}
+
+float3 ConvertFromSrgbNonlinear(float3 rgb)
+{
+	rgb = GammaToLinear(rgb, float3(1.0 / 1.055, 0.055 / 1.055, 1.0 / 12.92), float3(0.04045, 0.0, 2.4));
+	float3 rgb_matrix0 = float3(0.441543043, 0.442176282, 0.0868787393);
+	float3 rgb_matrix1 = float3(-0.124839157, 1.08557081, 0.0330650136);
+	float3 rgb_matrix2 = float3(-0.0362407565, 0.178385690, 0.936928093);
+	rgb = float3(dot(rgb, rgb_matrix0), dot(rgb, rgb_matrix1), dot(rgb, rgb_matrix2));
+	return rgb;
+}

--- a/plugins/obs-filters/gpu-delay.c
+++ b/plugins/obs-filters/gpu-delay.c
@@ -65,7 +65,7 @@ static void update_interval(struct gpu_delay_filter_data *f,
 			struct frame *frame =
 				circlebuf_data(&f->frames, i * sizeof(*frame));
 			frame->render =
-				gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+				gs_texrender_create(GS_RGBA16F, GS_ZS_NONE);
 		}
 
 		obs_leave_graphics();
@@ -226,7 +226,7 @@ static void gpu_delay_filter_render(void *data, gs_effect_t *effect)
 	gs_blend_state_push();
 	gs_blend_function(GS_BLEND_ONE, GS_BLEND_ZERO);
 
-	if (gs_texrender_begin(frame.render, f->cx, f->cy)) {
+	if (gs_texrender_begin(frame.render, f->cx, f->cy, GS_CS_ACESCG)) {
 		uint32_t parent_flags = obs_source_get_output_flags(target);
 		bool custom_draw = (parent_flags & OBS_SOURCE_CUSTOM_DRAW) != 0;
 		bool async = (parent_flags & OBS_SOURCE_ASYNC) != 0;

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -366,8 +366,9 @@ static inline const char *get_x264_colorspace_name(enum video_colorspace cs)
 {
 	switch (cs) {
 	case VIDEO_CS_DEFAULT:
-	case VIDEO_CS_601:
 		return "undef";
+	case VIDEO_CS_601:
+		return "smpte170m";
 	case VIDEO_CS_709:;
 	}
 

--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -352,6 +352,7 @@ static unsigned vlcs_video_format(void **p_data, char *chroma, unsigned *width,
 		obs_source_frame_init(&c->frame, new_format, *width, *height);
 
 		c->frame.format = new_format;
+		c->frame.colorspace = VIDEO_CS_DEFAULT;
 		c->frame.full_range = new_range;
 		range = c->frame.full_range ? VIDEO_RANGE_FULL
 					    : VIDEO_RANGE_PARTIAL;

--- a/plugins/win-dshow/ffmpeg-decode.c
+++ b/plugins/win-dshow/ffmpeg-decode.c
@@ -256,6 +256,7 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode, uint8_t *data,
 		bool success;
 
 		frame->format = new_format;
+		frame->colorspace = VIDEO_CS_601;
 		frame->range = decode->frame->color_range == AVCOL_RANGE_JPEG
 				       ? VIDEO_RANGE_FULL
 				       : VIDEO_RANGE_DEFAULT;

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -1084,6 +1084,7 @@ inline bool DShowInput::Activate(obs_data_t *settings)
 		return false;
 
 	enum video_colorspace cs = GetColorSpace(settings);
+	frame.colorspace = cs;
 	frame.range = GetColorRange(settings);
 
 	if (device.Start() != Result::Success)


### PR DESCRIPTION
Convert RGB values from and to the appropriate color spaces instead of
aliasing them. sRGB is assumed to be the neutral space. New shader
techniques have been added to all relevant effects.

Add colorspace enum value to obs_source/obs_source_frame to decide
which GPU technique to use later. Moving color matrix/range values into
shaders would make things simpler, but that can be refactored
separately.

Switch meaning of 601 from BT.470 BG to SMPTE170M. BT.470 BG is close
to BT.601 625, but the gamma curve is way different (2.8!), and 625
lines is PAL. SMPTE170M matches BT.601 525 in all relevant ways, and
525 lines the NTSC way. If OBS only supports one, I suspect 525 is more
common than 625 although I don't have stats to back that up.

deps/media-playback
----
Add explicit conversion for AVCOL_SPC_SMPTE170M -> to VIDEO_CS_601.

Attach colorspace enum value to the frame.

libobs
----
For shaders, Draw is now augmented with Draw[From/To][601/709], and
DrawMatrix has been replaced by DrawMatrix[From/To][601/709]. Draw
still exists because of scaling shaders that don't touch 601/709, but
DrawMatrix has no remaning uses, and has been removed. This might not
be the most scalable approach, but I think it'll do for now.

Add colorspace enum value to obs_source/obs_source_frame to decide
which GPU technique to use later.

Use colorspace value to decide GPU technique.

Fix scaling shaders to convert YUV to RGB before filtering to make
behavior consistent.

Aside: Gamma space may not be the best space for filtering; a
perceptual or linear space may produce more "correct" results, but that
can be addressed separately if desired.

decklink
----
Attach colorspace enum value to the frame.

obs-ffmpeg
----
Switch meaning of 601 from BT.470 BG to SMPTE170M.

obs-x264
----
Add explicit conversion for VIDEO_CS_601 -> "smpte170m" string. I see a
previous attempt to use "bt470bg" was reverted because of Twitch
transcode issues, but they might actually be correct because the gamma
curve for that is way different than BT.601. All changes here in total
should work correctly if Twitch implements proper color handling.

win-dshow
----
Attach colorspace enum value to the frame in ffmpeg_decode_video().

Attach colorspace enum value to the frame in in DShowInput::Activate();