### PR TITLE
UI: Fix unable to escape when renaming scene

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7290,3 +7290,17 @@ void SceneRenameDelegate::setEditorData(QWidget *editor,
 	if (lineEdit)
 		lineEdit->selectAll();
 }
+
+bool SceneRenameDelegate::eventFilter(QObject *editor, QEvent *event)
+{
+	if (event->type() == QEvent::KeyPress) {
+		QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+		if (keyEvent->key() == Qt::Key_Escape) {
+			QLineEdit *lineEdit = qobject_cast<QLineEdit*>(editor);
+			if (lineEdit)
+				lineEdit->undo();
+		}
+	}
+
+	return QStyledItemDelegate::eventFilter(editor, event);
+}

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -830,4 +830,7 @@ public:
 	SceneRenameDelegate(QObject *parent);
 	virtual void setEditorData(QWidget *editor, const QModelIndex &index)
 		const override;
+
+protected:
+	virtual bool eventFilter(QObject *editor, QEvent *event) override;
 };


### PR DESCRIPTION
Fixes https://obsproject.com/mantis/view.php?id=1443