### PR TITLE
libobs-opengl: Empty VAO

### DIFF
--- a/libobs-opengl/gl-helpers.h
+++ b/libobs-opengl/gl-helpers.h
@@ -27,8 +27,11 @@ static inline bool gl_success(const char *funcname)
 {
 	GLenum errorcode = glGetError();
 	if (errorcode != GL_NO_ERROR) {
-		blog(LOG_ERROR, "%s failed, glGetError returned 0x%X", funcname,
-		     errorcode);
+		do {
+			blog(LOG_ERROR, "%s failed, glGetError returned 0x%X",
+			     funcname, errorcode);
+			errorcode = glGetError();
+		} while (errorcode != GL_NO_ERROR);
 		return false;
 	}
 

--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -581,6 +581,8 @@ struct gs_device {
 	struct gl_platform *plat;
 	enum copy_type copy_type;
 
+	GLuint empty_vao;
+
 	gs_texture_t *cur_render_target;
 	gs_zstencil_t *cur_zstencil_buffer;
 	int cur_render_side;

--- a/libobs-opengl/gl-vertexbuffer.c
+++ b/libobs-opengl/gl-vertexbuffer.c
@@ -256,7 +256,7 @@ bool load_vb_buffers(struct gs_program *program, struct gs_vertex_buffer *vb,
 	struct gs_shader *shader = program->vertex_shader;
 	size_t i;
 
-	if (vb && !gl_bind_vertex_array(vb->vao))
+	if (!gl_bind_vertex_array(vb->vao))
 		return false;
 
 	for (i = 0; i < shader->attribs.num; i++) {


### PR DESCRIPTION
Use an empty VAO for shaders that generate their own vertices.