### PR TITLE
UI: Fix Int/Float Sliders and Spinboxes by partially reverting PR #1979

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -334,7 +334,6 @@ void OBSPropertiesView::AddInt(obs_property_t *prop, QFormLayout *layout,
 	spin->setValue(val);
 	spin->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 	spin->setSuffix(QT_UTF8(suffix));
-	spin->setFixedWidth(100);
 
 	WidgetInfo *info = new WidgetInfo(this, prop, spin);
 	children.emplace_back(info);
@@ -386,8 +385,6 @@ void OBSPropertiesView::AddFloat(obs_property_t *prop, QFormLayout *layout,
 	spin->setValue(val);
 	spin->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 	spin->setSuffix(QT_UTF8(suffix));
-	spin->setDecimals(1);
-	spin->setFixedWidth(100);
 
 	WidgetInfo *info = new WidgetInfo(this, prop, spin);
 	children.emplace_back(info);


### PR DESCRIPTION
### Description
Reverts the size and decimal places change done in #1979 which shouldn't have been part of that PR.

### Motivation and Context
PR #1979 broke support for various filters, sources and encoders and should not have been merged as it is.

### How Has This Been Tested?
Tested against all bundled plugins, stream effects, ffmpeg encoder, enc-aomedia1, enc-vfw, av-toolkit. All plugins returned to working correctly after this change.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
