### PR TITLE
libobs-opengl: Fix gl_error_to_str

### DIFF
--- a/libobs-opengl/gl-helpers.h
+++ b/libobs-opengl/gl-helpers.h
@@ -17,9 +17,12 @@
 
 #pragma once
 
-static char *gl_error_to_str(GLenum errorcode)
+static const char *gl_error_to_str(GLenum errorcode)
 {
-	static void *err_to_str[][2] = {
+	static const struct {
+		GLenum error;
+		const char *str;
+	} err_to_str[] = {
 		{
 			GL_INVALID_ENUM,
 			"GL_INVALID_ENUM",
@@ -48,17 +51,12 @@ static char *gl_error_to_str(GLenum errorcode)
 			GL_STACK_OVERFLOW,
 			"GL_STACK_OVERFLOW",
 		},
-		{
-			NULL,
-			"Unknown",
-		},
 	};
-	int i = 0;
-	while ((GLenum)err_to_str[i][0] != errorcode ||
-	       err_to_str[i][0] == NULL) {
-		i += 2;
+	for (size_t i = 0; i < sizeof(err_to_str) / sizeof(*err_to_str); i++) {
+		if (err_to_str[i].error == errorcode)
+			return err_to_str[i].str;
 	}
-	return err_to_str[i][1];
+	return "Unknown";
 }
 
 /*


### PR DESCRIPTION
### Description
Tweaked function to address some issues: compiler warnings, skipped
entries, and type safety.

### Motivation and Context
Noticed some new compiler warnings, and saw the function wasn't quite operating as intended.

### How Has This Been Tested?
Breakpoint inspection before and after to see entries were being skipped before, and are not skipped now. Compiler output is clean.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.