### PR TITLE
UI: Fix look of extra panels trash icon

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -1002,3 +1002,16 @@ VisibilityCheckBox::indicator:unchecked:hover {
 * [themeID="revertIcon"] {
     qproperty-icon: url(./Dark/revert.svg);
 }
+
+QPushButton#extraPanelDelete {
+     background: transparent;
+     border: none;
+}
+
+QPushButton#extraPanelDelete:hover {
+     background-color: #2a3a75;
+}
+
+QPushButton#extraPanelDelete:pressed {
+    background-color: #161f41;
+}

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -737,3 +737,15 @@ VisibilityCheckBox::indicator:unchecked {
 * [themeID="revertIcon"] {
     qproperty-icon: url(./Dark/revert.svg);
 }
+
+QPushButton#extraPanelDelete {
+    background-color: rgb(31, 30, 31);
+}
+
+QPushButton#extraPanelDelete:hover {
+    background-color: rgb(122,121,122);
+}
+
+QPushButton#extraPanelDelete:pressed {
+    background-color: rgb(31,30,31);
+}

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -1328,3 +1328,15 @@ VisibilityCheckBox::indicator:unchecked:hover {
 * [themeID="revertIcon"] {
     qproperty-icon: url(./Dark/revert.svg);
 }
+
+QPushButton#extraPanelDelete {
+    background-color: rgb(35, 38, 41);
+}
+
+QPushButton#extraPanelDelete:hover {
+     background-color: rgba(145, 76, 103);
+}
+
+QPushButton#extraPanelDelete:pressed {
+     background-color: rgb(240, 98, 146);
+}

--- a/UI/window-extra-browsers.cpp
+++ b/UI/window-extra-browsers.cpp
@@ -150,20 +150,18 @@ void ExtraBrowsersModel::AddDeleteButton(int idx)
 {
 	QTableView *widget = reinterpret_cast<QTableView *>(parent());
 
-	QSizePolicy policy(QSizePolicy::Expanding, QSizePolicy::Expanding,
-			   QSizePolicy::PushButton);
-	policy.setWidthForHeight(true);
-
 	QModelIndex index = createIndex(idx, (int)Column::Delete, nullptr);
 
 	QPushButton *del = new DelButton(index);
 	del->setProperty("themeID", "trashIcon");
-	del->setSizePolicy(policy);
-	del->setFlat(true);
+	del->setObjectName("extraPanelDelete");
+	del->setFixedSize(QSize(20, 20));
 	connect(del, &QPushButton::clicked, this,
 		&ExtraBrowsersModel::DeleteItem);
 
 	widget->setIndexWidget(index, del);
+	widget->setRowHeight(idx, 20);
+	widget->setColumnWidth(idx, 20);
 }
 
 void ExtraBrowsersModel::CheckToAdd()


### PR DESCRIPTION
### Description
This makes the trash icon background transparent in the extra browser panels dialog. I also fixed an issue where the button would change size when a new panel was added.

### Motivation and Context
It makes it look more consistent with the UI.

### How Has This Been Tested?
Ran program, everything looked like it should.

### Types of changes
UI change (change look of UI)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
