### PR TITLE
win-dshow: Suppress MJPEG error spam

### DIFF
--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -96,14 +96,24 @@ enum class BufferingType : int64_t {
 void ffmpeg_log(void *bla, int level, const char *msg, va_list args)
 {
 	DStr str;
-	if (level == AV_LOG_WARNING)
+	if (level == AV_LOG_WARNING) {
 		dstr_copy(str, "warning: ");
-	else if (level == AV_LOG_ERROR)
+	} else if (level == AV_LOG_ERROR) {
+		/* only print first of this message to avoid spam */
+		static bool suppress_app_field_spam = false;
+		if (strcmp(msg, "unable to decode APP fields: %s\n") == 0) {
+			if (suppress_app_field_spam)
+				return;
+
+			suppress_app_field_spam = true;
+		}
+
 		dstr_copy(str, "error:   ");
-	else if (level < AV_LOG_ERROR)
+	} else if (level < AV_LOG_ERROR) {
 		dstr_copy(str, "fatal:   ");
-	else
+	} else {
 		return;
+	}
 
 	dstr_cat(str, msg);
 	if (dstr_end(str) == '\n')


### PR DESCRIPTION
### Description
I think Logitech cameras are prone to spam errors about failing to decode app fields. Only print the first message for this benign error.

Plausible explanation: https://stackoverflow.com/questions/55439184

### Motivation and Context
Log files are filling up quickly.

### How Has This Been Tested?
I remember seeing this previously, but I am mysteriously unable to reproduce. I have otherwise breakpoint inspected the new code paths with some instruction pointer fakery.

TODO: Find someone to verify this fix.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.