### PR TITLE
libobs-d3d11: Add GPU driver version to log

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -781,6 +781,25 @@ static inline void LogD3DAdapters()
 		blog(LOG_INFO, "\t  Shared VRAM:    %u",
 		     desc.SharedSystemMemory);
 
+		/* driver version */
+		LARGE_INTEGER umd;
+		hr = adapter->CheckInterfaceSupport(__uuidof(IDXGIDevice),
+						    &umd);
+		if (SUCCEEDED(hr)) {
+			const uint64_t version = umd.QuadPart;
+			const uint16_t aa = (version >> 48) & 0xffff;
+			const uint16_t bb = (version >> 32) & 0xffff;
+			const uint16_t ccccc = (version >> 16) & 0xffff;
+			const uint16_t ddddd = version & 0xffff;
+			blog(LOG_INFO,
+			     "\t  Driver Version: %" PRIu16 ".%" PRIu16
+			     ".%" PRIu16 ".%" PRIu16,
+			     aa, bb, ccccc, ddddd);
+		} else {
+			blog(LOG_INFO, "\t  Driver Version: Unknown (0x%X)",
+			     (unsigned)hr);
+		}
+
 		LogAdapterMonitors(adapter);
 	}
 }


### PR DESCRIPTION
### Description
Add GPU driver version to info log. DX version string is not the nicest, but no need for IHV library.

### Motivation and Context
Handy to know what the GPU driver version is, so we can tell if users are out of date.

### How Has This Been Tested?
Driver strings were reported correctly when tested on AMD and Intel.

	Adapter 0: Intel(R) HD Graphics 530
	  Dedicated VRAM: 134217728
	  Shared VRAM:    4221272064
	  Driver Version: 26.20.100.7212
	  output 0: pos={0, 0}, size={2560, 1440}, attached=true
	Adapter 1: Radeon RX Vega
	  Dedicated VRAM: 4220833792
	  Shared VRAM:    4221272064
	  Driver Version: 26.20.13003.1007
	  output 0: pos={2560, 16}, size={3840, 2160}, attached=true

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.