### PR TITLE
UI: Add fallbacks when property defaults are changed

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -1835,6 +1835,74 @@ void WidgetInfo::ControlChanged()
 	}
 }
 
+static void SetInitColorValues(obs_data_t *settings, const char *name)
+{
+	long long val = obs_data_get_int(settings, name);
+	obs_data_set_int(settings, name, val);
+}
+
+static void SetInitFontValues(obs_data_t *settings, const char *name)
+{
+	obs_data_t *font_obj = obs_data_get_obj(settings, name);
+	const char *face = obs_data_get_string(font_obj, "face");
+	const char *style = obs_data_get_string(font_obj, "style");
+	int size = obs_data_get_int(font_obj, "size");
+	uint32_t flags = obs_data_get_int(font_obj, "flags");
+	obs_data_set_string(font_obj, "face", face);
+	obs_data_set_string(font_obj, "style", style);
+	obs_data_set_int(font_obj, "size", size);
+	obs_data_set_int(font_obj, "flags", flags);
+	obs_data_set_obj(settings, name, font_obj);
+	obs_data_release(font_obj);
+}
+
+static void SetInitPathValues(obs_data_t *settings, const char *name)
+{
+	const char *path = obs_data_get_string(settings, name);
+	obs_data_set_string(settings, name, path);
+}
+
+void WidgetInfo::SaveInitValues()
+{
+	const char *setting = obs_property_name(property);
+	obs_property_type type = obs_property_get_type(property);
+
+	switch (type) {
+	case OBS_PROPERTY_INVALID:
+		break;
+	case OBS_PROPERTY_BOOL:
+		BoolChanged(setting);
+		break;
+	case OBS_PROPERTY_INT:
+		IntChanged(setting);
+		break;
+	case OBS_PROPERTY_FLOAT:
+		FloatChanged(setting);
+		break;
+	case OBS_PROPERTY_TEXT:
+		TextChanged(setting);
+		break;
+	case OBS_PROPERTY_LIST:
+		ListChanged(setting);
+		break;
+	case OBS_PROPERTY_COLOR:
+		SetInitColorValues(view->settings, setting);
+		break;
+	case OBS_PROPERTY_FONT:
+		SetInitFontValues(view->settings, setting);
+		break;
+	case OBS_PROPERTY_PATH:
+		SetInitPathValues(view->settings, setting);
+		break;
+	case OBS_PROPERTY_FRAME_RATE:
+		if (!FrameRateChanged(widget, setting, view->settings))
+			return;
+		break;
+	default:
+		break;
+	}
+}
+
 class EditableItemDialog : public QDialog {
 	QLineEdit *edit;
 	QString filter;

--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -38,11 +38,14 @@ private:
 
 	void TogglePasswordText(bool checked);
 
+	void SaveInitValues();
+
 public:
 	inline WidgetInfo(OBSPropertiesView *view_, obs_property_t *prop,
 			  QWidget *widget_)
 		: view(view_), property(prop), widget(widget_)
 	{
+		SaveInitValues();
 	}
 
 public slots:


### PR DESCRIPTION
### Description
This makes it so when a source property has its default value changed and the user didn't change the size, the source will still retain its previous size.

### Motivation and Context
A couple of changes have been rejected because there was no compatibility when the defaults change. This makes it so these can be used without issues.

https://github.com/obsproject/obs-studio/pull/1921
https://github.com/obsproject/obs-studio/commit/e981c157499e2b82c5fc4ed6e2f07a44507cc262

### How Has This Been Tested?
I created a text source and didn't change the default font size of 32. I then changed the source default to 256. When I loaded OBS, the text source was still at size 32, as expected. I also tested with the color source and everything worked there as well.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
