### PR TITLE
libobs: Fix stale format in async frame cache

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2426,14 +2426,17 @@ cache_video(struct obs_source *source, const struct obs_source_frame *frame)
 		free_async_cache(source);
 		source->async_cache_width = frame->width;
 		source->async_cache_height = frame->height;
-		source->async_cache_format = frame->format;
-		source->async_cache_full_range = frame->full_range;
 	}
+
+	const enum video_format format = frame->format;
+	source->async_cache_format = format;
+	source->async_cache_full_range = frame->full_range;
 
 	for (size_t i = 0; i < source->async_cache.num; i++) {
 		struct async_frame *af = &source->async_cache.array[i];
 		if (!af->used) {
 			new_frame = af->frame;
+			new_frame->format = format;
 			af->used = true;
 			af->unused_count = 0;
 			break;
@@ -2444,7 +2447,6 @@ cache_video(struct obs_source *source, const struct obs_source_frame *frame)
 
 	if (!new_frame) {
 		struct async_frame new_af;
-		enum video_format format = frame->format;
 
 		new_frame = obs_source_frame_create(format, frame->width,
 						    frame->height);


### PR DESCRIPTION
### Description
The video format is not updated if switching between cache-compatible
formats, e.g. YUY2 and YVYU, resulting in the wrong conversion technique
being used. This change ensures the format is always up-to-date.

### Motivation and Context
Noticed the video format was not being updated with my format-testing plugin.

### How Has This Been Tested?
Correct technique is now used. Also checked format switching in win-dshow plugin still works.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.