### PR TITLE
Decklink: Use frame scheduling API to fix output audio drift

### DIFF
--- a/plugins/decklink/DecklinkOutput.cpp
+++ b/plugins/decklink/DecklinkOutput.cpp
@@ -57,7 +57,6 @@ bool DeckLinkOutput::Activate(DeckLinkDevice *device, long long modeId)
 		return false;
 	}
 
-
 	if (!instance->StartOutput(mode)) {
 		instance = nullptr;
 		return false;

--- a/plugins/decklink/decklink-device-instance.cpp
+++ b/plugins/decklink/decklink-device-instance.cpp
@@ -10,6 +10,9 @@
 #include <sstream>
 #include <algorithm>
 
+
+#define TIME_BASE 1000000000
+
 static inline enum video_format ConvertPixelFormat(BMDPixelFormat format)
 {
 	switch (format) {
@@ -388,6 +391,13 @@ bool DeckLinkDeviceInstance::StartOutput(DeckLinkDeviceMode *mode_)
 		return false;
 	}
 
+	output->SetScheduledFrameCompletionCallback(this);
+	mode_->GetFrameRate(&outputFrameDuration, &outputTimeScale);
+
+	outputDriftOffset = 0;
+
+	output->StartScheduledPlayback (os_gettime_ns(), TIME_BASE, 1.0);
+
 	return true;
 }
 
@@ -429,18 +439,59 @@ void DeckLinkDeviceInstance::DisplayVideoFrame(video_data *frame)
 	std::copy(outData, outData + (decklinkOutput->GetHeight() *
 		rowBytes), destData);
 
-	output->DisplayVideoFrameSync(decklinkOutputFrame);
+	int64_t length = (outputFrameDuration * TIME_BASE) / outputTimeScale;
+	int64_t timestamp = frame->timestamp;
+
+	output->ScheduleVideoFrame(decklinkOutputFrame,
+			timestamp + outputInitialScheduleOffset - outputDriftOffset,
+			length, TIME_BASE);
+
+	// deal with clock drift
+	BMDTimeValue stream_frame_time;
+	double playback_speed;
+	output->GetScheduledStreamTime(TIME_BASE,
+			&stream_frame_time, &playback_speed);
+
+	if (timestamp - outputDriftOffset - stream_frame_time > 4000000) {
+		outputDriftOffset += 500000;
+	}
+}
+
+HRESULT	DeckLinkDeviceInstance::ScheduledFrameCompleted (
+		IDeckLinkVideoFrame* completedFrame,
+		BMDOutputFrameCompletionResult result)
+{
+	if (result == bmdOutputFrameDropped) {
+		blog(LOG_ERROR, "Dropped Frame");
+	}
+
+	if (result == bmdOutputFrameDisplayedLate) {
+		blog(LOG_ERROR, "Late Frame");
+	}
+	return S_OK;
+}
+
+HRESULT DeckLinkDeviceInstance::ScheduledPlaybackHasStopped()
+{
+	return S_OK;
 }
 
 void DeckLinkDeviceInstance::WriteAudio(audio_data *frames)
 {
 	uint32_t sampleFramesWritten;
-	output->WriteAudioSamplesSync(frames->data[0],
+	output->ScheduleAudioSamples(frames->data[0],
 			frames->frames,
+			frames->timestamp + outputInitialScheduleOffset - outputDriftOffset,
+			TIME_BASE,
 			&sampleFramesWritten);
-}
 
-#define TIME_BASE 1000000000
+	if (sampleFramesWritten < frames->frames) {
+		blog(LOG_ERROR,
+				"Didn't write enough audio samples. Sent: %d, Written: %d",
+				frames->frames,
+				sampleFramesWritten);
+	}
+}
 
 HRESULT STDMETHODCALLTYPE DeckLinkDeviceInstance::VideoInputFrameArrived(
 		IDeckLinkVideoInputFrame *videoFrame,

--- a/plugins/decklink/decklink-device-instance.hpp
+++ b/plugins/decklink/decklink-device-instance.hpp
@@ -9,7 +9,7 @@
 class AudioRepacker;
 class DecklinkBase;
 
-class DeckLinkDeviceInstance : public IDeckLinkInputCallback {
+class DeckLinkDeviceInstance : public IDeckLinkVideoOutputCallback, public IDeckLinkInputCallback {
 protected:
 	struct obs_source_frame2 currentFrame;
 	struct obs_source_audio currentPacket;
@@ -32,6 +32,10 @@ protected:
 	AudioRepacker           *audioRepacker = nullptr;
 	speaker_layout          channelFormat = SPEAKERS_STEREO;
 	bool                    swap;
+	BMDTimeValue            outputFrameDuration = 0;
+	BMDTimeScale            outputTimeScale = 0;
+	int64_t                 outputInitialScheduleOffset = 1000000000;
+	int64_t                 outputDriftOffset = 0;
 
 	IDeckLinkMutableVideoFrame *decklinkOutputFrame = nullptr;
 
@@ -46,6 +50,9 @@ protected:
 public:
 	DeckLinkDeviceInstance(DecklinkBase *decklink, DeckLinkDevice *device);
 	virtual ~DeckLinkDeviceInstance();
+
+	virtual HRESULT STDMETHODCALLTYPE	ScheduledFrameCompleted (IDeckLinkVideoFrame* completedFrame, BMDOutputFrameCompletionResult result);
+	virtual HRESULT STDMETHODCALLTYPE	ScheduledPlaybackHasStopped ();
 
 	inline DeckLinkDevice *GetDevice() const {return device;}
 	inline long long GetActiveModeId() const

--- a/plugins/decklink/decklink-device-mode.cpp
+++ b/plugins/decklink/decklink-device-mode.cpp
@@ -32,6 +32,11 @@ BMDDisplayMode DeckLinkDeviceMode::GetDisplayMode(void) const
 	return bmdModeUnknown;
 }
 
+void DeckLinkDeviceMode::GetFrameRate (/* out */ BMDTimeValue *frameDuration, /* out */ BMDTimeScale *timeScale)
+{
+	mode->GetFrameRate(frameDuration, timeScale);
+}
+
 int DeckLinkDeviceMode::GetWidth()
 {
 	if (mode != nullptr)

--- a/plugins/decklink/decklink-device-mode.hpp
+++ b/plugins/decklink/decklink-device-mode.hpp
@@ -26,4 +26,6 @@ public:
 
 	int GetWidth();
 	int GetHeight();
+
+	void GetFrameRate(BMDTimeValue *frameDuration, BMDTimeScale *timeScale);
 };


### PR DESCRIPTION
This code uses the deckling scheduling API to use frame / audio timestamps to make sure that audio / video don't drift apart. This also add in clock drift compensation for this API.

This needs more testing but seemed to be successful with a 24 hour stream on my end.