### PR TITLE
various: Fix compiler/theme warnings

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -42,7 +42,6 @@ QWidget {
 	outline: none;
 	font-family: "Open Sans", "Tahoma", "Arial", sans-serif;
 	font-size: 12px;
-	overflow: auto;
 }
 
 #menubar {
@@ -650,14 +649,6 @@ QSlider::handle:disabled {
 }
 
 /* Volume Control */
-
-/* Old Meters */
-VolumeMeter {
-	qproperty-bkColor: rgb(8,8,11);
-	qproperty-magColor:;
-	qproperty-peakColor:;
-	qproperty-peakHoldColor: rgb(225,224,225);
-}
 
 VolumeMeter {
 

--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
@@ -207,6 +207,9 @@ void on_preview_scene_changed(enum obs_frontend_event event, void *param)
 
 void render_preview_source(void *param, uint32_t cx, uint32_t cy)
 {
+	UNUSED_PARAMETER(cx);
+	UNUSED_PARAMETER(cy);
+
 	auto ctx = (struct preview_output *)param;
 
 	if (!ctx->current_source)

--- a/UI/frontend-plugins/decklink-output-ui/forms/output.ui
+++ b/UI/frontend-plugins/decklink-output-ui/forms/output.ui
@@ -115,7 +115,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="keyerLabel">
      <property name="text">
       <string>Keyer output requires RGB mode in advanced settings.</string>
      </property>

--- a/UI/record-button.cpp
+++ b/UI/record-button.cpp
@@ -7,7 +7,6 @@ void RecordButton::resizeEvent(QResizeEvent *event)
 	if (!main->pause)
 		return;
 
-	QSize newSize = event->size();
 	QSize pauseSize = main->pause->size();
 	int height = main->ui->recordButton->size().height();
 
@@ -15,4 +14,6 @@ void RecordButton::resizeEvent(QResizeEvent *event)
 		main->pause->setMinimumSize(height, height);
 		main->pause->setMaximumSize(height, height);
 	}
+
+	event->accept();
 }

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -514,6 +514,7 @@ void VolumeMeter::setPeakMeterType(enum obs_peak_meter_type peakMeterType)
 void VolumeMeter::mousePressEvent(QMouseEvent *event)
 {
 	setFocus(Qt::MouseFocusReason);
+	event->accept();
 }
 
 void VolumeMeter::wheelEvent(QWheelEvent *event)

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -153,8 +153,8 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 		uint32_t colorA = 0xFFB26F52;
 		uint32_t colorB = 0xFF6FB252;
 
-		CreateTransitionScene(sourceA, "A", colorA);
-		CreateTransitionScene(sourceB, "B", colorB);
+		CreateTransitionScene(sourceA, (char *)"A", colorA);
+		CreateTransitionScene(sourceB, (char *)"B", colorB);
 
 		/**
 		 * The cloned source is made from scratch, rather than using

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4519,6 +4519,41 @@ void OBSBasicSettings::on_disableOSXVSync_clicked()
 #endif
 }
 
+QIcon OBSBasicSettings::GetGeneralIcon() const
+{
+	return generalIcon;
+}
+
+QIcon OBSBasicSettings::GetStreamIcon() const
+{
+	return streamIcon;
+}
+
+QIcon OBSBasicSettings::GetOutputIcon() const
+{
+	return outputIcon;
+}
+
+QIcon OBSBasicSettings::GetAudioIcon() const
+{
+	return audioIcon;
+}
+
+QIcon OBSBasicSettings::GetVideoIcon() const
+{
+	return videoIcon;
+}
+
+QIcon OBSBasicSettings::GetHotkeysIcon() const
+{
+	return hotkeysIcon;
+}
+
+QIcon OBSBasicSettings::GetAdvancedIcon() const
+{
+	return advancedIcon;
+}
+
 void OBSBasicSettings::SetGeneralIcon(const QIcon &icon)
 {
 	ui->listWidget->item(0)->setIcon(icon);

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -84,14 +84,20 @@ using OBSFFFormatDesc = std::unique_ptr<const ff_format_desc, OBSFFDeleter>;
 
 class OBSBasicSettings : public QDialog {
 	Q_OBJECT
-	Q_PROPERTY(QIcon generalIcon WRITE SetGeneralIcon NOTIFY SetGeneralIcon)
-	Q_PROPERTY(QIcon streamIcon WRITE SetStreamIcon NOTIFY SetStreamIcon)
-	Q_PROPERTY(QIcon outputIcon WRITE SetOutputIcon NOTIFY SetOutputIcon)
-	Q_PROPERTY(QIcon audioIcon WRITE SetAudioIcon NOTIFY SetAudioIcon)
-	Q_PROPERTY(QIcon videoIcon WRITE SetVideoIcon NOTIFY SetVideoIcon)
-	Q_PROPERTY(QIcon hotkeysIcon WRITE SetHotkeysIcon NOTIFY SetHotkeysIcon)
-	Q_PROPERTY(
-		QIcon advancedIcon WRITE SetAdvancedIcon NOTIFY SetAdvancedIcon)
+	Q_PROPERTY(QIcon generalIcon READ GetGeneralIcon WRITE SetGeneralIcon
+			   DESIGNABLE true)
+	Q_PROPERTY(QIcon streamIcon READ GetStreamIcon WRITE SetStreamIcon
+			   DESIGNABLE true)
+	Q_PROPERTY(QIcon outputIcon READ GetOutputIcon WRITE SetOutputIcon
+			   DESIGNABLE true)
+	Q_PROPERTY(QIcon audioIcon READ GetAudioIcon WRITE SetAudioIcon
+			   DESIGNABLE true)
+	Q_PROPERTY(QIcon videoIcon READ GetVideoIcon WRITE SetVideoIcon
+			   DESIGNABLE true)
+	Q_PROPERTY(QIcon hotkeysIcon READ GetHotkeysIcon WRITE SetHotkeysIcon
+			   DESIGNABLE true)
+	Q_PROPERTY(QIcon advancedIcon READ GetAdvancedIcon WRITE SetAdvancedIcon
+			   DESIGNABLE true)
 
 private:
 	OBSBasic *main;
@@ -277,6 +283,22 @@ private:
 	void FillAudioMonitoringDevices();
 
 	void RecalcOutputResPixels(const char *resText);
+
+	QIcon generalIcon;
+	QIcon streamIcon;
+	QIcon outputIcon;
+	QIcon audioIcon;
+	QIcon videoIcon;
+	QIcon hotkeysIcon;
+	QIcon advancedIcon;
+
+	QIcon GetGeneralIcon() const;
+	QIcon GetStreamIcon() const;
+	QIcon GetOutputIcon() const;
+	QIcon GetAudioIcon() const;
+	QIcon GetVideoIcon() const;
+	QIcon GetHotkeysIcon() const;
+	QIcon GetAdvancedIcon() const;
 
 private slots:
 	void on_theme_activated(int idx);

--- a/deps/obs-scripting/obs-scripting-lua.c
+++ b/deps/obs-scripting/obs-scripting-lua.c
@@ -590,9 +590,11 @@ static int enum_sources(lua_State *script)
 
 /* -------------------------------------------- */
 
-static bool source_enum_filters_proc(obs_source_t *source, obs_source_t *filter,
+static void source_enum_filters_proc(obs_source_t *source, obs_source_t *filter,
 				     void *param)
 {
+	UNUSED_PARAMETER(source);
+
 	lua_State *script = param;
 
 	obs_source_get_ref(filter);
@@ -600,7 +602,6 @@ static bool source_enum_filters_proc(obs_source_t *source, obs_source_t *filter,
 
 	size_t idx = lua_rawlen(script, -2);
 	lua_rawseti(script, -2, (int)idx + 1);
-	return true;
 }
 
 static int source_enum_filters(lua_State *script)

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -349,7 +349,7 @@ obs_properties_t *obs_get_encoder_properties(const char *id)
 	const struct obs_encoder_info *ei = find_encoder(id);
 	if (ei && (ei->get_properties || ei->get_properties2)) {
 		obs_data_t *defaults = get_defaults(ei);
-		obs_properties_t *properties;
+		obs_properties_t *properties = NULL;
 
 		if (ei->get_properties2) {
 			properties = ei->get_properties2(NULL, ei->type_data);

--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -230,7 +230,9 @@ static inline unsigned get_format_lines(enum video_format format,
 	case VIDEO_FORMAT_BGRX:
 	case VIDEO_FORMAT_Y800:
 		return height;
-	case VIDEO_FORMAT_NONE:;
+	case VIDEO_FORMAT_NONE:
+	default:
+		break;
 	}
 
 	return 0;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This fixes the warnings that show up when compiling OBS.

### Motivation and Context
Seeing warning are quite annoying and can sometimes make you think you made a mistake in your own code.

### How Has This Been Tested?
I have been compiling this on Linux to see if the warnings are gone.

### Types of changes
 - Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
