### PR TITLE
Add t-bar to studio mode

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -1050,3 +1050,36 @@ SceneTree#scenes {
 * [themeID="replayIconSmall"] {
     qproperty-icon: url(./Dark/save.svg);
 }
+
+/* Studio Mode T-Bar */
+
+QSlider[themeID="tBarSlider"] {
+	height: 80px;
+}
+
+QSlider::groove:horizontal[themeID="tBarSlider"] {
+	height: 5px;
+	margin: 0 12px;
+	background-color: QLinearGradient(x1: 0, y1: 0, x2: 0, y2: 1,
+		stop: 0 rgb(31,30,31),
+		stop: 0.75 rgb(50, 49, 50));
+	border: none;
+	border-radius: 2px;
+}
+
+QSlider::sub-page:horizontal[themeID="tBarSlider"] {
+	height: 5px;
+	margin: 0 12px;
+	background-color: QLinearGradient(x1: 0, y1: 0, x2: 0, y2: 1,
+		stop: 0 rgb(31,30,31),
+		stop: 0.75 rgb(50, 49, 50));
+	border: none;
+	border-radius: 2px;
+}
+
+QSlider::handle:horizontal[themeID="tBarSlider"] {
+	background-color: #d2d2d2;
+	width: 25px;
+	height: 80px;
+	margin: -24px -12px;
+}

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -815,3 +815,28 @@ SceneTree {
 * [themeID="replayIconSmall"] {
     qproperty-icon: url(./Dark/save.svg);
 }
+
+/* Studio Mode T-Bar */
+
+QSlider[themeID="tBarSlider"] {
+	height: 80px;
+}
+
+QSlider::groove:horizontal[themeID="tBarSlider"] {
+	border: 1px solid #4c4c4c;
+	height: 5px;
+	background: rgb(31,30,31);;
+	margin: 0 12px;
+}
+
+QSlider::sub-page:horizontal[themeID="tBarSlider"] {
+	background: rgb(31,30,31);;
+	border: 1px solid #4c4c4c;
+}
+
+QSlider::handle:horizontal[themeID="tBarSlider"] {
+	background-color: #d2d2d2;
+	width: 25px;
+	height: 80px;
+	margin: -24px -12px;
+}

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -1378,3 +1378,36 @@ SceneTree#scenes {
 * [themeID="replayIconSmall"] {
     qproperty-icon: url(./Dark/save.svg);
 }
+
+/* Studio Mode T-Bar */
+
+QSlider[themeID="tBarSlider"] {
+	height: 80px;
+}
+
+QSlider::groove:horizontal[themeID="tBarSlider"] {
+	height: 5px;
+	margin: 0 12px;
+	background-color: QLinearGradient(x1: 1, y1: 0, x2: 0, y2: 0,
+		stop: 0 rgb(35, 38, 41), /* Dark Gray */
+		stop: 0.75 rgb(50, 49, 50));
+	border: none;
+	border-radius: 2px;
+}
+
+QSlider::sub-page:horizontal[themeID="tBarSlider"] {
+	height: 5px;
+	margin: 0 12px;
+	background-color: QLinearGradient(x1: 1, y1: 0, x2: 0, y2: 0,
+		stop: 0 rgb(35, 38, 41), /* Dark Gray */
+		stop: 0.75 rgb(50, 49, 50));
+	border: none;
+	border-radius: 2px;
+}
+
+QSlider::handle:horizontal[themeID="tBarSlider"] {
+	background-color: #d2d2d2;
+	width: 25px;
+	height: 80px;
+	margin: -24px -12px;
+}

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -246,3 +246,29 @@ SceneTree {
 * [themeID="replayIconSmall"] {
     qproperty-icon: url(:res/images/save.svg);
 }
+
+/* Studio Mode T-Bar */
+
+QSlider[themeID="tBarSlider"] {
+	height: 80px;
+}
+
+QSlider::groove:horizontal[themeID="tBarSlider"] {
+	border: 1px solid #4c4c4c;
+	height: 5px;
+	background: #DCD9D7;
+	margin: 0 12px;
+}
+
+QSlider::sub-page:horizontal[themeID="tBarSlider"] {
+	background: #DCD9D7;
+	border: 1px solid #4c4c4c;
+}
+
+QSlider::handle:horizontal[themeID="tBarSlider"] {
+	background-color: #f3f3f3;
+	border: 1px solid #4c4c4c;
+	width: 25px;
+	height: 80px;
+	margin: -24px -12px;
+}

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -502,6 +502,11 @@ private:
 	QIcon GetBrowserIcon() const;
 	QIcon GetDefaultIcon() const;
 
+	QSlider *tBar;
+	bool tBarActive = false;
+	bool tBarDown = false;
+	void EnableTBar();
+
 public slots:
 	void DeferSaveBegin();
 	void DeferSaveEnd();
@@ -541,7 +546,8 @@ public slots:
 	void TransitionToScene(OBSScene scene, bool force = false);
 	void TransitionToScene(OBSSource scene, bool force = false,
 			       bool quickTransition = false,
-			       int quickDuration = 0, bool black = false);
+			       int quickDuration = 0, bool black = false,
+			       bool manual = false);
 	void SetCurrentScene(OBSSource scene, bool force = false);
 
 	bool AddSceneCollection(bool create_new,
@@ -644,6 +650,9 @@ private slots:
 	void SetGroupIcon(const QIcon &icon);
 	void SetSceneIcon(const QIcon &icon);
 	void SetDefaultIcon(const QIcon &icon);
+
+	void TBarChanged(int value);
+	void TBarReleased();
 
 private:
 	/* OBS Callbacks */

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -700,6 +700,9 @@ struct obs_source {
 	gs_texrender_t *transition_texrender[2];
 	pthread_mutex_t transition_mutex;
 	obs_source_t *transition_sources[2];
+	float transition_manual_clamp;
+	float transition_manual_torque;
+	float transition_manual_target;
 	float transition_manual_val;
 	bool transitioning_video;
 	bool transitioning_audio;
@@ -728,7 +731,7 @@ extern bool obs_source_init_context(struct obs_source *source,
 
 extern bool obs_transition_init(obs_source_t *transition);
 extern void obs_transition_free(obs_source_t *transition);
-extern void obs_transition_tick(obs_source_t *transition);
+extern void obs_transition_tick(obs_source_t *transition, float t);
 extern void obs_transition_enum_sources(obs_source_t *transition,
 					obs_source_enum_proc_t enum_callback,
 					void *param);

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -700,6 +700,7 @@ struct obs_source {
 	gs_texrender_t *transition_texrender[2];
 	pthread_mutex_t transition_mutex;
 	obs_source_t *transition_sources[2];
+	float transition_manual_val;
 	bool transitioning_video;
 	bool transitioning_audio;
 	bool transition_source_active[2];

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1067,7 +1067,7 @@ void obs_source_video_tick(obs_source_t *source, float seconds)
 		return;
 
 	if (source->info.type == OBS_SOURCE_TYPE_TRANSITION)
-		obs_transition_tick(source);
+		obs_transition_tick(source, seconds);
 
 	if ((source->info.output_flags & OBS_SOURCE_ASYNC) != 0)
 		async_tick(source);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1333,6 +1333,7 @@ EXPORT obs_source_t *obs_transition_get_active_source(obs_source_t *transition);
 
 enum obs_transition_mode {
 	OBS_TRANSITION_MODE_AUTO,
+	OBS_TRANSITION_MODE_MANUAL,
 };
 
 EXPORT bool obs_transition_start(obs_source_t *transition,
@@ -1340,6 +1341,8 @@ EXPORT bool obs_transition_start(obs_source_t *transition,
 				 uint32_t duration_ms, obs_source_t *dest);
 
 EXPORT void obs_transition_set(obs_source_t *transition, obs_source_t *source);
+
+EXPORT void obs_transition_set_manual_time(obs_source_t *transition, float t);
 
 enum obs_transition_scale_type {
 	OBS_TRANSITION_SCALE_MAX_ONLY,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1343,6 +1343,8 @@ EXPORT bool obs_transition_start(obs_source_t *transition,
 EXPORT void obs_transition_set(obs_source_t *transition, obs_source_t *source);
 
 EXPORT void obs_transition_set_manual_time(obs_source_t *transition, float t);
+EXPORT void obs_transition_set_manual_torque(obs_source_t *transition,
+					     float torque, float clamp);
 
 enum obs_transition_scale_type {
 	OBS_TRANSITION_SCALE_MAX_ONLY,


### PR DESCRIPTION
### Description
This adds the ability for users to manually transition between sources in studio mode.

![6fvbu-gub4l](https://user-images.githubusercontent.com/19962531/67346479-87e33700-f504-11e9-8328-a492caf50c16.gif)

### Motivation and Context
https://ideas.obsproject.com/posts/338/manual-scence-transition-control

### How Has This Been Tested?
In studio mode I transitioned back and forth between sources.

### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] Make it look better, instead of standard QSlider
