### PR TITLE
UI: Fix bandwidth test flag being saved to stream key

### DIFF
--- a/UI/auth-oauth.cpp
+++ b/UI/auth-oauth.cpp
@@ -301,7 +301,7 @@ void OAuthStreamKey::OnStreamConfig()
 
 	if (bwtest && strcmp(this->service(), "Twitch") == 0)
 		obs_data_set_string(settings, "key",
-				key_.append("?bandwidthtest=true").c_str());
+				(key_ + "?bandwidthtest=true").c_str());
 	else
 		obs_data_set_string(settings, "key", key_.c_str());
 


### PR DESCRIPTION
Previously enabling and disabling bandwidth testing in a certain order
lead to the parameter being included in the stream key that is saved to
disk, making it impossible to disable the bandwidth test later on.

By doing this properly and using string concatenation instead of
modifying (appending to) the key_ value this will no longer happen.