### PR TITLE
UI: Remove stats redundancy in view menu

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -395,7 +395,6 @@
     <addaction name="viewMenuToolbars"/>
     <addaction name="toggleStatusBar"/>
     <addaction name="separator"/>
-    <addaction name="stats"/>
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
@@ -728,7 +727,7 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>64</width>
+           <width>63</width>
            <height>16</height>
           </rect>
          </property>

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -151,8 +151,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>803</width>
-              <height>977</height>
+              <width>806</width>
+              <height>1225</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -235,13 +235,6 @@
                      </property>
                      <property name="checked">
                       <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="1">
-                    <widget class="QCheckBox" name="openStatsOnStartup">
-                     <property name="text">
-                      <string>Basic.Settings.General.OpenStatsOnStartup</string>
                      </property>
                     </widget>
                    </item>
@@ -1180,8 +1173,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>601</width>
-              <height>631</height>
+              <width>813</width>
+              <height>761</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -3628,8 +3621,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>555</width>
-              <height>469</height>
+              <width>767</width>
+              <height>582</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_50">
@@ -4444,8 +4437,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>803</width>
-              <height>781</height>
+              <width>791</width>
+              <height>970</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -5255,7 +5248,6 @@
   <tabstop>language</tabstop>
   <tabstop>theme</tabstop>
   <tabstop>enableAutoUpdates</tabstop>
-  <tabstop>openStatsOnStartup</tabstop>
   <tabstop>warnBeforeStreamStart</tabstop>
   <tabstop>warnBeforeStreamStop</tabstop>
   <tabstop>warnBeforeRecordStop</tabstop>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1787,9 +1787,6 @@ void OBSBasic::OBSInit()
 	ToggleMixerLayout(config_get_bool(App()->GlobalConfig(), "BasicWindow",
 					  "VerticalVolControl"));
 
-	if (config_get_bool(basicConfig, "General", "OpenStatsOnStartup"))
-		on_stats_triggered();
-
 	OBSBasicStats::InitializeValues();
 
 	/* ----------------------- */
@@ -3727,8 +3724,6 @@ void OBSBasic::CloseDialogs()
 		projector.clear();
 	}
 
-	if (!stats.isNull())
-		stats->close(); //call close to save Stats geometry
 	if (!remux.isNull())
 		remux->close();
 }
@@ -7297,20 +7292,6 @@ void OBSBasic::on_autoConfigure_triggered()
 	test.setModal(true);
 	test.show();
 	test.exec();
-}
-
-void OBSBasic::on_stats_triggered()
-{
-	if (!stats.isNull()) {
-		stats->show();
-		stats->raise();
-		return;
-	}
-
-	OBSBasicStats *statsDlg;
-	statsDlg = new OBSBasicStats(nullptr);
-	statsDlg->show();
-	stats = statsDlg;
 }
 
 void OBSBasic::on_actionShowAbout_triggered()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -202,7 +202,6 @@ private:
 	QPointer<QWidget> projectors[10];
 	QList<QPointer<QWidget>> windowProjectors;
 
-	QPointer<QWidget> stats;
 	QPointer<QWidget> remux;
 	QPointer<QWidget> extraBrowsers;
 
@@ -787,7 +786,6 @@ private slots:
 	void on_modeSwitch_clicked();
 
 	void on_autoConfigure_triggered();
-	void on_stats_triggered();
 
 	void on_resetUI_triggered();
 	void on_lockUI_toggled(bool lock);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -303,7 +303,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->language,             COMBO_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->theme, 		     COMBO_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->enableAutoUpdates,    CHECK_CHANGED,  GENERAL_CHANGED);
-	HookWidget(ui->openStatsOnStartup,   CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStart,CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStop, CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeRecordStop, CHECK_CHANGED,  GENERAL_CHANGED);
@@ -1066,9 +1065,6 @@ void OBSBasicSettings::LoadGeneralSettings()
 						 "EnableAutoUpdates");
 	ui->enableAutoUpdates->setChecked(enableAutoUpdates);
 #endif
-	bool openStatsOnStartup = config_get_bool(main->Config(), "General",
-						  "OpenStatsOnStartup");
-	ui->openStatsOnStartup->setChecked(openStatsOnStartup);
 
 	bool recordWhenStreaming = config_get_bool(
 		GetGlobalConfig(), "BasicWindow", "RecordWhenStreaming");
@@ -2738,9 +2734,6 @@ void OBSBasicSettings::SaveGeneralSettings()
 				"EnableAutoUpdates",
 				ui->enableAutoUpdates->isChecked());
 #endif
-	if (WidgetChanged(ui->openStatsOnStartup))
-		config_set_bool(main->Config(), "General", "OpenStatsOnStartup",
-				ui->openStatsOnStartup->isChecked());
 	if (WidgetChanged(ui->snappingEnabled))
 		config_set_bool(GetGlobalConfig(), "BasicWindow",
 				"SnappingEnabled",


### PR DESCRIPTION
### Description
This removes the redundant stats action in the view menu.

### Motivation and Context
It doesn't seem necessary to have a separate stats window when there is now a stats dock. I've also removed the show stats on startup option in the settings because docks are automatically saved when OBS is closed.
  
### How Has This Been Tested?
Ran program, everything works as expected.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
