### PR TITLE
Decklink: Explicit casts for truncation warnings

### DIFF
--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -22,7 +22,7 @@ static void *decklink_output_create(obs_data_t *settings, obs_output_t *output)
 
 	decklinkOutput->deviceHash = obs_data_get_string(settings, DEVICE_HASH);
 	decklinkOutput->modeID = obs_data_get_int(settings, MODE_ID);
-	decklinkOutput->keyerMode = obs_data_get_int(settings, KEYER);
+	decklinkOutput->keyerMode = (int)obs_data_get_int(settings, KEYER);
 
 	return decklinkOutput;
 }
@@ -33,7 +33,7 @@ static void decklink_output_update(void *data, obs_data_t *settings)
 
 	decklink->deviceHash = obs_data_get_string(settings, DEVICE_HASH);
 	decklink->modeID = obs_data_get_int(settings, MODE_ID);
-	decklink->keyerMode = obs_data_get_int(settings, KEYER);
+	decklink->keyerMode = (int)obs_data_get_int(settings, KEYER);
 }
 
 static bool decklink_output_start(void *data)


### PR DESCRIPTION
### Description
Fix compiler warnings about long long -> int conversion.

### Motivation and Context
Less build spam.

### How Has This Been Tested?
Compiler warnings have been fixed. Program did not crash.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.