### PR TITLE
obs-outputs: Fix leak with certs for rtmp

### DIFF
--- a/plugins/obs-outputs/librtmp/rtmp.h
+++ b/plugins/obs-outputs/librtmp/rtmp.h
@@ -381,6 +381,7 @@ extern "C"
     void RTMP_Init(RTMP *r);
     void RTMP_Close(RTMP *r);
     RTMP *RTMP_Alloc(void);
+    void RTMP_TLS_Free();
     void RTMP_Free(RTMP *r);
     void RTMP_EnableWrite(RTMP *r);
 

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -92,6 +92,7 @@ static void rtmp_stream_destroy(void *data)
 		}
 	}
 
+	RTMP_TLS_Free();
 	free_packets(stream);
 	dstr_free(&stream->path);
 	dstr_free(&stream->key);


### PR DESCRIPTION
Fix about a thousand leaks (one per certificate) with mbedTLS for rtmp.