### PR TITLE
Fix crash due to SIGPIPE from writing on closed socket

### DIFF
--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -40,6 +40,10 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
+#if defined(_WIN32)
+#define MSG_NOSIGNAL 0
+#endif
+
 #if defined(USE_MBEDTLS)
 #if defined(_WIN32)
 #include <windows.h>
@@ -4589,7 +4593,7 @@ RTMPSockBuf_Fill(RTMPSockBuf *sb)
         else
 #endif
         {
-            nBytes = recv(sb->sb_socket, sb->sb_start + sb->sb_size, nBytes, 0);
+            nBytes = recv(sb->sb_socket, sb->sb_start + sb->sb_size, nBytes, MSG_NOSIGNAL);
         }
         if (nBytes > 0)
         {
@@ -4642,7 +4646,7 @@ RTMPSockBuf_Send(RTMPSockBuf *sb, const char *buf, int len)
     else
 #endif
     {
-        rc = send(sb->sb_socket, buf, len, 0);
+        rc = send(sb->sb_socket, buf, len, MSG_NOSIGNAL);
     }
     return rc;
 }

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -16,6 +16,7 @@
 ******************************************************************************/
 
 #include "rtmp-stream.h"
+#include <signal.h>
 
 static const char *rtmp_stream_getname(void *unused)
 {
@@ -453,6 +454,16 @@ static void set_output_error(struct rtmp_stream *stream)
 
 static void *send_thread(void *data)
 {
+#ifndef _WIN32
+	// prevent SIGPIPE if write is called on a closed socket
+	struct sigaction sa;
+	sa.sa_handler = SIG_IGN;
+	sa.sa_flags = 0;
+	if (sigaction(SIGPIPE, &sa, 0) == -1) {
+		return NULL;
+	}
+#endif
+
 	struct rtmp_stream *stream = data;
 
 	os_set_thread_name("rtmp-stream: send_thread");


### PR DESCRIPTION
SIGPIPE is ignored in the top main thread, but I observed a crash due to SIGPIPE being emitted when embedtls was doing a `write()` on a socket that had been closed by the peer.