### PR TITLE
Use D3D_FEATURE_LEVEL_10_0 as baseline

### DIFF
--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -273,7 +273,6 @@ const static D3D_FEATURE_LEVEL featureLevels[] = {
 	D3D_FEATURE_LEVEL_11_0,
 	D3D_FEATURE_LEVEL_10_1,
 	D3D_FEATURE_LEVEL_10_0,
-	D3D_FEATURE_LEVEL_9_3,
 };
 
 void gs_device::RebuildDevice()

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -229,7 +229,6 @@ const static D3D_FEATURE_LEVEL featureLevels[] = {
 	D3D_FEATURE_LEVEL_11_0,
 	D3D_FEATURE_LEVEL_10_1,
 	D3D_FEATURE_LEVEL_10_0,
-	D3D_FEATURE_LEVEL_9_3,
 };
 
 /* ------------------------------------------------------------------------- */
@@ -355,7 +354,7 @@ void gs_device::InitDevice(uint32_t adapterIdx)
 {
 	wstring adapterName;
 	DXGI_ADAPTER_DESC desc;
-	D3D_FEATURE_LEVEL levelUsed = D3D_FEATURE_LEVEL_9_3;
+	D3D_FEATURE_LEVEL levelUsed = D3D_FEATURE_LEVEL_10_0;
 	HRESULT hr = 0;
 
 	adpIdx = adapterIdx;

--- a/plugins/win-capture/graphics-hook/d3d12-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d12-capture.cpp
@@ -137,13 +137,6 @@ static bool create_d3d12_tex(bb_info &bb)
 
 typedef PFN_D3D11ON12_CREATE_DEVICE create_11_on_12_t;
 
-const static D3D_FEATURE_LEVEL feature_levels[] = {
-	D3D_FEATURE_LEVEL_11_0,
-	D3D_FEATURE_LEVEL_10_1,
-	D3D_FEATURE_LEVEL_10_0,
-	D3D_FEATURE_LEVEL_9_3,
-};
-
 static bool d3d12_init_11on12(void)
 {
 	static HMODULE d3d11 = nullptr;

--- a/plugins/win-capture/graphics-hook/d3d9-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d9-capture.cpp
@@ -113,7 +113,6 @@ const static D3D_FEATURE_LEVEL feature_levels[] = {
 	D3D_FEATURE_LEVEL_11_0,
 	D3D_FEATURE_LEVEL_10_1,
 	D3D_FEATURE_LEVEL_10_0,
-	D3D_FEATURE_LEVEL_9_3,
 };
 
 static inline bool shex_init_d3d11()

--- a/plugins/win-capture/graphics-hook/gl-capture.c
+++ b/plugins/win-capture/graphics-hook/gl-capture.c
@@ -262,7 +262,6 @@ static const D3D_FEATURE_LEVEL feature_levels[] = {
 	D3D_FEATURE_LEVEL_11_0,
 	D3D_FEATURE_LEVEL_10_1,
 	D3D_FEATURE_LEVEL_10_0,
-	D3D_FEATURE_LEVEL_9_3,
 };
 
 static inline bool gl_shtex_init_d3d11(void)


### PR DESCRIPTION
### Description
It appears OBS never successfully supported 9.3 because it wasn't compiling against a 9.x shader profile. Just use 10.0 as the baseline.

### Motivation and Context
Make code intention clearer.

### How Has This Been Tested?
With debugger inspection/modifcation, verified 9.3 actually fails when loading shader bytecode, and 10.0 succeeds. Also verified straight path successfully uses 11.0 on my card.

GL and D3D9 game capture still work.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.