### PR TITLE
UI: Simplify resize output code

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7237,8 +7237,7 @@ void OBSBasic::on_actionShowAbout_triggered()
 
 void OBSBasic::ResizeOutputSizeOfSource()
 {
-	if (ui->streamButton->isChecked() || ui->recordButton->isChecked() ||
-	    (replayBufferButton && replayBufferButton->isChecked()))
+	if (obs_video_active())
 		return;
 
 	QMessageBox resize_output(this);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This simplifies checking if outputs are active in the resize output code.

### Motivation and Context
At the time I wrote the code, I didn't know there was the obs_video_active() function.

### How Has This Been Tested?
I tested the resizing of outputs and everything works as expected.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
