### PR TITLE
mac-vth264: Manually mark priority bits for frames

### DIFF
--- a/plugins/mac-vth264/encoder.c
+++ b/plugins/mac-vth264/encoder.c
@@ -1,5 +1,6 @@
 #include <obs-module.h>
 #include <util/darray.h>
+#include <obs-avc.h>
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <VideoToolbox/VideoToolbox.h>
@@ -671,6 +672,10 @@ static bool is_sample_keyframe(CMSampleBufferRef buffer)
 static bool parse_sample(struct vt_h264_encoder *enc, CMSampleBufferRef buffer,
 			 struct encoder_packet *packet, CMTime off)
 {
+	uint8_t *start;
+	uint8_t *end;
+	int type;
+
 	CMTime pts = CMSampleBufferGetPresentationTimeStamp(buffer);
 	CMTime dts = CMSampleBufferGetDecodeTimeStamp(buffer);
 
@@ -702,6 +707,37 @@ static bool parse_sample(struct vt_h264_encoder *enc, CMSampleBufferRef buffer,
 	packet->data = enc->packet_data.array;
 	packet->size = enc->packet_data.num;
 	packet->keyframe = keyframe;
+
+	/* ------------------------------------ */
+
+	start = enc->packet_data.array;
+	end = start + enc->packet_data.num;
+
+	start = (uint8_t *)obs_avc_find_startcode(start, end);
+	while (true) {
+		while (start < end && !*(start++))
+			;
+
+		if (start == end)
+			break;
+
+		type = start[0] & 0x1F;
+		if (type == OBS_NAL_SLICE_IDR || type == OBS_NAL_SLICE) {
+			uint8_t prev_type = (start[0] >> 5) & 0x3;
+			start[0] &= ~(3 << 5);
+
+			if (type & OBS_NAL_SLICE)
+				start[0] |= OBS_NAL_PRIORITY_HIGHEST << 5;
+			else if (type & OBS_NAL_SLICE_IDR)
+				start[0] |= OBS_NAL_PRIORITY_HIGH << 5;
+			else
+				start[0] |= prev_type << 5;
+		}
+
+		start = (uint8_t *)obs_avc_find_startcode(start, end);
+	}
+
+	/* ------------------------------------ */
 
 	CFRelease(buffer);
 	return true;


### PR DESCRIPTION
### Description
This PR is the mac-vth264 version of edfc2be in obs-qsv11.  There are no other changes.

### Motivation and Context
On macOS, when streaming with the vth264 hardware encoder, network congestion can trigger OBS to drop frames and never stop dropping frames.  The [obs-qsv11 plugin had this issue](https://obsproject.com/forum/threads/15-4-16-5-quicksync-issue-kbps-dropped-to-0-without-crash.57417/) from OBS Studio 0.16.0 to 0.16.5, but it was fixed in edfc2be for 0.16.6.  It was not fixed for mac-vth264.  This PR ports the fix from obs-qsv11 to mac-vth264, allowing users to recover from dropping frames with the Apple hardware encoder.
This has been reported and discussed in the OBS Project forums:
* https://obsproject.com/forum/threads/apple-hardware-encoder-destroys-stream.82677/
* https://obsproject.com/forum/threads/bitrate-drops-significantly-mid-stream.57051/

### How Has This Been Tested?
I do not have macOS for testing, so I have not tested this personally.  Some users have previously tested this patch with promising results.  Pinging @DDRBoxman and @cg2121 for macOS testing.

To test:
1. On macOS, start streaming with the hardware encoder (Apple VT H264 Hardware Encoder) with OBS.
2. Introduce network congestion.  This is easily done by resuming a browser session with a lot of tabs or opening a lot of browser tabs or streaming video at once.

Before this PR, once the bug is triggered, OBS should drop frames and never stop dropping frames.  After this PR, OBS should only drop frames as needed and then resume transmitting frames once able to.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
