### PR TITLE
Improve ffmpeg output error handling

### DIFF
--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -90,6 +90,30 @@ void OBSMessageBox::information(
 	mb.exec();
 }
 
+void OBSMessageBox::warning(
+	QWidget *parent,
+	const QString &title,
+	const QString &text)
+{
+	QMessageBox mb(QMessageBox::Warning,
+		title, text, QMessageBox::Ok,
+		parent);
+	mb.setButtonText(QMessageBox::Ok, QTStr("OK"));
+	mb.exec();
+}
+
+void OBSMessageBox::critical(
+	QWidget *parent,
+	const QString &title,
+	const QString &text)
+{
+	QMessageBox mb(QMessageBox::Critical,
+		title, text, QMessageBox::Ok,
+		parent);
+	mb.setButtonText(QMessageBox::Ok, QTStr("OK"));
+	mb.exec();
+}
+
 void QTToGSWindow(WId windowId, gs_window &gswindow)
 {
 #ifdef _WIN32

--- a/UI/qt-wrappers.hpp
+++ b/UI/qt-wrappers.hpp
@@ -48,6 +48,14 @@ public:
 			QWidget *parent,
 			const QString &title,
 			const QString &text);
+	static void warning(
+		QWidget *parent,
+		const QString &title,
+		const QString &text);
+	static void critical(
+		QWidget *parent,
+		const QString &title,
+		const QString &text);
 };
 
 void OBSErrorBox(QWidget *parent, const char *msg, ...);

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -434,7 +434,7 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 			return;
 
 		if (name.empty()) {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("NoNameEntered.Title"),
 					QTStr("NoNameEntered.Text"));
 			AddNewFilter(id);
@@ -444,7 +444,7 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 		existing_filter = obs_source_get_filter_by_name(source,
 				name.c_str());
 		if (existing_filter) {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("NameExists.Title"),
 					QTStr("NameExists.Text"));
 			obs_source_release(existing_filter);

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -63,7 +63,8 @@ static void OBSStopStreaming(void *data, calldata_t *params)
 	output->delayActive = false;
 	os_atomic_set_bool(&streaming_active, false);
 	QMetaObject::invokeMethod(output->main,
-			"StreamingStop", Q_ARG(int, code), Q_ARG(QString, arg_last_error));
+			"StreamingStop", Q_ARG(int, code),
+			Q_ARG(QString, arg_last_error));
 }
 
 static void OBSStartRecording(void *data, calldata_t *params)
@@ -81,11 +82,15 @@ static void OBSStopRecording(void *data, calldata_t *params)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler*>(data);
 	int code = (int)calldata_int(params, "code");
+	const char *last_error = calldata_string(params, "last_error");
+
+	QString arg_last_error = QString::fromUtf8(last_error);
 
 	output->recordingActive = false;
 	os_atomic_set_bool(&recording_active, false);
 	QMetaObject::invokeMethod(output->main,
-			"RecordingStop", Q_ARG(int, code));
+			"RecordingStop", Q_ARG(int, code),
+			Q_ARG(QString, arg_last_error));
 
 	UNUSED_PARAMETER(params);
 }
@@ -891,7 +896,7 @@ bool SimpleOutput::ConfigureRecording(bool updateReplayBuffer)
 
 	if (!dir) {
 		if (main->isVisible())
-			OBSMessageBox::information(main,
+			OBSMessageBox::warning(main,
 					QTStr("Output.BadPath.Title"),
 					QTStr("Output.BadPath.Text"));
 		else
@@ -1658,7 +1663,7 @@ bool AdvancedOutput::StartRecording()
 
 		if (!dir) {
 			if (main->isVisible())
-				OBSMessageBox::information(main,
+				OBSMessageBox::warning(main,
 						QTStr("Output.BadPath.Title"),
 						QTStr("Output.BadPath.Text"));
 			else
@@ -1758,7 +1763,7 @@ bool AdvancedOutput::StartReplayBuffer()
 
 		if (!dir) {
 			if (main->isVisible())
-				OBSMessageBox::information(main,
+				OBSMessageBox::warning(main,
 						QTStr("Output.BadPath.Title"),
 						QTStr("Output.BadPath.Text"));
 			else

--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -107,13 +107,13 @@ static bool GetProfileName(QWidget *parent, std::string &name,
 			return false;
 		}
 		if (name.empty()) {
-			OBSMessageBox::information(parent,
+			OBSMessageBox::warning(parent,
 					QTStr("NoNameEntered.Title"),
 					QTStr("NoNameEntered.Text"));
 			continue;
 		}
 		if (ProfileExists(name.c_str())) {
-			OBSMessageBox::information(parent,
+			OBSMessageBox::warning(parent,
 					QTStr("NameExists.Title"),
 					QTStr("NameExists.Text"));
 			continue;
@@ -526,7 +526,7 @@ void OBSBasic::on_actionImportProfile_triggered()
 					profileDir + "/recordEncoder.json");
 			RefreshProfiles();
 		} else {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("Basic.MainMenu.Profile.Import"),
 					QTStr("Basic.MainMenu.Profile.Exists"));
 		}

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -114,13 +114,13 @@ static bool GetSceneCollectionName(QWidget *parent, std::string &name,
 			return false;
 		}
 		if (name.empty()) {
-			OBSMessageBox::information(parent,
+			OBSMessageBox::warning(parent,
 					QTStr("NoNameEntered.Title"),
 					QTStr("NoNameEntered.Text"));
 			continue;
 		}
 		if (SceneCollectionExists(name.c_str())) {
-			OBSMessageBox::information(parent,
+			OBSMessageBox::warning(parent,
 					QTStr("NameExists.Title"),
 					QTStr("NameExists.Text"));
 			continue;

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -453,7 +453,7 @@ void OBSBasic::AddTransition()
 
 	if (accepted) {
 		if (name.empty()) {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("NoNameEntered.Title"),
 					QTStr("NoNameEntered.Text"));
 			AddTransition();
@@ -462,7 +462,7 @@ void OBSBasic::AddTransition()
 
 		source = FindTransition(name.c_str());
 		if (source) {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("NameExists.Title"),
 					QTStr("NameExists.Text"));
 
@@ -559,7 +559,7 @@ void OBSBasic::RenameTransition()
 
 	if (accepted) {
 		if (name.empty()) {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("NoNameEntered.Title"),
 					QTStr("NoNameEntered.Text"));
 			RenameTransition();
@@ -568,7 +568,7 @@ void OBSBasic::RenameTransition()
 
 		source = FindTransition(name.c_str());
 		if (source) {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("NameExists.Title"),
 					QTStr("NameExists.Text"));
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2790,7 +2790,7 @@ void OBSBasic::MixerRenameSource()
 			return;
 
 		if (name.empty()) {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("NoNameEntered.Title"),
 					QTStr("NoNameEntered.Text"));
 			continue;
@@ -2800,7 +2800,7 @@ void OBSBasic::MixerRenameSource()
 		obs_source_release(sourceTest);
 
 		if (sourceTest) {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("NameExists.Title"),
 					QTStr("NameExists.Text"));
 			continue;
@@ -3165,7 +3165,7 @@ void OBSBasic::DuplicateSelectedScene()
 			return;
 
 		if (name.empty()) {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("NoNameEntered.Title"),
 					QTStr("NoNameEntered.Text"));
 			continue;
@@ -3173,7 +3173,7 @@ void OBSBasic::DuplicateSelectedScene()
 
 		obs_source_t *source = obs_get_source_by_name(name.c_str());
 		if (source) {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("NameExists.Title"),
 					QTStr("NameExists.Text"));
 
@@ -4109,7 +4109,7 @@ void OBSBasic::on_actionAddScene_triggered()
 
 	if (accepted) {
 		if (name.empty()) {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("NoNameEntered.Title"),
 					QTStr("NoNameEntered.Text"));
 			on_actionAddScene_triggered();
@@ -4118,7 +4118,7 @@ void OBSBasic::on_actionAddScene_triggered()
 
 		obs_source_t *source = obs_get_source_by_name(name.c_str());
 		if (source) {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("NameExists.Title"),
 					QTStr("NameExists.Text"));
 
@@ -4869,7 +4869,7 @@ void OBSBasic::logUploadFinished(const QString &text, const QString &error)
 	ui->menuLogFiles->setEnabled(true);
 
 	if (text.isEmpty()) {
-		OBSMessageBox::information(this,
+		OBSMessageBox::critical(this,
 				QTStr("LogReturnDialog.ErrorUploadingLog"),
 				error);
 		return;
@@ -4898,11 +4898,11 @@ static void RenameListItem(OBSBasic *parent, QListWidget *listWidget,
 		listItem->setText(QT_UTF8(prevName));
 
 		if (foundSource) {
-			OBSMessageBox::information(parent,
+			OBSMessageBox::warning(parent,
 				QTStr("NameExists.Title"),
 				QTStr("NameExists.Text"));
 		} else if (name.empty()) {
-			OBSMessageBox::information(parent,
+			OBSMessageBox::warning(parent,
 				QTStr("NoNameEntered.Title"),
 				QTStr("NoNameEntered.Text"));
 		}
@@ -5363,7 +5363,7 @@ void OBSBasic::RecordingStart()
 	blog(LOG_INFO, RECORDING_START);
 }
 
-void OBSBasic::RecordingStop(int code)
+void OBSBasic::RecordingStop(int code, QString last_error)
 {
 	ui->statusbar->RecordingStopped();
 	ui->recordButton->setText(QTStr("Basic.Main.StartRecording"));
@@ -5375,19 +5375,32 @@ void OBSBasic::RecordingStop(int code)
 	blog(LOG_INFO, RECORDING_STOP);
 
 	if (code == OBS_OUTPUT_UNSUPPORTED && isVisible()) {
-		OBSMessageBox::information(this,
+		OBSMessageBox::critical(this,
 				QTStr("Output.RecordFail.Title"),
 				QTStr("Output.RecordFail.Unsupported"));
 
 	} else if (code == OBS_OUTPUT_NO_SPACE && isVisible()) {
-		OBSMessageBox::information(this,
+		OBSMessageBox::warning(this,
 				QTStr("Output.RecordNoSpace.Title"),
 				QTStr("Output.RecordNoSpace.Msg"));
 
 	} else if (code != OBS_OUTPUT_SUCCESS && isVisible()) {
-		OBSMessageBox::information(this,
+
+		const char *errorDescription;
+		DStr errorMessage;
+		bool use_last_error = true;
+
+		errorDescription = Str("Output.RecordError.Msg");
+
+		if (use_last_error && !last_error.isEmpty())
+			dstr_printf(errorMessage, "%s\n\n%s", errorDescription,
+				QT_TO_UTF8(last_error));
+		else
+			dstr_copy(errorMessage, errorDescription);
+
+		OBSMessageBox::critical(this,
 				QTStr("Output.RecordError.Title"),
-				QTStr("Output.RecordError.Msg"));
+				QT_UTF8(errorMessage));
 
 	} else if (code == OBS_OUTPUT_UNSUPPORTED && !isVisible()) {
 		SysTrayNotify(QTStr("Output.RecordFail.Unsupported"),
@@ -5528,17 +5541,17 @@ void OBSBasic::ReplayBufferStop(int code)
 	blog(LOG_INFO, REPLAY_BUFFER_STOP);
 
 	if (code == OBS_OUTPUT_UNSUPPORTED && isVisible()) {
-		OBSMessageBox::information(this,
+		OBSMessageBox::critical(this,
 				QTStr("Output.RecordFail.Title"),
 				QTStr("Output.RecordFail.Unsupported"));
 
 	} else if (code == OBS_OUTPUT_NO_SPACE && isVisible()) {
-		OBSMessageBox::information(this,
+		OBSMessageBox::warning(this,
 				QTStr("Output.RecordNoSpace.Title"),
 				QTStr("Output.RecordNoSpace.Msg"));
 
 	} else if (code != OBS_OUTPUT_SUCCESS && isVisible()) {
-		OBSMessageBox::information(this,
+		OBSMessageBox::critical(this,
 				QTStr("Output.RecordError.Title"),
 				QTStr("Output.RecordError.Msg"));
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -438,7 +438,7 @@ public slots:
 
 	void RecordingStart();
 	void RecordStopping();
-	void RecordingStop(int code);
+	void RecordingStop(int code, QString last_error);
 
 	void StartReplayBuffer();
 	void StopReplayBuffer();

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -215,7 +215,7 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 		AddExisting(QT_TO_UTF8(item->text()), visible, false);
 	} else {
 		if (ui->sourceName->text().isEmpty()) {
-			OBSMessageBox::information(this,
+			OBSMessageBox::warning(this,
 					QTStr("NoNameEntered.Title"),
 					QTStr("NoNameEntered.Text"));
 			return;

--- a/libobs/util/pipe-posix.c
+++ b/libobs/util/pipe-posix.c
@@ -73,6 +73,15 @@ size_t os_process_pipe_read(os_process_pipe_t *pp, uint8_t *data, size_t len)
 	return fread(data, 1, len, pp->file);
 }
 
+size_t os_process_pipe_read_err(os_process_pipe_t *pp, uint8_t *data, size_t len)
+{
+	/* XXX: unsupported on posix */
+	UNUSED_PARAMETER(pp);
+	UNUSED_PARAMETER(data);
+	UNUSED_PARAMETER(len);
+	return 0;
+}
+
 size_t os_process_pipe_write(os_process_pipe_t *pp, const uint8_t *data,
 		size_t len)
 {

--- a/libobs/util/pipe-windows.c
+++ b/libobs/util/pipe-windows.c
@@ -24,6 +24,7 @@
 struct os_process_pipe {
 	bool read_pipe;
 	HANDLE handle;
+	HANDLE handle_err;
 	HANDLE process;
 };
 
@@ -42,7 +43,7 @@ static bool create_pipe(HANDLE *input, HANDLE *output)
 }
 
 static inline bool create_process(const char *cmd_line, HANDLE stdin_handle,
-		HANDLE stdout_handle, HANDLE *process)
+		HANDLE stdout_handle, HANDLE stderr_handle, HANDLE *process)
 {
 	PROCESS_INFORMATION pi = {0};
 	wchar_t *cmd_line_w = NULL;
@@ -53,6 +54,7 @@ static inline bool create_process(const char *cmd_line, HANDLE stdin_handle,
 	si.dwFlags = STARTF_USESTDHANDLES | STARTF_FORCEOFFFEEDBACK;
 	si.hStdInput = stdin_handle;
 	si.hStdOutput = stdout_handle;
+	si.hStdError = stderr_handle;
 
 	os_utf8_to_wcs_ptr(cmd_line, 0, &cmd_line_w);
 	if (cmd_line_w) {
@@ -77,6 +79,7 @@ os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
 	bool read_pipe;
 	HANDLE process;
 	HANDLE output;
+	HANDLE err_input, err_output;
 	HANDLE input;
 	bool success;
 
@@ -90,26 +93,38 @@ os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
 		return NULL;
 	}
 
+	if (!create_pipe(&err_input, &err_output)) {
+		return NULL;
+	}
+
 	read_pipe = *type == 'r';
 
 	success = !!SetHandleInformation(read_pipe ? input : output,
-			HANDLE_FLAG_INHERIT, false);
+		HANDLE_FLAG_INHERIT, false);
+	if (!success) {
+		goto error;
+	}
+
+	success = !!SetHandleInformation(err_input, HANDLE_FLAG_INHERIT, false);
 	if (!success) {
 		goto error;
 	}
 
 	success = create_process(cmd_line, read_pipe ? NULL : input,
-			read_pipe ? output : NULL, &process);
+			read_pipe ? output : NULL, err_output, &process);
 	if (!success) {
 		goto error;
 	}
 
 	pp = bmalloc(sizeof(*pp));
+
 	pp->handle = read_pipe ? input : output;
 	pp->read_pipe = read_pipe;
 	pp->process = process;
+	pp->handle_err = err_input;
 
 	CloseHandle(read_pipe ? output : input);
+	CloseHandle(err_output);
 	return pp;
 
 error:
@@ -126,6 +141,7 @@ int os_process_pipe_destroy(os_process_pipe_t *pp)
 		DWORD code;
 
 		CloseHandle(pp->handle);
+		CloseHandle(pp->handle_err);
 
 		WaitForSingleObject(pp->process, INFINITE);
 		if (GetExitCodeProcess(pp->process, &code))
@@ -154,6 +170,25 @@ size_t os_process_pipe_read(os_process_pipe_t *pp, uint8_t *data, size_t len)
 	if (success && bytes_read) {
 		return bytes_read;
 	}
+
+	return 0;
+}
+
+size_t os_process_pipe_read_err(os_process_pipe_t *pp, uint8_t *data, size_t len)
+{
+	DWORD bytes_read;
+	bool success;
+
+	if (!pp || !pp->handle_err) {
+		return 0;
+	}
+
+	success = !!ReadFile(pp->handle_err, data, (DWORD)len, &bytes_read, NULL);
+	if (success && bytes_read) {
+		return bytes_read;
+	}
+	else
+		bytes_read = GetLastError();
 
 	return 0;
 }

--- a/libobs/util/pipe.h
+++ b/libobs/util/pipe.h
@@ -27,5 +27,7 @@ EXPORT int os_process_pipe_destroy(os_process_pipe_t *pp);
 
 EXPORT size_t os_process_pipe_read(os_process_pipe_t *pp, uint8_t *data,
 		size_t len);
+EXPORT size_t os_process_pipe_read_err(os_process_pipe_t *pp, uint8_t *data,
+	size_t len);
 EXPORT size_t os_process_pipe_write(os_process_pipe_t *pp, const uint8_t *data,
 		size_t len);

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -268,7 +268,7 @@ static bool new_stream(struct ffmpeg_mux *ffm, AVStream **stream,
 	AVCodec *codec;
 
 	if (!desc) {
-		printf("Couldn't find encoder '%s'\n", name);
+		fprintf(stderr, "Couldn't find encoder '%s'\n", name);
 		return false;
 	}
 
@@ -276,13 +276,13 @@ static bool new_stream(struct ffmpeg_mux *ffm, AVStream **stream,
 
 	codec = avcodec_find_encoder(desc->id);
 	if (!codec) {
-		printf("Couldn't create encoder");
+		fprintf(stderr, "Couldn't create encoder");
 		return false;
 	}
 
 	*stream = avformat_new_stream(ffm->output, codec);
 	if (!*stream) {
-		printf("Couldn't create stream for encoder '%s'\n", name);
+		fprintf(stderr, "Couldn't create stream for encoder '%s'\n", name);
 		return false;
 	}
 
@@ -469,7 +469,7 @@ static inline int open_output_file(struct ffmpeg_mux *ffm)
 		ret = avio_open(&ffm->output->pb, ffm->params.file,
 				AVIO_FLAG_WRITE);
 		if (ret < 0) {
-			printf("Couldn't open '%s', %s",
+			fprintf(stderr, "Couldn't open '%s', %s",
 					ffm->params.file, av_err2str(ret));
 			return FFM_ERROR;
 		}
@@ -482,7 +482,7 @@ static inline int open_output_file(struct ffmpeg_mux *ffm)
 	AVDictionary *dict = NULL;
 	if ((ret = av_dict_parse_string(&dict, ffm->params.muxer_settings,
 				"=", " ", 0))) {
-		printf("Failed to parse muxer settings: %s\n%s",
+		fprintf(stderr, "Failed to parse muxer settings: %s\n%s",
 				av_err2str(ret), ffm->params.muxer_settings);
 
 		av_dict_free(&dict);
@@ -501,7 +501,7 @@ static inline int open_output_file(struct ffmpeg_mux *ffm)
 
 	ret = avformat_write_header(ffm->output, &dict);
 	if (ret < 0) {
-		printf("Error opening '%s': %s",
+		fprintf(stderr, "Error opening '%s': %s",
 				ffm->params.file, av_err2str(ret));
 
 		av_dict_free(&dict);
@@ -521,7 +521,7 @@ static int ffmpeg_mux_init_context(struct ffmpeg_mux *ffm)
 
 	output_format = av_guess_format(NULL, ffm->params.file, NULL);
 	if (output_format == NULL) {
-		printf("Couldn't find an appropriate muxer for '%s'\n",
+		fprintf(stderr, "Couldn't find an appropriate muxer for '%s'\n",
 				ffm->params.file);
 		return FFM_ERROR;
 	}
@@ -529,7 +529,7 @@ static int ffmpeg_mux_init_context(struct ffmpeg_mux *ffm)
 	ret = avformat_alloc_output_context2(&ffm->output, output_format,
 			NULL, NULL);
 	if (ret < 0) {
-		printf("Couldn't initialize output context: %s\n",
+		fprintf(stderr, "Couldn't initialize output context: %s\n",
 				av_err2str(ret));
 		return FFM_ERROR;
 	}
@@ -679,7 +679,7 @@ int main(int argc, char *argv[])
 
 	ret = ffmpeg_mux_init(&ffm, argc, argv);
 	if (ret != FFM_SUCCESS) {
-		puts("Couldn't initialize muxer");
+		fprintf(stderr, "Couldn't initialize muxer\n");
 		return ret;
 	}
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -369,8 +369,22 @@ static void ffmpeg_mux_stop(void *data, uint64_t ts)
 
 static void signal_failure(struct ffmpeg_muxer *stream)
 {
-	int ret = deactivate(stream);
+	char error[1024];
+	int ret;
 	int code;
+
+	size_t len;
+
+	len = os_process_pipe_read_err(stream->pipe, (uint8_t *)error,
+		sizeof(error) - 1);
+
+	if (len > 0) {
+		error[len] = 0;
+		warn ("ffmpeg-mux: %s", error);
+		obs_output_set_last_error (stream->output, error);
+	}
+
+	ret = deactivate(stream);
 
 	switch (ret) {
 	case FFM_UNSUPPORTED:          code = OBS_OUTPUT_UNSUPPORTED; break;


### PR DESCRIPTION
These commits add a handle to the Win32 pipe structures to allow the ffmpeg-mux process to write to stderr and have OBS capture the output. This error data is stored in the ffmpeg data structure and eventually passed back to the UI if a critical error occurs, providing additional details to the infamous "An unspecified error occurred while recording" dialog. It also catches errors from internal use of ffmpeg-output where the ffmpeg-mux process isn't involved.

The UI was updated to support additional severity levels of QMessageBox implementations, so errors actually show an error box instead of an information box.