### PR TITLE
libobs-opengl: Implement shared textures

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -2357,7 +2357,7 @@ extern "C" EXPORT bool device_gdi_texture_available(void)
 	return true;
 }
 
-extern "C" EXPORT bool device_shared_texture_available(void)
+bool device_shared_texture_available(void)
 {
 	return true;
 }

--- a/libobs-opengl/gl-helpers.h
+++ b/libobs-opengl/gl-helpers.h
@@ -167,6 +167,13 @@ static inline bool gl_tex_param_i(GLenum target, GLenum param, GLint val)
 	return gl_success("glTexParameteri");
 }
 
+static inline GLint gl_get_tex_param_iv(GLenum target, GLint level,
+					GLenum param, GLint *store)
+{
+	glGetTexLevelParameteriv(target, level, param, store);
+	return gl_success("glGetTexParameteriv");
+}
+
 static inline bool gl_active_texture(GLenum texture_id)
 {
 	glActiveTexture(texture_id);

--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -215,6 +215,11 @@ const char *device_preprocessor_name(void)
 	return "_OPENGL";
 }
 
+bool device_shared_texture_available(void)
+{
+	return true;
+}
+
 int device_create(gs_device_t **p_device, uint32_t adapter)
 {
 	struct gs_device *device = bzalloc(sizeof(struct gs_device));

--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -124,6 +124,48 @@ static inline GLenum convert_gs_internal_format(enum gs_color_format format)
 	return 0;
 }
 
+static inline enum gs_color_format convert_gl_internal_format(GLenum format)
+{
+	switch (format) {
+	case GL_R8:
+		return GS_R8;
+	case GL_RGBA:
+		return GS_RGBA;
+	case GL_RGB:
+		return GS_BGRX;
+	case GL_BGRA:
+		return GS_RGBA;
+	case GL_RGB10_A2:
+		return GS_R10G10B10A2;
+	case GL_RGBA16:
+		return GS_RGBA16;
+	case GL_R16:
+		return GS_R16;
+	case GL_RGBA16F:
+		return GS_RGBA16F;
+	case GL_RGBA32F:
+		return GS_RGBA32F;
+	case GL_RG16F:
+		return GS_RG16F;
+	case GL_RG32F:
+		return GS_RG32F;
+	case GL_RG8:
+		return GS_R8G8;
+	case GL_R16F:
+		return GS_R16F;
+	case GL_R32F:
+		return GS_R32F;
+	case GL_COMPRESSED_RGBA_S3TC_DXT1_EXT:
+		return GS_DXT1;
+	case GL_COMPRESSED_RGBA_S3TC_DXT3_EXT:
+		return GS_DXT3;
+	case GL_COMPRESSED_RGBA_S3TC_DXT5_EXT:
+		return GS_DXT5;
+	default:
+		return GS_UNKNOWN;
+	}
+}
+
 static inline GLenum get_gl_format_type(enum gs_color_format format)
 {
 	switch (format) {
@@ -512,6 +554,7 @@ struct gs_texture {
 	bool is_dynamic;
 	bool is_render_target;
 	bool is_dummy;
+	bool is_shared;
 	bool gen_mipmaps;
 
 	gs_samplerstate_t *cur_sampler;

--- a/libobs-opengl/gl-windows.c
+++ b/libobs-opengl/gl-windows.c
@@ -593,8 +593,3 @@ EXPORT bool device_gdi_texture_available(void)
 {
 	return false;
 }
-
-EXPORT bool device_shared_texture_available(void)
-{
-	return false;
-}

--- a/libobs/graphics/device-exports.h
+++ b/libobs/graphics/device-exports.h
@@ -163,6 +163,7 @@ EXPORT void device_debug_marker_begin(gs_device_t *device,
 				      const char *markername,
 				      const float color[4]);
 EXPORT void device_debug_marker_end(gs_device_t *device);
+EXPORT bool device_shared_texture_available(void);
 
 #ifdef __cplusplus
 }

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -122,6 +122,8 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT(gs_texture_unmap);
 	GRAPHICS_IMPORT_OPTIONAL(gs_texture_is_rect);
 	GRAPHICS_IMPORT(gs_texture_get_obj);
+	GRAPHICS_IMPORT(device_texture_open_shared);
+	GRAPHICS_IMPORT(device_texture_get_shared_handle);
 
 	GRAPHICS_IMPORT(gs_cubetexture_destroy);
 	GRAPHICS_IMPORT(gs_cubetexture_get_size);
@@ -186,6 +188,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT(gs_shader_set_next_sampler);
 
 	GRAPHICS_IMPORT_OPTIONAL(device_nv12_available);
+	GRAPHICS_IMPORT(device_shared_texture_available);
 
 	GRAPHICS_IMPORT(device_debug_marker_begin);
 	GRAPHICS_IMPORT(device_debug_marker_end);
@@ -198,7 +201,6 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	/* win32 specific functions */
 #elif _WIN32
 	GRAPHICS_IMPORT(device_gdi_texture_available);
-	GRAPHICS_IMPORT(device_shared_texture_available);
 	GRAPHICS_IMPORT_OPTIONAL(device_get_duplicator_monitor_info);
 	GRAPHICS_IMPORT_OPTIONAL(device_duplicator_create);
 	GRAPHICS_IMPORT_OPTIONAL(gs_duplicator_destroy);
@@ -207,8 +209,6 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_create_gdi);
 	GRAPHICS_IMPORT_OPTIONAL(gs_texture_get_dc);
 	GRAPHICS_IMPORT_OPTIONAL(gs_texture_release_dc);
-	GRAPHICS_IMPORT_OPTIONAL(device_texture_open_shared);
-	GRAPHICS_IMPORT_OPTIONAL(device_texture_get_shared_handle);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_acquire_sync);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_release_sync);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_create_nv12);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -179,6 +179,9 @@ struct gs_exports {
 	void (*gs_texture_unmap)(gs_texture_t *tex);
 	bool (*gs_texture_is_rect)(const gs_texture_t *tex);
 	void *(*gs_texture_get_obj)(const gs_texture_t *tex);
+	gs_texture_t *(*device_texture_open_shared)(gs_device_t *device,
+						    uint32_t handle);
+	uint32_t (*device_texture_get_shared_handle)(gs_texture_t *tex);
 
 	void (*gs_cubetexture_destroy)(gs_texture_t *cubetex);
 	uint32_t (*gs_cubetexture_get_size)(const gs_texture_t *cubetex);
@@ -260,6 +263,7 @@ struct gs_exports {
 					   gs_samplerstate_t *sampler);
 
 	bool (*device_nv12_available)(gs_device_t *device);
+	bool (*device_shared_texture_available)(void);
 
 	void (*device_debug_marker_begin)(gs_device_t *device,
 					  const char *markername,
@@ -275,7 +279,6 @@ struct gs_exports {
 
 #elif _WIN32
 	bool (*device_gdi_texture_available)(void);
-	bool (*device_shared_texture_available)(void);
 
 	bool (*device_get_duplicator_monitor_info)(
 		gs_device_t *device, int monitor_idx,
@@ -295,9 +298,6 @@ struct gs_exports {
 	void *(*gs_texture_get_dc)(gs_texture_t *gdi_tex);
 	void (*gs_texture_release_dc)(gs_texture_t *gdi_tex);
 
-	gs_texture_t *(*device_texture_open_shared)(gs_device_t *device,
-						    uint32_t handle);
-	uint32_t (*device_texture_get_shared_handle)(gs_texture_t *tex);
 	int (*device_texture_acquire_sync)(gs_texture_t *tex, uint64_t key,
 					   uint32_t ms);
 	int (*device_texture_release_sync)(gs_texture_t *tex, uint64_t key);


### PR DESCRIPTION
### Description
Implement `device_texture_open_shared`, `device_texture_get_shared_handle` in `libobs-opengl`, change these functions to be platform-independent instead of win32 only. This allows the API function `gs_texture_open_shared` to function on OSX and Linux.

Note that the OpenGL implementation simply instantiates a `gs_texture_t` with the underlying handle, and infers the texture format and size using `glGetTexLevelParameteriv` (added `gl_get_tex_param_iv` to `gl-helpers.h` for conformity) similar to the D3D implementation.

`device_texture_get_shared_handle` simply returns the underlying texture since there is no shared handle unlike D3D.

OpenGL does not have a strict concept of shared textures, so this function can be used with either GLX/EGL sharelists with a separate context or plugin-provided GL textures using OBS's context using the newly added `device_get_device_obj` in bf41fd5a (thanks @jp9000).

### Motivation and Context
This is part of a discord discussion with Jim to allow plugins to interact with scene primitives in an API stable manner. The status quo requires [very hacky workarounds](https://github.com/wacossusca34/glava/blob/master/glava-obs/entry.c).

It is currently possible to assign the underlying texture using the pointer returned from `gs_texture_get_obj`, however this causes issues with `gs_texture_destroy` as it will blindly destroy the underlying buffer and texture since there is no way to indicate the associated resource is external, meaning the application has to _restore the old texture handle_ to avoid double-frees and resource leaks.

The best way is currently to _ignore_ OBS rendering primitives and just use GL calls directly to render a texture.

`gs_texture_open_shared` would be a much better way of doing this, yet it's currently a D3D specific function. This patch fixes that.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
