### PR TITLE
libobs/UI: Implement an item_locked event

### DIFF
--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -68,6 +68,7 @@ private:
 	OBSSignal groupReorderSignal;
 	OBSSignal deselectSignal;
 	OBSSignal visibleSignal;
+	OBSSignal lockedSignal;
 	OBSSignal renameSignal;
 	OBSSignal removeSignal;
 
@@ -80,6 +81,7 @@ private slots:
 	void ExitEditMode(bool save);
 
 	void VisibilityChanged(bool visible);
+	void LockedChanged(bool locked);
 	void Renamed(const QString &name);
 
 	void ExpandClicked(bool checked);

--- a/UI/visibility-item-widget.cpp
+++ b/UI/visibility-item-widget.cpp
@@ -94,6 +94,8 @@ VisibilityItemWidget::VisibilityItemWidget(obs_sceneitem_t *item_)
 			this);
 	signal_handler_connect(signal, "item_visible", OBSSceneItemVisible,
 			this);
+	signal_handler_connect(signal, "item_locked", OBSSceneItemLocked,
+			this);
 
 	connect(vis, SIGNAL(clicked(bool)),
 			this, SLOT(VisibilityClicked(bool)));
@@ -120,6 +122,8 @@ void VisibilityItemWidget::DisconnectItemSignals()
 	signal_handler_disconnect(signal, "item_remove", OBSSceneItemRemove,
 			this);
 	signal_handler_disconnect(signal, "item_visible", OBSSceneItemVisible,
+			this);
+	signal_handler_disconnect(signal, "item_locked", OBSSceneItemLocked,
 			this);
 
 	sceneRemoved = true;

--- a/docs/sphinx/reference-scenes.rst
+++ b/docs/sphinx/reference-scenes.rst
@@ -139,6 +139,10 @@ Scene Signals
 
    Called when a scene item's visibility state changes.
 
+**item_locked** (ptr scene, ptr item, bool locked)
+
+   Called when a scene item has been locked or unlocked.
+
 **item_select** (ptr scene, ptr item)
 **item_deselect** (ptr scene, ptr item)
 
@@ -403,6 +407,13 @@ Scene Item Functions
               bool obs_sceneitem_visible(const obs_sceneitem_t *item)
 
    Sets/gets the visibility state of the scene item.
+
+---------------------
+
+.. function:: bool obs_sceneitem_set_locked(obs_sceneitem_t *item, bool locked)
+              bool obs_sceneitem_locked(const obs_sceneitem_t *item)
+
+   Sets/gets the locked/unlocked state of the scene item.
 
 ---------------------
 

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -54,6 +54,7 @@ static const char *obs_scene_signals[] = {
 	"void item_select(ptr scene, ptr item)",
 	"void item_deselect(ptr scene, ptr item)",
 	"void item_transform(ptr scene, ptr item)",
+	"void item_locked(ptr scene, ptr item, bool locked)",
 	NULL
 };
 
@@ -2118,6 +2119,9 @@ bool obs_sceneitem_locked(const obs_sceneitem_t *item)
 
 bool obs_sceneitem_set_locked(obs_sceneitem_t *item, bool lock)
 {
+	struct calldata cd;
+	uint8_t stack[256];
+
 	if (!item)
 		return false;
 
@@ -2128,6 +2132,12 @@ bool obs_sceneitem_set_locked(obs_sceneitem_t *item, bool lock)
 		return false;
 
 	item->locked = lock;
+
+	calldata_init_fixed(&cd, stack, sizeof(stack));
+	calldata_set_ptr(&cd, "item", item);
+	calldata_set_bool(&cd, "locked", lock);
+
+	signal_parent(item->parent, "item_locked", &cd);
 
 	return true;
 }


### PR DESCRIPTION
Similar to item_visible, this event fires whenever a scene item is
locked or unlocked. This allows the UI and libobs to remain in sync
regarding scene elements' statuses.

Implements https://obsproject.com/mantis/view.php?id=1463