### PR TITLE
UI: Fix issue where multiview doesn't update

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -392,6 +392,12 @@ OBSBasic::OBSBasic(QWidget *parent)
 		SLOT(PreviewDisabledMenu(const QPoint &)));
 	connect(ui->enablePreviewButton, SIGNAL(clicked()), this,
 		SLOT(TogglePreview()));
+
+	connect(ui->scenes->model(),
+		SIGNAL(rowsMoved(QModelIndex, int, int, QModelIndex, int)),
+		this,
+		SLOT(ScenesReordered(const QModelIndex &, int, int,
+				     const QModelIndex &, int)));
 }
 
 static void SaveAudioDevice(const char *name, int channel, obs_data_t *parent,
@@ -7603,4 +7609,16 @@ void OBSBasic::CheckDiskSpaceRemaining()
 
 		DiskSpaceMessage();
 	}
+}
+
+void OBSBasic::ScenesReordered(const QModelIndex &parent, int start, int end,
+			       const QModelIndex &destination, int row)
+{
+	UNUSED_PARAMETER(parent);
+	UNUSED_PARAMETER(start);
+	UNUSED_PARAMETER(end);
+	UNUSED_PARAMETER(destination);
+	UNUSED_PARAMETER(row);
+
+	OBSProjector::UpdateMultiviewProjectors();
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -560,6 +560,9 @@ private slots:
 
 	void CheckDiskSpaceRemaining();
 
+	void ScenesReordered(const QModelIndex &parent, int start, int end,
+			     const QModelIndex &destination, int row);
+
 private:
 	/* OBS Callbacks */
 	static void SceneReordered(void *data, calldata_t *params);


### PR DESCRIPTION
### Description
This fixes an issue where the multiview wouldn't update when the scenes were reordered by drag and drop. 

### Motivation and Context
https://obsproject.com/mantis/view.php?id=1562

### How Has This Been Tested?
I reordered the scenes by drag & drop and the multiview was now updating.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
