### PR TITLE
GL support improvements

### DIFF
--- a/libobs-opengl/gl-shaderparser.c
+++ b/libobs-opengl/gl-shaderparser.c
@@ -167,7 +167,16 @@ static void gl_write_storage_var(struct gl_shader_parser *glsp,
 
 	if (st) {
 		gl_unwrap_storage_struct(glsp, st, var->name, input, prefix);
-	} else if (!input || strcmp(var->mapping, "VERTEXID")) {
+	} else {
+		if (input && (strcmp(var->mapping, "VERTEXID") == 0))
+			return;
+		if (strcmp(var->mapping, "POSITION") == 0) {
+			if (!input && (glsp->type == GS_SHADER_VERTEX))
+				return;
+			if (input && (glsp->type == GS_SHADER_PIXEL))
+				return;
+		}
+
 		struct gl_parser_attrib attrib;
 		gl_parser_attrib_init(&attrib);
 
@@ -555,17 +564,23 @@ static void gl_write_main_storage_assign(struct gl_shader_parser *glsp,
 
 		dstr_free(&src_copy);
 	} else {
-		if (!dstr_is_empty(&dst_copy))
-			dstr_cat_dstr(&glsp->gl_string, &dst_copy);
-		dstr_cat(&glsp->gl_string, " = ");
-		if (input && (strcmp(var->mapping, "VERTEXID") == 0))
-			dstr_cat(&glsp->gl_string, "uint(gl_VertexID)");
-		else {
-			if (src)
-				dstr_cat(&glsp->gl_string, src);
-			dstr_cat(&glsp->gl_string, var->name);
+		if (input || (glsp->type != GS_SHADER_VERTEX) ||
+		    (strcmp(var->mapping, "POSITION"))) {
+			if (!dstr_is_empty(&dst_copy))
+				dstr_cat_dstr(&glsp->gl_string, &dst_copy);
+			dstr_cat(&glsp->gl_string, " = ");
+			if (input && (strcmp(var->mapping, "VERTEXID") == 0))
+				dstr_cat(&glsp->gl_string, "uint(gl_VertexID)");
+			else if (input && (glsp->type == GS_SHADER_PIXEL) &&
+				 (strcmp(var->mapping, "POSITION") == 0))
+				dstr_cat(&glsp->gl_string, "gl_FragCoord");
+			else {
+				if (src)
+					dstr_cat(&glsp->gl_string, src);
+				dstr_cat(&glsp->gl_string, var->name);
+			}
+			dstr_cat(&glsp->gl_string, ";\n");
 		}
-		dstr_cat(&glsp->gl_string, ";\n");
 
 		if (!input)
 			gl_write_main_interface_assign(glsp, var, src);

--- a/libobs-opengl/gl-shaderparser.c
+++ b/libobs-opengl/gl-shaderparser.c
@@ -669,12 +669,6 @@ static void gl_rename_attributes(struct gl_shader_parser *glsp)
 		size_t val;
 
 		if (attrib->input) {
-			if (strcmp(attrib->mapping, "VERTEXID") == 0) {
-				dstr_replace(&glsp->gl_string,
-					     attrib->name.array, "gl_VertexID");
-				continue;
-			}
-
 			prefix = glsp->input_prefix;
 			val = input_idx++;
 		} else {

--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -106,7 +106,7 @@ static inline GLenum convert_gs_internal_format(enum gs_color_format format)
 	case GS_RG32F:
 		return GL_RG32F;
 	case GS_R8G8:
-		return GL_R16;
+		return GL_RG8;
 	case GS_R16F:
 		return GL_R16F;
 	case GS_R32F:
@@ -152,7 +152,7 @@ static inline GLenum get_gl_format_type(enum gs_color_format format)
 	case GS_RG32F:
 		return GL_FLOAT;
 	case GS_R8G8:
-		return GL_UNSIGNED_SHORT;
+		return GL_UNSIGNED_BYTE;
 	case GS_R16F:
 		return GL_UNSIGNED_SHORT;
 	case GS_R32F:


### PR DESCRIPTION
### Description
Small menu of GL improvements: fix GS_R8G8 using the wrong GL values, and update the GLSL generator to support gl_FragCoord. Also remove some unused code.

### Motivation and Context
- GS_R8G8 support will be necessary for an upcoming change to simplify YUV output shaders to store NV12 CbCr.
- gl_FragCoord allows usage of SV_Position-style PS inputs. It's a natural fit for fullscreen passes where gl_FragCoord.xy contains the texelFetch coordinates.
- Dead code leads to confusion.

### How Has This Been Tested?
- GS_R8G8 support has been exercised in a coming PR and now behaves as intended.
- gl_FragCoord support has been exercised in a coming PR and behaves as intended. All GLSL shaders generated on Windows application startup have been looked over, and interpolants look good. Tested various rescaling shaders and video recording on Mac.
- Breakpoint was set on dead code and never triggered during processing of shaders using VERTEXID.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.