### PR TITLE
UI: Add various preview improvements

### DIFF
--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -16,6 +16,7 @@ class QMouseEvent;
 #define ITEM_RIGHT (1 << 1)
 #define ITEM_TOP (1 << 2)
 #define ITEM_BOTTOM (1 << 3)
+#define ITEM_ROT (1 << 4)
 
 #define ZOOM_SENSITIVITY 1.125f
 
@@ -29,6 +30,7 @@ enum class ItemHandle : uint32_t {
 	BottomLeft = ITEM_BOTTOM | ITEM_LEFT,
 	BottomCenter = ITEM_BOTTOM,
 	BottomRight = ITEM_BOTTOM | ITEM_RIGHT,
+	Rot = ITEM_ROT
 };
 
 class OBSBasicPreview : public OBSQTDisplay {
@@ -44,6 +46,9 @@ private:
 	OBSSceneItem stretchGroup;
 	OBSSceneItem stretchItem;
 	ItemHandle stretchHandle = ItemHandle::None;
+	float rotateAngle;
+	vec2 rotatePoint;
+	vec2 offsetPoint;
 	vec2 stretchItemSize;
 	matrix4 screenToItem;
 	matrix4 itemToScreen;
@@ -51,6 +56,7 @@ private:
 
 	gs_texture_t *overflow = nullptr;
 	gs_vertbuffer_t *rectFill = nullptr;
+	gs_vertbuffer_t *circleFill = nullptr;
 
 	vec2 startPos;
 	vec2 mousePos;
@@ -67,6 +73,7 @@ private:
 	bool selectionBox = false;
 	int32_t scalingLevel = 0;
 	float scalingAmount = 1.0f;
+	float groupRot = 0.0f;
 
 	std::vector<obs_sceneitem_t *> hoveredPreviewItems;
 	std::vector<obs_sceneitem_t *> selectedItems;
@@ -99,6 +106,7 @@ private:
 	vec3 CalculateStretchPos(const vec3 &tl, const vec3 &br);
 	void CropItem(const vec2 &pos);
 	void StretchItem(const vec2 &pos);
+	void RotateItem(const vec2 &pos);
 
 	static void SnapItemMovement(vec2 &offset);
 	void MoveItems(const vec2 &pos);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds the following changes to the preview:
- Double clicking a source will open it's properties.
- Double clicking a group will open up that group for editing in the preview.
- Optional rotation handle can be enabled in settings.
- Handles and lines will now scale depending on the DPI OBS is running at.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Double clicking a source to open properties saves needing to find the corresponding source in the sources list, and can be quicker to find the source you mean to change properties for.

Editing groups are currently very finicky at best, since there's no way to click into them in the preview.

Rotation handles, while unnecessary for most setups can be useful when needing to change rotations often, and not wanting to use the transform dialog, so is added as an optional handle easily enabled in settings.

Handles and lines are too small on high DPI monitors because they use their standard DPI pixel widths.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This has been tested running Windows 10 64-bit, with many scene collections, old and new.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
 - New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
