### PR TITLE
UI: Don't update stats dock if hidden

### DIFF
--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -146,7 +146,10 @@ OBSBasicStats::OBSBasicStats(QWidget *parent, bool closeable)
 
 	QObject::connect(&timer, &QTimer::timeout, this, &OBSBasicStats::Update);
 	timer.setInterval(TIMER_INTERVAL);
-	timer.start();
+
+	if (isVisible())
+		timer.start();
+
 	Update();
 
 	OBSBasic *main = reinterpret_cast<OBSBasic*>(App()->GetMainWindow());
@@ -504,4 +507,14 @@ void OBSBasicStats::OutputLabels::Reset(obs_output_t *output)
 
 	first_total   = obs_output_get_total_frames(output);
 	first_dropped = obs_output_get_frames_dropped(output);
+}
+
+void OBSBasicStats::showEvent(QShowEvent *)
+{
+	timer.start(TIMER_INTERVAL);
+}
+
+void OBSBasicStats::hideEvent(QHideEvent *)
+{
+	timer.stop();
 }

--- a/UI/window-basic-stats.hpp
+++ b/UI/window-basic-stats.hpp
@@ -61,4 +61,8 @@ public:
 	static void InitializeValues();
 private:
 	QPointer<QObject> shortcutFilter;
+
+protected:
+	virtual void showEvent(QShowEvent *event) override;
+	virtual void hideEvent(QHideEvent *event) override;
 };


### PR DESCRIPTION
When the stats dock is hidden, the QTimer is still updating it, causing
unnecessary CPU usage.