### PR TITLE
UI: Ensure OBS launches when theme is missing

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1071,21 +1071,27 @@ bool OBSApp::InitTheme()
 	defaultPalette = palette();
 
 	const char *themeName =
-		config_get_string(globalConfig, "General", "CurrentTheme");
+		config_get_string(globalConfig, "General", "CurrentTheme2");
 
-	if (!themeName) {
+	if (!themeName)
+		/* Use deprecated "CurrentTheme" value if available */
+		themeName = config_get_string(globalConfig, "General",
+					      "CurrentTheme");
+	if (!themeName)
 		/* Use deprecated "Theme" value if available */
 		themeName = config_get_string(globalConfig, "General", "Theme");
-		if (!themeName)
-			themeName = DEFAULT_THEME;
-		if (!themeName)
-			themeName = "Dark";
-	}
+	if (!themeName)
+		themeName = DEFAULT_THEME;
+	if (!themeName)
+		themeName = "Dark";
 
 	if (strcmp(themeName, "Default") == 0)
 		themeName = "System";
 
-	return SetTheme(themeName);
+	if (strcmp(themeName, "System") != 0 && SetTheme(themeName))
+		return true;
+
+	return SetTheme("System");
 }
 
 OBSApp::OBSApp(int &argc, char **argv, profiler_name_store_t *store)

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2760,7 +2760,7 @@ void OBSBasicSettings::SaveGeneralSettings()
 		themeData = DEFAULT_THEME;
 
 	if (WidgetChanged(ui->theme)) {
-		config_set_string(GetGlobalConfig(), "General", "CurrentTheme",
+		config_set_string(GetGlobalConfig(), "General", "CurrentTheme2",
 				  QT_TO_UTF8(themeData));
 
 		App()->SetTheme(themeData.toUtf8().constData());


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change makes it so OBS will still launch even if a theme is missing. This change also deprecates the "CurrentTheme" config key, and is replaced by "CurrentTheme2".

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The code to make sure OBS fell back to the System theme in case of a missing theme had been accidentally removed. Changing the key prevents a new version of OBS setting a theme that doesn't exist in an older version, which would prevent that version from launching.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This has been tested by changing the old CurrentTheme key to a theme that didn't exist, and checking that OBS launched with the System theme after a dialog noting the missing theme. After changing the theme, I checked the CurrentTheme2 key is used instead.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
