### PR TITLE
UI: Remove and ignore obs.rc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ x64/
 ipch/
 GeneratedFiles/
 .moc/
+/UI/obs.rc
 
 /other/
 

--- a/UI/obs.rc
+++ b/UI/obs.rc
@@ -1,1 +1,0 @@
-IDI_ICON1 ICON DISCARDABLE "../cmake/winrc/obs-studio.ico"


### PR DESCRIPTION
Second time's the charm 😉 

This file gets automatically generated from obs.rc.in by CMake and
could get accidentally committed.

The info still gets generated correctly with this change.

![20-03-2019_03 10 54](https://user-images.githubusercontent.com/5058319/54654243-d1c2f500-4abd-11e9-86ea-141201c7def9.png)
