### PR TITLE
CI: Refine build-package-deps-osx.sh

### DIFF
--- a/CI/util/build-package-deps-osx.sh
+++ b/CI/util/build-package-deps-osx.sh
@@ -125,8 +125,9 @@ make install
 make -j 12
 ln -f -s libx264.*.dylib libx264.dylib
 find . -name \*.dylib -exec cp -a \{\} $DEPS_DEST/bin/ \;
-rsync -avh --prune-empty-dirs --include="*/" --include="*.h" --exclude="*" ../* $DEPS_DEST/include/
-rsync -avh --prune-empty-dirs --include="*/" --include="*.h" --exclude="*" ./* $DEPS_DEST/include/
+mkdir  $DEPS_DEST/include/x264
+rsync -avh --prune-empty-dirs --include="*/" --include="*.h" --exclude="*" ../* $DEPS_DEST/include/x264/
+rsync -avh --prune-empty-dirs --include="*/" --include="*.h" --exclude="*" ./* $DEPS_DEST/include/x264/
 
 cd $WORK_DIR
 
@@ -138,8 +139,8 @@ mkdir build
 cd ./build
 ../configure --enable-shared --disable-static --prefix="${PREFIX}" --libdir="${PREFIX}/bin"
 make -j 12
-mkdir -p $DEPS_DEST/include/jansson
 find . -name \*.dylib -exec cp -a \{\} $DEPS_DEST/bin/ \;
+mkdir $DEPS_DEST/include/jansson
 find . -name \*.h -exec cp -a \{\} $DEPS_DEST/include/jansson/ \;
 find ../src -name \*.h -exec cp -a \{\} $DEPS_DEST/include/jansson/ \;
 
@@ -156,8 +157,9 @@ cd ./build
 --disable-outdev=sdl --pkg-config-flags="--static" --extra-cflags="${CFLAGS}" --extra-ldflags="${LDFLAGS}"
 make -j 12
 find . -name \*.dylib -exec cp -a \{\} $DEPS_DEST/bin/ \;
-rsync -avh --prune-empty-dirs --include="*/" --include="*.h" --exclude="*" ../* $DEPS_DEST/include/
-rsync -avh --prune-empty-dirs --include="*/" --include="*.h" --exclude="*" ./* $DEPS_DEST/include/
+mkdir $DEPS_DEST/include/ffmpeg
+rsync -avh --prune-empty-dirs --include="*/" --include="*.h" --exclude="*" ../* $DEPS_DEST/include/ffmpeg/
+rsync -avh --prune-empty-dirs --include="*/" --include="*.h" --exclude="*" ./* $DEPS_DEST/include/ffmpeg/
 
 #luajit
 curl -L -O https://luajit.org/download/LuaJIT-2.0.5.tar.gz
@@ -166,7 +168,8 @@ cd LuaJIT-2.0.5
 make PREFIX="${PREFIX}"
 make PREFIX="${PREFIX}" install
 find "${PREFIX}/lib" -name libluajit\*.dylib -exec cp -a \{\} $DEPS_DEST/lib/ \;
-rsync -avh --prune-empty-dirs --include="*/" --include="*.h" --exclude="*" src/* $DEPS_DEST/include/
+mkdir $DEPS_DEST/include/luajit
+rsync -avh --prune-empty-dirs --include="*/" --include="*.h" --exclude="*" src/* $DEPS_DEST/include/luajit/
 make PREFIX="${PREFIX}" uninstall
 
 cd $WORK_DIR

--- a/cmake/Modules/FindFFmpeg.cmake
+++ b/cmake/Modules/FindFFmpeg.cmake
@@ -51,7 +51,12 @@ function(find_ffmpeg_library component header)
 			${PC_FFMPEG_${component}_INCLUDE_DIRS}
 		PATHS
 			/usr/include /usr/local/include /opt/local/include /sw/include
-		PATH_SUFFIXES ffmpeg libav include)
+		PATH_SUFFIXES
+			ffmpeg
+			libav
+			include
+			include/ffmpeg
+			include/libav)
 
 	find_library(FFMPEG_${component}_LIBRARY
 		NAMES

--- a/cmake/Modules/FindJansson.cmake
+++ b/cmake/Modules/FindJansson.cmake
@@ -29,7 +29,12 @@ find_path(Jansson_INCLUDE_DIR
 		${DepsPath}
 		${_JANSSON_INCLUDE_DIRS}
 	PATHS
-		/usr/include /usr/local/include /opt/local/include /sw/include)
+		/usr/include /usr/local/include /opt/local/include /sw/include
+	PATH_SUFFIXES
+		include
+		include/jansson
+		include/src
+		src)
 
 find_library(Jansson_LIB
 	NAMES ${_JANSSON_LIBRARIES} jansson libjansson

--- a/cmake/Modules/FindLibx264.cmake
+++ b/cmake/Modules/FindLibx264.cmake
@@ -34,7 +34,8 @@ find_path(X264_INCLUDE_DIR
 	PATHS
 		/usr/include /usr/local/include /opt/local/include /sw/include
 	PATH_SUFFIXES
-		include)
+		include
+		include/x264)
 
 find_library(X264_LIB
 	NAMES ${_X264_LIBRARIES} x264 libx264

--- a/plugins/obs-outputs/CMakeLists.txt
+++ b/plugins/obs-outputs/CMakeLists.txt
@@ -30,6 +30,7 @@ if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ftl-sdk/CMakeLists.txt")
 	add_definitions(-DFTL_STATIC_COMPILE)
 
 	include_directories(${LIBCURL_INCLUDE_DIRS})
+	include_directories(${OBS_JANSSON_INCLUDE_DIRS})
 
 	set(ftl_SOURCES
 		ftl-stream.c


### PR DESCRIPTION
* Add include directory suffixes in Jansson CMake module cc5399e97c4b5b2a9d21989019491ebffe291501
  * Jansson include directory now found by CMake when building OBS
* Consolidate include headers in subfolders of `obsdeps/include`
* Deparallelize libogg build to avoid make errors on some platforms
  * https://github.com/Homebrew/homebrew-core/blob/master/Formula/libogg.rb
* Preserve symlink versioning of libraries
  - Resulting archive 50% smaller
* Prune empty directories when rsync-ing header files
* Target OS X 10.11 when compiling x264 & FFmpeg
  * Fixes linking warning
* Replace all occurrences of `/tmp/obsdeps` with variable `PREFIX`
* Optimize (O2) Opus build
  * Fixes poor performance warning
* Omit building docs/examples/test