### PR TITLE
UI: Add ability to theme preview outline colors

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -1015,3 +1015,12 @@ QPushButton#extraPanelDelete:hover {
 QPushButton#extraPanelDelete:pressed {
     background-color: #161f41;
 }
+
+/* Preview Outline Colors */
+
+OBSBasicPreview {
+	qproperty-previewOutlineColor: #FF0000;
+	qproperty-cropColor: #00FF00;
+	qproperty-hoverOutlineColor: #0000FF;
+	qproperty-handleColor: #FF0000;
+}

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -749,3 +749,12 @@ QPushButton#extraPanelDelete:hover {
 QPushButton#extraPanelDelete:pressed {
     background-color: rgb(31,30,31);
 }
+
+/* Preview Outline Colors */
+
+OBSBasicPreview {
+	qproperty-previewOutlineColor: #FF0000;
+	qproperty-cropColor: #00FF00;
+	qproperty-hoverOutlineColor: #0000FF;
+	qproperty-handleColor:  #FF0000;
+}

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -1340,3 +1340,12 @@ QPushButton#extraPanelDelete:hover {
 QPushButton#extraPanelDelete:pressed {
      background-color: rgb(240, 98, 146);
 }
+
+/* Preview Outline Colors */
+
+OBSBasicPreview {
+	qproperty-previewOutlineColor: rgb(0, 188, 212);
+	qproperty-cropColor: rgb(255, 148, 194);
+	qproperty-hoverOutlineColor: rgb(240, 98, 146);
+	qproperty-handleColor: rgb(0, 188, 212);
+}

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -208,3 +208,12 @@ VisibilityCheckBox::indicator:unchecked {
 * [themeID="revertIcon"] {
     qproperty-icon: url(:res/images/revert.svg);
 }
+
+/* Preview Outline Colors */
+
+OBSBasicPreview {
+	qproperty-previewOutlineColor: #FF0000;
+	qproperty-cropColor: #00FF00;
+	qproperty-hoverOutlineColor: #0000FF;
+	qproperty-handleColor:  #FF0000;
+}

--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -16,6 +16,11 @@ class QMouseEvent;
 
 #define ZOOM_SENSITIVITY 1.125f
 
+#define PREVIEW_OUTLINE_COLOR 0xFF0000FF
+#define CROP_COLOR 0xFF00FF00
+#define HOVER_OUTLINE_COLOR 0xFFFF0000
+#define HANDLE_COLOR 0xFF0000FF
+
 enum class ItemHandle : uint32_t {
 	None = 0,
 	TopLeft = ITEM_TOP | ITEM_LEFT,
@@ -30,6 +35,14 @@ enum class ItemHandle : uint32_t {
 
 class OBSBasicPreview : public OBSQTDisplay {
 	Q_OBJECT
+	Q_PROPERTY(QColor previewOutlineColor MEMBER backgroundColor READ
+			   GetPreviewOutlineColor WRITE SetPreviewOutlineColor)
+	Q_PROPERTY(QColor cropColor MEMBER cropColor READ GetCropColor WRITE
+			   SetCropColor)
+	Q_PROPERTY(QColor hoverOutlineColor MEMBER hoverOutlineColor READ
+			   GetHoverOutlineColor WRITE SetHoverOutlineColor)
+	Q_PROPERTY(QColor handleColor MEMBER handleColor READ GetHandleColor
+			   WRITE SetHandleColor)
 
 	friend class SourceTree;
 
@@ -91,6 +104,11 @@ private:
 
 	void ProcessClick(const vec2 &pos);
 
+	uint32_t previewOutlineColor = PREVIEW_OUTLINE_COLOR;
+	uint32_t cropColor = CROP_COLOR;
+	uint32_t hoverOutlineColor = HOVER_OUTLINE_COLOR;
+	uint32_t handleColor = HANDLE_COLOR;
+
 public:
 	OBSBasicPreview(QWidget *parent, Qt::WindowFlags flags = 0);
 	~OBSBasicPreview();
@@ -139,4 +157,14 @@ public:
 	 * byte boundary. */
 	static inline void *operator new(size_t size) { return bmalloc(size); }
 	static inline void operator delete(void *ptr) { bfree(ptr); }
+
+	QColor GetPreviewOutlineColor() const;
+	QColor GetCropColor() const;
+	QColor GetHoverOutlineColor() const;
+	QColor GetHandleColor() const;
+
+	void SetPreviewOutlineColor(const QColor &color);
+	void SetCropColor(const QColor &color);
+	void SetHoverOutlineColor(const QColor &color);
+	void SetHandleColor(const QColor &color);
 };


### PR DESCRIPTION
### Description
This adds the ability for themes to style the preview outline, crop, hover outline and handle colors.
![Screenshot from 2019-08-04 04-37-54](https://user-images.githubusercontent.com/19962531/62422081-52038480-b672-11e9-8cf0-ccf421a98dff.png)
![Screenshot from 2019-08-04 04-47-33](https://user-images.githubusercontent.com/19962531/62422121-07363c80-b673-11e9-86ee-c98f50fea4ae.png)

### Motivation and Context
Themes should be able to set these colors as well.

### How Has This Been Tested?
This has been tested on Linux. It should work on other operating systems as well.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
