### PR TITLE
UI: Rename deprecated QPalette::ColorRole

### DIFF
--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -192,7 +192,7 @@ void RemuxEntryPathItemDelegate::paint(QPainter *painter,
 		if (state != Ready) {
 			QColor background = localOption.palette.color(
 				QPalette::ColorGroup::Disabled,
-				QPalette::ColorRole::Background);
+				QPalette::ColorRole::Window);
 
 			localOption.backgroundBrush = QBrush(background);
 		}


### PR DESCRIPTION
### Description
Rename QPalette::ColorRole::Background to Window.

### Motivation and Context
Compiler warning when using Qt 5.13.2. ColorRole::Window exists on older Qt versions though.

### How Has This Been Tested?
Enum value is the same numerically. Verified remux dialog color is the same, and different when using another value like WindowText.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.