### PR TITLE
Update obs-ffmpeg-source.c

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -322,7 +322,7 @@ static void ffmpeg_source_update(void *data, obs_data_t *settings)
 		input = (char *)obs_data_get_string(settings, "input");
 		input_format =
 			(char *)obs_data_get_string(settings, "input_format");
-		s->is_looping = false;
+		s->is_looping = obs_data_get_bool(settings, "looping");
 		s->close_when_inactive = true;
 	}
 


### PR DESCRIPTION
#2024 # Description
<!--- Describe your changes in detail. -->
I don't really know but, Looping is disabled in media source and .gif's don't loop when loaded from an URL

<!--- If this change includes UI elements, please include screenshots. -->
I think building the entire OBS is going to take long and loading it from a script not sure how I just wanted to fix this, and usually I have to google everything and yeah idk


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I don't really know but, Looping is disabled in media source and .gif's don't loop when loaded from an URL
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.


If it would be easier to test I would of have tested it but it's using obs-ffmpeg-source and thats something in obs and I'm not sure if I can overwrite this with a script and I'm not even sure how the script can be loaded in OBS.
