### PR TITLE
UI: Fix issue where space/esc hotkeys would be blank

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -875,6 +875,7 @@ Hotkeys.AppleKeypadSubtract="- (Keypad)"
 Hotkeys.AppleKeypadDecimal=". (Keypad)"
 Hotkeys.AppleKeypadEqual="= (Keypad)"
 Hotkeys.MouseButton="Mouse %1"
+Hotkeys.Escape="Esc"
 
 # audio hotkeys
 Mute="Mute"

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2037,6 +2037,7 @@ void OBSBasic::InitHotkeys()
 	t.apple_keypad_decimal         = Str("Hotkeys.AppleKeypadDecimal");
 	t.apple_keypad_equal           = Str("Hotkeys.AppleKeypadEqual");
 	t.mouse_num                    = Str("Hotkeys.MouseButton");
+	t.escape                       = Str("Hotkeys.Escape");
 	obs_hotkeys_set_translations(&t);
 
 	obs_hotkeys_set_audio_hotkeys_translations(Str("Mute"), Str("Unmute"),

--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -1479,6 +1479,7 @@ void obs_hotkeys_set_translations_s(
 	ADD_TRANSLATION(OBS_KEY_META, meta);
 	ADD_TRANSLATION(OBS_KEY_MENU, menu);
 	ADD_TRANSLATION(OBS_KEY_SPACE, space);
+	ADD_TRANSLATION(OBS_KEY_ESCAPE, escape);
 #ifdef __APPLE__
 	const char *numpad_str = t.apple_keypad_num;
 	ADD_TRANSLATION(OBS_KEY_NUMSLASH, apple_keypad_divide);

--- a/libobs/obs-hotkey.h
+++ b/libobs/obs-hotkey.h
@@ -126,6 +126,7 @@ struct obs_hotkeys_translations {
 	const char *apple_keypad_decimal;
 	const char *apple_keypad_equal;
 	const char *mouse_num; /* For example, "Mouse %1" */
+	const char *escape;
 };
 
 /* This function is an optional way to provide translations for specific keys

--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -1114,6 +1114,8 @@ void obs_key_to_str(obs_key_t key, struct dstr *dstr)
 	case OBS_KEY_NUMCOMMA:     return translate_key(key, "Numpad ,");
 	case OBS_KEY_NUMPERIOD:    return translate_key(key, "Numpad .");
 	case OBS_KEY_NUMSLASH:     return translate_key(key, "Numpad /");
+	case OBS_KEY_SPACE:        return translate_key(key, "Space");
+	case OBS_KEY_ESCAPE:       return translate_key(key, "Escape");
 	default:;
 	}
 


### PR DESCRIPTION
This also modifies libobs.

This only happened on Linux.

Fixes https://obsproject.com/mantis/view.php?id=1018