### PR TITLE
Replace ATL CComPtr with WRL ComPtr

### DIFF
--- a/plugins/obs-qsv11/common_directx11.h
+++ b/plugins/obs-qsv11/common_directx11.h
@@ -15,7 +15,7 @@ Copyright(c) 2005-2014 Intel Corporation. All Rights Reserved.
 #include <windows.h>
 #include <d3d11.h>
 #include <dxgi1_2.h>
-#include <atlbase.h>
+#include <wrl/client.h>
 
 #define DEVICE_MGR_TYPE MFX_HANDLE_D3D11_DEVICE
 
@@ -33,7 +33,7 @@ Copyright(c) 2005-2014 Intel Corporation. All Rights Reserved.
 //     - For switchable graphics solutions (mobile) make sure that Intel device is the active device
 mfxStatus CreateHWDevice(mfxSession session, mfxHDL* deviceHandle, HWND hWnd, bool bCreateSharedHandles);
 void CleanupHWDevice();
-void SetHWDeviceContext(CComPtr<ID3D11DeviceContext> devCtx);
-CComPtr<ID3D11DeviceContext> GetHWDeviceContext();
+void SetHWDeviceContext(Microsoft::WRL::ComPtr<ID3D11DeviceContext> devCtx);
+Microsoft::WRL::ComPtr<ID3D11DeviceContext> GetHWDeviceContext();
 void ClearYUVSurfaceD3D(mfxMemId memId);
 void ClearRGBSurfaceD3D(mfxMemId memId);

--- a/plugins/obs-qsv11/common_directx9.cpp
+++ b/plugins/obs-qsv11/common_directx9.cpp
@@ -5,7 +5,7 @@
 #include <initguid.h>
 #include <d3d9.h>
 #include <map>
-#include <atlbase.h>
+#include <wrl/client.h>
 
 
 #define D3DFMT_NV12 (D3DFORMAT)MAKEFOURCC('N','V','1','2')
@@ -17,9 +17,9 @@ std::map<mfxMemId*, mfxHDL>             dx9_allocResponses;
 std::map<mfxHDL, mfxFrameAllocResponse> dx9_allocDecodeResponses;
 std::map<mfxHDL, int>                   dx9_allocDecodeRefCount;
 
-CComPtr<IDirect3DDeviceManager9> m_manager;
-CComPtr<IDirectXVideoDecoderService> m_decoderService;
-CComPtr<IDirectXVideoProcessorService> m_processorService;
+Microsoft::WRL::ComPtr<IDirect3DDeviceManager9> m_manager;
+Microsoft::WRL::ComPtr<IDirectXVideoDecoderService> m_decoderService;
+Microsoft::WRL::ComPtr<IDirectXVideoProcessorService> m_processorService;
 HANDLE m_hDecoder;
 HANDLE m_hProcessor;
 DWORD m_surfaceUsage;
@@ -112,24 +112,24 @@ void DX9_CleanupHWDevice()
 	}
 	if (m_manager && m_hDecoder) {
 		m_manager->CloseDeviceHandle(m_hDecoder);
-		m_manager = NULL;
+		m_manager.Reset();
 		m_hDecoder = NULL;
 	}
 
 	if (m_manager && m_hProcessor) {
 		m_manager->CloseDeviceHandle(m_hProcessor);
-		m_manager = NULL;
+		m_manager.Reset();
 		m_hProcessor = NULL;
 	}
 
 	if (m_decoderService) {
 		// delete m_decoderService;
-		m_decoderService = NULL;
+		m_decoderService.Reset();
 	}
 
 	if (m_processorService) {
 		// delete m_processorService;
-		m_processorService = NULL;
+		m_processorService.Reset();
 	}
 }
 
@@ -356,7 +356,7 @@ mfxStatus _dx9_simple_alloc(mfxFrameAllocRequest* request, mfxFrameAllocResponse
 			if (FAILED(hr))
 				return MFX_ERR_MEMORY_ALLOC;
 		}
-		videoService = m_processorService;
+		videoService = m_processorService.Get();
 	}
 	else {
 		if (!m_hDecoder)
@@ -369,7 +369,7 @@ mfxStatus _dx9_simple_alloc(mfxFrameAllocRequest* request, mfxFrameAllocResponse
 			if (FAILED(hr))
 				return MFX_ERR_MEMORY_ALLOC;
 		}
-		videoService = m_decoderService;
+		videoService = m_decoderService.Get();
 	}
 
 	mfxHDLPair *dxMids = NULL, **dxMidPtrs = NULL;

--- a/plugins/obs-qsv11/device_directx9.cpp
+++ b/plugins/obs-qsv11/device_directx9.cpp
@@ -20,7 +20,7 @@ Copyright(c) 2011-2015 Intel Corporation. All Rights Reserved.
 #include "device_directx9.h"
 // #include "igfx_s3dcontrol.h"
 
-#include "atlbase.h"
+#include <wrl/client.h>
 
 // Macros
 #define MSDK_ZERO_MEMORY(VAR)                    {memset(&VAR, 0, sizeof(VAR));}
@@ -356,12 +356,12 @@ mfxStatus CD3D9Device::RenderFrame(mfxFrameSurface1 * pSurface, mfxFrameAllocato
         }
     }
 
-    CComPtr<IDirect3DSurface9> pBackBuffer;
+    Microsoft::WRL::ComPtr<IDirect3DSurface9> pBackBuffer;
     hr = m_pD3DD9->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &pBackBuffer);
 
     mfxHDLPair* dxMemId = (mfxHDLPair*)pSurface->Data.MemId;
 
-    hr = m_pD3DD9->StretchRect((IDirect3DSurface9*)dxMemId->first, NULL, pBackBuffer, NULL, D3DTEXF_LINEAR);
+    hr = m_pD3DD9->StretchRect((IDirect3DSurface9*)dxMemId->first, NULL, pBackBuffer.Get(), NULL, D3DTEXF_LINEAR);
     if (FAILED(hr))
     {
         return MFX_ERR_UNKNOWN;


### PR DESCRIPTION
WRL comes with WinSDK while ATL has to be installed separately and only CComPtr is used from it.

Disclaimer: Did not test beyond successful compilation.