### PR TITLE
Use PCI database IDs instead of string matching for devices

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -431,10 +431,6 @@ static bool set_priority(ID3D11Device *device)
 	return true;
 }
 
-static bool is_intel(const wstring &name)
-{
-	return wstrstri(name.c_str(), L"intel") != nullptr;
-}
 #endif
 
 void gs_device::InitDevice(uint32_t adapterIdx)
@@ -471,9 +467,9 @@ void gs_device::InitDevice(uint32_t adapterIdx)
 	blog(LOG_INFO, "D3D11 loaded successfully, feature level used: %x",
 	     (unsigned int)levelUsed);
 
-	/* adjust gpu thread priority */
+	/* adjust gpu thread priority on non-intel GPUs*/
 #if USE_GPU_PRIORITY
-	if (!is_intel(adapterName) && !set_priority(device)) {
+	if (desc.VendorId != 0x8086 && !set_priority(device)) {
 		blog(LOG_INFO, "D3D11 GPU priority setup "
 			       "failed (not admin?)");
 	}

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -40,42 +40,59 @@ extern struct obs_encoder_info vaapi_encoder_info;
 static const char *nvenc_check_name = "nvenc_check";
 
 #ifdef _WIN32
-static const wchar_t *blacklisted_adapters[] = {
-	L"720M", L"730M",  L"740M",  L"745M",  L"820M",  L"830M",
-	L"840M", L"845M",  L"920M",  L"930M",  L"940M",  L"945M",
-	L"1030", L"MX110", L"MX130", L"MX150", L"MX230", L"MX250",
-	L"M520", L"M500",  L"P500",  L"K620M",
+static const int blacklisted_adapters[] = {
+	0x1298, // GK208M [GeForce GT 720M]
+	0x1140, // GF117M [GeForce 610M/710M/810M/820M / GT 620M/625M/630M/720M]
+	0x1293, // GK208M [GeForce GT 730M]
+	0x1290, // GK208M [GeForce GT 730M]
+	0x0fe1, // GK107M [GeForce GT 730M]
+	0x0fdf, // GK107M [GeForce GT 740M]
+	0x1294, // GK208M [GeForce GT 740M]
+	0x1292, // GK208M [GeForce GT 740M]
+	0x0fe2, // GK107M [GeForce GT 745M]
+	0x0fe3, // GK107M [GeForce GT 745M]
+	0x1140, // GF117M [GeForce 610M/710M/810M/820M / GT 620M/625M/630M/720M]
+	0x0fed, // GK107M [GeForce 820M]
+	0x1340, // GM108M [GeForce 830M]
+	0x1393, // GM107M [GeForce 840M]
+	0x1341, // GM108M [GeForce 840M]
+	0x1398, // GM107M [GeForce 845M]
+	0x1390, // GM107M [GeForce 845M]
+	0x1344, // GM108M [GeForce 845M]
+	0x1299, // GK208BM [GeForce 920M]
+	0x134f, // GM108M [GeForce 920MX]
+	0x134e, // GM108M [GeForce 930MX]
+	0x1349, // GM108M [GeForce 930M]
+	0x1346, // GM108M [GeForce 930M]
+	0x179c, // GM107 [GeForce 940MX]
+	0x139c, // GM107M [GeForce 940M]
+	0x1347, // GM108M [GeForce 940M]
+	0x134d, // GM108M [GeForce 940MX]
+	0x134b, // GM108M [GeForce 940MX]
+	0x1399, // GM107M [GeForce 945M]
+	0x1348, // GM108M [GeForce 945M / 945A]
+	0x1d01, // GP108 [GeForce GT 1030]
+	0x0fc5, // GK107 [GeForce GT 1030]
+	0x174e, // GM108M [GeForce MX110]
+	0x174d, // GM108M [GeForce MX130]
+	0x1d10, // GP108M [GeForce MX150]
+	0x1d12, // GP108M [GeForce MX150]
+	0x1d11, // GP108M [GeForce MX230]
+	0x1d13, // GP108M [GeForce MX250]
+	0x1d52, // GP108BM [GeForce MX250]
+	0x137b, // GM108GLM [Quadro M520 Mobile]
+	0x1d33, // GP108GLM [Quadro P500 Mobile]
+	0x137a, // GM108GLM [Quadro K620M / Quadro M500M]
 };
 
 static const size_t num_blacklisted =
 	sizeof(blacklisted_adapters) / sizeof(blacklisted_adapters[0]);
 
-static bool is_adapter(const wchar_t *name, const wchar_t *adapter)
-{
-	const wchar_t *find = wstrstri(name, adapter);
-	if (!find) {
-		return false;
-	}
-
-	/* check before string for potential numeric mismatch */
-	if (find > name && iswdigit(find[-1]) && iswdigit(find[0])) {
-		return false;
-	}
-
-	/* check after string for potential numeric mismatch */
-	size_t len = wcslen(adapter);
-	if (iswdigit(find[len - 1]) && iswdigit(find[len])) {
-		return false;
-	}
-
-	return true;
-}
-
-static bool is_blacklisted(const wchar_t *name)
+static bool is_blacklisted(const int device_id)
 {
 	for (size_t i = 0; i < num_blacklisted; i++) {
-		const wchar_t *blacklisted_adapter = blacklisted_adapters[i];
-		if (is_adapter(name, blacklisted_adapter)) {
+		const int blacklisted_adapter = blacklisted_adapters[i];
+		if (device_id == blacklisted_adapter) {
 			return true;
 		}
 	}
@@ -128,8 +145,8 @@ static bool nvenc_device_available(void)
 			continue;
 		}
 
-		if (wstrstri(desc.Description, L"nvidia") &&
-		    !is_blacklisted(desc.Description)) {
+		// 0x10de = NVIDIA Corporation
+		if (desc.VendorId == 0x10de && !is_blacklisted(desc.DeviceId)) {
 			available = true;
 			goto finish;
 		}


### PR DESCRIPTION
### Description
This change replaces string / substring matching on the device name or description with static values from the PCI database, allowing more precise matching of devices and vendors.

### Motivation and Context
This allows more granular targeting of devices that potentially share the same names but with different features. It also helps avoid possible false positives as in c18aab29.

### How Has This Been Tested?
I verified the blacklisted adapter list was being matched against the device IDs instead of strings. All devices IDs were verified against the PCI database after entry to avoid typos that might have caused matching on the wrong ID.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
