### PR TITLE
frontend-tools: output timer tab stop order

### DIFF
--- a/UI/frontend-plugins/frontend-tools/forms/output-timer.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/output-timer.ui
@@ -232,6 +232,19 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>streamingTimerHours</tabstop>
+  <tabstop>streamingTimerMinutes</tabstop>
+  <tabstop>streamingTimerSeconds</tabstop>
+  <tabstop>outputTimerStream</tabstop>
+  <tabstop>autoStartStreamTimer</tabstop>
+  <tabstop>recordingTimerHours</tabstop>
+  <tabstop>recordingTimerMinutes</tabstop>
+  <tabstop>recordingTimerSeconds</tabstop>
+  <tabstop>outputTimerRecord</tabstop>
+  <tabstop>autoStartRecordTimer</tabstop>
+  <tabstop>pauseRecordTimer</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
### Description
output timer tab stop order

### Motivation and Context
The default tab stop order is strange.

### How Has This Been Tested?
On windows x64

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
