### PR TITLE
Added scenes menu to the trayMenu

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -219,6 +219,7 @@ private:
 	QPointer<QAction> showHide;
 	QPointer<QAction> exit;
 	QPointer<QMenu> trayMenu;
+	QPointer<QMenu> sceneMenu;
 	QPointer<QMenu> previewProjector;
 	QPointer<QMenu> studioProgramProjector;
 	QPointer<QMenu> multiviewProjectorMenu;
@@ -827,6 +828,7 @@ private slots:
 	void NudgeRight();
 
 	void OpenStudioProgramProjector();
+	void SelectScene();
 	void OpenPreviewProjector();
 	void OpenSourceProjector();
 	void OpenMultiviewProjector();


### PR DESCRIPTION

### Description
Added scenes menu to the trayMenu. 
User can change current scene from the statusbar/system tray.

![shot 2019-10-13 at 21 09 20](https://user-images.githubusercontent.com/63942/66720525-0140a280-edfe-11e9-96b5-651bb602762c.png)


### Motivation and Context
This allows single monitor streamers to change scenes without having to bring OBS to the front.

### How Has This Been Tested?
- Tested on macOS 10.14

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
