### PR TITLE
frontend-tools: Add option to pause output timer when rec is paused

### DIFF
--- a/UI/frontend-plugins/frontend-tools/data/locale/en-US.ini
+++ b/UI/frontend-plugins/frontend-tools/data/locale/en-US.ini
@@ -24,6 +24,7 @@ OutputTimer.Stream.StoppingIn="Streaming stopping in:"
 OutputTimer.Record.StoppingIn="Recording stopping in:"
 OutputTimer.Stream.EnableEverytime="Enable streaming timer every time"
 OutputTimer.Record.EnableEverytime="Enable recording timer every time"
+OutputTimer.Record.PauseTimer="Pause timer when recording is paused"
 
 Scripts="Scripts"
 LoadedScripts="Loaded Scripts"

--- a/UI/frontend-plugins/frontend-tools/forms/output-timer.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/output-timer.ui
@@ -52,6 +52,9 @@
      <property name="text">
       <string>Start</string>
      </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="3" column="4">
@@ -88,6 +91,9 @@
     <widget class="QPushButton" name="outputTimerRecord">
      <property name="text">
       <string>Start</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/UI/frontend-plugins/frontend-tools/forms/output-timer.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/output-timer.ui
@@ -1,215 +1,231 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>OutputTimer</class>
-   <widget class="QDialog" name="OutputTimer">
-    <property name="geometry">
-      <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>600</width>
-        <height>200</height>
-      </rect>
-    </property>
-    <property name="windowTitle">
-      <string>OutputTimer</string>
-    </property>
-    <layout class="QGridLayout" name="timerLayout">
-      <item row="0" column="1">
-        <widget class="QLabel" name="streamingLabel">
-          <property name="text">
-            <string>OutputTimer.Stream</string>
-          </property>
-        </widget>
-      </item>
-      <item row="0" column="2">
-        <widget class="QSpinBox" name="streamingTimerHours">
-          <property name="minimum">
-            <number>0</number>
-          </property>
-          <property name="maximum">
-            <number>24</number>
-          </property>
-          <property name="value">
-            <number>0</number>
-          </property>
-        </widget>
-      </item>
-      <item row="0" column="3">
-        <widget class="QLabel" name="hoursLabel">
-          <property name="text">
-            <string>Hours</string>
-          </property>
-        </widget>
-      </item>
-      <item row="0" column="4">
-        <widget class="QSpinBox" name="streamingTimerMinutes">
-          <property name="maximum">
-            <number>59</number>
-          </property>
-          <property name="value">
-            <number>0</number>
-          </property>
-        </widget>
-      </item>
-      <item row="0" column="5">
-        <widget class="QLabel" name="minutesLabel">
-          <property name="text">
-            <string>Minutes</string>
-          </property>
-        </widget>
-      </item>
-      <item row="0" column="6">
-        <widget class="QSpinBox" name="streamingTimerSeconds">
-          <property name="minimum">
-            <number>0</number>
-          </property>
-          <property name="maximum">
-            <number>59</number>
-          </property>
-          <property name="value">
-            <number>30</number>
-          </property>
-        </widget>
-      </item>
-      <item row="0" column="7">
-        <widget class="QLabel" name="secondsLabel">
-          <property name="text">
-            <string>Seconds</string>
-          </property>
-        </widget>
-      </item>
-      <item row="0" column="8">
-        <widget class="QPushButton" name="outputTimerStream">
-          <property name="text">
-            <string>Start</string>
-          </property>
-        </widget>
-      </item>
-      <item row="2" column="1">
-        <widget class="QLabel" name="streamStoppingIn">
-          <property name="text">
-            <string>OutputTimer.Stream.StoppingIn</string>
-          </property>
-        </widget>
-      </item>
-      <item row="2" column="2">
-        <widget class="QLabel" name="streamTime">
-          <property name="text">
-            <string>00:00:00</string>
-          </property>
-        </widget>
-      </item>
-      <item row="3" column="1">
-        <widget class="QLabel" name="recordingLabel">
-          <property name="text">
-            <string>OutputTimer.Record</string>
-          </property>
-        </widget>
-      </item>
-      <item row="3" column="2">
-        <widget class="QSpinBox" name="recordingTimerHours">
-          <property name="minimum">
-            <number>0</number>
-          </property>
-          <property name="maximum">
-            <number>24</number>
-          </property>
-          <property name="value">
-            <number>0</number>
-          </property>
-        </widget>
-      </item>
-      <item row="3" column="3">
-        <widget class="QLabel" name="hoursLabel_2">
-          <property name="text">
-            <string>Hours</string>
-          </property>
-        </widget>
-      </item>
-      <item row="3" column="4">
-        <widget class="QSpinBox" name="recordingTimerMinutes">
-          <property name="minimum">
-            <number>0</number>
-          </property>
-          <property name="maximum">
-            <number>59</number>
-          </property>
-          <property name="value">
-            <number>0</number>
-          </property>
-        </widget>
-      </item>
-      <item row="3" column="5">
-        <widget class="QLabel" name="minutesLabel_2">
-          <property name="text">
-            <string>Minutes</string>
-          </property>
-        </widget>
-      </item>
-      <item row="3" column="6">
-        <widget class="QSpinBox" name="recordingTimerSeconds">
-          <property name="minimum">
-            <number>0</number>
-          </property>
-          <property name="maximum">
-            <number>59</number>
-          </property>
-          <property name="value">
-            <number>30</number>
-          </property>
-        </widget>
-      </item>
-      <item row="3" column="7">
-        <widget class="QLabel" name="secondsLabel_2">
-          <property name="text">
-            <string>Seconds</string>
-          </property>
-        </widget>
-      </item>
-      <item row="3" column="8">
-        <widget class="QPushButton" name="outputTimerRecord">
-          <property name="text">
-            <string>Start</string>
-          </property>
-        </widget>
-      </item>
-      <item row="5" column="1">
-        <widget class="QLabel" name="recordStoppingIn">
-          <property name="text">
-            <string>OutputTimer.Record.StoppingIn</string>
-          </property>
-        </widget>
-      </item>
-      <item row="5" column="2">
-        <widget class="QLabel" name="recordTime">
-          <property name="text">
-            <string>00:00:00</string>
-          </property>
-        </widget>
-      </item>
-      <item row="1" column="1" colspan="3">
-        <widget class="QCheckBox" name="autoStartStreamTimer">
-          <property name="text">
-            <string>OutputTimer.Stream.EnableEverytime</string>
-          </property>
-        </widget>
-      </item>
-      <item row="4" column="1" colspan="3">
-        <widget class="QCheckBox" name="autoStartRecordTimer">
-          <property name="text">
-            <string>OutputTimer.Record.EnableEverytime</string>
-          </property>
-        </widget>
-      </item>
-      <item row="6" column="8">
-        <widget class="QDialogButtonBox" name="buttonBox">
-          <property name="standardButtons">
-            <set>QDialogButtonBox::Close</set>
-          </property>
-        </widget>
-      </item>
-    </layout>
-  </widget>
-  <resources />
-  <connections />
+ <widget class="QDialog" name="OutputTimer">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>697</width>
+    <height>240</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>OutputTimer</string>
+  </property>
+  <layout class="QGridLayout" name="timerLayout">
+   <item row="0" column="3">
+    <widget class="QLabel" name="hoursLabel">
+     <property name="text">
+      <string>Hours</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QSpinBox" name="recordingTimerHours">
+     <property name="minimum">
+      <number>0</number>
+     </property>
+     <property name="maximum">
+      <number>24</number>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="6">
+    <widget class="QSpinBox" name="streamingTimerSeconds">
+     <property name="minimum">
+      <number>0</number>
+     </property>
+     <property name="maximum">
+      <number>59</number>
+     </property>
+     <property name="value">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="8">
+    <widget class="QPushButton" name="outputTimerStream">
+     <property name="text">
+      <string>Start</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="4">
+    <widget class="QSpinBox" name="recordingTimerMinutes">
+     <property name="minimum">
+      <number>0</number>
+     </property>
+     <property name="maximum">
+      <number>59</number>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLabel" name="streamingLabel">
+     <property name="text">
+      <string>OutputTimer.Stream</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="4">
+    <widget class="QSpinBox" name="streamingTimerMinutes">
+     <property name="maximum">
+      <number>59</number>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="8">
+    <widget class="QPushButton" name="outputTimerRecord">
+     <property name="text">
+      <string>Start</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLabel" name="recordStoppingIn">
+     <property name="text">
+      <string>OutputTimer.Record.StoppingIn</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="7">
+    <widget class="QLabel" name="secondsLabel_2">
+     <property name="text">
+      <string>Seconds</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLabel" name="streamTime">
+     <property name="text">
+      <string>00:00:00</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="5">
+    <widget class="QLabel" name="minutesLabel_2">
+     <property name="text">
+      <string>Minutes</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QSpinBox" name="streamingTimerHours">
+     <property name="minimum">
+      <number>0</number>
+     </property>
+     <property name="maximum">
+      <number>24</number>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="2">
+    <widget class="QLabel" name="recordTime">
+     <property name="text">
+      <string>00:00:00</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="5">
+    <widget class="QLabel" name="minutesLabel">
+     <property name="text">
+      <string>Minutes</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="recordingLabel">
+     <property name="text">
+      <string>OutputTimer.Record</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="6">
+    <widget class="QSpinBox" name="recordingTimerSeconds">
+     <property name="minimum">
+      <number>0</number>
+     </property>
+     <property name="maximum">
+      <number>59</number>
+     </property>
+     <property name="value">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="3">
+    <widget class="QCheckBox" name="autoStartStreamTimer">
+     <property name="text">
+      <string>OutputTimer.Stream.EnableEverytime</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="streamStoppingIn">
+     <property name="text">
+      <string>OutputTimer.Stream.StoppingIn</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="3">
+    <widget class="QCheckBox" name="autoStartRecordTimer">
+     <property name="text">
+      <string>OutputTimer.Record.EnableEverytime</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="8">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="3">
+    <widget class="QLabel" name="hoursLabel_2">
+     <property name="text">
+      <string>Hours</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="7">
+    <widget class="QLabel" name="secondsLabel">
+     <property name="text">
+      <string>Seconds</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="3">
+    <widget class="QCheckBox" name="pauseRecordTimer">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>OutputTimer.Record.PauseTimer</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
 </ui>

--- a/UI/frontend-plugins/frontend-tools/output-timer.cpp
+++ b/UI/frontend-plugins/frontend-tools/output-timer.cpp
@@ -96,6 +96,8 @@ void OutputTimer::StreamTimerStart()
 	ui->outputTimerStream->setText(obs_module_text("Stop"));
 
 	UpdateStreamTimerDisplay();
+
+	ui->outputTimerStream->setChecked(true);
 }
 
 void OutputTimer::RecordTimerStart()
@@ -128,6 +130,8 @@ void OutputTimer::RecordTimerStart()
 	ui->outputTimerRecord->setText(obs_module_text("Stop"));
 
 	UpdateRecordTimerDisplay();
+
+	ui->outputTimerRecord->setChecked(true);
 }
 
 void OutputTimer::StreamTimerStop()
@@ -146,6 +150,7 @@ void OutputTimer::StreamTimerStop()
 		streamingTimerDisplay->stop();
 
 	ui->streamTime->setText("00:00:00");
+	ui->outputTimerStream->setChecked(false);
 }
 
 void OutputTimer::RecordTimerStop()
@@ -164,6 +169,7 @@ void OutputTimer::RecordTimerStop()
 		recordingTimerDisplay->stop();
 
 	ui->recordTime->setText("00:00:00");
+	ui->outputTimerRecord->setChecked(false);
 }
 
 void OutputTimer::UpdateStreamTimerDisplay()

--- a/UI/frontend-plugins/frontend-tools/output-timer.hpp
+++ b/UI/frontend-plugins/frontend-tools/output-timer.hpp
@@ -15,6 +15,8 @@ public:
 	OutputTimer(QWidget *parent);
 
 	void closeEvent(QCloseEvent *event) override;
+	void PauseRecordingTimer();
+	void UnpauseRecordingTimer();
 
 public slots:
 	void StreamingTimerButton();
@@ -37,4 +39,6 @@ private:
 	QTimer *recordingTimer;
 	QTimer *streamingTimerDisplay;
 	QTimer *recordingTimerDisplay;
+
+	int recordingTimeLeft;
 };


### PR DESCRIPTION
### Description
This adds an option to the output timer to pause the timer when the recording is paused.

### Motivation and Context
I made this because I noticed when using the output timer, it would continue even if the recording is paused.

### How Has This Been Tested?
I've tested by making recordings with the output timer and pausing/unpausing to make sure that everything works as intended.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.