### PR TITLE
image-source: Re-add fix of repeating images

### DIFF
--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -375,10 +375,15 @@ static void ss_update(void *data, obs_data_t *settings)
 		ss->transition = new_tr;
 	}
 
-	if (new_duration < 50)
-		new_duration = 50;
-	if (new_speed > (new_duration - 50))
-		new_speed = new_duration - 50;
+	if (strcmp(tr_name, "cut_transition") != 0) {
+		if (new_duration < 100)
+			new_duration = 100;
+
+		new_duration += new_speed;
+	} else {
+		if (new_duration < 50)
+			new_duration = 50;
+	}
 
 	ss->tr_speed = new_speed;
 	ss->tr_name = tr_name;
@@ -492,7 +497,7 @@ static void ss_next_slide(void *data)
 {
 	struct slideshow *ss = data;
 
-	if (!ss->files.num)
+	if (!ss->files.num || obs_transition_get_time(ss->transition) < 1.0f)
 		return;
 
 	if (++ss->cur_item >= ss->files.num)
@@ -505,7 +510,7 @@ static void ss_previous_slide(void *data)
 {
 	struct slideshow *ss = data;
 
-	if (!ss->files.num)
+	if (!ss->files.num || obs_transition_get_time(ss->transition) < 1.0f)
 		return;
 
 	if (ss->cur_item == 0)


### PR DESCRIPTION
With the dynamic loading of images being reverted, the fix for
this separate issue was also reverted.