### PR TITLE
CI: Fix framework symlinks when building osx app

### DIFF
--- a/CI/before-deploy-osx.sh
+++ b/CI/before-deploy-osx.sh
@@ -49,13 +49,13 @@ install_name_tool -change @rpath/libobs.0.dylib @executable_path/../Frameworks/l
 
 # copy sparkle into the app
 hr "Copying Sparkle.framework"
-cp -r ../../sparkle/Sparkle.framework ./OBS.app/Contents/Frameworks/
+cp -R ../../sparkle/Sparkle.framework ./OBS.app/Contents/Frameworks/
 install_name_tool -change @rpath/Sparkle.framework/Versions/A/Sparkle @executable_path/../Frameworks/Sparkle.framework/Versions/A/Sparkle ./OBS.app/Contents/MacOS/obs
 
 # Copy Chromium embedded framework to app Frameworks directory
 hr "Copying Chromium Embedded Framework.framework"
 sudo mkdir -p OBS.app/Contents/Frameworks
-sudo cp -r ../../cef_binary_${CEF_BUILD_VERSION}_macosx64/Release/Chromium\ Embedded\ Framework.framework OBS.app/Contents/Frameworks/
+sudo cp -R ../../cef_binary_${CEF_BUILD_VERSION}_macosx64/Release/Chromium\ Embedded\ Framework.framework OBS.app/Contents/Frameworks/
 
 install_name_tool -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui ./OBS.app/Contents/Plugins/obs-browser.so
 install_name_tool -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./OBS.app/Contents/Plugins/obs-browser.so

--- a/CI/install/osx/Info.plist
+++ b/CI/install/osx/Info.plist
@@ -9,13 +9,11 @@
 	<key>CFBundleGetInfoString</key>
 	<string>OBS - Free and Open Source Streaming/Recording Software</string>
 	<key>CFBundleExecutable</key>
-	<string>OBS</string>
+	<string>obs</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.obsproject.obs-studio</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.8.5</string>
 	<key>NSHighResolutionCapable</key>

--- a/CI/install/osx/packageApp.sh
+++ b/CI/install/osx/packageApp.sh
@@ -46,7 +46,7 @@ cp ../CI/install/osx/Info.plist ./OBS.app/Contents
 mv ./OBS.app/Contents/MacOS/libobs-opengl.so ./OBS.app/Contents/Frameworks
 
 # put qt network in here becasuse streamdeck uses it
-cp -r /usr/local/opt/qt/lib/QtNetwork.framework ./OBS.app/Contents/Frameworks
+cp -R /usr/local/opt/qt/lib/QtNetwork.framework ./OBS.app/Contents/Frameworks
 chmod +w ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
 install_name_tool -change /usr/local/Cellar/qt/5.10.1/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
 

--- a/CI/install/osx/packageApp.sh
+++ b/CI/install/osx/packageApp.sh
@@ -48,7 +48,12 @@ mv ./OBS.app/Contents/MacOS/libobs-opengl.so ./OBS.app/Contents/Frameworks
 # put qt network in here becasuse streamdeck uses it
 cp -R /usr/local/opt/qt/lib/QtNetwork.framework ./OBS.app/Contents/Frameworks
 chmod +w ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
+rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/Headers
+rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/QtNetwork.prl
+rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/Headers/
+chmod 644 ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/Resources/Info.plist
 install_name_tool -change /usr/local/Cellar/qt/5.10.1/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
+
 
 # decklink ui qt
 install_name_tool -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui ./OBS.app/Contents/Plugins/decklink-ouput-ui.so


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This fixes up a few last issues that were preventing signing the application.

*  Switching to -R fixes the symlinks in the frameworks
*  The QtNetwork framework is copied over differently than the other frameworks so we had to remove some stuff from it that was making signing angry
*  Also the binary name in the PList is case sensitive so we fix that.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Trying to get a new version of OBS out with Catalina fixes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Built, signed, notarized, awaiting deploy :)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
