### PR TITLE
libobs: Fix output type specifiers

### DIFF
--- a/libobs/media-io/video-io.c
+++ b/libobs/media-io/video-io.c
@@ -400,7 +400,7 @@ static void log_skipped(video_t *video)
 		blog(LOG_INFO, "Video stopped, number of "
 				"skipped frames due "
 				"to encoding lag: "
-				"%"PRIu32"/%"PRIu32" (%0.1f%%)",
+				"%ld/%ld (%0.1f%%)",
 				video->skipped_frames,
 				video->total_frames,
 				percentage_skipped);


### PR DESCRIPTION
This causes warnings in build logs. This earlier change https://github.com/obsproject/obs-studio/commit/36ffa65b68b0a0e625d3aed717323e7794b73b0e altered the types of variables but didn't change the output specifiers. The current code yields undefined behavior.