### PR TITLE
Fix duplicator ref count

### DIFF
--- a/libobs-d3d11/d3d11-duplicator.cpp
+++ b/libobs-d3d11/d3d11-duplicator.cpp
@@ -16,7 +16,7 @@
 ******************************************************************************/
 
 #include "d3d11-subsystem.hpp"
-#include <map>
+#include <unordered_map>
 
 static inline bool get_monitor(gs_device_t *device, int monitor_idx,
 			       IDXGIOutput **dxgiOutput)
@@ -122,11 +122,11 @@ EXPORT bool device_get_duplicator_monitor_info(gs_device_t *device,
 	return true;
 }
 
-static std::map<int, gs_duplicator *> instances;
+static std::unordered_map<int, gs_duplicator *> instances;
 
 void reset_duplicators(void)
 {
-	for (auto &pair : instances) {
+	for (std::pair<const int, gs_duplicator *> &pair : instances) {
 		pair.second->updated = false;
 	}
 }
@@ -136,7 +136,7 @@ EXPORT gs_duplicator_t *device_duplicator_create(gs_device_t *device,
 {
 	gs_duplicator *duplicator = nullptr;
 
-	auto it = instances.find(monitor_idx);
+	const auto it = instances.find(monitor_idx);
 	if (it != instances.end()) {
 		duplicator = it->second;
 		duplicator->refs++;

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -52,7 +52,7 @@ static inline void update_settings(struct duplicator_capture *capture,
 	obs_enter_graphics();
 
 	gs_duplicator_destroy(capture->duplicator);
-	capture->duplicator = gs_duplicator_create(capture->monitor);
+	capture->duplicator = NULL;
 	capture->width = 0;
 	capture->height = 0;
 	capture->x = 0;


### PR DESCRIPTION
### Description
Make duplicator_capture_tick the sole creater, and reference adder of
IDXGIOutputDuplication objects. This prevents a situation where
duplicator_capture::showing cause be false while
duplicator_capture::duplicator was not null at startup on background
scenes, preventing IDXGIOutputDuplication from being recreated when
DXGI_ERROR_ACCESS_LOST.

Also added OCD change to use unordered_map since keys don't need to be sorted.

### Motivation and Context
Access lost can be performed by triggering a UAC prompt, and if you do that on OBS without visiting the background scenes that capture the same display, the DX object won't be recreated.

### How Has This Been Tested?
Tested broken case is now not broken. Also tested other permutations of display capture scenes without issue.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.