### PR TITLE
UI: Fall back to XGetWMName if XFetchName fails

### DIFF
--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher-nix.cpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher-nix.cpp
@@ -126,9 +126,16 @@ static std::string GetWindowTitle(size_t i)
 	if (status >= Success && name != nullptr) {
 		std::string str(name);
 		windowTitle = str;
+		XFree(name);
+	} else {
+		XTextProperty xtp_new_name;
+		if (XGetWMName(disp(), w, &xtp_new_name) != 0 &&
+		    xtp_new_name.value != nullptr) {
+			std::string str((const char *)xtp_new_name.value);
+			windowTitle = str;
+			XFree(xtp_new_name.value);
+		}
 	}
-
-	XFree(name);
 
 	return windowTitle;
 }


### PR DESCRIPTION
### Description
There are instances where XFetchName will fail to get a window's name, even if it has a WM_NAME property set [[example](https://github.com/herbstluftwm/herbstluftwm/issues/64)]. Add a fallback to XGetWMName when this occurs.

### Motivation and Context
When OBS enumerates windows for the automatic scene switcher on Linux, any windows that return an empty string when passed to GetWindowTitle are ignored [[1](https://github.com/obsproject/obs-studio/blob/master/UI/frontend-plugins/frontend-tools/auto-scene-switcher-nix.cpp#L141)]. Since GetWindowTitle relies on XFetchName, some windows are skipped during the enumeration (e.g. Chrome).

### How Has This Been Tested?
I verified that Chrome as well as all the windows listed before the change were present in the dropdown menu for the automatic scene switcher. I also verified that automatic scene switching worked with Chrome. The details of my system as logged from OBS are below.
```
info: CPU Name: Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz
info: CPU Speed: 2710.102MHz
info: Physical Cores: 4, Logical Cores: 8
info: Physical Memory: 7749MB Total, 1359MB Free
info: Kernel Version: Linux 5.0.0-15-generic
info: Distribution: "Pop!_OS" "19.04"
info: Window System: X11.0, Vendor: The X.Org Foundation, Version: 1.20.4
info: Portable mode: false
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
