### PR TITLE
libobs: Add missing I422 switch case for name strings

### DIFF
--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -137,6 +137,8 @@ static inline const char *get_video_format_name(enum video_format format)
 		return "Y800";
 	case VIDEO_FORMAT_BGR3:
 		return "BGR3";
+	case VIDEO_FORMAT_I422:
+		return "I422";
 	case VIDEO_FORMAT_NONE:;
 	}
 


### PR DESCRIPTION
### Description
Add missing format name string for I422.

### Motivation and Context
Noticed compiler warning spam on Linux about the missing switch case.

### How Has This Been Tested?
Verified no regression. There's no visible effect because the function is only called for logging the active output format, and I422 is not supported as one.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.