### PR TITLE
WIP: Add ability to measure GPU timings through API queries.

### DIFF
--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -225,6 +225,27 @@ void gs_swap_chain::Rebuild(ID3D11Device *dev)
 	Init();
 }
 
+void gs_timer::Rebuild(ID3D11Device *dev)
+{
+	D3D11_QUERY_DESC disjoint_desc;
+	disjoint_desc.Query = D3D11_QUERY_TIMESTAMP_DISJOINT;
+	disjoint_desc.MiscFlags = 0;
+	HRESULT hr = dev->CreateQuery(&disjoint_desc,
+			&query_disjoint);
+	if (FAILED(hr))
+		throw HRError("Failed to create timer", hr);
+
+	D3D11_QUERY_DESC timer_desc;
+	timer_desc.Query = D3D11_QUERY_TIMESTAMP;
+	timer_desc.MiscFlags = 0;
+	hr = dev->CreateQuery(&timer_desc, &query_begin);
+	if (FAILED(hr))
+		throw HRError("Failed to create timer", hr);
+	hr = dev->CreateQuery(&timer_desc, &query_end);
+	if (FAILED(hr))
+		throw HRError("Failed to create timer", hr);
+}
+
 void SavedBlendState::Rebuild(ID3D11Device *dev)
 {
 	HRESULT hr = dev->CreateBlendState(&bd, &state);
@@ -295,6 +316,9 @@ try {
 			break;
 		case gs_type::gs_swap_chain:
 			((gs_swap_chain *)obj)->Release();
+			break;
+		case gs_type::gs_timer:
+			((gs_timer*)obj)->Release();
 			break;
 		}
 
@@ -371,6 +395,9 @@ try {
 			break;
 		case gs_type::gs_swap_chain:
 			((gs_swap_chain *)obj)->Rebuild(dev);
+			break;
+		case gs_type::gs_timer:
+			((gs_timer*)obj)->Rebuild(dev);
 			break;
 		}
 

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -292,6 +292,7 @@ enum class gs_type {
 	gs_pixel_shader,
 	gs_duplicator,
 	gs_swap_chain,
+	gs_timer,
 };
 
 struct gs_obj {
@@ -371,6 +372,22 @@ struct gs_index_buffer : gs_obj {
 
 	gs_index_buffer(gs_device_t *device, enum gs_index_type type,
 			void *indices, size_t num, uint32_t flags);
+};
+
+struct gs_timer : gs_obj {
+	ComPtr<ID3D11Query> query_disjoint;
+	ComPtr<ID3D11Query> query_begin;
+	ComPtr<ID3D11Query> query_end;
+
+	void Rebuild(ID3D11Device *dev);
+
+	inline void Release() {
+		query_disjoint.Release();
+		query_begin.Release();
+		query_end.Release();
+	}
+
+	gs_timer(gs_device_t *device);
 };
 
 struct gs_texture : gs_obj {

--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -386,6 +386,22 @@ device_samplerstate_create(gs_device_t *device,
 	return sampler;
 }
 
+gs_timer_t *device_timer_create(gs_device_t *device)
+{
+	struct gs_timer *timer;
+
+	GLuint queries[2];
+	glGenQueries(2, queries);
+	if (!gl_success("glGenQueries"))
+		return NULL;
+
+	timer = bzalloc(sizeof(struct gs_timer));
+	timer->queries[0] = queries[0];
+	timer->queries[1] = queries[1];
+
+	return timer;
+}
+
 enum gs_texture_type device_get_texture_type(const gs_texture_t *texture)
 {
 	return texture->type;
@@ -1442,4 +1458,45 @@ void gs_samplerstate_destroy(gs_samplerstate_t *samplerstate)
 				samplerstate->device->cur_samplers[i] = NULL;
 
 	samplerstate_release(samplerstate);
+}
+
+void gs_timer_destroy(gs_timer_t *timer)
+{
+	if (!timer)
+		return;
+
+	glDeleteQueries(2, timer->queries);
+	gl_success("glDeleteQueries");
+
+	bfree(timer);
+}
+
+void gs_timer_begin(gs_timer_t *timer)
+{
+	glQueryCounter(timer->queries[0], GL_TIMESTAMP);
+	gl_success("glQueryCounter");
+}
+
+void gs_timer_end(gs_timer_t *timer)
+{
+	glQueryCounter(timer->queries[1], GL_TIMESTAMP);
+	gl_success("glQueryCounter");
+}
+
+bool gs_timer_get_data(gs_timer_t *timer, uint64_t *frequency,
+		uint64_t *ticks)
+{
+	GLint available = 0;
+	glGetQueryObjectiv(timer->queries[1], GL_QUERY_RESULT_AVAILABLE,
+			&available);
+
+	GLuint64 begin, end;
+	glGetQueryObjectui64v(timer->queries[0], GL_QUERY_RESULT, &begin);
+	gl_success("glGetQueryObjectui64v");
+	glGetQueryObjectui64v(timer->queries[1], GL_QUERY_RESULT, &end);
+	gl_success("glGetQueryObjectui64v");
+
+	*frequency = 1000000000;
+	*ticks = end - begin;
+	return true;
 }

--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -396,6 +396,11 @@ static inline void samplerstate_release(gs_samplerstate_t *ss)
 		bfree(ss);
 }
 
+struct gs_timer
+{
+	GLuint queries[2];
+};
+
 struct gs_shader_param {
 	enum gs_shader_param_type type;
 

--- a/libobs/graphics/device-exports.h
+++ b/libobs/graphics/device-exports.h
@@ -76,6 +76,7 @@ EXPORT gs_indexbuffer_t *device_indexbuffer_create(gs_device_t *device,
 						   enum gs_index_type type,
 						   void *indices, size_t num,
 						   uint32_t flags);
+EXPORT gs_timer_t *device_timer_create(gs_device_t *device);
 EXPORT enum gs_texture_type
 device_get_texture_type(const gs_texture_t *texture);
 EXPORT void device_load_vertexbuffer(gs_device_t *device,

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -65,6 +65,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT(device_pixelshader_create);
 	GRAPHICS_IMPORT(device_vertexbuffer_create);
 	GRAPHICS_IMPORT(device_indexbuffer_create);
+	GRAPHICS_IMPORT(device_timer_create);
 	GRAPHICS_IMPORT(device_get_texture_type);
 	GRAPHICS_IMPORT(device_load_vertexbuffer);
 	GRAPHICS_IMPORT(device_load_indexbuffer);
@@ -152,6 +153,11 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT(gs_indexbuffer_get_data);
 	GRAPHICS_IMPORT(gs_indexbuffer_get_num_indices);
 	GRAPHICS_IMPORT(gs_indexbuffer_get_type);
+
+	GRAPHICS_IMPORT(gs_timer_destroy);
+	GRAPHICS_IMPORT(gs_timer_begin);
+	GRAPHICS_IMPORT(gs_timer_end);
+	GRAPHICS_IMPORT(gs_timer_get_data);
 
 	GRAPHICS_IMPORT(gs_shader_destroy);
 	GRAPHICS_IMPORT(gs_shader_get_num_params);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -77,6 +77,7 @@ struct gs_exports {
 						       void *indices,
 						       size_t num,
 						       uint32_t flags);
+	gs_timer_t *(*device_timer_create)(gs_device_t *device);
 	enum gs_texture_type (*device_get_texture_type)(
 		const gs_texture_t *texture);
 	void (*device_load_vertexbuffer)(gs_device_t *device,
@@ -218,6 +219,12 @@ struct gs_exports {
 		const gs_indexbuffer_t *indexbuffer);
 	enum gs_index_type (*gs_indexbuffer_get_type)(
 		const gs_indexbuffer_t *indexbuffer);
+
+	void (*gs_timer_destroy)(gs_timer_t *timer);
+	void (*gs_timer_begin)(gs_timer_t *timer);
+	void (*gs_timer_end)(gs_timer_t *timer);
+	bool (*gs_timer_get_data)(gs_timer_t *timer, uint64_t *frequency,
+			uint64_t *ticks);
 
 	void (*gs_shader_destroy)(gs_shader_t *shader);
 	int (*gs_shader_get_num_params)(const gs_shader_t *shader);

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -1525,6 +1525,16 @@ gs_indexbuffer_t *gs_indexbuffer_create(enum gs_index_type type, void *indices,
 		graphics->device, type, indices, num, flags);
 }
 
+gs_timer_t *gs_timer_create()
+{
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_timer_create"))
+		return NULL;
+
+	return graphics->exports.device_timer_create(graphics->device);
+}
+
 enum gs_texture_type gs_get_texture_type(const gs_texture_t *texture)
 {
 	graphics_t *graphics = thread_graphics;
@@ -2541,6 +2551,51 @@ enum gs_index_type gs_indexbuffer_get_type(const gs_indexbuffer_t *indexbuffer)
 		return (enum gs_index_type)0;
 
 	return thread_graphics->exports.gs_indexbuffer_get_type(indexbuffer);
+}
+
+void gs_timer_destroy(gs_timer_t *timer)
+{
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_timer_destroy"))
+		return;
+	if (!timer)
+		return;
+
+	graphics->exports.gs_timer_destroy(timer);
+}
+
+void gs_timer_begin(gs_timer_t *timer)
+{
+	graphics_t* graphics = thread_graphics;
+
+	if (!gs_valid("gs_timer_begin"))
+		return;
+	if (!timer)
+		return;
+
+	graphics->exports.gs_timer_begin(timer);
+}
+
+void gs_timer_end(gs_timer_t *timer)
+{
+	graphics_t* graphics = thread_graphics;
+
+	if (!gs_valid("gs_timer_end"))
+		return;
+	if (!timer)
+		return;
+
+	graphics->exports.gs_timer_end(timer);
+}
+
+bool gs_timer_get_data(gs_timer_t *timer, uint64_t *frequency, uint64_t *ticks)
+{
+	if (!gs_valid_p3("gs_timer_get_data", timer, frequency, ticks))
+		return false;
+
+	return thread_graphics->exports.gs_timer_get_data(timer, frequency,
+			ticks);
 }
 
 bool gs_nv12_available(void)

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -247,6 +247,7 @@ struct gs_index_buffer;
 struct gs_sampler_state;
 struct gs_shader;
 struct gs_swap_chain;
+struct gs_timer;
 struct gs_texrender;
 struct gs_shader_param;
 struct gs_effect;
@@ -263,6 +264,7 @@ typedef struct gs_vertex_buffer gs_vertbuffer_t;
 typedef struct gs_index_buffer gs_indexbuffer_t;
 typedef struct gs_sampler_state gs_samplerstate_t;
 typedef struct gs_swap_chain gs_swapchain_t;
+typedef struct gs_timer gs_timer_t;
 typedef struct gs_texture_render gs_texrender_t;
 typedef struct gs_shader gs_shader_t;
 typedef struct gs_shader_param gs_sparam_t;
@@ -633,6 +635,8 @@ EXPORT gs_indexbuffer_t *gs_indexbuffer_create(enum gs_index_type type,
 					       void *indices, size_t num,
 					       uint32_t flags);
 
+EXPORT gs_timer_t *gs_timer_create();
+
 EXPORT enum gs_texture_type gs_get_texture_type(const gs_texture_t *texture);
 
 EXPORT void gs_load_vertexbuffer(gs_vertbuffer_t *vertbuffer);
@@ -772,6 +776,12 @@ EXPORT size_t
 gs_indexbuffer_get_num_indices(const gs_indexbuffer_t *indexbuffer);
 EXPORT enum gs_index_type
 gs_indexbuffer_get_type(const gs_indexbuffer_t *indexbuffer);
+
+EXPORT void gs_timer_destroy(gs_timer_t *timer);
+EXPORT void gs_timer_begin(gs_timer_t *timer);
+EXPORT void gs_timer_end(gs_timer_t *timer);
+EXPORT bool
+gs_timer_get_data(gs_timer_t* timer, uint64_t *frequency, uint64_t *ticks);
 
 EXPORT bool gs_nv12_available(void);
 


### PR DESCRIPTION
It's probably a good idea to measure GPU times within the application itself, and not rely only on external tools. This feature is currently written for developers only, and off by default at compile-time. The macro GPU_TIMER_ENABLE needs to be hand-edited, similar to GS_USE_DEBUG_MARKERS. I've tested this using Direct3D and OpenGL on Windows so far.

I'm starting this as a draft PR to get some feedback. Separate files? Different names? Alternate API? Etc.