### PR TITLE
UI: Add ability to reorder filters by drag & drop

### DIFF
--- a/UI/focus-list.cpp
+++ b/UI/focus-list.cpp
@@ -1,4 +1,5 @@
 #include "focus-list.hpp"
+#include <QDragMoveEvent>
 
 FocusList::FocusList(QWidget *parent) : QListWidget(parent) {}
 
@@ -7,4 +8,20 @@ void FocusList::focusInEvent(QFocusEvent *event)
 	QListWidget::focusInEvent(event);
 
 	emit GotFocus();
+}
+
+void FocusList::dragMoveEvent(QDragMoveEvent *event)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	QPoint pos = event->position().toPoint();
+#else
+	QPoint pos = event->pos();
+#endif
+	int itemRow = row(itemAt(pos));
+
+	if ((itemRow == currentRow() + 1) ||
+	    (currentRow() == count() - 1 && itemRow == -1))
+		event->ignore();
+	else
+		QListWidget::dragMoveEvent(event);
 }

--- a/UI/focus-list.hpp
+++ b/UI/focus-list.hpp
@@ -2,6 +2,8 @@
 
 #include <QListWidget>
 
+class QDragMoveEvent;
+
 class FocusList : public QListWidget {
 	Q_OBJECT
 
@@ -10,6 +12,7 @@ public:
 
 protected:
 	void focusInEvent(QFocusEvent *event) override;
+	virtual void dragMoveEvent(QDragMoveEvent *event) override;
 
 signals:
 	void GotFocus();

--- a/UI/forms/OBSBasicFilters.ui
+++ b/UI/forms/OBSBasicFilters.ui
@@ -72,6 +72,15 @@
             <property name="spacing">
              <number>1</number>
             </property>
+            <property name="dragEnabled">
+             <bool>true</bool>
+            </property>
+            <property name="dragDropMode">
+             <enum>QAbstractItemView::InternalMove</enum>
+            </property>
+            <property name="defaultDropAction">
+             <enum>Qt::TargetMoveAction</enum>
+            </property>
            </widget>
           </item>
           <item>
@@ -284,6 +293,15 @@
             </property>
             <property name="spacing">
              <number>1</number>
+            </property>
+            <property name="dragEnabled">
+             <bool>true</bool>
+            </property>
+            <property name="dragDropMode">
+             <enum>QAbstractItemView::InternalMove</enum>
+            </property>
+            <property name="defaultDropAction">
+             <enum>Qt::TargetMoveAction</enum>
             </property>
            </widget>
           </item>

--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -207,6 +207,23 @@ QDataStream &operator>>(QDataStream &in, OBSScene &scene)
 	return in;
 }
 
+QDataStream &operator<<(QDataStream &out, const OBSSource &source)
+{
+	return out << QString(obs_source_get_uuid(source));
+}
+
+QDataStream &operator>>(QDataStream &in, OBSSource &source)
+{
+	QString uuid;
+
+	in >> uuid;
+
+	OBSSourceAutoRelease source_ = obs_get_source_by_uuid(QT_TO_UTF8(uuid));
+	source = source_;
+
+	return in;
+}
+
 void DeleteLayout(QLayout *layout)
 {
 	if (!layout)

--- a/UI/qt-wrappers.hpp
+++ b/UI/qt-wrappers.hpp
@@ -71,6 +71,8 @@ QDataStream &operator>>(QDataStream &in,
 			std::vector<std::shared_ptr<OBSSignal>> &signal_vec);
 QDataStream &operator<<(QDataStream &out, const OBSScene &scene);
 QDataStream &operator>>(QDataStream &in, OBSScene &scene);
+QDataStream &operator<<(QDataStream &out, const OBSSource &source);
+QDataStream &operator>>(QDataStream &in, OBSSource &source);
 
 QThread *CreateQThread(std::function<void()> func);
 

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -121,6 +121,10 @@ private slots:
 	void CopyFilter();
 	void PasteFilter();
 
+	void FiltersMoved(const QModelIndex &srcParent, int srcIdxStart,
+			  int srcIdxEnd, const QModelIndex &dstParent,
+			  int dstIdx);
+
 public:
 	OBSBasicFilters(QWidget *parent, OBSSource source_);
 	~OBSBasicFilters();

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -344,6 +344,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	qRegisterMetaTypeStreamOperators<std::vector<std::shared_ptr<OBSSignal>>>(
 		"std::vector<std::shared_ptr<OBSSignal>>");
 	qRegisterMetaTypeStreamOperators<OBSScene>("OBSScene");
+	qRegisterMetaTypeStreamOperators<OBSSource>("OBSSource");
 #endif
 
 	ui->scenes->setAttribute(Qt::WA_MacShowFocusRect, false);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1130,6 +1130,14 @@ EXPORT void obs_source_filter_set_order(obs_source_t *source,
 					obs_source_t *filter,
 					enum obs_order_movement movement);
 
+/** Gets filter index */
+EXPORT size_t obs_source_filter_get_index(obs_source_t *source,
+					  obs_source_t *filter);
+
+/** Sets filter index */
+EXPORT void obs_source_filter_set_index(obs_source_t *source,
+					obs_source_t *filter, size_t index);
+
 /** Gets the settings string for a source */
 EXPORT obs_data_t *obs_source_get_settings(const obs_source_t *source);
 


### PR DESCRIPTION
### Description
This adds the ability for filters to be reordered by drag & drop.

### Motivation and Context
The scenes and sources can be reordered this way, so it makes sense for filters as well.
https://ideas.obsproject.com/posts/369/re-order-filter-effects

### How Has This Been Tested?
I tested this by adding filters and dragging and dropping them. Everything worked as expected.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
