### PR TITLE
UI: Add option to use percent instead of dB

### DIFF
--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -4,6 +4,7 @@
 #include <QWidget>
 #include <QPointer>
 #include <QDoubleSpinBox>
+#include <QStackedWidget>
 #include "balance-slider.hpp"
 
 class QGridLayout;
@@ -11,6 +12,11 @@ class QLabel;
 class QSpinBox;
 class QCheckBox;
 class QComboBox;
+
+enum class VolumeType {
+	dB,
+	Percent,
+};
 
 class OBSAdvAudioCtrl : public QObject {
 	Q_OBJECT
@@ -23,6 +29,8 @@ private:
 	QPointer<QWidget> balanceContainer;
 
 	QPointer<QLabel> nameLabel;
+	QPointer<QStackedWidget> stackedWidget;
+	QPointer<QSpinBox> percent;
 	QPointer<QDoubleSpinBox> volume;
 	QPointer<QCheckBox> forceMono;
 	QPointer<BalanceSlider> balance;
@@ -54,6 +62,8 @@ public:
 	inline obs_source_t *GetSource() const { return source; }
 	void ShowAudioControl(QGridLayout *layout);
 
+	void SetVolumeWidget(VolumeType type);
+
 public slots:
 	void SourceFlagsChanged(uint32_t flags);
 	void SourceVolumeChanged(float volume);
@@ -61,6 +71,7 @@ public slots:
 	void SourceMixersChanged(uint32_t mixers);
 
 	void volumeChanged(double db);
+	void percentChanged(int percent);
 	void downmixMonoChanged(bool checked);
 	void balanceChanged(int val);
 	void syncOffsetChanged(int milliseconds);

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -91,6 +91,7 @@ Default="(Default)"
 Calculating="Calculating..."
 Fullscreen="Fullscreen"
 Windowed="Windowed"
+Percent="Percent"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"

--- a/UI/window-basic-adv-audio.hpp
+++ b/UI/window-basic-adv-audio.hpp
@@ -31,6 +31,9 @@ public slots:
 	void SourceAdded(OBSSource source);
 	void SourceRemoved(OBSSource source);
 
+	void ShowContextMenu(const QPoint &pos);
+	void SetVolumeType();
+
 public:
 	OBSBasicAdvAudio(QWidget *parent);
 	~OBSBasicAdvAudio();


### PR DESCRIPTION
### Description
This adds a right click option in the advanced audio properties to switch between dB and percent.

### Motivation and Context
Several users have stated they would rather use percent than dB.

### How Has This Been Tested?
I opened the advanced audio properties and switched between volume types and everything works as expected.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
