### PR TITLE
obs-ffmpeg: Remove unexposed vaapi parameters

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -173,12 +173,6 @@ static bool vaapi_update(void *data, obs_data_t *settings)
 	int bitrate = (int)obs_data_get_int(settings, "bitrate");
 	int keyint_sec = (int)obs_data_get_int(settings, "keyint_sec");
 
-	int qp = (int)obs_data_get_int(settings, "qp");
-	int quality = (int)obs_data_get_int(settings, "quality");
-
-	av_opt_set_int(enc->context->priv_data, "qp", qp, 0);
-	av_opt_set_int(enc->context->priv_data, "quality", quality, 0);
-
 	video_t *video = obs_encoder_video(enc->encoder);
 	const struct video_output_info *voi = video_output_get_info(video);
 	struct video_scale_info info;
@@ -218,8 +212,6 @@ static bool vaapi_update(void *data, obs_data_t *settings)
 
 	info("settings:\n"
 	     "\tdevice:       %s\n"
-	     "\tqp:           %d\n"
-	     "\tquality:      %d\n"
 	     "\tprofile:      %d\n"
 	     "\tlevel:        %d\n"
 	     "\tbitrate:      %d\n"
@@ -227,8 +219,8 @@ static bool vaapi_update(void *data, obs_data_t *settings)
 	     "\twidth:        %d\n"
 	     "\theight:       %d\n"
 	     "\tb-frames:     %d\n",
-	     device, qp, quality, profile, level, bitrate,
-	     enc->context->gop_size, enc->context->width, enc->context->height,
+	     device, profile, level, bitrate, enc->context->gop_size,
+	     enc->context->width, enc->context->height,
 	     enc->context->max_b_frames);
 
 	return vaapi_init_codec(enc, device);
@@ -453,8 +445,6 @@ static void vaapi_defaults(obs_data_t *settings)
 	obs_data_set_default_int(settings, "bitrate", 2500);
 	obs_data_set_default_int(settings, "keyint_sec", 0);
 	obs_data_set_default_int(settings, "bf", 0);
-	obs_data_set_default_int(settings, "qp", 20);
-	obs_data_set_default_int(settings, "quality", 0);
 	obs_data_set_default_int(settings, "rendermode", 0);
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
In ffmepg 4.2 setting qp overrides bitrate, this option isnt exposed
currently so users cannot disable it.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
https://obsproject.com/mantis/view.php?id=1534

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on ubuntu 18.04 with ffmpeg 4.1, no regression when recording. Someone with an affected device on ffmpeg 4.2 has confirmed this resolves the issue.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Removal of some settings, users might have tried to use them via json but they probably wouldnt have worked.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
