### PR TITLE
libobs: fix building modules once installed

### DIFF
--- a/libobs/graphics/quat.h
+++ b/libobs/graphics/quat.h
@@ -21,7 +21,7 @@
 #include "math-defs.h"
 #include "vec3.h"
 
-#include <util/sse-intrin.h>
+#include "../util/sse-intrin.h"
 
 /*
  * Quaternion math

--- a/libobs/graphics/vec3.h
+++ b/libobs/graphics/vec3.h
@@ -20,7 +20,7 @@
 #include "math-defs.h"
 #include "vec4.h"
 
-#include <util/sse-intrin.h>
+#include "../util/sse-intrin.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/libobs/graphics/vec4.h
+++ b/libobs/graphics/vec4.h
@@ -19,7 +19,7 @@
 
 #include "math-defs.h"
 
-#include <util/sse-intrin.h>
+#include "../util/sse-intrin.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/libobs/media-io/format-conversion.c
+++ b/libobs/media-io/format-conversion.c
@@ -17,7 +17,7 @@
 
 #include "format-conversion.h"
 
-#include <util/sse-intrin.h>
+#include "../util/sse-intrin.h"
 
 /* ...surprisingly, if I don't use a macro to force inlining, it causes the
  * CPU usage to boost by a tremendous amount in debug builds. */

--- a/libobs/obs-audio-controls.c
+++ b/libobs/obs-audio-controls.c
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <math.h>
 
-#include <util/sse-intrin.h>
+#include "util/sse-intrin.h"
 
 #include "util/threading.h"
 #include "util/bmem.h"


### PR DESCRIPTION
### Description
sse-intrin.h is a required header now, but the implicit path breaks building addons once the headers are installed.

Fix this by making the path explicit.
### Motivation and Context
Fixes compiling addons dependent on libobs.
Discovered when clean compiling obs-gstreamer

### How Has This Been Tested?
Tested building addons works correctly.
### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
