### PR TITLE
linux-capture: Fix bug where multiple 0x0 windows would appear

### DIFF
--- a/plugins/linux-capture/xhelpers.c
+++ b/plugins/linux-capture/xhelpers.c
@@ -108,7 +108,6 @@ int randr_screen_count(xcb_connection_t *xcb)
 {
 	if (!xcb)
 		return 0;
-
 	xcb_screen_t *screen;
 	screen = xcb_setup_roots_iterator(xcb_get_setup(xcb)).data;
 

--- a/plugins/linux-capture/xshm-input.c
+++ b/plugins/linux-capture/xshm-input.c
@@ -324,7 +324,9 @@ static bool xshm_server_changed(obs_properties_t *props, obs_property_t *p,
 			    ")",
 			    i, w, h, x, y);
 
-		obs_property_list_add_int(screens, screen_info.array, i);
+		if (h > 0 && w > 0)
+			obs_property_list_add_int(screens, screen_info.array,
+						  i);
 	}
 
 	/* handle missing screen */


### PR DESCRIPTION
### Description
Fixed a bug where randr was counting screen based upon number of crtcs even if they were not configured.

### Motivation and Context
Fixes [this mantis issue](https://obsproject.com/mantis/view.php?id=1555) where multiple monitors were being given with 0 width and height.

### How Has This Been Tested?
I was able to reproduce the bug on my system. Tested fix by running through line-by-line where the misreporting of screen numbers was occurring.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
