### PR TITLE
libobs: UI: Remove Qt usage from graphics thread

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3353,9 +3353,11 @@ void OBSBasic::RenderMain(void *data, uint32_t cx, uint32_t cy)
 	gs_viewport_push();
 	gs_projection_push();
 
-	QSize previewSize = GetPixelSize(window->ui->preview);
-	float right  = float(previewSize.width())  - window->previewX;
-	float bottom = float(previewSize.height()) - window->previewY;
+	obs_display_t *display = window->ui->preview->GetDisplay();
+	uint32_t width, height;
+	obs_display_size(display, &width, &height);
+	float right  = float(width)  - window->previewX;
+	float bottom = float(height) - window->previewY;
 
 	gs_ortho(-window->previewX, right,
 		-window->previewY, bottom,

--- a/libobs/obs-display.c
+++ b/libobs/obs-display.c
@@ -237,3 +237,19 @@ void obs_display_set_background_color(obs_display_t *display, uint32_t color)
 	if (display)
 		display->background_color = color;
 }
+
+void obs_display_size(obs_display_t *display,
+		uint32_t *width, uint32_t *height)
+{
+	*width = 0;
+	*height = 0;
+
+	if (display) {
+		pthread_mutex_lock(&display->draw_info_mutex);
+
+		*width = display->cx;
+		*height = display->cy;
+
+		pthread_mutex_unlock(&display->draw_info_mutex);
+	}
+}

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -813,6 +813,9 @@ EXPORT bool obs_display_enabled(obs_display_t *display);
 EXPORT void obs_display_set_background_color(obs_display_t *display,
 		uint32_t color);
 
+EXPORT void obs_display_size(obs_display_t *display,
+		uint32_t *width, uint32_t *height);
+
 
 /* ------------------------------------------------------------------------- */
 /* Sources */


### PR DESCRIPTION
This fixes Xcode warning about detecting UI usage from another thread.