### PR TITLE
Add the ability to pause and unpause recordings

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -235,6 +235,7 @@ set(obs_SOURCES
 	slider-ignorewheel.cpp
 	combobox-ignorewheel.cpp
 	spinbox-ignorewheel.cpp
+	record-button.cpp
 	volume-control.cpp
 	adv-audio-control.cpp
 	item-widget-helpers.cpp
@@ -289,6 +290,7 @@ set(obs_HEADERS
 	focus-list.hpp
 	menu-button.hpp
 	mute-checkbox.hpp
+	record-button.hpp
 	volume-control.hpp
 	adv-audio-control.hpp
 	item-widget-helpers.hpp

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -21,6 +21,7 @@ void EnumSceneCollections(function<bool(const char *, const char *)> &&cb);
 
 extern volatile bool streaming_active;
 extern volatile bool recording_active;
+extern volatile bool recording_paused;
 extern volatile bool replaybuf_active;
 
 /* ------------------------------------------------------------------------- */
@@ -263,6 +264,17 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	bool obs_frontend_recording_active(void) override
 	{
 		return os_atomic_load_bool(&recording_active);
+	}
+
+	void obs_frontend_recording_pause(bool pause) override
+	{
+		QMetaObject::invokeMethod(main, pause ? "PauseRecording"
+						      : "UnpauseRecording");
+	}
+
+	bool obs_frontend_recording_paused(void) override
+	{
+		return os_atomic_load_bool(&recording_paused);
 	}
 
 	void obs_frontend_replay_buffer_start(void) override

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -281,6 +281,9 @@ Output.StartRecordingFailed="Failed to start recording"
 Output.StartReplayFailed="Failed to start replay buffer"
 Output.StartFailedGeneric="Starting the output failed. Please check the log for details.\n\nNote: If you are using the NVENC or AMD encoders, make sure your video drivers are up to date."
 
+# replay buffer + pause warning message
+Output.ReplayBuffer.PauseWarning.Title="Cannot save replays while paused"
+Output.ReplayBuffer.PauseWarning.Text="Warning: Replays cannot be saved while recording is paused."
 
 # output connect messages
 Output.ConnectFail.Title="Failed to connect"
@@ -501,6 +504,8 @@ Basic.Main.StartRecording="Start Recording"
 Basic.Main.StartReplayBuffer="Start Replay Buffer"
 Basic.Main.StartStreaming="Start Streaming"
 Basic.Main.StopRecording="Stop Recording"
+Basic.Main.PauseRecording="Pause Recording"
+Basic.Main.UnpauseRecording="Unpause Recording"
 Basic.Main.StoppingRecording="Stopping Recording..."
 Basic.Main.StopReplayBuffer="Stop Replay Buffer"
 Basic.Main.StoppingReplayBuffer="Stopping Replay Buffer..."
@@ -678,6 +683,7 @@ Basic.Settings.Output.Simple.RecordingQuality.HQ="Indistinguishable Quality, Lar
 Basic.Settings.Output.Simple.RecordingQuality.Lossless="Lossless Quality, Tremendously Large File Size"
 Basic.Settings.Output.Simple.Warn.VideoBitrate="Warning: The streaming video bitrate will be set to %1, which is the upper limit for the current streaming service. If you're sure you want to go above %1, enable advanced encoder options and uncheck \"Enforce streaming service bitrate limits\"."
 Basic.Settings.Output.Simple.Warn.AudioBitrate="Warning: The streaming audio bitrate will be set to %1, which is the upper limit for the current streaming service. If you're sure you want to go above %1, enable advanced encoder options and uncheck \"Enforce streaming service bitrate limits\"."
+Basic.Settings.Output.Simple.Warn.CannotPause="Warning: Recordings cannot be paused if the recording quality is set to \"Same as stream\"."
 Basic.Settings.Output.Simple.Warn.Encoder="Warning: Recording with a software encoder at a different quality than the stream will require extra CPU usage if you stream and record at the same time."
 Basic.Settings.Output.Simple.Warn.Lossless="Warning: Lossless quality generates tremendously large file sizes! Lossless quality can use upward of 7 gigabytes of disk space per minute at high resolutions and framerates. Lossless is not recommended for long recordings unless you have a very large amount of disk space available."
 Basic.Settings.Output.Simple.Warn.Lossless.Msg="Are you sure you want to use lossless quality?"
@@ -909,6 +915,7 @@ SceneItemHide="Hide '%1'"
 OutputWarnings.NoTracksSelected="You must select at least one track"
 OutputWarnings.MultiTrackRecording="Warning: Certain formats (such as FLV) do not support multiple tracks per recording"
 OutputWarnings.MP4Recording="Warning: Recordings saved to MP4/MOV will be unrecoverable if the file cannot be finalized (e.g. as a result of BSODs, power losses, etc.). If you want to record multiple audio tracks consider using MKV and remux the recording to MP4/MOV after it is finished (File → Remux Recordings)"
+OutputWarnings.CannotPause="Warning: Recordings cannot be paused if the recording encoder is set to \"(Use stream encoder)\""
 
 # deleting final scene
 FinalScene.Title="Delete Scene"

--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -353,6 +353,10 @@ QToolButton:pressed {
 	qproperty-icon: url(./Dark/down.svg);
 }
 
+* [themeID="pauseIconSmall"] {
+	qproperty-icon: url(./Dark/media-pause.svg);
+}
+
 /* Tab Widget */
 
 QTabWidget::pane { /* The tab widget frame */

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -253,6 +253,10 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/down.svg);
 }
 
+* [themeID="pauseIconSmall"] {
+    qproperty-icon: url(./Dark/media-pause.svg);
+}
+
 
 /* Tab Widget */
 
@@ -575,6 +579,19 @@ MuteCheckBox::indicator:unchecked {
 
 OBSHotkeyLabel[hotkeyPairHover=true] {
     color: red;
+}
+
+/* Pause */
+PauseCheckBox {
+    outline: none;
+}
+
+PauseCheckBox::indicator:checked {
+    image: url(:/res/images/media-pause.svg);
+}
+
+PauseCheckBox::indicator:unchecked {
+    image: url(:/res/images/media-play.svg);
 }
 
 /* Group Collapse Checkbox */

--- a/UI/data/themes/Dark/media-pause.svg
+++ b/UI/data/themes/Dark/media-pause.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" fill="#d2d2d2">
+  <path d="M0 0v6h2v-6h-2zm4 0v6h2v-6h-2z" transform="translate(1 1)" />
+</svg>

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -507,6 +507,10 @@ QToolButton:pressed {
 	qproperty-icon: url(./Dark/down.svg);
 }
 
+* [themeID="pauseIconSmall"] {
+	qproperty-icon: url(./Dark/media-pause.svg);
+}
+
 /***********************/
 /* --- Combo boxes --- */
 /***********************/

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -39,6 +39,10 @@
     qproperty-icon: url(:/res/images/down.svg);
 }
 
+* [themeID="pauseIconSmall"] {
+    qproperty-icon: url(:/res/images/media-pause.svg);
+}
+
 MuteCheckBox {
     outline: none;
 }

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -116,7 +116,7 @@
      <x>0</x>
      <y>0</y>
      <width>1079</width>
-     <height>22</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -656,7 +656,7 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>64</width>
+           <width>80</width>
            <height>16</height>
           </rect>
          </property>
@@ -843,7 +843,7 @@
              <string notr="true"/>
             </property>
             <property name="icon">
-             <iconset resource="obs.qrc">
+             <iconset>
               <normaloff>:/res/images/add.png</normaloff>:/res/images/add.png</iconset>
             </property>
             <property name="flat">
@@ -878,7 +878,7 @@
              <string notr="true"/>
             </property>
             <property name="icon">
-             <iconset resource="obs.qrc">
+             <iconset>
               <normaloff>:/res/images/list_remove.png</normaloff>:/res/images/list_remove.png</iconset>
             </property>
             <property name="flat">
@@ -913,7 +913,7 @@
              <string notr="true"/>
             </property>
             <property name="icon">
-             <iconset resource="obs.qrc">
+             <iconset>
               <normaloff>:/res/images/configuration21_16.png</normaloff>:/res/images/configuration21_16.png</iconset>
             </property>
             <property name="flat">
@@ -1000,7 +1000,7 @@
    <attribute name="dockWidgetArea">
     <number>8</number>
    </attribute>
-   <widget class="QWidget" name="dockWidgetContents_3">
+   <widget class="QWidget" name="controlsDockContents">
     <layout class="QVBoxLayout" name="buttonsVLayout">
      <property name="spacing">
       <number>2</number>
@@ -1037,29 +1037,48 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="recordButton">
-       <property name="enabled">
-        <bool>true</bool>
+      <layout class="QHBoxLayout" name="recordingLayout">
+       <property name="spacing">
+        <number>2</number>
        </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="minimumSize">
-        <size>
-         <width>130</width>
-         <height>0</height>
-        </size>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>Basic.Main.StartRecording</string>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-       <property name="checkable">
-        <bool>true</bool>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-      </widget>
+       <item>
+        <widget class="RecordButton" name="recordButton">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>130</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Basic.Main.StartRecording</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
       <widget class="QPushButton" name="modeSwitch">
@@ -1115,7 +1134,7 @@
   </widget>
   <action name="actionAddScene">
    <property name="icon">
-    <iconset resource="obs.qrc">
+    <iconset>
      <normaloff>:/res/images/add.png</normaloff>:/res/images/add.png</iconset>
    </property>
    <property name="text">
@@ -1127,7 +1146,7 @@
   </action>
   <action name="actionAddSource">
    <property name="icon">
-    <iconset resource="obs.qrc">
+    <iconset>
      <normaloff>:/res/images/add.png</normaloff>:/res/images/add.png</iconset>
    </property>
    <property name="text">
@@ -1139,7 +1158,7 @@
   </action>
   <action name="actionRemoveScene">
    <property name="icon">
-    <iconset resource="obs.qrc">
+    <iconset>
      <normaloff>:/res/images/list_remove.png</normaloff>:/res/images/list_remove.png</iconset>
    </property>
    <property name="text">
@@ -1157,7 +1176,7 @@
   </action>
   <action name="actionRemoveSource">
    <property name="icon">
-    <iconset resource="obs.qrc">
+    <iconset>
      <normaloff>:/res/images/list_remove.png</normaloff>:/res/images/list_remove.png</iconset>
    </property>
    <property name="text">
@@ -1178,7 +1197,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="obs.qrc">
+    <iconset>
      <normaloff>:/res/images/properties.png</normaloff>:/res/images/properties.png</iconset>
    </property>
    <property name="text">
@@ -1190,7 +1209,7 @@
   </action>
   <action name="actionSceneUp">
    <property name="icon">
-    <iconset resource="obs.qrc">
+    <iconset>
      <normaloff>:/res/images/up.png</normaloff>:/res/images/up.png</iconset>
    </property>
    <property name="text">
@@ -1205,7 +1224,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="obs.qrc">
+    <iconset>
      <normaloff>:/res/images/up.png</normaloff>:/res/images/up.png</iconset>
    </property>
    <property name="text">
@@ -1217,7 +1236,7 @@
   </action>
   <action name="actionSceneDown">
    <property name="icon">
-    <iconset resource="obs.qrc">
+    <iconset>
      <normaloff>:/res/images/down.png</normaloff>:/res/images/down.png</iconset>
    </property>
    <property name="text">
@@ -1232,7 +1251,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset resource="obs.qrc">
+    <iconset>
      <normaloff>:/res/images/down.png</normaloff>:/res/images/down.png</iconset>
    </property>
    <property name="text">
@@ -1732,6 +1751,11 @@
    <extends>QDockWidget</extends>
    <header>window-dock.hpp</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>RecordButton</class>
+   <extends>QPushButton</extends>
+   <header>record-button.hpp</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/UI/forms/images/media-pause.svg
+++ b/UI/forms/images/media-pause.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" fill="#000000">
+  <path d="M0 0v6h2v-6h-2zm4 0v6h2v-6h-2z" transform="translate(1 1)" />
+</svg>

--- a/UI/forms/obs.qrc
+++ b/UI/forms/obs.qrc
@@ -1,5 +1,6 @@
 <RCC>
   <qresource prefix="/res">
+    <file>images/media-pause.svg</file>
     <file>images/mute.svg</file>
     <file>images/refresh.svg</file>
     <file>images/no_sources.svg</file>

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -227,6 +227,17 @@ bool obs_frontend_recording_active(void)
 	return !!callbacks_valid() ? c->obs_frontend_recording_active() : false;
 }
 
+void obs_frontend_recording_pause(bool pause)
+{
+	if (!!callbacks_valid())
+		c->obs_frontend_recording_pause(pause);
+}
+
+bool obs_frontend_recording_paused(void)
+{
+	return !!callbacks_valid() ? c->obs_frontend_recording_paused() : false;
+}
+
 void obs_frontend_replay_buffer_start(void)
 {
 	if (callbacks_valid())

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -44,6 +44,9 @@ enum obs_frontend_event {
 
 	OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP,
 	OBS_FRONTEND_EVENT_FINISHED_LOADING,
+
+	OBS_FRONTEND_EVENT_RECORDING_PAUSED,
+	OBS_FRONTEND_EVENT_RECORDING_UNPAUSED,
 };
 
 /* ------------------------------------------------------------------------- */
@@ -152,6 +155,8 @@ EXPORT bool obs_frontend_streaming_active(void);
 EXPORT void obs_frontend_recording_start(void);
 EXPORT void obs_frontend_recording_stop(void);
 EXPORT bool obs_frontend_recording_active(void);
+EXPORT void obs_frontend_recording_pause(bool pause);
+EXPORT bool obs_frontend_recording_paused(void);
 
 EXPORT void obs_frontend_replay_buffer_start(void);
 EXPORT void obs_frontend_replay_buffer_save(void);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -43,6 +43,8 @@ struct obs_frontend_callbacks {
 	virtual void obs_frontend_recording_start(void) = 0;
 	virtual void obs_frontend_recording_stop(void) = 0;
 	virtual bool obs_frontend_recording_active(void) = 0;
+	virtual void obs_frontend_recording_pause(bool pause) = 0;
+	virtual bool obs_frontend_recording_paused(void) = 0;
 
 	virtual void obs_frontend_replay_buffer_start(void) = 0;
 	virtual void obs_frontend_replay_buffer_save(void) = 0;

--- a/UI/record-button.cpp
+++ b/UI/record-button.cpp
@@ -1,0 +1,18 @@
+#include "record-button.hpp"
+#include "window-basic-main.hpp"
+
+void RecordButton::resizeEvent(QResizeEvent *event)
+{
+	OBSBasic *main = OBSBasic::Get();
+	if (!main->pause)
+		return;
+
+	QSize newSize = event->size();
+	QSize pauseSize = main->pause->size();
+	int height = main->ui->recordButton->size().height();
+
+	if (pauseSize.height() != height || pauseSize.width() != height) {
+		main->pause->setMinimumSize(height, height);
+		main->pause->setMaximumSize(height, height);
+	}
+}

--- a/UI/record-button.hpp
+++ b/UI/record-button.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <QPushButton>
+
+class RecordButton : public QPushButton {
+	Q_OBJECT
+
+public:
+	inline RecordButton(QWidget *parent = nullptr) : QPushButton(parent) {}
+
+	virtual void resizeEvent(QResizeEvent *event) override;
+};

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -12,6 +12,7 @@ extern bool EncoderAvailable(const char *encoder);
 
 volatile bool streaming_active = false;
 volatile bool recording_active = false;
+volatile bool recording_paused = false;
 volatile bool replaybuf_active = false;
 
 static void OBSStreamStarting(void *data, calldata_t *params)
@@ -88,6 +89,7 @@ static void OBSStopRecording(void *data, calldata_t *params)
 
 	output->recordingActive = false;
 	os_atomic_set_bool(&recording_active, false);
+	os_atomic_set_bool(&recording_paused, false);
 	QMetaObject::invokeMethod(output->main, "RecordingStop",
 				  Q_ARG(int, code),
 				  Q_ARG(QString, arg_last_error));

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -123,6 +123,7 @@ class OBSBasic : public OBSMainWindow {
 	friend class Auth;
 	friend class AutoConfig;
 	friend class AutoConfigStreamPage;
+	friend class RecordButton;
 	friend struct OBSStudioAPI;
 
 	enum class MoveDir { Up, Down, Left, Right };
@@ -204,6 +205,7 @@ private:
 
 	QPointer<QPushButton> transitionButton;
 	QPointer<QPushButton> replayBufferButton;
+	QScopedPointer<QPushButton> pause;
 
 	QScopedPointer<QSystemTrayIcon> trayIcon;
 	QPointer<QAction> sysTrayStream;
@@ -323,8 +325,8 @@ private:
 
 	int GetTopSelectedSourceItem();
 
-	obs_hotkey_pair_id streamingHotkeys, recordingHotkeys, replayBufHotkeys,
-		togglePreviewHotkeys;
+	obs_hotkey_pair_id streamingHotkeys, recordingHotkeys, pauseHotkeys,
+		replayBufHotkeys, togglePreviewHotkeys;
 	obs_hotkey_id forceStreamingStopHotkey;
 
 	void InitDefaultTransitions();
@@ -440,6 +442,7 @@ public slots:
 	void RecordStopping();
 	void RecordingStop(int code, QString last_error);
 
+	void ShowReplayBufferPauseWarning();
 	void StartReplayBuffer();
 	void StopReplayBuffer();
 
@@ -464,6 +467,9 @@ public slots:
 				const QString &name = QString());
 
 	void UpdatePatronJson(const QString &text, const QString &error);
+
+	void PauseRecording();
+	void UnpauseRecording();
 
 private slots:
 	void AddSceneItem(OBSSceneItem item);
@@ -557,6 +563,7 @@ private:
 	static void HotkeyTriggered(void *data, obs_hotkey_id id, bool pressed);
 
 	void AutoRemux();
+	void UpdatePause(bool activate = true);
 
 public:
 	OBSSource GetProgramSource();
@@ -759,6 +766,8 @@ private slots:
 
 	void on_resetUI_triggered();
 	void on_lockUI_toggled(bool lock);
+
+	void PauseToggled();
 
 	void logUploadFinished(const QString &text, const QString &error);
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -729,6 +729,8 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 		SLOT(AdvOutRecCheckWarnings()));
 	connect(ui->advOutRecFormat, SIGNAL(currentIndexChanged(int)), this,
 		SLOT(AdvOutRecCheckWarnings()));
+	connect(ui->advOutRecEncoder, SIGNAL(currentIndexChanged(int)), this,
+		SLOT(AdvOutRecCheckWarnings()));
 	AdvOutRecCheckWarnings();
 
 	ui->buttonBox->button(QDialogButtonBox::Apply)->setIcon(QIcon());
@@ -3929,6 +3931,13 @@ void OBSBasicSettings::AdvOutRecCheckWarnings()
 		warningMsg = QTStr("OutputWarnings.MultiTrackRecording");
 	}
 
+	bool useStreamEncoder = ui->advOutRecEncoder->currentIndex() == 0;
+	if (useStreamEncoder) {
+		if (!warningMsg.isEmpty())
+			warningMsg += "\n\n";
+		warningMsg += QTStr("OutputWarnings.CannotPause");
+	}
+
 	if (ui->advOutRecFormat->currentText().compare("mp4") == 0 ||
 	    ui->advOutRecFormat->currentText().compare("mov") == 0) {
 		if (!warningMsg.isEmpty())
@@ -4387,6 +4396,10 @@ void OBSBasicSettings::SimpleRecordingEncoderChanged()
 				warning += "\n\n";
 			warning += SIMPLE_OUTPUT_WARNING("Encoder");
 		}
+	} else {
+		if (!warning.isEmpty())
+			warning += "\n\n";
+		warning += SIMPLE_OUTPUT_WARNING("CannotPause");
 	}
 
 	if (qual != "Lossless" &&

--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -241,17 +241,28 @@ void OBSBasicStatusBar::UpdateStreamTime()
 	}
 }
 
+extern volatile bool recording_paused;
+
 void OBSBasicStatusBar::UpdateRecordTime()
 {
-	totalRecordSeconds++;
+	bool paused = os_atomic_load_bool(&recording_paused);
 
-	int seconds = totalRecordSeconds % 60;
-	int totalMinutes = totalRecordSeconds / 60;
-	int minutes = totalMinutes % 60;
-	int hours = totalMinutes / 60;
+	if (!paused)
+		totalRecordSeconds++;
 
 	QString text;
-	text.sprintf("REC: %02d:%02d:%02d", hours, minutes, seconds);
+
+	if (paused) {
+		text = QStringLiteral("REC: PAUSED");
+	} else {
+		int seconds = totalRecordSeconds % 60;
+		int totalMinutes = totalRecordSeconds / 60;
+		int minutes = totalMinutes % 60;
+		int hours = totalMinutes / 60;
+
+		text.sprintf("REC: %02d:%02d:%02d", hours, minutes, seconds);
+	}
+
 	recordTime->setText(text);
 	recordTime->setMinimumWidth(recordTime->width());
 }

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -124,6 +124,18 @@ Structures/Enumerations
      the program is either about to load a new scene collection, or the
      program is about to exit.
 
+   - **OBS_FRONTEND_FINISHED_LOADING**
+
+     Triggered when the program has finished loading.
+
+   - **OBS_FRONTEND_EVENT_RECORDING_PAUSED**
+
+     Triggered when the recording has been paused.
+
+   - **OBS_FRONTEND_EVENT_RECORDING_UNPAUSED**
+
+     Triggered when the recording has been unpaused.
+
 .. type:: struct obs_frontend_source_list
 
    - DARRAY(obs_source_t*) **sources**
@@ -399,6 +411,18 @@ Functions
 .. function:: bool obs_frontend_recording_active(void)
 
    :return: *true* if recording active, *false* otherwise.
+
+---------------------------------------
+
+.. function:: void obs_frontend_recording_pause(bool pause)
+
+   :pause: *true* to pause recording, *false* to unpause.
+
+---------------------------------------
+
+.. function:: bool obs_frontend_recording_paused(void)
+
+   :return: *true* if recording paused, *false* otherwise.
 
 ---------------------------------------
 

--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -66,6 +66,14 @@ Output Definition Structure (obs_output_info)
      When this capability flag is used, specifies that this output
      supports multiple encoded audio tracks simultaneously.
 
+   - **OBS_OUTPUT_CAN_PAUSE** - Output supports pausing.
+
+     When this capability flag is used, the output supports pausing.
+     When an output is paused, raw or encoded audio/video data will be
+     halted when paused down to the exact point to the closest video
+     frame.  Audio data will be correctly truncated down to the exact
+     audio sample according to that video frame timing.
+
 .. member:: const char *(*obs_output_info.get_name)(void *type_data)
 
    Get the translated name of the output type.
@@ -170,13 +178,9 @@ Output Definition Structure (obs_output_info)
 
    :return: The properties of the output
 
-.. member:: void (*obs_output_info.pause)(void *data)
+.. member:: void (*obs_output_info.unused1)(void *data)
 
-   Pauses the output (if the output supports pausing).
-
-   (Author's note: This is currently unimplemented)
-
-   (Optional)
+   This callback is no longer used.
 
 .. member:: uint64_t (*obs_output_info.get_total_bytes)(void *data)
 
@@ -256,6 +260,14 @@ Output Signals
                   | OBS_OUTPUT_UNSUPPORTED    - The settings, video/audio format, or codecs are unsupported by this output
                   | OBS_OUTPUT_NO_SPACE       - Ran out of disk space
                   | OBS_OUTPUT_ENCODE_ERROR   - Encoder error
+
+**pause** (ptr output)
+
+   Called when the output has been paused.
+
+**unpause** (ptr output)
+
+   Called when the output has been unpaused.
 
 **starting** (ptr output)
 
@@ -444,11 +456,18 @@ General Output Functions
 
 ---------------------
 
-.. function:: void obs_output_pause(obs_output_t *output)
+.. function:: bool obs_output_pause(obs_output_t *output, bool pause)
 
    Pause an output (if supported by the output).
 
-   (Author's Note: Not yet implemented)
+   :return: *true* if the output was paused successfuly, *false*
+            otherwise
+
+---------------------
+
+.. function:: bool obs_output_paused(const obs_output_t *output)
+
+   :return: *true* if the output is paused, *false* otherwise
 
 ---------------------
 
@@ -807,6 +826,14 @@ Functions used by outputs
                 | OBS_OUTPUT_DISCONNECTED   - Unexpectedly disconnected
                 | OBS_OUTPUT_UNSUPPORTED    - The settings, video/audio format, or codecs are unsupported by this output
                 | OBS_OUTPUT_NO_SPACE       - Ran out of disk space
+
+---------------------
+
+.. function:: uint64_t obs_output_get_pause_offset(obs_output_t *output)
+
+   Returns the current pause offset of the output.  Used with raw
+   outputs to calculate system timestamps when using calculated
+   timestamps (see FFmpeg output for an example).
 
 .. ---------------------------------------------------------------------------
 

--- a/libobs/obs-output.h
+++ b/libobs/obs-output.h
@@ -27,6 +27,7 @@ extern "C" {
 #define OBS_OUTPUT_ENCODED (1 << 2)
 #define OBS_OUTPUT_SERVICE (1 << 3)
 #define OBS_OUTPUT_MULTI_TRACK (1 << 4)
+#define OBS_OUTPUT_CAN_PAUSE (1 << 5)
 
 struct encoder_packet;
 
@@ -56,7 +57,7 @@ struct obs_output_info {
 
 	obs_properties_t *(*get_properties)(void *data);
 
-	void (*pause)(void *data);
+	void (*unused1)(void *data);
 
 	uint64_t (*get_total_bytes)(void *data);
 

--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -86,6 +86,9 @@ static void *gpu_encode_thread(void *unused)
 				}
 			}
 
+			if (video_pause_check(&encoder->pause, timestamp))
+				continue;
+
 			if (!encoder->start_ts)
 				encoder->start_ts = timestamp;
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1692,7 +1692,10 @@ EXPORT void obs_output_update(obs_output_t *output, obs_data_t *settings);
 EXPORT bool obs_output_can_pause(const obs_output_t *output);
 
 /** Pauses the output (if the functionality is allowed by the output */
-EXPORT void obs_output_pause(obs_output_t *output);
+EXPORT bool obs_output_pause(obs_output_t *output, bool pause);
+
+/** Returns whether output is paused */
+EXPORT bool obs_output_paused(const obs_output_t *output);
 
 /* Gets the current output settings string */
 EXPORT obs_data_t *obs_output_get_settings(const obs_output_t *output);
@@ -1867,6 +1870,8 @@ EXPORT void obs_output_end_data_capture(obs_output_t *output);
  */
 EXPORT void obs_output_signal_stop(obs_output_t *output, int code);
 
+EXPORT uint64_t obs_output_get_pause_offset(obs_output_t *output);
+
 /* ------------------------------------------------------------------------- */
 /* Encoders */
 
@@ -2030,6 +2035,9 @@ EXPORT void obs_encoder_packet_release(struct encoder_packet *packet);
 
 EXPORT void *obs_encoder_create_rerouted(obs_encoder_t *encoder,
 					 const char *reroute_id);
+
+/** Returns whether encoder is paused */
+EXPORT bool obs_encoder_paused(const obs_encoder_t *output);
 
 /* ------------------------------------------------------------------------- */
 /* Stream Services */

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -960,6 +960,7 @@ static uint64_t get_packet_sys_dts(struct ffmpeg_output *output,
 				   AVPacket *packet)
 {
 	struct ffmpeg_data *data = &output->ff_data;
+	uint64_t pause_offset = obs_output_get_pause_offset(output->output);
 	uint64_t start_ts;
 
 	AVRational time_base;
@@ -972,8 +973,9 @@ static uint64_t get_packet_sys_dts(struct ffmpeg_output *output,
 		start_ts = output->audio_start_ts;
 	}
 
-	return start_ts + (uint64_t)av_rescale_q(packet->dts, time_base,
-						 (AVRational){1, 1000000000});
+	return start_ts + pause_offset +
+	       (uint64_t)av_rescale_q(packet->dts, time_base,
+				      (AVRational){1, 1000000000});
 }
 
 static int process_packet(struct ffmpeg_output *output)
@@ -1247,7 +1249,8 @@ static uint64_t ffmpeg_output_total_bytes(void *data)
 
 struct obs_output_info ffmpeg_output = {
 	.id = "ffmpeg_output",
-	.flags = OBS_OUTPUT_AUDIO | OBS_OUTPUT_VIDEO | OBS_OUTPUT_MULTI_TRACK,
+	.flags = OBS_OUTPUT_AUDIO | OBS_OUTPUT_VIDEO | OBS_OUTPUT_MULTI_TRACK |
+		 OBS_OUTPUT_CAN_PAUSE,
 	.get_name = ffmpeg_output_getname,
 	.create = ffmpeg_output_create,
 	.destroy = ffmpeg_output_destroy,


### PR DESCRIPTION
This adds the ability to pause recordings.  The way that it works is it stops sending audio/video data to the output or the output's encoders.  The pause is as precise as possible and splices the audio data down to the exact pause point.

Due to the fact that it has to pause the encoders as well, pausing will not work if the output shares encoders with say the stream output.  The output must have separate encoders, thus it will not be available with output settings that have the recording encoder is set to "same as stream".

This feature works with both encoded outputs and raw outputs such as the FFmpeg output (which is typically used for lossless recording).

Because the recording output shares encoders with the replay buffer output, you cannot create replays while recording is paused.

Please feel free to comment and report any issues.