### PR TITLE
CI: Keep artifacts for PRs labelled "Seeking Testers"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,23 @@ variables:
   RESTREAM-HASH: $(restream_hash)
 
 jobs:
+- job: Prebuild
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - bash: |
+     if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Seeking Testers"'
+     then
+       echo "##vso[task.setvariable variable=prHasCILabel;isOutput=true]true"
+     fi
+    displayName: 'Check if PR should keep artifacts'
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    name: checkPrLabel
+
 - job: 'Build_macOS'
+  dependsOn: Prebuild
+  variables:
+    prHasCILabel: $[ dependencies.Prebuild.outputs['checkPrLabel.prHasCILabel'] ]
   pool:
     vmImage: 'macos-10.13'
   steps:
@@ -31,16 +47,19 @@ jobs:
     displayName: 'Build'
 
   - script: ./CI/before-deploy-osx.sh
-    condition: ne(variables['Build.Reason'], 'PullRequest')
+    condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['prHasCILabel'], true))
     displayName: 'Before Deploy'
 
   - task: PublishBuildArtifacts@1
-    condition: ne(variables['Build.Reason'], 'PullRequest')
+    condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['prHasCILabel'], true))
     inputs:
       pathtoPublish: './nightly'
       artifactName: build
 
 - job: 'Build_Windows32'
+  dependsOn: Prebuild
+  variables:
+    prHasCILabel: $[ dependencies.Prebuild.outputs['checkPrLabel.prHasCILabel'] ]
   pool:
     vmImage: 'vs2017-win2016'
   steps:
@@ -56,15 +75,18 @@ jobs:
       msbuildArguments: '/m /p:Configuration=RelWithDebInfo'
       solution: .\build32\obs-studio.sln
   - script: ./CI/before-deploy-win.cmd
-    condition: ne(variables['Build.Reason'], 'PullRequest')
+    condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['prHasCILabel'], true))
     displayName: 'Before deploy'
   - task: PublishBuildArtifacts@1
-    condition: ne(variables['Build.Reason'], 'PullRequest')
+    condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['prHasCILabel'], true))
     inputs:
       pathtoPublish: './build'
       artifactName: winbuild
 
 - job: 'Build_Windows64'
+  dependsOn: Prebuild
+  variables:
+    prHasCILabel: $[ dependencies.Prebuild.outputs['checkPrLabel.prHasCILabel'] ]
   pool:
     vmImage: 'vs2017-win2016'
   steps:
@@ -80,15 +102,18 @@ jobs:
       msbuildArguments: '/m /p:Configuration=RelWithDebInfo'
       solution: .\build64\obs-studio.sln
   - script: ./CI/before-deploy-win.cmd
-    condition: ne(variables['Build.Reason'], 'PullRequest')
+    condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['prHasCILabel'], true))
     displayName: 'Before deploy'
   - task: PublishBuildArtifacts@1
-    condition: ne(variables['Build.Reason'], 'PullRequest')
+    condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['prHasCILabel'], true))
     inputs:
       pathtoPublish: './build'
       artifactName: winbuild
 
 - job: 'Build_Linux'
+  dependsOn: Prebuild
+  variables:
+    prHasCILabel: $[ dependencies.Prebuild.outputs['checkPrLabel.prHasCILabel'] ]
   pool:
     vmImage: 'ubuntu-16.04'
   steps:


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change will result in build artifacts being kept for PRs that have the "Seeking Testers" label applied to them.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The purpose of the Seeking Testers label is to get testers of a particular feature. Limiting this to only people who are able to build OBS for themselves means we get fewer testers and opportunities to spot bugs early. By keeping the build artifacts of PRs with the label applied, a test build is created for us that can be easily shared.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This was tested using my accounts GitHub fork connected to Azure Pipelines.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- CI (a change to continuous integration scripts)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
