### PR TITLE
CMake 3.10, C++17, SWIG warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 if (UNIX AND POLICY CMP0072)
 	# In case of both legacy and glvnd OpenGL libraries found. Prefer GLVND
@@ -70,8 +70,9 @@ if(NOT CMAKE_BUILD_TYPE)
         set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 
-find_package(CXX11 REQUIRED)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX11_FLAGS}")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_EXTENSIONS NO)
 
 if(${CMAKE_C_COMPILER_ID} MATCHES "Clang" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
 	set(CMAKE_COMPILER_IS_CLANG TRUE)

--- a/UI/platform-windows.cpp
+++ b/UI/platform-windows.cpp
@@ -20,7 +20,6 @@
 #include "obs-config.h"
 #include "obs-app.hpp"
 #include "platform.hpp"
-using namespace std;
 
 #include <util/windows/win-version.h>
 #include <util/platform.h>
@@ -36,6 +35,8 @@ using namespace std;
 #include <util/windows/WinHandle.hpp>
 #include <util/windows/HRError.hpp>
 #include <util/windows/ComPtr.hpp>
+
+using namespace std;
 
 static inline bool check_path(const char *data, const char *path,
 			      string &output)

--- a/deps/obs-scripting/CMakeLists.txt
+++ b/deps/obs-scripting/CMakeLists.txt
@@ -7,6 +7,11 @@ endif()
 
 project(obs-scripting)
 
+if(POLICY CMP0068)
+	# RPATH settings on macOS do not affect install_name.
+	cmake_policy(SET CMP0068 NEW)
+endif()
+
 if(MSVC)
 	set(obs-scripting_PLATFORM_DEPS
 		w32-pthreads)

--- a/deps/obs-scripting/obslua/CMakeLists.txt
+++ b/deps/obs-scripting/obslua/CMakeLists.txt
@@ -2,7 +2,12 @@ cmake_minimum_required(VERSION 2.8)
 project(obslua)
 
 if(POLICY CMP0078)
+	# UseSWIG generates standard target names.
 	cmake_policy(SET CMP0078 OLD)
+endif()
+if(POLICY CMP0086)
+	# UseSWIG honors SWIG_MODULE_NAME via -module flag.
+	cmake_policy(SET CMP0086 OLD)
 endif()
 
 find_package(SWIG 2 REQUIRED)

--- a/deps/obs-scripting/obspython/CMakeLists.txt
+++ b/deps/obs-scripting/obspython/CMakeLists.txt
@@ -2,7 +2,12 @@ cmake_minimum_required(VERSION 2.8)
 project(obspython)
 
 if(POLICY CMP0078)
+	# UseSWIG generates standard target names.
 	cmake_policy(SET CMP0078 OLD)
+endif()
+if(POLICY CMP0086)
+	# UseSWIG honors SWIG_MODULE_NAME via -module flag.
+	cmake_policy(SET CMP0086 OLD)
 endif()
 
 find_package(SWIG 2 REQUIRED)


### PR DESCRIPTION
### Description
Use C++17 for compilation, enforce CMake 3.10 as minimum, and set explicit policy to clean up SWIG warnings.

Prerequisites:
- [x] AMF submodule fix: https://github.com/obsproject/obs-amd-encoder/pull/381
- [x] AMF submodule fix: https://github.com/obsproject/obs-amd-encoder/pull/384
- [x] AMF submodule fix: https://github.com/obsproject/obs-amd-encoder/pull/385
- [x] AMF submodule update: #2095
- [x] obs-browser submodule fix: https://github.com/obsproject/obs-browser/pull/177
- [x] obs-browser submodule update: c6f48b9107656b3f7fac8fa0eca256c39fda17ec

### Motivation and Context
I would like to eventually implement features like Windows 10 ScreenCapture, which requires WinRT, which requires C++17 to use the projection headers. I would imagine more features will eventually require a more recent version of C++, so it's probably worth biting the bullet at some point.

CMake 3.10 is required for CXX_STANDARD VS support.

An alternative fix for SWIG warnings would be to use the new policy, but I don't know what SWIG does, and what the consequences would be.

### How Has This Been Tested?
Compiles and runs on Windows/Mac/Linux.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
