### PR TITLE
win-capture: Add additional exe to window capture blacklist

### DIFF
--- a/plugins/win-capture/window-helpers.c
+++ b/plugins/win-capture/window-helpers.c
@@ -128,12 +128,23 @@ void get_window_class(struct dstr *class, HWND hwnd)
 
 /* not capturable or internal windows */
 static const char *internal_microsoft_exes[] = {
+	"startmenuexperiencehost",
 	"applicationframehost",
+	"peopleexperiencehost",
 	"shellexperiencehost",
+	"microsoft.notes",
 	"windowsinternal",
+	"systemsettings",
+	"textinputhost",
 	"winstore.app",
+	"searchapp",
+	"video.ui",
 	"searchui",
 	"lockapp",
+	"cortana",
+	"gamebar",
+	"tabtip",
+	"time",
 	NULL,
 };
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
These are additional internal windows processes that should not be listed in the Windows window capture dropdown. Ideally, this list should be updated to allow for external updates so that a new release is not necessary for this to be maintained.

### Motivation and Context
These show up in the window capture list and were confusing/cluttering. Since they cannot be captured anyway, no reason to have them listed.

### How Has This Been Tested?
Compiled on windows 10 x64, after adding these to the blacklist they no longer show up in the window capture list. All other executable correctly enumerate. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
