### PR TITLE
cmake: Fix SWIG deprecation warnings

### DIFF
--- a/deps/obs-scripting/obslua/CMakeLists.txt
+++ b/deps/obs-scripting/obslua/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 project(obslua)
 
+if(POLICY CMP0078)
+	cmake_policy(SET CMP0078 OLD)
+endif()
+
 find_package(SWIG 2 REQUIRED)
 include(${SWIG_USE_FILE})
 
@@ -16,7 +20,14 @@ endif()
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/libobs")
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-SWIG_ADD_MODULE(obslua lua obslua.i ../cstrcache.cpp ../cstrcache.h)
+if(CMAKE_VERSION VERSION_GREATER 3.7.2)
+	SWIG_ADD_LIBRARY(obslua
+		LANGUAGE lua
+		TYPE MODULE
+		SOURCES obslua.i ../cstrcache.cpp ../cstrcache.h)
+else()
+	SWIG_ADD_MODULE(obslua lua obslua.i ../cstrcache.cpp ../cstrcache.h)
+endif()
 SWIG_LINK_LIBRARIES(obslua obs-scripting libobs ${LUA_LIBRARIES} ${EXTRA_LIBS})
 
 function(install_plugin_bin_swig target additional_target)

--- a/deps/obs-scripting/obspython/CMakeLists.txt
+++ b/deps/obs-scripting/obspython/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 project(obspython)
 
+if(POLICY CMP0078)
+	cmake_policy(SET CMP0078 OLD)
+endif()
+
 find_package(SWIG 2 REQUIRED)
 include(${SWIG_USE_FILE})
 
@@ -30,7 +34,14 @@ if(WIN32)
 	string(REGEX REPLACE "_d" "" PYTHON_LIBRARIES "${PYTHON_LIBRARIES}")
 endif()
 
-SWIG_ADD_MODULE(obspython python obspython.i ../cstrcache.cpp ../cstrcache.h)
+if(CMAKE_VERSION VERSION_GREATER 3.7.2)
+	SWIG_ADD_LIBRARY(obspython
+		LANGUAGE python
+		TYPE MODULE
+		SOURCES  obspython.i ../cstrcache.cpp ../cstrcache.h)
+else()
+	SWIG_ADD_MODULE(obspython python obspython.i ../cstrcache.cpp ../cstrcache.h)
+endif()
 SWIG_LINK_LIBRARIES(obspython obs-scripting libobs ${PYTHON_LIBRARIES})
 
 function(install_plugin_bin_swig target additional_target)


### PR DESCRIPTION
### Description

This PR fixes some warnings that are produced when building with CMake 3.13 and above.

### Motivation and Context

When building with CMake 3.13, I get the following warnings: 

```
-- Found SWIG: /usr/bin/swig3.0 (found suitable version "3.0.12", minimum required is "2")
CMake Deprecation Warning at /usr/share/cmake-3.13/Modules/UseSWIG.cmake:524 (message):
  SWIG_ADD_MODULE is deprecated.  Use SWIG_ADD_LIBRARY instead.
Call Stack (most recent call first):
  deps/obs-scripting/obspython/CMakeLists.txt:33 (SWIG_ADD_MODULE)


CMake Warning (dev) at /usr/share/cmake-3.13/Modules/UseSWIG.cmake:564 (message):
  Policy CMP0078 is not set.  Run "cmake --help-policy CMP0078" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.
Call Stack (most recent call first):
  /usr/share/cmake-3.13/Modules/UseSWIG.cmake:525 (swig_add_library)
  deps/obs-scripting/obspython/CMakeLists.txt:33 (SWIG_ADD_MODULE)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Deprecation Warning at /usr/share/cmake-3.13/Modules/UseSWIG.cmake:524 (message):
  SWIG_ADD_MODULE is deprecated.  Use SWIG_ADD_LIBRARY instead.
Call Stack (most recent call first):
  deps/obs-scripting/obslua/CMakeLists.txt:19 (SWIG_ADD_MODULE)


CMake Warning (dev) at /usr/share/cmake-3.13/Modules/UseSWIG.cmake:564 (message):
  Policy CMP0078 is not set.  Run "cmake --help-policy CMP0078" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.
Call Stack (most recent call first):
  /usr/share/cmake-3.13/Modules/UseSWIG.cmake:525 (swig_add_library)
  deps/obs-scripting/obslua/CMakeLists.txt:19 (SWIG_ADD_MODULE)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

These were a source of frustration when working on other aspects of the project that touched CMake, because they show up every time a reconfigure happens.

### How Has This Been Tested?

Rebuilt and installed the project. Went to Tools → Scripts, added a python script and a lua script individually, and verified that both scripts worked as previously. Has not been tested with all older versions of CMake (according to the `cmake_minimum_version` statements across the project it should work back to CMake 3.2, CI only goes back to 3.5).

### Types of changes

Code cleanup in CMakeLists.txt for obslua and obspython.

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
