### PR TITLE
UI: Don't modify theme if already set

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -3509,7 +3509,8 @@ void OBSBasicSettings::on_theme_activated(int idx)
 	if (currT == defaultTheme)
 		currT = DEFAULT_THEME;
 
-	App()->SetTheme(currT.toUtf8().constData());
+	if (currT != App()->GetTheme())
+		App()->SetTheme(currT.toUtf8().constData());
 }
 
 void OBSBasicSettings::on_listWidget_itemSelectionChanged()
@@ -3535,7 +3536,8 @@ void OBSBasicSettings::on_buttonBox_clicked(QAbstractButton *button)
 	if (val == QDialogButtonBox::AcceptRole ||
 	    val == QDialogButtonBox::RejectRole) {
 		if (val == QDialogButtonBox::RejectRole) {
-			App()->SetTheme(savedTheme);
+			if (savedTheme != App()->GetTheme())
+				App()->SetTheme(savedTheme);
 #ifdef _WIN32
 			if (toggleAero)
 				SetAeroEnabled(!aeroWasDisabled);


### PR DESCRIPTION
### Description
Don't modify theme if already set. This includes reselecting the existing selection, and cancelling out of settings altogether. Takes a long time (7 seconds) in debug builds.

### Motivation and Context
Speed up programming workflows.

### How Has This Been Tested?
Selected all four themes redundantly and not. Cancelled out of settings redundantly and not. Themes were applied and not as expected without delays.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.