### PR TITLE
UI: Remove Area downscale filter option

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -752,7 +752,6 @@ Basic.Settings.Video.DisableAero="Disable Aero"
 Basic.Settings.Video.DownscaleFilter.Bilinear="Bilinear (Fastest, but blurry if scaling)"
 Basic.Settings.Video.DownscaleFilter.Bicubic="Bicubic (Sharpened scaling, 16 samples)"
 Basic.Settings.Video.DownscaleFilter.Lanczos="Lanczos (Sharpened scaling, 32 samples)"
-Basic.Settings.Video.DownscaleFilter.Area="Area"
 
 # basic mode 'audio' settings
 Basic.Settings.Audio="Audio"

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3442,8 +3442,6 @@ static inline enum obs_scale_type GetScaleType(ConfigFile &basicConfig)
 		return OBS_SCALE_BILINEAR;
 	else if (astrcmpi(scaleTypeStr, "lanczos") == 0)
 		return OBS_SCALE_LANCZOS;
-	else if (astrcmpi(scaleTypeStr, "area") == 0)
-		return OBS_SCALE_AREA;
 	else
 		return OBS_SCALE_BICUBIC;
 }

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1314,9 +1314,6 @@ void OBSBasicSettings::LoadDownscaleFilters()
 	ui->downscaleFilter->addItem(
 			QTStr("Basic.Settings.Video.DownscaleFilter.Lanczos"),
 			QT_UTF8("lanczos"));
-	ui->downscaleFilter->addItem(
-			QTStr("Basic.Settings.Video.DownscaleFilter.Area"),
-			QT_UTF8("area"));
 
 	const char *scaleType = config_get_string(main->Config(),
 			"Video", "ScaleType");
@@ -1325,8 +1322,6 @@ void OBSBasicSettings::LoadDownscaleFilters()
 		ui->downscaleFilter->setCurrentIndex(0);
 	else if (astrcmpi(scaleType, "lanczos") == 0)
 		ui->downscaleFilter->setCurrentIndex(2);
-	else if (astrcmpi(scaleType, "area") == 0)
-		ui->downscaleFilter->setCurrentIndex(3);
 	else
 		ui->downscaleFilter->setCurrentIndex(1);
 }


### PR DESCRIPTION
Originally added for completeness but wasn't actually implemented
correctly. Can be added back later if desired.