### PR TITLE
libobs-opengl: Require OpenGL 3.3 instead of 3.2

### DIFF
--- a/libobs-opengl/gl-shaderparser.c
+++ b/libobs-opengl/gl-shaderparser.c
@@ -692,7 +692,7 @@ static bool gl_shader_buildstring(struct gl_shader_parser *glsp)
 		return false;
 	}
 
-	dstr_copy(&glsp->gl_string, "#version 150\n\n");
+	dstr_copy(&glsp->gl_string, "#version 330\n\n");
 	dstr_cat(&glsp->gl_string, "const bool obs_glsl_compile = true;\n\n");
 	gl_write_params(glsp);
 	gl_write_inputs(glsp, main_func);

--- a/libobs-opengl/gl-windows.c
+++ b/libobs-opengl/gl-windows.c
@@ -154,35 +154,37 @@ static inline HGLRC gl_init_basic_context(HDC hdc)
 	return hglrc;
 }
 
-static const int attribs[] = {
-#ifdef _DEBUG
-	WGL_CONTEXT_FLAGS_ARB,        WGL_CONTEXT_DEBUG_BIT_ARB,
-#endif
-	WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_CORE_PROFILE_BIT_ARB, 0, 0};
-
 static inline HGLRC gl_init_context(HDC hdc)
 {
+	static const int attribs[] = {
 #ifdef _DEBUG
-	if (GLAD_WGL_ARB_create_context) {
-		HGLRC hglrc = wglCreateContextAttribsARB(hdc, 0, attribs);
-		if (!hglrc) {
-			blog(LOG_ERROR,
-			     "wglCreateContextAttribsARB failed, "
-			     "%lu",
-			     GetLastError());
-			return NULL;
-		}
-
-		if (!wgl_make_current(hdc, hglrc)) {
-			wglDeleteContext(hglrc);
-			return NULL;
-		}
-
-		return hglrc;
-	}
+		WGL_CONTEXT_FLAGS_ARB,
+		WGL_CONTEXT_DEBUG_BIT_ARB,
 #endif
+		WGL_CONTEXT_PROFILE_MASK_ARB,
+		WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
+		WGL_CONTEXT_MAJOR_VERSION_ARB,
+		3,
+		WGL_CONTEXT_MINOR_VERSION_ARB,
+		3,
+		0,
+		0};
 
-	return gl_init_basic_context(hdc);
+	HGLRC hglrc = wglCreateContextAttribsARB(hdc, 0, attribs);
+	if (!hglrc) {
+		blog(LOG_ERROR,
+		     "wglCreateContextAttribsARB failed, "
+		     "%lu",
+		     GetLastError());
+		return NULL;
+	}
+
+	if (!wgl_make_current(hdc, hglrc)) {
+		wglDeleteContext(hglrc);
+		return NULL;
+	}
+
+	return hglrc;
 }
 
 static bool gl_dummy_context_init(struct dummy_context *dummy)

--- a/libobs-opengl/gl-x11.c
+++ b/libobs-opengl/gl-x11.c
@@ -50,7 +50,7 @@ static const int ctx_attribs[] = {
 	GLX_CONTEXT_MAJOR_VERSION_ARB,
 	3,
 	GLX_CONTEXT_MINOR_VERSION_ARB,
-	2,
+	3,
 	None,
 };
 


### PR DESCRIPTION
### Description
There don't appear to be any GPUs that support 3.2, but not 3.3. GLSL
330 maps to HLSL Shader Model 4, so this will theoretically make shaders
programs less likely to diverge, particularly for behavior around NaNs.

### Motivation and Context
I'm using HLSL SM4 behavior for NaNs, and I think this makes things less likely to regress for OpenGL.

### How Has This Been Tested?
Verified 3.3+/330+ versions printed in log output on Windows (4.6), Mac (4.1), and Ubuntu WSL (3.3). Still requesting 3.2 for Mac, only options are 3.2 and 4.1, with the expectation that we get at least 3.3 back.

Tested Lanczos NaN behavior is as expected, min() returns non-NaN term. Breakpoint-inspected anisotropic extension code paths when implemented (Mac), and not implemented (Ubuntu WSL).

Went through NVIDIA/AMD/Intel GPU lists on Wikipedia to verify there aren't any that only support 3.2.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
