### PR TITLE
UI: Add Grid Mode to Scenes Widget

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -236,6 +236,7 @@ set(obs_SOURCES
 	window-remux.cpp
 	auth-base.cpp
 	source-tree.cpp
+	scene-tree.cpp
 	properties-view.cpp
 	focus-list.cpp
 	menu-button.cpp
@@ -288,6 +289,7 @@ set(obs_HEADERS
 	window-remux.hpp
 	auth-base.hpp
 	source-tree.hpp
+	scene-tree.hpp
 	properties-view.hpp
 	properties-view.moc.hpp
 	display-helpers.hpp

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -530,6 +530,8 @@ Basic.Main.ForceStopStreaming="Stop Streaming (discard delay)"
 Basic.Main.Group="Group %1"
 Basic.Main.GroupItems="Group Selected Items"
 Basic.Main.Ungroup="Ungroup"
+Basic.Main.GridMode="Grid Mode"
+Basic.Main.ListMode="List Mode"
 
 # basic mode file menu
 Basic.MainMenu.File="&File"

--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -1022,3 +1022,25 @@ OBSBasic {
     qproperty-sceneIcon: url(./Dark/sources/scene.svg);
     qproperty-defaultIcon: url(./Dark/sources/default.svg);
 }
+
+/* Scene Tree */
+
+SceneTree#scenes {
+    qproperty-gridItemWidth: 180;
+    qproperty-gridItemHeight: 35;
+}
+
+*[gridMode="true"] SceneTree#scenes {
+	border-bottom: none;
+}
+
+*[gridMode="false"] SceneTree#scenes {
+	border-bottom: 2px solid #2f2f2f;
+}
+
+*[gridMode="true"] SceneTree::item {
+    padding: 4px;
+    padding-left: 10px;
+    padding-right: 10px;
+    margin: 0px;
+}

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -12,6 +12,7 @@
 /*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            */
 /*   GNU General Public License for more details.                             */
 /*                                                                            */
+/*                                                                            */
 /*   You should have received a copy of the GNU General Public License        */
 /*   along with this program.  If not, see <http://www.gnu.org/licenses/>.    */
 /******************************************************************************/
@@ -773,4 +774,38 @@ OBSBasic {
     qproperty-groupIcon: url(./Dark/sources/group.svg);
     qproperty-sceneIcon: url(./Dark/sources/scene.svg);
     qproperty-defaultIcon: url(./Dark/sources/default.svg);
+}
+
+/* Scene Tree */
+
+SceneTree {
+    qproperty-gridItemWidth: 150;
+	qproperty-gridItemHeight: 27;
+}
+
+*[gridMode="true"] SceneTree::item {
+    color: rgb(225,224,225); /* veryLight */
+    background-color: rgb(76,76,76);
+    border: none;
+    border-radius: 3px;
+    padding: 4px;
+	padding-left: 10px;
+	padding-right: 10px;
+	margin: 1px;
+}
+
+*[gridMode="true"] SceneTree::item:selected {
+    background-color: rgb(122,121,122); /* light */
+}
+
+*[gridMode="true"] SceneTree::item:hover {
+    background-color: rgb(122,121,122); /* light */
+}
+
+*[gridMode="true"] SceneTree::item:pressed {
+    background-color: rgb(31,30,31); /* veryDark */
+}
+
+*[gridMode="true"] SceneTree::item:checked {
+    background-color: rgb(122,121,122); /* light */
 }

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -1365,3 +1365,10 @@ OBSBasic {
     qproperty-sceneIcon: url(./Dark/sources/scene.svg);
     qproperty-defaultIcon: url(./Dark/sources/default.svg);
 }
+
+/* Scene Tree */
+
+SceneTree#scenes {
+    qproperty-gridItemWidth: 150;
+    qproperty-gridItemHeight: 30;
+}

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -233,3 +233,10 @@ QListWidget::item,
 SourceTree::item {
 	height: 24px;
 }
+
+/* Scene Tree */
+
+SceneTree {
+    qproperty-gridItemWidth: 150;
+	qproperty-gridItemHeight: 24;
+}

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -474,7 +474,7 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QListWidget" name="scenes">
+         <widget class="SceneTree" name="scenes">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
             <horstretch>0</horstretch>
@@ -1817,6 +1817,11 @@
    <class>SourceTree</class>
    <extends>QListView</extends>
    <header>source-tree.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>SceneTree</class>
+   <extends>QListWidget</extends>
+   <header>scene-tree.hpp</header>
   </customwidget>
   <customwidget>
    <class>OBSDock</class>

--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -1,0 +1,188 @@
+#include "obs.hpp"
+#include "scene-tree.hpp"
+#include "obs-app.hpp"
+
+#include <QSizePolicy>
+#include <QScrollBar>
+#include <QDropEvent>
+#include <QPushButton>
+
+SceneTree::SceneTree(QWidget *parent_) : QListWidget(parent_)
+{
+	installEventFilter(this);
+	setDragDropMode(InternalMove);
+	setMovement(QListView::Snap);
+}
+
+void SceneTree::SetGridMode(bool grid)
+{
+	config_set_bool(App()->GlobalConfig(), "BasicWindow", "gridMode", grid);
+	parent()->setProperty("gridMode", grid);
+	gridMode = grid;
+
+	if (gridMode) {
+		setResizeMode(QListView::Adjust);
+		setViewMode(QListView::IconMode);
+		setUniformItemSizes(true);
+		setStyleSheet("*{padding: 0; margin: 0;}");
+	} else {
+		setViewMode(QListView::ListMode);
+		setResizeMode(QListView::Fixed);
+		setStyleSheet("");
+	}
+
+	resizeEvent(new QResizeEvent(size(), size()));
+}
+
+bool SceneTree::GetGridMode()
+{
+	return gridMode;
+}
+
+void SceneTree::SetGridItemWidth(int width)
+{
+	maxWidth = width;
+}
+
+void SceneTree::SetGridItemHeight(int height)
+{
+	itemHeight = height;
+}
+
+int SceneTree::GetGridItemWidth()
+{
+	return maxWidth;
+}
+
+int SceneTree::GetGridItemHeight()
+{
+	return itemHeight;
+}
+
+bool SceneTree::eventFilter(QObject *obj, QEvent *event)
+{
+	return QObject::eventFilter(obj, event);
+}
+
+void SceneTree::resizeEvent(QResizeEvent *event)
+{
+	QListWidget::resizeEvent(event);
+
+	if (gridMode) {
+		int scrollWid = verticalScrollBar()->sizeHint().width();
+		int h = visualItemRect(item(count() - 1)).bottom();
+
+		if (h < height()) {
+			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+			scrollWid = 0;
+		} else {
+			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+		}
+
+		int wid = contentsRect().width() - scrollWid - 1;
+		int items = (int)ceil((float)wid / maxWidth);
+		int itemWidth = wid / items;
+
+		setGridSize(QSize(itemWidth, itemHeight));
+
+		for (int i = 0; i < count(); i++) {
+			item(i)->setSizeHint(QSize(itemWidth, itemHeight));
+		}
+	} else {
+		setGridSize(QSize());
+		setSpacing(0);
+		for (int i = 0; i < count(); i++) {
+			item(i)->setData(Qt::SizeHintRole, QVariant());
+		}
+	}
+}
+
+void SceneTree::startDrag(Qt::DropActions supportedActions)
+{
+	QListWidget::startDrag(supportedActions);
+}
+
+void SceneTree::dropEvent(QDropEvent *event)
+{
+	QListWidget::dropEvent(event);
+	if (event->source() == this && gridMode) {
+		int scrollWid = verticalScrollBar()->sizeHint().width();
+		int h = visualItemRect(item(count() - 1)).bottom();
+
+		if (h < height()) {
+			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+			scrollWid = 0;
+		} else {
+			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+		}
+
+		float wid = contentsRect().width() - scrollWid - 1;
+
+		QPoint point = event->pos();
+
+		int x = (float)point.x() / wid * ceil(wid / maxWidth);
+		int y = point.y() / itemHeight;
+
+		int r = x + y * ceil(wid / maxWidth);
+
+		QListWidgetItem *item = takeItem(selectedIndexes()[0].row());
+		insertItem(r, item);
+		setCurrentItem(item);
+		resize(size());
+	}
+}
+
+void SceneTree::dragMoveEvent(QDragMoveEvent *event)
+{
+	if (gridMode) {
+		int scrollWid = verticalScrollBar()->sizeHint().width();
+		int h = visualItemRect(item(count() - 1)).bottom();
+
+		if (h < height()) {
+			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+			scrollWid = 0;
+		} else {
+			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+		}
+
+		float wid = contentsRect().width() - scrollWid - 1;
+
+		QPoint point = event->pos();
+
+		int x = (float)point.x() / wid * ceil(wid / maxWidth);
+		int y = point.y() / itemHeight;
+
+		int r = x + y * ceil(wid / maxWidth);
+		int orig = selectedIndexes()[0].row();
+
+		for (int i = 0; i < count(); i++) {
+			auto *wItem = item(i);
+
+			if (wItem->isSelected())
+				continue;
+
+			QModelIndex index = indexFromItem(wItem);
+
+			int off = (i >= r ? 1 : 0) -
+				  (i > orig && i > r ? 1 : 0) -
+				  (i > orig && i == r ? 2 : 0);
+
+			int xPos = (i + off) % (int)ceil(wid / maxWidth);
+			int yPos = (i + off) / (int)ceil(wid / maxWidth);
+			QSize g = gridSize();
+
+			QPoint position(xPos * g.width(), yPos * g.height());
+			setPositionForIndex(position, index);
+		}
+	} else {
+		QListWidget::dragMoveEvent(event);
+	}
+}
+
+void SceneTree::rowsInserted(const QModelIndex &parent, int start, int end)
+{
+	QListWidget::rowsInserted(parent, start, end);
+
+	QResizeEvent *event = new QResizeEvent(size(), size());
+	SceneTree::resizeEvent(event);
+}

--- a/UI/scene-tree.hpp
+++ b/UI/scene-tree.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QListWidget>
+#include <QEvent>
+#include <QItemDelegate>
+
+class SceneTree : public QListWidget {
+	Q_OBJECT
+	Q_PROPERTY(int gridItemWidth READ GetGridItemWidth WRITE
+			   SetGridItemWidth DESIGNABLE true)
+	Q_PROPERTY(int gridItemHeight READ GetGridItemHeight WRITE
+			   SetGridItemHeight DESIGNABLE true)
+
+	bool gridMode = false;
+	int maxWidth = 150;
+	int itemHeight = 24;
+
+public:
+	void SetGridMode(bool grid);
+	bool GetGridMode();
+
+	void SetGridItemWidth(int width);
+	void SetGridItemHeight(int height);
+	int GetGridItemWidth();
+	int GetGridItemHeight();
+
+	explicit SceneTree(QWidget *parent = nullptr);
+
+protected:
+	virtual bool eventFilter(QObject *obj, QEvent *event) override;
+	virtual void resizeEvent(QResizeEvent *event) override;
+	virtual void startDrag(Qt::DropActions supportedActions) override;
+	virtual void dropEvent(QDropEvent *event) override;
+	virtual void dragMoveEvent(QDragMoveEvent *event) override;
+	virtual void rowsInserted(const QModelIndex &parent, int start,
+				  int end) override;
+};

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -816,6 +816,7 @@ private slots:
 	void on_scenes_currentItemChanged(QListWidgetItem *current,
 					  QListWidgetItem *prev);
 	void on_scenes_customContextMenuRequested(const QPoint &pos);
+	void on_actionGridMode_triggered();
 	void on_actionAddScene_triggered();
 	void on_actionRemoveScene_triggered();
 	void on_actionSceneUp_triggered();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR adds an option to the right click menu in the scenes widget to switch modes. When in regular list mode, it'll let you select grid mode, and in grid mode, it'll let you select list mode. Grid mode changes the scenes widget to have a grid of buttons for scenes rather than a list, much like XSplit.

![](https://i.imgur.com/wzAyUbl.png)
![](https://i.imgur.com/ifwbL0X.png)
![](https://i.imgur.com/eEmCf1E.png)
![](https://i.imgur.com/uXbpzo1.png)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
To provide a familiar look and feel to people coming over from XSplit, and to show more scenes compactly in certain situations.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This has been tested on a Windows 10 PC using all 4 themes shipped with OBS.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
 - New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
