### PR TITLE
UI: Create an API to open projectors

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -371,6 +371,31 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		return App()->GlobalConfig();
 	}
 
+	void obs_frontend_open_projector(const char *type, int monitor,
+					 const char *geometry,
+					 const char *name) override
+	{
+		SavedProjectorInfo proj = {
+			ProjectorType::Preview,
+			monitor,
+			geometry ? geometry : "",
+			name ? name : "",
+		};
+		if (type) {
+			if (astrcmpi(type, "Source") == 0)
+				proj.type = ProjectorType::Source;
+			else if (astrcmpi(type, "Scene") == 0)
+				proj.type = ProjectorType::Scene;
+			else if (astrcmpi(type, "StudioProgram") == 0)
+				proj.type = ProjectorType::StudioProgram;
+			else if (astrcmpi(type, "Multiview") == 0)
+				proj.type = ProjectorType::Multiview;
+		}
+		QMetaObject::invokeMethod(main, "OpenSavedProjector",
+					  WaitConnection(),
+					  Q_ARG(SavedProjectorInfo *, &proj));
+	}
+
 	void obs_frontend_save(void) override { main->SaveProject(); }
 
 	void obs_frontend_defer_save_begin(void) override

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -327,6 +327,13 @@ config_t *obs_frontend_get_global_config(void)
 				   : nullptr;
 }
 
+void obs_frontend_open_projector(const char *type, int monitor,
+				 const char *geometry, const char *name)
+{
+	if (callbacks_valid())
+		c->obs_frontend_open_projector(type, monitor, geometry, name);
+}
+
 void obs_frontend_save(void)
 {
 	if (callbacks_valid())

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -165,6 +165,8 @@ EXPORT void obs_frontend_replay_buffer_save(void);
 EXPORT void obs_frontend_replay_buffer_stop(void);
 EXPORT bool obs_frontend_replay_buffer_active(void);
 
+EXPORT void obs_frontend_open_projector(const char *type, int monitor,
+					const char *geometry, const char *name);
 EXPORT void obs_frontend_save(void);
 EXPORT void obs_frontend_defer_save_begin(void);
 EXPORT void obs_frontend_defer_save_end(void);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -72,6 +72,9 @@ struct obs_frontend_callbacks {
 	virtual config_t *obs_frontend_get_profile_config(void) = 0;
 	virtual config_t *obs_frontend_get_global_config(void) = 0;
 
+	virtual void obs_frontend_open_projector(const char *type, int monitor,
+						 const char *geometry,
+						 const char *name) = 0;
 	virtual void obs_frontend_save(void) = 0;
 	virtual void obs_frontend_defer_save_begin(void) = 0;
 	virtual void obs_frontend_defer_save_end(void) = 0;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -242,6 +242,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	qRegisterMetaType<OBSSceneItem>("OBSSceneItem");
 	qRegisterMetaType<OBSSource>("OBSSource");
 	qRegisterMetaType<obs_hotkey_id>("obs_hotkey_id");
+	qRegisterMetaType<SavedProjectorInfo *>("SavedProjectorInfo *");
 
 	qRegisterMetaTypeStreamOperators<std::vector<std::shared_ptr<OBSSignal>>>(
 		"std::vector<std::shared_ptr<OBSSignal>>");

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6570,6 +6570,13 @@ void OBSBasic::OpenSceneWindow()
 void OBSBasic::OpenSavedProjectors()
 {
 	for (SavedProjectorInfo *info : savedProjectorsArray) {
+		OpenSavedProjector(info);
+	}
+}
+
+void OBSBasic::OpenSavedProjector(SavedProjectorInfo *info)
+{
+	if (info) {
 		OBSProjector *projector = nullptr;
 		switch (info->type) {
 		case ProjectorType::Source:
@@ -6577,7 +6584,7 @@ void OBSBasic::OpenSavedProjectors()
 			OBSSource source =
 				obs_get_source_by_name(info->name.c_str());
 			if (!source)
-				continue;
+				return;
 
 			projector = OpenProjector(source, info->monitor,
 						  info->type);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -621,6 +621,7 @@ private slots:
 	void ScenePasteFilters();
 
 	void CheckDiskSpaceRemaining();
+	void OpenSavedProjector(SavedProjectorInfo *info);
 
 	void ScenesReordered(const QModelIndex &parent, int start, int end,
 			     const QModelIndex &destination, int row);


### PR DESCRIPTION
This will allow customized setups to spawn whichever projectors they need, whenever they need them. It's more flexible than simply saving and restoring the last-used projectors, allowing more complicated setups that are managed by an external script.