### PR TITLE
libobs-d3d11: Disable NV12 format support for WARP

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -390,6 +390,11 @@ void gs_device::InitDevice(uint32_t adapterIdx)
 
 	nv12Supported = false;
 
+	/* WARP NV12 support is suspected to be buggy on older Windows */
+	if (desc.VendorId == 0x1414 && desc.DeviceId == 0x8c) {
+		return;
+	}
+
 	/* Intel CopyResource is very slow with NV12 */
 	if (desc.VendorId == 0x8086) {
 		return;


### PR DESCRIPTION
### Description
Disable NV12 format support for WARP. This is a speculative fix since I don't have an easy way to reproduce corruption on older Windows editions.

### Motivation and Context
Lots of help requests about busted WARP output.

### How Has This Been Tested?
Breakpoint inspection, and log output. NV12 is disabled when WARP is enabled, and potentially enabled when WARP is disabled.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.