### PR TITLE
UI: Hide Alpha channel field from the color picker

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -1675,8 +1675,7 @@ bool WidgetInfo::ColorChanged(const char *setting)
 	long long  val   = obs_data_get_int(view->settings, setting);
 	QColor     color = color_from_int(val);
 
-	QColorDialog::ColorDialogOptions options =
-		QColorDialog::ShowAlphaChannel;
+	QColorDialog::ColorDialogOptions options = 0;
 
 	/* The native dialog on OSX has all kinds of problems, like closing
 	 * other open QDialogs on exit, and


### PR DESCRIPTION
Do not allow the user to select the alpha component of a color.

While https://github.com/obsproject/obs-studio/commit/78d566916bfd9847e8777a031f590106de17aa36 is still in use why not to hide this useless stuff?

Also, people asking time to time:
https://obsproject.com/forum/threads/color-correction-filter.94484/