### PR TITLE
rtmp-services: Add YouStreamer

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -584,6 +584,13 @@ void AutoConfigStreamPage::UpdateKeyLink()
 		text += QTStr(
 			"Basic.AutoConfig.StreamPage.StreamKey.LinkToSite");
 		text += "</a>";
+	} else if (serviceName == "YouStreamer") {
+		text += " <a href=\"https://";
+		text += "app.youstreamer.com/stream";
+		text += "\">";
+		text += QTStr(
+			"Basic.AutoConfig.StreamPage.StreamKey.LinkToSite");
+		text += "</a>";
 	} else if (serviceName == "Facebook Live") {
 		text += " <a href=\"https://";
 		text += "www.facebook.com/live/create";

--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 117,
+	"version": 118,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 117
+			"version": 118
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -491,6 +491,15 @@
             ]
         },
         {
+            "name": "YouStreamer",
+            "servers": [
+                {
+                    "name": "Moscow",
+                    "url": "rtmp://push.youstreamer.com/in/"
+                }
+            ]
+        },
+        {
             "name": "Vaughn Live / iNSTAGIB",
             "servers": [
                 {


### PR DESCRIPTION
### Description

I added one more service to "plugins/rtmp-services/data/services.json"
It's called YouStreamer (https://youstreamer.com/en.html), it provides re-streaming services.

Also 2 files has been changed: 
"UI/window-basic-settings-stream.cpp" and "UI/window-basic-auto-config.cpp".
In both cases there is a minor update. When you select youstreamer service - there will be a link button to redirect to the page with stream key. 

### Types of changes
 - New feature (non-breaking change which adds functionality) 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
