### PR TITLE
obs-ffmpeg: Fix crash by using __stdcall calling convention for x86 compiling

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -193,7 +193,7 @@ static bool is_blacklisted(const wchar_t *name)
 	return false;
 }
 
-typedef HRESULT (*create_dxgi_proc)(const IID *, IDXGIFactory1 **);
+typedef HRESULT (__stdcall *create_dxgi_proc)(const IID *, IDXGIFactory1 **);
 
 static bool nvenc_device_available(void)
 {


### PR DESCRIPTION
When using typedefs for function pointers pointed to win32 apis, calling convention must be specified; For c/c++, __cdecl is default; For win32 apis, __stdcall is default