### PR TITLE
obs-osxbundle: New running executable for MacOS

### DIFF
--- a/cmake/osxbundle/OBS.cpp
+++ b/cmake/osxbundle/OBS.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <vector>
+#include <unistd.h>
+using namespace std;
+
+int main(int argc, char** argv) {
+
+    int i;
+    string start_cmd = "./obs";
+
+    for (i = 1; i < argc; i++) {
+        start_cmd += " ";
+        start_cmd += argv[i];
+    }
+
+    string work_dir = "";
+
+    if (argc > 0) {
+        int first_len = strlen(argv[0]);
+
+        vector<string> list(first_len, "");
+        int ptr = 0;
+
+        for (i = 0; i < first_len; i++) {
+            char cur = argv[0][i];
+            if (cur == '/') {
+                ptr++;
+            } else {
+                list[ptr] += cur;
+            }
+        }
+        for (i = 0; i < ptr; i++) {
+            work_dir += list[i] + "/";
+        }
+    }
+
+    work_dir += "../Resources/bin";
+
+    cout << "Setting up working dir: " << work_dir << endl;
+    if (chdir(work_dir.c_str())) {
+        cout << "Error with setting up working directory! OBS will closed!" << endl;
+        return 1;
+    }
+
+    cout << "Exec main OBS runnable: " << start_cmd << endl << endl;
+    system(start_cmd.c_str());
+
+    return 0;
+}


### PR DESCRIPTION
Fixed bug with no access request to microphone and camera. It needs binary executable for it request, not shell script

### Description
MacOS has security policy, that requires confirmation of access to the camera and microphone. But, with current realisation of startup shell script, it's impossible because MacOS demands Mach-O executable file, not shell script. So, it's realisation of **obslaunch.sh** on native C++. With it runnable MacOS ask about access, and all' fine

### Motivation and Context
I'm using MacOS Catalina and I can't use OBS with simple running from Launchpad because Microphone and Camera are not working, because OBS doesn't asking of access to them. 
Fix that can forums offer is running startup script from Terminal, that is not comfortable for using.
So, I wrote C++ version of **/Applications/OBS.app/Contents/MacOS/OBS**

### How Has This Been Tested?
MacBook Air 13 Middle 2013
i5 4250U, 4GB RAM, Mac OS Catalina 10.15.1

Running and using was successful tested.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
