### PR TITLE
UI: Fix main transition being set to the quick one

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -476,12 +476,13 @@ public slots:
 	void SaveProject();
 
 	void SetTransition(OBSSource transition);
+	void OverrideTransition(OBSSource transition);
 	void TransitionToScene(OBSScene scene, bool force = false,
 			       bool direct = false);
 	void TransitionToScene(OBSSource scene, bool force = false,
 			       bool direct = false,
 			       bool quickTransition = false,
-			       bool black = false);
+			       int quickDuration = 0, bool black = false);
 	void SetCurrentScene(OBSSource scene, bool force = false,
 			     bool direct = false);
 


### PR DESCRIPTION
### Description
This fixes an issue where using a quick transition, it would change
the main transition as well.

### Motivation and Context
I found it annoying when using a quick transition, then using the normal transition, it would use whatever the quick transition was.

### How Has This Been Tested?
I triggered a quick transition, then I transitioned normally, and everything worked as expected.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
