### PR TITLE
CI: Add Cirrus-CI config for FreeBSD builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,21 @@
+# $FreeBSD$
+
+freebsd_instance:
+  image: freebsd-12-1-release-amd64
+
+env:
+  CIRRUS_CLONE_DEPTH: 1
+
+task:
+  install_script:
+  - pkg install -y
+    v4l_compat swig30 ffmpeg curl dbus fdk-aac fontconfig
+    freetype2 jackit jansson luajit mbedtls pulseaudio speexdsp
+    libsysinfo libudev-devd libv4l libx264 cmake ninja
+    mesa-libs lua52 pkgconf
+    qt5-svg qt5-qmake qt5-buildtools qt5-x11extras
+  script:
+  - mkdir build
+  - cd build
+  - cmake -DUNIX_STRUCTURE=1 -GNinja ..
+  - ninja


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Add a FreeBSD CI build confg, using [Cirrus-CI](https://cirrus-ci.org/).

### Motivation and Context
Ensure FreeBSD continues to build (e.g. https://github.com/obsproject/obs-studio/commit/97c243fdf9b4450327a7ec2a50620a507bd22c39), complementing existing CI builds for other operating systems using Travis.

Note it was simple enough to install dependencies directly in .cirrus.yml, but if desired I'll change this to add a CI/install-depndencies-freebsd.sh akin to -linux.sh and move the `pkg install` step there.

Next step would be for obsproject to add the Cirrus-CI GitHub application and allow it to access the repository, as with Travis.

### How Has This Been Tested?
Tested by via Cirrus-CI in my fork: https://cirrus-ci.com/task/4868993894055936

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
