### PR TITLE
CI: Build on Ubuntu Xenial for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       before_deploy: "./CI/before-deploy-osx.sh"
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       before_install: "./CI/install-dependencies-linux.sh"
       before_script: "./CI/before-script-linux.sh"


### PR DESCRIPTION
Trusty is reaching EOL in April 2019.