### PR TITLE
CI: Build CEF with OS X 10.11 target

### DIFF
--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -57,6 +57,8 @@ tar -xf ./cef_binary_${CEF_BUILD_VERSION}_macosx64.tar.bz2
 cd ./cef_binary_${CEF_BUILD_VERSION}_macosx64
 # remove a broken test
 sed -i '.orig' '/add_subdirectory(tests\/ceftests)/d' ./CMakeLists.txt
+# target 10.11
+sed -i '.orig' s/\"10.9\"/\"10.11\"/ ./cmake/cef_variables.cmake
 mkdir build
 cd ./build
 cmake -DCMAKE_CXX_FLAGS="-std=c++11 -stdlib=libc++" -DCMAKE_EXE_LINKER_FLAGS="-std=c++11 -stdlib=libc++" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 ..


### PR DESCRIPTION
`-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11` fails to change target to 10.11