### PR TITLE
win-dshow: Undo using FFmpeg for MJPEG

### DIFF
--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -418,6 +418,8 @@ static inline video_format ConvertVideoFormat(VideoFormat format)
 		return VIDEO_FORMAT_UYVY;
 	case VideoFormat::HDYC:
 		return VIDEO_FORMAT_UYVY;
+	case VideoFormat::MJPEG:
+		return VIDEO_FORMAT_YUY2;
 	default:
 		return VIDEO_FORMAT_NONE;
 	}
@@ -497,11 +499,6 @@ void DShowInput::OnVideoData(const VideoConfig &config, unsigned char *data,
 {
 	if (videoConfig.format == VideoFormat::H264) {
 		OnEncodedVideoData(AV_CODEC_ID_H264, data, size, startTime);
-		return;
-	}
-
-	if (videoConfig.format == VideoFormat::MJPEG) {
-		OnEncodedVideoData(AV_CODEC_ID_MJPEG, data, size, startTime);
 		return;
 	}
 
@@ -908,12 +905,26 @@ bool DShowInput::UpdateVideoConfig(obs_data_t *settings)
 					 placeholders::_3, placeholders::_4,
 					 placeholders::_5);
 
-	videoConfig.format = videoConfig.internalFormat;
+	if (videoConfig.internalFormat != VideoFormat::MJPEG)
+		videoConfig.format = videoConfig.internalFormat;
 
 	if (!device.SetVideoConfig(&videoConfig)) {
 		blog(LOG_WARNING, "%s: device.SetVideoConfig failed",
 		     obs_source_get_name(source));
 		return false;
+	}
+
+	if (videoConfig.internalFormat == VideoFormat::MJPEG) {
+		videoConfig.format = VideoFormat::XRGB;
+		videoConfig.useDefaultConfig = false;
+
+		if (!device.SetVideoConfig(&videoConfig)) {
+			blog(LOG_WARNING,
+			     "%s: device.SetVideoConfig (XRGB) "
+			     "failed",
+			     obs_source_get_name(source));
+			return false;
+		}
 	}
 
 	DStr formatName = GetVideoFormatName(videoConfig.internalFormat);


### PR DESCRIPTION
### Description
There are reports of hitches, freezing, and latency under load. Will
need to be investigated another day.

### Motivation and Context
Don't want to break existing users.

### How Has This Been Tested?
Compiled and ran. Seems to behave as before.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.