### PR TITLE
libobs: Use movflags=faststart when remuxing to MP4

### DIFF
--- a/libobs/media-io/media-remux.c
+++ b/libobs/media-io/media-remux.c
@@ -22,6 +22,7 @@
 #include "../util/platform.h"
 
 #include <libavformat/avformat.h>
+#include <libavutil/opt.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -80,6 +81,10 @@ static inline bool init_output(media_remux_job_t job, const char *out_filename)
 	if (!job->ofmt_ctx) {
 		blog(LOG_ERROR, "media_remux: Could not create output context");
 		return false;
+	}
+
+	if (strcmp(job->ofmt_ctx->oformat->name, "mp4") == 0) {
+		av_opt_set(job->ofmt_ctx->priv_data, "movflags", "faststart", 0);
 	}
 
 	for (unsigned i = 0; i < job->ifmt_ctx->nb_streams; i++) {


### PR DESCRIPTION
As the file has to be fully read anyway to remux, I don't see why we can't also move the moov atom at the same time for better playback performance in video players / editors and improved YouTube upload times etc.