### PR TITLE
0001183: Add a keyboard shortcut to rename elements (scenes and sources) in OBS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -267,6 +267,11 @@ vic
 vividnightmare
 wangrui05
 wayne wang
+Florida Tech(Group 5)
+  Aayush Kapar
+  Bo Wang
+  Nicholas Sahm
+  Todd St. Onge
 
 Translators:
 Gol D. Ace (goldace)

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3987,7 +3987,7 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 		popup.addSeparator();
 		popup.addAction(QTStr("Duplicate"),
 				this, SLOT(DuplicateSelectedScene()));
-		popup.addAction(QTStr("Rename"),
+		popup.addAction(QTStr("Rename(F2)"),
 				this, SLOT(EditSceneName()));
 		popup.addAction(QTStr("Remove"),
 				this, SLOT(RemoveSelectedScene()));
@@ -4407,7 +4407,7 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		colorSelect = new ColorSelect(colorMenu);
 		popup.addMenu(AddBackgroundColorMenu(colorMenu,
 				colorWidgetAction, colorSelect, sceneItem));
-		popup.addAction(QTStr("Rename"), this,
+		popup.addAction(QTStr("Rename(F2)"), this,
 				SLOT(EditSceneItemName()));
 		popup.addAction(QTStr("Remove"), this,
 				SLOT(on_actionRemoveSource_triggered()));


### PR DESCRIPTION
I change the "Rename" to "Rename(F2)
After the "Rename" entry, there is "F2" (as same as the "Delete" entry and "Del") which fit for the Scenario 2 and Scenario 4