### PR TITLE
libobs: add missing FreeBSD #include to fix build

### DIFF
--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -38,6 +38,7 @@
 #include <sys/param.h>
 #include <sys/queue.h>
 #include <sys/socket.h>
+#include <sys/sysctl.h>
 #include <sys/user.h>
 #include <unistd.h>
 #include <libprocstat.h>


### PR DESCRIPTION
sysctlbyname requires #include <sys/sysctl.h>.  Perhaps this previously
worked due to header pollution that has since been cleaned up in newer
FreeBSD.

I found this issue while working on adding FreeBSD CI support via Cirrus-CI, building on FreeBSD 12.1.

- Bug fix (non-breaking change which fixes an issue)

- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
