### PR TITLE
Add monospace font for multiline text property

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -239,6 +239,11 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
 
 	if (type == OBS_TEXT_MULTILINE) {
 		QPlainTextEdit *edit = new QPlainTextEdit(QT_UTF8(val));
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+		edit->setTabStopDistance(40);
+#else
+		edit->setTabStopWidth(40);
+#endif
 		return NewWidget(prop, edit, SIGNAL(textChanged()));
 
 	} else if (type == OBS_TEXT_PASSWORD) {

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -235,6 +235,7 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
 {
 	const char *name = obs_property_name(prop);
 	const char *val = obs_data_get_string(settings, name);
+	const bool monospace = obs_property_text_monospace(prop);
 	obs_text_type type = obs_property_text_type(prop);
 
 	if (type == OBS_TEXT_MULTILINE) {
@@ -244,6 +245,11 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
 #else
 		edit->setTabStopWidth(40);
 #endif
+		if (monospace) {
+			QFont f("Courier");
+			f.setStyleHint(QFont::Monospace);
+			edit->setFont(f);
+		}
 		return NewWidget(prop, edit, SIGNAL(textChanged()));
 
 	} else if (type == OBS_TEXT_PASSWORD) {

--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -55,6 +55,7 @@ struct path_data {
 
 struct text_data {
 	enum obs_text_type type;
+	bool monospace;
 };
 
 struct list_data {
@@ -978,6 +979,12 @@ enum obs_text_type obs_property_text_type(obs_property_t *p)
 	return data ? data->type : OBS_TEXT_DEFAULT;
 }
 
+enum obs_text_type obs_property_text_monospace(obs_property_t *p)
+{
+	struct text_data *data = get_type_data(p, OBS_PROPERTY_TEXT);
+	return data ? data->monospace : false;
+}
+
 enum obs_path_type obs_property_path_type(obs_property_t *p)
 {
 	struct path_data *data = get_type_data(p, OBS_PROPERTY_PATH);
@@ -1049,6 +1056,15 @@ void obs_property_float_set_suffix(obs_property_t *p, const char *suffix)
 
 	bfree(data->suffix);
 	data->suffix = bstrdup(suffix);
+}
+
+void obs_property_text_set_monospace(obs_property_t *p, bool monospace)
+{
+	struct text_data *data = get_type_data(p, OBS_PROPERTY_TEXT);
+	if (!data)
+		return;
+
+	data->monospace = monospace;
 }
 
 void obs_property_list_clear(obs_property_t *p)

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -313,6 +313,7 @@ EXPORT double obs_property_float_step(obs_property_t *p);
 EXPORT enum obs_number_type obs_property_float_type(obs_property_t *p);
 EXPORT const char *obs_property_float_suffix(obs_property_t *p);
 EXPORT enum obs_text_type obs_property_text_type(obs_property_t *p);
+EXPORT enum obs_text_type obs_property_text_monospace(obs_property_t *p);
 EXPORT enum obs_path_type obs_property_path_type(obs_property_t *p);
 EXPORT const char *obs_property_path_filter(obs_property_t *p);
 EXPORT const char *obs_property_path_default_path(obs_property_t *p);
@@ -326,6 +327,7 @@ EXPORT void obs_property_float_set_limits(obs_property_t *p, double min,
 EXPORT void obs_property_int_set_suffix(obs_property_t *p, const char *suffix);
 EXPORT void obs_property_float_set_suffix(obs_property_t *p,
 					  const char *suffix);
+EXPORT void obs_property_text_set_monospace(obs_property_t *p, bool monospace);
 
 EXPORT void obs_property_list_clear(obs_property_t *p);
 


### PR DESCRIPTION
### Description
Will be in coordination with a future PR to `obs-browser` to set the CSS input as monospace.

![](http://scr.wzd.li/scr/2019-12-29_19-58-05.png)

This PR also halves the length of tab character for easier readability and consistency with modern editors.

### Motivation and Context
While the text property for OBS Browser's CSS doesn't support advanced code editor capabilities, and probably shouldn't, there can be a fair bit of custom CSS applied to third party webpages. This significantly improves the usability and readability of the Custom CSS field, and the same can be done for any other multi-line text property that contains code.

### How Has This Been Tested?
Apply this change to `obs-browser`:

https://github.com/WizardCM/obs-browser/commit/855ade440db17bd48fba8867918b9795adac822d

Then open the properties for a Browser source.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
