### PR TITLE
UI: Various screen reader fixes

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -390,8 +390,8 @@ Deinterlacing.TopFieldFirst="Top Field First"
 Deinterlacing.BottomFieldFirst="Bottom Field First"
 
 # volume control accessibility text
-VolControl.SliderUnmuted="Volume slider for '%1': %2"
-VolControl.SliderMuted="Volume slider for '%1': %2 (currently muted)"
+VolControl.SliderUnmuted="Volume slider for '%1':"
+VolControl.SliderMuted="Volume slider for '%1': (currently muted)"
 VolControl.Mute="Mute '%1'"
 VolControl.Properties="Properties for '%1'"
 
@@ -429,6 +429,12 @@ Basic.SourceSelect="Create/Select Source"
 Basic.SourceSelect.CreateNew="Create new"
 Basic.SourceSelect.AddExisting="Add Existing"
 Basic.SourceSelect.AddVisible="Make source visible"
+
+# source box
+Basic.Main.Sources.Visibility="Visibility"
+Basic.Main.Sources.VisibilityDescription="Controls the visibility of '%1' in the canvas"
+Basic.Main.Sources.Lock="Lock"
+Basic.Main.Sources.LockDescription="Locks the position and scale of '%1' in the canvas"
 
 # properties window
 Basic.PropertiesWindow="Properties for '%1'"
@@ -733,6 +739,7 @@ Basic.Settings.Output.Adv.Audio.Track6="Track 6"
 
 # basic mode 'output' settings - advanced section - recording subsection
 Basic.Settings.Output.Adv.Recording="Recording"
+Basic.Settings.Output.Adv.Recording.RecType="Recording Type"
 Basic.Settings.Output.Adv.Recording.Type="Type"
 Basic.Settings.Output.Adv.Recording.Type.Standard="Standard"
 Basic.Settings.Output.Adv.Recording.Type.FFmpegOutput="Custom Output (FFmpeg)"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -371,33 +371,13 @@
                      </property>
                     </widget>
                    </item>
-                   <item row="2" column="1">
-                    <widget class="QCheckBox" name="screenSnapping">
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="label_9">
                      <property name="text">
-                      <string>Basic.Settings.General.ScreenSnapping</string>
+                      <string>Basic.Settings.General.SnapDistance</string>
                      </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="4" column="1">
-                    <widget class="QCheckBox" name="centerSnapping">
-                     <property name="text">
-                      <string>Basic.Settings.General.CenterSnapping</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="1">
-                    <widget class="QCheckBox" name="sourceSnapping">
-                     <property name="text">
-                      <string>Basic.Settings.General.SourceSnapping</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
+                     <property name="buddy">
+                      <cstring>snapDistance</cstring>
                      </property>
                     </widget>
                    </item>
@@ -414,13 +394,13 @@
                      </property>
                     </widget>
                    </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="label_9">
+                   <item row="2" column="1">
+                    <widget class="QCheckBox" name="screenSnapping">
                      <property name="text">
-                      <string>Basic.Settings.General.SnapDistance</string>
+                      <string>Basic.Settings.General.ScreenSnapping</string>
                      </property>
-                     <property name="buddy">
-                      <cstring>snapDistance</cstring>
+                     <property name="checked">
+                      <bool>true</bool>
                      </property>
                     </widget>
                    </item>
@@ -439,6 +419,26 @@
                       </size>
                      </property>
                     </spacer>
+                   </item>
+                   <item row="3" column="1">
+                    <widget class="QCheckBox" name="sourceSnapping">
+                     <property name="text">
+                      <string>Basic.Settings.General.SourceSnapping</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="4" column="1">
+                    <widget class="QCheckBox" name="centerSnapping">
+                     <property name="text">
+                      <string>Basic.Settings.General.CenterSnapping</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
                    </item>
                   </layout>
                  </widget>
@@ -568,13 +568,6 @@
                    <property name="topMargin">
                     <number>2</number>
                    </property>
-                   <item row="1" column="1">
-                    <widget class="QCheckBox" name="overflowAlwaysVisible">
-                     <property name="text">
-                      <string>Basic.Settings.General.OverflowAlwaysVisible</string>
-                     </property>
-                    </widget>
-                   </item>
                    <item row="0" column="0">
                     <spacer name="horizontalSpacer_25">
                      <property name="orientation">
@@ -588,17 +581,24 @@
                      </property>
                     </spacer>
                    </item>
-                   <item row="2" column="1">
-                    <widget class="QCheckBox" name="overflowSelectionHide">
-                     <property name="text">
-                      <string>Basic.Settings.General.OverflowSelectionHidden</string>
-                     </property>
-                    </widget>
-                   </item>
                    <item row="0" column="1">
                     <widget class="QCheckBox" name="overflowHide">
                      <property name="text">
                       <string>Basic.Settings.General.OverflowHidden</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="1">
+                    <widget class="QCheckBox" name="overflowAlwaysVisible">
+                     <property name="text">
+                      <string>Basic.Settings.General.OverflowAlwaysVisible</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="1">
+                    <widget class="QCheckBox" name="overflowSelectionHide">
+                     <property name="text">
+                      <string>Basic.Settings.General.OverflowSelectionHidden</string>
                      </property>
                     </widget>
                    </item>
@@ -721,9 +721,6 @@
                      </property>
                     </widget>
                    </item>
-                   <item row="3" column="1">
-                    <widget class="QComboBox" name="multiviewLayout"/>
-                   </item>
                    <item row="3" column="0">
                     <widget class="QLabel" name="label_64">
                      <property name="text">
@@ -733,6 +730,9 @@
                       <cstring>multiviewLayout</cstring>
                      </property>
                     </widget>
+                   </item>
+                   <item row="3" column="1">
+                    <widget class="QComboBox" name="multiviewLayout"/>
                    </item>
                   </layout>
                  </widget>
@@ -4636,6 +4636,16 @@
                      </item>
                     </layout>
                    </item>
+                   <item row="3" column="0">
+                    <widget class="QLabel" name="label_33">
+                     <property name="text">
+                      <string>Basic.Settings.Advanced.Video.ColorSpace</string>
+                     </property>
+                     <property name="buddy">
+                      <cstring>colorSpace</cstring>
+                     </property>
+                    </widget>
+                   </item>
                    <item row="3" column="1">
                     <layout class="QHBoxLayout" name="horizontalLayout_20">
                      <property name="leftMargin">
@@ -4684,16 +4694,6 @@
                       <widget class="QComboBox" name="colorRange"/>
                      </item>
                     </layout>
-                   </item>
-                   <item row="3" column="0">
-                    <widget class="QLabel" name="label_33">
-                     <property name="text">
-                      <string>Basic.Settings.Advanced.Video.ColorSpace</string>
-                     </property>
-                     <property name="buddy">
-                      <cstring>colorSpace</cstring>
-                     </property>
-                    </widget>
                    </item>
                    <item row="4" column="0">
                     <spacer name="horizontalSpacer_12">
@@ -4746,6 +4746,23 @@
                      </property>
                     </widget>
                    </item>
+                   <item row="2" column="1">
+                    <widget class="QCheckBox" name="autoRemux">
+                     <property name="text">
+                      <string>Basic.Settings.Advanced.AutoRemux</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="0">
+                    <widget class="QLabel" name="label_57">
+                     <property name="text">
+                      <string>Basic.Settings.Output.ReplayBuffer.Prefix</string>
+                     </property>
+                     <property name="buddy">
+                      <cstring>simpleRBPrefix</cstring>
+                     </property>
+                    </widget>
+                   </item>
                    <item row="3" column="1">
                     <layout class="QHBoxLayout" name="horizontalLayout_14">
                      <property name="leftMargin">
@@ -4778,16 +4795,6 @@
                      </item>
                     </layout>
                    </item>
-                   <item row="3" column="0">
-                    <widget class="QLabel" name="label_57">
-                     <property name="text">
-                      <string>Basic.Settings.Output.ReplayBuffer.Prefix</string>
-                     </property>
-                     <property name="buddy">
-                      <cstring>simpleRBPrefix</cstring>
-                     </property>
-                    </widget>
-                   </item>
                    <item row="1" column="0">
                     <spacer name="horizontalSpacer_10">
                      <property name="orientation">
@@ -4800,13 +4807,6 @@
                       </size>
                      </property>
                     </spacer>
-                   </item>
-                   <item row="2" column="1">
-                    <widget class="QCheckBox" name="autoRemux">
-                     <property name="text">
-                      <string>Basic.Settings.Advanced.AutoRemux</string>
-                     </property>
-                    </widget>
                    </item>
                    <item row="2" column="0">
                     <spacer name="horizontalSpacer_16">
@@ -4839,6 +4839,16 @@
                    <property name="topMargin">
                     <number>2</number>
                    </property>
+                   <item row="0" column="1">
+                    <widget class="QCheckBox" name="streamDelayEnable">
+                     <property name="text">
+                      <string>Enable</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
                    <item row="1" column="0">
                     <widget class="QLabel" name="label_56">
                      <property name="text">
@@ -4915,16 +4925,6 @@
                      </property>
                     </widget>
                    </item>
-                   <item row="0" column="1">
-                    <widget class="QCheckBox" name="streamDelayEnable">
-                     <property name="text">
-                      <string>Enable</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
                    <item row="2" column="0">
                     <spacer name="horizontalSpacer_9">
                      <property name="orientation">
@@ -4963,6 +4963,16 @@
                      </property>
                      <property name="checked">
                       <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="label_17">
+                     <property name="text">
+                      <string>Basic.Settings.Output.RetryDelay</string>
+                     </property>
+                     <property name="buddy">
+                      <cstring>reconnectRetryDelay</cstring>
                      </property>
                     </widget>
                    </item>
@@ -5018,16 +5028,6 @@
                      </item>
                     </layout>
                    </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="label_17">
-                     <property name="text">
-                      <string>Basic.Settings.Output.RetryDelay</string>
-                     </property>
-                     <property name="buddy">
-                      <cstring>reconnectRetryDelay</cstring>
-                     </property>
-                    </widget>
-                   </item>
                    <item row="0" column="0">
                     <spacer name="horizontalSpacer_8">
                      <property name="orientation">
@@ -5072,6 +5072,16 @@
                    <item row="0" column="1">
                     <widget class="QComboBox" name="bindToIP"/>
                    </item>
+                   <item row="1" column="1">
+                    <widget class="QCheckBox" name="dynBitrate">
+                     <property name="toolTip">
+                      <string>Basic.Settings.Output.DynamicBitrate.TT</string>
+                     </property>
+                     <property name="text">
+                      <string>Basic.Settings.Output.DynamicBitrate.Beta</string>
+                     </property>
+                    </widget>
+                   </item>
                    <item row="2" column="1">
                     <widget class="QCheckBox" name="enableNewSocketLoop">
                      <property name="text">
@@ -5101,16 +5111,6 @@
                       </size>
                      </property>
                     </spacer>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QCheckBox" name="dynBitrate">
-                     <property name="toolTip">
-                      <string>Basic.Settings.Output.DynamicBitrate.TT</string>
-                     </property>
-                     <property name="text">
-                      <string>Basic.Settings.Output.DynamicBitrate.Beta</string>
-                     </property>
-                    </widget>
                    </item>
                   </layout>
                  </widget>

--- a/UI/hotkey-edit.cpp
+++ b/UI/hotkey-edit.cpp
@@ -293,11 +293,13 @@ void OBSHotkeyWidget::AddEdit(obs_key_combination combo, int idx)
 
 	auto add = new QPushButton;
 	add->setProperty("themeID", "addIconSmall");
+	add->setToolTip(QTStr("Add"));
 	add->setFixedSize(24, 24);
 	add->setFlat(true);
 
 	auto remove = new QPushButton;
 	remove->setProperty("themeID", "removeIconSmall");
+	remove->setToolTip(QTStr("Remove"));
 	remove->setEnabled(removeButtons.size() > 0);
 	remove->setFixedSize(24, 24);
 	remove->setFlat(true);

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -34,9 +34,11 @@
 #include <QGuiApplication>
 #include <QProxyStyle>
 #include <QScreen>
+#include <QAccessible>
 
 #include "qt-wrappers.hpp"
 #include "obs-app.hpp"
+#include "slider-ignorewheel.hpp"
 #include "window-basic-main.hpp"
 #include "window-basic-settings.hpp"
 #include "crash-report.hpp"
@@ -1720,6 +1722,17 @@ static auto ProfilerFree = [](void *) {
 	profiler_free();
 };
 
+QAccessibleInterface *accessibleFactory(const QString &classname,
+					QObject *object)
+{
+	if (classname == QLatin1String("VolumeSlider") && object &&
+	    object->isWidgetType())
+		return new VolumeAccessibleInterface(
+			static_cast<QWidget *>(object));
+
+	return nullptr;
+}
+
 static const char *run_program_init = "run_program_init";
 static int run_program(fstream &logFile, int argc, char *argv[])
 {
@@ -1743,6 +1756,8 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 
 	OBSApp program(argc, argv, profilerNameStore.get());
 	try {
+		QAccessible::installFactory(accessibleFactory);
+
 		bool created_log = false;
 
 		program.AppInit();

--- a/UI/slider-ignorewheel.cpp
+++ b/UI/slider-ignorewheel.cpp
@@ -1,4 +1,5 @@
 #include "slider-ignorewheel.hpp"
+#include "volume-control.hpp"
 
 SliderIgnoreScroll::SliderIgnoreScroll(QWidget *parent) : QSlider(parent)
 {
@@ -20,3 +21,82 @@ void SliderIgnoreScroll::wheelEvent(QWheelEvent *event)
 	else
 		QSlider::wheelEvent(event);
 }
+
+VolumeSlider::VolumeSlider(obs_fader_t *fader, QWidget *parent)
+	: SliderIgnoreScroll(parent)
+{
+	fad = fader;
+}
+
+VolumeSlider::VolumeSlider(obs_fader_t *fader, Qt::Orientation orientation,
+			   QWidget *parent)
+	: SliderIgnoreScroll(orientation, parent)
+{
+	fad = fader;
+}
+
+VolumeAccessibleInterface::VolumeAccessibleInterface(QWidget *w)
+	: QAccessibleWidget(w)
+{
+}
+
+VolumeSlider *VolumeAccessibleInterface::slider() const
+{
+	return qobject_cast<VolumeSlider *>(object());
+}
+
+QString VolumeAccessibleInterface::text(QAccessible::Text t) const
+{
+	if (slider()->isVisible()) {
+		switch (t) {
+		case QAccessible::Text::Value:
+			return currentValue().toString();
+		default:
+			break;
+		}
+	}
+	return QAccessibleWidget::text(t);
+}
+
+QVariant VolumeAccessibleInterface::currentValue() const
+{
+	QString text;
+	float db = obs_fader_get_db(slider()->fad);
+
+	if (db < -96.0f)
+		text = "-inf dB";
+	else
+		text = QString::number(db, 'f', 1).append(" dB");
+
+	return text;
+}
+
+void VolumeAccessibleInterface::setCurrentValue(const QVariant &value)
+{
+	slider()->setValue(value.toInt());
+}
+
+QVariant VolumeAccessibleInterface::maximumValue() const
+{
+	return slider()->maximum();
+}
+
+QVariant VolumeAccessibleInterface::minimumValue() const
+{
+	return slider()->minimum();
+}
+
+QVariant VolumeAccessibleInterface::minimumStepSize() const
+{
+	return slider()->singleStep();
+}
+
+QAccessible::Role VolumeAccessibleInterface::role() const
+{
+	return QAccessible::Role::Slider;
+}
+
+/**QAccessible::State VolumeAccessibleInterface::state() const
+{
+	return QAccessible::State::
+}**/

--- a/UI/slider-ignorewheel.hpp
+++ b/UI/slider-ignorewheel.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "obs.hpp"
 #include <QSlider>
 #include <QInputEvent>
 #include <QtCore/QObject>
+#include <QAccessibleWidget>
 
 class SliderIgnoreScroll : public QSlider {
 	Q_OBJECT
@@ -14,4 +16,36 @@ public:
 
 protected:
 	virtual void wheelEvent(QWheelEvent *event) override;
+};
+
+class VolumeSlider : public SliderIgnoreScroll {
+	Q_OBJECT
+
+public:
+	obs_fader_t *fad;
+
+	VolumeSlider(obs_fader_t *fader, QWidget *parent = nullptr);
+	VolumeSlider(obs_fader_t *fader, Qt::Orientation orientation,
+		     QWidget *parent = nullptr);
+};
+
+class VolumeAccessibleInterface : public QAccessibleWidget {
+
+public:
+	VolumeAccessibleInterface(QWidget *w);
+
+	QVariant currentValue() const;
+	void setCurrentValue(const QVariant &value);
+
+	QVariant maximumValue() const;
+	QVariant minimumValue() const;
+
+	QVariant minimumStepSize() const;
+
+private:
+	VolumeSlider *slider() const;
+
+protected:
+	virtual QAccessible::Role role() const override;
+	virtual QString text(QAccessible::Text t) const override;
 };

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -62,12 +62,18 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_)
 	vis->setFixedSize(16, 16);
 	vis->setChecked(obs_sceneitem_visible(sceneitem));
 	vis->setStyleSheet("background: none");
+	vis->setAccessibleName(QTStr("Basic.Main.Sources.Visibility"));
+	vis->setAccessibleDescription(
+		QTStr("Basic.Main.Sources.VisibilityDescription").arg(name));
 
 	lock = new LockedCheckBox();
 	lock->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 	lock->setFixedSize(16, 16);
 	lock->setChecked(obs_sceneitem_locked(sceneitem));
 	lock->setStyleSheet("background: none");
+	lock->setAccessibleName(QTStr("Basic.Main.Sources.Lock"));
+	lock->setAccessibleDescription(
+		QTStr("Basic.Main.Sources.LockDescription").arg(name));
 
 	label = new QLabel(QT_UTF8(name));
 	label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
@@ -107,8 +113,8 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_)
 		obs_sceneitem_set_locked(sceneitem, checked);
 	};
 
-	connect(vis, &QAbstractButton::clicked, setItemVisible);
-	connect(lock, &QAbstractButton::clicked, setItemLocked);
+	connect(vis, &QAbstractButton::toggled, setItemVisible);
+	connect(lock, &QAbstractButton::toggled, setItemLocked);
 }
 
 void SourceTreeItem::paintEvent(QPaintEvent *event)

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -89,7 +89,7 @@ void VolControl::updateText()
 					  : "VolControl.SliderUnmuted";
 
 	QString sourceName = obs_source_get_name(source);
-	QString accText = QTStr(accTextLookup).arg(sourceName, db);
+	QString accText = QTStr(accTextLookup).arg(sourceName);
 
 	slider->setAccessibleName(accText);
 }
@@ -161,7 +161,7 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 		QHBoxLayout *meterLayout = new QHBoxLayout;
 
 		volMeter = new VolumeMeter(nullptr, obs_volmeter, true);
-		slider = new SliderIgnoreScroll(Qt::Vertical);
+		slider = new VolumeSlider(obs_fader, Qt::Vertical);
 
 		nameLayout->setAlignment(Qt::AlignCenter);
 		meterLayout->setAlignment(Qt::AlignCenter);
@@ -205,7 +205,7 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 		QHBoxLayout *botLayout = new QHBoxLayout;
 
 		volMeter = new VolumeMeter(nullptr, obs_volmeter, false);
-		slider = new SliderIgnoreScroll(Qt::Horizontal);
+		slider = new VolumeSlider(obs_fader, Qt::Horizontal);
 
 		textLayout->setContentsMargins(0, 0, 0, 0);
 		textLayout->addWidget(nameLabel);
@@ -254,7 +254,7 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 
 	QWidget::connect(slider, SIGNAL(valueChanged(int)), this,
 			 SLOT(SliderChanged(int)));
-	QWidget::connect(mute, SIGNAL(clicked(bool)), this,
+	QWidget::connect(mute, SIGNAL(toggled(bool)), this,
 			 SLOT(SetMuted(bool)));
 
 	obs_fader_attach_source(obs_fader, source);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1486,7 +1486,7 @@ void OBSBasic::ResetOutputs()
 				QTStr("Basic.Main.StartReplayBuffer"), this);
 			replayBufferButton->setCheckable(true);
 			connect(replayBufferButton.data(),
-				&QPushButton::clicked, this,
+				&QPushButton::toggled, this,
 				&OBSBasic::ReplayBufferClicked);
 
 			replayBufferButton->setProperty("themeID",
@@ -7506,7 +7506,7 @@ void OBSBasic::UpdatePause(bool activate)
 		pause->setChecked(false);
 		pause->setProperty("themeID",
 				   QVariant(QStringLiteral("pauseIconSmall")));
-		connect(pause.data(), &QAbstractButton::clicked, this,
+		connect(pause.data(), &QAbstractButton::toggled, this,
 			&OBSBasic::PauseToggled);
 		ui->recordingLayout->addWidget(pause.data());
 	} else {

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -260,10 +260,9 @@ void OBSBasicSettings::HookWidget(QWidget *widget, const char *signal,
 #define COMBO_CHANGED   SIGNAL(currentIndexChanged(int))
 #define EDIT_CHANGED    SIGNAL(textChanged(const QString &))
 #define CBEDIT_CHANGED  SIGNAL(editTextChanged(const QString &))
-#define CHECK_CHANGED   SIGNAL(clicked(bool))
+#define CHECK_CHANGED   SIGNAL(toggled(bool))
 #define SCROLL_CHANGED  SIGNAL(valueChanged(int))
 #define DSCROLL_CHANGED SIGNAL(valueChanged(double))
-#define TOGGLE_CHANGED  SIGNAL(toggled(bool))
 
 #define GENERAL_CHANGED SLOT(GeneralChanged())
 #define STREAM1_CHANGED SLOT(Stream1Changed())
@@ -726,18 +725,68 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	InitStreamPage();
 	LoadSettings(false);
 
+	ui->advOutTrack1->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track1"));
+	ui->advOutTrack2->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track2"));
+	ui->advOutTrack3->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track3"));
+	ui->advOutTrack4->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track4"));
+	ui->advOutTrack5->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track5"));
+	ui->advOutTrack6->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track6"));
+
+	ui->advOutRecTrack1->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track1"));
+	ui->advOutRecTrack2->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track2"));
+	ui->advOutRecTrack3->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track3"));
+	ui->advOutRecTrack4->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track4"));
+	ui->advOutRecTrack5->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track5"));
+	ui->advOutRecTrack6->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track6"));
+
+	ui->advOutFFTrack1->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track1"));
+	ui->advOutFFTrack2->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track2"));
+	ui->advOutFFTrack3->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track3"));
+	ui->advOutFFTrack4->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track4"));
+	ui->advOutFFTrack5->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track5"));
+	ui->advOutFFTrack6->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Audio.Track6"));
+
+	ui->snappingEnabled->setAccessibleName(
+		QTStr("Basic.Settings.General.Snapping"));
+	ui->systemTrayEnabled->setAccessibleName(
+		QTStr("Basic.Settings.General.SysTray"));
+	ui->label_31->setAccessibleName(
+		QTStr("Basic.Settings.Output.Adv.Recording.RecType"));
+	ui->streamDelayEnable->setAccessibleName(
+		QTStr("Basic.Settings.Advanced.StreamDelay"));
+	ui->reconnectEnable->setAccessibleName(
+		QTStr("Basic.Settings.Output.Reconnect"));
+
 	// Add warning checks to advanced output recording section controls
-	connect(ui->advOutRecTrack1, SIGNAL(clicked()), this,
+	connect(ui->advOutRecTrack1, SIGNAL(toggled()), this,
 		SLOT(AdvOutRecCheckWarnings()));
-	connect(ui->advOutRecTrack2, SIGNAL(clicked()), this,
+	connect(ui->advOutRecTrack2, SIGNAL(toggled()), this,
 		SLOT(AdvOutRecCheckWarnings()));
-	connect(ui->advOutRecTrack3, SIGNAL(clicked()), this,
+	connect(ui->advOutRecTrack3, SIGNAL(toggled()), this,
 		SLOT(AdvOutRecCheckWarnings()));
-	connect(ui->advOutRecTrack4, SIGNAL(clicked()), this,
+	connect(ui->advOutRecTrack4, SIGNAL(toggled()), this,
 		SLOT(AdvOutRecCheckWarnings()));
-	connect(ui->advOutRecTrack5, SIGNAL(clicked()), this,
+	connect(ui->advOutRecTrack5, SIGNAL(toggled()), this,
 		SLOT(AdvOutRecCheckWarnings()));
-	connect(ui->advOutRecTrack6, SIGNAL(clicked()), this,
+	connect(ui->advOutRecTrack6, SIGNAL(toggled()), this,
 		SLOT(AdvOutRecCheckWarnings()));
 	connect(ui->advOutRecFormat, SIGNAL(currentIndexChanged(int)), this,
 		SLOT(AdvOutRecCheckWarnings()));


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This commit fixes various issues with screen readers in the main OBS interface.

Checkboxes or buttons which toggle, when receiving an activate signal from the screen reader would visually update, but not perform any action. This is because they're listening only for clicks. They should all now be listening for toggles instead.

The screen reader would navigate through the UI in the order that elements are defined in the .ui XML, and not by their row positions. The XML has been reordered so that things should be defined in their row order.

Audio track selection now says Track 1, 2, etc, rather than just the number. Various checkboxes that just say "Enable" now have accessible text that says what the enable is for (since it says "checkbox", the fact it's an enable should hopefully be clear). Type in the recording tab of output now has accessible text which says "Recording Type".

All the right side buttons in hotkeys now have tooltips, and by extension, accessible text. Currently it does not yet say what hotkey the action is in relation to, but that would require more locales.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The goal of this PR is to improve the experience of using screen readers in OBS.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This has been tested with NVDA running on Windows 10 1903.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
