### PR TITLE
UI: Do not show [x] (close) for primary dock widgets

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6503,11 +6503,14 @@ void OBSBasic::on_lockUI_toggled(bool lock)
 		? QDockWidget::NoDockWidgetFeatures
 		: QDockWidget::AllDockWidgetFeatures;
 
-	ui->scenesDock->setFeatures(features);
-	ui->sourcesDock->setFeatures(features);
-	ui->mixerDock->setFeatures(features);
-	ui->transitionsDock->setFeatures(features);
-	ui->controlsDock->setFeatures(features);
+	QDockWidget::DockWidgetFeatures mainFeatures = features;
+	mainFeatures &= ~QDockWidget::QDockWidget::DockWidgetClosable;
+
+	ui->scenesDock->setFeatures(mainFeatures);
+	ui->sourcesDock->setFeatures(mainFeatures);
+	ui->mixerDock->setFeatures(mainFeatures);
+	ui->transitionsDock->setFeatures(mainFeatures);
+	ui->controlsDock->setFeatures(mainFeatures);
 	statsDock->setFeatures(features);
 
 	for (int i = extraDocks.size() - 1; i >= 0 ; i--) {


### PR DESCRIPTION
This solves the issue of users who close the primary dock widgets and can't figure out how to get them back, who for whatever reason choose not to read the message box when closing dock widgets that tells them how to get it back.  The users can still hide the primary dock widgets via the View menu, but they can no longer close them via the [x] button on the dock widget.