### PR TITLE
Support for URL/web link drag and drop 

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -984,6 +984,11 @@ About.Authors="Authors"
 About.License="License"
 About.Contribute="Support the OBS Project"
 
+# Drag-drop URL
+AddUrl.Title="Add Source via URL"
+AddUrl.Text="You have dragged a URL into OBS. This will automatically add the link as a source. Continue?"
+AddUrl.Text.Url="URL: %1"
+
 # Dynamic output size
 ResizeOutputSizeOfSource="Resize output (source size)"
 ResizeOutputSizeOfSource.Text="The base and output resolutions will be resized to the size of the current source."

--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -63,6 +63,9 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 	const char *type = nullptr;
 	QString name;
 
+	obs_video_info ovi;
+	obs_get_video_info(&ovi);
+
 	switch (image) {
 	case DropType_RawText:
 		obs_data_set_string(settings, "text", data);
@@ -97,6 +100,8 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 	case DropType_Html:
 		obs_data_set_bool(settings, "is_local_file", true);
 		obs_data_set_string(settings, "local_file", data);
+		obs_data_set_int(settings, "width", ovi.base_width);
+		obs_data_set_int(settings, "height", ovi.base_height);
 		name = QUrl::fromLocalFile(QString(data)).fileName();
 		type = "browser_source";
 		break;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -170,6 +170,7 @@ class OBSBasic : public OBSMainWindow {
 		DropType_Image,
 		DropType_Media,
 		DropType_Html,
+		DropType_Url,
 	};
 
 private:
@@ -435,6 +436,9 @@ private:
 	inline void OnDeactivate();
 
 	void AddDropSource(const char *file, DropType image);
+	void AddDropURL(const char *url, QString &name, obs_data_t *settings,
+			const obs_video_info &ovi);
+	void ConfirmDropUrl(const QString &url);
 	void dragEnterEvent(QDragEnterEvent *event) override;
 	void dragLeaveEvent(QDragLeaveEvent *event) override;
 	void dragMoveEvent(QDragMoveEvent *event) override;


### PR DESCRIPTION
### Description
Extending the ability to drag files into the OBS window to automatically add it to the scene, this adds the ability to do the same for web links (especially when dragged from a web browser).

Web links can be built into any web element, like a button or thumbnail. The web developer can also define the width, height, and source name for when the source is added. See the link below when testing. Dragged links default to canvas size.

![](http://scr.wzd.li/scr/2019-12-28_19-03-09.gif)

### Motivation and Context
Users should be able to efficiently build their overlays. With web overlays becoming more and more popular, this PR aims to improve the workflow of importing them.

### How Has This Been Tested?
Drag any one of these into OBS: https://wizardcm.github.io/OBS-Drag-Demo/

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
