### PR TITLE
obs-scripting: Use a recursive mutex for Lua scripting

### DIFF
--- a/deps/obs-scripting/obs-scripting-lua-source.c
+++ b/deps/obs-scripting/obs-scripting-lua-source.c
@@ -641,7 +641,12 @@ static int obs_lua_register_source(lua_State *script)
 	if (!existing) {
 		ls.data = current_lua_script;
 
-		pthread_mutex_init(&ls.definition_mutex, NULL);
+		pthread_mutexattr_t mutexattr;
+		pthread_mutexattr_init(&mutexattr);
+		pthread_mutexattr_settype(&mutexattr, PTHREAD_MUTEX_RECURSIVE);
+		pthread_mutex_init(&ls.definition_mutex, &mutexattr);
+		pthread_mutexattr_destroy(&mutexattr);
+
 		info.type_data = bmemdup(&ls, sizeof(ls));
 		info.free_type_data = obs_lua_source_free_type_data;
 		info.get_name = obs_lua_source_get_name;


### PR DESCRIPTION
# Description
In the current OBS Studio stacking multiple Lua filters registered by the same script will freeze OBS Studio in place, with no way to fix it on the user side. Any progress made until that moment is lost if there was no scene collection save happening. If there was one happening during the freeze, the collection might end up corrupted and the backup is loaded instead.

This is due to the fact that the mutex we use does not allow a recursive lock, so when that eventually happens everything just freezes since we already hold a lock on the mutex and are trying to lock it again.

### Motivation and Context
When a Lua script creates a filter, that filter can't be used more than once in the same filter stack, which is severely limiting, and actually counterproductive as OBS Studio simply freezes in place. 

### How Has This Been Tested?
Tested against two Lua filters, one for color conversion and one for mathematical formulae scaling.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
