### PR TITLE
UI: Properly inform user if recording path is invalid

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5416,6 +5416,12 @@ void OBSBasic::StartRecording()
 	if (disableOutputsRef)
 		return;
 
+	if (!OutputPathValid()) {
+		OutputPathInvalidMessage();
+		ui->recordButton->setChecked(false);
+		return;
+	}
+
 	if (LowDiskSpace()) {
 		DiskSpaceMessage();
 		ui->recordButton->setChecked(false);
@@ -7653,6 +7659,20 @@ const char *OBSBasic::GetCurrentOutputPath()
 	}
 
 	return path;
+}
+
+void OBSBasic::OutputPathInvalidMessage()
+{
+	blog(LOG_ERROR, "Recording stopped because of bad output path");
+
+	OBSMessageBox::critical(this, QTStr("Output.BadPath.Title"),
+				QTStr("Output.BadPath.Text"));
+}
+
+bool OBSBasic::OutputPathValid()
+{
+	const char *path = GetCurrentOutputPath();
+	return path && *path && QDir(path).exists();
 }
 
 void OBSBasic::DiskSpaceMessage()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -683,6 +683,9 @@ private:
 	void UpdatePause(bool activate = true);
 	void UpdateReplayBuffer(bool activate = true);
 
+	bool OutputPathValid();
+	void OutputPathInvalidMessage();
+
 	bool LowDiskSpace();
 	void DiskSpaceMessage();
 


### PR DESCRIPTION
### Description
When setting with an invalid output path, press the "start recording" button, UI will remind that output path is invalid (not low disk space).
![image](https://user-images.githubusercontent.com/19875776/71574146-6fa22080-2b22-11ea-855c-92fbe73be86e.png)

### Motivation and Context
This occurs to me when I change the output dir's name, and it reminds me that I need more space to start recording. I have tried deleting for 20G datas and it still reminds me that I need more space. So, I check the source code and fix it.

### How Has This Been Tested?
I've tested it in Windows 10 1809, Intel Core i7 4720HQ with NVIDIA GTX 950M, and it works as expect.
![image](https://user-images.githubusercontent.com/19875776/71574146-6fa22080-2b22-11ea-855c-92fbe73be86e.png)
It affects method OBSBasic::StartRecording() in window-basic-main.cpp:5412 with a branch code.

### Types of changes
Bug fix.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
