### PR TITLE
libobs: Don't corrupt obs_properties in ..._remove_by_name

### DIFF
--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -330,9 +330,32 @@ void obs_properties_remove_by_name(obs_properties_t *props, const char *name)
 
 	while (cur) {
 		if (strcmp(cur->name, name) == 0) {
+			// Fix props->last pointer.
+			if (props->last == &cur->next) {
+				if (cur == prev) {
+					// If we are the last entry and there
+					// is no previous entry, reset.
+					props->last = &props->first_property;
+				} else {
+					// If we are the last entry and there
+					// is a previous entry, update.
+					props->last = &prev->next;
+				}
+			}
+
+			// Fix props->first_property.
+			if (props->first_property == cur)
+				props->first_property = cur->next;
+
+			// Update the previous element next pointer with our
+			// next pointer. This is an automatic no-op if both
+			// elements alias the same memory.
 			prev->next = cur->next;
-			cur->next = 0;
+
+			// Finally clear our own next pointer and destroy.
+			cur->next = NULL;
 			obs_property_destroy(cur);
+
 			break;
 		}
 


### PR DESCRIPTION
### Description
Fixes the corrupted obs_properties structure that happens when the obs_properties_remove_by_name encounters the first or the last element.

### Motivation and Context
Stream Effects 0.8.0 makes heavy use of the obs_properties_remove_by_name feature, which breaks when used on the first or last element in the obs_properties_t*. This means that OBS enters an invalid state, and any future attempts to read from the obs_properties_t* object lead to memory corruption, or even a crash.

### How Has This Been Tested?
Validated against new Stream Effects code. Stopped crashing.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
