### PR TITLE
Fix VAAPI CBR

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -193,6 +193,7 @@ static bool vaapi_update(void *data, obs_data_t *settings)
 	enc->context->max_b_frames = bf;
 	enc->context->level        = level;
 	enc->context->bit_rate     = bitrate * 1000;
+	enc->context->rc_max_rate  = bitrate * 1000;
 
 	enc->context->width  = obs_encoder_get_width(enc->encoder);
 	enc->context->height = obs_encoder_get_height(enc->encoder);


### PR DESCRIPTION
In my setup, while VAAPI encoding works, the output bitrate varies wildly. Using examples from the FFmpeg wiki, I devised this patch that makes the bitrate more stable.

According to the FFmpeg wiki, the configuration created by the VAAPI plugin for FFmpeg is referred to as VBR. Setting maxrate makes it CBR. Reference: https://trac.ffmpeg.org/wiki/Hardware/VAAPI#Encode-only