### PR TITLE
UI: Declare missing override. Remove redundant virtual declarations

### DIFF
--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -49,7 +49,7 @@ private:
 
 public:
 	OBSAdvAudioCtrl(QGridLayout *layout, obs_source_t *source_);
-	virtual ~OBSAdvAudioCtrl();
+	~OBSAdvAudioCtrl();
 
 	inline obs_source_t *GetSource() const { return source; }
 	void ShowAudioControl(QGridLayout *layout);

--- a/UI/auth-base.hpp
+++ b/UI/auth-base.hpp
@@ -37,7 +37,7 @@ public:
 	typedef std::function<std::shared_ptr<Auth>()> create_cb;
 
 	inline Auth(const Def &d) : def(d) {}
-	virtual ~Auth() {}
+	~Auth() {}
 
 	inline Type type() const { return def.type; }
 	inline const char *service() const { return def.service.c_str(); }

--- a/UI/auth-mixer.hpp
+++ b/UI/auth-mixer.hpp
@@ -14,14 +14,14 @@ class MixerAuth : public OAuthStreamKey {
 	std::string name;
 	std::string id;
 
-	virtual bool RetryLogin() override;
+	bool RetryLogin() override;
 
-	virtual void SaveInternal() override;
-	virtual bool LoadInternal() override;
+	void SaveInternal() override;
+	bool LoadInternal() override;
 
 	bool GetChannelInfo(bool allow_retry = true);
 
-	virtual void LoadUI() override;
+	void LoadUI() override;
 
 public:
 	MixerAuth(const Def &d);

--- a/UI/auth-oauth.hpp
+++ b/UI/auth-oauth.hpp
@@ -23,7 +23,7 @@ public:
 	inline QString GetCode() const { return code; }
 	inline bool LoadFail() const { return fail; }
 
-	virtual int exec() override;
+	int exec() override;
 
 public slots:
 	void urlChanged(const QString &url);
@@ -53,8 +53,8 @@ protected:
 	uint64_t expire_time = 0;
 	int currentScopeVer = 0;
 
-	virtual void SaveInternal() override;
-	virtual bool LoadInternal() override;
+	void SaveInternal() override;
+	bool LoadInternal() override;
 
 	virtual bool RetryLogin() = 0;
 	bool TokenExpired();
@@ -75,5 +75,5 @@ public:
 
 	inline const std::string &key() const { return key_; }
 
-	virtual void OnStreamConfig() override;
+	void OnStreamConfig() override;
 };

--- a/UI/auth-restream.hpp
+++ b/UI/auth-restream.hpp
@@ -13,14 +13,14 @@ class RestreamAuth : public OAuthStreamKey {
 	QSharedPointer<QAction> infoMenu;
 	bool uiLoaded = false;
 
-	virtual bool RetryLogin() override;
+	bool RetryLogin() override;
 
-	virtual void SaveInternal() override;
-	virtual bool LoadInternal() override;
+	void SaveInternal() override;
+	bool LoadInternal() override;
 
 	bool GetChannelInfo();
 
-	virtual void LoadUI() override;
+	void LoadUI() override;
 
 public:
 	RestreamAuth(const Def &d);

--- a/UI/auth-twitch.hpp
+++ b/UI/auth-twitch.hpp
@@ -26,14 +26,14 @@ class TwitchAuth : public OAuthStreamKey {
 
 	std::string name;
 
-	virtual bool RetryLogin() override;
+	bool RetryLogin() override;
 
-	virtual void SaveInternal() override;
-	virtual bool LoadInternal() override;
+	void SaveInternal() override;
+	bool LoadInternal() override;
 
 	bool GetChannelInfo();
 
-	virtual void LoadUI() override;
+	void LoadUI() override;
 
 public:
 	TwitchAuth(const Def &d);

--- a/UI/combobox-ignorewheel.hpp
+++ b/UI/combobox-ignorewheel.hpp
@@ -11,5 +11,5 @@ public:
 	ComboBoxIgnoreScroll(QWidget *parent = nullptr);
 
 protected:
-	virtual void wheelEvent(QWheelEvent *event) override;
+	void wheelEvent(QWheelEvent *event) override;
 };

--- a/UI/frontend-plugins/frontend-tools/captions-mssapi.hpp
+++ b/UI/frontend-plugins/frontend-tools/captions-mssapi.hpp
@@ -42,6 +42,6 @@ class mssapi_captions : public captions_handler {
 
 public:
 	mssapi_captions(captions_cb callback, const std::string &lang);
-	virtual ~mssapi_captions();
-	virtual void pcm_data(const void *data, size_t frames) override;
+	~mssapi_captions();
+	void pcm_data(const void *data, size_t frames) override;
 };

--- a/UI/horizontal-scroll-area.hpp
+++ b/UI/horizontal-scroll-area.hpp
@@ -14,5 +14,5 @@ public:
 	}
 
 protected:
-	virtual void resizeEvent(QResizeEvent *event) override;
+	void resizeEvent(QResizeEvent *event) override;
 };

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -55,11 +55,10 @@ class OBSTranslator : public QTranslator {
 	Q_OBJECT
 
 public:
-	virtual bool isEmpty() const override { return false; }
+	bool isEmpty() const override { return false; }
 
-	virtual QString translate(const char *context, const char *sourceText,
-				  const char *disambiguation,
-				  int n) const override;
+	QString translate(const char *context, const char *sourceText,
+			  const char *disambiguation, int n) const override;
 };
 
 typedef std::function<void()> VoidFunc;

--- a/UI/qt-display.hpp
+++ b/UI/qt-display.hpp
@@ -26,7 +26,7 @@ public:
 	OBSQTDisplay(QWidget *parent = nullptr,
 		     Qt::WindowFlags flags = nullptr);
 
-	virtual QPaintEngine *paintEngine() const override;
+	QPaintEngine *paintEngine() const override;
 
 	inline obs_display_t *GetDisplay() const { return display; }
 

--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -226,7 +226,7 @@ public:
 	}
 
 private:
-	virtual void run() override { func(); }
+	void run() override { func(); }
 
 	std::function<void()> func;
 };

--- a/UI/record-button.hpp
+++ b/UI/record-button.hpp
@@ -8,5 +8,5 @@ class RecordButton : public QPushButton {
 public:
 	inline RecordButton(QWidget *parent = nullptr) : QPushButton(parent) {}
 
-	virtual void resizeEvent(QResizeEvent *event) override;
+	void resizeEvent(QResizeEvent *event) override;
 };

--- a/UI/slider-ignorewheel.hpp
+++ b/UI/slider-ignorewheel.hpp
@@ -13,5 +13,5 @@ public:
 			   QWidget *parent = nullptr);
 
 protected:
-	virtual void wheelEvent(QWheelEvent *event) override;
+	void wheelEvent(QWheelEvent *event) override;
 };

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -31,7 +31,7 @@ class SourceTreeItem : public QWidget {
 
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
 
-	virtual bool eventFilter(QObject *object, QEvent *event) override;
+	bool eventFilter(QObject *object, QEvent *event) override;
 
 	void Update(bool force);
 
@@ -72,7 +72,7 @@ private:
 	OBSSignal renameSignal;
 	OBSSignal removeSignal;
 
-	virtual void paintEvent(QPaintEvent *event) override;
+	void paintEvent(QPaintEvent *event) override;
 
 private slots:
 	void Clear();
@@ -122,12 +122,11 @@ public:
 	explicit SourceTreeModel(SourceTree *st);
 	~SourceTreeModel();
 
-	virtual int rowCount(const QModelIndex &parent) const override;
-	virtual QVariant data(const QModelIndex &index,
-			      int role) const override;
+	int rowCount(const QModelIndex &parent) const override;
+	QVariant data(const QModelIndex &index, int role) const override;
 
-	virtual Qt::ItemFlags flags(const QModelIndex &index) const override;
-	virtual Qt::DropActions supportedDropActions() const override;
+	Qt::ItemFlags flags(const QModelIndex &index) const override;
+	Qt::DropActions supportedDropActions() const override;
 };
 
 class SourceTree : public QListView {
@@ -184,13 +183,12 @@ public slots:
 	void Edit(int idx);
 
 protected:
-	virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
-	virtual void dropEvent(QDropEvent *event) override;
-	virtual void mouseMoveEvent(QMouseEvent *event) override;
-	virtual void leaveEvent(QEvent *event) override;
-	virtual void paintEvent(QPaintEvent *event) override;
+	void mouseDoubleClickEvent(QMouseEvent *event) override;
+	void dropEvent(QDropEvent *event) override;
+	void mouseMoveEvent(QMouseEvent *event) override;
+	void leaveEvent(QEvent *event) override;
+	void paintEvent(QPaintEvent *event) override;
 
-	virtual void
-	selectionChanged(const QItemSelection &selected,
-			 const QItemSelection &deselected) override;
+	void selectionChanged(const QItemSelection &selected,
+			      const QItemSelection &deselected) override;
 };

--- a/UI/spinbox-ignorewheel.hpp
+++ b/UI/spinbox-ignorewheel.hpp
@@ -11,5 +11,5 @@ public:
 	SpinBoxIgnoreScroll(QWidget *parent = nullptr);
 
 protected:
-	virtual void wheelEvent(QWheelEvent *event) override;
+	void wheelEvent(QWheelEvent *event) override;
 };

--- a/UI/vertical-scroll-area.hpp
+++ b/UI/vertical-scroll-area.hpp
@@ -14,5 +14,5 @@ public:
 	}
 
 protected:
-	virtual void resizeEvent(QResizeEvent *event) override;
+	void resizeEvent(QResizeEvent *event) override;
 };

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -178,8 +178,8 @@ public:
 	qreal getInputPeakHoldDuration() const;
 	void setInputPeakHoldDuration(qreal v);
 	void setPeakMeterType(enum obs_peak_meter_type peakMeterType);
-	virtual void mousePressEvent(QMouseEvent *event) override;
-	virtual void wheelEvent(QWheelEvent *event) override;
+	void mousePressEvent(QMouseEvent *event) override;
+	void wheelEvent(QWheelEvent *event) override;
 
 protected:
 	void paintEvent(QPaintEvent *event) override;

--- a/UI/win-update/update-window.hpp
+++ b/UI/win-update/update-window.hpp
@@ -17,8 +17,8 @@ public slots:
 	void on_yes_clicked();
 	void on_no_clicked();
 	void on_skip_clicked();
-	virtual void accept() override;
-	virtual void reject() override;
+	void accept() override;
+	void reject() override;
 
 private:
 	std::unique_ptr<Ui_OBSUpdate> ui;

--- a/UI/win-update/win-update.hpp
+++ b/UI/win-update/win-update.hpp
@@ -9,7 +9,7 @@ class AutoUpdateThread : public QThread {
 	bool manualUpdate;
 	bool user_confirmed = false;
 
-	virtual void run() override;
+	void run() override;
 
 	void info(const QString &title, const QString &text);
 	int queryUpdate(bool manualUpdate, const char *text_utf8);
@@ -25,7 +25,7 @@ public:
 class WhatsNewInfoThread : public QThread {
 	Q_OBJECT
 
-	virtual void run() override;
+	void run() override;
 
 signals:
 	void Result(const QString &text);

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -106,7 +106,7 @@ class AutoConfig : public QWizard {
 	void TestHardwareEncoding();
 	bool CanTestServer(const char *server);
 
-	virtual void done(int result) override;
+	void done(int result) override;
 
 	void SaveStreamSettings();
 	void SaveSettings();
@@ -134,7 +134,7 @@ public:
 	AutoConfigStartPage(QWidget *parent = nullptr);
 	~AutoConfigStartPage();
 
-	virtual int nextId() const override;
+	int nextId() const override;
 
 public slots:
 	void on_prioritizeStreaming_clicked();
@@ -152,8 +152,8 @@ public:
 	AutoConfigVideoPage(QWidget *parent = nullptr);
 	~AutoConfigVideoPage();
 
-	virtual int nextId() const override;
-	virtual bool validatePage() override;
+	int nextId() const override;
+	bool validatePage() override;
 };
 
 class AutoConfigStreamPage : public QWizardPage {
@@ -179,9 +179,9 @@ public:
 	AutoConfigStreamPage(QWidget *parent = nullptr);
 	~AutoConfigStreamPage();
 
-	virtual bool isComplete() const override;
-	virtual int nextId() const override;
-	virtual bool validatePage() override;
+	bool isComplete() const override;
+	int nextId() const override;
+	bool validatePage() override;
 
 	void OnAuthConnected();
 	void OnOAuthStreamKeyConnected();
@@ -255,10 +255,10 @@ public:
 	AutoConfigTestPage(QWidget *parent = nullptr);
 	~AutoConfigTestPage();
 
-	virtual void initializePage() override;
-	virtual void cleanupPage() override;
-	virtual bool isComplete() const override;
-	virtual int nextId() const override;
+	void initializePage() override;
+	void cleanupPage() override;
+	bool isComplete() const override;
+	int nextId() const override;
 
 public slots:
 	void NextStage();

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -116,5 +116,5 @@ public:
 	void Init();
 
 protected:
-	virtual void closeEvent(QCloseEvent *event) override;
+	void closeEvent(QCloseEvent *event) override;
 };

--- a/UI/window-basic-interaction.hpp
+++ b/UI/window-basic-interaction.hpp
@@ -64,7 +64,7 @@ public:
 	void Init();
 
 protected:
-	virtual void closeEvent(QCloseEvent *event) override;
+	void closeEvent(QCloseEvent *event) override;
 };
 
 typedef std::function<bool(QObject *, QEvent *)> EventFilterFunc;

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -222,7 +222,7 @@ struct SimpleOutput : BasicOutputHandler {
 	void UpdateRecordingSettings_amd_cqp(int cqp);
 	void UpdateRecordingSettings();
 	void UpdateRecordingAudioSettings();
-	virtual void Update() override;
+	void Update() override;
 
 	void SetupOutputs();
 	int GetAudioBitrate() const;
@@ -236,15 +236,15 @@ struct SimpleOutput : BasicOutputHandler {
 	void UpdateRecording();
 	bool ConfigureRecording(bool useReplayBuffer);
 
-	virtual bool StartStreaming(obs_service_t *service) override;
-	virtual bool StartRecording() override;
-	virtual bool StartReplayBuffer() override;
-	virtual void StopStreaming(bool force) override;
-	virtual void StopRecording(bool force) override;
-	virtual void StopReplayBuffer(bool force) override;
-	virtual bool StreamingActive() const override;
-	virtual bool RecordingActive() const override;
-	virtual bool ReplayBufferActive() const override;
+	bool StartStreaming(obs_service_t *service) override;
+	bool StartRecording() override;
+	bool StartReplayBuffer() override;
+	void StopStreaming(bool force) override;
+	void StopRecording(bool force) override;
+	void StopReplayBuffer(bool force) override;
+	bool StreamingActive() const override;
+	bool RecordingActive() const override;
+	bool ReplayBufferActive() const override;
 };
 
 void SimpleOutput::LoadRecordingPreset_Lossless()
@@ -1058,7 +1058,7 @@ struct AdvancedOutput : BasicOutputHandler {
 	inline void UpdateStreamSettings();
 	inline void UpdateRecordingSettings();
 	inline void UpdateAudioSettings();
-	virtual void Update() override;
+	void Update() override;
 
 	inline void SetupStreaming();
 	inline void SetupRecording();
@@ -1066,15 +1066,15 @@ struct AdvancedOutput : BasicOutputHandler {
 	void SetupOutputs();
 	int GetAudioBitrate(size_t i) const;
 
-	virtual bool StartStreaming(obs_service_t *service) override;
-	virtual bool StartRecording() override;
-	virtual bool StartReplayBuffer() override;
-	virtual void StopStreaming(bool force) override;
-	virtual void StopRecording(bool force) override;
-	virtual void StopReplayBuffer(bool force) override;
-	virtual bool StreamingActive() const override;
-	virtual bool RecordingActive() const override;
-	virtual bool ReplayBufferActive() const override;
+	bool StartStreaming(obs_service_t *service) override;
+	bool StartRecording() override;
+	bool StartReplayBuffer() override;
+	void StopStreaming(bool force) override;
+	void StopRecording(bool force) override;
+	void StopReplayBuffer(bool force) override;
+	bool StreamingActive() const override;
+	bool RecordingActive() const override;
+	bool ReplayBufferActive() const override;
 };
 
 static OBSData GetDataFromJsonFile(const char *jsonFile)

--- a/UI/window-basic-main-outputs.hpp
+++ b/UI/window-basic-main-outputs.hpp
@@ -30,7 +30,7 @@ struct BasicOutputHandler {
 
 	inline BasicOutputHandler(OBSBasic *main_) : main(main_) {}
 
-	virtual ~BasicOutputHandler(){};
+	virtual ~BasicOutputHandler() {}
 
 	virtual bool StartStreaming(obs_service_t *service) = 0;
 	virtual bool StartRecording() = 0;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -656,8 +656,8 @@ public:
 	static OBSBasic *Get();
 
 protected:
-	virtual void closeEvent(QCloseEvent *event) override;
-	virtual void changeEvent(QEvent *event) override;
+	void closeEvent(QCloseEvent *event) override;
+	void changeEvent(QEvent *event) override;
 
 private slots:
 	void on_actionFullscreenInterface_triggered();
@@ -821,14 +821,14 @@ public slots:
 
 public:
 	explicit OBSBasic(QWidget *parent = 0);
-	virtual ~OBSBasic();
+	~OBSBasic();
 
-	virtual void OBSInit() override;
+	void OBSInit() override;
 
-	virtual config_t *Config() const override;
+	config_t *Config() const override;
 
-	virtual int GetProfilePath(char *path, size_t size,
-				   const char *file) const override;
+	int GetProfilePath(char *path, size_t size,
+			   const char *file) const override;
 
 	static void InitBrowserPanelSafeBlock();
 
@@ -841,9 +841,9 @@ class SceneRenameDelegate : public QStyledItemDelegate {
 
 public:
 	SceneRenameDelegate(QObject *parent);
-	virtual void setEditorData(QWidget *editor,
-				   const QModelIndex &index) const override;
+	void setEditorData(QWidget *editor,
+			   const QModelIndex &index) const override;
 
 protected:
-	virtual bool eventFilter(QObject *editor, QEvent *event) override;
+	bool eventFilter(QObject *editor, QEvent *event) override;
 };

--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -97,15 +97,15 @@ public:
 
 	static OBSBasicPreview *Get();
 
-	virtual void keyPressEvent(QKeyEvent *event) override;
-	virtual void keyReleaseEvent(QKeyEvent *event) override;
+	void keyPressEvent(QKeyEvent *event) override;
+	void keyReleaseEvent(QKeyEvent *event) override;
 
-	virtual void wheelEvent(QWheelEvent *event) override;
+	void wheelEvent(QWheelEvent *event) override;
 
-	virtual void mousePressEvent(QMouseEvent *event) override;
-	virtual void mouseReleaseEvent(QMouseEvent *event) override;
-	virtual void mouseMoveEvent(QMouseEvent *event) override;
-	virtual void leaveEvent(QEvent *event) override;
+	void mousePressEvent(QMouseEvent *event) override;
+	void mouseReleaseEvent(QMouseEvent *event) override;
+	void mouseMoveEvent(QMouseEvent *event) override;
+	void leaveEvent(QEvent *event) override;
 
 	void DrawOverflow();
 	void DrawSceneEditing();

--- a/UI/window-basic-properties.hpp
+++ b/UI/window-basic-properties.hpp
@@ -71,6 +71,6 @@ public:
 	void Init();
 
 protected:
-	virtual void closeEvent(QCloseEvent *event) override;
-	virtual void reject() override;
+	void closeEvent(QCloseEvent *event) override;
+	void reject() override;
 };

--- a/UI/window-basic-stats.hpp
+++ b/UI/window-basic-stats.hpp
@@ -58,7 +58,7 @@ class OBSBasicStats : public QWidget {
 	void Update();
 	void Reset();
 
-	virtual void closeEvent(QCloseEvent *event) override;
+	void closeEvent(QCloseEvent *event) override;
 
 	static void OBSFrontendEvent(enum obs_frontend_event event, void *ptr);
 
@@ -78,6 +78,6 @@ private slots:
 	void RecordingTimeLeft();
 
 protected:
-	virtual void showEvent(QShowEvent *event) override;
-	virtual void hideEvent(QHideEvent *event) override;
+	void showEvent(QShowEvent *event) override;
+	void hideEvent(QHideEvent *event) override;
 };

--- a/UI/window-remux.hpp
+++ b/UI/window-remux.hpp
@@ -53,8 +53,8 @@ class OBSRemux : public QDialog {
 
 	const char *recPath;
 
-	virtual void closeEvent(QCloseEvent *event) override;
-	virtual void reject() override;
+	void closeEvent(QCloseEvent *event) override;
+	void reject() override;
 
 	bool autoRemux;
 	QString autoRemuxFile;
@@ -62,15 +62,15 @@ class OBSRemux : public QDialog {
 public:
 	explicit OBSRemux(const char *recPath, QWidget *parent = nullptr,
 			  bool autoRemux = false);
-	virtual ~OBSRemux() override;
+	~OBSRemux();
 
 	using job_t = std::shared_ptr<struct media_remux_job>;
 
 	void AutoRemux(QString inFile, QString outFile);
 
 protected:
-	void dropEvent(QDropEvent *ev);
-	void dragEnterEvent(QDragEnterEvent *ev);
+	void dropEvent(QDropEvent *ev) override;
+	void dragEnterEvent(QDragEnterEvent *ev) override;
 
 	void remuxNextEntry();
 
@@ -147,7 +147,7 @@ class RemuxWorker : public QObject {
 	void UpdateProgress(float percent);
 
 	explicit RemuxWorker() : isWorking(false) {}
-	virtual ~RemuxWorker(){};
+	~RemuxWorker() {}
 
 private slots:
 	void remux(const QString &source, const QString &target);
@@ -165,17 +165,16 @@ class RemuxEntryPathItemDelegate : public QStyledItemDelegate {
 public:
 	RemuxEntryPathItemDelegate(bool isOutput, const QString &defaultPath);
 
-	virtual QWidget *createEditor(QWidget *parent,
-				      const QStyleOptionViewItem & /* option */,
-				      const QModelIndex &index) const override;
+	QWidget *createEditor(QWidget *parent,
+			      const QStyleOptionViewItem & /* option */,
+			      const QModelIndex &index) const override;
 
-	virtual void setEditorData(QWidget *editor,
-				   const QModelIndex &index) const override;
-	virtual void setModelData(QWidget *editor, QAbstractItemModel *model,
-				  const QModelIndex &index) const override;
-	virtual void paint(QPainter *painter,
-			   const QStyleOptionViewItem &option,
+	void setEditorData(QWidget *editor,
 			   const QModelIndex &index) const override;
+	void setModelData(QWidget *editor, QAbstractItemModel *model,
+			  const QModelIndex &index) const override;
+	void paint(QPainter *painter, const QStyleOptionViewItem &option,
+		   const QModelIndex &index) const override;
 
 private:
 	bool isOutput;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
- window-remux.hpp: mark 'dropEvent' and 'dragEnterEvent' override
- Remove redundant virtual declarations throughout UI

### Motivation and Context
- 'dropEvent' and 'dragEnterEvent' override methods in qwidget.h but are not marked 'override'
- CPP Core Guidelines C.128: Virtual functions should specify exactly one of virtual, override, or final (https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-override)
- C.128 regarding destructors: If a base class destructor is declared virtual, one should avoid declaring derived class destructors virtual or override
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [ ] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
