### PR TITLE
obs-outputs: Log FTL during configure

### DIFF
--- a/plugins/obs-outputs/CMakeLists.txt
+++ b/plugins/obs-outputs/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ftl-sdk/CMakeLists.txt")
 	find_package(Libcurl REQUIRED)
+	message(STATUS "Found ftl-sdk: ftl outputs enabled")
 
 	add_definitions(-DFTL_STATIC_COMPILE)
 


### PR DESCRIPTION

### Description
Adds a status message during configuration about ftl-outputs being enabled.

### Motivation and Context
Without this its hard to review downstream packagers' logs to know if they have configured the build correctly for what users expect in a default install.

### How Has This Been Tested?
cmake outputs a line as expected during configuration.

### Types of changes
Build System

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
