### PR TITLE
libobs/audio-monitoring: only remove monitor from monitors array if set

### DIFF
--- a/libobs/audio-monitoring/win32/wasapi-output.c
+++ b/libobs/audio-monitoring/win32/wasapi-output.c
@@ -451,11 +451,11 @@ void audio_monitor_destroy(struct audio_monitor *monitor)
 {
 	if (monitor) {
 		audio_monitor_free(monitor);
-
-		pthread_mutex_lock(&obs->audio.monitoring_mutex);
-		da_erase_item(obs->audio.monitors, &monitor);
-		pthread_mutex_unlock(&obs->audio.monitoring_mutex);
-
+		if (obs->audio.monitors.num) {
+			pthread_mutex_lock(&obs->audio.monitoring_mutex);
+			da_erase_item(obs->audio.monitors, &monitor);
+			pthread_mutex_unlock(&obs->audio.monitoring_mutex);
+		}
 		bfree(monitor);
 	}
 }


### PR DESCRIPTION
### Description
Check if obs->audio is set and has monitors before trying remove a monitor.

### Motivation and Context
in obs_shutdown obs_free_audio is called before obs_free_data which destroys source which destroy there monitor
so obs->audio is zeroed so the mutex (obs->audio.monitoring_mutex) can not bet set and the monitor can not be removed from the array (obs->audio.monitors)
This could cause a crash when closing the application.

### How Has This Been Tested?
Having show and hide transitions (#1905) and closing the application

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
