### PR TITLE
libobs: Improve low-resolution bilinear sampling

### DIFF
--- a/libobs/data/bilinear_lowres_scale.effect
+++ b/libobs/data/bilinear_lowres_scale.effect
@@ -1,12 +1,11 @@
 /*
- * bilinear low res scaling, samples 9 pixels of a larger image to scale to a
+ * bilinear low res scaling, samples 8 pixels of a larger image to scale to a
  * low resolution image below half size
  */
 
 uniform float4x4 ViewProj;
 uniform texture2d image;
 uniform float4x4 color_matrix;
-uniform float2 base_dimension_i;
 
 sampler_state textureSampler {
 	Filter    = Linear;
@@ -34,19 +33,24 @@ float4 pixel(float2 uv)
 
 float4 DrawLowresBilinear(VertData v_in)
 {
-	float2 stepxy = base_dimension_i;
-	float4 out_color;
+	float2 uv = v_in.uv;
+	float2 stepxy  = float2(ddx(uv.x), ddy(uv.y));
+	float2 stepxy1 = stepxy * 0.0625;
+	float2 stepxy3 = stepxy * 0.1875;
+	float2 stepxy5 = stepxy * 0.3125;
+	float2 stepxy7 = stepxy * 0.4375;
 
-	out_color  = pixel(v_in.uv);
-	out_color += pixel(v_in.uv + float2(-stepxy.x, -stepxy.y));
-	out_color += pixel(v_in.uv + float2(-stepxy.x,       0.0));
-	out_color += pixel(v_in.uv + float2(-stepxy.x,  stepxy.y));
-	out_color += pixel(v_in.uv + float2(      0.0, -stepxy.y));
-	out_color += pixel(v_in.uv + float2(      0.0,  stepxy.y));
-	out_color += pixel(v_in.uv + float2( stepxy.x, -stepxy.y));
-	out_color += pixel(v_in.uv + float2( stepxy.x,       0.0));
-	out_color += pixel(v_in.uv + float2( stepxy.x,  stepxy.y));
-	return out_color / float4(9.0, 9.0, 9.0, 9.0);
+	// Simulate Direct3D 8-sample pattern
+	float4 out_color;
+	out_color  = pixel(uv + float2( stepxy1.x, -stepxy3.y));
+	out_color += pixel(uv + float2(-stepxy1.x,  stepxy3.y));
+	out_color += pixel(uv + float2( stepxy5.x,  stepxy1.y));
+	out_color += pixel(uv + float2(-stepxy3.x, -stepxy5.y));
+	out_color += pixel(uv + float2(-stepxy5.x,  stepxy5.y));
+	out_color += pixel(uv + float2(-stepxy7.x, -stepxy1.y));
+	out_color += pixel(uv + float2( stepxy3.x,  stepxy7.y));
+	out_color += pixel(uv + float2( stepxy7.x, -stepxy7.y));
+	return out_color * 0.125;
 }
 
 float4 PSDrawLowresBilinearRGBA(VertData v_in) : TARGET


### PR DESCRIPTION
The issue with the current bilinear_lowres_scale effect is that it
samples adjacent texels, disregarding the texel-to-pixel ratio. If the
ratio is large, this can lead to aliasing. This change provides a fair
set of texture samples across the entire pixel.

The 8-sample pattern used here comes from Direct3D.

**Example**

Consider this image, a white square with 9 evenly spaced black squares.:
![stress24](https://user-images.githubusercontent.com/10396506/57676953-8cf99d00-75da-11e9-9e4b-165b053d6ad2.png)

Downsampling from 24x24 to 3x3 leads to a completely black image because all samples are concentrated within the black squares:
![image](https://user-images.githubusercontent.com/10396506/57676999-aa2e6b80-75da-11e9-86ba-e25acf8bede7.png)

With samples spread out to cover the entire pixel, we get a nice light-gray as expected:
![image](https://user-images.githubusercontent.com/10396506/57677059-ce8a4800-75da-11e9-9521-7a2683c30d59.png)