### PR TITLE
UI: Add ability to rename filters with F2 (Return on Mac)

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -139,6 +139,26 @@ OBSBasicFilters::OBSBasicFilters(QWidget *parent, OBSSource source_)
 		ui->rightContainerLayout->insertStretch(1);
 		ui->preview->hide();
 	}
+
+	QAction *renameAsync = new QAction(ui->asyncWidget);
+	renameAsync->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+	connect(renameAsync, SIGNAL(triggered()), this,
+		SLOT(RenameAsyncFilter()));
+	ui->asyncWidget->addAction(renameAsync);
+
+	QAction *renameEffect = new QAction(ui->effectWidget);
+	renameEffect->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+	connect(renameEffect, SIGNAL(triggered()), this,
+		SLOT(RenameEffectFilter()));
+	ui->effectWidget->addAction(renameEffect);
+
+#ifdef __APPLE__
+	renameAsync->setShortcut({Qt::Key_Return});
+	renameEffect->setShortcut({Qt::Key_Return});
+#else
+	renameAsync->setShortcut({Qt::Key_F2});
+	renameEffect->setShortcut({Qt::Key_F2});
+#endif
 }
 
 OBSBasicFilters::~OBSBasicFilters()


### PR DESCRIPTION
### Description
This adds the ability to rename the filters with F2 (Return on Mac).

### Motivation and Context
https://ideas.obsproject.com/posts/532/f2-to-quickly-rename-filters

### How Has This Been Tested?
Renamed filters with the shortcut.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
