### PR TITLE
libobs: Fix format selection

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1509,7 +1509,7 @@ bool set_async_texture_size(struct obs_source *source,
 		source->async_gpu_conversion = true;
 
 		enum gs_color_format format =
-			CONVERT_RGB_LIMITED
+			(cur == CONVERT_RGB_LIMITED)
 				? convert_video_format(frame->format)
 				: GS_BGRX;
 		source->async_texrender =


### PR DESCRIPTION
Fix ternary test to use BGRX render targets for YUV to RGB
conversions. The previous behavior may have been fine though since
the shaders fill the alpha channel with 1.0 anyway.