### PR TITLE
Frontend API: provide a "transition duration changed" event

### DIFF
--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -47,6 +47,8 @@ enum obs_frontend_event {
 
 	OBS_FRONTEND_EVENT_RECORDING_PAUSED,
 	OBS_FRONTEND_EVENT_RECORDING_UNPAUSED,
+
+	OBS_FRONTEND_EVENT_TRANSITION_DURATION_CHANGED,
 };
 
 /* ------------------------------------------------------------------------- */

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -616,6 +616,15 @@ void OBSBasic::on_transitionProps_clicked()
 	menu.exec(QCursor::pos());
 }
 
+void OBSBasic::on_transitionDuration_valueChanged(int value)
+{
+	if (api) {
+		api->on_event(OBS_FRONTEND_EVENT_TRANSITION_DURATION_CHANGED);
+	}
+
+	UNUSED_PARAMETER(value);
+}
+
 QuickTransition *OBSBasic::GetQuickTransition(int id)
 {
 	for (QuickTransition &qt : quickTransitions) {

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -788,6 +788,7 @@ private slots:
 	void on_transitionAdd_clicked();
 	void on_transitionRemove_clicked();
 	void on_transitionProps_clicked();
+	void on_transitionDuration_valueChanged(int value);
 
 	void on_modeSwitch_clicked();
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR adds the `OBS_FRONTEND_EVENT_TRANSITION_DURATION_CHANGED` event to the Frontend API and ties it to value changes of the global "transition duration" control in the main UI.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The motivation behind this is to complement the transition duration getter and setter functions (`obs_frontend_get_transition_duration` and `obs_frontend_set_transition_duration`) provided by the Frontend API with an event that gives the possibility to keep track of changes on that value.

The context behind this is that I'd like to fix how obs-websocket keeps track of transition duration changes. Currently it's a ugly hack that:
   - Fetches the pointer of the main window from the Frontend API (and casts it to a QMainWindow type)
   - Calls `QWidget::findChild` to find a `QSpinBox` named `transitionDuration`
   - Then connects a signal handler to the `QSpinBox`'s `valueChanged(int)` signal

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on Windows 10 1803 by putting a breakpoint in `OBSBasic::on_transitionDuration_valueChanged(int)`, a conditional breakpoint for event 13 (the number of the `TRANSITION_DURATION_CHANGED` event) in the `api-interface::on_event` internal function of the Frontend API, and making sure these two breakpoints are reached when the transition duration is changed.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
