### PR TITLE
UI: Allow switch to existing theme to reload

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -3509,8 +3509,7 @@ void OBSBasicSettings::on_theme_activated(int idx)
 	if (currT == defaultTheme)
 		currT = DEFAULT_THEME;
 
-	if (currT != App()->GetTheme())
-		App()->SetTheme(currT.toUtf8().constData());
+	App()->SetTheme(currT.toUtf8().constData());
 }
 
 void OBSBasicSettings::on_listWidget_itemSelectionChanged()


### PR DESCRIPTION
### Description
Reload the theme even if the user selects the currently selected theme from the settings dialog.

### Motivation and Context
This is useful for people making changes to theme files.

### How Has This Been Tested?
Theme now reloads when selecting the currently selected theme.

### Types of changes
- New feature (non-breaking change which adds functionality)

(Not really "new" since this behavior existed in the last release.)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.