### PR TITLE
win-capture: Fix hook collisions with multiple game captures

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -1251,8 +1251,13 @@ static inline enum capture_result init_capture_data(struct game_capture *gc)
 
 	CloseHandle(gc->hook_data_map);
 
-	gc->hook_data_map = open_map_plus_id(gc, SHMEM_TEXTURE,
-					     gc->global_hook_info->map_id);
+	wchar_t name[64];
+	_snwprintf(name, 64, L"%s_%d_", SHMEM_TEXTURE,
+		   (uint32_t)(uintptr_t)gc->window);
+
+	gc->hook_data_map =
+		open_map_plus_id(gc, name, gc->global_hook_info->map_id);
+
 	if (!gc->hook_data_map) {
 		DWORD error = GetLastError();
 		if (error == 2) {

--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -490,10 +490,11 @@ static inline void unlock_shmem_tex(int id)
 	}
 }
 
-static inline bool init_shared_info(size_t size)
+static inline bool init_shared_info(size_t size, HWND window)
 {
 	wchar_t name[64];
-	_snwprintf(name, 64, L"%s%u", SHMEM_TEXTURE, ++shmem_id_counter);
+	_snwprintf(name, 64, L"%s_%d_%u", SHMEM_TEXTURE,
+		   (uint32_t)(uintptr_t)window, ++shmem_id_counter);
 
 	shmem_file_handle = CreateFileMappingW(INVALID_HANDLE_VALUE, NULL,
 					       PAGE_READWRITE, 0, (DWORD)size,
@@ -519,7 +520,7 @@ bool capture_init_shtex(struct shtex_data **data, HWND window, uint32_t base_cx,
 			uint32_t base_cy, uint32_t cx, uint32_t cy,
 			uint32_t format, bool flip, uintptr_t handle)
 {
-	if (!init_shared_info(sizeof(struct shtex_data))) {
+	if (!init_shared_info(sizeof(struct shtex_data), window)) {
 		hlog("capture_init_shtex: Failed to initialize memory");
 		return false;
 	}
@@ -700,7 +701,7 @@ bool capture_init_shmem(struct shmem_data **data, HWND window, uint32_t base_cx,
 	uint32_t total_size = aligned_header + aligned_tex * 2 + 32;
 	uintptr_t align_pos;
 
-	if (!init_shared_info(total_size)) {
+	if (!init_shared_info(total_size, window)) {
 		hlog("capture_init_shmem: Failed to initialize memory");
 		return false;
 	}


### PR DESCRIPTION
Before this change, after a game capture source would send a signal to
init or restart a graphics hook, it would respond to any and all hook
ready signals.

With multiple game capture sources in the same scene, a source could
receive the signal intended for another source, and show the wrong
texture.

This change adds the window handle to the name for shared data with the
hook, resulting in hooks for other sources being ignored.