### PR TITLE
decklink-ui: Show the state of outputs in the decklink dialog

### DIFF
--- a/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.cpp
@@ -122,6 +122,19 @@ void DecklinkOutputUI::PropertiesChanged()
 	SaveSettings();
 }
 
+void DecklinkOutputUI::OutputStateChanged(bool active)
+{
+	QString text;
+	if (active) {
+		text = QString(obs_module_text("OutputState.Active"));
+	} else {
+		text = QString(obs_module_text("OutputState.Idle"));
+	}
+
+	QMetaObject::invokeMethod(ui->outputStatus, "setText",
+				  Q_ARG(QString, text));
+}
+
 void DecklinkOutputUI::StartPreviewOutput()
 {
 	SavePreviewSettings();
@@ -136,4 +149,17 @@ void DecklinkOutputUI::StopPreviewOutput()
 void DecklinkOutputUI::PreviewPropertiesChanged()
 {
 	SavePreviewSettings();
+}
+
+void DecklinkOutputUI::PreviewOutputStateChanged(bool active)
+{
+	QString text;
+	if (active) {
+		text = QString(obs_module_text("OutputState.Active"));
+	} else {
+		text = QString(obs_module_text("OutputState.Idle"));
+	}
+
+	QMetaObject::invokeMethod(ui->previewOutputStatus, "setText",
+				  Q_ARG(QString, text));
 }

--- a/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.h
+++ b/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.h
@@ -16,9 +16,13 @@ public slots:
 	void StopOutput();
 	void PropertiesChanged();
 
+	void OutputStateChanged(bool);
+
 	void StartPreviewOutput();
 	void StopPreviewOutput();
 	void PreviewPropertiesChanged();
+
+	void PreviewOutputStateChanged(bool);
 
 public:
 	std::unique_ptr<Ui_Output> ui;

--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
@@ -65,6 +65,8 @@ void output_start()
 			obs_data_release(settings);
 
 			main_output_running = true;
+
+			doUI->OutputStateChanged(true);
 		}
 	}
 }
@@ -75,6 +77,7 @@ void output_stop()
 		obs_output_stop(output);
 		obs_output_release(output);
 		main_output_running = false;
+		doUI->OutputStateChanged(false);
 	}
 }
 
@@ -153,6 +156,7 @@ void preview_output_start()
 			obs_output_start(context.output);
 
 			preview_output_running = true;
+			doUI->PreviewOutputStateChanged(true);
 		}
 	}
 }
@@ -178,6 +182,7 @@ void preview_output_stop()
 		video_output_close(context.video_queue);
 
 		preview_output_running = false;
+		doUI->PreviewOutputStateChanged(false);
 	}
 }
 

--- a/UI/frontend-plugins/decklink-output-ui/forms/output.ui
+++ b/UI/frontend-plugins/decklink-output-ui/forms/output.ui
@@ -42,7 +42,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="spacing">
-      <number>-1</number>
+      <number>6</number>
      </property>
      <item>
       <spacer name="horizontalSpacer">
@@ -56,6 +56,13 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="outputStatus">
+       <property name="text">
+        <string>OutputState.Idle</string>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QPushButton" name="startOutput">
@@ -97,6 +104,13 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="previewOutputStatus">
+       <property name="text">
+        <string>OutputState.Idle</string>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QPushButton" name="startPreviewOutput">


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a UI label to show the current state of the decklink output.

![Annotation 2019-07-16 215155](https://user-images.githubusercontent.com/207897/61343606-fc2a8200-a813-11e9-8a4a-bc16344418a5.png)


### Motivation and Context
Previously users had to remember the state of the output, this should add some sanity to this

### How Has This Been Tested?
Tested on Windows starting and stopping decklink outputs

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
