### PR TITLE
UI: Dark theme consistency for Scenes vs Sources

### DIFF
--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -100,12 +100,19 @@ QMenuBar::item {
     background-color: rgb(58,57,58); /* dark */
 }
 
-QListWidget::item:selected:!active {
+QListWidget {
+    font-family: "MS Shell Dlg 2";
+    font-size: 8pt;
+}
+
+QListWidget::item:selected:!active,
+SourceTree::item:selected:!active {
     color: rgb(255, 255, 255);
     background-color: rgb(48,47,48);
 }
 
-QListWidget QLineEdit {
+QListWidget QLineEdit,
+SourceTree QLineEdit {
     padding-top: 0px;
     padding-bottom: 0px;
     padding-right: 0;


### PR DESCRIPTION
Selected but unfocused Source colour (improves visibility)
 - Before:
![2019-05-16_22-16-50](https://user-images.githubusercontent.com/941350/57855105-3d5edf80-782d-11e9-9885-776897245348.png)
- After:
![2019-05-16_22-15-50](https://user-images.githubusercontent.com/941350/57855115-42239380-782d-11e9-9b7c-1cdd573aa40c.png)



Scenes font (most visible when using uppercase "i") - only problem with this change is that it slightly changes the height of the element so that aspect no longer matches Sources
 - Before:
![2019-05-16_22-51-19](https://user-images.githubusercontent.com/941350/57855130-4d76bf00-782d-11e9-880d-3a569cc61655.png)
- After:
![2019-05-16_22-51-36](https://user-images.githubusercontent.com/941350/57855141-549dcd00-782d-11e9-8cbd-af537c5f881b.png)



Padding when editing Source name (was slightly cut off)
- Before:
![2019-05-16_22-16-58](https://user-images.githubusercontent.com/941350/57855162-5e273500-782d-11e9-9ed8-f1a3897fad61.png)
- After:
![2019-05-16_22-17-34](https://user-images.githubusercontent.com/941350/57855178-654e4300-782d-11e9-9d32-73b1027ea260.png)
