### PR TITLE
cmake: Install 'libobs.pc' under the correct 'libdir'

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -454,7 +454,7 @@ if(UNIX AND NOT APPLE)
 		set(PRIVATE_LIBS "${PRIVATE_LIBS} -l${LIB}")
 	endforeach()
 	CONFIGURE_FILE("libobs.pc.in" "libobs.pc" @ONLY)
-	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libobs.pc" DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
+	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libobs.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endif()
 
 set_target_properties(libobs PROPERTIES

--- a/libobs/libobs.pc.in
+++ b/libobs/libobs.pc.in
@@ -1,7 +1,7 @@
-prefix=@DEST_DIR@
+prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@OBS_LIBRARY_DESTINATION@
-includedir=${prefix}/include
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: libobs
 Description: OBS Studio Library


### PR DESCRIPTION
I've only tested this on a multilib Gentoo install, but it looks like it should be correct for others as well.  :]
