### PR TITLE
UI: Redesign hotkeys interface

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -94,9 +94,17 @@ Windowed="Windowed"
 Percent="Percent"
 RefreshBrowser="Refresh"
 AspectRatio="Aspect Ratio <b>%1:%2</b>"
+<<<<<<< HEAD
 LockVolume="Lock Volume"
 LogViewer="Log Viewer"
 ShowOnStartup="Show on startup"
+=======
+Frontend="Frontend"
+Source="Source"
+Outputs="Outputs"
+Encoders="Encoders"
+Services="Services"
+>>>>>>> afd0c49c... UI: Redesign filters interface
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"
@@ -916,6 +924,7 @@ Basic.AdvAudio.AudioTracks="Tracks"
 Basic.Settings.Hotkeys="Hotkeys"
 Basic.Settings.Hotkeys.Pair="Key combinations shared with '%1' act as toggles"
 Basic.Settings.Hotkeys.Filter="Filter"
+Basic.Settings.Hotkeys.NoHotkeys="No hotkeys available"
 
 # basic mode hotkeys
 Basic.Hotkeys.SelectScene="Switch to scene"

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2174,6 +2174,9 @@ void OBSBasic::InitHotkeys()
 	obs_hotkeys_set_sceneitem_hotkeys_translations(Str("SceneItemShow"),
 						       Str("SceneItemHide"));
 
+	obs_hotkeys_set_filter_hotkeys_translations(Str("Enable"),
+						    Str("Disable"));
+
 	obs_hotkey_enable_callback_rerouting(true);
 	obs_hotkey_set_callback_routing_func(OBSBasic::HotkeyTriggered, this);
 }

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -234,8 +234,35 @@ private:
 	void OnOAuthStreamKeyConnected();
 	void OnAuthConnected();
 	QString lastService;
+
 	int prevLangIndex;
 	bool prevBrowserAccel;
+
+	QTabWidget *tabs;
+	QLabel *noHotkeys;
+	QWidget *hotkeysFrontend;
+	QWidget *hotkeysScenes;
+	QWidget *hotkeysSources;
+	QWidget *hotkeysFilters;
+	QWidget *hotkeysOutputs;
+	QWidget *hotkeysEncoders;
+	QWidget *hotkeysServices;
+
+	QComboBox *scenesCombo;
+	QComboBox *sourcesCombo;
+	QComboBox *filtersSourceCombo;
+	QComboBox *filtersCombo;
+	QComboBox *outputsCombo;
+	QComboBox *encodersCombo;
+	QComboBox *servicesCombo;
+
+	QLabel *sceneLabel;
+	QLabel *sourceLabel;
+	QLabel *filtersSourceLabel;
+	QLabel *outputLabel;
+	QLabel *encoderLabel;
+	QLabel *serviceLabel;
+
 private slots:
 	void UpdateServerList();
 	void UpdateKeyLink();
@@ -245,6 +272,10 @@ private slots:
 	void on_disconnectAccount_clicked();
 	void on_useStreamKey_clicked();
 	void on_useAuth_toggled();
+
+	void HotkeysTabChanged(int tab);
+	void HotkeysComboChanged(const QString &text);
+	void FiltersSourceComboChanged(const QString &text);
 
 private:
 	/* output */
@@ -308,6 +339,16 @@ private:
 	QIcon GetAdvancedIcon() const;
 
 	int CurrentFLVTrack();
+
+	using encoders_elem_t =
+		std::tuple<OBSEncoder, QPointer<QLabel>, QPointer<QWidget>>;
+	using outputs_elem_t =
+		std::tuple<OBSOutput, QPointer<QLabel>, QPointer<QWidget>>;
+	using services_elem_t =
+		std::tuple<OBSService, QPointer<QLabel>, QPointer<QWidget>>;
+	using sources_elem_t =
+		std::tuple<OBSSource, QPointer<QLabel>, QPointer<QWidget>>;
+	std::vector<sources_elem_t> filters;
 
 private slots:
 	void on_theme_activated(int idx);

--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -1615,3 +1615,14 @@ void obs_hotkeys_set_sceneitem_hotkeys_translations(const char *show,
 	SET_T(hide);
 #undef SET_T
 }
+
+void obs_hotkeys_set_filter_hotkeys_translations(const char *enable,
+						 const char *disable)
+{
+#define SET_T(n)               \
+	bfree(obs->hotkeys.n); \
+	obs->hotkeys.n = bstrdup(n)
+	SET_T(enable);
+	SET_T(disable);
+#undef SET_T
+}

--- a/libobs/obs-hotkey.h
+++ b/libobs/obs-hotkey.h
@@ -148,6 +148,9 @@ obs_hotkeys_set_audio_hotkeys_translations(const char *mute, const char *unmute,
 					   const char *push_to_mute,
 					   const char *push_to_talk);
 
+EXPORT void obs_hotkeys_set_filter_hotkeys_translations(const char *enable,
+							const char *disable);
+
 EXPORT void obs_hotkeys_set_sceneitem_hotkeys_translations(const char *show,
 							   const char *hide);
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -400,6 +400,8 @@ struct obs_core_hotkeys {
 	char *push_to_talk;
 	char *sceneitem_show;
 	char *sceneitem_hide;
+	char *enable;
+	char *disable;
 };
 
 struct obs_core {
@@ -725,6 +727,7 @@ struct obs_source {
 	uint64_t push_to_mute_stop_time;
 	uint64_t push_to_talk_delay;
 	uint64_t push_to_talk_stop_time;
+	obs_hotkey_pair_id filters_key;
 
 	/* transitions */
 	uint64_t transition_start_time;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -768,6 +768,8 @@ static inline bool obs_init_hotkeys(void)
 	hotkeys->push_to_talk = bstrdup("Push-to-talk");
 	hotkeys->sceneitem_show = bstrdup("Show '%1'");
 	hotkeys->sceneitem_hide = bstrdup("Hide '%1'");
+	hotkeys->enable = bstrdup("Enable");
+	hotkeys->disable = bstrdup("Disable");
 
 	if (!obs_hotkeys_platform_init(hotkeys))
 		return false;
@@ -815,6 +817,8 @@ static inline void obs_free_hotkeys(void)
 
 	bfree(hotkeys->mute);
 	bfree(hotkeys->unmute);
+	bfree(hotkeys->enable);
+	bfree(hotkeys->disable);
 	bfree(hotkeys->push_to_mute);
 	bfree(hotkeys->push_to_talk);
 	bfree(hotkeys->sceneitem_show);


### PR DESCRIPTION
### Description
This overhauls the hotkeys interface with better organization with tabs and drop downs to select the scene, source, etc. Filter hotkeys have also been added.

![Screenshot from 2019-10-17 21-47-28](https://user-images.githubusercontent.com/19962531/67062283-70810400-f128-11e9-9e08-018a45d505fe.png)
![Screenshot from 2019-10-17 21-48-09](https://user-images.githubusercontent.com/19962531/67062290-78d93f00-f128-11e9-9f46-c3fce5f2ec4b.png)
![Screenshot from 2019-10-17 21-47-01](https://user-images.githubusercontent.com/19962531/67062301-81317a00-f128-11e9-9b5b-e553b1e8583e.png)

### Motivation and Context
Hotkeys were a mess.

Filter hotkeys:
https://ideas.obsproject.com/posts/67/allow-hotkeys-to-be-setup-for-filters

### How Has This Been Tested?
Tested by running program to see if hotkeys UI looked better.

### Types of changes
- New feature (non-breaking change which adds functionality)
- UI overhaul

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
