### PR TITLE
deps/obs-scripting: Expose matrix3 & 4 to scripting

### DIFF
--- a/deps/obs-scripting/obslua/obslua.i
+++ b/deps/obs-scripting/obslua/obslua.i
@@ -7,6 +7,8 @@
 #include <graphics/vec4.h>
 #include <graphics/vec3.h>
 #include <graphics/vec2.h>
+#include <graphics/matrix4.h>
+#include <graphics/matrix3.h>
 #include <graphics/quat.h>
 #include <graphics/image-file.h>
 #include <obs.h>
@@ -82,6 +84,8 @@ static inline void wrap_blog(int log_level, const char *message)
 %include "graphics/vec4.h"
 %include "graphics/vec3.h"
 %include "graphics/vec2.h"
+%include "graphics/matrix4.h"
+%include "graphics/matrix3.h"
 %include "graphics/quat.h"
 %include "graphics/image-file.h"
 %include "obs-scripting-config.h"

--- a/deps/obs-scripting/obspython/obspython.i
+++ b/deps/obs-scripting/obspython/obspython.i
@@ -8,6 +8,8 @@
 #include <graphics/vec4.h>
 #include <graphics/vec3.h>
 #include <graphics/vec2.h>
+#include <graphics/matrix4.h>
+#include <graphics/matrix3.h>
 #include <graphics/quat.h>
 #include <obs.h>
 #include <obs-hotkey.h>
@@ -81,6 +83,8 @@ static inline void wrap_blog(int log_level, const char *message)
 %include "graphics/vec4.h"
 %include "graphics/vec3.h"
 %include "graphics/vec2.h"
+%include "graphics/matrix4.h"
+%include "graphics/matrix3.h"
 %include "graphics/quat.h"
 %include "obs-scripting-config.h"
 %include "obs-data.h"


### PR DESCRIPTION

### Description
Adds matrix3.h and matrix4.h to the scripting build so you can create matrix3 and matrix4 structs from Lua and Python.

### Motivation and Context
Various functions available in the scripting API aren't usable currently since you can't create the matrix3 and matrix4 values needed for their arguments (without ugly hacks).

### How Has This Been Tested?
Tested with a Lua and Python script each to get all scene item canvas positions via their box transform which needs a matrix4, and also tried some basic matrix math. All results looked correct.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
