### PR TITLE
cmake: Jansson - add include path suffixes

### DIFF
--- a/cmake/Modules/FindJansson.cmake
+++ b/cmake/Modules/FindJansson.cmake
@@ -29,7 +29,12 @@ find_path(Jansson_INCLUDE_DIR
 		${DepsPath}
 		${_JANSSON_INCLUDE_DIRS}
 	PATHS
-		/usr/include /usr/local/include /opt/local/include /sw/include)
+		/usr/include /usr/local/include /opt/local/include /sw/include
+	PATH_SUFFIXES
+		include
+		include/jansson
+		include/src
+		src)
 
 find_library(Jansson_LIB
 	NAMES ${_JANSSON_LIBRARIES} jansson libjansson

--- a/plugins/obs-outputs/CMakeLists.txt
+++ b/plugins/obs-outputs/CMakeLists.txt
@@ -26,10 +26,12 @@ endif()
 
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ftl-sdk/CMakeLists.txt")
 	find_package(Libcurl REQUIRED)
+	find_package(Jansson QUIET)
 
 	add_definitions(-DFTL_STATIC_COMPILE)
 
 	include_directories(${LIBCURL_INCLUDE_DIRS})
+	include_directories(${JANSSON_INCLUDE_DIRS})
 
 	set(ftl_SOURCES
 		ftl-stream.c
@@ -48,7 +50,7 @@ if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ftl-sdk/CMakeLists.txt")
 		ftl-sdk/libftl/ftl.h
 		ftl-sdk/libftl/ftl_private.h)
 	set(ftl_IMPORTS
-		${OBS_JANSSON_IMPORT}
+		${JANSSON_LIBRARIES}
 		${LIBCURL_LIBRARIES})
 
 	if (WIN32)


### PR DESCRIPTION
Previously, CMake found the Jansson library but failed to find the headers in obsdeps. This PR adds suffixes `include/src` & `include/jansson` which will find jansson.h in the current obsdeps configuration (jansson.h is located in `/tmp/obsdeps/include/src`) as well as with the changes proposed in PR #1898 (all Jansson headers are placed in `/tmp/obsdeps/include/jansson`).