### PR TITLE
UI: Don't hide cursor over multiview

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -74,7 +74,7 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 
 	bool hideCursor = config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "HideProjectorCursor");
-	if (hideCursor && !isWindow) {
+	if (hideCursor && !isWindow && type != ProjectorType::Multiview) {
 		QPixmap empty(16, 16);
 		empty.fill(Qt::transparent);
 		setCursor(QCursor(empty));


### PR DESCRIPTION
I considered making this an option, but I decided against it because
I felt it wasn't necessary and would make the settings more complex.
Opinions are welcome.