### PR TITLE
UI: Fix swap scene issue with double click mode

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -131,7 +131,7 @@ void OBSBasic::TriggerQuickTransition(int id)
 			overridingTransition = true;
 		}
 
-		TransitionToScene(source, false, false, true, qt->duration,
+		TransitionToScene(source, false, true, qt->duration,
 				  qt->fadeToBlack);
 	}
 }
@@ -255,10 +255,10 @@ obs_source_t *OBSBasic::FindTransition(const char *name)
 	return nullptr;
 }
 
-void OBSBasic::TransitionToScene(OBSScene scene, bool force, bool direct)
+void OBSBasic::TransitionToScene(OBSScene scene, bool force)
 {
 	obs_source_t *source = obs_scene_get_source(scene);
-	TransitionToScene(source, force, direct);
+	TransitionToScene(source, force);
 }
 
 void OBSBasic::TransitionStopped()
@@ -304,7 +304,7 @@ void OBSBasic::TransitionFullyStopped()
 	}
 }
 
-void OBSBasic::TransitionToScene(OBSSource source, bool force, bool direct,
+void OBSBasic::TransitionToScene(OBSSource source, bool force,
 				 bool quickTransition, int quickDuration,
 				 bool black)
 {
@@ -319,7 +319,7 @@ void OBSBasic::TransitionToScene(OBSSource source, bool force, bool direct,
 		lastProgramScene = programScene;
 		programScene = OBSGetWeakRef(source);
 
-		if (swapScenesMode && !force && !direct && !black) {
+		if (swapScenesMode && !force && !black) {
 			OBSSource newScene = OBSGetStrongRef(lastProgramScene);
 
 			if (!sceneDuplicationMode && newScene == source)
@@ -676,10 +676,10 @@ int OBSBasic::GetQuickTransitionIdx(int id)
 	return -1;
 }
 
-void OBSBasic::SetCurrentScene(obs_scene_t *scene, bool force, bool direct)
+void OBSBasic::SetCurrentScene(obs_scene_t *scene, bool force)
 {
 	obs_source_t *source = obs_scene_get_source(scene);
-	SetCurrentScene(source, force, direct);
+	SetCurrentScene(source, force);
 }
 
 template<typename T> static T GetOBSRef(QListWidgetItem *item)
@@ -687,14 +687,10 @@ template<typename T> static T GetOBSRef(QListWidgetItem *item)
 	return item->data(static_cast<int>(QtDataRole::OBSRef)).value<T>();
 }
 
-void OBSBasic::SetCurrentScene(OBSSource scene, bool force, bool direct)
+void OBSBasic::SetCurrentScene(OBSSource scene, bool force)
 {
-	if (!IsPreviewProgramMode() && !direct) {
-		TransitionToScene(scene, force, false);
-
-	} else if (IsPreviewProgramMode() && direct) {
-		TransitionToScene(scene, force, true);
-
+	if (!IsPreviewProgramMode()) {
+		TransitionToScene(scene, force);
 	} else {
 		OBSSource actualLastScene = OBSGetStrongRef(lastScene);
 		if (actualLastScene != scene) {

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4561,12 +4561,8 @@ void OBSBasic::on_scenes_itemDoubleClicked(QListWidgetItem *witem)
 			config_get_bool(App()->GlobalConfig(), "BasicWindow",
 					"TransitionOnDoubleClick");
 
-		if (doubleClickSwitch) {
-			OBSScene scene = GetCurrentScene();
-
-			if (scene)
-				SetCurrentScene(scene, false, true);
-		}
+		if (doubleClickSwitch)
+			TransitionClicked();
 	}
 }
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -372,8 +372,7 @@ private:
 
 	void SetPreviewProgramMode(bool enabled);
 	void ResizeProgram(uint32_t cx, uint32_t cy);
-	void SetCurrentScene(obs_scene_t *scene, bool force = false,
-			     bool direct = false);
+	void SetCurrentScene(obs_scene_t *scene, bool force = false);
 	static void RenderProgram(void *data, uint32_t cx, uint32_t cy);
 
 	std::vector<QuickTransition> quickTransitions;
@@ -477,14 +476,11 @@ public slots:
 
 	void SetTransition(OBSSource transition);
 	void OverrideTransition(OBSSource transition);
-	void TransitionToScene(OBSScene scene, bool force = false,
-			       bool direct = false);
+	void TransitionToScene(OBSScene scene, bool force = false);
 	void TransitionToScene(OBSSource scene, bool force = false,
-			       bool direct = false,
 			       bool quickTransition = false,
 			       int quickDuration = 0, bool black = false);
-	void SetCurrentScene(OBSSource scene, bool force = false,
-			     bool direct = false);
+	void SetCurrentScene(OBSSource scene, bool force = false);
 
 	bool AddSceneCollection(bool create_new,
 				const QString &name = QString());


### PR DESCRIPTION
### Description
This fixes an issue where if swap scenes was enabled in studio mode, double clicking to transition wouldn't swap the scenes.

### Motivation and Context
https://obsproject.com/mantis/view.php?id=1554

### How Has This Been Tested?
In studio mode I enabled double click and swap mode and transitioned. Everything now works as expected.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
