### PR TITLE
libobs: UI: Fix rotated line scale

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -395,6 +395,8 @@ static void update_item_transform(struct obs_scene_item *item, bool update_tex)
 		scale.y = (float)height * item->scale.y;
 	}
 
+	item->box_scale = scale;
+
 	add_alignment(&base_origin, item->align, (int)scale.x, (int)scale.y);
 
 	matrix4_identity(&item->box_transform);
@@ -1260,6 +1262,7 @@ static inline void duplicate_item_data(struct obs_scene_item *dst,
 	dst->output_scale = src->output_scale;
 	dst->scale_filter = src->scale_filter;
 	dst->box_transform = src->box_transform;
+	dst->box_scale = src->box_scale;
 	dst->draw_transform = src->draw_transform;
 	dst->bounds_type = src->bounds_type;
 	dst->bounds_align = src->bounds_align;
@@ -2045,6 +2048,13 @@ void obs_sceneitem_get_box_transform(const obs_sceneitem_t *item,
 {
 	if (item)
 		matrix4_copy(transform, &item->box_transform);
+}
+
+void obs_sceneitem_get_box_scale(const obs_sceneitem_t *item,
+		struct vec2 *scale)
+{
+	if (item)
+		*scale = item->box_scale;
 }
 
 bool obs_sceneitem_visible(const obs_sceneitem_t *item)

--- a/libobs/obs-scene.h
+++ b/libobs/obs-scene.h
@@ -65,6 +65,7 @@ struct obs_scene_item {
 	enum obs_scale_type   scale_filter;
 
 	struct matrix4        box_transform;
+	struct vec2           box_scale;
 	struct matrix4        draw_transform;
 
 	enum obs_bounds_type  bounds_type;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1453,6 +1453,8 @@ EXPORT void obs_sceneitem_get_draw_transform(const obs_sceneitem_t *item,
 		struct matrix4 *transform);
 EXPORT void obs_sceneitem_get_box_transform(const obs_sceneitem_t *item,
 		struct matrix4 *transform);
+EXPORT void obs_sceneitem_get_box_scale(const obs_sceneitem_t *item,
+		struct vec2 *scale);
 
 EXPORT bool obs_sceneitem_visible(const obs_sceneitem_t *item);
 EXPORT bool obs_sceneitem_set_visible(obs_sceneitem_t *item, bool visible);


### PR DESCRIPTION
The line drawing functions previously assumed the upper-left 3x3 for
box_transform only held scale. The matrix can also hold rotation, so
pass in scale separately.

Fixes https://obsproject.com/mantis/view.php?id=1442