### PR TITLE
sRGB GPU formats, linear color-handling

### DIFF
--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -86,7 +86,7 @@ void OBSQTDisplay::CreateDisplay()
 	gs_init_data info = {};
 	info.cx = size.width();
 	info.cy = size.height();
-	info.format = GS_RGBA;
+	info.format = GS_RGBA_SRGB;
 	info.zsformat = GS_ZS_NONE;
 
 	QTToGSWindow(winId(), info.window);

--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -33,18 +33,22 @@ void gs_index_buffer::Rebuild(ID3D11Device *dev)
 
 void gs_texture_2d::RebuildSharedTextureFallback()
 {
+	static const gs_color_format format = GS_BGRA;
+
 	td = {};
 	td.Width = 2;
 	td.Height = 2;
 	td.MipLevels = 1;
-	td.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	td.Format = ConvertGSTextureFormatResource(format);
 	td.ArraySize = 1;
 	td.SampleDesc.Count = 1;
 	td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
 
 	width = td.Width;
 	height = td.Height;
-	dxgiFormat = td.Format;
+	dxgiFormat = ConvertGSTextureFormat(format);
+	dxgiFormatResource = td.Format;
+	dxgiFormatNoSrgb = ConvertGSTextureFormatNoSrgb(format);
 	levels = 1;
 
 	resourceDesc = {};

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -100,6 +100,78 @@ static inline DXGI_FORMAT ConvertGSTextureFormat(gs_color_format format)
 		return DXGI_FORMAT_BC3_UNORM;
 	case GS_R8G8:
 		return DXGI_FORMAT_R8G8_UNORM;
+	case GS_RGBA_SRGB:
+		return DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+	case GS_BGRX_SRGB:
+		return DXGI_FORMAT_B8G8R8X8_UNORM_SRGB;
+	case GS_BGRA_SRGB:
+		return DXGI_FORMAT_B8G8R8A8_UNORM_SRGB;
+	}
+
+	return DXGI_FORMAT_UNKNOWN;
+}
+
+static inline DXGI_FORMAT ConvertGSTextureFormatResource(gs_color_format format)
+{
+	switch (format) {
+	case GS_UNKNOWN:
+		return DXGI_FORMAT_UNKNOWN;
+	case GS_A8:
+		return DXGI_FORMAT_A8_UNORM;
+	case GS_R8:
+		return DXGI_FORMAT_R8_UNORM;
+	case GS_RGBA:
+		return DXGI_FORMAT_R8G8B8A8_UNORM;
+	case GS_BGRX:
+		return DXGI_FORMAT_B8G8R8X8_UNORM;
+	case GS_BGRA:
+		return DXGI_FORMAT_B8G8R8A8_UNORM;
+	case GS_R10G10B10A2:
+		return DXGI_FORMAT_R10G10B10A2_UNORM;
+	case GS_RGBA16:
+		return DXGI_FORMAT_R16G16B16A16_UNORM;
+	case GS_R16:
+		return DXGI_FORMAT_R16_UNORM;
+	case GS_RGBA16F:
+		return DXGI_FORMAT_R16G16B16A16_FLOAT;
+	case GS_RGBA32F:
+		return DXGI_FORMAT_R32G32B32A32_FLOAT;
+	case GS_RG16F:
+		return DXGI_FORMAT_R16G16_FLOAT;
+	case GS_RG32F:
+		return DXGI_FORMAT_R32G32_FLOAT;
+	case GS_R16F:
+		return DXGI_FORMAT_R16_FLOAT;
+	case GS_R32F:
+		return DXGI_FORMAT_R32_FLOAT;
+	case GS_DXT1:
+		return DXGI_FORMAT_BC1_UNORM;
+	case GS_DXT3:
+		return DXGI_FORMAT_BC2_UNORM;
+	case GS_DXT5:
+		return DXGI_FORMAT_BC3_UNORM;
+	case GS_R8G8:
+		return DXGI_FORMAT_R8G8_UNORM;
+	case GS_RGBA_SRGB:
+		return DXGI_FORMAT_R8G8B8A8_TYPELESS;
+	case GS_BGRX_SRGB:
+		return DXGI_FORMAT_B8G8R8X8_TYPELESS;
+	case GS_BGRA_SRGB:
+		return DXGI_FORMAT_B8G8R8A8_TYPELESS;
+	}
+
+	return DXGI_FORMAT_UNKNOWN;
+}
+
+static inline DXGI_FORMAT ConvertGSTextureFormatNoSrgb(gs_color_format format)
+{
+	switch (format) {
+	case GS_RGBA_SRGB:
+		return DXGI_FORMAT_R8G8B8A8_UNORM;
+	case GS_BGRX_SRGB:
+		return DXGI_FORMAT_B8G8R8X8_UNORM;
+	case GS_BGRA_SRGB:
+		return DXGI_FORMAT_B8G8R8A8_UNORM;
 	}
 
 	return DXGI_FORMAT_UNKNOWN;
@@ -144,6 +216,12 @@ static inline gs_color_format ConvertDXGITextureFormat(DXGI_FORMAT format)
 		return GS_DXT3;
 	case DXGI_FORMAT_BC3_UNORM:
 		return GS_DXT5;
+	case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+		return GS_RGBA_SRGB;
+	case DXGI_FORMAT_B8G8R8X8_UNORM_SRGB:
+		return GS_BGRX_SRGB;
+	case DXGI_FORMAT_B8G8R8A8_UNORM_SRGB:
+		return GS_BGRA_SRGB;
 	}
 
 	return GS_UNKNOWN;
@@ -409,11 +487,14 @@ struct gs_texture : gs_obj {
 struct gs_texture_2d : gs_texture {
 	ComPtr<ID3D11Texture2D> texture;
 	ComPtr<ID3D11RenderTargetView> renderTarget[6];
+	ComPtr<ID3D11RenderTargetView> renderTargetNoSrgb[6];
 	ComPtr<IDXGISurface1> gdiSurface;
 
 	uint32_t width = 0, height = 0;
 	uint32_t flags = 0;
 	DXGI_FORMAT dxgiFormat = DXGI_FORMAT_UNKNOWN;
+	DXGI_FORMAT dxgiFormatResource = DXGI_FORMAT_UNKNOWN;
+	DXGI_FORMAT dxgiFormatNoSrgb = DXGI_FORMAT_UNKNOWN;
 	bool isRenderTarget = false;
 	bool isGDICompatible = false;
 	bool isDynamic = false;

--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -173,6 +173,7 @@ void device_load_swapchain(gs_device_t *device, gs_swapchain_t *swap)
 	device->cur_swap = swap;
 	if (swap) {
 		[device->plat->context setView:swap->wi->view];
+		gl_enable(GL_FRAMEBUFFER_SRGB);
 	} else {
 		[device->plat->context clearDrawable];
 	}

--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -71,6 +71,12 @@ static inline GLenum convert_gs_format(enum gs_color_format format)
 		return GL_RGBA;
 	case GS_DXT5:
 		return GL_RGBA;
+	case GS_RGBA_SRGB:
+		return GL_RGBA;
+	case GS_BGRX_SRGB:
+		return GL_BGRA;
+	case GS_BGRA_SRGB:
+		return GL_BGRA;
 	case GS_UNKNOWN:
 		return 0;
 	}
@@ -117,6 +123,12 @@ static inline GLenum convert_gs_internal_format(enum gs_color_format format)
 		return GL_COMPRESSED_RGBA_S3TC_DXT3_EXT;
 	case GS_DXT5:
 		return GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
+	case GS_RGBA_SRGB:
+		return GL_SRGB8_ALPHA8;
+	case GS_BGRX_SRGB:
+		return GL_SRGB8;
+	case GS_BGRA_SRGB:
+		return GL_SRGB8_ALPHA8;
 	case GS_UNKNOWN:
 		return 0;
 	}
@@ -162,6 +174,12 @@ static inline GLenum get_gl_format_type(enum gs_color_format format)
 	case GS_DXT3:
 		return GL_UNSIGNED_BYTE;
 	case GS_DXT5:
+		return GL_UNSIGNED_BYTE;
+	case GS_RGBA_SRGB:
+		return GL_UNSIGNED_BYTE;
+	case GS_BGRX_SRGB:
+		return GL_UNSIGNED_BYTE;
+	case GS_BGRA_SRGB:
 		return GL_UNSIGNED_BYTE;
 	case GS_UNKNOWN:
 		return 0;

--- a/libobs-opengl/gl-windows.c
+++ b/libobs-opengl/gl-windows.c
@@ -41,6 +41,9 @@ static inline int get_color_format_bits(enum gs_color_format format)
 {
 	switch ((uint32_t)format) {
 	case GS_RGBA:
+	case GS_BGRA:
+	case GS_RGBA_SRGB:
+	case GS_BGRA_SRGB:
 		return 32;
 	default:
 		return 0;
@@ -554,7 +557,9 @@ void device_load_swapchain(gs_device_t *device, gs_swapchain_t *swap)
 		hdc = swap->wi->hdc;
 
 	if (hdc) {
-		if (!wgl_make_current(hdc, device->plat->hrc))
+		if (wgl_make_current(hdc, device->plat->hrc))
+			gl_enable(GL_FRAMEBUFFER_SRGB);
+		else
 			blog(LOG_ERROR, "device_load_swapchain (GL) failed");
 	}
 }

--- a/libobs-opengl/gl-x11.c
+++ b/libobs-opengl/gl-x11.c
@@ -554,13 +554,17 @@ extern void device_load_swapchain(gs_device_t *device, gs_swapchain_t *swap)
 		XID window = swap->wi->window;
 		if (!glXMakeContextCurrent(dpy, window, window, ctx)) {
 			blog(LOG_ERROR, "Failed to make context current.");
+			return;
 		}
 	} else {
 		GLXPbuffer pbuf = device->plat->pbuffer;
 		if (!glXMakeContextCurrent(dpy, pbuf, pbuf, ctx)) {
 			blog(LOG_ERROR, "Failed to make context current.");
+			return;
 		}
 	}
+
+	gl_enable(GL_FRAMEBUFFER_SRGB);
 }
 
 enum swap_type {

--- a/libobs/data/opaque.effect
+++ b/libobs/data/opaque.effect
@@ -25,11 +25,33 @@ float4 PSDraw(VertInOut vert_in) : TARGET
 	return float4(image.Sample(def_sampler, vert_in.uv).rgb, 1.0);
 }
 
+float SrgbToLinear(float c)
+{
+	return (c <= 0.04045) ? (c / 12.92) : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float4 PSDrawSrgb(VertInOut vert_in) : TARGET
+{
+	float3 rgb = image.Sample(def_sampler, vert_in.uv).rgb;
+	rgb = float3(SrgbToLinear(rgb.r), SrgbToLinear(rgb.g),
+			SrgbToLinear(rgb.b));
+	return float4(rgb, 1.0);
+}
+
 technique Draw
 {
 	pass
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDraw(vert_in);
+	}
+}
+
+technique DrawSrgb
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawSrgb(vert_in);
 	}
 }

--- a/libobs/graphics/device-exports.h
+++ b/libobs/graphics/device-exports.h
@@ -98,6 +98,9 @@ EXPORT gs_texture_t *device_get_render_target(const gs_device_t *device);
 EXPORT gs_zstencil_t *device_get_zstencil_target(const gs_device_t *device);
 EXPORT void device_set_render_target(gs_device_t *device, gs_texture_t *tex,
 				     gs_zstencil_t *zstencil);
+EXPORT void device_set_render_target_no_srgb(gs_device_t *device,
+					     gs_texture_t *tex,
+					     gs_zstencil_t *zstencil);
 EXPORT void device_set_cube_render_target(gs_device_t *device,
 					  gs_texture_t *cubetex, int side,
 					  gs_zstencil_t *zstencil);

--- a/libobs/graphics/effect.c
+++ b/libobs/graphics/effect.c
@@ -480,7 +480,7 @@ void gs_effect_set_vec4(gs_eparam_t *param, const struct vec4 *val)
 void gs_effect_set_color(gs_eparam_t *param, uint32_t argb)
 {
 	struct vec4 v_color;
-	vec4_from_bgra(&v_color, argb);
+	vec4_from_bgra_srgb(&v_color, argb);
 	effect_setval_inline(param, &v_color, sizeof(struct vec4));
 }
 

--- a/libobs/graphics/graphics-ffmpeg.c
+++ b/libobs/graphics/graphics-ffmpeg.c
@@ -211,11 +211,11 @@ static inline enum gs_color_format convert_format(enum AVPixelFormat format)
 {
 	switch ((int)format) {
 	case AV_PIX_FMT_RGBA:
-		return GS_RGBA;
+		return GS_RGBA_SRGB;
 	case AV_PIX_FMT_BGRA:
-		return GS_BGRA;
+		return GS_BGRA_SRGB;
 	case AV_PIX_FMT_BGR0:
-		return GS_BGRX;
+		return GS_BGRX_SRGB;
 	}
 
 	return GS_BGRX;
@@ -229,7 +229,8 @@ uint8_t *gs_create_texture_file_data(const char *file,
 	uint8_t *data = NULL;
 
 	if (ffmpeg_image_init(&image, file)) {
-		data = bmalloc(image.cx * image.cy * 4);
+		const int size = image.cx * image.cy * 4;
+		data = bmalloc(size);
 
 		if (ffmpeg_image_decode(&image, data, image.cx * 4)) {
 			*format = convert_format(image.format);

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -78,6 +78,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT(device_get_render_target);
 	GRAPHICS_IMPORT(device_get_zstencil_target);
 	GRAPHICS_IMPORT(device_set_render_target);
+	GRAPHICS_IMPORT(device_set_render_target_no_srgb);
 	GRAPHICS_IMPORT(device_set_cube_render_target);
 	GRAPHICS_IMPORT(device_copy_texture_region);
 	GRAPHICS_IMPORT(device_copy_texture);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -100,6 +100,9 @@ struct gs_exports {
 	gs_zstencil_t *(*device_get_zstencil_target)(const gs_device_t *device);
 	void (*device_set_render_target)(gs_device_t *device, gs_texture_t *tex,
 					 gs_zstencil_t *zstencil);
+	void (*device_set_render_target_no_srgb)(gs_device_t *device,
+						 gs_texture_t *tex,
+						 gs_zstencil_t *zstencil);
 	void (*device_set_cube_render_target)(gs_device_t *device,
 					      gs_texture_t *cubetex, int side,
 					      gs_zstencil_t *zstencil);

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -1662,6 +1662,17 @@ void gs_set_render_target(gs_texture_t *tex, gs_zstencil_t *zstencil)
 						   zstencil);
 }
 
+void gs_set_render_target_no_srgb(gs_texture_t *tex, gs_zstencil_t *zstencil)
+{
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_set_render_target"))
+		return;
+
+	graphics->exports.device_set_render_target_no_srgb(graphics->device,
+							   tex, zstencil);
+}
+
 void gs_set_cube_render_target(gs_texture_t *cubetex, int side,
 			       gs_zstencil_t *zstencil)
 {

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -73,6 +73,9 @@ enum gs_color_format {
 	GS_DXT3,
 	GS_DXT5,
 	GS_R8G8,
+	GS_RGBA_SRGB,
+	GS_BGRX_SRGB,
+	GS_BGRA_SRGB,
 };
 
 enum gs_zstencil_format {
@@ -434,6 +437,8 @@ EXPORT gs_texrender_t *gs_texrender_create(enum gs_color_format format,
 EXPORT void gs_texrender_destroy(gs_texrender_t *texrender);
 EXPORT bool gs_texrender_begin(gs_texrender_t *texrender, uint32_t cx,
 			       uint32_t cy);
+EXPORT bool gs_texrender_begin_no_srgb(gs_texrender_t *texrender, uint32_t cx,
+				       uint32_t cy);
 EXPORT void gs_texrender_end(gs_texrender_t *texrender);
 EXPORT void gs_texrender_reset(gs_texrender_t *texrender);
 EXPORT gs_texture_t *gs_texrender_get_texture(const gs_texrender_t *texrender);
@@ -651,6 +656,8 @@ EXPORT gs_texture_t *gs_get_render_target(void);
 EXPORT gs_zstencil_t *gs_get_zstencil_target(void);
 
 EXPORT void gs_set_render_target(gs_texture_t *tex, gs_zstencil_t *zstencil);
+EXPORT void gs_set_render_target_no_srgb(gs_texture_t *tex,
+					 gs_zstencil_t *zstencil);
 EXPORT void gs_set_cube_render_target(gs_texture_t *cubetex, int side,
 				      gs_zstencil_t *zstencil);
 
@@ -908,6 +915,12 @@ static inline uint32_t gs_get_format_bpp(enum gs_color_format format)
 		return 8;
 	case GS_R8G8:
 		return 16;
+	case GS_RGBA_SRGB:
+		return 32;
+	case GS_BGRX_SRGB:
+		return 32;
+	case GS_BGRA_SRGB:
+		return 32;
 	case GS_UNKNOWN:
 		return 0;
 	}

--- a/libobs/graphics/image-file.c
+++ b/libobs/graphics/image-file.c
@@ -153,7 +153,7 @@ static bool init_animated_gif(gs_image_file_t *image, const char *path,
 
 		image->cx = (uint32_t)image->gif.width;
 		image->cy = (uint32_t)image->gif.height;
-		image->format = GS_RGBA;
+		image->format = GS_RGBA_SRGB;
 
 		if (mem_usage) {
 			*mem_usage += image->cx * image->cy * 4;

--- a/libobs/graphics/texture-render.c
+++ b/libobs/graphics/texture-render.c
@@ -116,6 +116,36 @@ bool gs_texrender_begin(gs_texrender_t *texrender, uint32_t cx, uint32_t cy)
 	return true;
 }
 
+bool gs_texrender_begin_no_srgb(gs_texrender_t *texrender, uint32_t cx,
+				uint32_t cy)
+{
+	if (!texrender || texrender->rendered)
+		return false;
+
+	if (!cx || !cy)
+		return false;
+
+	if (texrender->cx != cx || texrender->cy != cy)
+		if (!texrender_resetbuffer(texrender, cx, cy))
+			return false;
+
+	if (!texrender->target)
+		return false;
+
+	gs_viewport_push();
+	gs_projection_push();
+	gs_matrix_push();
+	gs_matrix_identity();
+
+	texrender->prev_target = gs_get_render_target();
+	texrender->prev_zs = gs_get_zstencil_target();
+	gs_set_render_target_no_srgb(texrender->target, texrender->zs);
+
+	gs_set_viewport(0, 0, texrender->cx, texrender->cy);
+
+	return true;
+}
+
 void gs_texrender_end(gs_texrender_t *texrender)
 {
 	if (!texrender)

--- a/libobs/graphics/vec4.h
+++ b/libobs/graphics/vec4.h
@@ -226,6 +226,25 @@ static inline void vec4_from_rgba(struct vec4 *dst, uint32_t rgba)
 	dst->w = (float)((double)(rgba & 0xFF) * (1.0 / 255.0));
 }
 
+static inline float srgb_to_float(uint32_t c)
+{
+	const float nonlinear = (float)c * (1.0f / 255.0f);
+	return (nonlinear <= 0.04045f)
+		       ? nonlinear / 12.92f
+		       : powf((nonlinear + 0.055f) / 1.055f, 2.4f);
+}
+
+static inline void vec4_from_rgba_srgb(struct vec4 *dst, uint32_t rgba)
+{
+	dst->x = srgb_to_float(rgba & 0xFF);
+	rgba >>= 8;
+	dst->y = srgb_to_float(rgba & 0xFF);
+	rgba >>= 8;
+	dst->z = srgb_to_float(rgba & 0xFF);
+	rgba >>= 8;
+	dst->w = (float)((double)(rgba & 0xFF) * (1.0 / 255.0));
+}
+
 static inline void vec4_from_bgra(struct vec4 *dst, uint32_t bgra)
 {
 	dst->z = (float)((double)(bgra & 0xFF) * (1.0 / 255.0));
@@ -233,6 +252,17 @@ static inline void vec4_from_bgra(struct vec4 *dst, uint32_t bgra)
 	dst->y = (float)((double)(bgra & 0xFF) * (1.0 / 255.0));
 	bgra >>= 8;
 	dst->x = (float)((double)(bgra & 0xFF) * (1.0 / 255.0));
+	bgra >>= 8;
+	dst->w = (float)((double)(bgra & 0xFF) * (1.0 / 255.0));
+}
+
+static inline void vec4_from_bgra_srgb(struct vec4 *dst, uint32_t bgra)
+{
+	dst->z = srgb_to_float(bgra & 0xFF);
+	bgra >>= 8;
+	dst->y = srgb_to_float(bgra & 0xFF);
+	bgra >>= 8;
+	dst->x = srgb_to_float(bgra & 0xFF);
 	bgra >>= 8;
 	dst->w = (float)((double)(bgra & 0xFF) * (1.0 / 255.0));
 }

--- a/libobs/obs-display.c
+++ b/libobs/obs-display.c
@@ -164,7 +164,7 @@ static inline void render_display_begin(struct obs_display *display,
 
 	gs_begin_scene();
 
-	vec4_from_rgba(&clear_color, display->background_color);
+	vec4_from_rgba_srgb(&clear_color, display->background_color);
 	clear_color.w = 1.0f;
 
 	gs_clear(GS_CLEAR_COLOR | GS_CLEAR_DEPTH | GS_CLEAR_STENCIL,

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -775,11 +775,11 @@ static inline enum gs_color_format
 convert_video_format(enum video_format format)
 {
 	if (format == VIDEO_FORMAT_RGBA)
-		return GS_RGBA;
+		return GS_RGBA_SRGB;
 	else if (format == VIDEO_FORMAT_BGRA)
-		return GS_BGRA;
+		return GS_BGRA_SRGB;
 
-	return GS_BGRX;
+	return GS_BGRX_SRGB;
 }
 
 extern void obs_source_activate(obs_source_t *source, enum view_type type);

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -424,7 +424,8 @@ static void update_item_transform(struct obs_scene_item *item, bool update_tex)
 
 	} else if (!item->item_render && item_texture_enabled(item)) {
 		obs_enter_graphics();
-		item->item_render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+		item->item_render =
+			gs_texrender_create(GS_RGBA_SRGB, GS_ZS_NONE);
 		obs_leave_graphics();
 	}
 
@@ -792,7 +793,8 @@ static void scene_load_item(struct obs_scene *scene, obs_data_t *item_data)
 
 	} else if (!item->item_render && item_texture_enabled(item)) {
 		obs_enter_graphics();
-		item->item_render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+		item->item_render =
+			gs_texrender_create(GS_RGBA_SRGB, GS_ZS_NONE);
 		obs_leave_graphics();
 	}
 
@@ -1301,7 +1303,7 @@ static inline void duplicate_item_data(struct obs_scene_item *dst,
 		if (!dst->item_render && item_texture_enabled(dst)) {
 			obs_enter_graphics();
 			dst->item_render =
-				gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+				gs_texrender_create(GS_RGBA_SRGB, GS_ZS_NONE);
 			obs_leave_graphics();
 		}
 	}
@@ -1672,7 +1674,8 @@ static obs_sceneitem_t *obs_scene_add_internal(obs_scene_t *scene,
 
 	if (item_texture_enabled(item)) {
 		obs_enter_graphics();
-		item->item_render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+		item->item_render =
+			gs_texrender_create(GS_RGBA_SRGB, GS_ZS_NONE);
 		obs_leave_graphics();
 	}
 

--- a/libobs/obs-source-deinterlace.c
+++ b/libobs/obs-source-deinterlace.c
@@ -196,7 +196,7 @@ void set_deinterlace_texture_size(obs_source_t *source)
 {
 	if (source->async_gpu_conversion) {
 		source->async_prev_texrender =
-			gs_texrender_create(GS_BGRX, GS_ZS_NONE);
+			gs_texrender_create(GS_BGRX_SRGB, GS_ZS_NONE);
 
 		source->async_prev_texture = gs_texture_create(
 			source->async_convert_width,

--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -51,9 +51,9 @@ bool obs_transition_init(obs_source_t *transition)
 
 	transition->transition_alignment = OBS_ALIGN_LEFT | OBS_ALIGN_TOP;
 	transition->transition_texrender[0] =
-		gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+		gs_texrender_create(GS_RGBA_SRGB, GS_ZS_NONE);
 	transition->transition_texrender[1] =
-		gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+		gs_texrender_create(GS_RGBA_SRGB, GS_ZS_NONE);
 	transition->transition_source_active[0] = true;
 
 	return transition->transition_texrender[0] != NULL &&

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1516,7 +1516,7 @@ bool set_async_texture_size(struct obs_source *source,
 		enum gs_color_format format =
 			(cur == CONVERT_RGB_LIMITED)
 				? convert_video_format(frame->format)
-				: GS_BGRX;
+				: GS_BGRX_SRGB;
 		source->async_texrender =
 			gs_texrender_create(format, GS_ZS_NONE);
 
@@ -1641,7 +1641,7 @@ static bool update_async_texrender(struct obs_source *source,
 		select_conversion_technique(frame->format, frame->full_range);
 	gs_technique_t *tech = gs_effect_get_technique(conv, tech_name);
 
-	if (!gs_texrender_begin(texrender, cx, cy)) {
+	if (!gs_texrender_begin_no_srgb(texrender, cx, cy)) {
 		GS_DEBUG_MARKER_END();
 		return false;
 	}

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -231,9 +231,9 @@ static bool obs_init_textures(struct obs_video_info *ovi)
 #endif
 	}
 
-	video->render_texture = gs_texture_create(ovi->base_width,
-						  ovi->base_height, GS_RGBA, 1,
-						  NULL, GS_RENDER_TARGET);
+	video->render_texture =
+		gs_texture_create(ovi->base_width, ovi->base_height,
+				  GS_RGBA_SRGB, 1, NULL, GS_RENDER_TARGET);
 
 	if (!video->render_texture)
 		return false;

--- a/plugins/image-source/color-source.c
+++ b/plugins/image-source/color-source.c
@@ -75,7 +75,7 @@ static void color_source_render(void *data, gs_effect_t *effect)
 	gs_technique_t *tech = gs_effect_get_technique(solid, "Solid");
 
 	struct vec4 colorVal;
-	vec4_from_rgba(&colorVal, context->color);
+	vec4_from_rgba_srgb(&colorVal, context->color);
 	gs_effect_set_vec4(color, &colorVal);
 
 	gs_technique_begin(tech);

--- a/plugins/obs-filters/chroma-key-filter.c
+++ b/plugins/obs-filters/chroma-key-filter.c
@@ -86,7 +86,7 @@ static inline void color_settings_update(struct chroma_key_filter_data *filter,
 	filter->brightness = (float)brightness;
 	filter->gamma = (float)gamma;
 
-	vec4_from_rgba(&filter->color, color);
+	vec4_from_rgba_srgb(&filter->color, color);
 }
 
 static inline void chroma_settings_update(struct chroma_key_filter_data *filter,
@@ -195,7 +195,7 @@ static void chroma_key_render(void *data, gs_effect_t *effect)
 	uint32_t height = obs_source_get_base_height(target);
 	struct vec2 pixel_size;
 
-	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
+	if (!obs_source_process_filter_begin(filter->context, GS_RGBA_SRGB,
 					     OBS_ALLOW_DIRECT_RENDERING))
 		return;
 

--- a/plugins/obs-filters/color-correction-filter.c
+++ b/plugins/obs-filters/color-correction-filter.c
@@ -221,7 +221,7 @@ static void color_correction_filter_update(void *data, obs_data_t *settings)
 
 	/* Now get the overlay color data. */
 	uint32_t color = (uint32_t)obs_data_get_int(settings, SETTING_COLOR);
-	vec4_from_rgba(&filter->color, color);
+	vec4_from_rgba_srgb(&filter->color, color);
 
 	/*
 	* Now let's build our Color 'overlay' matrix.
@@ -342,7 +342,7 @@ static void color_correction_filter_render(void *data, gs_effect_t *effect)
 {
 	struct color_correction_filter_data *filter = data;
 
-	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
+	if (!obs_source_process_filter_begin(filter->context, GS_RGBA_SRGB,
 					     OBS_ALLOW_DIRECT_RENDERING))
 		return;
 

--- a/plugins/obs-filters/color-grade-filter.c
+++ b/plugins/obs-filters/color-grade-filter.c
@@ -139,7 +139,7 @@ static void color_grade_filter_render(void *data, gs_effect_t *effect)
 		return;
 	}
 
-	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
+	if (!obs_source_process_filter_begin(filter->context, GS_RGBA_SRGB,
 					     OBS_ALLOW_DIRECT_RENDERING))
 		return;
 

--- a/plugins/obs-filters/color-key-filter.c
+++ b/plugins/obs-filters/color-key-filter.c
@@ -76,7 +76,7 @@ static inline void color_settings_update(struct color_key_filter_data *filter,
 	filter->brightness = (float)brightness;
 	filter->gamma = (float)gamma;
 
-	vec4_from_rgba(&filter->color, color);
+	vec4_from_rgba_srgb(&filter->color, color);
 }
 
 static inline void key_settings_update(struct color_key_filter_data *filter,
@@ -98,7 +98,7 @@ static inline void key_settings_update(struct color_key_filter_data *filter,
 	else if (strcmp(key_type, "magenta") == 0)
 		key_color = 0xFF00FF;
 
-	vec4_from_rgba(&filter->key_color, key_color | 0xFF000000);
+	vec4_from_rgba_srgb(&filter->key_color, key_color | 0xFF000000);
 
 	filter->similarity = (float)similarity / 1000.0f;
 	filter->smoothness = (float)smoothness / 1000.0f;
@@ -170,7 +170,7 @@ static void color_key_render(void *data, gs_effect_t *effect)
 {
 	struct color_key_filter_data *filter = data;
 
-	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
+	if (!obs_source_process_filter_begin(filter->context, GS_RGBA_SRGB,
 					     OBS_ALLOW_DIRECT_RENDERING))
 		return;
 

--- a/plugins/obs-filters/crop-filter.c
+++ b/plugins/obs-filters/crop-filter.c
@@ -186,7 +186,7 @@ static void crop_filter_render(void *data, gs_effect_t *effect)
 {
 	struct crop_filter_data *filter = data;
 
-	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
+	if (!obs_source_process_filter_begin(filter->context, GS_RGBA_SRGB,
 					     OBS_NO_DIRECT_RENDERING))
 		return;
 

--- a/plugins/obs-filters/data/luma_key_filter.effect
+++ b/plugins/obs-filters/data/luma_key_filter.effect
@@ -25,13 +25,24 @@ VertData VSDefault(VertData v_in)
 	return vert_out;
 }
 
+float LinearToSrgb(float c)
+{
+	return (c <= 0.0031308) ?
+			(12.92 * c) :
+			(1.055 * pow(c, 1.0 / 2.4) - 0.055);
+}
+
 float4 PSALumaKeyRGBA(VertData v_in) : TARGET
 {
 	float4 rgba = image.Sample(textureSampler, v_in.uv);
 
-	float4 lumaCoef = float4(0.2989, 0.5870, 0.1140, 0.0);
+	float3 nonlinear = float3(
+			LinearToSrgb(rgba.r),
+			LinearToSrgb(rgba.g),
+			LinearToSrgb(rgba.b));
+	float3 lumaCoef = float3(0.2126, 0.7152, 0.0722);
 
-	float luminance = dot(rgba, lumaCoef);
+	float luminance = dot(nonlinear, lumaCoef);
 
 	float clo = smoothstep(lumaMin, lumaMin + lumaMinSmooth, luminance);
 	float chi = 1. - smoothstep(lumaMax - lumaMaxSmooth, lumaMax, luminance);

--- a/plugins/obs-filters/gpu-delay.c
+++ b/plugins/obs-filters/gpu-delay.c
@@ -65,7 +65,7 @@ static void update_interval(struct gpu_delay_filter_data *f,
 			struct frame *frame =
 				circlebuf_data(&f->frames, i * sizeof(*frame));
 			frame->render =
-				gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+				gs_texrender_create(GS_RGBA_SRGB, GS_ZS_NONE);
 		}
 
 		obs_leave_graphics();

--- a/plugins/obs-filters/luma-key-filter.c
+++ b/plugins/obs-filters/luma-key-filter.c
@@ -105,7 +105,7 @@ static void luma_key_render(void *data, gs_effect_t *effect)
 {
 	struct luma_key_filter_data *filter = data;
 
-	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
+	if (!obs_source_process_filter_begin(filter->context, GS_RGBA_SRGB,
 					     OBS_ALLOW_DIRECT_RENDERING))
 		return;
 

--- a/plugins/obs-filters/mask-filter.c
+++ b/plugins/obs-filters/mask-filter.c
@@ -53,7 +53,7 @@ static void mask_filter_update(void *data, obs_data_t *settings)
 	color &= 0xFFFFFF;
 	color |= (uint32_t)(((double)opacity) * 2.55) << 24;
 
-	vec4_from_rgba(&filter->color, color);
+	vec4_from_rgba_srgb(&filter->color, color);
 
 	obs_enter_graphics();
 	gs_image_file_free(&filter->image);
@@ -216,7 +216,7 @@ static void mask_filter_render(void *data, gs_effect_t *effect)
 		vec2_div(&add_val, &add_val, &mask_size);
 	}
 
-	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
+	if (!obs_source_process_filter_begin(filter->context, GS_RGBA_SRGB,
 					     OBS_ALLOW_DIRECT_RENDERING))
 		return;
 

--- a/plugins/obs-filters/scale-filter.c
+++ b/plugins/obs-filters/scale-filter.c
@@ -280,7 +280,7 @@ static void scale_filter_render(void *data, gs_effect_t *effect)
 		return;
 	}
 
-	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
+	if (!obs_source_process_filter_begin(filter->context, GS_RGBA_SRGB,
 					     OBS_NO_DIRECT_RENDERING))
 		return;
 

--- a/plugins/obs-filters/scroll-filter.c
+++ b/plugins/obs-filters/scroll-filter.c
@@ -188,7 +188,7 @@ static void scroll_filter_render(void *data, gs_effect_t *effect)
 	vec2_set(&mul_val, (float)cx / (float)base_cx,
 		 (float)cy / (float)base_cy);
 
-	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
+	if (!obs_source_process_filter_begin(filter->context, GS_RGBA_SRGB,
 					     OBS_NO_DIRECT_RENDERING))
 		return;
 

--- a/plugins/obs-filters/sharpness-filter.c
+++ b/plugins/obs-filters/sharpness-filter.c
@@ -77,7 +77,7 @@ static void sharpness_render(void *data, gs_effect_t *effect)
 {
 	struct sharpness_data *filter = data;
 
-	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
+	if (!obs_source_process_filter_begin(filter->context, GS_RGBA_SRGB,
 					     OBS_ALLOW_DIRECT_RENDERING))
 		return;
 

--- a/plugins/win-capture/dc-capture.c
+++ b/plugins/win-capture/dc-capture.c
@@ -168,7 +168,7 @@ void dc_capture_capture(struct dc_capture *capture, HWND window)
 static void draw_texture(struct dc_capture *capture, gs_effect_t *effect)
 {
 	gs_texture_t *texture = capture->texture;
-	gs_technique_t *tech = gs_effect_get_technique(effect, "Draw");
+	gs_technique_t *tech = gs_effect_get_technique(effect, "DrawSrgb");
 	gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
 	size_t passes;
 


### PR DESCRIPTION
Starting up a draft PR for the implementation of sRGB formats to improve color handling. There are a few motivations:

- Some color blends are very wrong; e.g. the average of 0 and 255 is 188 for sRGB, not 128.
- Scale filters produce colors that are darker than they should be from interpolating nonlinear colors. Filtered texture samples have the same problem.
- Existing color filters probably produce images that are not mathematically correct although I'm still in the process of learning what correct means for some of them.
- Make color handling appear more consistent with #1713 to reduce "surprising" behavior. The same shaders can be used for both ACEScg and sRGB spaces in many situations since the shader values will be linear in both cases.

See this Google doc for more details as I continue to implement and test: https://docs.google.com/document/d/13Jh1QFgjveNKjdWXt3ksHzoAZl7ZS_Ich3QGeKnQzt4/edit?usp=sharing

**Implementation**
- [x] D3D support
- OpenGL support:
  - [x] WIndows
  - [x] Mac
  - [x] Linux
- Filters
  - [ ] chroma-key-filter
  - [ ] color-correction-filter
  - [ ] color-grade-filter
  - [ ] color-key-filter
  - [ ] crop-filter
  - [ ] gpu-delay
  - [ ] luma-key-filter [L* vs. Y'? (What do the two curves look like for 709 grays?)]
  - [ ] mask-filter
  - [ ] scale-filter
  - [ ] scroll-filter
  - [ ] sharpness-filter
- Inputs
  - [ ] linux-capture
  - [ ] obs-browser
  - [ ] obs-text
  - [ ] text-freetype2
  - [ ] win-capture
- Transitions
  - [ ] Cut
  - [ ] Fade
  - [ ] Fade to Color
  - [ ] Luma Wipe
  - [ ] Slide
  - [ ] Stinger
  - [ ] Swipe
- Image handling:
  - [x] FFmpeg
  - [ ] ImageMagick?
- [ ] decklink-output-ui
- [ ] [Other modified code paths]

**Testing**
- Document/test all code paths that have changed or are likely to regress here
  - Check OS/GPU/API permutations (Windows/Mac/Linux, NVIDIA/Intel, Direct3D/OpenGL)
- Check for Intel perf regressions
  - [x] Added sRGB shader math for Win32 HDC sources (measurements read cheaper, ha)
  - [x] General sRGB render target usage (definitely slower)
  - [ ] Upper bound on performance regression?
- [ ] TBD (All Tests)
  - [Add tests here]