### PR TITLE
UI: Add option to warn on stop recording

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -262,6 +262,10 @@ ConfirmStart.Text="Are you sure you want to start the stream?"
 ConfirmStop.Title="Stop Stream?"
 ConfirmStop.Text="Are you sure you want to stop the stream?"
 
+# confirm stop record dialog box
+ConfirmStopRecord.Title="Stop Recording?"
+ConfirmStopRecord.Text="Are you sure you want to stop recording?"
+
 # confirm bandwidth test dialog box
 ConfirmBWTest.Title="Start Bandwidth Test?"
 ConfirmBWTest.Text="You have OBS configured in bandwidth test mode. This mode allows for network testing without your channel going live. Once you are done testing, you will need to disable it in order for viewers to be able to see your stream.\n\nDo you want to continue?"
@@ -614,6 +618,7 @@ Basic.Settings.General.EnableAutoUpdates="Automatically check for updates on sta
 Basic.Settings.General.OpenStatsOnStartup="Open stats dialog on startup"
 Basic.Settings.General.WarnBeforeStartingStream="Show confirmation dialog when starting streams"
 Basic.Settings.General.WarnBeforeStoppingStream="Show confirmation dialog when stopping streams"
+Basic.Settings.General.WarnBeforeStoppingRecord="Show confirmation dialog when stopping recording"
 Basic.Settings.General.Projectors="Projectors"
 Basic.Settings.General.HideProjectorCursor="Hide cursor over projectors"
 Basic.Settings.General.ProjectorAlwaysOnTop="Make projectors always on top"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -291,13 +291,20 @@
                     </widget>
                    </item>
                    <item row="2" column="1">
+                    <widget class="QCheckBox" name="warnBeforeRecordStop">
+                     <property name="text">
+                      <string>Basic.Settings.General.WarnBeforeStoppingRecord</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="1">
                     <widget class="QCheckBox" name="recordWhenStreaming">
                      <property name="text">
                       <string>Basic.Settings.General.RecordWhenStreaming</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="3" column="1">
+                   <item row="4" column="1">
                     <widget class="QCheckBox" name="keepRecordStreamStops">
                      <property name="enabled">
                       <bool>false</bool>
@@ -307,14 +314,14 @@
                      </property>
                     </widget>
                    </item>
-                   <item row="4" column="1">
+                   <item row="5" column="1">
                     <widget class="QCheckBox" name="replayWhileStreaming">
                      <property name="text">
                       <string>Basic.Settings.General.ReplayBufferWhileStreaming</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="5" column="1">
+                   <item row="6" column="1">
                     <widget class="QCheckBox" name="keepReplayStreamStops">
                      <property name="enabled">
                       <bool>false</bool>
@@ -5235,6 +5242,7 @@
   <tabstop>openStatsOnStartup</tabstop>
   <tabstop>warnBeforeStreamStart</tabstop>
   <tabstop>warnBeforeStreamStop</tabstop>
+  <tabstop>warnBeforeRecordStop</tabstop>
   <tabstop>recordWhenStreaming</tabstop>
   <tabstop>keepRecordStreamStops</tabstop>
   <tabstop>replayWhileStreaming</tabstop>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5679,6 +5679,20 @@ void OBSBasic::on_streamButton_clicked()
 void OBSBasic::on_recordButton_clicked()
 {
 	if (outputHandler->RecordingActive()) {
+		bool confirm = config_get_bool(GetGlobalConfig(), "BasicWindow",
+					       "WarnBeforeStoppingRecord");
+
+		if (confirm && isVisible()) {
+			QMessageBox::StandardButton button =
+				OBSMessageBox::question(
+					this, QTStr("ConfirmStopRecord.Title"),
+					QTStr("ConfirmStopRecord.Text"));
+
+			if (button == QMessageBox::No) {
+				ui->recordButton->setChecked(true);
+				return;
+			}
+		}
 		StopRecording();
 	} else {
 		if (!NoSourcesConfirmation()) {

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -306,6 +306,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->openStatsOnStartup,   CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStart,CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStop, CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->warnBeforeRecordStop, CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->hideProjectorCursor,  CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->projectorAlwaysOnTop, CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->recordWhenStreaming,  CHECK_CHANGED,  GENERAL_CHANGED);
@@ -1120,6 +1121,10 @@ void OBSBasicSettings::LoadGeneralSettings()
 	bool warnBeforeStreamStop = config_get_bool(
 		GetGlobalConfig(), "BasicWindow", "WarnBeforeStoppingStream");
 	ui->warnBeforeStreamStop->setChecked(warnBeforeStreamStop);
+
+	bool warnBeforeRecordStop = config_get_bool(
+		GetGlobalConfig(), "BasicWindow", "WarnBeforeStoppingRecord");
+	ui->warnBeforeRecordStop->setChecked(warnBeforeRecordStop);
 
 	bool hideProjectorCursor = config_get_bool(
 		GetGlobalConfig(), "BasicWindow", "HideProjectorCursor");
@@ -2760,6 +2765,9 @@ void OBSBasicSettings::SaveGeneralSettings()
 	config_set_bool(GetGlobalConfig(), "BasicWindow",
 			"WarnBeforeStoppingStream",
 			ui->warnBeforeStreamStop->isChecked());
+	config_set_bool(GetGlobalConfig(), "BasicWindow",
+			"WarnBeforeStoppingRecord",
+			ui->warnBeforeRecordStop->isChecked());
 
 	config_set_bool(GetGlobalConfig(), "BasicWindow", "HideProjectorCursor",
 			ui->hideProjectorCursor->isChecked());


### PR DESCRIPTION
OBS has an option to warn before stopping a stream, but it doesn't have
a similar warning for recording. This can result in a recording being
unintentionally stopped.

Add an option to warn when the "Stop Recording" button is pressed.

Note: While OBS also has an option to warn on stream start, this
patch purposefully does not add similar warn on recording start option.
This is because accidentally starting to record isn't risky in the same
way that accidentally starting to stream is.