### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
+
+<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->
+
+### Description
+<!--- Describe your changes in detail. -->
+<!--- If this change includes UI elements, please include screenshots. -->
+
+### Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open Mantis issue, or implements feature request -->
+<!--- from the Ideas page, please link to the issue here. -->
+
+### How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment (hardware, OS version, etc.),-->
+<!--- and the tests you ran, including how it may affect other areas of code. -->
+
+### Types of changes
+<!--- What types of changes does your PR introduce? Uncomment all that apply -->
+<!--- - Bug fix (non-breaking change which fixes an issue) -->
+<!--- - New feature (non-breaking change which adds functionality) -->
+<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
+<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
+<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
+<!--- - Documentation (a change to documentation pages) -->
+
+### Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
+- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
+- [ ] My code is not on the master branch.
+- [ ] The code has been tested.
+- [ ] All commit messages are properly formatted and commits squashed where appropriate.
+


### PR DESCRIPTION
### Description
This PR adds a template to github for PR submissions. It also serves as an example to what the template will look like. Make sure to view the raw file, as there is commented information for the PR submitter that is not visible in the PR itself.

### Motivation and Context
This is intended to help those who are making pull requests form a better narrative around the PR, as well as helping current contributors by providing a consistent set of information to view.

### How Has This Been Tested?
This was tested on my local branch. The template shows correctly when a new PR is submitted through github.

### Types of changes
- Documentation (a change to documentation pages)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format). (N/A in this case)
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.