### PR TITLE
UI: set names on scenes duplicated for Studio Mode

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -318,7 +318,7 @@ void OBSBasic::TransitionToScene(OBSSource source, bool force, bool direct,
 
 	if (usingPreviewProgram && sceneDuplicationMode) {
 		scene = obs_scene_duplicate(
-			scene, NULL,
+			scene, obs_source_get_name(obs_scene_get_source(scene)),
 			editPropertiesMode ? OBS_SCENE_DUP_PRIVATE_COPY
 					   : OBS_SCENE_DUP_PRIVATE_REFS);
 		source = obs_scene_get_source(scene);
@@ -1210,7 +1210,9 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		obs_scene_t *dup;
 		if (sceneDuplicationMode) {
 			dup = obs_scene_duplicate(
-				curScene, nullptr,
+				curScene,
+				obs_source_get_name(
+					obs_scene_get_source(curScene)),
 				editPropertiesMode
 					? OBS_SCENE_DUP_PRIVATE_COPY
 					: OBS_SCENE_DUP_PRIVATE_REFS);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

When a transition is running and "Duplicate Scenes" is enabled in Studio Mode, the scenes are duplicated without their names and it makes it impossible to know the names of the source and destination scenes.

This PR fixes this behaviour by setting proper names (from their origins) on scenes duplicated by the "Duplicate Scenes" functionality of Studio Mode.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

It started as a [bug report for obs-websocket](https://github.com/Palakis/obs-websocket/issues/259). I think fixing names on duplicated Studio Mode scenes could benefit other plugin developers as well, unless it is an issue or not the right fix for this situation.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on macOS with obs-websocket 4.6.1 and the "Duplicate Scenes" option enabled, watching for the contents of the "from-scene" and "to-scene" properties on the TransitionBegin event.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.