### PR TITLE
UI: Add start fresh button in advanced settings

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -589,7 +589,9 @@ Basic.MainMenu.Help.About="&About"
 # basic mode settings dialog
 Basic.Settings.ProgramRestart="The program must be restarted for these settings to take effect."
 Basic.Settings.ConfirmTitle="Confirm Changes"
-Basic.Settings.Confirm="You have unsaved changes. Save changes?"
+Basic.Settings.Confirm="You have unsaved changes.  Save changes?"
+Basic.Settings.StartFresh="Start Fresh"
+Basic.Settings.StartFresh.Confirm="WARNING! This will permanently delete your profiles and scene collections and start all over. Are you sure you want to do this?"
 
 # basic mode 'general' settings
 Basic.Settings.General="General"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -151,8 +151,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>808</width>
-              <height>989</height>
+              <width>804</width>
+              <height>1225</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -1173,8 +1173,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>747</width>
-              <height>808</height>
+              <width>813</width>
+              <height>770</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -4471,9 +4471,9 @@
             <property name="geometry">
              <rect>
               <x>0</x>
-              <y>0</y>
-              <width>765</width>
-              <height>993</height>
+              <y>-430</y>
+              <width>806</width>
+              <height>1061</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -5192,6 +5192,19 @@
                     </spacer>
                    </item>
                   </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="startFresh">
+                  <property name="maximumSize">
+                   <size>
+                    <width>125</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Basic.Settings.StartFresh</string>
+                  </property>
                  </widget>
                 </item>
                </layout>

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -34,6 +34,7 @@
 #include <QScreen>
 #include <QStandardItemModel>
 #include <QSpacerItem>
+#include <QProcess>
 
 #include "audio-encoders.hpp"
 #include "hotkey-edit.hpp"
@@ -563,6 +564,9 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 			this, SLOT(UpdateStreamDelayEstimate()));
 	connect(ui->advOutTrack6Bitrate, SIGNAL(currentIndexChanged(int)),
 			this, SLOT(UpdateStreamDelayEstimate()));
+
+	connect(ui->startFresh, SIGNAL(clicked()), this, SLOT(StartFresh()));
+	ui->startFresh->setEnabled(!obs_video_active());
 
 	//Apply button disabled until change.
 	EnableApplyButton(false);
@@ -3385,22 +3389,24 @@ bool OBSBasicSettings::QueryChanges()
 {
 	QMessageBox::StandardButton button;
 
-	button = OBSMessageBox::question(this,
-			QTStr("Basic.Settings.ConfirmTitle"),
-			QTStr("Basic.Settings.Confirm"),
-			QMessageBox::Yes | QMessageBox::No |
-			QMessageBox::Cancel);
+	if (!forceRestart) {
+		button = OBSMessageBox::question(this,
+				QTStr("Basic.Settings.ConfirmTitle"),
+				QTStr("Basic.Settings.Confirm"),
+				QMessageBox::Yes | QMessageBox::No |
+				QMessageBox::Cancel);
 
-	if (button == QMessageBox::Cancel) {
-		return false;
-	} else if (button == QMessageBox::Yes) {
-		SaveSettings();
-	} else {
-		LoadSettings(true);
+		if (button == QMessageBox::Cancel) {
+			return false;
+		} else if (button == QMessageBox::Yes) {
+			SaveSettings();
+		} else {
+			LoadSettings(true);
 #ifdef _WIN32
-		if (toggleAero)
-			SetAeroEnabled(!aeroWasDisabled);
+			if (toggleAero)
+				SetAeroEnabled(!aeroWasDisabled);
 #endif
+		}
 	}
 
 	ClearChanged();
@@ -4536,4 +4542,32 @@ void OBSBasicSettings::SetHotkeysIcon(const QIcon &icon)
 void OBSBasicSettings::SetAdvancedIcon(const QIcon &icon)
 {
 	ui->listWidget->item(6)->setIcon(icon);
+}
+
+void OBSBasicSettings::StartFresh()
+{
+	QMessageBox::StandardButton button = QMessageBox::question(this,
+			QTStr("Basic.Settings.StartFresh"),
+			QTStr("Basic.Settings.StartFresh.Confirm"),
+			QMessageBox::Yes | QMessageBox::No,
+			QMessageBox::No);
+
+	if (button == QMessageBox::No) 
+		return;
+
+	char configDir[512];
+	int ret = GetConfigPath(configDir, sizeof(configDir),
+			"obs-studio/");
+
+	/* Check user dir first. */
+	if (ret > 0) {
+		forceRestart = true;
+		QDir dir(QT_UTF8(configDir));
+		dir.removeRecursively();
+
+		QProcess::startDetached(qApp->arguments()[0],
+				qApp->arguments());
+
+		main->close();
+	}
 }

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -116,6 +116,7 @@ private:
 	bool videoChanged = false;
 	bool hotkeysChanged = false;
 	bool advancedChanged = false;
+	bool forceRestart = false;
 	int  pageIndex = 0;
 	bool loading = true;
 	std::string savedTheme;
@@ -241,6 +242,7 @@ private slots:
 	void on_disconnectAccount_clicked();
 	void on_useStreamKey_clicked();
 	void on_useAuth_toggled();
+	void StartFresh();
 private:
 
 	/* output */


### PR DESCRIPTION
This adds a "Start Fresh" button in the advanced settings which deletes
the user's profiles and scene collections and starts all over. My main
concern with this, is that a user would accidently click this and delete
all of their stuff. But it is buried in the advanced settings, and there
is a confirmation box with a explicit warning in it.