### PR TITLE
libobs-d3d11: Unnecessary type conversions

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -1358,7 +1358,8 @@ void device_set_render_target(gs_device_t *device, gs_texture_t *tex,
 		return;
 	}
 
-	ID3D11RenderTargetView *rt = tex2d ? tex2d->renderTarget[0] : nullptr;
+	ID3D11RenderTargetView *rt = tex2d ? tex2d->renderTarget[0].Get()
+					   : nullptr;
 
 	device->curRenderTarget = tex2d;
 	device->curRenderSide = 0;


### PR DESCRIPTION
Use raw pointer on both sides of ternary test result to remove
conversions.