### PR TITLE
UI: Declare missing overrides

### DIFF
--- a/UI/window-remux.hpp
+++ b/UI/window-remux.hpp
@@ -69,8 +69,8 @@ public:
 	void AutoRemux(QString inFile, QString outFile);
 
 protected:
-	void dropEvent(QDropEvent *ev);
-	void dragEnterEvent(QDragEnterEvent *ev);
+	virtual void dropEvent(QDropEvent *ev) override;
+	virtual void dragEnterEvent(QDragEnterEvent *ev) override;
 
 	void remuxNextEntry();
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
window-remux.hpp: Add missing override declaration to 'dropEvent' and 'dragEnterEvent' methods (matching existing style).
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
'dropEvent' and 'dragEnterEvent' override methods in qwidget.h but are not marked 'override'
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Compiled and launched on macOS 10.14. Compiler warnings regarding undeclared virtual methods ('dropEvent' and 'dragEnterEvent') no longer appear. No new warnings in UI during compilation. Zero memory leaks reported after program termination.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
