### PR TITLE
obs-filters: Enhance Color Key and Chroma Key filters with perceptual…

### DIFF
--- a/plugins/obs-filters/color-key-filter.c
+++ b/plugins/obs-filters/color-key-filter.c
@@ -13,6 +13,7 @@
 #define SETTING_KEY_COLOR              "key_color"
 #define SETTING_SIMILARITY             "similarity"
 #define SETTING_SMOOTHNESS             "smoothness"
+#define SETTING_COLORSPACE             "color_space"
 
 #define TEXT_OPACITY                   obs_module_text("Opacity")
 #define TEXT_CONTRAST                  obs_module_text("Contrast")
@@ -22,6 +23,7 @@
 #define TEXT_KEY_COLOR                 obs_module_text("KeyColor")
 #define TEXT_SIMILARITY                obs_module_text("Similarity")
 #define TEXT_SMOOTHNESS                obs_module_text("Smoothness")
+#define TEXT_COLORSPACE                obs_module_text("ColorSpace")
 
 /* clang-format on */
 
@@ -38,6 +40,7 @@ struct color_key_filter_data {
 	gs_eparam_t *key_color_param;
 	gs_eparam_t *similarity_param;
 	gs_eparam_t *smoothness_param;
+	gs_eparam_t *color_space_param;
 
 	struct vec4 color;
 	float contrast;
@@ -47,6 +50,7 @@ struct color_key_filter_data {
 	struct vec4 key_color;
 	float similarity;
 	float smoothness;
+	int color_space;
 };
 
 static const char *color_key_name(void *unused)
@@ -84,6 +88,8 @@ static inline void key_settings_update(struct color_key_filter_data *filter,
 {
 	int64_t similarity = obs_data_get_int(settings, SETTING_SIMILARITY);
 	int64_t smoothness = obs_data_get_int(settings, SETTING_SMOOTHNESS);
+	int64_t color_space = obs_data_get_int(settings, SETTING_COLORSPACE);
+
 	uint32_t key_color =
 		(uint32_t)obs_data_get_int(settings, SETTING_KEY_COLOR);
 	const char *key_type =
@@ -95,6 +101,10 @@ static inline void key_settings_update(struct color_key_filter_data *filter,
 		key_color = 0xFF0000;
 	else if (strcmp(key_type, "red") == 0)
 		key_color = 0x0000FF;
+	else if (strcmp(key_type, "yellow") == 0)
+		key_color = 0xFFFF00;
+	else if (strcmp(key_type, "cyan") == 0)
+		key_color = 0x00FFFF;
 	else if (strcmp(key_type, "magenta") == 0)
 		key_color = 0xFF00FF;
 
@@ -102,6 +112,7 @@ static inline void key_settings_update(struct color_key_filter_data *filter,
 
 	filter->similarity = (float)similarity / 1000.0f;
 	filter->smoothness = (float)smoothness / 1000.0f;
+	filter->color_space = (int)color_space;
 }
 
 static void color_key_update(void *data, obs_data_t *settings)
@@ -151,6 +162,8 @@ static void *color_key_create(obs_data_t *settings, obs_source_t *context)
 			filter->effect, "similarity");
 		filter->smoothness_param = gs_effect_get_param_by_name(
 			filter->effect, "smoothness");
+		filter->color_space_param = gs_effect_get_param_by_name(
+			filter->effect, "color_space");
 	}
 
 	obs_leave_graphics();
@@ -181,6 +194,7 @@ static void color_key_render(void *data, gs_effect_t *effect)
 	gs_effect_set_vec4(filter->key_color_param, &filter->key_color);
 	gs_effect_set_float(filter->similarity_param, filter->similarity);
 	gs_effect_set_float(filter->smoothness_param, filter->smoothness);
+	gs_effect_set_int(filter->color_space_param, filter->color_space);
 
 	obs_source_process_filter_end(filter->context, filter->effect, 0, 0);
 
@@ -211,13 +225,24 @@ static obs_properties_t *color_key_properties(void *data)
 	obs_property_list_add_string(p, obs_module_text("Green"), "green");
 	obs_property_list_add_string(p, obs_module_text("Blue"), "blue");
 	obs_property_list_add_string(p, obs_module_text("Red"), "red");
+	obs_property_list_add_string(p, obs_module_text("Yellow"), "yellow");
+	obs_property_list_add_string(p, obs_module_text("Cyan"), "cyan");
 	obs_property_list_add_string(p, obs_module_text("Magenta"), "magenta");
+
 	obs_property_list_add_string(p, obs_module_text("CustomColor"),
 				     "custom");
 
 	obs_property_set_modified_callback(p, key_type_changed);
-
 	obs_properties_add_color(props, SETTING_KEY_COLOR, TEXT_KEY_COLOR);
+
+	obs_property_t *t = obs_properties_add_list(props, SETTING_COLORSPACE,
+						    TEXT_COLORSPACE,
+						    OBS_COMBO_TYPE_LIST,
+						    OBS_COMBO_FORMAT_INT);
+	obs_property_list_add_int(t, "RGB", 0);
+	obs_property_list_add_int(t, "LAB", 1);
+	obs_property_list_add_int(t, "DE2000", 2);
+
 	obs_properties_add_int_slider(props, SETTING_SIMILARITY,
 				      TEXT_SIMILARITY, 1, 1000, 1);
 	obs_properties_add_int_slider(props, SETTING_SMOOTHNESS,
@@ -246,6 +271,7 @@ static void color_key_defaults(obs_data_t *settings)
 	obs_data_set_default_string(settings, SETTING_COLOR_TYPE, "green");
 	obs_data_set_default_int(settings, SETTING_SIMILARITY, 80);
 	obs_data_set_default_int(settings, SETTING_SMOOTHNESS, 50);
+	obs_data_set_default_int(settings, SETTING_COLORSPACE, 1);
 }
 
 struct obs_source_info color_key_filter = {

--- a/plugins/obs-filters/data/chroma_key_filter.effect
+++ b/plugins/obs-filters/data/chroma_key_filter.effect
@@ -11,11 +11,12 @@ uniform float contrast;
 uniform float brightness;
 uniform float gamma;
 
-uniform float2 chroma_key;
+uniform float4 chroma_key;
 uniform float2 pixel_size;
 uniform float similarity;
 uniform float smoothness;
 uniform float spill;
+uniform int color_space;
 
 sampler_state textureSampler {
 	Filter    = Linear;
@@ -36,15 +37,208 @@ VertData VSDefault(VertData v_in)
 	return vert_out;
 }
 
-float4 CalcColor(float4 rgba)
+float RGBToXYZChannel(float c)
 {
-	return float4(pow(rgba.rgb, float3(gamma, gamma, gamma)) * contrast + brightness, rgba.a);
+	return c > 0.04045 ? pow((c + 0.055) / 1.055, 2.4) : c / 12.92;
+}
+
+float3 RGBToXYZ(float3 rgb)
+{
+	rgb.r = RGBToXYZChannel(rgb.r);
+	rgb.g = RGBToXYZChannel(rgb.g);
+	rgb.b = RGBToXYZChannel(rgb.b);
+
+	const float3x3 RGBToXYZMatrix = float3x3(
+		0.4124564, 0.3575761, 0.1804375,
+		0.2126729, 0.7151522, 0.0721750,
+		0.0193339, 0.1191920, 0.9503041);
+
+	return 100.0 * mul(rgb, RGBToXYZMatrix);
+}
+
+float XYZToLABChannel(float c)
+{
+    return c > 0.008856 ? pow(c, 1.0 / 3.0) : (7.787 * c) + (16.0 / 116.0);
+}
+
+float3 XYZToLAB(float3 xyz)
+{
+	const float3 WhiteBalance = float3(95.047, 100, 108.883);
+    xyz /= WhiteBalance;
+
+	const float FY = XYZToLABChannel(xyz.y);
+
+	const float L = (116.0 * FY) - 16.0;
+	const float A = 500.0 * (XYZToLABChannel(xyz.x) - FY);
+	const float B = 200.0 * (FY - XYZToLABChannel(xyz.z));
+
+	return float3(L, A, B);
+}
+
+#define epsilon 1e-10
+
+#define kL 1.0
+#define kC 1.0
+#define kH 1.0
+
+#define deg6InRad   0.10472
+#define deg25InRad  0.436332
+#define deg30InRad  0.523599
+#define deg63InRad  1.09956
+#define deg180InRad 3.14159
+#define deg275InRad 4.79966
+#define deg360InRad 6.28319
+
+#define pow25To7 6103515625.0
+
+float CIEDE2000_distance(float3 one, float3 two)
+{
+	const float L1 = one.x;
+	const float a1 = one.y;
+	const float b1 = one.z;
+
+	const float L2 = two.x;
+	const float a2 = two.y;
+	const float b2 = two.z;
+
+	const float C1 = sqrt((a1 * a1) + (b1 * b1));
+	const float C2 = sqrt((a2 * a2) + (b2 * b2));
+	const float CBar = 0.5 * (C1 + C2) ;
+
+	const float G = 0.5 * (1 - sqrt(pow(CBar, 7) / (pow(CBar, 7) + pow25To7)));
+	const float a1Prime = (1.0 + G) * a1;
+	const float a2Prime = (1.0 + G) * a2;
+
+	const float C1Prime = sqrt((a1Prime * a1Prime) + (b1 * b1));
+	const float C2Prime = sqrt((a2Prime * a2Prime) + (b2 * b2));
+
+	float h1Prime;
+	if (abs(b1) < epsilon && abs(a1Prime) < epsilon)
+	{
+		h1Prime = 0.0;
+	}
+	else
+	{
+		h1Prime = atan2(b1, a1Prime);
+		if (h1Prime < 0)
+			h1Prime += deg360InRad;
+	}
+
+	float h2Prime;
+	if (abs(b2) < epsilon && abs(a2Prime) < epsilon)
+	{
+		h2Prime = 0.0;
+	}
+	else
+	{
+		h2Prime = atan2(b2, a2Prime);
+		if (h2Prime < 0)
+			h2Prime += deg360InRad;
+	}
+
+	const float deltaLPrime = L2 - L1;
+	const float deltaCPrime = C2Prime - C1Prime;
+
+	const float CPrimeProduct = C1Prime * C2Prime;
+	float deltahPrime;
+	if (CPrimeProduct < epsilon)
+	{
+		deltahPrime = 0;
+	}
+	else
+	{
+		deltahPrime = h2Prime - h1Prime;
+		if (deltahPrime < -deg180InRad)
+		{
+			deltahPrime += deg360InRad;
+		}
+		else if (deltahPrime > deg180InRad)
+		{
+			deltahPrime -= deg360InRad;
+		}
+	}
+
+	const float deltaHPrime = 2.0 * sqrt(CPrimeProduct) * sin(deltahPrime * 0.5);
+
+	const float barLPrime = 0.5 * (L1 + L2);
+	const float barCPrime = 0.5 * (C1Prime + C2Prime);
+
+	const float hPrimeSum = h1Prime + h2Prime;
+	float barhPrime;
+	if (C1Prime * C2Prime < epsilon)
+	{
+		barhPrime = hPrimeSum;
+	}
+	else
+	{
+		if (abs(h1Prime - h2Prime) <= deg180InRad)
+		{
+			barhPrime = 0.5 * hPrimeSum;
+		}
+		else
+		{
+			if (hPrimeSum < deg360InRad)
+			{
+				barhPrime = 0.5 * (hPrimeSum + deg360InRad);
+			}
+			else
+			{
+				barhPrime = 0.5 * (hPrimeSum - deg360InRad);
+			}
+		}
+	}
+
+	const float T = 1.0 -
+		(0.17 * cos(barhPrime - deg30InRad)) +
+	    (0.24 * cos(2.0 * barhPrime)) +
+	    (0.32 * cos((3.0 * barhPrime) + deg6InRad)) -
+	    (0.20 * cos((4.0 * barhPrime) - deg63InRad));
+
+	const float deltaThetaHalf = (barhPrime - deg275InRad) / deg25InRad;
+	const float deltaTheta = deg30InRad * exp(- (deltaThetaHalf * deltaThetaHalf));
+
+	const float RCPartial = pow(barCPrime, 7.0);
+	const float RC = 2.0 * sqrt(RCPartial / (RCPartial + pow25To7));
+
+	const float SLPartial = (barLPrime - 50.0) * (barLPrime - 50.0);
+	const float SL = 1.0 + ((0.015 * SLPartial) / sqrt(20 + SLPartial));
+
+	const float SC = 1.0 + (0.045 * barCPrime);
+	const float SH = 1.0 + (0.015 * barCPrime * T);
+	const float RT = (-sin(2.0 * deltaTheta)) * RC;
+
+	const float deltaL = deltaLPrime / (kL * SL);
+	const float deltaC = deltaCPrime / (kC * SC);
+	const float deltaH = deltaHPrime / (kH * SH);
+
+	const float deltaESquared = (deltaL * deltaL) + (deltaC * deltaC) + (deltaH * deltaH) + (RT * deltaC * deltaH);
+	return sqrt(deltaESquared);
 }
 
 float GetChromaDist(float3 rgb)
 {
-	float4 yuvx = mul(float4(rgb.rgb, 1.0), yuv_mat);
-	return distance(chroma_key, yuvx.yz);
+	if(color_space == 0)
+	{
+		float4 yuvx = mul(float4(rgb.rgb, 1.0), yuv_mat);
+		float4 chroma_yuvx = mul(float4(chroma_key.rgb, 1.0), yuv_mat);
+
+		return distance(chroma_yuvx.yz, yuvx.yz);
+	}
+
+	float3 chroma_key_lab = XYZToLAB(RGBToXYZ(chroma_key.rgb));
+	float3 lab = XYZToLAB(RGBToXYZ(rgb));
+
+	if(color_space == 1)
+	{
+		return distance(chroma_key_lab, lab) / 200.0;
+	}
+
+	return CIEDE2000_distance(chroma_key_lab, lab) / 200.0;
+}
+
+float4 CalcColor(float4 rgba)
+{
+	return float4(pow(rgba.rgb, float3(gamma, gamma, gamma)) * contrast + brightness, rgba.a);
 }
 
 float4 SampleTexture(float2 uv)

--- a/plugins/obs-filters/data/color_key_filter.effect
+++ b/plugins/obs-filters/data/color_key_filter.effect
@@ -9,6 +9,7 @@ uniform float gamma;
 uniform float4 key_color;
 uniform float similarity;
 uniform float smoothness;
+uniform int color_space;
 
 sampler_state textureSampler {
 	Filter    = Linear;
@@ -29,14 +30,205 @@ VertData VSDefault(VertData v_in)
 	return vert_out;
 }
 
-float4 CalcColor(float4 rgba)
+float RGBToXYZChannel(float c)
 {
-	return float4(pow(rgba.rgb, float3(gamma, gamma, gamma)) * contrast + brightness, rgba.a);
+	return c > 0.04045 ? pow((c + 0.055) / 1.055, 2.4) : c / 12.92;
+}
+
+float3 RGBToXYZ(float3 rgb)
+{
+	rgb.r = RGBToXYZChannel(rgb.r);
+	rgb.g = RGBToXYZChannel(rgb.g);
+	rgb.b = RGBToXYZChannel(rgb.b);
+
+	const float3x3 RGBToXYZMatrix = float3x3(
+		0.4124564, 0.3575761, 0.1804375,
+		0.2126729, 0.7151522, 0.0721750,
+		0.0193339, 0.1191920, 0.9503041);
+
+	return 100.0 * mul(rgb, RGBToXYZMatrix);
+}
+
+float XYZToLABChannel(float c)
+{
+    return c > 0.008856 ? pow(c, 1.0 / 3.0) : (7.787 * c) + (16.0 / 116.0);
+}
+
+float3 XYZToLAB(float3 xyz)
+{
+	const float3 WhiteBalance = float3(95.047, 100, 108.883);
+    xyz /= WhiteBalance;
+
+	const float FY = XYZToLABChannel(xyz.y);
+
+	const float L = (116.0 * FY) - 16.0;
+	const float A = 500.0 * (XYZToLABChannel(xyz.x) - FY);
+	const float B = 200.0 * (FY - XYZToLABChannel(xyz.z));
+
+	return float3(L, A, B);
+}
+
+#define epsilon 1e-10
+
+#define kL 1.0
+#define kC 1.0
+#define kH 1.0
+
+#define deg6InRad   0.10472
+#define deg25InRad  0.436332
+#define deg30InRad  0.523599
+#define deg63InRad  1.09956
+#define deg180InRad 3.14159
+#define deg275InRad 4.79966
+#define deg360InRad 6.28319
+
+#define pow25To7 6103515625.0
+
+float CIEDE2000_distance(float3 one, float3 two)
+{
+	const float L1 = one.x;
+	const float a1 = one.y;
+	const float b1 = one.z;
+
+	const float L2 = two.x;
+	const float a2 = two.y;
+	const float b2 = two.z;
+
+	const float C1 = sqrt((a1 * a1) + (b1 * b1));
+	const float C2 = sqrt((a2 * a2) + (b2 * b2));
+	const float CBar = 0.5 * (C1 + C2) ;
+
+	const float G = 0.5 * (1 - sqrt(pow(CBar, 7) / (pow(CBar, 7) + pow25To7)));
+	const float a1Prime = (1.0 + G) * a1;
+	const float a2Prime = (1.0 + G) * a2;
+
+	const float C1Prime = sqrt((a1Prime * a1Prime) + (b1 * b1));
+	const float C2Prime = sqrt((a2Prime * a2Prime) + (b2 * b2));
+
+	float h1Prime;
+	if (abs(b1) < epsilon && abs(a1Prime) < epsilon)
+	{
+		h1Prime = 0.0;
+	}
+	else
+	{
+		h1Prime = atan2(b1, a1Prime);
+		if (h1Prime < 0)
+			h1Prime += deg360InRad;
+	}
+
+	float h2Prime;
+	if (abs(b2) < epsilon && abs(a2Prime) < epsilon)
+	{
+		h2Prime = 0.0;
+	}
+	else
+	{
+		h2Prime = atan2(b2, a2Prime);
+		if (h2Prime < 0)
+			h2Prime += deg360InRad;
+	}
+
+	const float deltaLPrime = L2 - L1;
+	const float deltaCPrime = C2Prime - C1Prime;
+
+	const float CPrimeProduct = C1Prime * C2Prime;
+	float deltahPrime;
+	if (CPrimeProduct < epsilon)
+	{
+		deltahPrime = 0;
+	}
+	else
+	{
+		deltahPrime = h2Prime - h1Prime;
+		if (deltahPrime < -deg180InRad)
+		{
+			deltahPrime += deg360InRad;
+		}
+		else if (deltahPrime > deg180InRad)
+		{
+			deltahPrime -= deg360InRad;
+		}
+	}
+
+	const float deltaHPrime = 2.0 * sqrt(CPrimeProduct) * sin(deltahPrime * 0.5);
+
+	const float barLPrime = 0.5 * (L1 + L2);
+	const float barCPrime = 0.5 * (C1Prime + C2Prime);
+
+	const float hPrimeSum = h1Prime + h2Prime;
+	float barhPrime;
+	if (C1Prime * C2Prime < epsilon)
+	{
+		barhPrime = hPrimeSum;
+	}
+	else
+	{
+		if (abs(h1Prime - h2Prime) <= deg180InRad)
+		{
+			barhPrime = 0.5 * hPrimeSum;
+		}
+		else
+		{
+			if (hPrimeSum < deg360InRad)
+			{
+				barhPrime = 0.5 * (hPrimeSum + deg360InRad);
+			}
+			else
+			{
+				barhPrime = 0.5 * (hPrimeSum - deg360InRad);
+			}
+		}
+	}
+
+	const float T = 1.0 -
+		(0.17 * cos(barhPrime - deg30InRad)) +
+	    (0.24 * cos(2.0 * barhPrime)) +
+	    (0.32 * cos((3.0 * barhPrime) + deg6InRad)) -
+	    (0.20 * cos((4.0 * barhPrime) - deg63InRad));
+
+	const float deltaThetaHalf = (barhPrime - deg275InRad) / deg25InRad;
+	const float deltaTheta = deg30InRad * exp(- (deltaThetaHalf * deltaThetaHalf));
+
+	const float RCPartial = pow(barCPrime, 7.0);
+	const float RC = 2.0 * sqrt(RCPartial / (RCPartial + pow25To7));
+
+	const float SLPartial = (barLPrime - 50.0) * (barLPrime - 50.0);
+	const float SL = 1.0 + ((0.015 * SLPartial) / sqrt(20 + SLPartial));
+
+	const float SC = 1.0 + (0.045 * barCPrime);
+	const float SH = 1.0 + (0.015 * barCPrime * T);
+	const float RT = (-sin(2.0 * deltaTheta)) * RC;
+
+	const float deltaL = deltaLPrime / (kL * SL);
+	const float deltaC = deltaCPrime / (kC * SC);
+	const float deltaH = deltaHPrime / (kH * SH);
+
+	const float deltaESquared = (deltaL * deltaL) + (deltaC * deltaC) + (deltaH * deltaH) + (RT * deltaC * deltaH);
+	return sqrt(deltaESquared);
 }
 
 float GetColorDist(float3 rgb)
 {
-	return distance(key_color.rgb, rgb);
+	if(color_space == 0)
+	{
+		return distance(key_color.rgb, rgb);
+	}
+
+	const float3 key_color_lab = XYZToLAB(RGBToXYZ(key_color.rgb));
+	const float3 lab = XYZToLAB(RGBToXYZ(rgb));
+
+	if(color_space == 1)
+	{
+		return distance(key_color_lab, lab) / 200;
+	}
+
+	return CIEDE2000_distance(key_color_lab, lab) / 200.0;
+}
+
+float4 CalcColor(float4 rgba)
+{
+	return float4(pow(rgba.rgb, float3(gamma, gamma, gamma)) * contrast + brightness, rgba.a);
 }
 
 float4 ProcessColorKey(float4 rgba, VertData v_in)


### PR DESCRIPTION
### Description
This PR adds options for different distance algorithms to be used by the Color Key and Chroma Key filters, which are more computationally expensive but are more applicable in a wider range of green screen conditions.

### Motivation and Context
sRGB is not particularly good at representing color distances due to a lack of perceptual uniformity; making a picture by adding 1 to an sRGB value over and over doesn't result in a smooth and uniform transition, but introduces very obvious banding.

This is somewhat less than ideal when dealing with a color or chroma key based on color distances; it's often the case that a suboptimally chosen green from the image will bleed into red/pink/peach flesh tones before matching a darker green. 

Luckily, the [CIELAB color space](https://en.wikipedia.org/wiki/CIELAB_color_space) and [CIEDE2000 color difference algorithm](https://en.wikipedia.org/wiki/Color_difference#CIEDE2000) were invented to deal with just this problem. By implementing these higher quality algorithms, we can substantially increase the selectivity of the Color Key filter, and moderately increase the selectivity of the Chroma Key filter, allowing for them to be used more effectively depending on the lighting and coloring situation.

### How Has This Been Tested?
This has been tested in real world usage on Windows and OSX.

As this code by and large does not touch existing code paths (except to call out to different HLSL scripts), let's instead show some real world usage.

#### Color Key ####
This filter gets huge enhancements from the better color distance algorithms, because it's largely focused on color.

##### Original Image #####
![unchromad](https://user-images.githubusercontent.com/25004108/64161837-4be8fb00-ce0c-11e9-9eaa-b1fadeb639ac.jpg)

As you can see, we have a somewhat uneven green screen. This actually took a fair bit of lighting, a relatively large Manhattan apartment, and a lot of time tightening up that screen. I anticipate most Twitch streamers have worse screens to work with.

##### RGB Color Key #####
![original2](https://user-images.githubusercontent.com/25004108/64161372-8aca8100-ce0b-11e9-9105-7ad4eb5bbb98.png)

No matter what is done with the similarity slider, the original color key simply is not capable of removing the background without taking away the foreground, notably my hands.

##### Lab Color Key #####
<img width="864" alt="lab2" src="https://user-images.githubusercontent.com/25004108/64161438-a3d33200-ce0b-11e9-84ef-a596aae85bed.png">

As you can see here, projecting into a more uniform color space dramatically reduces the amount of foreground alpha'ing, resulting in a remarkably good result besides a very highly reflective piece of foil.

##### DE2000 Color Key #####
![de2002](https://user-images.githubusercontent.com/25004108/64161503-bfd6d380-ce0b-11e9-8317-3c36d77a8abc.png)

Apologies for the close up, but this is with the same settings as the other two (along with some tweaking of the sensitivity slider).

Unfortunately, it appears the darkest greens are about as far away as the bright green spilled onto my dress, but I would still rank this decidedly better than the original RGB implementation.

##### Winner: LAB #####
For just a small amount of computational power, we get a dramatically better result.

While this merely shows the generic green, I selected the lightest and darkest greens as well, finding that the results were largely the same.

#### Chroma Key ####
Chroma key focuses on hue and not luminescence, so it only gets a moderate boost from the more uniform color spaces. Note that this test was against a video file, which is why the images are at slightly different points in time, to demonstrate the faults of each.

##### Original Image #####
![original3](https://user-images.githubusercontent.com/25004108/64164891-00d1e680-ce12-11e9-89c4-fbb90530c431.jpg)

Again, a poorly lit green screen.

##### YUV Chroma Key #####
![yuv3](https://user-images.githubusercontent.com/25004108/64164972-1c3cf180-ce12-11e9-9e07-98dca6286b52.png)

On the whole, not bad, I guess my lighting and such is getting better.
On the other hand, I cannot get rid of the clipping on my shirt sleeve, as minor as it may be.

##### LAB Chroma Key #####
![lab3](https://user-images.githubusercontent.com/25004108/64165042-3d9ddd80-ce12-11e9-951f-927364a6402f.png)

LAB manages to by and large get rid of the artifacts on my shirt that YUV creates, but there is some noticeable banding and boiling around my hands.

##### DE2000 Chroma Key #####
![DE2000_3](https://user-images.githubusercontent.com/25004108/64165153-79d13e00-ce12-11e9-8c6e-492777c5e62e.png)

Finally, DE2000 manage to completely avoid my hands, resulting in a great result here, with nearly no boiling even around my very finicky skin tone.

##### Winner: DE2000 #####
While computationally more expensive, it's tighter bounds can really help clean up around problem areas.

### Types of changes
This is a simple enhancement, but it is not a breaking change.
All workflows should be identical; there are just more options now, which may work better in differing contexts.

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
