### PR TITLE
UI: Fix toggled signal of property groups

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -1349,7 +1349,7 @@ void OBSPropertiesView::AddGroup(obs_property_t *prop, QFormLayout *layout)
 	children.emplace_back(info);
 
 	// Signals
-	connect(groupBox, SIGNAL(toggled()), info, SLOT(ControlChanged()));
+	connect(groupBox, SIGNAL(toggled(bool)), info, SLOT(ControlChanged()));
 }
 
 void OBSPropertiesView::AddProperty(obs_property_t *property,


### PR DESCRIPTION
### Description
Fixes the issue where checkable property groups did not correctly store their state, as the signal `toggled()` doesn't actually exist. The correct signal is called `toggled(bool)` and once this fix is applied, checkable property groups correctly store their state into the obs_data_t object.

### Motivation and Context
It's required because things are broken right now. Original PR was not tested extensively, so this is my attempt at fixing up all the messes I've made with the additions.

### How Has This Been Tested?
Tested with obs-ffmpeg-encoder's libvpx-vp9 implementation which uses a checkable property group. It correctly kept its state even after closing the settings window.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
