### PR TITLE
libobs: Remove unnecessary divides from Lanczos

### DIFF
--- a/libobs/data/lanczos_scale.effect
+++ b/libobs/data/lanczos_scale.effect
@@ -112,14 +112,16 @@ float4 DrawLanczos(FragData f_in, bool undistort)
 	float3 coltap135 = weight3(f_rev_half.y + 0.5);
 
 	// Need normalization if divided value near zero
-	float rowsum = rowtap024.x + rowtap024.y + rowtap024.z;
-	rowsum += rowtap135.x + rowtap135.y + rowtap135.z;
-	rowtap024 = rowtap024 / rowsum;
-	rowtap135 = rowtap135 / rowsum;
-	float colsum = coltap024.x + coltap024.y + coltap024.z;
-	colsum += coltap135.x + coltap135.y + coltap135.z;
-	coltap024 = coltap024 / colsum;
-	coltap135 = coltap135 / colsum;
+	float rowsum = rowtap024.x + rowtap024.y + rowtap024.z +
+		rowtap135.x + rowtap135.y + rowtap135.z;
+	float rowsum_i = 1.0 / rowsum;
+	rowtap024 = rowtap024 * rowsum_i;
+	rowtap135 = rowtap135 * rowsum_i;
+	float colsum = coltap024.x + coltap024.y + coltap024.z +
+		coltap135.x + coltap135.y + coltap135.z;
+	float colsum_i = 1.0 / colsum;
+	coltap024 = coltap024 * colsum_i;
+	coltap135 = coltap135 * colsum_i;
 
 	float2 uv0 = (-2.5 - f) * stepxy + pos;
 	float2 uv1 = uv0 + stepxy;


### PR DESCRIPTION
### Description
Remove some divides that I meant to remove earlier.

### Motivation and Context
Reciprocal operations are very expensive, and it's better to be explicit than trust the compiler when possible.

### How Has This Been Tested?
Tested Lanczos still works 2560x1440 -> 1536x864

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.