### PR TITLE
UI: Stop recording when disk space is low

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -287,6 +287,10 @@ OBSBasic::OBSBasic(QWidget *parent)
 		SLOT(UpdateCPUUsage()));
 	cpuUsageTimer->start(3000);
 
+	diskFullTimer = new QTimer(this);
+	connect(diskFullTimer, SIGNAL(timeout()), this,
+		SLOT(CheckDiskSpaceRemaining()));
+
 	QAction *renameScene = new QAction(ui->scenesDock);
 	renameScene->setShortcutContext(Qt::WidgetWithChildrenShortcut);
 	connect(renameScene, SIGNAL(triggered()), this, SLOT(EditSceneName()));
@@ -5294,6 +5298,12 @@ void OBSBasic::StartRecording()
 	if (disableOutputsRef)
 		return;
 
+	if (LowDiskSpace()) {
+		DiskSpaceMessage();
+		ui->recordButton->setChecked(false);
+		return;
+	}
+
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_RECORDING_STARTING);
 
@@ -5337,6 +5347,9 @@ void OBSBasic::RecordingStart()
 	recordingStopping = false;
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_RECORDING_STARTED);
+
+	if (!diskFullTimer->isActive())
+		diskFullTimer->start(1000);
 
 	OnActivate();
 	UpdatePause();
@@ -5402,6 +5415,9 @@ void OBSBasic::RecordingStop(int code, QString last_error)
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_RECORDING_STOPPED);
 
+	if (diskFullTimer->isActive())
+		diskFullTimer->stop();
+
 	if (remuxAfterRecord)
 		AutoRemux();
 
@@ -5456,6 +5472,12 @@ void OBSBasic::StartReplayBuffer()
 		return;
 
 	if (!NoSourcesConfirmation()) {
+		replayBufferButton->setChecked(false);
+		return;
+	}
+
+	if (LowDiskSpace()) {
+		DiskSpaceMessage();
 		replayBufferButton->setChecked(false);
 		return;
 	}
@@ -7454,5 +7476,44 @@ void OBSBasic::UpdatePause(bool activate)
 		ui->recordingLayout->addWidget(pause.data());
 	} else {
 		pause.reset();
+	}
+}
+
+#define MBYTE (1024ULL * 1024ULL)
+#define MBYTES_LEFT_STOP_REC 50ULL
+#define MAX_BYTES_LEFT (MBYTES_LEFT_STOP_REC * MBYTE)
+
+void OBSBasic::DiskSpaceMessage()
+{
+	blog(LOG_ERROR, "Recording stopped because of low disk space");
+
+	OBSMessageBox::critical(this, QTStr("Output.RecordNoSpace.Title"),
+				QTStr("Output.RecordNoSpace.Msg"));
+}
+
+bool OBSBasic::LowDiskSpace()
+{
+	const char *mode = config_get_string(Config(), "Output", "Mode");
+	const char *path =
+		strcmp(mode, "Advanced")
+			? config_get_string(Config(), "SimpleOutput",
+					    "FilePath")
+			: config_get_string(Config(), "AdvOut", "RecFilePath");
+
+	uint64_t num_bytes = os_get_free_disk_space(path);
+
+	if (num_bytes < (MAX_BYTES_LEFT))
+		return true;
+	else
+		return false;
+}
+
+void OBSBasic::CheckDiskSpaceRemaining()
+{
+	if (LowDiskSpace()) {
+		StopRecording();
+		StopReplayBuffer();
+
+		DiskSpaceMessage();
 	}
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -170,6 +170,8 @@ private:
 	QPointer<OBSAbout> about;
 
 	QPointer<QTimer> cpuUsageTimer;
+	QPointer<QTimer> diskFullTimer;
+
 	os_cpu_usage_info_t *cpuUsageInfo = nullptr;
 
 	OBSService service;
@@ -540,6 +542,8 @@ private slots:
 	void SceneCopyFilters();
 	void ScenePasteFilters();
 
+	void CheckDiskSpaceRemaining();
+
 private:
 	/* OBS Callbacks */
 	static void SceneReordered(void *data, calldata_t *params);
@@ -563,7 +567,11 @@ private:
 	static void HotkeyTriggered(void *data, obs_hotkey_id id, bool pressed);
 
 	void AutoRemux();
+
 	void UpdatePause(bool activate = true);
+
+	bool LowDiskSpace();
+	void DiskSpaceMessage();
 
 public:
 	OBSSource GetProgramSource();


### PR DESCRIPTION
This stops the recording when disk space is low. It is currently
set to stop when disk space is below 500 MB.