### PR TITLE
win-dshow: Fix color range when using FFmpeg decode

### DIFF
--- a/plugins/win-dshow/ffmpeg-decode.h
+++ b/plugins/win-dshow/ffmpeg-decode.h
@@ -58,6 +58,7 @@ extern bool ffmpeg_decode_audio(struct ffmpeg_decode *decode, uint8_t *data,
 
 extern bool ffmpeg_decode_video(struct ffmpeg_decode *decode, uint8_t *data,
 				size_t size, long long *ts,
+				enum video_range_type range,
 				struct obs_source_frame2 *frame,
 				bool *got_output);
 

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -178,6 +178,7 @@ struct DShowInput {
 	VideoConfig videoConfig;
 	AudioConfig audioConfig;
 
+	video_range_type range;
 	obs_source_frame2 frame;
 	obs_source_audio audio;
 
@@ -481,7 +482,7 @@ void DShowInput::OnEncodedVideoData(enum AVCodecID id, unsigned char *data,
 
 	bool got_output;
 	bool success = ffmpeg_decode_video(video_decoder, data, size, &ts,
-					   &frame, &got_output);
+					   range, &frame, &got_output);
 	if (!success) {
 		blog(LOG_WARNING, "Error decoding video");
 		return;
@@ -1079,13 +1080,14 @@ inline bool DShowInput::Activate(obs_data_t *settings)
 	if (!device.ConnectFilters())
 		return false;
 
-	enum video_colorspace cs = GetColorSpace(settings);
-	frame.range = GetColorRange(settings);
-
 	if (device.Start() != Result::Success)
 		return false;
 
-	bool success = video_format_get_parameters(cs, frame.range,
+	enum video_colorspace cs = GetColorSpace(settings);
+	range = GetColorRange(settings);
+	frame.range = range;
+
+	bool success = video_format_get_parameters(cs, range,
 						   frame.color_matrix,
 						   frame.color_range_min,
 						   frame.color_range_max);


### PR DESCRIPTION
### Description
Full color range seems to be active when decoding video with FFMmpeg
even when partial is explicitly selected. This should keep the range
synchronized.

### Motivation and Context
Annoying to select partial color range, and get full colors.

Forum post: https://obsproject.com/forum/threads/obs-studio-24-0-release-candidate-5.109625/page-4#post-418657

### How Has This Been Tested?
Was able to reproduce the original bug. Tested fix with breakpoint inspection using Default/Full/Partial settings for both on-the-fly changes and application startup.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.