### PR TITLE
rtmp-stream: Fix comparison between signed and unsigned ints

### DIFF
--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -1342,7 +1342,7 @@ static void check_to_drop_frames(struct rtmp_stream *stream, bool pframes)
 			return;
 		}
 
-		if (buffer_duration_usec >= DBR_TRIGGER_USEC) {
+		if ((uint64_t)buffer_duration_usec >= DBR_TRIGGER_USEC) {
 			pthread_mutex_lock(&stream->dbr_mutex);
 			bitrate_changed = dbr_bitrate_lowered(stream);
 			pthread_mutex_unlock(&stream->dbr_mutex);


### PR DESCRIPTION
### Description
I've found another compiler warning where it warned about comparisons between signed and unsigned integers. 

### Motivation and Context
Cleaning up warnings.

### How Has This Been Tested?
Warning doesn't show up anymore.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
