### PR TITLE
WIP linux-capture: Search for extant window by ID

### DIFF
--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -575,6 +575,7 @@ void XCompcapMain::tick(float seconds)
 
 	XCompcap::processEvents();
 
+	Window prevWin = p->win;
 	if (p->win && XCompcap::windowWasReconfigured(p->win)) {
 		p->window_check_time = FIND_WINDOW_INTERVAL;
 		p->win = 0;
@@ -589,15 +590,24 @@ void XCompcapMain::tick(float seconds)
 		if (p->window_check_time < FIND_WINDOW_INTERVAL)
 			return;
 
-		Window newWin = getWindowFromString(p->windowName);
+		for (Window cwin : XCompcap::getTopLevelWindows()) {
+			if (cwin == prevWin) {
+				p->win = cwin;
+				break;
+			}
+		}
+		if (!p->win) {
+			Window newWin = getWindowFromString(p->windowName);
 
-		p->window_check_time = 0.0;
+			p->window_check_time = 0.0;
 
-		if (newWin && XGetWindowAttributes(xdisp, newWin, &attr)) {
-			p->win = newWin;
-			updateSettings(0);
-		} else {
-			return;
+			if (newWin &&
+			    XGetWindowAttributes(xdisp, newWin, &attr)) {
+				p->win = newWin;
+				updateSettings(0);
+			} else {
+				return;
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, a changing window title can trigger the casted window to
spontaneously switch to another window of the same class in the event of
a window reconfiguration.

This behaviour has been present since 5d16e4489, where any calls which
might lookup a window ID that no longer exists were removed, and instead
a fallback can occur to a window of the same class.

Rather than try any lookup of an ID which might no longer exists, this
change iterates through all windows to see if any window ID matches the
window we were already capturing. This causes the casted window to
persist in the event of a window title change.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
In the event of window configuration, search for a window ID matching the window that was being cast before falling through to a class-match lookup.

<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested locally. Ubuntu 18.04, i3wm. 

* Setup a scene with an xcomposite capture based on title. 
  * The window being captured had multiple other windows with the same class. 
* Changed the title of the window and triggered a window reconfiguration.
* The window continued being captured, rather than OBS switching to the other (older) window with the same class.
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
