### PR TITLE
libobs-opengl: Fix glGetError() infinite loop

### DIFF
--- a/libobs-opengl/gl-helpers.h
+++ b/libobs-opengl/gl-helpers.h
@@ -27,10 +27,18 @@ static inline bool gl_success(const char *funcname)
 {
 	GLenum errorcode = glGetError();
 	if (errorcode != GL_NO_ERROR) {
+		int attempts = 8;
 		do {
 			blog(LOG_ERROR, "%s failed, glGetError returned 0x%X",
 			     funcname, errorcode);
 			errorcode = glGetError();
+
+			--attempts;
+			if (attempts == 0) {
+				blog(LOG_ERROR, "Too many GL errors, moving on",
+				     funcname, errorcode);
+				break;
+			}
 		} while (errorcode != GL_NO_ERROR);
 		return false;
 	}


### PR DESCRIPTION
### Description
glGetError() returns GL_INVALID_OPERATION during OBS shutdown when GL is
used on Windows. This change gives up after eight errors.

This could be avoided by stopping the graphics thread before window
destruction, but the shutdown code looks like it could be tricky to
reorder.

### Motivation and Context
Infinite loop on shutdown prevents the process from terminating.

### How Has This Been Tested?
Using GL on Windows, OBS now breaks out of the loop and terminates. The log is consistent with code intent. Also tried OBS shutdown using D3D and there was no regression.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
