### PR TITLE
CI: Fix travis test on OSX

### DIFF
--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -10,7 +10,7 @@ set -e
 # Echo all commands before executing
 set -v
 
-if [ -v "$TRAVIS" ]; then
+if [[ $TRAVIS ]]; then
   git fetch --unshallow
 fi
 


### PR DESCRIPTION
`-v` test not supported in OS X system bash