### PR TITLE
UI: Add null check for rename of default theme

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1029,7 +1029,7 @@ bool OBSApp::InitTheme()
 	const char *themeName = config_get_string(globalConfig, "General",
 			"CurrentTheme");
 
-	if (strcmp(themeName, "Default") == 0)
+	if (themeName && strcmp(themeName, "Default") == 0)
 		themeName = "System";
 
 	if (!themeName) {


### PR DESCRIPTION
Without this, we strcmp a null pointer if no theme is set in the
configuration file.