### PR TITLE
UI: Fix path calculation for disk space check

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -681,6 +681,8 @@ public:
 
 	static OBSBasic *Get();
 
+	const char *GetCurrentOutputPath();
+
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;
 	virtual void changeEvent(QEvent *event) override;

--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -297,13 +297,7 @@ void OBSBasicStats::Update()
 
 	/* ------------------ */
 
-	const char *mode = config_get_string(main->Config(), "Output", "Mode");
-	const char *path = strcmp(mode, "Advanced")
-				   ? config_get_string(main->Config(),
-						       "SimpleOutput",
-						       "FilePath")
-				   : config_get_string(main->Config(), "AdvOut",
-						       "RecFilePath");
+	const char *path = main->GetCurrentOutputPath();
 
 #define MBYTE (1024ULL * 1024ULL)
 #define GBYTE (1024ULL * 1024ULL * 1024ULL)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
When using custom FFmpeg output mode, the check would instead use the standard recording path which is no longer visible in the settings. This commit also simplifies the checks by moving the duplicated code to a new function.

I am creating a PR instead of directly commiting as I am not sure whether creating a new public function in the OBSBasic class is the best way to allow both the main window and stats window access to the output path.

### Motivation and Context
This fixes cases where users couldn't record due to the wrong output path being checked.

### How Has This Been Tested?
I tested every recording output mode to verify the free disk space matched the selected file path.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
