### PR TITLE
libobs, v4l2: Add BGR24 color format

### DIFF
--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -42,6 +42,7 @@ static inline GLenum convert_gs_format(enum gs_color_format format)
 	case GS_A8:          return GL_RED;
 	case GS_R8:          return GL_RED;
 	case GS_RGBA:        return GL_RGBA;
+	case GS_BGR24:       return GL_BGR;
 	case GS_BGRX:        return GL_BGRA;
 	case GS_BGRA:        return GL_BGRA;
 	case GS_R10G10B10A2: return GL_RGBA;
@@ -69,6 +70,7 @@ static inline GLenum convert_gs_internal_format(enum gs_color_format format)
 	case GS_A8:          return GL_R8; /* NOTE: use GL_TEXTURE_SWIZZLE_x */
 	case GS_R8:          return GL_R8;
 	case GS_RGBA:        return GL_RGBA;
+	case GS_BGR24:       return GL_RGB;
 	case GS_BGRX:        return GL_RGB;
 	case GS_BGRA:        return GL_RGBA;
 	case GS_R10G10B10A2: return GL_RGB10_A2;
@@ -96,6 +98,7 @@ static inline GLenum get_gl_format_type(enum gs_color_format format)
 	case GS_A8:          return GL_UNSIGNED_BYTE;
 	case GS_R8:          return GL_UNSIGNED_BYTE;
 	case GS_RGBA:        return GL_UNSIGNED_BYTE;
+	case GS_BGR24:       return GL_UNSIGNED_BYTE;
 	case GS_BGRX:        return GL_UNSIGNED_BYTE;
 	case GS_BGRA:        return GL_UNSIGNED_BYTE;
 	case GS_R10G10B10A2: return GL_UNSIGNED_INT_10_10_10_2;

--- a/libobs/graphics/graphics-ffmpeg.c
+++ b/libobs/graphics/graphics-ffmpeg.c
@@ -204,9 +204,10 @@ void gs_free_image_deps(void)
 static inline enum gs_color_format convert_format(enum AVPixelFormat format)
 {
 	switch ((int)format) {
-	case AV_PIX_FMT_RGBA: return GS_RGBA;
-	case AV_PIX_FMT_BGRA: return GS_BGRA;
-	case AV_PIX_FMT_BGR0: return GS_BGRX;
+	case AV_PIX_FMT_RGBA:  return GS_RGBA;
+	case AV_PIX_FMT_BGRA:  return GS_BGRA;
+	case AV_PIX_FMT_BGR0:  return GS_BGRX;
+	case AV_PIX_FMT_BGR24: return GS_BGR24;
 	}
 
 	return GS_BGRX;

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -59,6 +59,7 @@ enum gs_color_format {
 	GS_R8,
 	GS_RGBA,
 	GS_BGRX,
+	GS_BGR24,
 	GS_BGRA,
 	GS_R10G10B10A2,
 	GS_RGBA16,
@@ -861,6 +862,7 @@ static inline uint32_t gs_get_format_bpp(enum gs_color_format format)
 	case GS_A8:          return 8;
 	case GS_R8:          return 8;
 	case GS_RGBA:        return 32;
+	case GS_BGR24:       return 24;
 	case GS_BGRX:        return 32;
 	case GS_BGRA:        return 32;
 	case GS_R10G10B10A2: return 32;

--- a/libobs/media-io/video-frame.c
+++ b/libobs/media-io/video-frame.c
@@ -82,6 +82,13 @@ void video_frame_init(struct video_frame *frame, enum video_format format,
 		frame->linesize[0] = width*2;
 		break;
 
+	case VIDEO_FORMAT_BGR24:
+		size = width * height * 3;
+		ALIGN_SIZE(size, alignment);
+		frame->data[0] = bmalloc(size);
+		frame->linesize[0] = width*3;
+		break;
+
 	case VIDEO_FORMAT_RGBA:
 	case VIDEO_FORMAT_BGRA:
 	case VIDEO_FORMAT_BGRX:

--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -44,6 +44,7 @@ enum video_format {
 
 	/* packed uncompressed formats */
 	VIDEO_FORMAT_RGBA,
+	VIDEO_FORMAT_BGR24,
 	VIDEO_FORMAT_BGRA,
 	VIDEO_FORMAT_BGRX,
 	VIDEO_FORMAT_Y800, /* grayscale */
@@ -96,6 +97,7 @@ static inline bool format_is_yuv(enum video_format format)
 		return true;
 	case VIDEO_FORMAT_NONE:
 	case VIDEO_FORMAT_RGBA:
+	case VIDEO_FORMAT_BGR24:
 	case VIDEO_FORMAT_BGRA:
 	case VIDEO_FORMAT_BGRX:
 	case VIDEO_FORMAT_Y800:
@@ -108,16 +110,17 @@ static inline bool format_is_yuv(enum video_format format)
 static inline const char *get_video_format_name(enum video_format format)
 {
 	switch (format) {
-	case VIDEO_FORMAT_I420: return "I420";
-	case VIDEO_FORMAT_NV12: return "NV12";
-	case VIDEO_FORMAT_YVYU: return "YVYU";
-	case VIDEO_FORMAT_YUY2: return "YUY2";
-	case VIDEO_FORMAT_UYVY: return "UYVY";
-	case VIDEO_FORMAT_RGBA: return "RGBA";
-	case VIDEO_FORMAT_BGRA: return "BGRA";
-	case VIDEO_FORMAT_BGRX: return "BGRX";
-	case VIDEO_FORMAT_I444: return "I444";
-	case VIDEO_FORMAT_Y800: return "Y800";
+	case VIDEO_FORMAT_I420:  return "I420";
+	case VIDEO_FORMAT_NV12:  return "NV12";
+	case VIDEO_FORMAT_YVYU:  return "YVYU";
+	case VIDEO_FORMAT_YUY2:  return "YUY2";
+	case VIDEO_FORMAT_UYVY:  return "UYVY";
+	case VIDEO_FORMAT_RGBA:  return "RGBA";
+	case VIDEO_FORMAT_BGR24: return "BGR24";
+	case VIDEO_FORMAT_BGRA:  return "BGRA";
+	case VIDEO_FORMAT_BGRX:  return "BGRX";
+	case VIDEO_FORMAT_I444:  return "I444";
+	case VIDEO_FORMAT_Y800:  return "Y800";
 	case VIDEO_FORMAT_NONE:;
 	}
 

--- a/libobs/media-io/video-scaler-ffmpeg.c
+++ b/libobs/media-io/video-scaler-ffmpeg.c
@@ -29,17 +29,18 @@ static inline enum AVPixelFormat get_ffmpeg_video_format(
 		enum video_format format)
 {
 	switch (format) {
-	case VIDEO_FORMAT_NONE: return AV_PIX_FMT_NONE;
-	case VIDEO_FORMAT_I420: return AV_PIX_FMT_YUV420P;
-	case VIDEO_FORMAT_NV12: return AV_PIX_FMT_NV12;
-	case VIDEO_FORMAT_YVYU: return AV_PIX_FMT_NONE;
-	case VIDEO_FORMAT_YUY2: return AV_PIX_FMT_YUYV422;
-	case VIDEO_FORMAT_UYVY: return AV_PIX_FMT_UYVY422;
-	case VIDEO_FORMAT_RGBA: return AV_PIX_FMT_RGBA;
-	case VIDEO_FORMAT_BGRA: return AV_PIX_FMT_BGRA;
-	case VIDEO_FORMAT_BGRX: return AV_PIX_FMT_BGRA;
-	case VIDEO_FORMAT_Y800: return AV_PIX_FMT_GRAY8;
-	case VIDEO_FORMAT_I444: return AV_PIX_FMT_YUV444P;
+	case VIDEO_FORMAT_NONE:  return AV_PIX_FMT_NONE;
+	case VIDEO_FORMAT_I420:  return AV_PIX_FMT_YUV420P;
+	case VIDEO_FORMAT_NV12:  return AV_PIX_FMT_NV12;
+	case VIDEO_FORMAT_YVYU:  return AV_PIX_FMT_NONE;
+	case VIDEO_FORMAT_YUY2:  return AV_PIX_FMT_YUYV422;
+	case VIDEO_FORMAT_UYVY:  return AV_PIX_FMT_UYVY422;
+	case VIDEO_FORMAT_RGBA:  return AV_PIX_FMT_RGBA;
+	case VIDEO_FORMAT_BGR24: return AV_PIX_FMT_BGR24;
+	case VIDEO_FORMAT_BGRA:  return AV_PIX_FMT_BGRA;
+	case VIDEO_FORMAT_BGRX:  return AV_PIX_FMT_BGRA;
+	case VIDEO_FORMAT_Y800:  return AV_PIX_FMT_GRAY8;
+	case VIDEO_FORMAT_I444:  return AV_PIX_FMT_YUV444P;
 	}
 
 	return AV_PIX_FMT_NONE;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -782,6 +782,8 @@ static inline enum gs_color_format convert_video_format(
 {
 	if (format == VIDEO_FORMAT_RGBA)
 		return GS_RGBA;
+	else if (format == VIDEO_FORMAT_BGR24)
+		return GS_BGR24;
 	else if (format == VIDEO_FORMAT_BGRA)
 		return GS_BGRA;
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1356,6 +1356,7 @@ static inline enum convert_type get_convert_type(enum video_format format,
 
 	case VIDEO_FORMAT_NONE:
 	case VIDEO_FORMAT_RGBA:
+	case VIDEO_FORMAT_BGR24:
 	case VIDEO_FORMAT_BGRA:
 	case VIDEO_FORMAT_BGRX:
 		return full_range ? CONVERT_NONE : CONVERT_RGB_LIMITED;
@@ -1572,6 +1573,7 @@ static const char *select_conversion_technique(enum video_format format,
 
 		case VIDEO_FORMAT_BGRA:
 		case VIDEO_FORMAT_BGRX:
+		case VIDEO_FORMAT_BGR24:
 		case VIDEO_FORMAT_RGBA:
 		case VIDEO_FORMAT_NONE:
 			if (full_range)
@@ -2297,6 +2299,7 @@ static void copy_frame_data(struct obs_source_frame *dst,
 	case VIDEO_FORMAT_UYVY:
 	case VIDEO_FORMAT_NONE:
 	case VIDEO_FORMAT_RGBA:
+	case VIDEO_FORMAT_BGR24:
 	case VIDEO_FORMAT_BGRA:
 	case VIDEO_FORMAT_BGRX:
 	case VIDEO_FORMAT_Y800:

--- a/plugins/linux-v4l2/v4l2-helpers.h
+++ b/plugins/linux-v4l2/v4l2-helpers.h
@@ -69,6 +69,9 @@ static inline enum video_format v4l2_to_obs_video_format(uint_fast32_t format)
 #ifdef V4L2_PIX_FMT_ABGR32
 	case V4L2_PIX_FMT_ABGR32: return VIDEO_FORMAT_BGRA;
 #endif
+#ifdef V4L2_PIX_FMT_BGR24
+	case V4L2_PIX_FMT_BGR24:  return VIDEO_FORMAT_BGR24;
+#endif
 	default:                  return VIDEO_FORMAT_NONE;
 	}
 }

--- a/plugins/obs-ffmpeg/obs-ffmpeg-formats.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-formats.h
@@ -11,17 +11,18 @@ static inline enum AVPixelFormat obs_to_ffmpeg_video_format(
 		enum video_format format)
 {
 	switch (format) {
-	case VIDEO_FORMAT_NONE: return AV_PIX_FMT_NONE;
-	case VIDEO_FORMAT_I444: return AV_PIX_FMT_YUV444P;
-	case VIDEO_FORMAT_I420: return AV_PIX_FMT_YUV420P;
-	case VIDEO_FORMAT_NV12: return AV_PIX_FMT_NV12;
-	case VIDEO_FORMAT_YVYU: return AV_PIX_FMT_NONE;
-	case VIDEO_FORMAT_YUY2: return AV_PIX_FMT_YUYV422;
-	case VIDEO_FORMAT_UYVY: return AV_PIX_FMT_UYVY422;
-	case VIDEO_FORMAT_RGBA: return AV_PIX_FMT_RGBA;
-	case VIDEO_FORMAT_BGRA: return AV_PIX_FMT_BGRA;
-	case VIDEO_FORMAT_BGRX: return AV_PIX_FMT_BGRA;
-	case VIDEO_FORMAT_Y800: return AV_PIX_FMT_GRAY8;
+	case VIDEO_FORMAT_NONE:  return AV_PIX_FMT_NONE;
+	case VIDEO_FORMAT_I444:  return AV_PIX_FMT_YUV444P;
+	case VIDEO_FORMAT_I420:  return AV_PIX_FMT_YUV420P;
+	case VIDEO_FORMAT_NV12:  return AV_PIX_FMT_NV12;
+	case VIDEO_FORMAT_YVYU:  return AV_PIX_FMT_NONE;
+	case VIDEO_FORMAT_YUY2:  return AV_PIX_FMT_YUYV422;
+	case VIDEO_FORMAT_UYVY:  return AV_PIX_FMT_UYVY422;
+	case VIDEO_FORMAT_RGBA:  return AV_PIX_FMT_RGBA;
+	case VIDEO_FORMAT_BGR24: return AV_PIX_FMT_BGR24;
+	case VIDEO_FORMAT_BGRA:  return AV_PIX_FMT_BGRA;
+	case VIDEO_FORMAT_BGRX:  return AV_PIX_FMT_BGRA;
+	case VIDEO_FORMAT_Y800:  return AV_PIX_FMT_GRAY8;
 	}
 
 	return AV_PIX_FMT_NONE;
@@ -37,6 +38,7 @@ static inline enum video_format ffmpeg_to_obs_video_format(
 	case AV_PIX_FMT_YUYV422: return VIDEO_FORMAT_YUY2;
 	case AV_PIX_FMT_UYVY422: return VIDEO_FORMAT_UYVY;
 	case AV_PIX_FMT_RGBA:    return VIDEO_FORMAT_RGBA;
+	case AV_PIX_FMT_RGB24:   return VIDEO_FORMAT_BGR24;
 	case AV_PIX_FMT_BGRA:    return VIDEO_FORMAT_BGRA;
 	case AV_PIX_FMT_GRAY8:   return VIDEO_FORMAT_Y800;
 	case AV_PIX_FMT_NONE:


### PR DESCRIPTION
This commit adds the BGR24 color format to libobs and v4l2.
The motivation for this was that my capture card only supports this type
of RGB format and the quality gain is significant over YUYV.