### PR TITLE
libobs: Call both get_defaults and get_defaults2

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -63,8 +63,12 @@ static bool init_encoder(struct obs_encoder *encoder, const char *name,
 	if (pthread_mutex_init(&encoder->outputs_mutex, NULL) != 0)
 		return false;
 
-	if (encoder->orig_info.get_defaults)
+	if (encoder->orig_info.get_defaults) {
 		encoder->orig_info.get_defaults(encoder->context.settings);
+	}
+	if (encoder->orig_info.get_defaults2) {
+		encoder->orig_info.get_defaults2(encoder->context.settings, encoder->orig_info.type_data);
+	}
 
 	return true;
 }
@@ -312,10 +316,11 @@ void obs_encoder_set_name(obs_encoder_t *encoder, const char *name)
 static inline obs_data_t *get_defaults(const struct obs_encoder_info *info)
 {
 	obs_data_t *settings = obs_data_create();
+	if (info->get_defaults) {
+		info->get_defaults(settings);
+	}
 	if (info->get_defaults2) {
 		info->get_defaults2(settings, info->type_data);
-	} else if (info->get_defaults) {
-		info->get_defaults(settings);
 	}
 	return settings;
 }

--- a/libobs/obs-encoder.h
+++ b/libobs/obs-encoder.h
@@ -238,6 +238,9 @@ struct obs_encoder_info {
 
 	/**
 	 * Gets the default settings for this encoder
+	 * 
+	 * If get_defaults is also defined both will be called, and the first
+	 * call will be to get_defaults, then to get_defaults2.
 	 *
 	 * @param[out]  settings  Data to assign default settings to
 	 * @param[in]   typedata  Type Data

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -324,11 +324,13 @@ static obs_source_t *obs_source_create_internal(const char *id,
 		goto fail;
 
 	if (info) {
-		if (info->get_defaults2)
+		if (info->get_defaults) {
+			info->get_defaults(source->context.settings);
+		}
+		if (info->get_defaults2) {
 			info->get_defaults2(info->type_data,
 					    source->context.settings);
-		else if (info->get_defaults)
-			info->get_defaults(source->context.settings);
+		}
 	}
 
 	if (!obs_source_init(source))

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -441,6 +441,9 @@ struct obs_source_info {
 
 	/**
 	 * Gets the default settings for this source
+	 * 
+	 * If get_defaults is also defined both will be called, and the first
+	 * call will be to get_defaults, then to get_defaults2.
 	 *
 	 * @param       type_data The type_data variable of this structure
 	 * @param[out]  settings  Data to assign default settings to


### PR DESCRIPTION
### Description
Back in commit 93549ea17cb696b064ec0b967a667170e8d25595 I've introduced get_defaults2 and get_properties2 APIs in order to drastically reduce code duplication, but ended up not using it for a long time. Until I began to work on obs-ffmpeg-encoder, which actively used these new APIs, and ended up with really weird bugs.

One was that even though get_defaults2 was being called, all the values that were at the default values were giving back 0 instead of the actual default - which meant that the UI got the correct values, but something was broken somewhere else. After a short debugging session, I found the cause to be 'init_encoder', which I did not modify with the original commit - a mistake on my part which should have been caught had I properly tested the change.

Additionally there is no reason to not call both get_defaults and get_defaults2, as long as they are called in the order that the get_defaults2 callback can override defaults from get_defaults, as the get_defaults2 callback knows more about the correct default values.

### Motivation and Context
This was primarily because of obs-ffmpeg-encoder somehow failing despite the correct APIs being used, which led to a debugging session to figure out the problem.

### How Has This Been Tested?
This change has been tested against obs-ffmpeg-encoder, which once this fix was applied had the correct defaults when the settings object reached the encoder's create and update callbacks. The default key frame interval was no longer 0 and had the correct value of 2.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Possibly breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format). (But I did not run obs-encoder.c itself through clang-format, as it would change too much. Only that section that I changed)
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
