### PR TITLE
libobs: Fix obs_property_float_set_limits

### DIFF
--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -789,7 +789,7 @@ void obs_property_int_set_limits(obs_property_t *p,
 void obs_property_float_set_limits(obs_property_t *p,
 		double min, double max, double step)
 {
-	struct float_data *data = get_type_data(p, OBS_PROPERTY_INT);
+	struct float_data *data = get_type_data(p, OBS_PROPERTY_FLOAT);
 	if (!data)
 		return;
 


### PR DESCRIPTION
This function incorrectly checked for an Integer type instead of a Float type, causing it to do nothing.