### PR TITLE
obs-scripting: Fix Python in new MacOS .app bundles

### DIFF
--- a/CI/before-deploy-osx.sh
+++ b/CI/before-deploy-osx.sh
@@ -22,9 +22,9 @@ hr "Moving OBS LUA"
 mv ./rundir/RelWithDebInfo/data/obs-scripting/obslua.so ./rundir/RelWithDebInfo/bin/
 
 # Move obspython
-# hr "Moving OBS Python"
-# mv ./rundir/RelWithDebInfo/data/obs-scripting/_obspython.so ./rundir/RelWithDebInfo/bin/
-# mv ./rundir/RelWithDebInfo/data/obs-scripting/obspython.py ./rundir/RelWithDebInfo/bin/
+hr "Moving OBS Python"
+mv ./rundir/RelWithDebInfo/data/obs-scripting/_obspython.so ./rundir/RelWithDebInfo/bin/
+mv ./rundir/RelWithDebInfo/data/obs-scripting/obspython.py ./rundir/RelWithDebInfo/bin/
 
 # Package everything into a nice .app
 hr "Packaging .app"

--- a/CI/install/osx/packageApp.sh
+++ b/CI/install/osx/packageApp.sh
@@ -35,6 +35,7 @@ cp ../CI/install/osx/Info.plist ./OBS.app/Contents
 -x ./OBS.app/Contents/MacOS/obs \
 -x ./OBS.app/Contents/MacOS/obs-ffmpeg-mux \
 -x ./OBS.app/Contents/MacOS/obslua.so \
+-x ./OBS.app/Contents/MacOS/_obspython.so \
 -x ./OBS.app/Contents/Plugins/obs-x264.so \
 -x ./OBS.app/Contents/Plugins/text-freetype2.so \
 -x ./OBS.app/Contents/Plugins/obs-libfdk.so

--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -1651,6 +1651,13 @@ bool obs_scripting_load_python(const char *python_path)
 
 	add_to_python_path(SCRIPT_DIR);
 
+#if __APPLE__
+	char *exec_path = os_get_executable_path_ptr("");
+	if (exec_path)
+		add_to_python_path(exec_path);
+	bfree(exec_path);
+#endif
+
 	py_obspython = PyImport_ImportModule("obspython");
 	bool success = !py_error();
 	if (!success) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fixes python in the new MacOS .app bundles. 

Moves `obspython.py` and `_obspython.so` to the binary directory like the Lua one and adds the bin directory as python import path so it can find and import `obspython`. The bin path needs to be looked up at runtime since app bundles don't set the current working dir so relative paths aren't an option. 
Keeps adding the normal SCRIPT_DIR path for running out of rundir.

### Motivation and Context
Python doesn't work anymore on MacOS when run from the .app bundle since folder structure changed a bit and it can't find obspython.

### How Has This Been Tested?
Locally on 10.15 with macports python 3.7 against a locally build OBS and against the Azure CI built OBS.
In a 10.14.0 VM with homebrew and macports python 3.7 against OBS built via Azure CI.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
