### PR TITLE
Ui scroll wheel events

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -232,6 +232,9 @@ set(obs_SOURCES
 	focus-list.cpp
 	menu-button.cpp
 	double-slider.cpp
+	slider-ignorewheel.cpp
+	comboBox-ignorewheel.cpp
+	spinBox-ignorewheel.cpp
 	volume-control.cpp
 	adv-audio-control.cpp
 	item-widget-helpers.cpp
@@ -283,6 +286,9 @@ set(obs_HEADERS
 	display-helpers.hpp
 	balance-slider.hpp
 	double-slider.hpp
+	slider-ignorewheel.hpp
+	comboBox-ignorewheel.hpp
+	spinBox-ignorewheel.hpp
 	focus-list.hpp
 	menu-button.hpp
 	mute-checkbox.hpp

--- a/UI/comboBox-ignorewheel.cpp
+++ b/UI/comboBox-ignorewheel.cpp
@@ -1,0 +1,19 @@
+#include "comboBox-ignorewheel.hpp"
+
+ComboBoxIgnoreScroll::ComboBoxIgnoreScroll(QWidget *parent) : QComboBox(parent)
+{
+	setFocusPolicy(Qt::StrongFocus);
+}
+
+void ComboBoxIgnoreScroll::wheelEvent(QWheelEvent * event)
+{
+	if (!hasFocus())
+		event->ignore();
+	else
+		QComboBox::wheelEvent(event);
+}
+
+void ComboBoxIgnoreScroll::leaveEvent(QEvent * event)
+{
+	clearFocus();
+}

--- a/UI/comboBox-ignorewheel.hpp
+++ b/UI/comboBox-ignorewheel.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QComboBox>
+#include <QInputEvent>
+#include <QtCore/QObject>
+
+
+class ComboBoxIgnoreScroll : public QComboBox {
+	Q_OBJECT
+
+public:
+	ComboBoxIgnoreScroll(QWidget *parent = nullptr);
+
+protected:
+
+	virtual void wheelEvent(QWheelEvent *event) override;
+	virtual void leaveEvent(QEvent *event) override;
+};
+
+

--- a/UI/double-slider.cpp
+++ b/UI/double-slider.cpp
@@ -2,7 +2,7 @@
 
 #include <cmath>
 
-DoubleSlider::DoubleSlider(QWidget *parent) : QSlider(parent)
+DoubleSlider::DoubleSlider(QWidget *parent) : SliderIgnoreScroll(parent)
 {
 	connect(this, SIGNAL(valueChanged(int)),
 			this, SLOT(intValChanged(int)));

--- a/UI/double-slider.hpp
+++ b/UI/double-slider.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <QSlider>
+#include "slider-ignorewheel.hpp"
 
-class DoubleSlider : public QSlider {
+class DoubleSlider : public SliderIgnoreScroll {
 	Q_OBJECT
 
 	double minVal, maxVal, minStep;

--- a/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
@@ -17,6 +17,9 @@ set(decklink-ouput-ui_HEADERS
 	../../properties-view.moc.hpp
 	../../vertical-scroll-area.hpp
 	../../double-slider.hpp
+	../../slider-ignorewheel.hpp
+	../../comboBox-ignorewheel.hpp
+	../../spinBox-ignorewheel.hpp
 	./DecklinkOutputUI.h
 	decklink-ui-main.h
 	)
@@ -25,6 +28,9 @@ set(decklink-ouput-ui_SOURCES
 	../../properties-view.cpp
 	../../vertical-scroll-area.cpp
 	../../double-slider.cpp
+	../../slider-ignorewheel.cpp
+	../../comboBox-ignorewheel.cpp
+	../../spinBox-ignorewheel.cpp
 	./DecklinkOutputUI.cpp
 	decklink-ui-main.cpp
 	)

--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -28,6 +28,9 @@ set(frontend-tools_HEADERS
 	../../horizontal-scroll-area.hpp
 	../../vertical-scroll-area.hpp
 	../../double-slider.hpp
+	../../slider-ignorewheel.hpp
+	../../comboBox-ignorewheel.hpp
+	../../spinBox-ignorewheel.hpp
 	)
 set(frontend-tools_SOURCES
 	${frontend-tools_SOURCES}
@@ -38,6 +41,9 @@ set(frontend-tools_SOURCES
 	../../horizontal-scroll-area.cpp
 	../../vertical-scroll-area.cpp
 	../../double-slider.cpp
+	../../slider-ignorewheel.cpp
+	../../comboBox-ignorewheel.cpp
+	../../spinBox-ignorewheel.cpp
 	)
 set(frontend-tools_UI
 	${frontend-tools_UI}

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -20,6 +20,9 @@
 #include <QStackedWidget>
 #include <QDir>
 #include "double-slider.hpp"
+#include "slider-ignorewheel.hpp"
+#include "spinBox-ignorewheel.hpp"
+#include "comboBox-ignorewheel.hpp"
 #include "qt-wrappers.hpp"
 #include "properties-view.hpp"
 #include "properties-view.moc.hpp"
@@ -321,7 +324,7 @@ void OBSPropertiesView::AddInt(obs_property_t *prop, QFormLayout *layout,
 
 	const char *name = obs_property_name(prop);
 	int        val   = (int)obs_data_get_int(settings, name);
-	QSpinBox   *spin = new QSpinBox();
+	QSpinBox   *spin = new SpinBoxIgnoreScroll();
 
 	if (!obs_property_enabled(prop))
 		spin->setEnabled(false);
@@ -340,7 +343,7 @@ void OBSPropertiesView::AddInt(obs_property_t *prop, QFormLayout *layout,
 	children.emplace_back(info);
 
 	if (type == OBS_NUMBER_SLIDER) {
-		QSlider *slider = new QSlider();
+		QSlider *slider = new SliderIgnoreScroll();
 		slider->setMinimum(minVal);
 		slider->setMaximum(maxVal);
 		slider->setPageStep(stepVal);
@@ -481,7 +484,7 @@ static string from_obs_data_autoselect(obs_data_t *data, const char *name,
 QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 {
 	const char       *name  = obs_property_name(prop);
-	QComboBox        *combo = new QComboBox();
+	QComboBox        *combo = new ComboBoxIgnoreScroll();
 	obs_combo_type   type   = obs_property_list_type(prop);
 	obs_combo_format format = obs_property_list_format(prop);
 	size_t           count  = obs_property_list_item_count(prop);
@@ -913,7 +916,7 @@ static QWidget *CreateSimpleFPSValues(OBSFrameRatePropertyWidget *fpsProps,
 	auto items = vector<common_frame_rate>{};
 	items.reserve(sizeof(common_fps)/sizeof(common_frame_rate));
 
-	auto combo = fpsProps->simpleFPS = new QComboBox{};
+	auto combo = fpsProps->simpleFPS = new ComboBoxIgnoreScroll{};
 
 	combo->addItem("", QVariant::fromValue(make_fps(0, 0)));
 	for (const auto &fps : common_fps) {
@@ -993,7 +996,7 @@ static QWidget *CreateRationalFPS(OBSFrameRatePropertyWidget *fpsProps,
 	auto str = QTStr("Basic.PropertiesView.FPS.ValidFPSRanges");
 	auto rlabel = new QLabel{str};
 
-	auto combo = fpsProps->fpsRange = new QComboBox{};
+	auto combo = fpsProps->fpsRange = new ComboBoxIgnoreScroll{};
 	auto convert_fps = media_frames_per_second_to_fps;
 	//auto convert_fi  = media_frames_per_second_to_frame_interval;
 
@@ -1014,8 +1017,8 @@ static QWidget *CreateRationalFPS(OBSFrameRatePropertyWidget *fpsProps,
 
 	layout->addRow(rlabel, combo);
 
-	auto num_edit = fpsProps->numEdit = new QSpinBox{};
-	auto den_edit = fpsProps->denEdit = new QSpinBox{};
+	auto num_edit = fpsProps->numEdit = new SpinBoxIgnoreScroll{};
+	auto den_edit = fpsProps->denEdit = new SpinBoxIgnoreScroll{};
 
 	num_edit->setRange(0, INT_MAX);
 	den_edit->setRange(0, INT_MAX);
@@ -1044,7 +1047,7 @@ static OBSFrameRatePropertyWidget *CreateFrameRateWidget(obs_property_t *prop,
 
 	swap(widget->fps_ranges, fps_ranges);
 
-	auto combo = widget->modeSelect = new QComboBox{};
+	auto combo = widget->modeSelect = new ComboBoxIgnoreScroll{};
 	combo->addItem(QTStr("Basic.PropertiesView.FPS.Simple"),
 			QVariant::fromValue(frame_rate_tag::simple()));
 	combo->addItem(QTStr("Basic.PropertiesView.FPS.Rational"),

--- a/UI/slider-ignorewheel.cpp
+++ b/UI/slider-ignorewheel.cpp
@@ -1,0 +1,19 @@
+#include "slider-ignorewheel.hpp"
+
+SliderIgnoreScroll::SliderIgnoreScroll(QWidget *parent) : QSlider(parent)
+{
+	setFocusPolicy(Qt::StrongFocus);
+}
+
+void SliderIgnoreScroll::wheelEvent(QWheelEvent * event)
+{
+	if (!hasFocus())
+		event->ignore();
+	else
+		QSlider::wheelEvent(event);
+}
+
+void SliderIgnoreScroll::leaveEvent(QEvent * event)
+{
+	clearFocus();
+}

--- a/UI/slider-ignorewheel.hpp
+++ b/UI/slider-ignorewheel.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QSlider>
+#include <QInputEvent>
+#include <QtCore/QObject>
+
+
+class SliderIgnoreScroll : public QSlider {
+	Q_OBJECT
+
+public:
+	SliderIgnoreScroll(QWidget *parent = nullptr);
+
+protected:
+
+	virtual void wheelEvent(QWheelEvent *event) override;
+	virtual void leaveEvent(QEvent *event) override;
+};
+
+

--- a/UI/spinBox-ignorewheel.cpp
+++ b/UI/spinBox-ignorewheel.cpp
@@ -1,0 +1,19 @@
+#include "spinBox-ignorewheel.hpp"
+
+SpinBoxIgnoreScroll::SpinBoxIgnoreScroll(QWidget *parent) : QSpinBox(parent)
+{
+	setFocusPolicy(Qt::StrongFocus);
+}
+
+void SpinBoxIgnoreScroll::wheelEvent(QWheelEvent * event)
+{
+	if (!hasFocus())
+		event->ignore();
+	else
+		QSpinBox::wheelEvent(event);
+}
+
+void SpinBoxIgnoreScroll::leaveEvent(QEvent * event)
+{
+	clearFocus();
+}

--- a/UI/spinBox-ignorewheel.hpp
+++ b/UI/spinBox-ignorewheel.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QSpinBox>
+#include <QInputEvent>
+#include <QtCore/QObject>
+
+
+class SpinBoxIgnoreScroll : public QSpinBox {
+	Q_OBJECT
+
+public:
+	SpinBoxIgnoreScroll(QWidget *parent = nullptr);
+
+protected:
+
+	virtual void wheelEvent(QWheelEvent *event) override;
+	virtual void leaveEvent(QEvent *event) override;
+};
+
+


### PR DESCRIPTION
0001214: Scroll wheel events modifies keyboard focus
Uses eventFilter to disable scrollwheel for comboBox, Slider, and Spin box when adding sources. 

