### PR TITLE
UI: Add box select to preview

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -194,6 +194,9 @@ if(MSVC)
 		../deps/libff/libff/ff-util.c
 		PROPERTIES COMPILE_FLAGS -Dinline=__inline
 		)
+	set(obs_PLATFORM_LIBRARIES
+		${obs_PLATFORM_LIBRARIES}
+		w32-pthreads)
 endif()
 
 set(obs_SOURCES

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -30,6 +30,8 @@ class SourceTreeItem : public QWidget {
 	friend class SourceTreeModel;
 
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
+	void enterEvent(QEvent *event) override;
+	void leaveEvent(QEvent *event) override;
 
 	virtual bool eventFilter(QObject *object, QEvent *event) override;
 


### PR DESCRIPTION
This change adds the ability to box select by clicking and dragging from
an empty part of the preview.

Shift + Drag add any items in the box to the selection. Alt + Drag will
remove items in the box from the selection. Ctrl + Drag inverts the
selected state for items in the box.

Regular Click + Drag: ![Regular Drag](https://i.imgur.com/aJTV0AE.gif)

Shift + Drag: ![Shift Drag](https://i.imgur.com/Fsgrwxu.gif)

Alt + Drag: ![Alt Drag](https://i.imgur.com/XvDLLFj.gif)

Ctrl + Drag: ![Ctrl Drag](https://i.imgur.com/EVRFY55.gif)