### PR TITLE
Simplify YUV conversion, and direct YUV444P support

### DIFF
--- a/deps/media-playback/media-playback/closest-format.h
+++ b/deps/media-playback/media-playback/closest-format.h
@@ -21,6 +21,8 @@ static enum AVPixelFormat closest_format(enum AVPixelFormat fmt)
 	switch (fmt) {
 	case AV_PIX_FMT_YUYV422:
 		return AV_PIX_FMT_YUYV422;
+	case AV_PIX_FMT_YUV444P:
+		return AV_PIX_FMT_YUV444P;
 
 	case AV_PIX_FMT_YUV422P:
 	case AV_PIX_FMT_YUVJ422P:

--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -34,6 +34,7 @@ static inline enum video_format convert_pixel_format(int f)
 	case AV_PIX_FMT_YUV420P: return VIDEO_FORMAT_I420;
 	case AV_PIX_FMT_NV12:    return VIDEO_FORMAT_NV12;
 	case AV_PIX_FMT_YUYV422: return VIDEO_FORMAT_YUY2;
+	case AV_PIX_FMT_YUV444P: return VIDEO_FORMAT_I444;
 	case AV_PIX_FMT_UYVY422: return VIDEO_FORMAT_UYVY;
 	case AV_PIX_FMT_RGBA:    return VIDEO_FORMAT_RGBA;
 	case AV_PIX_FMT_BGRA:    return VIDEO_FORMAT_BGRA;

--- a/libobs/data/area.effect
+++ b/libobs/data/area.effect
@@ -1,7 +1,4 @@
 uniform float4x4 ViewProj;
-uniform float4x4 color_matrix;
-uniform float3 color_range_min = {0.0, 0.0, 0.0};
-uniform float3 color_range_max = {1.0, 1.0, 1.0};
 uniform float2 base_dimension_i;
 uniform texture2d image;
 
@@ -57,65 +54,11 @@ float4 PSDrawAreaRGBA(VertInOut vert_in) : TARGET
 	return float4(totalcolor.rgb / totalcolor.a, totalcolor.a);
 }
 
-float3 ConvertFromYuv(float3 yuv)
-{
-	yuv = clamp(yuv, color_range_min, color_range_max);
-	return saturate(mul(float4(yuv, 1.0), color_matrix)).rgb;
-}
-
-float4 PSDrawAreaMatrix(VertInOut vert_in) : TARGET
-{
-	float3 totalcolor = float3(0.0, 0.0, 0.0);
-
-	float2 uv = vert_in.uv;
-	float2 uvdelta = float2(ddx(uv.x), ddy(uv.y));
-
-	// Handle potential OpenGL flip.
-	uvdelta.y = abs(uvdelta.y);
-
-	float2 uvhalfdelta = 0.5 * uvdelta;
-	float2 uvmin = uv - uvhalfdelta;
-	float2 uvmax = uv + uvhalfdelta;
-
-	int2 loadindexmin = int2(uvmin / base_dimension_i);
-	int2 loadindexmax = int2(uvmax / base_dimension_i);
-
-	float2 targetpos = uv / uvdelta;
-	float2 targetposmin = targetpos - 0.5;
-	float2 targetposmax = targetpos + 0.5;
-	float2 scale = base_dimension_i / uvdelta;
-	for (int loadindexy = loadindexmin.y; loadindexy <= loadindexmax.y; ++loadindexy)
-	{
-		for (int loadindexx = loadindexmin.x; loadindexx <= loadindexmax.x; ++loadindexx)
-		{
-			int2 loadindex = int2(loadindexx, loadindexy);
-			float2 potentialtargetmin = float2(loadindex) * scale;
-			float2 potentialtargetmax = potentialtargetmin + scale;
-			float2 targetmin = max(potentialtargetmin, targetposmin);
-			float2 targetmax = min(potentialtargetmax, targetposmax);
-			float area = (targetmax.x - targetmin.x) * (targetmax.y - targetmin.y);
-			float3 yuv = image.Load(int3(loadindex, 0)).xyz;
-			totalcolor += area * ConvertFromYuv(yuv);
-		}
-	}
-
-	return float4(totalcolor, 1.0);
-}
-
 technique Draw
 {
 	pass
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawAreaRGBA(vert_in);
-	}
-}
-
-technique DrawMatrix
-{
-	pass
-	{
-		vertex_shader = VSDefault(vert_in);
-		pixel_shader  = PSDrawAreaMatrix(vert_in);
 	}
 }

--- a/libobs/data/bicubic_scale.effect
+++ b/libobs/data/bicubic_scale.effect
@@ -7,8 +7,6 @@
 uniform float4x4 ViewProj;
 uniform texture2d image;
 uniform float4x4 color_matrix;
-uniform float3 color_range_min = {0.0, 0.0, 0.0};
-uniform float3 color_range_max = {1.0, 1.0, 1.0};
 uniform float2 base_dimension_i;
 uniform float undistort_factor = 1.0;
 
@@ -134,11 +132,9 @@ float4 PSDrawBicubicRGBA(VertData v_in, bool undistort) : TARGET
 
 float4 PSDrawBicubicMatrix(VertData v_in) : TARGET
 {
-	float4 rgba = DrawBicubic(v_in, false);
-	float4 yuv;
-
-	yuv.xyz = clamp(rgba.xyz, color_range_min, color_range_max);
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+	float3 rgb = DrawBicubic(v_in, false).rgb;
+	float3 yuv = mul(float4(saturate(rgb), 1.0), color_matrix).xyz;
+	return float4(yuv, 1.0);
 }
 
 technique Draw

--- a/libobs/data/bilinear_lowres_scale.effect
+++ b/libobs/data/bilinear_lowres_scale.effect
@@ -6,8 +6,6 @@
 uniform float4x4 ViewProj;
 uniform texture2d image;
 uniform float4x4 color_matrix;
-uniform float3 color_range_min = {0.0, 0.0, 0.0};
-uniform float3 color_range_max = {1.0, 1.0, 1.0};
 uniform float2 base_dimension_i;
 
 sampler_state textureSampler {
@@ -58,10 +56,9 @@ float4 PSDrawLowresBilinearRGBA(VertData v_in) : TARGET
 
 float4 PSDrawLowresBilinearMatrix(VertData v_in) : TARGET
 {
-	float4 yuv = DrawLowresBilinear(v_in);
-
-	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max);
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+	float3 rgb = DrawLowresBilinear(v_in);
+	float3 yuv = mul(float4(saturate(rgb), 1.0), color_matrix).xyz;
+	return float4(yuv, 1.0);
 }
 
 technique Draw

--- a/libobs/data/default.effect
+++ b/libobs/data/default.effect
@@ -1,7 +1,5 @@
 uniform float4x4 ViewProj;
 uniform float4x4 color_matrix;
-uniform float3 color_range_min = {0.0, 0.0, 0.0};
-uniform float3 color_range_max = {1.0, 1.0, 1.0};
 uniform texture2d image;
 
 sampler_state def_sampler {
@@ -30,9 +28,9 @@ float4 PSDrawBare(VertInOut vert_in) : TARGET
 
 float4 PSDrawMatrix(VertInOut vert_in) : TARGET
 {
-	float4 yuv = image.Sample(def_sampler, vert_in.uv);
-	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max);
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+	float3 rgb = image.Sample(def_sampler, vert_in.uv).rgb;
+	float3 yuv = mul(float4(saturate(rgb), 1.0), color_matrix).xyz;
+	return float4(yuv, 1.0);
 }
 
 technique Draw

--- a/libobs/data/deinterlace_base.effect
+++ b/libobs/data/deinterlace_base.effect
@@ -18,9 +18,6 @@
 
 uniform float4x4 ViewProj;
 uniform texture2d image;
-uniform float4x4 color_matrix;
-uniform float3 color_range_min = {0.0, 0.0, 0.0};
-uniform float3 color_range_max = {1.0, 1.0, 1.0};
 
 uniform texture2d previous_image;
 uniform float2 dimensions;
@@ -267,27 +264,12 @@ VertData VSDefault(VertData v_in)
 	return vert_out;
 }
 
-#define TECHNIQUE(rgba_ps, matrix_ps) \
+#define TECHNIQUE(rgba_ps) \
 technique Draw \
 { \
 	pass \
 	{ \
 		vertex_shader = VSDefault(v_in); \
 		pixel_shader  = rgba_ps(v_in); \
-	} \
-} \
-float4 matrix_ps(VertData v_in) : TARGET \
-{ \
-	float4 yuv = rgba_ps(v_in); \
-	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max); \
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix)); \
-} \
-\
-technique DrawMatrix \
-{ \
-	pass \
-	{ \
-		vertex_shader = VSDefault(v_in); \
-		pixel_shader  = matrix_ps(v_in); \
 	} \
 }

--- a/libobs/data/deinterlace_blend.effect
+++ b/libobs/data/deinterlace_blend.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE( PSBlendRGBA, PSBlendMatrix);
+TECHNIQUE(PSBlendRGBA);

--- a/libobs/data/deinterlace_blend_2x.effect
+++ b/libobs/data/deinterlace_blend_2x.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSBlendRGBA_2x, PSBlendMatrix_2x);
+TECHNIQUE(PSBlendRGBA_2x);

--- a/libobs/data/deinterlace_discard.effect
+++ b/libobs/data/deinterlace_discard.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSDiscardRGBA, PSDiscardMatrix);
+TECHNIQUE(PSDiscardRGBA);

--- a/libobs/data/deinterlace_discard_2x.effect
+++ b/libobs/data/deinterlace_discard_2x.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSDiscardRGBA_2x, PSDiscardMatrix_2x);
+TECHNIQUE(PSDiscardRGBA_2x);

--- a/libobs/data/deinterlace_linear.effect
+++ b/libobs/data/deinterlace_linear.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSLinearRGBA, PSLinearMatrix);
+TECHNIQUE(PSLinearRGBA);

--- a/libobs/data/deinterlace_linear_2x.effect
+++ b/libobs/data/deinterlace_linear_2x.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSLinearRGBA_2x, PSLinearxMatrixA_2x);
+TECHNIQUE(PSLinearRGBA_2x);

--- a/libobs/data/deinterlace_yadif.effect
+++ b/libobs/data/deinterlace_yadif.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSYadifMode0RGBA, PSYadifMode0Matrix);
+TECHNIQUE(PSYadifMode0RGBA);

--- a/libobs/data/deinterlace_yadif_2x.effect
+++ b/libobs/data/deinterlace_yadif_2x.effect
@@ -18,4 +18,4 @@
 
 #include "deinterlace_base.effect"
 
-TECHNIQUE(PSYadifMode0RGBA_2x, PSYadifMode0Matrix_2x);
+TECHNIQUE(PSYadifMode0RGBA_2x);

--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -42,6 +42,10 @@ uniform int       int_input_width;
 uniform int       int_u_plane_offset;
 uniform int       int_v_plane_offset;
 
+uniform float4x4  color_matrix;
+uniform float3    color_range_min = {0.0, 0.0, 0.0};
+uniform float3    color_range_max = {1.0, 1.0, 1.0};
+
 uniform texture2d image;
 
 sampler_state def_sampler {
@@ -283,8 +287,10 @@ float4 PSPacked422_Reverse(VertInOut vert_in, int u_pos, int v_pos,
 	x += input_width_i_d2;
 
 	float4 texel = image.Sample(def_sampler, float2(x, y));
-	return float4(odd > 0.5 ? texel[y1_pos] : texel[y0_pos],
-			texel[u_pos], texel[v_pos], 1.0);
+	float3 yuv = float3(odd > 0.5 ? texel[y1_pos] : texel[y0_pos],
+			texel[u_pos], texel[v_pos]);
+	yuv = clamp(yuv, color_range_min, color_range_max);
+	return saturate(mul(float4(yuv, 1.0), color_matrix));
 }
 
 float4 PSPlanar420_Reverse(VertInOut vert_in) : TARGET
@@ -297,12 +303,32 @@ float4 PSPlanar420_Reverse(VertInOut vert_in) : TARGET
 	int chroma1    = int_u_plane_offset + chroma_offset;
 	int chroma2    = int_v_plane_offset + chroma_offset;
 
-	return float4(
+	float3 yuv = float3(
 		GetIntOffsetColor(lum_offset),
 		GetIntOffsetColor(chroma1),
-		GetIntOffsetColor(chroma2),
-		1.0
+		GetIntOffsetColor(chroma2)
 	);
+	yuv = clamp(yuv, color_range_min, color_range_max);
+	return saturate(mul(float4(yuv, 1.0), color_matrix));
+}
+
+float4 PSPlanar444_Reverse(VertInOut vert_in) : TARGET
+{
+	int x = int(vert_in.uv.x * width  + PRECISION_OFFSET);
+	int y = int(vert_in.uv.y * height + PRECISION_OFFSET);
+
+	int lum_offset = y * int_width + x;
+	int chroma_offset = y * int_width + x;
+	int chroma1    = int_u_plane_offset + chroma_offset;
+	int chroma2    = int_v_plane_offset + chroma_offset;
+
+	float3 yuv = float3(
+		GetIntOffsetColor(lum_offset),
+		GetIntOffsetColor(chroma1),
+		GetIntOffsetColor(chroma2)
+	);
+	yuv = clamp(yuv, color_range_min, color_range_max);
+	return saturate(mul(float4(yuv, 1.0), color_matrix));
 }
 
 float4 PSNV12_Reverse(VertInOut vert_in) : TARGET
@@ -314,12 +340,13 @@ float4 PSNV12_Reverse(VertInOut vert_in) : TARGET
 	int chroma_offset = (y / 2) * (int_width / 2) + x / 2;
 	int chroma        = int_u_plane_offset + chroma_offset * 2;
 
-	return float4(
+	float3 yuv = float3(
 		GetIntOffsetColor(lum_offset),
 		GetIntOffsetColor(chroma),
-		GetIntOffsetColor(chroma + 1),
-		1.0
+		GetIntOffsetColor(chroma + 1)
 	);
+	yuv = clamp(yuv, color_range_min, color_range_max);
+	return saturate(mul(float4(yuv, 1.0), color_matrix));
 }
 
 technique Planar420
@@ -400,6 +427,15 @@ technique I420_Reverse
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSPlanar420_Reverse(vert_in);
+	}
+}
+
+technique I444_Reverse
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSPlanar444_Reverse(vert_in);
 	}
 }
 

--- a/libobs/data/lanczos_scale.effect
+++ b/libobs/data/lanczos_scale.effect
@@ -7,8 +7,6 @@
 uniform float4x4 ViewProj;
 uniform texture2d image;
 uniform float4x4 color_matrix;
-uniform float3 color_range_min = {0.0, 0.0, 0.0};
-uniform float3 color_range_max = {1.0, 1.0, 1.0};
 uniform float2 base_dimension_i;
 uniform float undistort_factor = 1.0;
 
@@ -142,11 +140,9 @@ float4 PSDrawLanczosRGBA(FragData v_in, bool undistort) : TARGET
 
 float4 PSDrawLanczosMatrix(FragData v_in) : TARGET
 {
-	float4 rgba = DrawLanczos(v_in, false);
-	float4 yuv;
-
-	yuv.xyz = clamp(rgba.xyz, color_range_min, color_range_max);
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
+	float3 rgb = DrawLanczos(v_in, false).rgb;
+	float3 yuv = mul(float4(saturate(rgb), 1.0), color_matrix).xyz;
+	return float4(yuv, 1.0);
 }
 
 technique Draw

--- a/libobs/data/repeat.effect
+++ b/libobs/data/repeat.effect
@@ -1,7 +1,4 @@
 uniform float4x4 ViewProj;
-uniform float4x4 color_matrix;
-uniform float3 color_range_min = {0.0, 0.0, 0.0};
-uniform float3 color_range_max = {1.0, 1.0, 1.0};
 uniform texture2d image;
 uniform float2 scale;
 
@@ -29,27 +26,11 @@ float4 PSDrawBare(VertInOut vert_in) : TARGET
 	return image.Sample(def_sampler, vert_in.uv);
 }
 
-float4 PSDrawMatrix(VertInOut vert_in) : TARGET
-{
-	float4 yuv = image.Sample(def_sampler, vert_in.uv);
-	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max);
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
-}
-
 technique Draw
 {
 	pass
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawBare(vert_in);
-	}
-}
-
-technique DrawMatrix
-{
-	pass
-	{
-		vertex_shader = VSDefault(vert_in);
-		pixel_shader  = PSDrawMatrix(vert_in);
 	}
 }

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -645,10 +645,6 @@ struct obs_source {
 	enum video_format               async_format;
 	enum video_format               async_cache_format;
 	enum gs_color_format            async_texture_format;
-	float                           async_color_matrix[16];
-	bool                            async_full_range;
-	float                           async_color_range_min[3];
-	float                           async_color_range_max[3];
 	int                             async_plane_offset[2];
 	bool                            async_flip;
 	bool                            async_active;


### PR DESCRIPTION
These changes move YUV -> RGB from later shaders into the earlier format conversion shaders. I444 was not covered, and format conversion had to be implemented. This paves the way for changes like #1713 to simplify and speed up by good amounts. See commit descriptions for details.

I have tested all code diffs at least once in some fashion, so I feel decent about this change.