### PR TITLE
win-capture: Fix rare crash when OpenGL programs exit with graphics-hook

### DIFF
--- a/plugins/win-capture/graphics-hook/gl-capture.c
+++ b/plugins/win-capture/graphics-hook/gl-capture.c
@@ -30,6 +30,7 @@ static struct func_hook wgl_swap_buffers;
 static struct func_hook wgl_delete_context;
 
 static bool darkest_dungeon_fix = false;
+static bool functions_initialized = false;
 
 struct gl_data {
 	HDC hdc;
@@ -724,7 +725,6 @@ static void gl_shmem_capture(void)
 
 static void gl_capture(HDC hdc)
 {
-	static bool functions_initialized = false;
 	static bool critical_failure = false;
 
 	if (critical_failure) {
@@ -828,7 +828,7 @@ static BOOL WINAPI hook_wgl_delete_context(HGLRC hrc)
 {
 	BOOL ret;
 
-	if (capture_active()) {
+	if (capture_active() && functions_initialized) {
 		HDC last_hdc = jimglGetCurrentDC();
 		HGLRC last_hrc = jimglGetCurrentContext();
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

*This PR has been edited/clarified by Jim*

### Description
When hooking a program that has both DirectX and OpenGL contexts in use, it is possible to cause a crash on shutdown due to capture_active() returning true when an OpenGL context is deleted.  Normally, when capturing an OpenGL program, this would not happen because the 'active' variable would not be set due to OpenGL capture not being initialized, but if DirectX is captured while an OpenGL context is available, and OpenGL could not load these required functions, then GL can crash due to trying to use unavailable functions.

This case is extremely rare and doesn't happen under normal circumstances; only if a program is using both DirectX and OpenGL within the same program simultaneously, and *only* if OpenGL could not load the required functions.  This likely almost never happens under normal programs, games, and hardware.  This was apparently produced by hooking a GL Qt program that used QWebEngine, which used multiple contexts at once.

### How Has This Been Tested?
win10 x64 application with qt 5.12.4 test success 

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
