### PR TITLE
UI: Use constant string as version string

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1376,7 +1376,7 @@ const char *OBSApp::GetVersionString() const
 		return OBS_FULL_VERSION;
 }
 
-bool OBSApp::IsPortableMode()
+bool OBSApp::IsPortableMode() const
 {
 	return portable_mode;
 }

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1349,35 +1349,31 @@ bool OBSApp::OBSInit()
 	return true;
 }
 
-string OBSApp::GetVersionString() const
+const char *OBSApp::GetVersionString() const
 {
-	stringstream ver;
-
-#ifdef HAVE_OBSCONFIG_H
-	ver << OBS_VERSION;
-#else
-	ver << LIBOBS_API_MAJOR_VER << "." << LIBOBS_API_MINOR_VER << "."
-	    << LIBOBS_API_PATCH_VER;
-
+#ifndef HAVE_OBSCONFIG_H
+#undef OBS_VERSION
+#define OBS_VERSION
+	STRINGIFY_(LIBOBS_API_MAJOR_VER)
+	"." STRINGIFY_(LIBOBS_API_MINOR_VER) "." STRINGIFY_(
+		LIBOBS_API_PATCH_VER)
 #endif
-	ver << " (";
 
 #ifdef _WIN32
-	if (sizeof(void *) == 8)
-		ver << "64-bit, ";
-	else
-		ver << "32-bit, ";
-
-	ver << "windows)";
+#if _WIN64
+#define OBS_FULL_VERSION OBS_VERSION " (64-bit, windows)"
+#else
+#define OBS_FULL_VERSION OBS_VERSION " (32-bit, windows)"
+#endif
 #elif __APPLE__
-	ver << "mac)";
+#define OBS_FULL_VERSION OBS_VERSION " (mac)"
 #elif __FreeBSD__
-	ver << "freebsd)";
+#define OBS_FULL_VERSION OBS_VERSION " (freebsd)"
 #else /* assume linux for the time being */
-	ver << "linux)";
+#define OBS_FULL_VERSION OBS_VERSION " (linux)"
 #endif
 
-	return ver.str();
+		return OBS_FULL_VERSION;
 }
 
 bool OBSApp::IsPortableMode()

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -142,7 +142,7 @@ public:
 
 	const char *GetLastCrashLog() const;
 
-	std::string GetVersionString() const;
+	const char *GetVersionString() const;
 	bool IsPortableMode();
 
 	const char *InputAudioSource() const;

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -143,7 +143,7 @@ public:
 	const char *GetLastCrashLog() const;
 
 	const char *GetVersionString() const;
-	bool IsPortableMode();
+	bool IsPortableMode() const;
 
 	const char *InputAudioSource() const;
 	const char *OutputAudioSource() const;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Version string is always the same, should not be created in runtime. Use
macro to produce it as constant string in compilation.

### Motivation and Context
Reduce binary size obs64.exe from 3341312(156e2f3aeca12c88f6aa46434a372782d4662eec) to 3257344 bytes (82KB).
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Run and verify correct version number is displayed in title.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
