### PR TITLE
libobs: Merge obs_source_process_filter_(tech_)?end functions

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3383,32 +3383,20 @@ void obs_source_process_filter_tech_end(obs_source_t *filter,
 		render_filter_bypass(target, effect, tech);
 	} else {
 		texture = gs_texrender_get_texture(filter->filter_texrender);
-		render_filter_tex(texture, effect, width, height, tech);
+		if (texture) {
+			render_filter_tex(texture, effect, width, height, tech);
+		}
 	}
 }
 
 void obs_source_process_filter_end(obs_source_t *filter, gs_effect_t *effect,
 				   uint32_t width, uint32_t height)
 {
-	obs_source_t *target, *parent;
-	gs_texture_t *texture;
-	uint32_t parent_flags;
-
 	if (!obs_ptr_valid(filter, "obs_source_process_filter_end"))
 		return;
 
-	target = obs_filter_get_target(filter);
-	parent = obs_filter_get_parent(filter);
-	parent_flags = parent->info.output_flags;
-
-	if (can_bypass(target, parent, parent_flags, filter->allow_direct)) {
-		render_filter_bypass(target, effect, "Draw");
-	} else {
-		texture = gs_texrender_get_texture(filter->filter_texrender);
-		if (texture)
-			render_filter_tex(texture, effect, width, height,
-					  "Draw");
-	}
+	obs_source_process_filter_tech_end(filter, effect, width, height,
+					   "Draw");
 }
 
 void obs_source_skip_video_filter(obs_source_t *filter)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
I merged ```obs_source_process_filter_end``` and ```obs_source_process_filter_tech_end``` functions because they have almost the same logic, but in the aspect of variable validation I will say that they should complement each other.
I also moved the ```texture``` variable validate from ```obs_source_process_filter_end``` to ```obs_source_process_filter_tech_end```.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I met a crash when remove filter and in visual studio it shows that crash happened in ```parent_flags = parent->info.output_flags;``` with ```parent == nullptr```. 
But it seems quite hard to reproduce: never happened again during the following test.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
It doesn't crash during following code running. 
(Though this code not reproduced the crash before modify the code.) 
```
#include <obs.h>
#include <../obs-frontend-api/obs-frontend-api.h>
#include <obs-module.h>

#include <thread>

#include "graphics/vec4.h"
#include "graphics/matrix4.h"

OBS_DECLARE_MODULE()

struct test_filter_data {
	obs_source_t                   *context;
};

static const char *test_filter_get_name(void *unused)
{
	return "";
}

static void test_filter_destroy(void *data)
{
	struct test_filter_data *filter = (struct test_filter_data*) data;
	bfree(filter);
}

static void test_filter_update(void *data, obs_data_t *settings)
{
}

static void *test_filter_create(obs_data_t *settings, obs_source_t *context)
{
	struct test_filter_data *filter = (struct test_filter_data*) bzalloc(sizeof(*filter));
	filter->context = context;

	if (settings)
		test_filter_update(filter, settings);
	return filter;
}

static obs_properties_t *test_filter_properties(void *data)
{
	obs_properties_t *props = obs_properties_create();
	return props;
}

static void test_filter_defaults(obs_data_t *settings)
{
}

static void test_filter_tick(void *data, float seconds)
{
}


static void test_filter_render(void *data, gs_effect_t *effect)
{
	struct test_filter_data *filter = (struct test_filter_data*) data;

	gs_effect_t* def_effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);

	if (!obs_source_process_filter_begin(filter->context, GS_RGBA, OBS_ALLOW_DIRECT_RENDERING))
		return;
	std::this_thread::sleep_for(std::chrono::milliseconds(15));
	obs_source_process_filter_tech_end(filter->context, def_effect, 0, 0, "Draw");
}

static void register_test_filter()
{
	obs_source_info ${};
	$.id = "test_filter";
	$.type = OBS_SOURCE_TYPE_FILTER;
	$.output_flags = OBS_SOURCE_VIDEO;
	$.get_name = test_filter_get_name;
	$.create = test_filter_create;
	$.destroy = test_filter_destroy;
	$.update = test_filter_update;
	$.get_properties = test_filter_properties;
	$.get_defaults = test_filter_defaults;
	$.video_tick = test_filter_tick;
	$.video_render = test_filter_render;

	obs_register_source(&$);
}

bool obs_module_load()
{
	register_test_filter();

	obs_frontend_add_tools_menu_item("crash it", [](void*) {
		obs_data* src_conf = obs_data_create();
		obs_data_set_string(src_conf, "text", "test text");
		obs_source* test_source = obs_source_create("text_gdiplus", "test source", src_conf, nullptr);
		obs_data_release(src_conf);

		obs_source* scene_source = obs_frontend_get_current_scene();
		obs_scene* scene = obs_scene_from_source(scene_source);
		obs_scene_add(scene, test_source);
		obs_source_release(scene_source);

		obs_source_addref(test_source);
		std::thread([test_source] {
			for (;;)
			{
				obs_source* test_filter = obs_source_create("test_filter", "test filter", nullptr, nullptr);
				obs_source_filter_add(test_source, test_filter);
				std::this_thread::sleep_for(std::chrono::milliseconds(6));
				obs_source_filter_remove(test_source, test_filter);
				obs_source_release(test_filter);
			}
			obs_source_release(test_source);
		}).detach();

		obs_source_release(test_source);

	}, nullptr);
	return true;
}
```

### Types of changes
* Code cleanup
* Bug fix
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
