### PR TITLE
libobs-d3d11: Fix null input layout rebuild

### DIFF
--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -178,10 +178,13 @@ void gs_vertex_shader::Rebuild(ID3D11Device *dev)
 	if (FAILED(hr))
 		throw HRError("Failed to create vertex shader", hr);
 
-	hr = dev->CreateInputLayout(layoutData.data(), (UINT)layoutData.size(),
-				    data.data(), data.size(), &layout);
-	if (FAILED(hr))
-		throw HRError("Failed to create input layout", hr);
+	const UINT layoutSize = (UINT)layoutData.size();
+	if (layoutSize > 0) {
+		hr = dev->CreateInputLayout(layoutData.data(), layoutSize,
+					    data.data(), data.size(), &layout);
+		if (FAILED(hr))
+			throw HRError("Failed to create input layout", hr);
+	}
 
 	if (constantSize) {
 		hr = dev->CreateBuffer(&bd, NULL, &constants);


### PR DESCRIPTION
### Description
Don't build input layout without VS inputs on device loss.

### Motivation and Context
Building an input layout without VS inputs will result in a DX failure, and OBS exception (crash). Having VS without inputs is relatively new; the creation logic was fixed up, but not the rebuild logic.

### How Has This Been Tested?
Used debugger to force-call RebuildDevice(). Crashes without change. Doesn't crash with change.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.