### PR TITLE
Add support for YUV alpha formats

### DIFF
--- a/deps/media-playback/media-playback/closest-format.h
+++ b/deps/media-playback/media-playback/closest-format.h
@@ -61,6 +61,15 @@ static enum AVPixelFormat closest_format(enum AVPixelFormat fmt)
 	case AV_PIX_FMT_YUV420P14LE:
 		return AV_PIX_FMT_YUV420P;
 
+	case AV_PIX_FMT_YUVA420P:
+		return AV_PIX_FMT_YUVA420P;
+
+	case AV_PIX_FMT_YUVA422P:
+		return AV_PIX_FMT_YUVA422P;
+
+	case AV_PIX_FMT_YUVA444P:
+		return AV_PIX_FMT_YUVA444P;
+
 	case AV_PIX_FMT_RGBA:
 	case AV_PIX_FMT_BGRA:
 	case AV_PIX_FMT_BGR0:

--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -48,6 +48,12 @@ static inline enum video_format convert_pixel_format(int f)
 		return VIDEO_FORMAT_BGRA;
 	case AV_PIX_FMT_BGR0:
 		return VIDEO_FORMAT_BGRX;
+	case AV_PIX_FMT_YUVA420P:
+		return VIDEO_FORMAT_I40A;
+	case AV_PIX_FMT_YUVA422P:
+		return VIDEO_FORMAT_I42A;
+	case AV_PIX_FMT_YUVA444P:
+		return VIDEO_FORMAT_YUVA;
 	default:;
 	}
 

--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -31,6 +31,7 @@ uniform float3    color_range_max = {1.0, 1.0, 1.0};
 uniform texture2d image;
 uniform texture2d image1;
 uniform texture2d image2;
+uniform texture2d image3;
 
 sampler_state def_sampler {
 	Filter   = Linear;
@@ -256,6 +257,19 @@ float3 PSPlanar420_Reverse(VertTexPos frag_in) : TARGET
 	return rgb;
 }
 
+float4 PSPlanar420A_Reverse(VertTexPos frag_in) : TARGET
+{
+	int3 xy0_luma = int3(frag_in.pos.xy, 0);
+	float y = image.Load(xy0_luma).x;
+	int3 xy0_chroma = int3(frag_in.uv, 0);
+	float cb = image1.Load(xy0_chroma).x;
+	float cr = image2.Load(xy0_chroma).x;
+	float alpha = image3.Load(xy0_luma).x;
+	float3 yuv = float3(y, cb, cr);
+	float4 rgba = float4(YUV_to_RGB(yuv), alpha);
+	return rgba;
+}
+
 float3 PSPlanar422_Reverse(FragPosWide frag_in) : TARGET
 {
 	float y = image.Load(int3(frag_in.pos_wide.xz, 0)).x;
@@ -267,6 +281,19 @@ float3 PSPlanar422_Reverse(FragPosWide frag_in) : TARGET
 	return rgb;
 }
 
+float4 PSPlanar422A_Reverse(FragPosWide frag_in) : TARGET
+{
+	int3 xy0_luma = int3(frag_in.pos_wide.xz, 0);
+	float y = image.Load(xy0_luma).x;
+	int3 xy0_chroma = int3(frag_in.pos_wide.yz, 0);
+	float cb = image1.Load(xy0_chroma).x;
+	float cr = image2.Load(xy0_chroma).x;
+	float alpha = image3.Load(xy0_luma).x;
+	float3 yuv = float3(y, cb, cr);
+	float4 rgba = float4(YUV_to_RGB(yuv), alpha);
+	return rgba;
+}
+
 float3 PSPlanar444_Reverse(FragPos frag_in) : TARGET
 {
 	int3 xy0 = int3(frag_in.pos.xy, 0);
@@ -276,6 +303,25 @@ float3 PSPlanar444_Reverse(FragPos frag_in) : TARGET
 	float3 yuv = float3(y, cb, cr);
 	float3 rgb = YUV_to_RGB(yuv);
 	return rgb;
+}
+
+float4 PSPlanar444A_Reverse(FragPos frag_in) : TARGET
+{
+	int3 xy0 = int3(frag_in.pos.xy, 0);
+	float y = image.Load(xy0).x;
+	float cb = image1.Load(xy0).x;
+	float cr = image2.Load(xy0).x;
+	float alpha = image3.Load(xy0).x;
+	float3 yuv = float3(y, cb, cr);
+	float4 rgba = float4(YUV_to_RGB(yuv), alpha);
+	return rgba;
+}
+
+float4 PSAYUV_Reverse(FragPos frag_in) : TARGET
+{
+	float4 yuva = image.Load(int3(frag_in.pos.xy, 0));
+	float4 rgba = float4(YUV_to_RGB(yuva.xyz), yuva.a);
+	return rgba;
 }
 
 float3 PSNV12_Reverse(VertTexPos frag_in) : TARGET
@@ -429,6 +475,15 @@ technique I420_Reverse
 	}
 }
 
+technique I40A_Reverse
+{
+	pass
+	{
+		vertex_shader = VSTexPosHalfHalf_Reverse(id);
+		pixel_shader  = PSPlanar420A_Reverse(frag_in);
+	}
+}
+
 technique I422_Reverse
 {
 	pass
@@ -438,12 +493,39 @@ technique I422_Reverse
 	}
 }
 
+technique I42A_Reverse
+{
+	pass
+	{
+		vertex_shader = VSPosWide_Reverse(id);
+		pixel_shader  = PSPlanar422A_Reverse(frag_in);
+	}
+}
+
 technique I444_Reverse
 {
 	pass
 	{
 		vertex_shader = VSPos(id);
 		pixel_shader  = PSPlanar444_Reverse(frag_in);
+	}
+}
+
+technique YUVA_Reverse
+{
+	pass
+	{
+		vertex_shader = VSPos(id);
+		pixel_shader  = PSPlanar444A_Reverse(frag_in);
+	}
+}
+
+technique AYUV_Reverse
+{
+	pass
+	{
+		vertex_shader = VSPos(id);
+		pixel_shader  = PSAYUV_Reverse(frag_in);
 	}
 }
 

--- a/libobs/media-io/video-frame.c
+++ b/libobs/media-io/video-frame.c
@@ -85,6 +85,7 @@ void video_frame_init(struct video_frame *frame, enum video_format format,
 	case VIDEO_FORMAT_RGBA:
 	case VIDEO_FORMAT_BGRA:
 	case VIDEO_FORMAT_BGRX:
+	case VIDEO_FORMAT_AYUV:
 		size = width * height * 4;
 		ALIGN_SIZE(size, alignment);
 		frame->data[0] = bmalloc(size);
@@ -125,6 +126,72 @@ void video_frame_init(struct video_frame *frame, enum video_format format,
 		frame->linesize[1] = width / 2;
 		frame->linesize[2] = width / 2;
 		break;
+
+	case VIDEO_FORMAT_I40A:
+		size = width * height;
+		ALIGN_SIZE(size, alignment);
+		offsets[0] = size;
+		size += (width / 2) * (height / 2);
+		ALIGN_SIZE(size, alignment);
+		offsets[1] = size;
+		size += (width / 2) * (height / 2);
+		ALIGN_SIZE(size, alignment);
+		offsets[2] = size;
+		size += width * height;
+		ALIGN_SIZE(size, alignment);
+		frame->data[0] = bmalloc(size);
+		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
+		frame->data[2] = (uint8_t *)frame->data[0] + offsets[1];
+		frame->data[3] = (uint8_t *)frame->data[0] + offsets[2];
+		frame->linesize[0] = width;
+		frame->linesize[1] = width / 2;
+		frame->linesize[2] = width / 2;
+		frame->linesize[3] = width;
+		break;
+
+	case VIDEO_FORMAT_I42A:
+		size = width * height;
+		ALIGN_SIZE(size, alignment);
+		offsets[0] = size;
+		size += (width / 2) * height;
+		ALIGN_SIZE(size, alignment);
+		offsets[1] = size;
+		size += (width / 2) * height;
+		ALIGN_SIZE(size, alignment);
+		offsets[2] = size;
+		size += width * height;
+		ALIGN_SIZE(size, alignment);
+		frame->data[0] = bmalloc(size);
+		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
+		frame->data[2] = (uint8_t *)frame->data[0] + offsets[1];
+		frame->data[3] = (uint8_t *)frame->data[0] + offsets[2];
+		frame->linesize[0] = width;
+		frame->linesize[1] = width / 2;
+		frame->linesize[2] = width / 2;
+		frame->linesize[3] = width;
+		break;
+
+	case VIDEO_FORMAT_YUVA:
+		size = width * height;
+		ALIGN_SIZE(size, alignment);
+		offsets[0] = size;
+		size += width * height;
+		ALIGN_SIZE(size, alignment);
+		offsets[1] = size;
+		size += width * height;
+		ALIGN_SIZE(size, alignment);
+		offsets[2] = size;
+		size += width * height;
+		ALIGN_SIZE(size, alignment);
+		frame->data[0] = bmalloc(size);
+		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
+		frame->data[2] = (uint8_t *)frame->data[0] + offsets[1];
+		frame->data[3] = (uint8_t *)frame->data[0] + offsets[2];
+		frame->linesize[0] = width;
+		frame->linesize[1] = width;
+		frame->linesize[2] = width;
+		frame->linesize[3] = width;
+		break;
 	}
 }
 
@@ -154,6 +221,7 @@ void video_frame_copy(struct video_frame *dst, const struct video_frame *src,
 	case VIDEO_FORMAT_BGRA:
 	case VIDEO_FORMAT_BGRX:
 	case VIDEO_FORMAT_BGR3:
+	case VIDEO_FORMAT_AYUV:
 		memcpy(dst->data[0], src->data[0], src->linesize[0] * cy);
 		break;
 
@@ -162,6 +230,21 @@ void video_frame_copy(struct video_frame *dst, const struct video_frame *src,
 		memcpy(dst->data[0], src->data[0], src->linesize[0] * cy);
 		memcpy(dst->data[1], src->data[1], src->linesize[1] * cy);
 		memcpy(dst->data[2], src->data[2], src->linesize[2] * cy);
+		break;
+
+	case VIDEO_FORMAT_I40A:
+		memcpy(dst->data[0], src->data[0], src->linesize[0] * cy);
+		memcpy(dst->data[1], src->data[1], src->linesize[1] * cy / 2);
+		memcpy(dst->data[2], src->data[2], src->linesize[2] * cy / 2);
+		memcpy(dst->data[3], src->data[3], src->linesize[3] * cy);
+		break;
+
+	case VIDEO_FORMAT_I42A:
+	case VIDEO_FORMAT_YUVA:
+		memcpy(dst->data[0], src->data[0], src->linesize[0] * cy);
+		memcpy(dst->data[1], src->data[1], src->linesize[1] * cy);
+		memcpy(dst->data[2], src->data[2], src->linesize[2] * cy);
+		memcpy(dst->data[3], src->data[3], src->linesize[3] * cy);
 		break;
 	}
 }

--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -56,6 +56,18 @@ enum video_format {
 
 	/* planar 4:2:2 */
 	VIDEO_FORMAT_I422,
+
+	/* planar 4:2:0 with alpha */
+	VIDEO_FORMAT_I40A,
+
+	/* planar 4:2:2 with alpha */
+	VIDEO_FORMAT_I42A,
+
+	/* planar 4:4:4 with alpha */
+	VIDEO_FORMAT_YUVA,
+
+	/* packed 4:4:4 with alpha */
+	VIDEO_FORMAT_AYUV,
 };
 
 enum video_colorspace {
@@ -99,6 +111,10 @@ static inline bool format_is_yuv(enum video_format format)
 	case VIDEO_FORMAT_YUY2:
 	case VIDEO_FORMAT_UYVY:
 	case VIDEO_FORMAT_I444:
+	case VIDEO_FORMAT_I40A:
+	case VIDEO_FORMAT_I42A:
+	case VIDEO_FORMAT_YUVA:
+	case VIDEO_FORMAT_AYUV:
 		return true;
 	case VIDEO_FORMAT_NONE:
 	case VIDEO_FORMAT_RGBA:
@@ -137,6 +153,14 @@ static inline const char *get_video_format_name(enum video_format format)
 		return "Y800";
 	case VIDEO_FORMAT_BGR3:
 		return "BGR3";
+	case VIDEO_FORMAT_I40A:
+		return "I40A";
+	case VIDEO_FORMAT_I42A:
+		return "I42A";
+	case VIDEO_FORMAT_YUVA:
+		return "YUVA";
+	case VIDEO_FORMAT_AYUV:
+		return "AYUV";
 	case VIDEO_FORMAT_NONE:;
 	}
 

--- a/libobs/media-io/video-scaler-ffmpeg.c
+++ b/libobs/media-io/video-scaler-ffmpeg.c
@@ -55,6 +55,12 @@ get_ffmpeg_video_format(enum video_format format)
 		return AV_PIX_FMT_BGR24;
 	case VIDEO_FORMAT_I422:
 		return AV_PIX_FMT_YUV422P;
+	case VIDEO_FORMAT_I40A:
+		return AV_PIX_FMT_YUVA420P;
+	case VIDEO_FORMAT_I42A:
+		return AV_PIX_FMT_YUVA422P;
+	case VIDEO_FORMAT_YUVA:
+		return AV_PIX_FMT_YUVA444P;
 	}
 
 	return AV_PIX_FMT_NONE;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -772,12 +772,18 @@ static inline bool frame_out_of_bounds(const obs_source_t *source, uint64_t ts)
 static inline enum gs_color_format
 convert_video_format(enum video_format format)
 {
-	if (format == VIDEO_FORMAT_RGBA)
+	switch (format) {
+	case VIDEO_FORMAT_RGBA:
 		return GS_RGBA;
-	else if (format == VIDEO_FORMAT_BGRA)
+	case VIDEO_FORMAT_BGRA:
+	case VIDEO_FORMAT_I40A:
+	case VIDEO_FORMAT_I42A:
+	case VIDEO_FORMAT_YUVA:
+	case VIDEO_FORMAT_AYUV:
 		return GS_BGRA;
-
-	return GS_BGRX;
+	default:
+		return GS_BGRX;
+	}
 }
 
 extern void obs_source_activate(obs_source_t *source, enum view_type type);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-formats.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-formats.h
@@ -37,6 +37,12 @@ obs_to_ffmpeg_video_format(enum video_format format)
 		return AV_PIX_FMT_BGR24;
 	case VIDEO_FORMAT_I422:
 		return AV_PIX_FMT_YUV422P;
+	case VIDEO_FORMAT_I40A:
+		return AV_PIX_FMT_YUVA420P;
+	case VIDEO_FORMAT_I42A:
+		return AV_PIX_FMT_YUVA422P;
+	case VIDEO_FORMAT_YUVA:
+		return AV_PIX_FMT_YUVA444P;
 	}
 
 	return AV_PIX_FMT_NONE;
@@ -66,6 +72,12 @@ ffmpeg_to_obs_video_format(enum AVPixelFormat format)
 		return VIDEO_FORMAT_BGR3;
 	case AV_PIX_FMT_YUV422P:
 		return VIDEO_FORMAT_I422;
+	case AV_PIX_FMT_YUVA420P:
+		return VIDEO_FORMAT_I40A;
+	case AV_PIX_FMT_YUVA422P:
+		return VIDEO_FORMAT_I42A;
+	case AV_PIX_FMT_YUVA444P:
+		return VIDEO_FORMAT_YUVA;
 	case AV_PIX_FMT_NONE:
 	default:
 		return VIDEO_FORMAT_NONE;


### PR DESCRIPTION
### Description
Enable OBS to convert YUV alpha formats to RGBA on the GPU to free up CPU.

### Motivation and Context
The GPU is much faster at processing images than the CPU.

### How Has This Been Tested?
Breakpoint inspection to verify old path (swscale MMX) has been replaced by new code paths.

Tested dancer1.webm and soccer1.webm from Google blog on Windows and Mac using Media Source. Converted those yuva420p videos to yuva422p and yuva444p using FFmpeg. AYUV tested with custom plugin since FFmpeg does not support.

Performance was measured using a custom plugin source at 1080p.

I40A -> RGBA, 1080p, CPU
swscale (MMX), Intel i7-6700: 1910 us -> 0 us

GPU measurements used Intel GPA with SetStablePowerState.

I40A -> RGBA, 1080p, GPU
Intel HD Graphics 530: 0 us -> 677 us
NVIDIA RTX 2080 Ti: 0 us -> 43 us

### Types of changes
- New feature (non-breaking change which adds functionality)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.