### PR TITLE
UI: Streaming Settings Validation On Stream Start & User Help

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -245,6 +245,7 @@ set(obs_SOURCES
 	combobox-ignorewheel.cpp
 	spinbox-ignorewheel.cpp
 	record-button.cpp
+	ui-validation.cpp
 	url-push-button.cpp
 	volume-control.cpp
 	adv-audio-control.cpp
@@ -302,6 +303,7 @@ set(obs_HEADERS
 	menu-button.hpp
 	mute-checkbox.hpp
 	record-button.hpp
+	ui-validation.hpp
 	url-push-button.hpp
 	volume-control.hpp
 	adv-audio-control.hpp

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -679,6 +679,11 @@ Basic.Settings.Stream.TTVAddon.None="None"
 Basic.Settings.Stream.TTVAddon.BTTV="BetterTTV"
 Basic.Settings.Stream.TTVAddon.FFZ="FrankerFaceZ"
 Basic.Settings.Stream.TTVAddon.Both="BetterTTV and FrankerFaceZ"
+Basic.Settings.Stream.MissingSettingAlert="Missing Stream Setup"
+Basic.Settings.Stream.StreamSettingsWarning="Open Settings"
+Basic.Settings.Stream.MissingUrlAndApiKey="URL and Stream Key are missing.\n\nOpen settings to enter the URL and Stream Key in the 'stream' tab."
+Basic.Settings.Stream.MissingUrl="Stream URL is missing.\n\nOpen settings to enter the URL in the 'Stream' tab."
+Basic.Settings.Stream.MissingStreamKey="Stream key is missing.\n\nOpen settings to enter the stream key in the 'Stream' tab."
 
 # basic mode 'output' settings
 Basic.Settings.Output="Output"

--- a/UI/ui-validation.cpp
+++ b/UI/ui-validation.cpp
@@ -1,0 +1,56 @@
+#include "ui-validation.hpp"
+
+#include <obs.hpp>
+#include <QString>
+#include <QMessageBox>
+#include <QPushButton>
+
+#include <obs-app.hpp>
+
+static int CountVideoSources()
+{
+	int count = 0;
+	auto countSources = [](void *param, obs_source_t *source) {
+		if (!source)
+			return true;
+
+		uint32_t flags = obs_source_get_output_flags(source);
+		if ((flags & OBS_SOURCE_VIDEO) != 0)
+			(*reinterpret_cast<int *>(param))++;
+
+		return true;
+	};
+
+	obs_enum_sources(countSources, &count);
+	return count;
+}
+
+bool UIValidation::NoSourcesConfirmation(QWidget *parent)
+{
+	// There are sources, don't need confirmation
+	if (CountVideoSources() != 0)
+		return true;
+
+	// Ignore no video if no parent is visible to alert on
+	if (!parent->isVisible())
+		return true;
+
+	QString msg = QTStr("NoSources.Text");
+	msg += "\n\n";
+	msg += QTStr("NoSources.Text.AddSource");
+
+	QMessageBox messageBox(parent);
+	messageBox.setWindowTitle(QTStr("NoSources.Title"));
+	messageBox.setText(msg);
+
+	QAbstractButton *yesButton =
+		messageBox.addButton(QTStr("Yes"), QMessageBox::YesRole);
+	messageBox.addButton(QTStr("No"), QMessageBox::NoRole);
+	messageBox.setIcon(QMessageBox::Question);
+	messageBox.exec();
+
+	if (messageBox.clickedButton() != yesButton)
+		return false;
+	else
+		return true;
+}

--- a/UI/ui-validation.hpp
+++ b/UI/ui-validation.hpp
@@ -3,13 +3,28 @@
 #include <QObject>
 #include <QWidget>
 
+#include <obs.hpp>
+
+enum class StreamSettingsAction {
+	OpenSettings,
+	Cancel,
+	ContinueStream,
+};
+
 class UIValidation : public QObject {
 	Q_OBJECT
 
 public:
-	// Shows alert box notifying there are no video sources
-	// Returns true if user clicks "Yes"
-	// Returns false if user clicks "No"
-	// Blocks UI
+	/* Confirm video about to record or stream has sources.  Shows alert
+	 * box notifying there are no video sources Returns true if user clicks
+	 * "Yes" Returns false if user clicks "No" */
 	static bool NoSourcesConfirmation(QWidget *parent);
+
+	/* Check streaming requirements, shows warning with options to open
+	 * settings, cancel stream, or attempt connection anyways.  If setup
+	 * basics is missing in stream, explain missing fields and offer to
+	 * open settings, cancel, or continue.  Returns Continue if all
+	 * settings are valid. */
+	static StreamSettingsAction
+	StreamSettingsConfirmation(QWidget *parent, OBSService service);
 };

--- a/UI/ui-validation.hpp
+++ b/UI/ui-validation.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <QObject>
+#include <QWidget>
+
+class UIValidation : public QObject {
+	Q_OBJECT
+
+public:
+	// Shows alert box notifying there are no video sources
+	// Returns true if user clicks "Yes"
+	// Returns false if user clicks "No"
+	// Blocks UI
+	static bool NoSourcesConfirmation(QWidget *parent);
+};

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5754,6 +5754,20 @@ void OBSBasic::on_streamButton_clicked()
 			return;
 		}
 
+		auto action =
+			UIValidation::StreamSettingsConfirmation(this, service);
+		switch (action) {
+		case StreamSettingsAction::ContinueStream:
+			break;
+		case StreamSettingsAction::OpenSettings:
+			on_action_Settings_triggered();
+			ui->streamButton->setChecked(false);
+			return;
+		case StreamSettingsAction::Cancel:
+			ui->streamButton->setChecked(false);
+			return;
+		}
+
 		bool confirm = config_get_bool(GetGlobalConfig(), "BasicWindow",
 					       "WarnBeforeStartingStream");
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -54,6 +54,7 @@
 #include "display-helpers.hpp"
 #include "volume-control.hpp"
 #include "remote-text.hpp"
+#include "ui-validation.hpp"
 #include <fstream>
 #include <sstream>
 
@@ -162,25 +163,6 @@ static void AddExtraModulePaths()
 }
 
 extern obs_frontend_callbacks *InitializeAPIInterface(OBSBasic *main);
-
-static int CountVideoSources()
-{
-	int count = 0;
-
-	auto countSources = [](void *param, obs_source_t *source) {
-		if (!source)
-			return true;
-
-		uint32_t flags = obs_source_get_output_flags(source);
-		if ((flags & OBS_SOURCE_VIDEO) != 0)
-			(*reinterpret_cast<int *>(param))++;
-
-		return true;
-	};
-
-	obs_enum_sources(countSources, &count);
-	return count;
-}
 
 void assignDockToggle(QDockWidget *dock, QAction *action)
 {
@@ -5600,7 +5582,7 @@ void OBSBasic::StartReplayBuffer()
 	if (disableOutputsRef)
 		return;
 
-	if (!NoSourcesConfirmation()) {
+	if (!UIValidation::NoSourcesConfirmation(this)) {
 		replayBufferButton->setChecked(false);
 		return;
 	}
@@ -5745,30 +5727,6 @@ void OBSBasic::ReplayBufferStop(int code)
 	OnDeactivate();
 }
 
-bool OBSBasic::NoSourcesConfirmation()
-{
-	if (CountVideoSources() == 0 && isVisible()) {
-		QString msg;
-		msg = QTStr("NoSources.Text");
-		msg += "\n\n";
-		msg += QTStr("NoSources.Text.AddSource");
-
-		QMessageBox messageBox(this);
-		messageBox.setWindowTitle(QTStr("NoSources.Title"));
-		messageBox.setText(msg);
-		QAbstractButton *Yes = messageBox.addButton(
-			QTStr("Yes"), QMessageBox::YesRole);
-		messageBox.addButton(QTStr("No"), QMessageBox::NoRole);
-		messageBox.setIcon(QMessageBox::Question);
-		messageBox.exec();
-
-		if (messageBox.clickedButton() != Yes)
-			return false;
-	}
-
-	return true;
-}
-
 void OBSBasic::on_streamButton_clicked()
 {
 	if (outputHandler->StreamingActive()) {
@@ -5791,7 +5749,7 @@ void OBSBasic::on_streamButton_clicked()
 
 		StopStreaming();
 	} else {
-		if (!NoSourcesConfirmation()) {
+		if (!UIValidation::NoSourcesConfirmation(this)) {
 			ui->streamButton->setChecked(false);
 			return;
 		}
@@ -5852,7 +5810,7 @@ void OBSBasic::on_recordButton_clicked()
 		}
 		StopRecording();
 	} else {
-		if (!NoSourcesConfirmation()) {
+		if (!UIValidation::NoSourcesConfirmation(this)) {
 			ui->recordButton->setChecked(false);
 			return;
 		}

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -456,8 +456,6 @@ private:
 
 	void ReceivedIntroJson(const QString &text);
 
-	bool NoSourcesConfirmation();
-
 #ifdef BROWSER_AVAILABLE
 	QList<QSharedPointer<QDockWidget>> extraBrowserDocks;
 	QList<QSharedPointer<QAction>> extraBrowserDockActions;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

The first commit PR moves UI verification to another class to be reusable.
The second commit adds checks to "Start Streaming" user action prompting users to fill out streaming URL, service, and stream keys if they're missing. 


![Screen Shot 2019-11-26 at 5 28 14 PM](https://user-images.githubusercontent.com/1580980/69685903-de4b1480-1072-11ea-8903-24350f800631.png)

![Screen Shot 2019-11-26 at 5 19 28 PM](https://user-images.githubusercontent.com/1580980/69685904-dee3ab00-1072-11ea-94b2-fcf74d02694e.png)



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

When we use the server error to respond to user's failing to start a
stream it is slow to return an error and unclear to the user what went
wrong. 

In the case of preset services (Youtube, Facebook, Twitch) we check there is a Stream Key before
attempting to start a stream.

In the case of "custom" we only verify there is a URL since for some
services that's all that is required or the user may use user/password
authentication.

In both cases the short explanation and Settings link button will guide users to solve the issue more smoothly. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

MacbookPro. MacOSX 10.14.6. 
- Tested custom stream with no URL in settings prompts the user.
- Tested custom stream with URL in setting does not prompt the user.
- Tested preset service with no Stream Key prompts the user.
- Tested preset service with any Stream Key does not prompt the user. 
- The "do you want to start" stream button still works. 
- Does not affect stopping the stream. 
- Start/Stop Streaming button is reset when streaming is aborted. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

 - Bug fix (non-breaking change which fixes an issue)
 - New feature (non-breaking change which adds functionality)
 - UI Improvement 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
