### PR TITLE
libobs: Add function to remove properties

### DIFF
--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -271,6 +271,31 @@ obs_property_t *obs_properties_get(obs_properties_t *props, const char *name)
 	return NULL;
 }
 
+void obs_properties_remove_by_name(obs_properties_t *props, const char *name)
+{
+	if (!props)
+		return;
+
+	/* obs_properties_t is a forward-linked-list, so we need to keep both
+	 * previous and current pointers around. That way we can fix up the
+	 * pointers for the previous element if we find a match.
+	 */
+	struct obs_property *cur = props->first_property;
+	struct obs_property *prev = props->first_property;
+
+	while (cur) {
+		if (strcmp(cur->name, name) == 0) {
+			prev->next = cur->next;
+			cur->next = 0;
+			obs_property_destroy(cur);
+			break;
+		}
+
+		prev = cur;
+		cur = cur->next;
+	}
+}
+
 void obs_properties_apply_settings(obs_properties_t *props, obs_data_t *settings)
 {
 	struct obs_property *p;

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -122,6 +122,19 @@ EXPORT obs_property_t *obs_properties_first(obs_properties_t *props);
 EXPORT obs_property_t *obs_properties_get(obs_properties_t *props,
 		const char *property);
 
+/** Remove a property from a properties list.
+ *
+ * Removes a property from a properties list. Only valid in either
+ * get_properties or modified_callback(2). modified_callback(2) must return
+ * true so that all UI properties are rebuilt and returning false is undefined
+ * behavior.
+ *
+ * @param props Properties to remove from.
+ * @param property Name of the property to remove.
+ */
+EXPORT void obs_properties_remove_by_name(obs_properties_t *props,
+		const char *property);
+
 /**
  * Applies settings to the properties by calling all the necessary
  * modification callbacks


### PR DESCRIPTION
At the moment it is not possible to properly create a dynamic workflow for sources and encoders which have a dynamic number of properties that change depending on other values. As these values most of the time can be changed by the user, fake names have to be used, which makes the code extremely complicated.

With this OBS Studio supports removing properties again in the modified_properties callback, however only if true is returned. Returning false and using the function is currently undefined behavior.