### PR TITLE
UI, libobs: Add ability to copy/paste single filter

### DIFF
--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -111,6 +111,9 @@ private slots:
 	void EffectFilterNameEdited(QWidget *editor,
 				    QAbstractItemDelegate::EndEditHint endHint);
 
+	void CopyFilter();
+	void PasteFilter();
+
 public:
 	OBSBasicFilters(QWidget *parent, OBSSource source_);
 	~OBSBasicFilters();

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1112,6 +1112,7 @@ retryScene:
 
 	copyStrings.clear();
 	copyFiltersString = nullptr;
+	copyFilter = nullptr;
 
 	LogScenes();
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -840,6 +840,8 @@ public:
 	QIcon GetGroupIcon() const;
 	QIcon GetSceneIcon() const;
 
+	OBSWeakSource copyFilter = nullptr;
+
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;
 	virtual void changeEvent(QEvent *event) override;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1085,6 +1085,8 @@ EXPORT obs_source_t *obs_source_get_filter_by_name(obs_source_t *source,
 						   const char *name);
 
 EXPORT void obs_source_copy_filters(obs_source_t *dst, obs_source_t *src);
+EXPORT void obs_source_copy_single_filter(obs_source_t *dst,
+					  obs_source_t *filter);
 
 EXPORT bool obs_source_enabled(const obs_source_t *source);
 EXPORT void obs_source_set_enabled(obs_source_t *source, bool enabled);


### PR DESCRIPTION
### Description
This adds the ability to copy and paste a single filter.

### Motivation and Context
Users might want to copy a single filter, instead of all filters.

### How Has This Been Tested?
Copy and pasted filters.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
