### PR TITLE
Fix audio buffering for devices like GV-USB2

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -211,6 +211,7 @@ static inline void discard_audio(struct obs_core_audio *audio,
 		if (is_audio_source)
 			blog(LOG_DEBUG, "can't discard, data still pending");
 #endif
+		source->audio_ts = ts->end;
 		return;
 	}
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1267,8 +1267,11 @@ static void source_output_audio_data(obs_source_t *source,
 		if (diff > MAX_TS_VAR && !using_direct_ts)
 			handle_ts_jump(source, source->next_audio_ts_min,
 				       in.timestamp, diff, os_time);
-		else if (diff < TS_SMOOTHING_THRESHOLD)
+		else if (diff < TS_SMOOTHING_THRESHOLD) {
+			if (source->async_unbuffered && source->async_decoupled)
+				source->timing_adjust = os_time - in.timestamp;
 			in.timestamp = source->next_audio_ts_min;
+		}
 	}
 
 	source->last_audio_ts = in.timestamp;

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -800,6 +800,11 @@ static inline bool IsEncoded(const VideoConfig &config)
 	       wstrstri(config.name.c_str(), L"stream engine") != NULL;
 }
 
+static inline bool IsDecoupled(const VideoConfig &config)
+{
+	return wstrstri(config.name.c_str(), L"GV-USB2") != NULL;
+}
+
 inline void DShowInput::SetupBuffering(obs_data_t *settings)
 {
 	BufferingType bufType;
@@ -813,6 +818,7 @@ inline void DShowInput::SetupBuffering(obs_data_t *settings)
 		useBuffering = bufType == BufferingType::On;
 
 	obs_source_set_async_unbuffered(source, !useBuffering);
+	obs_source_set_async_decoupled(source, IsDecoupled(videoConfig));
 }
 
 static DStr GetVideoFormatName(VideoFormat format);


### PR DESCRIPTION
This PR attempts to address buffering and audio loss problems with GV-USB2 in a robust way.

See https://obsproject.com/mantis/view.php?id=1269