### PR TITLE
UI: Show Scene Collection name in the Scenes dock

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6644,6 +6644,9 @@ void OBSBasic::UpdateTitleBar()
 	name << " - " << Str("TitleBar.Scenes") << ": " << sceneCollection;
 
 	setWindowTitle(QT_UTF8(name.str().c_str()));
+
+	ui->scenesDock->setWindowTitle(QTStr("Basic.Main.Scenes") + ": " +
+				       sceneCollection);
 }
 
 int OBSBasic::GetProfilePath(char *path, size_t size, const char *file) const


### PR DESCRIPTION
### Description
Displays the name of the currently active scene collection in the title of the Scenes dock.

![Example of named Scenes dock](http://scr.wzd.li/scr/2019-11-26_22-44-27.png)
![Example of long Scene Collection name](http://scr.wzd.li/scr/2019-11-26_22-50-16.png)

### Motivation and Context
This is a QoL change that can also improve discoverability of Scene Collections, as by default it'll say "Scenes: Untitled".

I decided putting the code in `UpdateTitleBar()` made the most sense as it'll ensure they're always in sync.

### How Has This Been Tested?
Launched OBS, noted the name of the dock changed to match the name of the active scene collection.
Switched scene collections, name changed accordingly.
View -> Docks menu is unaffected.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
