### PR TITLE
UI: Fix source icons being shifted to the right

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -317,7 +317,7 @@ void SourceTreeItem::EnterEditMode()
 	editor->setStyleSheet("background: none");
 	editor->selectAll();
 	editor->installEventFilter(this);
-	boxLayout->insertWidget(1, editor);
+	boxLayout->insertWidget(2, editor);
 	setFocusProxy(editor);
 }
 
@@ -336,7 +336,7 @@ void SourceTreeItem::ExitEditMode(bool save)
 	delete editor;
 	editor = nullptr;
 	setFocusPolicy(Qt::NoFocus);
-	boxLayout->insertWidget(1, label);
+	boxLayout->insertWidget(2, label);
 
 	/* ----------------------------------------- */
 	/* check for empty string                    */


### PR DESCRIPTION
### Description
This fixes an issue where the source icons were moved to the right when renaming a source.

### Motivation and Context
Fixes a bug mentioned in Discord.

### How Has This Been Tested?
Renamed source and the issue didn't happen anymore.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
