### PR TITLE
D3D swap chain enhancements

### DIFF
--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -86,7 +86,7 @@ void OBSQTDisplay::CreateDisplay()
 	gs_init_data info = {};
 	info.cx = size.width();
 	info.cy = size.height();
-	info.format = GS_RGBA;
+	info.format = GS_BGRA;
 	info.zsformat = GS_ZS_NONE;
 
 	QTToGSWindow(winId(), info.window);

--- a/libobs-opengl/gl-windows.c
+++ b/libobs-opengl/gl-windows.c
@@ -41,6 +41,7 @@ static inline int get_color_format_bits(enum gs_color_format format)
 {
 	switch ((uint32_t)format) {
 	case GS_RGBA:
+	case GS_BGRA:
 		return 32;
 	default:
 		return 0;

--- a/libobs-opengl/gl-x11.c
+++ b/libobs-opengl/gl-x11.c
@@ -95,53 +95,6 @@ struct gl_platform {
 	GLXPbuffer pbuffer;
 };
 
-static void print_info_stuff(const struct gs_init_data *info)
-{
-	blog(LOG_INFO,
-	     "X and Y: %i %i\n"
-	     "Backbuffers: %i\n"
-	     "Color Format: %i\n"
-	     "ZStencil Format: %i\n"
-	     "Adapter: %i\n",
-	     info->cx, info->cy, info->num_backbuffers, info->format,
-	     info->zsformat, info->adapter);
-}
-/* The following utility functions are copied verbatim from WGL code.
- * GLX and WGL are more similar than most people realize. */
-
-/* For now, only support basic 32bit formats for graphics output. */
-static inline int get_color_format_bits(enum gs_color_format format)
-{
-	switch ((uint32_t)format) {
-	case GS_RGBA:
-		return 32;
-	default:
-		return 0;
-	}
-}
-
-static inline int get_depth_format_bits(enum gs_zstencil_format zsformat)
-{
-	switch ((uint32_t)zsformat) {
-	case GS_Z16:
-		return 16;
-	case GS_Z24_S8:
-		return 24;
-	default:
-		return 0;
-	}
-}
-
-static inline int get_stencil_format_bits(enum gs_zstencil_format zsformat)
-{
-	switch ((uint32_t)zsformat) {
-	case GS_Z24_S8:
-		return 8;
-	default:
-		return 0;
-	}
-}
-
 /*
  * Since we cannot take advantage of the asynchronous nature of xcb,
  * all of the helper functions are synchronous but thread-safe.

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -1272,9 +1272,6 @@ gs_swapchain_t *gs_swapchain_create(const struct gs_init_data *data)
 	if (!gs_valid_p("gs_swapchain_create", data))
 		return NULL;
 
-	if (new_data.num_backbuffers == 0)
-		new_data.num_backbuffers = 1;
-
 	return graphics->exports.device_swapchain_create(graphics->device,
 							 &new_data);
 }


### PR DESCRIPTION
### Description
Use FLIP_DISCARD on Windows 10 to skip a copy, and BGRA on D3D for supposed benefits. The swap chain format field is ignored on Mac and Linux.

FLIP_DISCARD info:
https://devblogs.microsoft.com/directx/dxgi-flip-model/

BGRA info:
https://social.msdn.microsoft.com/Forums/windowsapps/en-US/f56e4449-f3e1-491e-9f64-e65e989a518a/best-swap-buffer-format-rgba-or-bgra-
"I believe there are some flip optimizatoin benefits to using BGR rather than RGB."

### Motivation and Context
Trying to save unnecessary GPU work.

### How Has This Been Tested?
Tested WIndows 10 D3D/GL, Mac, and Ubuntu (via WSL) still work. Test OBS runs on Windows 7 using Parallels.

Verified Windows 10 respects flip mode change using PresentMon tool.
DXGI_SWAP_EFFECT_DISCARD: "Composed: Copy with GPU GDI"
DXGI_SWAP_EFFECT_FLIP_DISCARD, main preview: "Composed: Flip"
DXGI_SWAP_EFFECT_FLIP_DISCARD, fullscreen projector: "Hardware Composed: Independent Flip"

I don't know why, but timings seem to oscillate every other frame.

PresentMon MsInPresentAPI/MsUntilRenderComplete timings
AMD RX 5700, 6 frame sample, Main Preview

Before:
0.393/2.785
0.339/0.806
0.344/2.825
0.497/0.935
0.346/2.808
0.383/0.754

After:
0.257/0.643
0.264/1.511
0.286/0.673
0.279/1.509
0.267/0.605
0.27/1.416

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
