### PR TITLE
UI: Fix issue with preview projector

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -653,6 +653,9 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 			source = curSource;
 			window->source = source;
 		}
+	} else if (window->type == ProjectorType::Preview &&
+		   !main->IsPreviewProgramMode()) {
+		window->source = nullptr;
 	}
 
 	if (source)


### PR DESCRIPTION
### Description
This fixes an issue where the preview projector stopped working when toggling studio mode.

### Motivation and Context
https://obsproject.com/mantis/view.php?id=1401

### How Has This Been Tested?
I created a preview projector and switched in and out of studio mode, and everything works as it should.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
