### PR TITLE
UI: Use dB for volume in adv. audio properties

### DIFF
--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -3,6 +3,7 @@
 #include <obs.hpp>
 #include <QWidget>
 #include <QPointer>
+#include <QDoubleSpinBox>
 #include "balance-slider.hpp"
 
 class QGridLayout;
@@ -22,7 +23,7 @@ private:
 	QPointer<QWidget>      balanceContainer;
 
 	QPointer<QLabel>       nameLabel;
-	QPointer<QSpinBox>     volume;
+	QPointer<QDoubleSpinBox> volume;
 	QPointer<QCheckBox>    forceMono;
 	QPointer<BalanceSlider>balance;
 	QPointer<QLabel>       labelL;
@@ -59,7 +60,7 @@ public slots:
 	void SourceSyncChanged(int64_t offset);
 	void SourceMixersChanged(uint32_t mixers);
 
-	void volumeChanged(int percentage);
+	void volumeChanged(double db);
 	void downmixMonoChanged(bool checked);
 	void balanceChanged(int val);
 	void syncOffsetChanged(int milliseconds);

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -824,7 +824,7 @@ Basic.Settings.Advanced.AutoRemux.MP4="(record as mkv)"
 # advanced audio properties
 Basic.AdvAudio="Advanced Audio Properties"
 Basic.AdvAudio.Name="Name"
-Basic.AdvAudio.Volume="Volume (%)"
+Basic.AdvAudio.Volume="Volume"
 Basic.AdvAudio.Mono="Downmix to Mono"
 Basic.AdvAudio.Balance="Balance"
 Basic.AdvAudio.SyncOffset="Sync Offset (ms)"

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -14,6 +14,7 @@
 using namespace std;
 
 #define CLAMP(x, min, max) ((x) < (min) ? (min) : ((x) > (max) ? (max) : (x)))
+#define FADER_PRECISION 4096.0
 
 QWeakPointer<VolumeMeterTimer> VolumeMeter::updateTimer;
 
@@ -47,7 +48,8 @@ void VolControl::OBSVolumeMuted(void *data, calldata_t *calldata)
 void VolControl::VolumeChanged()
 {
 	slider->blockSignals(true);
-	slider->setValue((int) (obs_fader_get_deflection(obs_fader) * 100.0f));
+	slider->setValue((int) (obs_fader_get_deflection(obs_fader) *
+			FADER_PRECISION));
 	slider->blockSignals(false);
 
 	updateText();
@@ -66,7 +68,7 @@ void VolControl::SetMuted(bool checked)
 
 void VolControl::SliderChanged(int vol)
 {
-	obs_fader_set_deflection(obs_fader, float(vol) * 0.01f);
+	obs_fader_set_deflection(obs_fader, float(vol) / FADER_PRECISION);
 	updateText();
 }
 
@@ -234,7 +236,7 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 	volLabel->setFont(font);
 
 	slider->setMinimum(0);
-	slider->setMaximum(100);
+	slider->setMaximum(int(FADER_PRECISION));
 
 	bool muted = obs_source_muted(source);
 	mute->setChecked(muted);

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -118,7 +118,7 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 		: source      (std::move(source_)),
 		levelTotal    (0.0f),
 		levelCount    (0.0f),
-		obs_fader     (obs_fader_create(OBS_FADER_CUBIC)),
+		obs_fader     (obs_fader_create(OBS_FADER_LOG)),
 		obs_volmeter  (obs_volmeter_create(OBS_FADER_LOG)),
 		vertical      (vertical)
 {

--- a/libobs/obs-audio-controls.c
+++ b/libobs/obs-audio-controls.c
@@ -932,3 +932,12 @@ void obs_volmeter_remove_callback(obs_volmeter_t *volmeter,
 	pthread_mutex_unlock(&volmeter->callback_mutex);
 }
 
+float obs_mul_to_db(float mul)
+{
+	return mul_to_db(mul);
+}
+
+float obs_db_to_mul(float db)
+{
+	return db_to_mul(db);
+}

--- a/libobs/obs-audio-controls.h
+++ b/libobs/obs-audio-controls.h
@@ -273,6 +273,9 @@ EXPORT void obs_volmeter_add_callback(obs_volmeter_t *volmeter,
 EXPORT void obs_volmeter_remove_callback(obs_volmeter_t *volmeter,
 		obs_volmeter_updated_t callback, void *param);
 
+EXPORT float obs_mul_to_db(float mul);
+EXPORT float obs_db_to_mul(float db);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This changes the volume to dB, instead of percent, in the advanced audio properties. I've set the range from -120.0 dB to +12.0 dB with 0.1 dB increments. I believe users would understand dB more easily than percents.

![Screenshot from 2019-04-28 00-55-17](https://user-images.githubusercontent.com/19962531/56860205-7526e580-6959-11e9-9016-0f1184e5009e.png)
