### PR TITLE
Log Sample Rate for WASAPI devices

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -3685,19 +3685,19 @@
                    <item row="0" column="1">
                     <widget class="QComboBox" name="sampleRate">
                      <property name="currentText">
-                      <string notr="true">44.1khz</string>
+                      <string notr="true">44.1 kHz</string>
                      </property>
                      <property name="currentIndex">
                       <number>0</number>
                      </property>
                      <item>
                       <property name="text">
-                       <string>44.1khz</string>
+                       <string>44.1 kHz</string>
                       </property>
                      </item>
                      <item>
                       <property name="text">
-                       <string>48khz</string>
+                       <string>48 kHz</string>
                       </property>
                      </item>
                     </widget>

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2189,9 +2189,9 @@ void OBSBasicSettings::LoadAudioSettings()
 
 	const char *str;
 	if (sampleRate == 48000)
-		str = "48khz";
+		str = "48 kHz";
 	else
-		str = "44.1khz";
+		str = "44.1 kHz";
 
 	int sampleRateIdx = ui->sampleRate->findText(str);
 	if (sampleRateIdx != -1)
@@ -3253,7 +3253,7 @@ void OBSBasicSettings::SaveAudioSettings()
 	}
 
 	int sampleRate = 44100;
-	if (sampleRateStr == "48khz")
+	if (sampleRateStr == "48 kHz")
 		sampleRate = 48000;
 
 	if (WidgetChanged(ui->sampleRate))

--- a/plugins/win-wasapi/enum-wasapi.hpp
+++ b/plugins/win-wasapi/enum-wasapi.hpp
@@ -2,6 +2,7 @@
 
 #define WIN32_MEAN_AND_LEAN
 #include <windows.h>
+#include <initguid.h>
 #include <mmdeviceapi.h>
 #include <audioclient.h>
 #include <propsys.h>


### PR DESCRIPTION
### Description
This adds the device's sample rate to the log file when a WASAPI device is initialized. If the sample rate detection fails, a hyphen is shown instead.

As part of this change, I also noticed the display of the sample rate in Settings -> Audio was a little hard to read *and* slightly inaccurate, and fixed that too.

```
WASAPI: Device '5.1 Speakers (High Definition Audio Device)' [48000 Hz] initialized
WASAPI: Device 'CABLE-B Output (VB-Audio Cable B)' [48000 Hz] initialized
```

### Motivation and Context
Often, if a user runs into audio de-sync issues or clicking sounds, it's caused by an inconsistency between a device's sample rate, and the sample rate configured in OBS. This will make troubleshooting such situations easier.

### How Has This Been Tested?
* Configured a Desktop Audio Device, Mic/Aux device, and Audio Input Capture Device, then checked the log to ensure they each reported a sample rate that matches what Windows is configured for

### Types of changes
- New feature (non-breaking change which adds functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
