### PR TITLE
[WIP] decklink-output-ui: Use single button for starting/stopping

### DIFF
--- a/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.h
+++ b/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.h
@@ -5,11 +5,38 @@
 #include "ui_output.h"
 #include "../../UI/properties-view.hpp"
 
+extern bool main_output_running;
+extern bool preview_output_running;
+
+extern obs_output_t *output_main;
+extern obs_output_t *output_preview;
+
+struct preview_output {
+	bool enabled;
+	obs_source_t *current_source;
+	obs_output_t *output;
+
+	video_t *video_queue;
+	gs_texrender_t *texrender;
+	gs_stagesurf_t *stagesurface;
+	uint8_t *video_data;
+	uint32_t video_linesize;
+
+	obs_video_info ovi;
+};
+
+extern struct preview_output context;
+
 class DecklinkOutputUI : public QDialog {
 	Q_OBJECT
 private:
 	OBSPropertiesView *propertiesView;
 	OBSPropertiesView *previewPropertiesView;
+
+	OBSSignal decklinkOutStart;
+	OBSSignal decklinkOutStop;
+	OBSSignal decklinkPreviewOutStart;
+	OBSSignal decklinkPreviewOutStop;
 
 public slots:
 	void StartOutput();
@@ -20,9 +47,18 @@ public slots:
 	void StopPreviewOutput();
 	void PreviewPropertiesChanged();
 
+	void ToggleOutput();
+	void TogglePreviewOutput();
+
+	void OutputButtonSetStarted();
+	void OutputButtonSetStopped();
+	void PreviewOutputButtonSetStarted();
+	void PreviewOutputButtonSetStopped();
+
 public:
 	std::unique_ptr<Ui_Output> ui;
 	DecklinkOutputUI(QWidget *parent);
+	~DecklinkOutputUI();
 
 	void ShowHideDialog();
 

--- a/UI/frontend-plugins/decklink-output-ui/forms/output.ui
+++ b/UI/frontend-plugins/decklink-output-ui/forms/output.ui
@@ -42,7 +42,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="spacing">
-      <number>-1</number>
+      <number>6</number>
      </property>
      <item>
       <spacer name="horizontalSpacer">
@@ -62,12 +62,8 @@
        <property name="text">
         <string>Start</string>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="stopOutput">
-       <property name="text">
-        <string>Stop</string>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -103,12 +99,8 @@
        <property name="text">
         <string>Start</string>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="stopPreviewOutput">
-       <property name="text">
-        <string>Stop</string>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -39,6 +39,10 @@ static void decklink_output_update(void *data, obs_data_t *settings)
 static bool decklink_output_start(void *data)
 {
 	auto *decklink = (DeckLinkOutput *)data;
+
+	if (!decklink)
+		return false;
+
 	struct obs_audio_info aoi;
 
 	if (!obs_get_audio_info(&aoi)) {


### PR DESCRIPTION
### Description
This makes the start/stop buttons a toggle in the Decklink output ui.

![Capture](https://user-images.githubusercontent.com/19962531/61455466-39346880-a929-11e9-9c29-75c83dfda77c.PNG)

### Motivation and Context
I found it annoying that there were two separate buttons for starting/stopping.

### How Has This Been Tested?
I created a Decklink output and everything worked as expected.

### Types of changes
Improving existing feature.

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
