### PR TITLE
UI: Convert remux path separators to OS native style

### DIFF
--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -461,6 +461,7 @@ void RemuxQueueModel::checkInputPath(int row)
 	if (entry.sourcePath.isEmpty()) {
 		entry.state = RemuxEntryState::Empty;
 	} else {
+		entry.sourcePath = QDir::toNativeSeparators(entry.sourcePath);
 		QFileInfo fileInfo(entry.sourcePath);
 		if (fileInfo.exists())
 			entry.state = RemuxEntryState::Ready;
@@ -468,8 +469,9 @@ void RemuxQueueModel::checkInputPath(int row)
 			entry.state = RemuxEntryState::InvalidPath;
 
 		if (entry.state == RemuxEntryState::Ready)
-			entry.targetPath = fileInfo.path() + QDir::separator() +
-					   fileInfo.completeBaseName() + ".mp4";
+			entry.targetPath = QDir::toNativeSeparators(
+				fileInfo.path() + QDir::separator() +
+				fileInfo.completeBaseName() + ".mp4");
 	}
 
 	if (entry.state == RemuxEntryState::Ready && isProcessing)


### PR DESCRIPTION

### Description
Alter the Remux input path function to use QDir's Native Separators function. This means that the user will not see unix style on windows and vice versa.
![image](https://user-images.githubusercontent.com/12771982/71565653-f811c880-2b04-11ea-945e-15794e87edd1.png)

### Motivation and Context
Solves issue #2272

### How Has This Been Tested?
I have tested this on a Windows 10 machine. The remux process still functions as normal.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix 

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
