### PR TITLE
UI: Remove unused code from visibility item widget

### DIFF
--- a/UI/visibility-item-widget.cpp
+++ b/UI/visibility-item-widget.cpp
@@ -1,6 +1,5 @@
 #include "visibility-item-widget.hpp"
 #include "visibility-checkbox.hpp"
-#include "locked-checkbox.hpp"
 #include "qt-wrappers.hpp"
 #include "obs-app.hpp"
 #include <QListWidget>
@@ -42,136 +41,6 @@ VisibilityItemWidget::VisibilityItemWidget(obs_source_t *source_)
 		SLOT(VisibilityClicked(bool)));
 }
 
-VisibilityItemWidget::VisibilityItemWidget(obs_sceneitem_t *item_)
-	: item(item_),
-	  source(obs_sceneitem_get_source(item)),
-	  renamedSignal(obs_source_get_signal_handler(source), "rename",
-			OBSSourceRenamed, this)
-{
-	const char *name = obs_source_get_name(source);
-	bool enabled = obs_sceneitem_visible(item);
-	bool locked = obs_sceneitem_locked(item);
-	obs_scene_t *scene = obs_sceneitem_get_scene(item);
-	obs_source_t *sceneSource = obs_scene_get_source(scene);
-
-	vis = new VisibilityCheckBox();
-	vis->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
-	/* Fix for non-apple systems where the spacing would be too big */
-#ifndef __APPLE__
-	vis->setMaximumSize(16, 16);
-#endif
-	vis->setChecked(enabled);
-
-	lock = new LockedCheckBox();
-	lock->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
-	/* Fix for non-apple systems where the spacing would be too big */
-#ifndef __APPLE__
-	lock->setMaximumSize(16, 16);
-#endif
-	lock->setChecked(locked);
-
-	label = new QLabel(QT_UTF8(name));
-	label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-
-#ifdef __APPLE__
-	vis->setAttribute(Qt::WA_LayoutUsesWidgetRect);
-	lock->setAttribute(Qt::WA_LayoutUsesWidgetRect);
-#endif
-
-	QHBoxLayout *itemLayout = new QHBoxLayout();
-	itemLayout->addWidget(vis);
-	itemLayout->addWidget(lock);
-	itemLayout->addWidget(label);
-	itemLayout->setContentsMargins(5, 2, 5, 2);
-	itemLayout->setSpacing(2);
-
-	setLayout(itemLayout);
-	setStyleSheet("background-color: rgba(255, 255, 255, 0);");
-
-	signal_handler_t *signal = obs_source_get_signal_handler(sceneSource);
-	signal_handler_connect(signal, "remove", OBSSceneRemove, this);
-	signal_handler_connect(signal, "item_remove", OBSSceneItemRemove, this);
-	signal_handler_connect(signal, "item_visible", OBSSceneItemVisible,
-			       this);
-	signal_handler_connect(signal, "item_locked", OBSSceneItemLocked, this);
-
-	connect(vis, SIGNAL(clicked(bool)), this,
-		SLOT(VisibilityClicked(bool)));
-
-	connect(lock, SIGNAL(clicked(bool)), this, SLOT(LockClicked(bool)));
-}
-
-VisibilityItemWidget::~VisibilityItemWidget()
-{
-	DisconnectItemSignals();
-}
-
-void VisibilityItemWidget::DisconnectItemSignals()
-{
-	if (!item || sceneRemoved)
-		return;
-
-	obs_scene_t *scene = obs_sceneitem_get_scene(item);
-	obs_source_t *sceneSource = obs_scene_get_source(scene);
-	signal_handler_t *signal = obs_source_get_signal_handler(sceneSource);
-
-	signal_handler_disconnect(signal, "remove", OBSSceneRemove, this);
-	signal_handler_disconnect(signal, "item_remove", OBSSceneItemRemove,
-				  this);
-	signal_handler_disconnect(signal, "item_visible", OBSSceneItemVisible,
-				  this);
-	signal_handler_disconnect(signal, "item_locked", OBSSceneItemLocked,
-				  this);
-
-	sceneRemoved = true;
-}
-
-void VisibilityItemWidget::OBSSceneRemove(void *param, calldata_t *data)
-{
-	VisibilityItemWidget *window =
-		reinterpret_cast<VisibilityItemWidget *>(param);
-
-	window->DisconnectItemSignals();
-
-	UNUSED_PARAMETER(data);
-}
-
-void VisibilityItemWidget::OBSSceneItemRemove(void *param, calldata_t *data)
-{
-	VisibilityItemWidget *window =
-		reinterpret_cast<VisibilityItemWidget *>(param);
-	obs_sceneitem_t *item = (obs_sceneitem_t *)calldata_ptr(data, "item");
-
-	if (item == window->item)
-		window->DisconnectItemSignals();
-}
-
-void VisibilityItemWidget::OBSSceneItemVisible(void *param, calldata_t *data)
-{
-	VisibilityItemWidget *window =
-		reinterpret_cast<VisibilityItemWidget *>(param);
-	obs_sceneitem_t *curItem =
-		(obs_sceneitem_t *)calldata_ptr(data, "item");
-	bool enabled = calldata_bool(data, "visible");
-
-	if (window->item == curItem)
-		QMetaObject::invokeMethod(window, "SourceEnabled",
-					  Q_ARG(bool, enabled));
-}
-
-void VisibilityItemWidget::OBSSceneItemLocked(void *param, calldata_t *data)
-{
-	VisibilityItemWidget *window =
-		reinterpret_cast<VisibilityItemWidget *>(param);
-	obs_sceneitem_t *curItem =
-		(obs_sceneitem_t *)calldata_ptr(data, "item");
-	bool locked = calldata_bool(data, "locked");
-
-	if (window->item == curItem)
-		QMetaObject::invokeMethod(window, "SourceLocked",
-					  Q_ARG(bool, locked));
-}
-
 void VisibilityItemWidget::OBSSourceEnabled(void *param, calldata_t *data)
 {
 	VisibilityItemWidget *window =
@@ -194,28 +63,13 @@ void VisibilityItemWidget::OBSSourceRenamed(void *param, calldata_t *data)
 
 void VisibilityItemWidget::VisibilityClicked(bool visible)
 {
-	if (item)
-		obs_sceneitem_set_visible(item, visible);
-	else
-		obs_source_set_enabled(source, visible);
-}
-
-void VisibilityItemWidget::LockClicked(bool locked)
-{
-	if (item)
-		obs_sceneitem_set_locked(item, locked);
+	obs_source_set_enabled(source, visible);
 }
 
 void VisibilityItemWidget::SourceEnabled(bool enabled)
 {
 	if (vis->isChecked() != enabled)
 		vis->setChecked(enabled);
-}
-
-void VisibilityItemWidget::SourceLocked(bool locked)
-{
-	if (lock->isChecked() != locked)
-		lock->setChecked(locked);
 }
 
 void VisibilityItemWidget::SourceRenamed(QString name)
@@ -294,15 +148,6 @@ void SetupVisibilityItem(QListWidget *list, QListWidgetItem *item,
 			 obs_source_t *source)
 {
 	VisibilityItemWidget *baseWidget = new VisibilityItemWidget(source);
-
-	item->setSizeHint(baseWidget->sizeHint());
-	list->setItemWidget(item, baseWidget);
-}
-
-void SetupVisibilityItem(QListWidget *list, QListWidgetItem *item,
-			 obs_sceneitem_t *sceneItem)
-{
-	VisibilityItemWidget *baseWidget = new VisibilityItemWidget(sceneItem);
 
 	item->setSizeHint(baseWidget->sizeHint());
 	list->setItemWidget(item, baseWidget);

--- a/UI/visibility-item-widget.hpp
+++ b/UI/visibility-item-widget.hpp
@@ -9,47 +9,32 @@ class QLineEdit;
 class QListWidget;
 class QListWidgetItem;
 class VisibilityCheckBox;
-class LockedCheckBox;
 
 class VisibilityItemWidget : public QWidget {
 	Q_OBJECT
 
 private:
-	OBSSceneItem item;
 	OBSSource source;
 	QLabel *label = nullptr;
 	VisibilityCheckBox *vis = nullptr;
-	LockedCheckBox *lock = nullptr;
 	QString oldName;
 
-	OBSSignal sceneRemoveSignal;
 	OBSSignal enabledSignal;
 	OBSSignal renamedSignal;
-	bool sceneRemoved = false;
 
 	bool active = false;
 	bool selected = false;
 
-	static void OBSSceneRemove(void *param, calldata_t *data);
-	static void OBSSceneItemRemove(void *param, calldata_t *data);
-	static void OBSSceneItemVisible(void *param, calldata_t *data);
-	static void OBSSceneItemLocked(void *param, calldata_t *data);
 	static void OBSSourceEnabled(void *param, calldata_t *data);
 	static void OBSSourceRenamed(void *param, calldata_t *data);
 
-	void DisconnectItemSignals();
-
 private slots:
 	void VisibilityClicked(bool visible);
-	void LockClicked(bool locked);
 	void SourceEnabled(bool enabled);
 	void SourceRenamed(QString name);
-	void SourceLocked(bool locked);
 
 public:
 	VisibilityItemWidget(obs_source_t *source);
-	VisibilityItemWidget(obs_sceneitem_t *item);
-	~VisibilityItemWidget();
 
 	void SetColor(const QColor &color, bool active, bool selected);
 };
@@ -66,5 +51,3 @@ public:
 
 void SetupVisibilityItem(QListWidget *list, QListWidgetItem *item,
 			 obs_source_t *source);
-void SetupVisibilityItem(QListWidget *list, QListWidgetItem *item,
-			 obs_sceneitem_t *sceneItem);


### PR DESCRIPTION
### Description
This removes unnecessary code from the visibility item widget because the scene item list widget is its own class now.

### Motivation and Context
This simplifies code.

### How Has This Been Tested?
The filters list widget still works as expected.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.