### PR TITLE
Pair of small fixes

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -1358,7 +1358,8 @@ void device_set_render_target(gs_device_t *device, gs_texture_t *tex,
 		return;
 	}
 
-	ID3D11RenderTargetView *rt = tex2d ? tex2d->renderTarget[0] : nullptr;
+	ID3D11RenderTargetView *rt = tex2d ? tex2d->renderTarget[0].Get()
+					   : nullptr;
 
 	device->curRenderTarget = tex2d;
 	device->curRenderSide = 0;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1509,7 +1509,7 @@ bool set_async_texture_size(struct obs_source *source,
 		source->async_gpu_conversion = true;
 
 		enum gs_color_format format =
-			CONVERT_RGB_LIMITED
+			(cur == CONVERT_RGB_LIMITED)
 				? convert_video_format(frame->format)
 				: GS_BGRX;
 		source->async_texrender =


### PR DESCRIPTION
I don't think either fix makes a significant user impact, but the code is less gross.

- Use raw pointer in ternary operator to avoid unnecessary type conversions.
- Fix broken format selection to use BGRX render targets for YUV -> RGB conversions. I don't think the previous behavior was necessarily broken since we always fill the alpha channel with 1.0 in shader anyway.