### PR TITLE
obs-qsv: Add all target usage options

### DIFF
--- a/plugins/obs-qsv11/QSV_Encoder.h
+++ b/plugins/obs-qsv11/QSV_Encoder.h
@@ -74,7 +74,16 @@ static const struct qsv_rate_control_info qsv_ratecontrols[] = {
 	{"AVBR", false},  {"ICQ", true},  {"LA_ICQ", true}, {"LA_CBR", true},
 	{"LA_VBR", true}, {0, false}};
 static const char *const qsv_profile_names[] = {"high", "main", "baseline", 0};
-static const char *const qsv_usage_names[] = {"quality", "balanced", "speed",
+static const char *const qsv_usage_names[] = {"quality",
+					      "balanced",
+					      "speed",
+					      "veryslow",
+					      "slower",
+					      "slow",
+					      "medium",
+					      "fast",
+					      "faster"
+					      "veryfast",
 					      0};
 
 typedef struct qsv_t qsv_t;

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -359,6 +359,20 @@ static void update_params(struct obs_qsv *obsqsv, obs_data_t *settings)
 		obsqsv->params.nTargetUsage = MFX_TARGETUSAGE_BALANCED;
 	else if (astrcmpi(target_usage, "speed") == 0)
 		obsqsv->params.nTargetUsage = MFX_TARGETUSAGE_BEST_SPEED;
+	else if (astrcmpi(target_usage, "veryslow") == 0)
+		obsqsv->params.nTargetUsage = MFX_TARGETUSAGE_1;
+	else if (astrcmpi(target_usage, "slower") == 0)
+		obsqsv->params.nTargetUsage = MFX_TARGETUSAGE_2;
+	else if (astrcmpi(target_usage, "slow") == 0)
+		obsqsv->params.nTargetUsage = MFX_TARGETUSAGE_3;
+	else if (astrcmpi(target_usage, "medium") == 0)
+		obsqsv->params.nTargetUsage = MFX_TARGETUSAGE_4;
+	else if (astrcmpi(target_usage, "fast") == 0)
+		obsqsv->params.nTargetUsage = MFX_TARGETUSAGE_5;
+	else if (astrcmpi(target_usage, "faster") == 0)
+		obsqsv->params.nTargetUsage = MFX_TARGETUSAGE_6;
+	else if (astrcmpi(target_usage, "veryfast") == 0)
+		obsqsv->params.nTargetUsage = MFX_TARGETUSAGE_7;
 
 	if (astrcmpi(profile, "baseline") == 0)
 		obsqsv->params.nCodecProfile = MFX_PROFILE_AVC_BASELINE;


### PR DESCRIPTION
I've added, and named all Target Usage options, TU6 most definitely should be exposed, as it's quality is far superior to the current "speed" option.

Used the terminology from [Intel's own publication](https://www.intel.com/content/dam/www/public/us/en/documents/white-papers/cloud-computing-quicksync-video-ffmpeg-white-paper.pdf), left old settings there for compatibility reasons.

Currently untested.