### PR TITLE
obs-ffmpeg: Set some parameters for dynamic bitrate in new nvenc

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -243,7 +243,8 @@ static bool nvenc_update(void *data, obs_data_t *settings)
 		params.resetEncoder = 1;
 		params.forceIDR = 1;
 
-		if (FAILED(nv.nvEncReconfigureEncoder(enc->session, &params))) {
+		if (NV_FAILED(nv.nvEncReconfigureEncoder(enc->session,
+							 &params))) {
 			return false;
 		}
 	}

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -240,6 +240,8 @@ static bool nvenc_update(void *data, obs_data_t *settings)
 		NV_ENC_RECONFIGURE_PARAMS params = {0};
 		params.version = NV_ENC_RECONFIGURE_PARAMS_VER;
 		params.reInitEncodeParams = enc->params;
+		params.resetEncoder = 1;
+		params.forceIDR = 1;
 
 		if (FAILED(nv.nvEncReconfigureEncoder(enc->session, &params))) {
 			return false;


### PR DESCRIPTION
### Description
This sets some nvenc API parameters used when the encoder is reconfigured, as when the bitrate is changed (dynamic bitrate).

### Motivation and Context
It has been reported that jim-nvenc with dynamic bitrate sometimes gets stalled mid-stream.
This does not occur with ffmpeg nvenc.
I've set additional parameters which I used with Timo when we implemented dynamic bitrate support in ffmpeg for nvenc.

### How Has This Been Tested?
This has been tested on windows 10 with a Turing GPU.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
- Performance enhancement (non-breaking change which improves efficiency) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
