### PR TITLE
libobs: add pointer check in reset_raw_output

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2035,32 +2035,36 @@ static bool begin_delayed_capture(obs_output_t *output)
 
 static void reset_raw_output(obs_output_t *output)
 {
-	const struct audio_output_info *aoi =
-		audio_output_get_info(output->audio);
-	struct audio_convert_info conv = output->audio_conversion;
-	struct audio_convert_info info = {
-		aoi->samples_per_sec,
-		aoi->format,
-		aoi->speakers,
-	};
-
 	clear_audio_buffers(output);
 
-	if (output->audio_conversion_set) {
-		if (conv.samples_per_sec)
-			info.samples_per_sec = conv.samples_per_sec;
-		if (conv.format != AUDIO_FORMAT_UNKNOWN)
-			info.format = conv.format;
-		if (conv.speakers != SPEAKERS_UNKNOWN)
-			info.speakers = conv.speakers;
+	if (output->audio) {
+		const struct audio_output_info *aoi =
+			audio_output_get_info(output->audio);
+		struct audio_convert_info conv = output->audio_conversion;
+		struct audio_convert_info info = {
+			aoi->samples_per_sec,
+			aoi->format,
+			aoi->speakers,
+		};
+
+		if (output->audio_conversion_set) {
+			if (conv.samples_per_sec)
+				info.samples_per_sec = conv.samples_per_sec;
+			if (conv.format != AUDIO_FORMAT_UNKNOWN)
+				info.format = conv.format;
+			if (conv.speakers != SPEAKERS_UNKNOWN)
+				info.speakers = conv.speakers;
+		}
+
+		output->sample_rate = info.samples_per_sec;
+		output->planes = get_audio_planes(info.format, info.speakers);
+		output->total_audio_frames = 0;
+		output->audio_size =
+			get_audio_size(info.format, info.speakers, 1);
 	}
 
 	output->audio_start_ts = 0;
 	output->video_start_ts = 0;
-	output->sample_rate = info.samples_per_sec;
-	output->planes = get_audio_planes(info.format, info.speakers);
-	output->total_audio_frames = 0;
-	output->audio_size = get_audio_size(info.format, info.speakers, 1);
 
 	pause_reset(&output->pause);
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Fixes a possible null pointer access in the `reset_raw_output` function of outputs.

### Motivation and Context

In libobs, if the audio component of an output is set to `nullptr` (through `obs_output_set_media`), the program will crash when starting an output. The crash happens in a function called `reset_raw_output`, which belongs to `obs-output.c`.

The `reset_raw_output` internal function of `obs-output.c` calls `audio_output_get_info` with a pointer to an audio component (`audio_t`) as its only parameter, and returns a pointer to information about this component. If the parameter is null, `audio_output_get_info` returns null.

However, the code that comes after the call to `audio_output_get_info` doesn't check if the returned pointer is valid. If it's not, the program crashes.

This PR fixes this issue.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on Windows 10 64-bit (version 1903) with obs-ndi 4.6.0 as the source of the crash.

### Types of changes

Bug fix

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [x] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
