### PR TITLE
UI: Add dropdown for Twitch chat extension

### DIFF
--- a/UI/auth-twitch.cpp
+++ b/UI/auth-twitch.cpp
@@ -217,8 +217,16 @@ void TwitchAuth::LoadUI()
 	cef->add_force_popup_url(moderation_tools_url, chat.data());
 
 	script = "localStorage.setItem('twilight.theme', 1);";
-	script += bttv_script;
-	script += ffz_script;
+
+	const int twAddonChoice =
+		config_get_int(main->Config(), service(), "AddonChoice");
+	if (twAddonChoice) {
+		if (twAddonChoice & 0x1)
+			script += bttv_script;
+		if (twAddonChoice & 0x2)
+			script += ffz_script;
+	}
+
 	browser->setStartupScript(script);
 
 	main->addDockWidget(Qt::RightDockWidgetArea, chat.data());
@@ -261,8 +269,15 @@ void TwitchAuth::LoadSecondaryUIPanes()
 	script += name;
 	script += "/dashboard/live";
 	script += referrer_script2;
-	script += bttv_script;
-	script += ffz_script;
+
+	const int twAddonChoice =
+		config_get_int(main->Config(), service(), "AddonChoice");
+	if (twAddonChoice) {
+		if (twAddonChoice & 0x1)
+			script += bttv_script;
+		if (twAddonChoice & 0x2)
+			script += ffz_script;
+	}
 
 	/* ----------------------------------- */
 

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -670,6 +670,11 @@ Basic.Settings.Stream.Custom.UseAuthentication="Use authentication"
 Basic.Settings.Stream.Custom.Username="Username"
 Basic.Settings.Stream.Custom.Password="Password"
 Basic.Settings.Stream.BandwidthTestMode="Enable Bandwidth Test Mode"
+Basic.Settings.Stream.TTVAddon="Twitch Chat Add-Ons"
+Basic.Settings.Stream.TTVAddon.None="None"
+Basic.Settings.Stream.TTVAddon.BTTV="BetterTTV"
+Basic.Settings.Stream.TTVAddon.FFZ="FrankerFaceZ"
+Basic.Settings.Stream.TTVAddon.Both="BetterTTV and FrankerFaceZ"
 
 # basic mode 'output' settings
 Basic.Settings.Output="Output"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -151,8 +151,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>630</width>
-              <height>1035</height>
+              <width>803</width>
+              <height>977</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -1012,18 +1012,18 @@
                  </widget>
                 </item>
                 <item>
-                <widget class="UrlPushButton" name="getStreamKeyButton">
-                 <property name="toolTip">
-                  <string/>
-                 </property>
-                 <property name="toolTipDuration">
-                  <number>-4</number>
-                 </property>
-                 <property name="text">
-                  <string>Basic.AutoConfig.StreamPage.GetStreamKey</string>
-                 </property>
-                </widget>
-               </item>
+                 <widget class="UrlPushButton" name="getStreamKeyButton">
+                  <property name="toolTip">
+                   <string/>
+                  </property>
+                  <property name="toolTipDuration">
+                   <number>-4</number>
+                  </property>
+                  <property name="text">
+                   <string>Basic.AutoConfig.StreamPage.GetStreamKey</string>
+                  </property>
+                 </widget>
+                </item>
                </layout>
               </widget>
              </item>
@@ -1102,7 +1102,7 @@
                </property>
               </widget>
              </item>
-             <item row="7" column="0">
+             <item row="8" column="0">
               <widget class="QLabel" name="authUsernameLabel">
                <property name="text">
                 <string>Basic.Settings.Stream.Custom.Username</string>
@@ -1112,10 +1112,10 @@
                </property>
               </widget>
              </item>
-             <item row="7" column="1">
+             <item row="8" column="1">
               <widget class="QLineEdit" name="authUsername"/>
              </item>
-             <item row="8" column="0">
+             <item row="9" column="0">
               <widget class="QLabel" name="authPwLabel">
                <property name="text">
                 <string>Basic.Settings.Stream.Custom.Password</string>
@@ -1125,7 +1125,7 @@
                </property>
               </widget>
              </item>
-             <item row="8" column="1">
+             <item row="9" column="1">
               <widget class="QWidget" name="authPwWidget" native="true">
                <layout class="QHBoxLayout" name="horizontalLayout_25">
                 <property name="leftMargin">
@@ -1155,6 +1155,19 @@
                  </widget>
                 </item>
                </layout>
+              </widget>
+             </item>
+             <item row="7" column="1">
+              <widget class="QComboBox" name="twitchAddonDropdown"/>
+             </item>
+             <item row="7" column="0">
+              <widget class="QLabel" name="twitchAddonLabel">
+               <property name="text">
+                <string>Basic.Settings.Stream.TTVAddon</string>
+               </property>
+               <property name="buddy">
+                <cstring>twitchAddonDropdown</cstring>
+               </property>
               </widget>
              </item>
             </layout>
@@ -1193,8 +1206,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>739</width>
-              <height>793</height>
+              <width>601</width>
+              <height>631</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -2268,7 +2281,7 @@
                               <property name="currentIndex">
                                <number>0</number>
                               </property>
-                              <widget class="QWidget" name="recTracks" native="true">
+                              <widget class="QWidget" name="recTracks">
                                <layout class="QHBoxLayout" name="horizontalLayout_9">
                                 <property name="leftMargin">
                                  <number>0</number>
@@ -3702,8 +3715,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>696</width>
-              <height>601</height>
+              <width>555</width>
+              <height>469</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_50">
@@ -4518,8 +4531,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>759</width>
-              <height>930</height>
+              <width>803</width>
+              <height>781</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_23">

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -735,6 +735,18 @@ bool OBSApp::InitGlobalConfig()
 		changed = true;
 	}
 
+#define PRE_24_1_DEFS "Pre24.1Defaults"
+	if (!config_has_user_value(globalConfig, "General", PRE_24_1_DEFS)) {
+		bool useOldDefaults = lastVersion &&
+				      lastVersion <
+					      MAKE_SEMANTIC_VERSION(24, 1, 0);
+
+		config_set_bool(globalConfig, "General", PRE_24_1_DEFS,
+				useOldDefaults);
+		changed = true;
+	}
+#undef PRE_24_1_DEFS
+
 	if (config_has_user_value(globalConfig, "BasicWindow",
 				  "MultiviewLayout")) {
 		const char *layout = config_get_string(

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1199,6 +1199,15 @@ bool OBSBasic::InitBasicConfigDefaults()
 	}
 
 	/* ----------------------------------------------------- */
+	/* set twitch chat extensions to "both" if prev version  */
+	/* is under 24.1                                         */
+	if (config_get_bool(GetGlobalConfig(), "General", "Pre24.1Defaults") &&
+	    !config_has_user_value(basicConfig, "Twitch", "AddonChoice")) {
+		config_set_int(basicConfig, "Twitch", "AddonChoice", 3);
+		changed = true;
+	}
+
+	/* ----------------------------------------------------- */
 
 	if (changed)
 		config_save_safe(basicConfig, "tmp", nullptr);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -337,6 +337,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->customServer,         EDIT_CHANGED,   STREAM1_CHANGED);
 	HookWidget(ui->key,                  EDIT_CHANGED,   STREAM1_CHANGED);
 	HookWidget(ui->bandwidthTestEnable,  CHECK_CHANGED,  STREAM1_CHANGED);
+	HookWidget(ui->twitchAddonDropdown,  COMBO_CHANGED,  STREAM1_CHANGED);
 	HookWidget(ui->useAuth,              CHECK_CHANGED,  STREAM1_CHANGED);
 	HookWidget(ui->authUsername,         EDIT_CHANGED,   STREAM1_CHANGED);
 	HookWidget(ui->authPw,               EDIT_CHANGED,   STREAM1_CHANGED);
@@ -3486,6 +3487,12 @@ void OBSBasicSettings::closeEvent(QCloseEvent *event)
 {
 	if (Changed() && !QueryChanges())
 		event->ignore();
+
+	if (forceAuthReload) {
+		main->auth->Save();
+		main->auth->Load();
+		forceAuthReload = false;
+	}
 }
 
 void OBSBasicSettings::on_theme_activated(int idx)

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -115,6 +115,7 @@ private:
 	bool advancedChanged = false;
 	int pageIndex = 0;
 	bool loading = true;
+	bool forceAuthReload = false;
 	std::string savedTheme;
 
 	int lastSimpleRecQualityIdx = 0;


### PR DESCRIPTION
### Description
Adds dropdown menu in stream settings that offers the option to change which twitch chat extension will be used in the "Chat" dock.

(Only visible when authenticated with Twitch.)

### Motivation and Context
BTTV and FFZ conflict in some cases, removing either will upset people so instead make it a choice for users: None, BTTV, FFZ, or both.

### How Has This Been Tested?
Windows 10, switched between services and options on offer, made sure that they all work.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
