### PR TITLE
Log display refresh rates, and monitor names on D3D11

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -724,6 +724,53 @@ bool device_enum_adapters(bool (*callback)(void *param, const char *name,
 	}
 }
 
+static bool GetMonitorTarget(const MONITORINFOEX &info,
+			     DISPLAYCONFIG_TARGET_DEVICE_NAME &target)
+{
+	bool found = false;
+
+	UINT32 numPath, numMode;
+	if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &numPath,
+					&numMode) == ERROR_SUCCESS) {
+		std::vector<DISPLAYCONFIG_PATH_INFO> paths(numPath);
+		std::vector<DISPLAYCONFIG_MODE_INFO> modes(numMode);
+		if (QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &numPath,
+				       paths.data(), &numMode, modes.data(),
+				       nullptr) == ERROR_SUCCESS) {
+			paths.resize(numPath);
+			for (size_t i = 0; i < numPath; ++i) {
+				const DISPLAYCONFIG_PATH_INFO &path = paths[i];
+
+				DISPLAYCONFIG_SOURCE_DEVICE_NAME
+				source;
+				source.header.type =
+					DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+				source.header.size = sizeof(source);
+				source.header.adapterId =
+					path.sourceInfo.adapterId;
+				source.header.id = path.sourceInfo.id;
+				if (DisplayConfigGetDeviceInfo(
+					    &source.header) == ERROR_SUCCESS &&
+				    wcscmp(info.szDevice,
+					   source.viewGdiDeviceName) == 0) {
+					target.header.type =
+						DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;
+					target.header.size = sizeof(target);
+					target.header.adapterId =
+						path.sourceInfo.adapterId;
+					target.header.id = path.targetInfo.id;
+					found = DisplayConfigGetDeviceInfo(
+							&target.header) ==
+						ERROR_SUCCESS;
+					break;
+				}
+			}
+		}
+	}
+
+	return found;
+}
+
 static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 {
 	UINT i;
@@ -736,9 +783,14 @@ static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 
 		unsigned refresh = 0;
 
+		bool target_found = false;
+		DISPLAYCONFIG_TARGET_DEVICE_NAME target;
+
 		MONITORINFOEX info;
 		info.cbSize = sizeof(info);
 		if (GetMonitorInfo(desc.Monitor, &info)) {
+			target_found = GetMonitorTarget(info, target);
+
 			DEVMODE mode;
 			mode.dmSize = sizeof(mode);
 			mode.dmDriverExtra = 0;
@@ -748,16 +800,22 @@ static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 			}
 		}
 
+		if (!target_found) {
+			target.monitorFriendlyDeviceName[0] = 0;
+		}
+
 		const RECT &rect = desc.DesktopCoordinates;
 		blog(LOG_INFO,
 		     "\t  output %u: "
 		     "pos={%d, %d}, "
 		     "size={%d, %d}, "
 		     "attached=%s, "
-		     "refresh=%u",
+		     "refresh=%u, "
+		     "name=%ls",
 		     i, rect.left, rect.top, rect.right - rect.left,
 		     rect.bottom - rect.top,
-		     desc.AttachedToDesktop ? "true" : "false", refresh);
+		     desc.AttachedToDesktop ? "true" : "false", refresh,
+		     target.monitorFriendlyDeviceName);
 	}
 }
 

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -734,15 +734,30 @@ static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 		if (FAILED(output->GetDesc(&desc)))
 			continue;
 
-		RECT rect = desc.DesktopCoordinates;
+		unsigned refresh = 0;
+
+		MONITORINFOEX info;
+		info.cbSize = sizeof(info);
+		if (GetMonitorInfo(desc.Monitor, &info)) {
+			DEVMODE mode;
+			mode.dmSize = sizeof(mode);
+			mode.dmDriverExtra = 0;
+			if (EnumDisplaySettings(info.szDevice,
+						ENUM_CURRENT_SETTINGS, &mode)) {
+				refresh = mode.dmDisplayFrequency;
+			}
+		}
+
+		const RECT &rect = desc.DesktopCoordinates;
 		blog(LOG_INFO,
 		     "\t  output %u: "
 		     "pos={%d, %d}, "
 		     "size={%d, %d}, "
-		     "attached=%s",
+		     "attached=%s, "
+		     "refresh=%u",
 		     i, rect.left, rect.top, rect.right - rect.left,
 		     rect.bottom - rect.top,
-		     desc.AttachedToDesktop ? "true" : "false");
+		     desc.AttachedToDesktop ? "true" : "false", refresh);
 	}
 }
 


### PR DESCRIPTION
### Description
Log display refresh rates, and monitor names.

### Motivation and Context
Common issue for mismatched monitor refresh rates to cause problems.

### How Has This Been Tested?
Ran on my current PC.

	Adapter 0: Intel(R) HD Graphics 530
	  Dedicated VRAM: 134217728
	  Shared VRAM:    4221272064
	  output 0: pos={0, 0}, size={2560, 1440}, attached=true, refresh=120, name=ROG PG279Q
	Adapter 1: Radeon RX Vega
	  Dedicated VRAM: 4220833792
	  Shared VRAM:    4221272064
	  output 0: pos={2560, 0}, size={3840, 2160}, attached=true, refresh=60, name=DELL UP2718Q

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.