### PR TITLE
win-dshow: fix issue decoding some H.264 stream

### DIFF
--- a/plugins/win-dshow/ffmpeg-decode.c
+++ b/plugins/win-dshow/ffmpeg-decode.c
@@ -63,14 +63,15 @@ void ffmpeg_decode_free(struct ffmpeg_decode *decode)
 static inline enum video_format convert_pixel_format(int f)
 {
 	switch (f) {
-	case AV_PIX_FMT_NONE:    return VIDEO_FORMAT_NONE;
-	case AV_PIX_FMT_YUV420P: return VIDEO_FORMAT_I420;
-	case AV_PIX_FMT_NV12:    return VIDEO_FORMAT_NV12;
-	case AV_PIX_FMT_YUYV422: return VIDEO_FORMAT_YUY2;
-	case AV_PIX_FMT_UYVY422: return VIDEO_FORMAT_UYVY;
-	case AV_PIX_FMT_RGBA:    return VIDEO_FORMAT_RGBA;
-	case AV_PIX_FMT_BGRA:    return VIDEO_FORMAT_BGRA;
-	case AV_PIX_FMT_BGR0:    return VIDEO_FORMAT_BGRX;
+	case AV_PIX_FMT_NONE:     return VIDEO_FORMAT_NONE;
+	case AV_PIX_FMT_YUV420P:
+	case AV_PIX_FMT_YUVJ420P: return VIDEO_FORMAT_I420;
+	case AV_PIX_FMT_NV12:     return VIDEO_FORMAT_NV12;
+	case AV_PIX_FMT_YUYV422:  return VIDEO_FORMAT_YUY2;
+	case AV_PIX_FMT_UYVY422:  return VIDEO_FORMAT_UYVY;
+	case AV_PIX_FMT_RGBA:     return VIDEO_FORMAT_RGBA;
+	case AV_PIX_FMT_BGRA:     return VIDEO_FORMAT_BGRA;
+	case AV_PIX_FMT_BGR0:     return VIDEO_FORMAT_BGRX;
 	default:;
 	}
 


### PR DESCRIPTION
Logitech C920 web camera will output YUVJ420P H.264 in 1080p which is not supported yet.