### PR TITLE
Support for new autogenerated OBS Dependencies (WIP)

### DIFF
--- a/cmake/Modules/CopyMSVCBins.cmake
+++ b/cmake/Modules/CopyMSVCBins.cmake
@@ -58,8 +58,10 @@ file(GLOB FFMPEG_BIN_FILES
 	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/opus*.dll"
 
 	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/libogg*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/ogg*.dll"
 	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/libvorbis*.dll"
 	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/libogg*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/ogg*.dll"
 	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/libvorbis*.dll"
 
 	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/libvpx*.dll"
@@ -71,13 +73,58 @@ file(GLOB FFMPEG_BIN_FILES
 	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/opus*.dll"
 	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/libbz2*.dll"
 	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/zlib*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/libzlib*.dll"
 	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/libbz2*.dll"
 	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/zlib*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/libzlib*.dll"
 
 	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/libbz2*.dll"
 	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/zlib*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/libzlib*.dll"
 	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/libbz2*.dll"
 	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/zlib*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/libzlib*.dll"
+
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/libsrt*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/srt*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/libsrt*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/srt*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/libsrt*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/srt*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/libsrt*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/srt*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/libmbedcrypto*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/mbedcrypto*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/libmbedcrypto*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/mbedcrypto*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/libmbedcrypto*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/mbedcrypto*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/libmbedcrypto*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/mbedcrypto*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/libmbedx509*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/mbedx509*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/libmbedx509*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/mbedx509*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/libmbedx509*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/mbedx509*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/libmbedx509*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/mbedx509*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/libmbedtls*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/mbedtls*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/libmbedtls*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/mbedtls*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/libmbedtls*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/mbedtls*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/libmbedtls*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/mbedtls*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/libwinpthread*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/winpthread*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/libwinpthread*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/winpthread*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/libwinpthread*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/winpthread*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/libwinpthread*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/winpthread*.dll"
 	)
 
 file(GLOB X264_BIN_FILES
@@ -130,13 +177,21 @@ file(GLOB LUA_BIN_FILES
 	"${LUAJIT_INCLUDE_DIR}/bin${_bin_suffix}/lua*.dll"
 	"${LUAJIT_INCLUDE_DIR}/bin/lua*.dll"
 	"${LUAJIT_INCLUDE_DIR}/lua*.dll"
+	"${LUAJIT_INCLUDE_DIR}/../../bin${_bin_suffix}/lua.dll"
+	"${LUAJIT_INCLUDE_DIR}/../../bin/lua.dll"
+	"${LUAJIT_INCLUDE_DIR}/../bin${_bin_suffix}/lua.dll"
+	"${LUAJIT_INCLUDE_DIR}/../bin/lua.dll"
+	"${LUAJIT_INCLUDE_DIR}/bin${_bin_suffix}/lua.dll"
+	"${LUAJIT_INCLUDE_DIR}/bin/lua.dll"
+	"${LUAJIT_INCLUDE_DIR}/lua.dll"
 	)
 
 if (ZLIB_LIB)
 	GET_FILENAME_COMPONENT(ZLIB_BIN_PATH ${ZLIB_LIB} PATH)
 endif()
 file(GLOB ZLIB_BIN_FILES
-	"${ZLIB_BIN_PATH}/zlib*.dll")
+	"${ZLIB_BIN_PATH}/zlib*.dll"
+	"${ZLIB_BIN_PATH}/libzlib*.dll")
 
 if (NOT ZLIB_BIN_FILES)
 	file(GLOB ZLIB_BIN_FILES
@@ -144,6 +199,10 @@ if (NOT ZLIB_BIN_FILES)
 		"${ZLIB_INCLUDE_DIR}/../bin/zlib*.dll"
 		"${ZLIB_INCLUDE_DIR}/bin${_bin_suffix}/zlib*.dll"
 		"${ZLIB_INCLUDE_DIR}/bin/zlib*.dll"
+		"${ZLIB_INCLUDE_DIR}/../bin${_bin_suffix}/libzlib*.dll"
+		"${ZLIB_INCLUDE_DIR}/../bin/libzlib*.dll"
+		"${ZLIB_INCLUDE_DIR}/bin${_bin_suffix}/libzlib*.dll"
+		"${ZLIB_INCLUDE_DIR}/bin/libzlib*.dll"
 		)
 endif()
 

--- a/cmake/Modules/FindLuajit.cmake
+++ b/cmake/Modules/FindLuajit.cmake
@@ -51,7 +51,7 @@ FIND_PATH(LUAJIT_INCLUDE_DIR
 		)
 
 find_library(LUAJIT_LIB
-	NAMES ${_LUAJIT_LIBRARIES} luajit luajit-51 luajit-5.1 lua51
+	NAMES ${_LUAJIT_LIBRARIES} lua liblua luajit luajit-51 luajit-5.1 lua51
 	HINTS
 		ENV LuajitPath${_lib_suffix}
 		ENV LuajitPath

--- a/cmake/Modules/FindPythonDeps.cmake
+++ b/cmake/Modules/FindPythonDeps.cmake
@@ -38,7 +38,7 @@ FIND_PATH(PYTHON_INCLUDE_DIR
 		)
 
 find_library(PYTHON_LIB
-	NAMES ${_PYTHON_LIBRARIES} python36
+	NAMES ${_PYTHON_LIBRARIES} python38 python37 python36
 	HINTS
 		ENV PythonPath${_lib_suffix}
 		ENV PythonPath

--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -55,6 +55,7 @@
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/md5.h>
 #include <mbedtls/base64.h>
+#include <mbedtls/x509_crt.h>
 #define MD5_DIGEST_LENGTH 16
 
 #elif defined(USE_POLARSSL)

--- a/plugins/obs-outputs/librtmp/rtmp_sys.h
+++ b/plugins/obs-outputs/librtmp/rtmp_sys.h
@@ -86,6 +86,8 @@
 #include <mbedtls/ssl.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
+#include <mbedtls/x509.h>
+#include <mbedtls/x509_crt.h>
 
 #define my_dhm_P \
     "E4004C1F94182000103D883A448B3F80" \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Modifies the necessary files to support the new automatically generated obs dependencies archives. These are slightly different from what used to be in dependencies.zip due to changes in binary or linked names.

A test win-deps.7z is available at: https://github.com/Xaymar/obs-deps/suites/283034446/artifacts/186217. Note that at the time of writing this, some dependencies are still missing: python3, swig, websockets. These dependencies need to be copied from the original dependencies.zip for the time until they are added.

### Motivation and Context
The `dependencies.zip` content randomly changes and relies on someone not messing up. It is far better to have all the dependencies automatically generated from CI, so I went ahead and made [a PR to obs-deps](https://github.com/obsproject/obs-deps/pull/2), which does exactly that.

### How Has This Been Tested?
- Tested streaming SRT with PR #1748 applied, OBS-OBS, OBS-ffplay and ffmpeg-ffplay streaming worked without any major flaws. No crashes or new bugs here.
- Added the obs-ffmpeg-encoder plugin, which I used for H264 and H265 encoding tests (relies on ffmpeg).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Performance enhancement (non-breaking change which improves efficiency)
- Breaking change (fix or feature that would cause existing functionality to change)

### Dependencies:
- [ ] [Automatically generated obs-deps for Windows](https://github.com/obsproject/obs-deps/pull/2)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.