### PR TITLE
libobs: Fix invalid max_anisotropy value

### DIFF
--- a/libobs-opengl/gl-windows.c
+++ b/libobs-opengl/gl-windows.c
@@ -532,7 +532,7 @@ void device_enter_context(gs_device_t *device)
 		hdc = device->cur_swap->wi->hdc;
 
 	if (!wgl_make_current(hdc, device->plat->hrc))
-		blog(LOG_ERROR, "device_load_swapchain (GL) failed");
+		blog(LOG_ERROR, "device_enter_context (GL) failed");
 }
 
 void device_leave_context(gs_device_t *device)

--- a/libobs/graphics/shader-parser.c
+++ b/libobs/graphics/shader-parser.c
@@ -104,6 +104,8 @@ void shader_sampler_convert(struct shader_sampler *ss,
 	size_t i;
 	memset(info, 0, sizeof(struct gs_sampler_info));
 
+	info->max_anisotropy = 1;
+
 	for (i = 0; i < ss->states.num; i++) {
 		const char *state = ss->states.array[i];
 		const char *value = ss->values.array[i];

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -344,6 +344,7 @@ static int obs_init_graphics(struct obs_video_info *ovi)
 			NULL);
 	bfree(filename);
 
+	point_sampler.max_anisotropy = 1;
 	video->point_sampler = gs_samplerstate_create(&point_sampler);
 
 	obs->video.transparent_texture = gs_texture_create(2, 2, GS_RGBA, 1,


### PR DESCRIPTION
max_anisotropy is initialized to zero, but the minimum value is 1.