### PR TITLE
libobs: Fix cursor draw position bug when cropping a window capture.

### DIFF
--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -664,7 +664,8 @@ void XCompcapMain::render(gs_effect_t *effect)
 		effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
 
 		while (gs_effect_loop(effect, "Draw")) {
-			xcursor_render(p->cursor);
+			xcursor_render(p->cursor, -p->cur_cut_left,
+				       -p->cur_cut_top);
 		}
 	}
 }

--- a/plugins/linux-capture/xcursor.c
+++ b/plugins/linux-capture/xcursor.c
@@ -103,7 +103,7 @@ void xcursor_tick(xcursor_t *data)
 	XFree(xc);
 }
 
-void xcursor_render(xcursor_t *data)
+void xcursor_render(xcursor_t *data, int x_offset, int y_offset)
 {
 	if (!data->tex)
 		return;
@@ -117,7 +117,8 @@ void xcursor_render(xcursor_t *data)
 	gs_enable_color(true, true, true, false);
 
 	gs_matrix_push();
-	gs_matrix_translate3f(data->render_x, data->render_y, 0.0f);
+	gs_matrix_translate3f(data->render_x + x_offset,
+			      data->render_y + y_offset, 0.0f);
 	gs_draw_sprite(data->tex, 0, 0, 0);
 	gs_matrix_pop();
 

--- a/plugins/linux-capture/xcursor.h
+++ b/plugins/linux-capture/xcursor.h
@@ -61,7 +61,7 @@ void xcursor_tick(xcursor_t *data);
  *
  * This needs to be executed within a valid render context
  */
-void xcursor_render(xcursor_t *data);
+void xcursor_render(xcursor_t *data, int x_offset, int y_offset);
 
 /**
  * Specify offset for the cursor


### PR DESCRIPTION
When cropping the left or top of a window capture, OBS would
misalign the drawn cursor, placing it as if the entire window were
being captured. Instead, offset the captured cursor by the same
number of pixels, thus placing the cursor back where it belongs.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixes a bug in window capture with the cursor visible and a left/top crop.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Linux. Needs Windows testing but not expected to have any impact (applies only to X11).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
