### PR TITLE
libobs-d3d11: Disable NV12 usage for Intel

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -390,6 +390,11 @@ void gs_device::InitDevice(uint32_t adapterIdx)
 
 	nv12Supported = false;
 
+	/* Intel CopyResource is very slow with NV12 */
+	if (desc.VendorId == 0x8086) {
+		return;
+	}
+
 	ComQIPtr<ID3D11Device1> d3d11_1(device);
 	if (!d3d11_1) {
 		return;


### PR DESCRIPTION
### Description
NV12 GPU copies to staging textures for CPU read take a ridiculously
long time on my integrated Intel GPU. Using R8/R8G8 instead seems to be
a huge speed-up.

### Motivation and Context
Intel GPU needs all the help it can get, and this appears to be a big win for NV12 output.

### How Has This Been Tested?
Verified x264 and NVENC with my NVIDIA card still works with Intel as primary. Also verified NVENC new still works with NVIDIA as primary.

Intel HD Graphics 530, D3D11 query timings, SetStablePowerState

NV12: ~3268 us (minimum of wild timings)
R8/R8G8: ~781 us (most frequently occurring timing)

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.