### PR TITLE
obs-outputs: add "Obs Studio" to encoder name

### DIFF
--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -817,7 +817,7 @@ static int try_connect(struct rtmp_stream *stream)
 
 	RTMP_EnableWrite(&stream->rtmp);
 
-	dstr_copy(&stream->encoder_name, "FMLE/3.0 (compatible; FMSc/1.0)");
+	dstr_copy(&stream->encoder_name, "FMLE/3.0 (compatible; OBS Studio; FMSc/1.0)");
 
 	set_rtmp_dstr(&stream->rtmp.Link.pubUser,   &stream->username);
 	set_rtmp_dstr(&stream->rtmp.Link.pubPasswd, &stream->password);


### PR DESCRIPTION
Currently RTMP flashVer does not include any mention of OBS. This  change adds "OBS Studio" identifier. This change would make it possible to identify OBS as the streaming software used.

This PR is an identical change to PR https://github.com/obsproject/obs-studio/pull/464 - it is closed and merged but to some other repository.