### PR TITLE
UI: Make Dark theme group box title bold

### DIFF
--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -142,7 +142,14 @@ QDockWidget::close-button:pressed, QDockWidget::float-button:pressed {
 QGroupBox {
     border: 1px solid rgb(31,30,31); /* veryDark */;
     border-radius: 5px;
-    padding-top: 16px;
+    padding-top: 24px;
+    font-weight: bold;
+}
+
+QGroupBox::title {
+    subcontrol-origin: margin;
+    left: 4px;
+    top: 4px;
 }
 
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This changes the group box title to be bold and adjusts position of title a few pixels.

### Motivation and Context
This makes the group boxes easier to distinguish between each other and I believe it is
more aesthetically pleasing.

### How Has This Been Tested?
I tested this on Linux only but I should be just fine on Mac/Windows.

### Types of changes
Visual change (changes look of UI)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.

![Screenshot from 2019-07-12 08-22-51](https://user-images.githubusercontent.com/19962531/61131264-5b883b00-a47e-11e9-963c-978285877d62.png)

