### PR TITLE
obs-qsv11: Remove leftover stack variable

### DIFF
--- a/plugins/obs-qsv11/QSV_Encoder.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder.cpp
@@ -79,8 +79,6 @@ void qsv_encoder_version(unsigned short *major, unsigned short *minor)
 
 qsv_t *qsv_encoder_open(qsv_param_t *pParams)
 {
-	bool false_value = false;
-
 	QSV_Encoder_Internal *pEncoder = new QSV_Encoder_Internal(impl, ver);
 	mfxStatus sts = pEncoder->Open(pParams);
 	if (sts != MFX_ERR_NONE) {


### PR DESCRIPTION
### Description
Removed a leftover stack variable. The code that used it has been removed.

### Motivation and Context
Tired of seeing the warning for it.

### How Has This Been Tested?
Just compiled and ran. Did not actually try to use QSV, but I would be surprised if it broke.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.