### PR TITLE
libobs: Fix dark lines using Lanczos

### DIFF
--- a/libobs/data/lanczos_scale.effect
+++ b/libobs/data/lanczos_scale.effect
@@ -111,6 +111,16 @@ float4 DrawLanczos(FragData f_in, bool undistort)
 	float3 coltap024 = weight3(f_rev_half.y);
 	float3 coltap135 = weight3(f_rev_half.y + 0.5);
 
+	// Need normalization if divided value near zero
+	float rowsum = rowtap024.x + rowtap024.y + rowtap024.z;
+	rowsum += rowtap135.x + rowtap135.y + rowtap135.z;
+	rowtap024 = rowtap024 / rowsum;
+	rowtap135 = rowtap135 / rowsum;
+	float colsum = coltap024.x + coltap024.y + coltap024.z;
+	colsum += coltap135.x + coltap135.y + coltap135.z;
+	coltap024 = coltap024 / colsum;
+	coltap135 = coltap135 / colsum;
+
 	float2 uv0 = (-2.5 - f) * stepxy + pos;
 	float2 uv1 = uv0 + stepxy;
 	float2 uv2 = uv1 + stepxy;


### PR DESCRIPTION
### Description
When texel samples are not exactly on texel centers, weight calculations
will involve a divide by a number very close to zero, resulting in
precision issues. Restore normalization of weights to compensate.

### Motivation and Context
Dark lines were seen using Lanczos with specific resolutions.

### How Has This Been Tested?
Tested 2560x1440 -> 1536x864 before and after. Dark lines are gone.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.