### PR TITLE
UI: Fix hover item spottiness

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -110,6 +110,19 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_)
 	connect(lock, &QAbstractButton::clicked, setItemLocked);
 }
 
+void SourceTreeItem::enterEvent(QEvent *event)
+{
+	OBSBasicPreview *preview = OBSBasicPreview::Get();
+	preview->hoveredListItem = this->sceneitem;
+}
+
+void SourceTreeItem::leaveEvent(QEvent *event)
+{
+	OBSBasicPreview *preview = OBSBasicPreview::Get();
+	if (preview->hoveredListItem == this->sceneitem)
+		preview->hoveredListItem = nullptr;
+}
+
 void SourceTreeItem::paintEvent(QPaintEvent *event)
 {
 	QStyleOption opt;
@@ -1265,24 +1278,6 @@ void SourceTree::dropEvent(QDropEvent *event)
 	event->setDropAction(Qt::CopyAction);
 
 	QListView::dropEvent(event);
-}
-
-void SourceTree::mouseMoveEvent(QMouseEvent *event)
-{
-	QPoint pos = event->pos();
-	SourceTreeItem *item = qobject_cast<SourceTreeItem *>(childAt(pos));
-
-	OBSBasicPreview *preview = OBSBasicPreview::Get();
-	preview->hoveredListItem = !!item ? item->sceneitem : nullptr;
-
-	QListView::mouseMoveEvent(event);
-}
-
-void SourceTree::leaveEvent(QEvent *event)
-{
-	OBSBasicPreview *preview = OBSBasicPreview::Get();
-	preview->hoveredListItem = nullptr;
-	QListView::leaveEvent(event);
 }
 
 void SourceTree::selectionChanged(

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -44,7 +44,9 @@ class SourceTreeItem : public QWidget {
 	void ReconnectSignals();
 
 	Type type = Type::Unknown;
-
+protected:
+	virtual void enterEvent(QEvent *event) override;
+	virtual void leaveEvent(QEvent *event) override;
 public:
 	explicit SourceTreeItem(SourceTree *tree, OBSSceneItem sceneitem);
 	bool IsEditing();
@@ -175,8 +177,6 @@ public slots:
 protected:
 	virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
 	virtual void dropEvent(QDropEvent *event) override;
-	virtual void mouseMoveEvent(QMouseEvent *event) override;
-	virtual void leaveEvent(QEvent *event) override;
 
 	virtual void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
 };

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -616,7 +616,6 @@ void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 		cropping     = false;
 
 		OBSSceneItem item = GetItemAtPos(pos, true);
-		hoveredPreviewItem = item;
 	}
 }
 
@@ -1163,7 +1162,7 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 		return;
 
 	if (mouseDown) {
-		hoveredPreviewItem = nullptr;
+		hoveredListItem = nullptr;
 
 		vec2 pos = GetMouseEventPos(event);
 
@@ -1205,15 +1204,8 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 		vec2 pos = GetMouseEventPos(event);
 		OBSSceneItem item = GetItemAtPos(pos, true);
 
-		hoveredPreviewItem = item;
+		hoveredListItem = item;
 	}
-}
-
-void OBSBasicPreview::leaveEvent(QEvent *event)
-{
-	hoveredPreviewItem = nullptr;
-
-	UNUSED_PARAMETER(event);
 }
 
 static void DrawSquareAtPos(float x, float y)
@@ -1411,8 +1403,7 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *scene,
 	OBSBasicPreview *prev = reinterpret_cast<OBSBasicPreview*>(param);
 	OBSBasic *main = OBSBasic::Get();
 
-	bool hovered = prev->hoveredPreviewItem == item ||
-	               prev->hoveredListItem == item;
+	bool hovered = prev->hoveredListItem == item;
 	bool selected = obs_sceneitem_selected(item);
 
 	if (!selected && !hovered)

--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -32,6 +32,7 @@ class OBSBasicPreview : public OBSQTDisplay {
 	Q_OBJECT
 
 	friend class SourceTree;
+	friend class SourceTreeItem;
 
 private:
 	obs_sceneitem_crop startCrop;
@@ -61,7 +62,6 @@ private:
 	int32_t      scalingLevel   = 0;
 	float        scalingAmount  = 1.0f;
 
-	obs_sceneitem_t *hoveredPreviewItem = nullptr;
 	obs_sceneitem_t *hoveredListItem    = nullptr;
 
 	static vec2 GetMouseEventPos(QMouseEvent *event);
@@ -105,7 +105,6 @@ public:
 	virtual void mousePressEvent(QMouseEvent *event) override;
 	virtual void mouseReleaseEvent(QMouseEvent *event) override;
 	virtual void mouseMoveEvent(QMouseEvent *event) override;
-	virtual void leaveEvent(QEvent *event) override;
 
 	void DrawOverflow();
 	void DrawSceneEditing();


### PR DESCRIPTION
Mouse move events do not always fire* (frustrating) and so are not
reliable to detect hover events. Instead we modify the enter and leave
widget events (which do always fire) to reliably show the outline.