### PR TITLE
Add planar 4:2:2 video support; Use FFmpeg MJPEG decoder instead of DirectShow

### DIFF
--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -363,6 +363,25 @@ float4 PSPlanar420_Reverse(FragTex frag_in) : TARGET
 	return saturate(mul(float4(yuv, 1.0), color_matrix));
 }
 
+float4 PSPlanar422_Reverse(FragTex frag_in) : TARGET
+{
+	int x = int(frag_in.uv.x * width  + PRECISION_OFFSET);
+	int y = int(frag_in.uv.y * height + PRECISION_OFFSET);
+
+	int lum_offset = y * int_width + x;
+	int chroma_offset = y * (int_width / 2) + x / 2;
+	int chroma1    = int_u_plane_offset + chroma_offset;
+	int chroma2    = int_v_plane_offset + chroma_offset;
+
+	float3 yuv = float3(
+		GetIntOffsetColor(lum_offset),
+		GetIntOffsetColor(chroma1),
+		GetIntOffsetColor(chroma2)
+	);
+	yuv = clamp(yuv, color_range_min, color_range_max);
+	return saturate(mul(float4(yuv, 1.0), color_matrix));
+}
+
 float4 PSPlanar444_Reverse(FragTex frag_in) : TARGET
 {
 	int x = int(frag_in.uv.x * width  + PRECISION_OFFSET);
@@ -532,6 +551,15 @@ technique I420_Reverse
 	{
 		vertex_shader = VSPosTex(id);
 		pixel_shader  = PSPlanar420_Reverse(frag_in);
+	}
+}
+
+technique I422_Reverse
+{
+	pass
+	{
+		vertex_shader = VSPosTex(id);
+		pixel_shader  = PSPlanar422_Reverse(frag_in);
 	}
 }
 

--- a/libobs/media-io/video-frame.c
+++ b/libobs/media-io/video-frame.c
@@ -108,6 +108,23 @@ void video_frame_init(struct video_frame *frame, enum video_format format,
 		frame->data[0] = bmalloc(size);
 		frame->linesize[0] = width * 3;
 		break;
+
+	case VIDEO_FORMAT_I422:
+		size = width * height;
+		ALIGN_SIZE(size, alignment);
+		offsets[0] = size;
+		size += (width / 2) * height;
+		ALIGN_SIZE(size, alignment);
+		offsets[1] = size;
+		size += (width / 2) * height;
+		ALIGN_SIZE(size, alignment);
+		frame->data[0] = bmalloc(size);
+		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
+		frame->data[2] = (uint8_t *)frame->data[0] + offsets[1];
+		frame->linesize[0] = width;
+		frame->linesize[1] = width / 2;
+		frame->linesize[2] = width / 2;
+		break;
 	}
 }
 
@@ -141,6 +158,7 @@ void video_frame_copy(struct video_frame *dst, const struct video_frame *src,
 		break;
 
 	case VIDEO_FORMAT_I444:
+	case VIDEO_FORMAT_I422:
 		memcpy(dst->data[0], src->data[0], src->linesize[0] * cy);
 		memcpy(dst->data[1], src->data[1], src->linesize[1] * cy);
 		memcpy(dst->data[2], src->data[2], src->linesize[2] * cy);

--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -53,6 +53,9 @@ enum video_format {
 
 	/* more packed uncompressed formats */
 	VIDEO_FORMAT_BGR3,
+
+	/* planar 4:2:2 */
+	VIDEO_FORMAT_I422,
 };
 
 enum video_colorspace {

--- a/libobs/media-io/video-scaler-ffmpeg.c
+++ b/libobs/media-io/video-scaler-ffmpeg.c
@@ -53,6 +53,8 @@ get_ffmpeg_video_format(enum video_format format)
 		return AV_PIX_FMT_YUV444P;
 	case VIDEO_FORMAT_BGR3:
 		return AV_PIX_FMT_BGR24;
+	case VIDEO_FORMAT_I422:
+		return AV_PIX_FMT_YUV422P;
 	}
 
 	return AV_PIX_FMT_NONE;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-formats.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-formats.h
@@ -35,6 +35,8 @@ obs_to_ffmpeg_video_format(enum video_format format)
 		return AV_PIX_FMT_GRAY8;
 	case VIDEO_FORMAT_BGR3:
 		return AV_PIX_FMT_BGR24;
+	case VIDEO_FORMAT_I422:
+		return AV_PIX_FMT_YUV422P;
 	}
 
 	return AV_PIX_FMT_NONE;
@@ -62,6 +64,8 @@ ffmpeg_to_obs_video_format(enum AVPixelFormat format)
 		return VIDEO_FORMAT_Y800;
 	case AV_PIX_FMT_BGR24:
 		return VIDEO_FORMAT_BGR3;
+	case AV_PIX_FMT_YUV422P:
+		return VIDEO_FORMAT_I422;
 	case AV_PIX_FMT_NONE:
 	default:
 		return VIDEO_FORMAT_NONE;

--- a/plugins/win-dshow/ffmpeg-decode.c
+++ b/plugins/win-dshow/ffmpeg-decode.c
@@ -74,6 +74,9 @@ static inline enum video_format convert_pixel_format(int f)
 		return VIDEO_FORMAT_YUY2;
 	case AV_PIX_FMT_UYVY422:
 		return VIDEO_FORMAT_UYVY;
+	case AV_PIX_FMT_YUV422P:
+	case AV_PIX_FMT_YUVJ422P:
+		return VIDEO_FORMAT_I422;
 	case AV_PIX_FMT_RGBA:
 		return VIDEO_FORMAT_RGBA;
 	case AV_PIX_FMT_BGRA:

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -418,8 +418,6 @@ static inline video_format ConvertVideoFormat(VideoFormat format)
 		return VIDEO_FORMAT_UYVY;
 	case VideoFormat::HDYC:
 		return VIDEO_FORMAT_UYVY;
-	case VideoFormat::MJPEG:
-		return VIDEO_FORMAT_YUY2;
 	default:
 		return VIDEO_FORMAT_NONE;
 	}
@@ -499,6 +497,11 @@ void DShowInput::OnVideoData(const VideoConfig &config, unsigned char *data,
 {
 	if (videoConfig.format == VideoFormat::H264) {
 		OnEncodedVideoData(AV_CODEC_ID_H264, data, size, startTime);
+		return;
+	}
+
+	if (videoConfig.format == VideoFormat::MJPEG) {
+		OnEncodedVideoData(AV_CODEC_ID_MJPEG, data, size, startTime);
 		return;
 	}
 
@@ -905,26 +908,12 @@ bool DShowInput::UpdateVideoConfig(obs_data_t *settings)
 					 placeholders::_3, placeholders::_4,
 					 placeholders::_5);
 
-	if (videoConfig.internalFormat != VideoFormat::MJPEG)
-		videoConfig.format = videoConfig.internalFormat;
+	videoConfig.format = videoConfig.internalFormat;
 
 	if (!device.SetVideoConfig(&videoConfig)) {
 		blog(LOG_WARNING, "%s: device.SetVideoConfig failed",
 		     obs_source_get_name(source));
 		return false;
-	}
-
-	if (videoConfig.internalFormat == VideoFormat::MJPEG) {
-		videoConfig.format = VideoFormat::XRGB;
-		videoConfig.useDefaultConfig = false;
-
-		if (!device.SetVideoConfig(&videoConfig)) {
-			blog(LOG_WARNING,
-			     "%s: device.SetVideoConfig (XRGB) "
-			     "failed",
-			     obs_source_get_name(source));
-			return false;
-		}
 	}
 
 	DStr formatName = GetVideoFormatName(videoConfig.internalFormat);


### PR DESCRIPTION
The former change supports the latter. Better CPU usage, and lower latency on my webcam.