### PR TITLE
libobs: Fix Area scale filter for GLSL

### DIFF
--- a/libobs/data/area.effect
+++ b/libobs/data/area.effect
@@ -28,30 +28,30 @@ float4 PSDrawAreaRGBA(VertInOut vert_in) : TARGET
 {
 	float4 totalcolor = float4(0.0, 0.0, 0.0, 0.0);
 
-	const float2 uv = vert_in.uv;
-	const float2 uvdelta = float2(ddx(uv.x), ddy(uv.y));
+	float2 uv = vert_in.uv;
+	float2 uvdelta = float2(ddx(uv.x), ddy(uv.y));
 
-	const float2 uvhalfdelta = 0.5 * uvdelta;
-	const float2 uvmin = uv - uvhalfdelta;
-	const float2 uvmax = uv + uvhalfdelta;
+	float2 uvhalfdelta = 0.5 * uvdelta;
+	float2 uvmin = uv - uvhalfdelta;
+	float2 uvmax = uv + uvhalfdelta;
 
-	const int2 loadindexmin = int2(uvmin / base_dimension_i);
-	const int2 loadindexmax = int2(uvmax / base_dimension_i);
+	int2 loadindexmin = int2(uvmin / base_dimension_i);
+	int2 loadindexmax = int2(uvmax / base_dimension_i);
 
-	const float2 targetpos = uv / uvdelta;
-	const float2 targetposleft = targetpos - 0.5;
-	const float2 targetposright = targetpos + 0.5;
+	float2 targetpos = uv / uvdelta;
+	float2 targetposleft = targetpos - 0.5;
+	float2 targetposright = targetpos + 0.5;
 	for (int loadindexy = loadindexmin.y; loadindexy <= loadindexmax.y; ++loadindexy)
 	{
 		for (int loadindexx = loadindexmin.x; loadindexx <= loadindexmax.x; ++loadindexx)
 		{
-			const float2 loadindex = float2(loadindexx, loadindexy);
-			const float2 potentialtargetmin = loadindex / uvdelta * base_dimension_i;
-			const float2 potentialtargetmax = (loadindex + 1.0) / uvdelta * base_dimension_i;
-			const float2 targetmin = max(potentialtargetmin, targetposleft);
-			const float2 targetmax = min(potentialtargetmax, targetposright);
-			const float area = (targetmax.x - targetmin.x) * (targetmax.y - targetmin.y);
-			const float4 sample = image.SampleLevel(def_sampler, (loadindex + 0.5) * base_dimension_i, 0.0);
+			float2 loadindex = float2(loadindexx, loadindexy);
+			float2 potentialtargetmin = loadindex / uvdelta * base_dimension_i;
+			float2 potentialtargetmax = (loadindex + 1.0) / uvdelta * base_dimension_i;
+			float2 targetmin = max(potentialtargetmin, targetposleft);
+			float2 targetmax = min(potentialtargetmax, targetposright);
+			float area = (targetmax.x - targetmin.x) * (targetmax.y - targetmin.y);
+			float4 sample = image.SampleLevel(def_sampler, (loadindex + 0.5) * base_dimension_i, 0.0);
 			totalcolor += area * float4(sample.rgb * sample.a, sample.a);
 		}
 	}
@@ -69,30 +69,30 @@ float4 PSDrawAreaMatrix(VertInOut vert_in) : TARGET
 {
 	float3 totalcolor = float3(0.0, 0.0, 0.0);
 
-	const float2 uv = vert_in.uv;
-	const float2 uvdelta = float2(ddx(uv.x), ddy(uv.y));
+	float2 uv = vert_in.uv;
+	float2 uvdelta = float2(ddx(uv.x), ddy(uv.y));
 
-	const float2 uvhalfdelta = 0.5 * uvdelta;
-	const float2 uvmin = uv - uvhalfdelta;
-	const float2 uvmax = uv + uvhalfdelta;
+	float2 uvhalfdelta = 0.5 * uvdelta;
+	float2 uvmin = uv - uvhalfdelta;
+	float2 uvmax = uv + uvhalfdelta;
 
-	const int2 loadindexmin = int2(uvmin / base_dimension_i);
-	const int2 loadindexmax = int2(uvmax / base_dimension_i);
+	int2 loadindexmin = int2(uvmin / base_dimension_i);
+	int2 loadindexmax = int2(uvmax / base_dimension_i);
 
-	const float2 targetpos = uv / uvdelta;
-	const float2 targetposleft = targetpos - 0.5;
-	const float2 targetposright = targetpos + 0.5;
+	float2 targetpos = uv / uvdelta;
+	float2 targetposleft = targetpos - 0.5;
+	float2 targetposright = targetpos + 0.5;
 	for (int loadindexy = loadindexmin.y; loadindexy <= loadindexmax.y; ++loadindexy)
 	{
 		for (int loadindexx = loadindexmin.x; loadindexx <= loadindexmax.x; ++loadindexx)
 		{
-			const float2 loadindex = float2(loadindexx, loadindexy);
-			const float2 potentialtargetmin = loadindex / uvdelta * base_dimension_i;
-			const float2 potentialtargetmax = (loadindex + 1.0) / uvdelta * base_dimension_i;
-			const float2 targetmin = max(potentialtargetmin, targetposleft);
-			const float2 targetmax = min(potentialtargetmax, targetposright);
-			const float area = (targetmax.x - targetmin.x) * (targetmax.y - targetmin.y);
-			const float3 yuv = image.SampleLevel(def_sampler, (loadindex + 0.5) * base_dimension_i, 0.0).xyz;
+			float2 loadindex = float2(loadindexx, loadindexy);
+			float2 potentialtargetmin = loadindex / uvdelta * base_dimension_i;
+			float2 potentialtargetmax = (loadindex + 1.0) / uvdelta * base_dimension_i;
+			float2 targetmin = max(potentialtargetmin, targetposleft);
+			float2 targetmax = min(potentialtargetmax, targetposright);
+			float area = (targetmax.x - targetmin.x) * (targetmax.y - targetmin.y);
+			float3 yuv = image.SampleLevel(def_sampler, (loadindex + 0.5) * base_dimension_i, 0.0).xyz;
 			totalcolor += area * ConvertFromYuv(yuv);
 		}
 	}


### PR DESCRIPTION
Remove const qualifiers because they are syntax errors for GLSL when
used like in C.