### PR TITLE
deps/media-playback: Add missing header to CMake

### DIFF
--- a/deps/media-playback/CMakeLists.txt
+++ b/deps/media-playback/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(
 	)
 
 set(media-playback_HEADERS
+	media-playback/closest-format.h
 	media-playback/decode.h
 	media-playback/media.h
 	)


### PR DESCRIPTION
### Description
Add closest-format.h to CMake file list.

### Motivation and Context
I use VS solution search frequently, and not having the header in the project results in lost search hits.

### How Has This Been Tested?
VS now lists the header file. Application still runs.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.