### PR TITLE
libobs: Ignore non-type based flags for filter compatibility

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2273,11 +2273,15 @@ static bool filter_compatible(obs_source_t *source, obs_source_t *filter)
 	uint32_t s_caps = source->info.output_flags;
 	uint32_t f_caps = filter->info.output_flags;
 
-	if ((f_caps & OBS_SOURCE_AUDIO) != 0 &&
-	    (f_caps & OBS_SOURCE_VIDEO) == 0)
-		f_caps &= ~OBS_SOURCE_ASYNC;
+	// If the filter is video and the source is video, succeed.
+	if ((s_caps & (f_caps & OBS_SOURCE_VIDEO)) != 0)
+		return true;
 
-	return (s_caps & f_caps) == f_caps;
+	// If the filter is audio and the source is audio, succeed.
+	if ((s_caps & (f_caps & OBS_SOURCE_AUDIO)) != 0)
+		return true;
+
+	return false;
 }
 
 void obs_source_filter_add(obs_source_t *source, obs_source_t *filter)


### PR DESCRIPTION
### Description
Slightly changes the internal logic of filter_compatible to be:
- If the source has video, and the filter has video support, then return true.
- If the source has audio, and the filter has audio support, then return true.
- Otherwise return false.
This fixes cases where adding flags to the filters would cause it to only work on very specific sources.

### Motivation and Context
See #2223 which is fixed by this.

### How Has This Been Tested?
Tested against #2223 which works after this fix. Needs testing against async sources.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
