### PR TITLE
libobs: fix single-button hotkeys for Windows

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -854,6 +854,7 @@ Basic.Settings.Advanced.Hotkeys.HotkeyFocusBehavior="Hotkey Focus Behavior"
 Basic.Settings.Advanced.Hotkeys.NeverDisableHotkeys="Never disable hotkeys"
 Basic.Settings.Advanced.Hotkeys.DisableHotkeysInFocus="Disable hotkeys when main window is in focus"
 Basic.Settings.Advanced.Hotkeys.DisableHotkeysOutOfFocus="Disable hotkeys when main window is not in focus"
+Basic.Settings.Advanced.Hotkeys.SuppressHotkeys="Register OBS hotkeys globally and do not pass them to other windows"
 Basic.Settings.Advanced.AutoRemux="Automatically remux to mp4"
 Basic.Settings.Advanced.AutoRemux.MP4="(record as mkv)"
 

--- a/UI/data/locale/ru-RU.ini
+++ b/UI/data/locale/ru-RU.ini
@@ -773,6 +773,7 @@ Basic.Settings.Advanced.Hotkeys.HotkeyFocusBehavior="Поведение фоку
 Basic.Settings.Advanced.Hotkeys.NeverDisableHotkeys="Никогда не отключать горячие клавиши"
 Basic.Settings.Advanced.Hotkeys.DisableHotkeysInFocus="Отключить горячие клавиши, если главное окно находится в фокусе"
 Basic.Settings.Advanced.Hotkeys.DisableHotkeysOutOfFocus="Отключать горячие клавиши, когда главное окно вне фокуса"
+Basic.Settings.Advanced.Hotkeys.SuppressHotkeys="Регистрировать горячие клавиши OBS глобально и не передавать их в другие окна"
 Basic.Settings.Advanced.AutoRemux="Автоматически ремультиплексировать в mp4"
 Basic.Settings.Advanced.AutoRemux.MP4="(записывать как mkv)"
 

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -5243,6 +5243,13 @@
                    <item row="0" column="1">
                     <widget class="QComboBox" name="hotkeyFocusType"/>
                    </item>
+                   <item row="2" column="1">
+                    <widget class="QCheckBox" name="suppressHotkeys">
+                     <property name="text">
+                      <string>Basic.Settings.Advanced.Hotkeys.SuppressHotkeys</string>
+                     </property>
+                    </widget>
+                   </item>
                    <item row="1" column="0">
                     <spacer name="horizontalSpacer_14">
                      <property name="orientation">

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -435,6 +435,11 @@ bool OBSApp::InitGlobalConfigDefaults()
 	config_set_default_string(globalConfig, "General", "HotkeyFocusType",
 				  "NeverDisableHotkeys");
 
+#ifdef _WIN32
+	config_set_default_bool(globalConfig, "General", "SuppressHotkeys",
+				false);
+#endif
+
 	config_set_default_bool(globalConfig, "BasicWindow",
 				"VerticalVolControl", false);
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -471,6 +471,9 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->enableNewSocketLoop,  CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->enableLowLatencyMode, CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->hotkeyFocusType,      COMBO_CHANGED,  ADV_CHANGED);
+#ifdef _WIN32
+	HookWidget(ui->suppressHotkeys,      CHECK_CHANGED,  ADV_CHANGED);
+#endif
 	HookWidget(ui->autoRemux,            CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->dynBitrate,           CHECK_CHANGED,  ADV_CHANGED);
 	/* clang-format on */
@@ -2296,6 +2299,10 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	bool autoRemux = config_get_bool(main->Config(), "Video", "AutoRemux");
 	const char *hotkeyFocusType = config_get_string(
 		App()->GlobalConfig(), "General", "HotkeyFocusType");
+#ifdef _WIN32
+	bool suppressHotkeys = config_get_bool(App()->GlobalConfig(), "General",
+					       "SuppressHotkeys");
+#endif
 	bool dynBitrate =
 		config_get_bool(main->Config(), "Output", "DynamicBitrate");
 
@@ -2372,6 +2379,9 @@ void OBSBasicSettings::LoadAdvancedSettings()
 #endif
 
 	SetComboByValue(ui->hotkeyFocusType, hotkeyFocusType);
+#ifdef _WIN32
+	ui->suppressHotkeys->setChecked(suppressHotkeys);
+#endif
 
 	loading = false;
 }
@@ -2972,6 +2982,13 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	bool browserHWAccel = ui->browserHWAccel->isChecked();
 	config_set_bool(App()->GlobalConfig(), "General", "BrowserHWAccel",
 			browserHWAccel);
+
+	if (WidgetChanged(ui->suppressHotkeys)) {
+		bool checked = ui->suppressHotkeys->isChecked();
+		config_set_bool(App()->GlobalConfig(), "General",
+				"SuppressHotkeys", checked);
+		resuppress_global_hotkeys(checked);
+	}
 #endif
 
 	if (WidgetChanged(ui->hotkeyFocusType)) {

--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -644,6 +644,9 @@ static inline void create_binding(obs_hotkey_t *hotkey,
 	binding->key = combo;
 	binding->hotkey_id = hotkey->id;
 	binding->hotkey = hotkey;
+#ifdef _WIN32
+	suppress_global_hotkey(combo);
+#endif
 }
 
 static inline void load_binding(obs_hotkey_t *hotkey, obs_data_t *data)
@@ -988,7 +991,9 @@ static inline void remove_bindings(obs_hotkey_id id)
 	while (find_binding(id, &idx)) {
 		obs_hotkey_binding_t *binding =
 			&obs->hotkeys.bindings.array[idx];
-
+#ifdef _WIN32
+		unsuppress_global_hotkey(binding->key);
+#endif
 		if (binding->pressed)
 			release_pressed_binding(binding);
 

--- a/libobs/obs-hotkey.h
+++ b/libobs/obs-hotkey.h
@@ -314,6 +314,7 @@ EXPORT obs_key_t obs_key_from_name(const char *name);
 #ifdef _WIN32
 bool suppress_global_hotkey(obs_key_combination_t combo);
 bool unsuppress_global_hotkey(obs_key_combination_t combo);
+EXPORT void resuppress_global_hotkeys(bool suppress);
 #endif
 
 static inline bool obs_key_combination_is_empty(obs_key_combination_t combo)

--- a/libobs/obs-hotkey.h
+++ b/libobs/obs-hotkey.h
@@ -311,6 +311,11 @@ EXPORT int obs_key_to_virtual_key(obs_key_t key);
 EXPORT const char *obs_key_to_name(obs_key_t key);
 EXPORT obs_key_t obs_key_from_name(const char *name);
 
+#ifdef _WIN32
+bool suppress_global_hotkey(obs_key_combination_t combo);
+bool unsuppress_global_hotkey(obs_key_combination_t combo);
+#endif
+
 static inline bool obs_key_combination_is_empty(obs_key_combination_t combo)
 {
 	return !combo.modifiers && combo.key == OBS_KEY_NONE;

--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -963,3 +963,18 @@ bool unsuppress_global_hotkey(obs_key_combination_t combo)
 {
 	return UnregisterHotKey(NULL, get_hotkey_id(combo));
 }
+
+static bool resuppress_callback(void *data, size_t idx,
+				obs_hotkey_binding_t *binding)
+{
+	bool suppress = *(bool *)data;
+	unsuppress_global_hotkey(binding->key);
+	if (suppress)
+		suppress_global_hotkey(binding->key);
+	return true;
+}
+
+void resuppress_global_hotkeys(bool suppress)
+{
+	obs_enum_hotkey_bindings(resuppress_callback, &suppress);
+}


### PR DESCRIPTION
# Description

This PR makes OBS register hotkeys in Windows using `RegisterHotKey` effectively suppressing them for other programs.

### Motivation and Context

Before this PR OBS hotkeys were passing to active windows causing erratic and unpredictable behavior. For example setting F1 for mute audio source would bring up "How can we help you?" page in Chrome.

### How Has This Been Tested?

Tested on Windows 8.1 x64

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
