### PR TITLE
UI: Fix incorrect padding usage in Rachni theme

### DIFF
--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -231,9 +231,9 @@ QGroupBox {
 QGroupBox::title {
 	color: rgb(240, 98, 146); /* Pink (Secondary) */
 	left: 20px;
+	top: -7px;
 	padding-left: 5px;
 	padding-right: 4px;
-	padding-top: -14px;
 }
 
 /*****************/


### PR DESCRIPTION
Negative values in padding may lead to unpredictable behavior
(example: https://github.com/obsproject/obs-studio/pull/1610#issuecomment-455804938)

This patch emulates similar shift of the text that was main goal by the theme creator, so it doesn't changes appearance of the theme itself.