### PR TITLE
libobs: Add missing format to format_is_yuv & get_video_format_name

### DIFF
--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -95,6 +95,7 @@ static inline bool format_is_yuv(enum video_format format)
 	switch (format) {
 	case VIDEO_FORMAT_I420:
 	case VIDEO_FORMAT_NV12:
+	case VIDEO_FORMAT_I422:
 	case VIDEO_FORMAT_YVYU:
 	case VIDEO_FORMAT_YUY2:
 	case VIDEO_FORMAT_UYVY:
@@ -119,6 +120,8 @@ static inline const char *get_video_format_name(enum video_format format)
 		return "I420";
 	case VIDEO_FORMAT_NV12:
 		return "NV12";
+	case VIDEO_FORMAT_I422:
+		return "I422";
 	case VIDEO_FORMAT_YVYU:
 		return "YVYU";
 	case VIDEO_FORMAT_YUY2:


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Insert VIDEO_FORMAT_I422 into switch cases: format_is_yuv and get_video_format_name. Rearrange video formats (in logical order) for consistency: 4:2:0, 4:2:2 (planar, packed), 4:4:4, uncompressed

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fix compiling warning: VIDEO_FORMAT_I422 not included in switch case...

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compilation warning no longer appears.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
