### PR TITLE
libobs-opengl: Fix Clang warnings

### DIFF
--- a/libobs-opengl/gl-helpers.h
+++ b/libobs-opengl/gl-helpers.h
@@ -78,8 +78,8 @@ static inline bool gl_success(const char *funcname)
 
 			--attempts;
 			if (attempts == 0) {
-				blog(LOG_ERROR, "Too many GL errors, moving on",
-				     funcname, errorcode);
+				blog(LOG_ERROR,
+				     "Too many GL errors, moving on");
 				break;
 			}
 		} while (errorcode != GL_NO_ERROR);

--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -388,6 +388,8 @@ device_samplerstate_create(gs_device_t *device,
 
 gs_timer_t *device_timer_create(gs_device_t *device)
 {
+	UNUSED_PARAMETER(device);
+
 	struct gs_timer *timer;
 
 	GLuint queries[2];
@@ -404,6 +406,8 @@ gs_timer_t *device_timer_create(gs_device_t *device)
 
 gs_timer_range_t *device_timer_range_create(gs_device_t *device)
 {
+	UNUSED_PARAMETER(device);
+
 	return NULL;
 }
 
@@ -1504,15 +1508,26 @@ bool gs_timer_get_data(gs_timer_t *timer, uint64_t *ticks)
 	return true;
 }
 
-void gs_timer_range_destroy(gs_timer_range_t *range) {}
+void gs_timer_range_destroy(gs_timer_range_t *range)
+{
+	UNUSED_PARAMETER(range);
+}
 
-void gs_timer_range_begin(gs_timer_range_t *range) {}
+void gs_timer_range_begin(gs_timer_range_t *range)
+{
+	UNUSED_PARAMETER(range);
+}
 
-void gs_timer_range_end(gs_timer_range_t *range) {}
+void gs_timer_range_end(gs_timer_range_t *range)
+{
+	UNUSED_PARAMETER(range);
+}
 
 bool gs_timer_range_get_data(gs_timer_range_t *range, bool *disjoint,
 			     uint64_t *frequency)
 {
+	UNUSED_PARAMETER(range);
+
 	*disjoint = false;
 	*frequency = 1000000000;
 	return true;


### PR DESCRIPTION
### Description
Fix Clang warnings in libobs-opengl.

### Motivation and Context
Noticed a bunch of warnings when compiling from Xcode.

### How Has This Been Tested?
Code builds clean in VS and Xcode. OpenGL path still draws to screen.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.