### PR TITLE
win-wasapi: Fix audio capture after USB sound card unplugging

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -448,7 +448,7 @@ DWORD WINAPI WASAPISource::CaptureThread(LPVOID param)
 	bool         reconnect = false;
 
 	/* Output devices don't signal, so just make it check every 10 ms */
-	DWORD        dur       = source->isInputDevice ? INFINITE : 10;
+	DWORD        dur       = source->isInputDevice ? RECONNECT_INTERVAL : 10;
 
 	HANDLE sigs[2] = {
 		source->receiveSignal,

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -366,6 +366,8 @@ DWORD WINAPI WASAPISource::ReconnectThread(LPVOID param)
 
 	os_set_thread_name("win-wasapi: reconnect thread");
 
+	CoInitializeEx(0, COINIT_MULTITHREADED);
+
 	while (!WaitForSignal(source->stopSignal, RECONNECT_INTERVAL)) {
 		if (source->TryInitialize())
 			break;

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -1,6 +1,7 @@
 #include "enum-wasapi.hpp"
 
 #include <obs-module.h>
+#include <obs.h>
 #include <util/platform.h>
 #include <util/windows/HRError.hpp>
 #include <util/windows/ComPtr.hpp>
@@ -368,10 +369,15 @@ DWORD WINAPI WASAPISource::ReconnectThread(LPVOID param)
 
 	CoInitializeEx(0, COINIT_MULTITHREADED);
 
+	obs_monitoring_type type = obs_source_get_monitoring_type(source->source);
+	obs_source_set_monitoring_type(source->source, OBS_MONITORING_TYPE_NONE);
+
 	while (!WaitForSignal(source->stopSignal, RECONNECT_INTERVAL)) {
 		if (source->TryInitialize())
 			break;
 	}
+
+	obs_source_set_monitoring_type(source->source, type);
 
 	source->reconnectThread = nullptr;
 	source->reconnecting = false;


### PR DESCRIPTION
BUG: OBS audio input capture gets frozen if USB sound card is disconnected and then reconnected. This also might happen accidentally on sound card power cycle.

After this PR user does not have to restart OBS or re-add audio source after said event.

Note: if audio input device is set to Default, Windows might automatically fallback to available input device and this PR effect is unnoticeable. To test it properly please explicitly select your sound card as input and monitoring device.