### PR TITLE
UI: Display infinity symbol when volume is at 0 percent

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -82,7 +82,7 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	volume->setValue(obs_mul_to_db(vol));
 
 	if (volume->value() < MIN_DB)
-		volume->setSpecialValueText("-inf dB");
+		volume->setSpecialValueText("-" + QT_UTF8("\u221E") + " dB");
 
 	forceMono->setChecked((flags & OBS_SOURCE_FLAG_FORCE_MONO) != 0);
 
@@ -293,7 +293,7 @@ void OBSAdvAudioCtrl::SourceMixersChanged(uint32_t mixers)
 void OBSAdvAudioCtrl::volumeChanged(double db)
 {
 	if (db < MIN_DB) {
-		volume->setSpecialValueText("-inf dB");
+		volume->setSpecialValueText("-" + QT_UTF8("\u221E") + " dB");
 		db = -INFINITY;
 	}
 

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -74,9 +74,15 @@ void VolControl::SliderChanged(int vol)
 
 void VolControl::updateText()
 {
-	QString db = QString::number(obs_fader_get_db(obs_fader), 'f', 1)
-			     .append(" dB");
-	volLabel->setText(db);
+	QString text;
+	float db = obs_fader_get_db(obs_fader);
+
+	if (db < -96.0f)
+		text = "-" + QT_UTF8("\u221E") + " dB";
+	else
+		text = QString::number(db, 'f', 1).append(" dB");
+
+	volLabel->setText(text);
 
 	bool muted = obs_source_muted(source);
 	const char *accTextLookup = muted ? "VolControl.SliderMuted"


### PR DESCRIPTION
### Description
This displays the infinity symbol when volume is at 0 percent.

![Screenshot from 2019-07-19 23-17-58](https://user-images.githubusercontent.com/19962531/61573909-fe8f1500-aa7b-11e9-98e3-446eeb9d10e4.png)
![Screenshot from 2019-07-19 23-18-41](https://user-images.githubusercontent.com/19962531/61573911-02bb3280-aa7c-11e9-8908-42ac809694f9.png)

### Motivation and Context
This symbol is easier to understand than inf and is language independent.

### How Has This Been Tested?
I ran the program and everything worked as expected.

### Types of changes
-Visual change (improves look of UI)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
