### PR TITLE
UI: Fix issue where rec time left would show negative time

### DIFF
--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -176,7 +176,6 @@ OBSBasicStats::OBSBasicStats(QWidget *parent, bool closeable)
 	QObject::connect(&recTimeLeft, &QTimer::timeout, this,
 			&OBSBasicStats::RecordingTimeLeft);
 	recTimeLeft.setInterval(REC_TIME_LEFT_INTERVAL);
-	recTimeLeft.start();
 
 	OBSBasic *main = reinterpret_cast<OBSBasic*>(App()->GetMainWindow());
 


### PR DESCRIPTION
The recording time left timer was being called an unnecessary time,
in the stats constructor, when it should have only been started
when the recording starts.