### PR TITLE
cmake: Compile option to fix libcaption linking

### DIFF
--- a/CI/before-script-linux.sh
+++ b/CI/before-script-linux.sh
@@ -8,4 +8,4 @@ fi
 set -ex
 ccache -s || echo "CCache is not available."
 mkdir build && cd build
-cmake ..
+cmake -DBUILD_CAPTIONS=ON ..

--- a/deps/libcaption/CMakeLists.txt
+++ b/deps/libcaption/CMakeLists.txt
@@ -5,6 +5,10 @@ if (WIN32)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif()
 
+if (UNIX AND NOT APPLE)
+  add_compile_options("-fPIC")
+endif()
+
 # Don't need to prefix local includes with "caption/*"
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/caption)
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This is a small fix for compiling libcaption for compilation on Linux, `-wPIC` should only be set on linux if i have done the checking correct

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This is to allow caption plugins like [OBS-Captions-Plugin](https://github.com/ratwithacompiler/OBS-captions-plugin/) to be installed on the linux version of OBS. This was blocked mainly by this compilation error 
```
/usr/bin/ld: ../deps/libcaption/libcaption.a(mpeg.c.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
```


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
compiled OBS 

**Enviroment info**:
uname output: `Linux IoansThinkpad 5.3.4-arch1-1-ARCH #1 SMP PREEMPT Sat Oct 5 13:44:11 UTC 2019 x86_64 GNU/Linux`
Hardware: Lenovo ThinkPad T450 i5-5200U RAM 12gb 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
