### PR TITLE
Clean up COM initialization

### DIFF
--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -1259,9 +1259,15 @@ void obs_init_win32_crash_handler(void)
 	initialize_crash_handler();
 }
 
-void initialize_com(void)
+bool initialize_com(void)
 {
-	CoInitializeEx(0, COINIT_MULTITHREADED);
+	const HRESULT hr = CoInitializeEx(0, COINIT_APARTMENTTHREADED);
+	const bool success = SUCCEEDED(hr);
+	if (success)
+		blog(LOG_INFO, "CoInitializeEx succeeded: 0x%08X", hr);
+	else
+		blog(LOG_ERROR, "CoInitializeEx failed: 0x%08X", hr);
+	return success;
 }
 
 void uninitialize_com(void)

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -871,8 +871,9 @@ static bool obs_init(const char *locale, const char *module_config_path,
 }
 
 #ifdef _WIN32
-extern void initialize_com(void);
+extern bool initialize_com(void);
 extern void uninitialize_com(void);
+static bool com_initialized = false;
 #endif
 
 /* Separate from actual context initialization
@@ -933,7 +934,7 @@ bool obs_startup(const char *locale, const char *module_config_path,
 	}
 
 #ifdef _WIN32
-	initialize_com();
+	com_initialized = initialize_com();
 #endif
 
 	success = obs_init(locale, module_config_path, store);
@@ -1048,7 +1049,8 @@ void obs_shutdown(void)
 	bfree(cmdline_args.argv);
 
 #ifdef _WIN32
-	uninitialize_com();
+	if (com_initialized)
+		uninitialize_com();
 #endif
 }
 

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -386,7 +386,14 @@ DWORD WINAPI WASAPISource::ReconnectThread(LPVOID param)
 
 	os_set_thread_name("win-wasapi: reconnect thread");
 
-	CoInitializeEx(0, COINIT_MULTITHREADED);
+	const HRESULT hr = CoInitializeEx(0, COINIT_MULTITHREADED);
+	const bool com_initialized = SUCCEEDED(hr);
+	if (!com_initialized) {
+		blog(LOG_ERROR,
+		     "[WASAPISource::ReconnectThread]"
+		     " CoInitializeEx failed: 0x%08X",
+		     hr);
+	}
 
 	obs_monitoring_type type =
 		obs_source_get_monitoring_type(source->source);
@@ -399,6 +406,9 @@ DWORD WINAPI WASAPISource::ReconnectThread(LPVOID param)
 	}
 
 	obs_source_set_monitoring_type(source->source, type);
+
+	if (com_initialized)
+		CoUninitialize();
 
 	source->reconnectThread = nullptr;
 	source->reconnecting = false;


### PR DESCRIPTION
### Description
Balance COM initialization calls, log failures, and have main thread request STA rather than MTA.

### Motivation and Context
Current code misleads people into thinking MTA is used on the main thread when it is not because Qt initializes COM first.

Unbalanced initialization calls are not causing any known issues, but no need to take chances.

### How Has This Been Tested?
Breakpoint inspection for all code paths, and verified log output for all branches, including paths that require some fakery to exercise.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.