### PR TITLE
libobs: UI: Add Area for downscale output

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -786,6 +786,7 @@ Basic.Settings.Video.DisableAero="Disable Aero"
 Basic.Settings.Video.DownscaleFilter.Bilinear="Bilinear (Fastest, but blurry if scaling)"
 Basic.Settings.Video.DownscaleFilter.Bicubic="Bicubic (Sharpened scaling, 16 samples)"
 Basic.Settings.Video.DownscaleFilter.Lanczos="Lanczos (Sharpened scaling, 36 samples)"
+Basic.Settings.Video.DownscaleFilter.Area="Area (Weighted sum, 1/2/4 samples)"
 
 # basic mode 'audio' settings
 Basic.Settings.Audio="Audio"

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3447,6 +3447,8 @@ static inline enum obs_scale_type GetScaleType(ConfigFile &basicConfig)
 		return OBS_SCALE_BILINEAR;
 	else if (astrcmpi(scaleTypeStr, "lanczos") == 0)
 		return OBS_SCALE_LANCZOS;
+	else if (astrcmpi(scaleTypeStr, "area") == 0)
+		return OBS_SCALE_AREA;
 	else
 		return OBS_SCALE_BICUBIC;
 }

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1333,6 +1333,9 @@ void OBSBasicSettings::LoadDownscaleFilters()
 	ui->downscaleFilter->addItem(
 		QTStr("Basic.Settings.Video.DownscaleFilter.Lanczos"),
 		QT_UTF8("lanczos"));
+	ui->downscaleFilter->addItem(
+		QTStr("Basic.Settings.Video.DownscaleFilter.Area"),
+		QT_UTF8("area"));
 
 	const char *scaleType =
 		config_get_string(main->Config(), "Video", "ScaleType");
@@ -1341,6 +1344,8 @@ void OBSBasicSettings::LoadDownscaleFilters()
 		ui->downscaleFilter->setCurrentIndex(0);
 	else if (astrcmpi(scaleType, "lanczos") == 0)
 		ui->downscaleFilter->setCurrentIndex(2);
+	else if (astrcmpi(scaleType, "area") == 0)
+		ui->downscaleFilter->setCurrentIndex(3);
 	else
 		ui->downscaleFilter->setCurrentIndex(1);
 }

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -168,6 +168,8 @@ get_scale_effect_internal(struct obs_core_video *video)
 		return video->default_effect;
 	case OBS_SCALE_LANCZOS:
 		return video->lanczos_effect;
+	case OBS_SCALE_AREA:
+		return video->area_effect;
 	case OBS_SCALE_BICUBIC:
 	default:;
 	}


### PR DESCRIPTION
### Description
Add Area scaling for downscale output. Previously only available for scene items and scale filter.

### Motivation and Context
Now that Lanczos downscale blurring has been removed, the Area shader can attempt to fill the void. We may see user reports of people wanting a blurring downscale where Bilinear doesn't do the job.

### How Has This Been Tested?
Verified Area and Lanczos menu selections work.
Verified in RenderDoc that the correct shaders were being used.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.