### PR TITLE
libobs: Fix GS_UNSIGNED_LONG definition

### DIFF
--- a/libobs-opengl/gl-indexbuffer.c
+++ b/libobs-opengl/gl-indexbuffer.c
@@ -38,7 +38,7 @@ gs_indexbuffer_t *device_indexbuffer_create(gs_device_t *device,
 		uint32_t flags)
 {
 	struct gs_index_buffer *ib = bzalloc(sizeof(struct gs_index_buffer));
-	size_t width = type == GS_UNSIGNED_LONG ? sizeof(long) : sizeof(short);
+	size_t width = type == GS_UNSIGNED_LONG ? 4 : 2;
 
 	ib->device  = device;
 	ib->data    = indices;

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -1517,9 +1517,7 @@ gs_indexbuffer_t *gs_indexbuffer_create(enum gs_index_type type,
 		return NULL;
 
 	if (indices && num && (flags & GS_DUP_BUFFER) != 0) {
-		size_t size = type == GS_UNSIGNED_SHORT
-			? sizeof(unsigned short)
-			: sizeof(unsigned long);
+		size_t size = type == GS_UNSIGNED_SHORT ? 2 : 4;
 		indices = bmemdup(indices, size * num);
 	}
 


### PR DESCRIPTION
GS_UNSIGNED_LONG is defined as sizeof(long) in some places, making it 8
outside of Windows instead of 4 as it should be.

Fixes https://obsproject.com/mantis/view.php?id=1444