### PR TITLE
UI: Add stats reset hotkey

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -210,6 +210,7 @@ Basic.Stats.DroppedFrames="Dropped Frames (Network)"
 Basic.Stats.MegabytesSent="Total Data Output"
 Basic.Stats.Bitrate="Bitrate"
 Basic.Stats.DiskFullIn="Disk full in (approx.)"
+Basic.Stats.ResetStats="Reset Stats"
 
 ResetUIWarning.Title="Are you sure you want to reset the UI?"
 ResetUIWarning.Text="Resetting the UI will hide additional docks. You will need to unhide these docks from the view menu if you want them to be visible.\n\nAre you sure you want to reset the UI?"

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2214,6 +2214,19 @@ void OBSBasic::CreateHotkeys()
 	transitionHotkey = obs_hotkey_register_frontend(
 		"OBSBasic.Transition", Str("Transition"), transition, this);
 	LoadHotkey(transitionHotkey, "OBSBasic.Transition");
+
+	auto resetStats = [](void *data, obs_hotkey_id, obs_hotkey_t *,
+			     bool pressed) {
+		if (pressed)
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data),
+						  "ResetStatsHotkey",
+						  Qt::QueuedConnection);
+	};
+
+	statsHotkey = obs_hotkey_register_frontend(
+		"OBSBasic.ResetStats", Str("Basic.Stats.ResetStats"),
+		resetStats, this);
+	LoadHotkey(statsHotkey, "OBSBasic.ResetStats");
 }
 
 void OBSBasic::ClearHotkeys()
@@ -2226,6 +2239,7 @@ void OBSBasic::ClearHotkeys()
 	obs_hotkey_unregister(forceStreamingStopHotkey);
 	obs_hotkey_unregister(togglePreviewProgramHotkey);
 	obs_hotkey_unregister(transitionHotkey);
+	obs_hotkey_unregister(statsHotkey);
 }
 
 OBSBasic::~OBSBasic()
@@ -7621,4 +7635,11 @@ void OBSBasic::ScenesReordered(const QModelIndex &parent, int start, int end,
 	UNUSED_PARAMETER(row);
 
 	OBSProjector::UpdateMultiviewProjectors();
+}
+
+void OBSBasic::ResetStatsHotkey()
+{
+	QList<OBSBasicStats *> list = findChildren<OBSBasicStats *>();
+
+	foreach(OBSBasicStats * s, list) s->Reset();
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -386,6 +386,7 @@ private:
 	volatile bool previewProgramMode = false;
 	obs_hotkey_id togglePreviewProgramHotkey = 0;
 	obs_hotkey_id transitionHotkey = 0;
+	obs_hotkey_id statsHotkey = 0;
 	int quickTransitionIdCounter = 1;
 	bool overridingTransition = false;
 
@@ -562,6 +563,8 @@ private slots:
 
 	void ScenesReordered(const QModelIndex &parent, int start, int end,
 			     const QModelIndex &destination, int row);
+
+	void ResetStatsHotkey();
 
 private:
 	/* OBS Callbacks */

--- a/UI/window-basic-stats.hpp
+++ b/UI/window-basic-stats.hpp
@@ -56,7 +56,6 @@ class OBSBasicStats : public QWidget {
 
 	void AddOutputLabels(QString name);
 	void Update();
-	void Reset();
 
 	virtual void closeEvent(QCloseEvent *event) override;
 
@@ -76,6 +75,9 @@ private:
 
 private slots:
 	void RecordingTimeLeft();
+
+public slots:
+	void Reset();
 
 protected:
 	virtual void showEvent(QShowEvent *event) override;


### PR DESCRIPTION
### Description
This adds a hotkey to reset stats.

### Motivation and Context
https://ideas.obsproject.com/posts/374/stats-panel-reset-hotkey

### How Has This Been Tested?
Created hotkey and the stats were reset as expected.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
