### PR TITLE
cmake: Add AMD AGS library

### DIFF
--- a/cmake/Modules/CopyMSVCBins.cmake
+++ b/cmake/Modules/CopyMSVCBins.cmake
@@ -147,6 +147,21 @@ if (NOT ZLIB_BIN_FILES)
 		)
 endif()
 
+if (AGS_LIB)
+	GET_FILENAME_COMPONENT(AGS_BIN_PATH ${AGS_LIB} PATH)
+endif()
+file(GLOB AGS_BIN_FILES
+	"${AGS_BIN_PATH}/amd_ags_x*.dll")
+
+if (NOT AGS_BIN_FILES)
+	file(GLOB AGS_BIN_FILES
+		"${AGS_INCLUDE_DIR}/../bin${_bin_suffix}/amd_ags_x*.dll"
+		"${AGS_INCLUDE_DIR}/../bin/amd_ags_x*.dll"
+		"${AGS_INCLUDE_DIR}/bin${_bin_suffix}/amd_ags_x*.dll"
+		"${AGS_INCLUDE_DIR}/bin/amd_ags_x*.dll"
+		)
+endif()
+
 file(GLOB QT_DEBUG_BIN_FILES
 	"${Qt5Core_DIR}/../../../bin/Qt5Cored.dll"
 	"${Qt5Core_DIR}/../../../bin/Qt5Guid.dll"
@@ -192,6 +207,7 @@ set(ALL_BASE_BIN_FILES
 	${LUA_BIN_FILES}
 	${SSL_BIN_FILES}
 	${ZLIB_BIN_FILES}
+	${AGS_BIN_FILES}
 	${LIBFDK_BIN_FILES}
 	${FREETYPE_BIN_FILES}
 	${QT_ICU_BIN_FILES})
@@ -245,6 +261,7 @@ message(STATUS "curl files: ${CURL_BIN_FILES}")
 message(STATUS "lua files: ${LUA_BIN_FILES}")
 message(STATUS "ssl files: ${SSL_BIN_FILES}")
 message(STATUS "zlib files: ${ZLIB_BIN_FILES}")
+message(STATUS "AGS files: ${AGS_BIN_FILES}")
 message(STATUS "QT Debug files: ${QT_DEBUG_BIN_FILES}")
 message(STATUS "QT Debug Platform files: ${QT_DEBUG_PLAT_BIN_FILES}")
 message(STATUS "QT Debug Styles files: ${QT_DEBUG_STYLES_BIN_FILES}")

--- a/cmake/Modules/FindAGS.cmake
+++ b/cmake/Modules/FindAGS.cmake
@@ -1,0 +1,70 @@
+# Once done these will be defined:
+#
+#  AGS_FOUND
+#  AGS_INCLUDE_DIRS
+#  AGS_LIBRARIES
+#
+# For use in OBS: 
+#
+#  AGS_INCLUDE_DIR
+
+find_package(PkgConfig QUIET)
+if (PKG_CONFIG_FOUND)
+	pkg_check_modules(_AGS QUIET ags)
+endif()
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	set(_lib_suffix 64)
+	set(_file_suffix 64)
+else()
+	set(_lib_suffix 32)
+	set(_file_suffix 86)
+endif()
+
+find_path(AGS_INCLUDE_DIR
+	NAMES amd_ags.h
+	HINTS
+		ENV agsPath${_lib_suffix}
+		ENV agsPath
+		ENV DepsPath${_lib_suffix}
+		ENV DepsPath
+		${agsPath${_lib_suffix}}
+		${agsPath}
+		${DepsPath${_lib_suffix}}
+		${DepsPath}
+		${_AGS_INCLUDE_DIRS}
+	PATHS
+		/usr/include /usr/local/include /opt/local/include /sw/include
+	PATH_SUFFIXES
+		include)
+
+find_library(AGS_LIB
+	NAMES ${_AGS_LIBRARIES} amd_ags_x${_file_suffix}
+	HINTS
+		ENV agsPath${_lib_suffix}
+		ENV agsPath
+		ENV DepsPath${_lib_suffix}
+		ENV DepsPath
+		${agsPath${_lib_suffix}}
+		${agsPath}
+		${DepsPath${_lib_suffix}}
+		${DepsPath}
+		${_AGS_LIBRARY_DIRS}
+	PATHS
+		/usr/lib /usr/local/lib /opt/local/lib /sw/lib
+	PATH_SUFFIXES
+		lib${_lib_suffix} lib
+		libs${_lib_suffix} libs
+		bin${_lib_suffix} bin
+		../lib${_lib_suffix} ../lib
+		../libs${_lib_suffix} ../libs
+		../bin${_lib_suffix} ../bin)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ags DEFAULT_MSG AGS_LIB AGS_INCLUDE_DIR)
+mark_as_advanced(AGS_INCLUDE_DIR AGS_LIB)
+
+if(AGS_FOUND)
+	set(AGS_INCLUDE_DIRS ${AGS_INCLUDE_DIR})
+	set(AGS_LIBRARIES ${AGS_LIB})
+endif()


### PR DESCRIPTION
We can use this to perform driver version checks for AMF.

### Description
Add AMD AGS library. We can use this to perform driver version checks for AMF.

### Motivation and Context
AMF crashes mysteriously on startup, and we can try to reduce those incidents by not starting up AMF unless the driver is new enough.

### How Has This Been Tested?
Breakpoint-inspected 32-bit and 64-bit Windows with this change, and the plugin change to use AGS. This library is Windows-only. TODO: Mac/Linux regression?

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
