### PR TITLE
UI: Use yes/no dialog when warning about replay hotkey

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -324,7 +324,7 @@ Output.RecordError.Title="Recording error"
 Output.RecordError.Msg="An unspecified error occurred while recording."
 Output.RecordError.EncodeErrorMsg="An encoder error occurred while recording."
 Output.ReplayBuffer.NoHotkey.Title="No hotkey set!"
-Output.ReplayBuffer.NoHotkey.Msg="No save hotkey set for replay buffer. Please set the \"Save\" hotkey to use for saving replay recordings."
+Output.ReplayBuffer.NoHotkey.Msg="No save hotkey set for replay buffer. There is also a save button next to the replay buffer button. You can set the \"Save\" hotkey in the hotkeys section of the settings. Do you want to continue?"
 
 # output recording messages
 Output.BadPath.Title="Bad File Path"


### PR DESCRIPTION
### Description
Add yes/no dialog with 'Do not show again' checkbox when starting replay buffer without hotkey.

### Motivation and Context
Since there is a button now for saving replays, a hotkey requirement isn't necessary anymore. This asks users if they want to continue without the hotkey.

### How Has This Been Tested?
Started replay buffer.

### Types of change
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
