### PR TITLE
UI: Fix Qt deprecation warnings

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -577,10 +577,9 @@ void OBSPropertiesView::AddEditableList(obs_property_t *prop,
 	for (size_t i = 0; i < count; i++) {
 		obs_data_t *item = obs_data_array_item(array, i);
 		list->addItem(QT_UTF8(obs_data_get_string(item, "value")));
-		list->setItemSelected(list->item((int)i),
-				      obs_data_get_bool(item, "selected"));
-		list->setItemHidden(list->item((int)i),
-				    obs_data_get_bool(item, "hidden"));
+		QListWidgetItem *const list_item = list->item((int)i);
+		list_item->setSelected(obs_data_get_bool(item, "selected"));
+		list_item->setHidden(obs_data_get_bool(item, "hidden"));
 		obs_data_release(item);
 	}
 


### PR DESCRIPTION
### Description
Use desired functions instead of deprecated ones.

### Motivation and Context
Clean up compiler warnings.

### How Has This Been Tested?
The selected and hidden properties were faked in debugger, and tested to save and propagate correctly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.