### PR TITLE
obs-filters: Remove unused function in shader

### DIFF
--- a/plugins/obs-filters/data/color_key_filter.effect
+++ b/plugins/obs-filters/data/color_key_filter.effect
@@ -39,13 +39,6 @@ float GetColorDist(float3 rgb)
 	return distance(key_color.rgb, rgb);
 }
 
-float4 SampleYUVToRGB(float2 uv)
-{
-	float4 yuv = image.Sample(textureSampler, uv);
-	yuv.xyz = clamp(yuv.xyz, color_range_min, color_range_max);
-	return saturate(mul(float4(yuv.xyz, 1.0), color_matrix));
-}
-
 float4 ProcessColorKey(float4 rgba, VertData v_in)
 {
 	float colorDist = GetColorDist(rgba.rgb);


### PR DESCRIPTION
SampleYUVToRGB() is no longer used after the previous DrawMatrix purge.