### PR TITLE
UI/updater: Various updates

### DIFF
--- a/UI/win-update/updater/CMakeLists.txt
+++ b/UI/win-update/updater/CMakeLists.txt
@@ -28,6 +28,7 @@ set(updater_SOURCES
 	http.cpp
 	hash.cpp
 	updater.rc
+	updater.manifest
 	)
 
 add_definitions(-DNOMINMAX -DUNICODE -D_UNICODE)

--- a/UI/win-update/updater/updater.cpp
+++ b/UI/win-update/updater/updater.cpp
@@ -1251,7 +1251,7 @@ static bool Update(wchar_t *cmdLine)
 
 	for (size_t i = 0; i < packageCount; i++) {
 		if (!AddPackageUpdateFiles(packages, i, tempPath)) {
-			Status(L"Failed to process update packages");
+			Status(L"Update failed: Failed to process update packages");
 			return false;
 		}
 	}
@@ -1264,6 +1264,7 @@ static bool Update(wchar_t *cmdLine)
 
 	if (!updates.size()) {
 		Status(L"All available updates are already installed.");
+		SetDlgItemText(hwndMain, IDC_BUTTON, L"Launch OBS");
 		return true;
 	}
 

--- a/UI/win-update/updater/updater.cpp
+++ b/UI/win-update/updater/updater.cpp
@@ -1141,6 +1141,12 @@ static bool Update(wchar_t *cmdLine)
 	SetDlgItemTextW(hwndMain, IDC_STATUS,
 			L"Searching for available updates...");
 
+	HWND hProgress = GetDlgItem(hwndMain, IDC_PROGRESS);
+	LONG_PTR style = GetWindowLongPtr(hProgress, GWL_STYLE);
+	SetWindowLongPtr(hProgress, GWL_STYLE, style | PBS_MARQUEE);
+
+	SendDlgItemMessage(hwndMain, IDC_PROGRESS, PBM_SETMARQUEE, 1, 0);
+
 	/* ------------------------------------- *
 	 * Check if updating portable build      */
 
@@ -1249,6 +1255,9 @@ static bool Update(wchar_t *cmdLine)
 			return false;
 		}
 	}
+
+	SendDlgItemMessage(hwndMain, IDC_PROGRESS, PBM_SETMARQUEE, 0, 0);
+	SetWindowLongPtr(hProgress, GWL_STYLE, style);
 
 	/* ------------------------------------- *
 	 * Exit if updates already installed     */
@@ -1460,8 +1469,10 @@ static DWORD WINAPI UpdateThread(void *arg)
 		if (WaitForSingleObject(cancelRequested, 0) == WAIT_OBJECT_0)
 			Status(L"Update aborted.");
 
-		SendDlgItemMessage(hwndMain, IDC_PROGRESS, PBM_SETSTATE,
-				PBST_ERROR, 0);
+		HWND hProgress = GetDlgItem(hwndMain, IDC_PROGRESS);
+		LONG_PTR style = GetWindowLongPtr(hProgress, GWL_STYLE);
+		SetWindowLongPtr(hProgress, GWL_STYLE, style & ~PBS_MARQUEE);
+		SendMessage(hProgress, PBM_SETSTATE, PBST_ERROR, 0);
 
 		SetDlgItemText(hwndMain, IDC_BUTTON, L"Exit");
 		EnableWindow(GetDlgItem(hwndMain, IDC_BUTTON), true);

--- a/UI/win-update/updater/updater.manifest
+++ b/UI/win-update/updater/updater.manifest
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+
+<asmv3:application>
+	<asmv3:windowsSettings xmlns="https://schemas.microsoft.com/SMI/2005/WindowsSettings">
+		<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">system</dpiAwareness>
+		<dpiAware>true</dpiAware>
+	</asmv3:windowsSettings>
+</asmv3:application>
+
+<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+	<application>
+		<!-- Windows 10 -->
+		<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+		<!-- Windows 8.1 -->
+		<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+		<!-- Windows Vista -->
+		<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+		<!-- Windows 7 -->
+		<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+		<!-- Windows 8 -->
+		<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+	</application>
+</compatibility>
+</assembly>


### PR DESCRIPTION
This modernizes the OBS updater a bit by adding a DPI manifest so it doesn't look blurry on high DPI displays, adds a marquee progress bar during the existing file check so the program doesn't appear frozen and clarifies some action text.