### PR TITLE
Fix various clang-tidy and CppCheck warnings.

### DIFF
--- a/UI/auth-oauth.cpp
+++ b/UI/auth-oauth.cpp
@@ -259,7 +259,7 @@ try {
 
 	return true;
 
-} catch (ErrorInfo info) {
+} catch (ErrorInfo &info) {
 	if (!retry) {
 		QString title = QTStr("Auth.AuthFailure.Title");
 		QString text = QTStr("Auth.AuthFailure.Text")

--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -6,7 +6,7 @@
 #include <QResizeEvent>
 #include <QShowEvent>
 
-static inline long long color_to_int(QColor color)
+static inline long long color_to_int(const QColor &color)
 {
 	auto shift = [&](unsigned val, int shift) {
 		return ((val & 0xff) << shift);

--- a/UI/win-update/win-update.cpp
+++ b/UI/win-update/win-update.cpp
@@ -146,7 +146,7 @@ try {
 
 	return true;
 
-} catch (string text) {
+} catch (string &text) {
 	blog(LOG_WARNING, "%s: %s", __FUNCTION__, text.c_str());
 	return false;
 }
@@ -174,7 +174,7 @@ try {
 
 	return true;
 
-} catch (string text) {
+} catch (string &text) {
 	blog(LOG_WARNING, "%s: %s", __FUNCTION__, text.c_str());
 	return false;
 }
@@ -229,7 +229,7 @@ try {
 
 	return true;
 
-} catch (string text) {
+} catch (string &text) {
 	blog(LOG_DEBUG, "%s: %s", __FUNCTION__, text.c_str());
 	return false;
 }
@@ -332,7 +332,7 @@ try {
 
 	return true;
 
-} catch (string text) {
+} catch (string &text) {
 	blog(LOG_WARNING, "%s: %s", __FUNCTION__, text.c_str());
 	return false;
 }
@@ -384,7 +384,7 @@ try {
 
 	return true;
 
-} catch (string text) {
+} catch (string &text) {
 	blog(LOG_WARNING, "%s: %s", __FUNCTION__, text.c_str());
 	return false;
 }
@@ -430,7 +430,7 @@ try {
 
 	return true;
 
-} catch (string text) {
+} catch (string &text) {
 	blog(LOG_WARNING, "%s: %s", __FUNCTION__, text.c_str());
 	return false;
 }
@@ -750,7 +750,7 @@ try {
 
 	QMetaObject::invokeMethod(App()->GetMainWindow(), "close");
 
-} catch (string text) {
+} catch (string &text) {
 	blog(LOG_WARNING, "%s: %s", __FUNCTION__, text.c_str());
 }
 
@@ -845,6 +845,6 @@ try {
 
 	emit Result(QString::fromUtf8(text.c_str()));
 
-} catch (string text) {
+} catch (string &text) {
 	blog(LOG_WARNING, "%s: %s", __FUNCTION__, text.c_str());
 }

--- a/libobs-d3d11/d3d11-duplicator.cpp
+++ b/libobs-d3d11/d3d11-duplicator.cpp
@@ -87,7 +87,7 @@ EXPORT bool device_get_duplicator_monitor_info(gs_device_t *device,
 		if (FAILED(hr))
 			throw HRError("GetDesc failed", hr);
 
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR,
 		     "device_get_duplicator_monitor_info: "
 		     "%s (%08lX)",
@@ -151,7 +151,7 @@ EXPORT gs_duplicator_t *device_duplicator_create(gs_device_t *device,
 		blog(LOG_DEBUG, "device_duplicator_create: %s", error);
 		return nullptr;
 
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_DEBUG, "device_duplicator_create: %s (%08lX)",
 		     error.str, error.hr);
 		return nullptr;

--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -405,6 +405,6 @@ try {
 } catch (const char *error) {
 	bcrash("Failed to recreate D3D11: %s", error);
 
-} catch (HRError error) {
+} catch (HRError &error) {
 	bcrash("Failed to recreate D3D11: %s (%08lX)", error.str, error.hr);
 }

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -342,7 +342,7 @@ try {
 	}
 	return bad_driver;
 
-} catch (HRError error) {
+} catch (HRError &error) {
 	blog(LOG_WARNING, "HasBadNV12Output failed: %s (%08lX)", error.str,
 	     error.hr);
 	return false;
@@ -712,7 +712,7 @@ bool device_enum_adapters(bool (*callback)(void *param, const char *name,
 		EnumD3DAdapters(callback, param);
 		return true;
 
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_WARNING, "Failed enumerating devices: %s (%08lX)",
 		     error.str, error.hr);
 		return false;
@@ -792,12 +792,12 @@ int device_create(gs_device_t **p_device, uint32_t adapter)
 
 		device = new gs_device(adapter);
 
-	} catch (UnsupportedHWError error) {
+	} catch (UnsupportedHWError &error) {
 		blog(LOG_ERROR, "device_create (D3D11): %s (%08lX)", error.str,
 		     error.hr);
 		errorcode = GS_ERROR_NOT_SUPPORTED;
 
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR, "device_create (D3D11): %s (%08lX)", error.str,
 		     error.hr);
 		errorcode = GS_ERROR_FAIL;
@@ -831,7 +831,7 @@ gs_swapchain_t *device_swapchain_create(gs_device_t *device,
 
 	try {
 		swap = new gs_swap_chain(device, data);
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR, "device_swapchain_create (D3D11): %s (%08lX)",
 		     error.str, error.hr);
 		LogD3D11ErrorDetails(error, device);
@@ -861,7 +861,7 @@ void device_resize(gs_device_t *device, uint32_t cx, uint32_t cy)
 			depthView = device->curZStencilBuffer->view;
 		device->context->OMSetRenderTargets(1, &renderView, depthView);
 
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR, "device_resize (D3D11): %s (%08lX)", error.str,
 		     error.hr);
 		LogD3D11ErrorDetails(error, device);
@@ -911,7 +911,7 @@ gs_texture_t *device_texture_create(gs_device_t *device, uint32_t width,
 		texture = new gs_texture_2d(device, width, height, color_format,
 					    levels, data, flags, GS_TEXTURE_2D,
 					    false);
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR, "device_texture_create (D3D11): %s (%08lX)",
 		     error.str, error.hr);
 		LogD3D11ErrorDetails(error, device);
@@ -932,7 +932,7 @@ gs_texture_t *device_cubetexture_create(gs_device_t *device, uint32_t size,
 		texture = new gs_texture_2d(device, size, size, color_format,
 					    levels, data, flags,
 					    GS_TEXTURE_CUBE, false);
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR,
 		     "device_cubetexture_create (D3D11): %s "
 		     "(%08lX)",
@@ -971,7 +971,7 @@ gs_zstencil_t *device_zstencil_create(gs_device_t *device, uint32_t width,
 	try {
 		zstencil =
 			new gs_zstencil_buffer(device, width, height, format);
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR, "device_zstencil_create (D3D11): %s (%08lX)",
 		     error.str, error.hr);
 		LogD3D11ErrorDetails(error, device);
@@ -988,7 +988,7 @@ gs_stagesurf_t *device_stagesurface_create(gs_device_t *device, uint32_t width,
 	try {
 		surf = new gs_stage_surface(device, width, height,
 					    color_format);
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR,
 		     "device_stagesurface_create (D3D11): %s "
 		     "(%08lX)",
@@ -1006,7 +1006,7 @@ device_samplerstate_create(gs_device_t *device,
 	gs_sampler_state *ss = NULL;
 	try {
 		ss = new gs_sampler_state(device, info);
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR,
 		     "device_samplerstate_create (D3D11): %s "
 		     "(%08lX)",
@@ -1025,14 +1025,14 @@ gs_shader_t *device_vertexshader_create(gs_device_t *device,
 	try {
 		shader = new gs_vertex_shader(device, file, shader_string);
 
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR,
 		     "device_vertexshader_create (D3D11): %s "
 		     "(%08lX)",
 		     error.str, error.hr);
 		LogD3D11ErrorDetails(error, device);
 
-	} catch (ShaderError error) {
+	} catch (ShaderError &const error) {
 		const char *buf =
 			(const char *)error.errors->GetBufferPointer();
 		if (error_string)
@@ -1058,14 +1058,14 @@ gs_shader_t *device_pixelshader_create(gs_device_t *device,
 	try {
 		shader = new gs_pixel_shader(device, file, shader_string);
 
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR,
 		     "device_pixelshader_create (D3D11): %s "
 		     "(%08lX)",
 		     error.str, error.hr);
 		LogD3D11ErrorDetails(error, device);
 
-	} catch (ShaderError error) {
+	} catch (ShaderError &const error) {
 		const char *buf =
 			(const char *)error.errors->GetBufferPointer();
 		if (error_string)
@@ -1089,7 +1089,7 @@ gs_vertbuffer_t *device_vertexbuffer_create(gs_device_t *device,
 	gs_vertex_buffer *buffer = NULL;
 	try {
 		buffer = new gs_vertex_buffer(device, data, flags);
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR,
 		     "device_vertexbuffer_create (D3D11): %s "
 		     "(%08lX)",
@@ -1111,7 +1111,7 @@ gs_indexbuffer_t *device_indexbuffer_create(gs_device_t *device,
 	gs_index_buffer *buffer = NULL;
 	try {
 		buffer = new gs_index_buffer(device, type, indices, num, flags);
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR, "device_indexbuffer_create (D3D11): %s (%08lX)",
 		     error.str, error.hr);
 		LogD3D11ErrorDetails(error, device);
@@ -1558,7 +1558,7 @@ void device_draw(gs_device_t *device, enum gs_draw_mode draw_mode,
 		blog(LOG_ERROR, "device_draw (D3D11): %s", error);
 		return;
 
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR, "device_draw (D3D11): %s (%08lX)", error.str,
 		     error.hr);
 		LogD3D11ErrorDetails(error, device);
@@ -2275,7 +2275,7 @@ device_texture_create_gdi(gs_device_t *device, uint32_t width, uint32_t height)
 		texture = new gs_texture_2d(device, width, height, GS_BGRA, 1,
 					    nullptr, GS_RENDER_TARGET,
 					    GS_TEXTURE_2D, true);
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR, "device_texture_create_gdi (D3D11): %s (%08lX)",
 		     error.str, error.hr);
 		LogD3D11ErrorDetails(error, device);
@@ -2333,7 +2333,7 @@ extern "C" EXPORT gs_texture_t *device_texture_open_shared(gs_device_t *device,
 	gs_texture *texture = nullptr;
 	try {
 		texture = new gs_texture_2d(device, handle);
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR, "gs_texture_open_shared (D3D11): %s (%08lX)",
 		     error.str, error.hr);
 		LogD3D11ErrorDetails(error, device);
@@ -2420,7 +2420,7 @@ device_texture_create_nv12(gs_device_t *device, gs_texture_t **p_tex_y,
 					  true);
 		tex_uv = new gs_texture_2d(device, tex_y->texture, flags);
 
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR, "gs_texture_create_nv12 (D3D11): %s (%08lX)",
 		     error.str, error.hr);
 		LogD3D11ErrorDetails(error, device);
@@ -2446,7 +2446,7 @@ device_stagesurface_create_nv12(gs_device_t *device, uint32_t width,
 	gs_stage_surface *surf = NULL;
 	try {
 		surf = new gs_stage_surface(device, width, height);
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_ERROR,
 		     "device_stagesurface_create (D3D11): %s "
 		     "(%08lX)",

--- a/libobs/graphics/matrix4.c
+++ b/libobs/graphics/matrix4.c
@@ -118,7 +118,7 @@ float matrix4_determinant(const struct matrix4 *m)
 	float m3x3[9];
 	int n;
 
-	for (n = 0; n < 4; n++, i *= -1.0f) {
+	for (n = 0; n < 4; n++, i = -i) { // NOLINT(clang-tidy-cert-flp30-c)
 		get_3x3_submatrix(m3x3, m, 0, n);
 
 		det = get_3x3_determinant(m3x3);

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -349,7 +349,7 @@ obs_properties_t *obs_get_encoder_properties(const char *id)
 	const struct obs_encoder_info *ei = find_encoder(id);
 	if (ei && (ei->get_properties || ei->get_properties2)) {
 		obs_data_t *defaults = get_defaults(ei);
-		obs_properties_t *properties;
+		obs_properties_t *properties = NULL;
 
 		if (ei->get_properties2) {
 			properties = ei->get_properties2(NULL, ei->type_data);

--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -183,6 +183,7 @@ static void log_aero(void)
 	composition_enabled = (dwm_is_composition_enabled_t)GetProcAddress(
 		dwm, "DwmIsCompositionEnabled");
 	if (!composition_enabled) {
+		FreeLibrary(dwm);
 		return;
 	}
 
@@ -832,10 +833,13 @@ void reset_win32_symbol_paths(void)
 			(void *)GetProcAddress(mod, "SymInitializeW");
 		sym_set_search_path_w =
 			(void *)GetProcAddress(mod, "SymSetSearchPathW");
-		if (!sym_initialize_w || !sym_set_search_path_w)
+		if (!sym_initialize_w || !sym_set_search_path_w) {
+			FreeLibrary(mod);
 			return;
+		}
 
 		initialize_success = true;
+		// Leaks 'mod' once.
 	}
 
 	if (!initialize_success)

--- a/plugins/win-capture/get-graphics-offsets/dxgi-offsets.cpp
+++ b/plugins/win-capture/get-graphics-offsets/dxgi-offsets.cpp
@@ -56,6 +56,7 @@ static inline bool dxgi_init(dxgi_info &info)
 	create = (d3d10create_t)GetProcAddress(d3d10_module,
 					       "D3D10CreateDeviceAndSwapChain");
 	if (!create) {
+		FreeLibrary(d3d10_module);
 		return false;
 	}
 
@@ -64,12 +65,14 @@ static inline bool dxgi_init(dxgi_info &info)
 
 	hr = create_factory(&factory_iid, (void **)&factory);
 	if (FAILED(hr)) {
+		FreeLibrary(d3d10_module);
 		return false;
 	}
 
 	hr = factory->EnumAdapters1(0, &adapter);
 	factory->Release();
 	if (FAILED(hr)) {
+		FreeLibrary(d3d10_module);
 		return false;
 	}
 
@@ -87,10 +90,12 @@ static inline bool dxgi_init(dxgi_info &info)
 		    D3D10_SDK_VERSION, &desc, &info.swap, &device);
 	adapter->Release();
 	if (FAILED(hr)) {
+		FreeLibrary(d3d10_module);
 		return false;
 	}
 
 	device->Release();
+	FreeLibrary(d3d10_module);
 	return true;
 }
 

--- a/plugins/win-capture/inject-library.c
+++ b/plugins/win-capture/inject-library.c
@@ -113,6 +113,7 @@ int inject_library_safe_obf(DWORD thread_id, const wchar_t *dll,
 	size_t i;
 
 	if (!lib || !user32) {
+		FreeLibrary(lib);
 		return INJECT_ERROR_UNLIKELY_FAIL;
 	}
 
@@ -123,6 +124,7 @@ int inject_library_safe_obf(DWORD thread_id, const wchar_t *dll,
 #endif
 
 	if (!proc) {
+		FreeLibrary(lib);
 		return INJECT_ERROR_UNLIKELY_FAIL;
 	}
 

--- a/plugins/win-wasapi/enum-wasapi.cpp
+++ b/plugins/win-wasapi/enum-wasapi.cpp
@@ -91,7 +91,7 @@ void GetWASAPIAudioDevices(vector<AudioDeviceInfo> &devices, bool input)
 	try {
 		GetWASAPIAudioDevices_(devices, input);
 
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		blog(LOG_WARNING, "[GetWASAPIAudioDevices] %s: %lX", error.str,
 		     error.hr);
 	}

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -319,7 +319,7 @@ bool WASAPISource::TryInitialize()
 	try {
 		Initialize();
 
-	} catch (HRError error) {
+	} catch (HRError &error) {
 		if (previouslyFailed)
 			return active;
 


### PR DESCRIPTION
### Description
This fixes warnings generated by clang-tidy and CppCheck which both check for by-value exceptions and const correctness. In all cases that I know of, catching by value is not necessary, and we also don't seem to modify the exception either, so we can use const& instead of directly accessing a copy of the exception.

### Motivation and Context
Got annoyed by the extreme noise that comes from obs-studio when clang-tidy and CppCheck is run over it.

### How Has This Been Tested?
This has no effect on functionality, only portability.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested. (How do you test a non-functional change?)
- [x] All commit messages are properly formatted and commits squashed where appropriate.
