### PR TITLE
obs-ffmpeg: Use av_opt_set on context instead of priv_data

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -183,7 +183,8 @@ static bool parse_params(AVCodecContext *context, char **opts)
 			*assign = 0;
 			value = assign + 1;
 
-			if (av_opt_set(context->priv_data, name, value, 0)) {
+			if (av_opt_set(context, name, value,
+				       AV_OPT_SEARCH_CHILDREN)) {
 				blog(LOG_WARNING, "Failed to set %s=%s", name,
 				     value);
 				ret = false;


### PR DESCRIPTION
Note: may need more testing with other encoders and usage scenarios.

### Description
Certain ffmpeg parameters such as "bufsize" or "maxrate" have to be applied to `context` rather than to `context->priv_data`. In order to make sure options are still passed to the encoder setting set `AV_OPT_SEARCH_CHILDREN`.

### Motivation and Context
This PR fixes setting certain options for ffmpeg encoders such as "maxrate" or "bufsize" which were previously unavailable.

### How Has This Been Tested?
Tested on Windows with the latest ffmpeg deps and the NVENC and x264 encoders (based on a bug report about not being able to set maxrate/bufsize). Verified to now pass both parameters and encoder settings successfully.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
