### PR TITLE
Revert "Revert "image-source: Set default size of color source to can…

### DIFF
--- a/plugins/image-source/color-source.c
+++ b/plugins/image-source/color-source.c
@@ -101,9 +101,12 @@ static uint32_t color_source_getheight(void *data)
 
 static void color_source_defaults(obs_data_t *settings)
 {
+	struct obs_video_info ovi;
+	obs_get_video_info(&ovi);
+
 	obs_data_set_default_int(settings, "color", 0xFFFFFFFF);
-	obs_data_set_default_int(settings, "width", 400);
-	obs_data_set_default_int(settings, "height", 400);
+	obs_data_set_default_int(settings, "width", ovi.base_width);
+	obs_data_set_default_int(settings, "height", ovi.base_height);
 }
 
 struct obs_source_info color_source_info = {


### PR DESCRIPTION
### Description
This can be merged after #2073 is merged.

### Motivation and Context
This was originally reverted because there were no fallbacks for when the source defaults are changed.

### How Has This Been Tested?
Tested with PR #2073

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
