### PR TITLE
UI: Fix Area sample count text

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -786,7 +786,7 @@ Basic.Settings.Video.DisableAero="Disable Aero"
 Basic.Settings.Video.DownscaleFilter.Bilinear="Bilinear (Fastest, but blurry if scaling)"
 Basic.Settings.Video.DownscaleFilter.Bicubic="Bicubic (Sharpened scaling, 16 samples)"
 Basic.Settings.Video.DownscaleFilter.Lanczos="Lanczos (Sharpened scaling, 36 samples)"
-Basic.Settings.Video.DownscaleFilter.Area="Area (Weighted sum, 1/2/4 samples)"
+Basic.Settings.Video.DownscaleFilter.Area="Area (Weighted sum, 4/6/9 samples)"
 
 # basic mode 'audio' settings
 Basic.Settings.Audio="Audio"


### PR DESCRIPTION
### Description
Downscale will either fetch 2x2, 2x3, 3x2, or 3x3 texels.

### Motivation and Context
Originally thought it would be 1x1, 1x2, 2x1, or 2x2 texels, but I'm pretty sure the new values are correct.

### How Has This Been Tested?
Verified menu text has been updated.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.