### PR TITLE
libobs: UI: Remove DrawBackdrop() to save fullscreen pass

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1330,9 +1330,7 @@ void OBSBasic::RenderProgram(void *data, uint32_t cx, uint32_t cy)
 	gs_set_viewport(window->programX, window->programY, window->programCX,
 			window->programCY);
 
-	window->DrawBackdrop(float(ovi.base_width), float(ovi.base_height));
-
-	obs_render_main_texture();
+	obs_render_main_texture_src_color_only();
 	gs_load_vertexbuffer(nullptr);
 
 	/* --------------------------------------- */

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3341,15 +3341,16 @@ void OBSBasic::RenderMain(void *data, uint32_t cx, uint32_t cy)
 	gs_set_viewport(window->previewX, window->previewY, window->previewCX,
 			window->previewCY);
 
-	window->DrawBackdrop(float(ovi.base_width), float(ovi.base_height));
-
 	if (window->IsPreviewProgramMode()) {
+		window->DrawBackdrop(float(ovi.base_width),
+				     float(ovi.base_height));
+
 		OBSScene scene = window->GetCurrentScene();
 		obs_source_t *source = obs_scene_get_source(scene);
 		if (source)
 			obs_source_video_render(source);
 	} else {
-		obs_render_main_texture();
+		obs_render_main_texture_src_color_only();
 	}
 	gs_load_vertexbuffer(nullptr);
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1645,7 +1645,10 @@ void obs_render_main_view(void)
 	obs_view_render(&obs->data.main_view);
 }
 
-void obs_render_main_texture(void)
+static void obs_render_main_texture_internal(enum gs_blend_type src_c,
+					     enum gs_blend_type dest_c,
+					     enum gs_blend_type src_a,
+					     enum gs_blend_type dest_a)
 {
 	struct obs_core_video *video;
 	gs_texture_t *tex;
@@ -1665,12 +1668,24 @@ void obs_render_main_texture(void)
 	gs_effect_set_texture(param, tex);
 
 	gs_blend_state_push();
-	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+	gs_blend_function_separate(src_c, dest_c, src_a, dest_a);
 
 	while (gs_effect_loop(effect, "Draw"))
 		gs_draw_sprite(tex, 0, 0, 0);
 
 	gs_blend_state_pop();
+}
+
+void obs_render_main_texture(void)
+{
+	obs_render_main_texture_internal(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA,
+					 GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+}
+
+void obs_render_main_texture_src_color_only(void)
+{
+	obs_render_main_texture_internal(GS_BLEND_ONE, GS_BLEND_ZERO,
+					 GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 }
 
 gs_texture_t *obs_get_main_texture(void)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -649,6 +649,9 @@ EXPORT void obs_render_main_view(void);
 /** Renders the last main output texture */
 EXPORT void obs_render_main_texture(void);
 
+/** Renders the last main output texture ignoring background color */
+EXPORT void obs_render_main_texture_src_color_only(void);
+
 /** Returns the last main output texture.  This can return NULL if the texture
  * is unavailable. */
 EXPORT gs_texture_t *obs_get_main_texture(void);


### PR DESCRIPTION
### Description
Use blend states to simulate the black background of
DrawBackdrop() for the following situations:

- Main preview window (Studio Mode off)
- Studio Mode: Program

This does not effect:

- Studio Mode: Preview (still uses DrawBackdrop)
- Fullscreen Projector (uses GPU clear to black)
- Windowed Projector (uses GPU clear to black)

### Motivation and Context
It's a waste of GPU time to do two fullscreen passes to render final mix
previews.

### How Has This Been Tested?
Checked transparent and opaque scenes in previously mentioned preview scenarios and video output.

Intel GPA, SetStablePowerState, Intel HD Graphics 530, 1920x1080

Before:
DrawBackdrop: ~529 us
main texture: ~367 us (Cheaper than drawing a black quad?)

After:
[DrawBackdrop optimized away]
main texture: ~383 us

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.