### PR TITLE
Revert GS_RGBX changes made as part of #1934

### DIFF
--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -41,8 +41,6 @@ static inline GLenum convert_gs_format(enum gs_color_format format)
 		return GL_RED;
 	case GS_RGBA:
 		return GL_RGBA;
-	case GS_RGBX:
-		return GL_RGBA;
 	case GS_BGRX:
 		return GL_BGRA;
 	case GS_BGRA:
@@ -89,8 +87,6 @@ static inline GLenum convert_gs_internal_format(enum gs_color_format format)
 		return GL_R8;
 	case GS_RGBA:
 		return GL_RGBA;
-	case GS_RGBX:
-		return GL_RGB;
 	case GS_BGRX:
 		return GL_RGB;
 	case GS_BGRA:
@@ -136,8 +132,6 @@ static inline GLenum get_gl_format_type(enum gs_color_format format)
 	case GS_R8:
 		return GL_UNSIGNED_BYTE;
 	case GS_RGBA:
-		return GL_UNSIGNED_BYTE;
-	case GS_RGBX:
 		return GL_UNSIGNED_BYTE;
 	case GS_BGRX:
 		return GL_UNSIGNED_BYTE;

--- a/libobs-opengl/gl-texture2d.c
+++ b/libobs-opengl/gl-texture2d.c
@@ -122,8 +122,7 @@ gs_texture_t *device_texture_create(gs_device_t *device, uint32_t width,
 		did_init =
 			gl_tex_param_i(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
 
-		bool did_unbind =
-			gl_bind_texture(GL_TEXTURE_2D, tex->base.texture);
+		bool did_unbind = gl_bind_texture(GL_TEXTURE_2D, 0);
 		if (!did_init || !did_unbind)
 			goto fail;
 	}

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -58,7 +58,6 @@ enum gs_color_format {
 	GS_A8,
 	GS_R8,
 	GS_RGBA,
-	GS_RGBX,
 	GS_BGRX,
 	GS_BGRA,
 	GS_R10G10B10A2,
@@ -894,8 +893,6 @@ static inline uint32_t gs_get_format_bpp(enum gs_color_format format)
 	case GS_R8:
 		return 8;
 	case GS_RGBA:
-		return 32;
-	case GS_RGBX:
 		return 32;
 	case GS_BGRX:
 		return 32;

--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -303,13 +303,17 @@ static void xcc_cleanup(XCompcapMain_private *p)
 static gs_color_format gs_format_from_tex()
 {
 	GLint iformat = 0;
-	// we can probably fix the intel swapped texture by querying via
-	// GL_ARB_internalformat_query
+	// consider GL_ARB_internalformat_query
 	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT,
 				 &iformat);
+
+	// These formats are known to be wrong on Intel platforms. We intentionally
+	// use swapped internal formats here to preserve historic behavior which
+	// swapped colors accidentally and because D3D11 would not support a
+	// GS_RGBX format
 	switch (iformat) {
 	case GL_RGB:
-		return GS_RGBX;
+		return GS_BGRX;
 	case GL_RGBA:
 		return GS_RGBA;
 	default:


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Revert the GS_RGBX changes which introduced an ABI breaking change and is unsupportable on D3D11 backends (In two steps to preserve a pure revert commit and a separate commit remove from linux-capture).

Fix a typo in DUMMY texture creation introduced in the same PR.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on intel/nvidia/nouveau and it shows no regressions from the committed PR.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
