### PR TITLE
GPU debug markers

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1305,6 +1305,8 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 void OBSBasic::RenderProgram(void *data, uint32_t cx, uint32_t cy)
 {
+	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DEFAULT, "RenderProgram");
+
 	OBSBasic *window = static_cast<OBSBasic*>(data);
 	obs_video_info ovi;
 
@@ -1332,6 +1334,8 @@ void OBSBasic::RenderProgram(void *data, uint32_t cx, uint32_t cy)
 
 	gs_projection_pop();
 	gs_viewport_pop();
+
+	GS_DEBUG_MARKER_END();
 
 	UNUSED_PARAMETER(cx);
 	UNUSED_PARAMETER(cy);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3310,6 +3310,8 @@ void OBSBasic::DrawBackdrop(float cx, float cy)
 	if (!box)
 		return;
 
+	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DEFAULT, "DrawBackdrop");
+
 	gs_effect_t    *solid = obs_get_base_effect(OBS_EFFECT_SOLID);
 	gs_eparam_t    *color = gs_effect_get_param_by_name(solid, "color");
 	gs_technique_t *tech  = gs_effect_get_technique(solid, "Solid");
@@ -3332,10 +3334,14 @@ void OBSBasic::DrawBackdrop(float cx, float cy)
 	gs_technique_end(tech);
 
 	gs_load_vertexbuffer(nullptr);
+
+	GS_DEBUG_MARKER_END();
 }
 
 void OBSBasic::RenderMain(void *data, uint32_t cx, uint32_t cy)
 {
+	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DEFAULT, "RenderMain");
+
 	OBSBasic *window = static_cast<OBSBasic*>(data);
 	obs_video_info ovi;
 
@@ -3366,7 +3372,6 @@ void OBSBasic::RenderMain(void *data, uint32_t cx, uint32_t cy)
 
 	window->DrawBackdrop(float(ovi.base_width), float(ovi.base_height));
 
-
 	if (window->IsPreviewProgramMode()) {
 		OBSScene scene = window->GetCurrentScene();
 		obs_source_t *source = obs_scene_get_source(scene);
@@ -3391,6 +3396,8 @@ void OBSBasic::RenderMain(void *data, uint32_t cx, uint32_t cy)
 
 	gs_projection_pop();
 	gs_viewport_pop();
+
+	GS_DEBUG_MARKER_END();
 
 	UNUSED_PARAMETER(cx);
 	UNUSED_PARAMETER(cy);

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -1360,6 +1360,8 @@ bool OBSBasicPreview::DrawSelectedOverflow(obs_scene_t *scene,
 	if (!visible)
 		return true;
 
+	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DEFAULT, "DrawSelectedOverflow");
+
 	obs_transform_info info;
 	obs_sceneitem_get_info(item, &info);
 
@@ -1384,6 +1386,8 @@ bool OBSBasicPreview::DrawSelectedOverflow(obs_scene_t *scene,
 	}
 
 	gs_matrix_pop();
+
+	GS_DEBUG_MARKER_END();
 
 	UNUSED_PARAMETER(scene);
 	return true;
@@ -1450,6 +1454,8 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *scene,
 	if (!visible)
 		return true;
 
+	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DEFAULT, "DrawSelectedItem");
+
 	obs_transform_info info;
 	obs_sceneitem_get_info(item, &info);
 
@@ -1501,6 +1507,8 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *scene,
 
 	gs_matrix_pop();
 
+	GS_DEBUG_MARKER_END();
+
 	UNUSED_PARAMETER(scene);
 	UNUSED_PARAMETER(param);
 	return true;
@@ -1516,6 +1524,8 @@ void OBSBasicPreview::DrawOverflow()
 
 	if (hidden)
 		return;
+
+	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DEFAULT, "DrawOverflow");
 
 	if (!overflow) {
 		std::string path;
@@ -1535,12 +1545,16 @@ void OBSBasicPreview::DrawOverflow()
 	}
 
 	gs_load_vertexbuffer(nullptr);
+
+	GS_DEBUG_MARKER_END();
 }
 
 void OBSBasicPreview::DrawSceneEditing()
 {
 	if (locked)
 		return;
+
+	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DEFAULT, "DrawSceneEditing");
 
 	OBSBasic *main = reinterpret_cast<OBSBasic*>(App()->GetMainWindow());
 
@@ -1567,6 +1581,8 @@ void OBSBasicPreview::DrawSceneEditing()
 
 	gs_technique_end_pass(tech);
 	gs_technique_end(tech);
+
+	GS_DEBUG_MARKER_END();
 }
 
 void OBSBasicPreview::ResetScrollingOffset()

--- a/libobs-d3d11/CMakeLists.txt
+++ b/libobs-d3d11/CMakeLists.txt
@@ -30,6 +30,7 @@ set_target_properties(libobs-d3d11
 		PREFIX "")
 target_link_libraries(libobs-d3d11
 	libobs
+	d3d9
 	d3d11
 	dxgi)
 

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -21,6 +21,7 @@
 #include <util/dstr.h>
 #include <util/util.hpp>
 #include <graphics/matrix3.h>
+#include <d3d9.h>
 #include "d3d11-subsystem.hpp"
 
 struct UnsupportedHWError : HRError {
@@ -2215,6 +2216,24 @@ extern "C" EXPORT bool device_shared_texture_available(void)
 extern "C" EXPORT bool device_nv12_available(gs_device_t *device)
 {
 	return device->nv12Supported;
+}
+
+extern "C" EXPORT void device_debug_marker_begin(gs_device_t *,
+		const char *markername, const float color[4])
+{
+	D3DCOLOR bgra = D3DCOLOR_ARGB((DWORD)(255.0f * color[3]),
+			(DWORD)(255.0f * color[0]), (DWORD)(255.0f * color[1]),
+			(DWORD)(255.0f * color[2]));
+
+	wchar_t wide[64];
+	os_utf8_to_wcs(markername, 0, wide, _countof(wide));
+
+	D3DPERF_BeginEvent(bgra, wide);
+}
+
+extern "C" EXPORT void device_debug_marker_end(gs_device_t *)
+{
+	D3DPERF_EndEvent();
 }
 
 extern "C" EXPORT gs_texture_t *device_texture_create_gdi(gs_device_t *device,

--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -1341,6 +1341,22 @@ void device_projection_pop(gs_device_t *device)
 	da_pop_back(device->proj_stack);
 }
 
+void device_debug_marker_begin(gs_device_t *device,
+		const char *markername, const float color[4])
+{
+	UNUSED_PARAMETER(device);
+	UNUSED_PARAMETER(color);
+
+	glPushDebugGroupKHR(GL_DEBUG_SOURCE_APPLICATION, 0, -1, markername);
+}
+
+void device_debug_marker_end(gs_device_t *device)
+{
+	UNUSED_PARAMETER(device);
+
+	glPopDebugGroupKHR();
+}
+
 void gs_swapchain_destroy(gs_swapchain_t *swapchain)
 {
 	if (!swapchain)

--- a/libobs/graphics/device-exports.h
+++ b/libobs/graphics/device-exports.h
@@ -142,6 +142,9 @@ EXPORT void device_frustum(gs_device_t *device, float left, float right,
 		float top, float bottom, float znear, float zfar);
 EXPORT void device_projection_push(gs_device_t *device);
 EXPORT void device_projection_pop(gs_device_t *device);
+EXPORT void device_debug_marker_begin(gs_device_t *device,
+		const char *markername, const float color[4]);
+EXPORT void device_debug_marker_end(gs_device_t *device);
 
 #ifdef __cplusplus
 }

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -173,6 +173,9 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 
 	GRAPHICS_IMPORT_OPTIONAL(device_nv12_available);
 
+	GRAPHICS_IMPORT(device_debug_marker_begin);
+	GRAPHICS_IMPORT(device_debug_marker_end);
+
 	/* OSX/Cocoa specific functions */
 #ifdef __APPLE__
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_create_from_iosurface);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -234,6 +234,10 @@ struct gs_exports {
 
 	bool (*device_nv12_available)(gs_device_t *device);
 
+	void (*device_debug_marker_begin)(gs_device_t *device,
+			const char *markername, const float color[4]);
+	void (*device_debug_marker_end)(gs_device_t *device);
+
 #ifdef __APPLE__
 	/* OSX/Cocoa specific functions */
 	gs_texture_t *(*device_texture_create_from_iosurface)(gs_device_t *dev,

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -2557,6 +2557,52 @@ bool gs_nv12_available(void)
 			thread_graphics->device);
 }
 
+void gs_debug_marker_begin(const float color[4],
+		const char *markername)
+{
+	if (!gs_valid("gs_debug_marker_begin"))
+		return;
+
+	if (!markername)
+		markername = "(null)";
+
+	thread_graphics->exports.device_debug_marker_begin(
+			thread_graphics->device, markername,
+			color);
+}
+
+void gs_debug_marker_begin_format(const float color[4],
+		const char *format, ...)
+{
+	if (!gs_valid("gs_debug_marker_begin"))
+		return;
+
+	if (format)
+	{
+		char markername[64];
+		va_list args;
+		va_start(args, format);
+		vsnprintf(markername, sizeof(markername), format, args);
+		va_end(args);
+		thread_graphics->exports.device_debug_marker_begin(
+			thread_graphics->device, markername,
+			color);
+	}
+	else
+	{
+		gs_debug_marker_begin(color, NULL);
+	}
+}
+
+void gs_debug_marker_end(void)
+{
+	if (!gs_valid("gs_debug_marker_end"))
+		return;
+
+	thread_graphics->exports.device_debug_marker_end(
+			thread_graphics->device);
+}
+
 #ifdef __APPLE__
 
 /** Platform specific functions */

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -761,6 +761,34 @@ EXPORT enum gs_index_type gs_indexbuffer_get_type(
 
 EXPORT bool     gs_nv12_available(void);
 
+#define GS_USE_DEBUG_MARKERS 0
+#if GS_USE_DEBUG_MARKERS
+static const float GS_DEBUG_COLOR_DEFAULT[] = { 0.5f, 0.5f, 0.5f, 1.0f };
+static const float GS_DEBUG_COLOR_RENDER_VIDEO[] = { 0.0f, 0.5f, 0.0f, 1.0f };
+static const float GS_DEBUG_COLOR_MAIN_TEXTURE[] = { 0.0f, 0.25f, 0.0f, 1.0f };
+static const float GS_DEBUG_COLOR_DISPLAY[] = { 0.0f, 0.5f, 0.5f, 1.0f };
+static const float GS_DEBUG_COLOR_SOURCE[] = { 0.0f, 0.5f, 5.0f, 1.0f };
+static const float GS_DEBUG_COLOR_ITEM[] = { 0.5f, 0.0f, 0.0f, 1.0f };
+static const float GS_DEBUG_COLOR_ITEM_TEXTURE[] = { 0.25f, 0.0f, 0.0f, 1.0f };
+static const float GS_DEBUG_COLOR_CONVERT_FORMAT[] = { 0.5f, 0.5f, 0.0f, 1.0f };
+#define GS_DEBUG_MARKER_BEGIN(color, markername) \
+		gs_debug_marker_begin(color, markername)
+#define GS_DEBUG_MARKER_BEGIN_FORMAT(color, format, ...) \
+		gs_debug_marker_begin_format(color, format, \
+		__VA_ARGS__)
+#define GS_DEBUG_MARKER_END() gs_debug_marker_end()
+#else
+#define GS_DEBUG_MARKER_BEGIN(color, markername) ((void)0)
+#define GS_DEBUG_MARKER_BEGIN_FORMAT(color, format, ...) ((void)0)
+#define GS_DEBUG_MARKER_END() ((void)0)
+#endif
+
+EXPORT void     gs_debug_marker_begin(const float color[4],
+		const char *markername);
+EXPORT void     gs_debug_marker_begin_format(const float color[4],
+		const char *format, ...);
+EXPORT void     gs_debug_marker_end(void);
+
 #ifdef __APPLE__
 
 /** platform specific function for creating (GL_TEXTURE_RECTANGLE) textures

--- a/libobs/obs-display.c
+++ b/libobs/obs-display.c
@@ -175,7 +175,6 @@ static inline void render_display_begin(struct obs_display *display,
 static inline void render_display_end()
 {
 	gs_end_scene();
-	gs_present();
 }
 
 void render_display(struct obs_display *display)
@@ -184,6 +183,8 @@ void render_display(struct obs_display *display)
 	bool size_changed;
 
 	if (!display || !display->enabled) return;
+
+	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DISPLAY, "obs_display");
 
 	/* -------------------------------------------- */
 
@@ -214,6 +215,10 @@ void render_display(struct obs_display *display)
 	pthread_mutex_unlock(&display->draw_callbacks_mutex);
 
 	render_display_end();
+
+	GS_DEBUG_MARKER_END();
+
+	gs_present();
 }
 
 void obs_display_set_enabled(obs_display_t *display, bool enable)

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -462,6 +462,8 @@ static inline bool item_texture_enabled(const struct obs_scene_item *item)
 
 static void render_item_texture(struct obs_scene_item *item)
 {
+	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_ITEM_TEXTURE, "render_item_texture");
+
 	gs_texture_t *tex = gs_texrender_get_texture(item->item_render);
 	gs_effect_t *effect = obs->video.default_effect;
 	enum obs_scale_type type = item->scale_filter;
@@ -510,16 +512,24 @@ static void render_item_texture(struct obs_scene_item *item)
 
 	while (gs_effect_loop(effect, "Draw"))
 		obs_source_draw(tex, 0, 0, 0, 0, 0);
+
+	GS_DEBUG_MARKER_END();
 }
 
 static inline void render_item(struct obs_scene_item *item)
 {
+	GS_DEBUG_MARKER_BEGIN_FORMAT(GS_DEBUG_COLOR_ITEM, "Item: %s",
+			obs_source_get_name_no_null(item->source));
+
 	if (item->item_render) {
 		uint32_t width  = obs_source_get_width(item->source);
 		uint32_t height = obs_source_get_height(item->source);
 
 		if (!width || !height)
+		{
+			GS_DEBUG_MARKER_END();
 			return;
+		}
 
 		uint32_t cx = calc_cx(item, width);
 		uint32_t cy = calc_cy(item, height);
@@ -556,6 +566,8 @@ static inline void render_item(struct obs_scene_item *item)
 		obs_source_video_render(item->source);
 	}
 	gs_matrix_pop();
+
+	GS_DEBUG_MARKER_END();
 }
 
 static void scene_video_tick(void *data, float seconds)

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -120,6 +120,8 @@ static inline void render_main_texture(struct obs_core_video *video,
 		int cur_texture)
 {
 	profile_start(render_main_texture_name);
+	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_MAIN_TEXTURE,
+			render_main_texture_name);
 
 	struct vec4 clear_color;
 	vec4_set(&clear_color, 0.0f, 0.0f, 0.0f, 0.0f);
@@ -145,6 +147,7 @@ static inline void render_main_texture(struct obs_core_video *video,
 
 	video->textures_rendered[cur_texture] = true;
 
+	GS_DEBUG_MARKER_END();
 	profile_end(render_main_texture_name);
 }
 
@@ -773,7 +776,10 @@ static inline void output_frame(bool raw_active, const bool gpu_active)
 	gs_enter_context(video->graphics);
 
 	profile_start(output_frame_render_video_name);
+	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_RENDER_VIDEO,
+			output_frame_render_video_name);
 	render_video(video, raw_active, gpu_active, cur_texture, prev_texture);
+	GS_DEBUG_MARKER_END();
 	profile_end(output_frame_render_video_name);
 
 	if (raw_active) {

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -909,6 +909,9 @@ EXPORT obs_data_t *obs_source_get_settings(const obs_source_t *source);
 /** Gets the name of a source */
 EXPORT const char *obs_source_get_name(const obs_source_t *source);
 
+/** Gets the name of a source without null */
+EXPORT const char *obs_source_get_name_no_null(const obs_source_t *source);
+
 /** Sets the name of a source */
 EXPORT void obs_source_set_name(obs_source_t *source, const char *name);
 

--- a/libobs/util/windows/ComPtr.hpp
+++ b/libobs/util/windows/ComPtr.hpp
@@ -68,7 +68,8 @@ public:
 
 	inline ComPtr<T> &operator=(ComPtr<T> &&c)
 	{
-		if (this != &c) {
+		unsigned char& alias = reinterpret_cast<unsigned char&>(c);
+		if (this != (ComPtr<T>*)&alias) {
 			Kill();
 			ptr = c.ptr;
 			c.ptr = nullptr;


### PR DESCRIPTION
Add some GPU debug markers, so I have a better sense of where I am when dealing with RenderDoc captures.

This feature is disabled by default, and is toggled by flipping GS_USE_DEBUG_MARKERS from 0 to 1. There's a lot of ways to go about this, but I tried to be as reasonable as I could. I'm not married to this setup, so let me know if there's anything you want done differently.

Three changes: one prerequisite fix to ComPtr, one to add the API support, and one to make use of it.

Some things could be nicer; having names for each obs_display, adding support for resource labels, etc. This stuff just seemed like the low-hanging fruit.