### PR TITLE
libobs: Export obs_group_from_source

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -470,8 +470,6 @@ void obs_source_copy_filters(obs_source_t *dst, obs_source_t *src)
 	duplicate_filters(dst, src, dst->context.private);
 }
 
-extern obs_scene_t *obs_group_from_source(const obs_source_t *source);
-
 obs_source_t *obs_source_duplicate(obs_source_t *source, const char *new_name,
 				   bool create_private)
 {

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1603,6 +1603,9 @@ EXPORT void obs_sceneitem_group_enum_items(obs_sceneitem_t *group,
 							    void *),
 					   void *param);
 
+/** Gets the group from its source, or NULL if not a group */
+EXPORT obs_scene_t *obs_group_from_source(const obs_source_t *source);
+
 EXPORT void obs_sceneitem_defer_group_resize_begin(obs_sceneitem_t *item);
 EXPORT void obs_sceneitem_defer_group_resize_end(obs_sceneitem_t *item);
 


### PR DESCRIPTION
### Description
export obs_group_from_source to allow it to be used

### Motivation and Context
I need it to loop through the scene items of a group

### How Has This Been Tested?
Using it in a lua script

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.