### PR TITLE
UI, libobs: Fix compiler warnings

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -650,13 +650,15 @@ void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 
 			std::lock_guard<std::mutex> lock(selectMutex);
 			if (altDown || ctrlDown || shiftDown) {
-				for (int i = 0; i < selectedItems.size(); i++) {
+				for (size_t i = 0; i < selectedItems.size();
+				     i++) {
 					obs_sceneitem_select(selectedItems[i],
 							     true);
 				}
 			}
 
-			for (int i = 0; i < hoveredPreviewItems.size(); i++) {
+			for (size_t i = 0; i < hoveredPreviewItems.size();
+			     i++) {
 				bool select = true;
 				obs_sceneitem_t *item = hoveredPreviewItems[i];
 
@@ -1677,7 +1679,7 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *scene,
 	bool hovered = false;
 	{
 		std::lock_guard<std::mutex> lock(prev->selectMutex);
-		for (int i = 0; i < prev->hoveredPreviewItems.size(); i++) {
+		for (size_t i = 0; i < prev->hoveredPreviewItems.size(); i++) {
 			if (prev->hoveredPreviewItems[i] == item) {
 				hovered = true;
 				break;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -139,6 +139,8 @@ static bool obs_init_gpu_conversion(struct obs_video_info *ovi)
 			if (!video->convert_textures[2])
 				return false;
 			break;
+		default:
+			break;
 		}
 #ifdef _WIN32
 	}
@@ -189,6 +191,8 @@ static bool obs_init_gpu_copy_surfaces(struct obs_video_info *ovi, size_t i)
 			ovi->output_width, ovi->output_height, GS_R8);
 		if (!video->copy_surfaces[i][2])
 			return false;
+		break;
+	default:
 		break;
 	}
 


### PR DESCRIPTION
### Description
This fixes some compiler warnings.

### Motivation and Context
Makes the compiling process less spammy.

### How Has This Been Tested?
Recompiled program, warnings didn't show up anymore. Everything still works.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
