### PR TITLE
UI: Add ability to change projector type

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -88,6 +88,8 @@ Group="Group"
 DoNotShowAgain="Do not show again"
 Default="(Default)"
 Calculating="Calculating..."
+Fullscreen="Fullscreen"
+Windowed="Windowed"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -199,8 +199,7 @@ private:
 	ConfigFile basicConfig;
 
 	std::vector<SavedProjectorInfo *> savedProjectorsArray;
-	QPointer<QWidget> projectors[10];
-	QList<QPointer<QWidget>> windowProjectors;
+	std::vector<OBSProjector *> projectors;
 
 	QPointer<QWidget> stats;
 	QPointer<QWidget> remux;
@@ -305,7 +304,7 @@ private:
 	void Nudge(int dist, MoveDir dir);
 
 	OBSProjector *OpenProjector(obs_source_t *source, int monitor,
-				    QString title, ProjectorType type);
+				    ProjectorType type);
 
 	void GetAudioSourceFilters();
 	void GetAudioSourceProperties();
@@ -688,6 +687,10 @@ public:
 	static OBSBasic *Get();
 
 	const char *GetCurrentOutputPath();
+
+	void DeleteProjector(OBSProjector *projector);
+	void AddProjectorMenuMonitors(QMenu *parent, QObject *target,
+				      const char *slot);
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -9,7 +9,6 @@
 #include "qt-wrappers.hpp"
 #include "platform.hpp"
 
-static QList<OBSProjector *> windowedProjectors;
 static QList<OBSProjector *> multiviewProjectors;
 static bool updatingMultiview = false, drawLabel, drawSafeArea, mouseSwitching,
 	    transitionOnDoubleClick;
@@ -17,38 +16,26 @@ static MultiviewLayout multiviewLayout;
 static size_t maxSrcs, numSrcs;
 
 OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
-			   QString title, ProjectorType type_)
+			   ProjectorType type_)
 	: OBSQTDisplay(widget, Qt::Window),
 	  source(source_),
 	  removedSignal(obs_source_get_signal_handler(source), "remove",
 			OBSSourceRemoved, this)
 {
-	projectorTitle = std::move(title);
-	savedMonitor = monitor;
-	isWindow = savedMonitor < 0;
 	type = type_;
 
-	if (isWindow) {
-		setWindowIcon(
-			QIcon::fromTheme("obs", QIcon(":/res/images/obs.png")));
+	setWindowIcon(QIcon::fromTheme("obs", QIcon(":/res/images/obs.png")));
+	UpdateProjectorTitle(QT_UTF8(obs_source_get_name(source)));
 
-		UpdateProjectorTitle(projectorTitle);
-		windowedProjectors.push_back(this);
-
+	if (monitor == -1)
 		resize(480, 270);
-	} else {
-		setWindowFlags(Qt::FramelessWindowHint |
-			       Qt::X11BypassWindowManagerHint);
+	else
+		SetMonitor(monitor);
 
-		QScreen *screen = QGuiApplication::screens()[savedMonitor];
-		setGeometry(screen->geometry());
-
-		QAction *action = new QAction(this);
-		action->setShortcut(Qt::Key_Escape);
-		addAction(action);
-		connect(action, SIGNAL(triggered()), this,
-			SLOT(EscapeTriggered()));
-	}
+	QAction *action = new QAction(this);
+	action->setShortcut(Qt::Key_Escape);
+	addAction(action);
+	connect(action, SIGNAL(triggered()), this, SLOT(EscapeTriggered()));
 
 	SetAlwaysOnTop(this, config_get_bool(GetGlobalConfig(), "BasicWindow",
 					     "ProjectorAlwaysOnTop"));
@@ -70,13 +57,8 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 
 	connect(this, &OBSQTDisplay::DisplayCreated, addDrawCallback);
 
-	bool hideCursor = config_get_bool(GetGlobalConfig(), "BasicWindow",
-					  "HideProjectorCursor");
-	if (hideCursor && !isWindow && type != ProjectorType::Multiview) {
-		QPixmap empty(16, 16);
-		empty.fill(Qt::transparent);
-		setCursor(QCursor(empty));
-	}
+	if (isFullScreen())
+		SetHideCursor();
 
 	if (type == ProjectorType::Multiview) {
 		obs_enter_graphics();
@@ -146,8 +128,7 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 	show();
 
 	// We need it here to allow keyboard input in X11 to listen to Escape
-	if (!isWindow)
-		activateWindow();
+	activateWindow();
 }
 
 OBSProjector::~OBSProjector()
@@ -180,10 +161,26 @@ OBSProjector::~OBSProjector()
 	if (type == ProjectorType::Multiview)
 		multiviewProjectors.removeAll(this);
 
-	if (isWindow)
-		windowedProjectors.removeAll(this);
-
 	App()->DecrementSleepInhibition();
+}
+
+void OBSProjector::SetMonitor(int monitor)
+{
+	savedMonitor = monitor;
+	QScreen *screen = QGuiApplication::screens()[monitor];
+	showFullScreen();
+	setGeometry(screen->geometry());
+}
+
+void OBSProjector::SetHideCursor()
+{
+	bool hideCursor = config_get_bool(GetGlobalConfig(), "BasicWindow",
+					  "HideProjectorCursor");
+
+	if (hideCursor && type != ProjectorType::Multiview)
+		setCursor(Qt::BlankCursor);
+	else
+		setCursor(Qt::ArrowCursor);
 }
 
 static OBSSource CreateLabel(const char *name, size_t h)
@@ -820,7 +817,19 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 	OBSQTDisplay::mousePressEvent(event);
 
 	if (event->button() == Qt::RightButton) {
+		OBSBasic *main =
+			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 		QMenu popup(this);
+
+		QMenu *projectorMenu = new QMenu(QTStr("Fullscreen"));
+		main->AddProjectorMenuMonitors(projectorMenu, this,
+					       SLOT(OpenFullScreenProjector()));
+		popup.addMenu(projectorMenu);
+
+		if (GetMonitor() > -1)
+			popup.addAction(QTStr("Windowed"), this,
+					SLOT(OpenWindowedProjector()));
+
 		popup.addAction(QTStr("Close"), this, SLOT(EscapeTriggered()));
 		popup.exec(QCursor::pos());
 	}
@@ -844,7 +853,8 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 
 void OBSProjector::EscapeTriggered()
 {
-	deleteLater();
+	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	main->DeleteProjector(this);
 }
 
 void OBSProjector::UpdateMultiview()
@@ -937,15 +947,39 @@ void OBSProjector::UpdateMultiview()
 
 void OBSProjector::UpdateProjectorTitle(QString name)
 {
-	projectorTitle = name;
+	bool window = (GetMonitor() == -1);
 
 	QString title = nullptr;
 	switch (type) {
 	case ProjectorType::Scene:
-		title = QTStr("SceneWindow") + " - " + name;
+		if (!window)
+			title = QTStr("SceneProjector") + " - " + name;
+		else
+			title = QTStr("SceneWindow") + " - " + name;
 		break;
 	case ProjectorType::Source:
-		title = QTStr("SourceWindow") + " - " + name;
+		if (!window)
+			title = QTStr("SourceProjector") + " - " + name;
+		else
+			title = QTStr("SourceWindow") + " - " + name;
+		break;
+	case ProjectorType::Preview:
+		if (!window)
+			title = QTStr("PreviewProjector");
+		else
+			title = QTStr("PreviewWindow");
+		break;
+	case ProjectorType::StudioProgram:
+		if (!window)
+			title = QTStr("StudioProgramProjector");
+		else
+			title = QTStr("StudioProgramWindow");
+		break;
+	case ProjectorType::Multiview:
+		if (!window)
+			title = QTStr("MultiviewProjector");
+		else
+			title = QTStr("MultiviewWindow");
 		break;
 	default:
 		title = name;
@@ -986,7 +1020,42 @@ void OBSProjector::UpdateMultiviewProjectors()
 
 void OBSProjector::RenameProjector(QString oldName, QString newName)
 {
-	for (auto &projector : windowedProjectors)
-		if (projector->projectorTitle == oldName)
-			projector->UpdateProjectorTitle(newName);
+	if (oldName == newName)
+		return;
+
+	UpdateProjectorTitle(newName);
+}
+
+void OBSProjector::OpenFullScreenProjector()
+{
+	if (!isFullScreen())
+		prevGeometry = geometry();
+
+	int monitor = sender()->property("monitor").toInt();
+	SetMonitor(monitor);
+	SetHideCursor();
+
+	UpdateProjectorTitle(QT_UTF8(obs_source_get_name(source)));
+}
+
+void OBSProjector::OpenWindowedProjector()
+{
+	showFullScreen();
+	showNormal();
+	setCursor(Qt::ArrowCursor);
+
+	if (!prevGeometry.isNull())
+		setGeometry(prevGeometry);
+	else
+		resize(480, 270);
+
+	savedMonitor = -1;
+
+	UpdateProjectorTitle(QT_UTF8(obs_source_get_name(source)));
+}
+
+void OBSProjector::closeEvent(QCloseEvent *event)
+{
+	EscapeTriggered();
+	event->accept();
 }

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -34,10 +34,9 @@ private:
 
 	void mousePressEvent(QMouseEvent *event) override;
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
+	void closeEvent(QCloseEvent *event) override;
 
-	int savedMonitor;
-	bool isWindow;
-	QString projectorTitle;
+	int savedMonitor = -1;
 	ProjectorType type = ProjectorType::Source;
 	std::vector<OBSWeakSource> multiviewScenes;
 	std::vector<OBSSource> multiviewLabels;
@@ -73,17 +72,23 @@ private:
 	void UpdateMultiview();
 	void UpdateProjectorTitle(QString name);
 
+	QRect prevGeometry;
+	void SetHideCursor();
+	void SetMonitor(int monitor);
+
 private slots:
 	void EscapeTriggered();
+	void OpenFullScreenProjector();
+	void OpenWindowedProjector();
 
 public:
 	OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
-		     QString title, ProjectorType type_);
+		     ProjectorType type_);
 	~OBSProjector();
 
 	OBSSource GetSource();
 	ProjectorType GetProjectorType();
 	int GetMonitor();
 	static void UpdateMultiviewProjectors();
-	static void RenameProjector(QString oldName, QString newName);
+	void RenameProjector(QString oldName, QString newName);
 };


### PR DESCRIPTION
### Description
This adds the ability for projectors to change between fullscreen and windowed mode. In windowed mode, when switching to fullscreen, the user can select which monitor to set it to. Also, when in fullscreen mode, the monitor can be changed to a different one. These options are accessed in the right-click menu of the projector. This also simplifies the saving and loading of projectors code.

### Motivation and Context
This makes the projectors a more powerful tool.

### How Has This Been Tested?
I've created different types of projectors and switched between modes and monitors. 

### Types of changes
- New feature (non-breaking change which adds functionality) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] Fix bugs mentioned by @WizardCM 
