### PR TITLE
image-source: Add all available transitions to slideshow

### DIFF
--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -580,6 +580,10 @@ EXPORT void obs_enum_sources(bool (*enum_proc)(void *, obs_source_t *),
 			     void *param);
 
 /** Enumerates scenes */
+EXPORT void obs_enum_private_sources(bool (*enum_proc)(void *, obs_source_t *),
+				 void *param);
+
+/** Enumerates scenes */
 EXPORT void obs_enum_scenes(bool (*enum_proc)(void *, obs_source_t *),
 			    void *param);
 
@@ -611,6 +615,9 @@ EXPORT obs_encoder_t *obs_get_encoder_by_name(const char *name);
 
 /** Gets an service by its name. */
 EXPORT obs_service_t *obs_get_service_by_name(const char *name);
+
+/** Find private source */
+EXPORT obs_source_t *obs_get_private_source_by_name(const char *name);
 
 enum obs_base_effect {
 	OBS_EFFECT_DEFAULT,         /**< RGB/YUV */


### PR DESCRIPTION
### Description
This adds all transitions configured by the user, in the main UI, to the slideshow source.

### Motivation and Context
This is a redo of #1361. That was rejected because it relied on the frontend api. This adds functions to libobs to get the transitions.

### How Has This Been Tested?
Created a Luma Wipe transition and added it to the slideshow source.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
