### PR TITLE
obs-frontend-api: Access system tray icon from API

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -67,6 +67,11 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		return (void*)main->winId();
 	}
 
+	void *obs_frontend_get_system_tray(void) override
+	{
+		return (void*)main->trayIcon.data();
+	}
+
 	void obs_frontend_get_scenes(
 			struct obs_frontend_source_list *sources) override
 	{

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -71,6 +71,13 @@ void *obs_frontend_get_main_window_handle(void)
 		: nullptr;
 }
 
+void *obs_frontend_get_system_tray(void)
+{
+	return !!callbacks_valid()
+		? c->obs_frontend_get_system_tray()
+		: nullptr;
+}
+
 char **obs_frontend_get_scene_names(void)
 {
 	if (!callbacks_valid())

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -82,6 +82,7 @@ static inline void obs_frontend_source_list_free(
 
 EXPORT void *obs_frontend_get_main_window(void);
 EXPORT void *obs_frontend_get_main_window_handle(void);
+EXPORT void *obs_frontend_get_system_tray(void);
 
 EXPORT char **obs_frontend_get_scene_names(void);
 EXPORT void obs_frontend_get_scenes(struct obs_frontend_source_list *sources);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -9,6 +9,7 @@ struct obs_frontend_callbacks {
 	virtual ~obs_frontend_callbacks() {}
 	virtual void *obs_frontend_get_main_window(void)=0;
 	virtual void *obs_frontend_get_main_window_handle(void)=0;
+	virtual void *obs_frontend_get_system_tray(void)=0;
 
 	virtual void obs_frontend_get_scenes(
 			struct obs_frontend_source_list *sources)=0;


### PR DESCRIPTION
All UI elements are accessible through the obs frontend api via
obs_frontend_api_get_main_window, except for the tray icon and its
elements. This commit adds an obs_frontend_api_get_system_tray function
which returns the pointer to the QSystemTrayIcon cast to void*.