### PR TITLE
libobs: Raise max caption output lines limit from 4 to 15

### DIFF
--- a/UI/frontend-plugins/frontend-tools/captions-mssapi.cpp
+++ b/UI/frontend-plugins/frontend-tools/captions-mssapi.cpp
@@ -6,6 +6,8 @@
 #define error(format, ...) do_log(LOG_ERROR, format, ##__VA_ARGS__)
 #define debug(format, ...) do_log(LOG_DEBUG, format, ##__VA_ARGS__)
 
+#define MSS_CAPTION_MAX_LENGTH (4*32)
+
 mssapi_captions::mssapi_captions(
 		captions_cb callback,
 		const std::string &lang) try
@@ -138,8 +140,12 @@ try {
 				if (FAILED(hr))
 					continue;
 
+				wchar_t capped[MSS_CAPTION_MAX_LENGTH+1];
+				swprintf(capped, MSS_CAPTION_MAX_LENGTH+1, L"%.*s",
+						(int)wcslen(text), (wchar_t *)text);
+
 				char text_utf8[512];
-				os_wcs_to_utf8(text, 0, text_utf8, 512);
+				os_wcs_to_utf8(capped, 0, text_utf8, 512);
 
 				callback(text_utf8);
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -841,7 +841,7 @@ struct obs_weak_output {
 };
 
 #define CAPTION_LINE_CHARS (32)
-#define CAPTION_LINE_BYTES (4*CAPTION_LINE_CHARS)
+#define CAPTION_LINE_BYTES (15*CAPTION_LINE_CHARS)
 struct caption_text {
 	char text[CAPTION_LINE_BYTES+1];
 	struct caption_text *next;


### PR DESCRIPTION
Currently all captions output is limit to at most 4 lines of 32 chars each even though the standard and libcaption allow for 15 lines. This appears to just be an aesthetic choice for the Windows Text-To-Speech provider. 

This adjusts the global limit to 15 lines so that everything else can use caption output unrestricted. The Windows TTS provider captions get shortened to 4 lines locally now to keep those looking the same.

This would be very useful when adding new caption providers for accessibility once captions are useable via scripting. Having only 4 lines to work with is very restricting currently.

Tested with 15 lines on Twitch successfully.
