### PR TITLE
obs-text: add missing include to fix build

### DIFF
--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <string>
 #include <memory>
+#include <locale>
 
 using namespace std;
 using namespace Gdiplus;


### PR DESCRIPTION
### Description
Pull request #2079 added localisation functions but without the needed include of the `locale` headers, breaking the build of obs-text under VS 2019

### Motivation and Context
Fix for broken build

### How Has This Been Tested?
Adding the include fixes the build on Visual Studio 2019 (x64 Windows 10)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
