### PR TITLE
UI: Add ability to delete all references of a source

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -94,6 +94,7 @@ Windowed="Windowed"
 Percent="Percent"
 AspectRatio="Aspect Ratio <b>%1:%2</b>"
 LockVolume="Lock Volume"
+RemoveAll="Remove all references"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -148,7 +148,6 @@ class SourceTree : public QListView {
 
 	void UpdateNoSourcesMessage();
 
-	void ResetWidgets();
 	void UpdateWidget(const QModelIndex &idx, obs_sceneitem_t *item);
 	void UpdateWidgets(bool force = false);
 
@@ -181,6 +180,7 @@ public:
 
 	void UpdateIcons();
 	void SetIconsVisible(bool visible);
+	void ResetWidgets();
 
 public slots:
 	inline void ReorderItems() { GetStm()->ReorderItems(); }

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -546,7 +546,8 @@ void OBSBasic::on_transitionRemove_clicked()
 {
 	OBSSource tr = GetCurrentTransition();
 
-	if (!tr || !obs_source_configurable(tr) || !QueryRemoveSource(tr))
+	if (!tr || !obs_source_configurable(tr) ||
+	    !std::get<0>(QueryRemoveSource(tr)))
 		return;
 
 	int idx = ui->transitions->findData(QVariant::fromValue<OBSSource>(tr));

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -314,7 +314,8 @@ private:
 	OBSSceneItem GetSceneItem(QListWidgetItem *item);
 	OBSSceneItem GetCurrentSceneItem();
 
-	bool QueryRemoveSource(obs_source_t *source);
+	std::tuple<bool, bool> QueryRemoveSource(obs_source_t *source,
+						 bool item = false);
 
 	void TimedCheckForUpdates();
 	void CheckForUpdates(bool manualUpdate);
@@ -961,6 +962,8 @@ private slots:
 	void StackedMixerAreaContextMenuRequested();
 
 	void ResizeOutputSizeOfSource();
+
+	void RemoveAllItemReferences(OBSSceneItem item);
 
 public slots:
 	void on_actionResetTransform_triggered();


### PR DESCRIPTION
### Description
This adds the ability for the user to delete all references of a source.

### Motivation and Context
https://ideas.obsproject.com/posts/681/global-delete-source

### How Has This Been Tested?
Tested by deleting sources.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
