### PR TITLE
obs-scripting: Fix Python on MacOS

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -373,14 +373,6 @@ if (APPLE)
 	target_link_libraries(obs
 			Qt5::MacExtras)
 	set_target_properties(obs PROPERTIES LINK_FLAGS "-pagezero_size 10000 -image_base 100000000")
-	set_property(
-		TARGET obs
-		APPEND
-		PROPERTY INSTALL_RPATH
-		"/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/lib/"
-		"/Library/Frameworks/Python.framework/Versions/3.6/lib/"
-		"/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/"
-	)
 endif()
 
 define_graphic_modules(obs)

--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -61,7 +61,7 @@ if(NOT UNIX_STRUCTURE)
 		set(OBS_INSTALL_PREFIX "")
 		set(OBS_RELATIVE_PREFIX "../")
 
-		set(OBS_SCRIPT_PLUGIN_DESTINATION "${OBS_DATA_DESTINATION}/obs-scripting/${_lib_suffix}bit")
+		set(OBS_SCRIPT_PLUGIN_DESTINATION "${OBS_DATA_DESTINATION}/obs-scripting")
 	else()
 		set(OBS_EXECUTABLE_DESTINATION "bin/${_lib_suffix}bit")
 		set(OBS_EXECUTABLE32_DESTINATION "bin/32bit")

--- a/deps/obs-scripting/obs-scripting-python-import.c
+++ b/deps/obs-scripting/obs-scripting-python-import.c
@@ -32,6 +32,12 @@
 #define SO_EXT ".dylib"
 #endif
 
+#ifdef __APPLE__
+#define PYTHON_LIB_SUBDIR "lib/"
+#else
+#define PYTHON_LIB_SUBDIR ""
+#endif
+
 bool import_python(const char *python_path)
 {
 	struct dstr lib_path;
@@ -44,7 +50,7 @@ bool import_python(const char *python_path)
 	dstr_init_copy(&lib_path, python_path);
 	dstr_replace(&lib_path, "\\", "/");
 	if (!dstr_is_empty(&lib_path)) {
-		dstr_cat(&lib_path, "/");
+		dstr_cat(&lib_path, "/" PYTHON_LIB_SUBDIR);
 	}
 	dstr_cat(&lib_path, PYTHON_LIB SO_EXT);
 

--- a/deps/obs-scripting/obspython/CMakeLists.txt
+++ b/deps/obs-scripting/obspython/CMakeLists.txt
@@ -42,7 +42,12 @@ if(CMAKE_VERSION VERSION_GREATER 3.7.2)
 else()
 	SWIG_ADD_MODULE(obspython python obspython.i ../cstrcache.cpp ../cstrcache.h)
 endif()
-SWIG_LINK_LIBRARIES(obspython obs-scripting libobs ${PYTHON_LIBRARIES})
+
+IF(APPLE)
+	SWIG_LINK_LIBRARIES(obspython obs-scripting libobs)
+ELSE()
+	SWIG_LINK_LIBRARIES(obspython obs-scripting libobs ${PYTHON_LIBRARIES})
+ENDIF()
 
 function(install_plugin_bin_swig target additional_target)
 	if(APPLE)
@@ -57,14 +62,7 @@ function(install_plugin_bin_swig target additional_target)
 		PREFIX "")
 
 	if (APPLE)
-		set_property(
-				TARGET ${additional_target}
-				APPEND
-				PROPERTY INSTALL_RPATH
-				"/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/lib/"
-				"/Library/Frameworks/Python.framework/Versions/3.6/lib/"
-				"/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/"
-		)
+		SET_TARGET_PROPERTIES(${additional_target} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 	endif()
 
 	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/obspython.py"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Make python scripting work on MacOS with a user supplied python version, just like on Windows.

### Motivation and Context
Python scripting is really useful and would be nice to have available on MacOS but currently requries some manual changes to get it to work.

### How Has This Been Tested?
Manually tested locally on my machine (10.14.6) against homebrew and macports pythons.

On a fresh 10.14.0 VM with only a Azure CI built OBS installed and homebrew python and macports pythons. 

All worked succesfully, with both python 3.6 and 3.7 depending on what the respective OBS was built with.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.

Minor issue is that changing the interpreter after one has been loaded does require an OBS restart to use the new one (but I think Windows behaves the same based on a quick try?).