### PR TITLE
UI: Add copy/paste of multiple selected sources

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1047,7 +1047,7 @@ retryScene:
 		opt_start_replaybuffer = false;
 	}
 
-	copyString = nullptr;
+	copyStrings.clear();
 	copyFiltersString = nullptr;
 
 	LogScenes();
@@ -5828,6 +5828,11 @@ int OBSBasic::GetTopSelectedSourceItem()
 	return selectedItems.count() ? selectedItems[0].row() : -1;
 }
 
+QModelIndexList OBSBasic::GetAllSelectedSourceItems()
+{
+	return ui->sources->selectionModel()->selectedIndexes();
+}
+
 void OBSBasic::on_preview_customContextMenuRequested(const QPoint &pos)
 {
 	CreateSourcePopupMenu(GetTopSelectedSourceItem(), true);
@@ -7011,41 +7016,52 @@ bool OBSBasic::sysTrayMinimizeToTray()
 
 void OBSBasic::on_actionCopySource_triggered()
 {
-	OBSSceneItem item = GetCurrentSceneItem();
-	if (!item)
-		return;
+	copyStrings.clear();
+	bool allowPastingDuplicate = true;
 
-	on_actionCopyTransform_triggered();
+	for (auto &selectedSource : GetAllSelectedSourceItems()) {
+		OBSSceneItem item = ui->sources->Get(selectedSource.row());
+		if (!item)
+			continue;
 
-	OBSSource source = obs_sceneitem_get_source(item);
+		on_actionCopyTransform_triggered();
 
-	copyString = obs_source_get_name(source);
-	copyVisible = obs_sceneitem_visible(item);
+		OBSSource source = obs_sceneitem_get_source(item);
+
+		copyStrings.push_front(obs_source_get_name(source));
+
+		copyVisible = obs_sceneitem_visible(item);
+
+		uint32_t output_flags = obs_source_get_output_flags(source);
+		if (!(output_flags & OBS_SOURCE_DO_NOT_DUPLICATE) == 0)
+			allowPastingDuplicate = false;
+	}
 
 	ui->actionPasteRef->setEnabled(true);
-
-	uint32_t output_flags = obs_source_get_output_flags(source);
-	if ((output_flags & OBS_SOURCE_DO_NOT_DUPLICATE) == 0)
-		ui->actionPasteDup->setEnabled(true);
-	else
-		ui->actionPasteDup->setEnabled(false);
+	ui->actionPasteDup->setEnabled(allowPastingDuplicate);
 }
 
 void OBSBasic::on_actionPasteRef_triggered()
 {
-	/* do not allow duplicate refs of the same group in the same scene */
-	OBSScene scene = GetCurrentScene();
-	if (!!obs_scene_get_group(scene, copyString))
-		return;
+	for (auto &copyString : copyStrings) {
+		/* do not allow duplicate refs of the same group in the same scene */
+		OBSScene scene = GetCurrentScene();
+		if (!!obs_scene_get_group(scene, copyString))
+			continue;
 
-	OBSBasicSourceSelect::SourcePaste(copyString, copyVisible, false);
-	on_actionPasteTransform_triggered();
+		OBSBasicSourceSelect::SourcePaste(copyString, copyVisible,
+						  false);
+		on_actionPasteTransform_triggered();
+	}
 }
 
 void OBSBasic::on_actionPasteDup_triggered()
 {
-	OBSBasicSourceSelect::SourcePaste(copyString, copyVisible, true);
-	on_actionPasteTransform_triggered();
+	for (auto &copyString : copyStrings) {
+		OBSBasicSourceSelect::SourcePaste(copyString, copyVisible,
+						  true);
+		on_actionPasteTransform_triggered();
+	}
 }
 
 void OBSBasic::AudioMixerCopyFilters()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -155,7 +155,7 @@ private:
 	bool previewEnabled = true;
 	bool fullscreenInterface = false;
 
-	const char *copyString;
+	std::list<const char *> copyStrings;
 	const char *copyFiltersString = nullptr;
 	bool copyVisible = true;
 
@@ -329,6 +329,8 @@ private:
 	void SaveProjectNow();
 
 	int GetTopSelectedSourceItem();
+
+	QModelIndexList GetAllSelectedSourceItems();
 
 	obs_hotkey_pair_id streamingHotkeys, recordingHotkeys, pauseHotkeys,
 		replayBufHotkeys, togglePreviewHotkeys;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
When selecting multiple sources and copying them (through the context menu or Ctrl+C) and then pasting them (as references or duplicates) all of the selected sources that were copied are now pasted instead of just the first selected source. 
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Implements the feature requested here:
https://obsproject.com/mantis/view.php?id=1560

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
- Windows 10 x64  
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Manually verified that the behavior for single source copy/pasting remained consistent between the release version of OBS and the proposed changes.
- Verified that pasting as references works as intended for multiple sources (i.e. they all function as references). 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
