### PR TITLE
libobs: Remove unnecessary frame pipelining

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -240,14 +240,13 @@ struct obs_tex_frame {
 struct obs_core_video {
 	graphics_t                      *graphics;
 	gs_stagesurf_t                  *copy_surfaces[NUM_TEXTURES];
-	gs_texture_t                    *render_textures[NUM_TEXTURES];
-	gs_texture_t                    *output_textures[NUM_TEXTURES];
-	gs_texture_t                    *convert_textures[NUM_TEXTURES];
-	gs_texture_t                    *convert_uv_textures[NUM_TEXTURES];
-	bool                            textures_rendered[NUM_TEXTURES];
-	bool                            textures_output[NUM_TEXTURES];
+	gs_texture_t                    *render_texture;
+	gs_texture_t                    *output_texture;
+	gs_texture_t                    *convert_texture;
+	gs_texture_t                    *convert_uv_texture;
+	bool                            texture_rendered;
 	bool                            textures_copied[NUM_TEXTURES];
-	bool                            textures_converted[NUM_TEXTURES];
+	bool                            texture_converted;
 	bool                            using_nv12_tex;
 	struct circlebuf                vframe_info_buffer;
 	struct circlebuf                vframe_info_buffer_gpu;


### PR DESCRIPTION
Remove three instances of unnecessary double-buffering. They are not
needed to avoid stalls, and cause increased memory traffic when
measured on Intel HD 530, presumably because texture data will remain
in cache if sampled immediately after write.

(Note: GPU timings from Intel GPA are volatile.)

NV12, 3 Draws:
RGBA -> UYVX: 628 us -> 543 us
UYVX -> Y: 522 us -> 507 us
UYVX -> UV: 315 us -> 187 us
Total, Duration: 1594 us -> 1153 us
Total, GTI Read Throughput: 25.2 MB -> 15.9 MB