### PR TITLE
win-wasapi: Speaker enum fixes

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -16,9 +16,8 @@ using namespace std;
 
 static void GetWASAPIDefaults(obs_data_t *settings);
 
-// Fix inconsistent defs of speaker_surround between avutil & wasapi
-#define KSAUDIO_SPEAKER_2POINT1 (KSAUDIO_SPEAKER_STEREO|SPEAKER_LOW_FREQUENCY)
-#define KSAUDIO_SPEAKER_4POINT1 (KSAUDIO_SPEAKER_QUAD|SPEAKER_LOW_FREQUENCY)
+#define OBS_KSAUDIO_SPEAKER_4POINT1 \
+		(KSAUDIO_SPEAKER_SURROUND|SPEAKER_LOW_FREQUENCY)
 
 class WASAPISource {
 	ComPtr<IMMDevice>           device;
@@ -245,7 +244,7 @@ static speaker_layout ConvertSpeakerLayout(DWORD layout, WORD channels)
 	switch (layout) {
 	case KSAUDIO_SPEAKER_2POINT1:          return SPEAKERS_2POINT1;
 	case KSAUDIO_SPEAKER_SURROUND:         return SPEAKERS_4POINT0;
-	case KSAUDIO_SPEAKER_4POINT1:          return SPEAKERS_4POINT1;
+	case OBS_KSAUDIO_SPEAKER_4POINT1:      return SPEAKERS_4POINT1;
 	case KSAUDIO_SPEAKER_5POINT1_SURROUND: return SPEAKERS_5POINT1;
 	case KSAUDIO_SPEAKER_7POINT1_SURROUND: return SPEAKERS_7POINT1;
 	}


### PR DESCRIPTION
Remove KSAUDIO_SPEAKER_2POINT1 because it is included in the Windows
SDK. (I'm guessing it wasn't before.)

Redefine 4POINT1 as KSAUDIO_SPEAKER_SURROUND|SPEAKER_LOW_FREQUENCY
instead of KSAUDIO_SPEAKER_QUAD|SPEAKER_LOW_FREQUENCY. See definitions:

FFmpeg 4.1: FL+FR+FC+LFE+BC
WASAPI QUAD: FL+FR+BL+BR (looks wrong)
WASAPI SURROUND: FL+FR+FC+BC
WASAPI LOW_FREQUENCY: LFE