### PR TITLE
CI: Fix error deleting QT network framework on OSX

### DIFF
--- a/CI/install/osx/packageApp.sh
+++ b/CI/install/osx/packageApp.sh
@@ -6,10 +6,10 @@ mkdir OBS.app/Contents/MacOS
 mkdir OBS.app/Contents/Plugins
 mkdir OBS.app/Contents/Resources
 
-cp -r rundir/RelWithDebInfo/bin/ ./OBS.app/Contents/MacOS
-cp -r rundir/RelWithDebInfo/data ./OBS.app/Contents/Resources
+cp -R rundir/RelWithDebInfo/bin/ ./OBS.app/Contents/MacOS
+cp -R rundir/RelWithDebInfo/data ./OBS.app/Contents/Resources
 cp ../CI/install/osx/obs.icns ./OBS.app/Contents/Resources
-cp -r rundir/RelWithDebInfo/obs-plugins/ ./OBS.app/Contents/Plugins
+cp -R rundir/RelWithDebInfo/obs-plugins/ ./OBS.app/Contents/Plugins
 cp ../CI/install/osx/Info.plist ./OBS.app/Contents
 
 ../CI/install/osx/dylibBundler -b -cd -d ./OBS.app/Contents/Frameworks -p @executable_path/../Frameworks/ \
@@ -47,7 +47,7 @@ mv ./OBS.app/Contents/MacOS/libobs-opengl.so ./OBS.app/Contents/Frameworks
 
 # put qt network in here becasuse streamdeck uses it
 cp -R /usr/local/opt/qt/lib/QtNetwork.framework ./OBS.app/Contents/Frameworks
-chmod +w ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
+chmod -R +w ./OBS.app/Contents/Frameworks/QtNetwork.framework
 rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/Headers
 rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/QtNetwork.prl
 rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/Headers/


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
1. Recursively add write permission to entire QT Network framework in order to delete the Headers (as per #2236).
2. Replace deprecated `cp -r` with `cp -R`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
QT files may not have write permission, resulting in these commands prompting for override permission to delete each file inside the Headers path:
```bash
rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/Headers
rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/QtNetwork.prl
rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/Headers/
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
