### PR TITLE
Remove volume render targets

### DIFF
--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -302,9 +302,6 @@ void gs_texture_3d::Rebuild(ID3D11Device *dev)
 	if (FAILED(hr))
 		throw HRError("Failed to create resource view", hr);
 
-	if (isRenderTarget)
-		InitRenderTargets();
-
 	acquired = false;
 
 	if ((td.MiscFlags & D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX) != 0) {

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -494,12 +494,10 @@ struct gs_texture_2d : gs_texture {
 
 struct gs_texture_3d : gs_texture {
 	ComPtr<ID3D11Texture3D> texture;
-	ComPtr<ID3D11RenderTargetView> renderTarget[6];
 
 	uint32_t width = 0, height = 0, depth = 0;
 	uint32_t flags = 0;
 	DXGI_FORMAT dxgiFormat = DXGI_FORMAT_UNKNOWN;
-	bool isRenderTarget = false;
 	bool isDynamic = false;
 	bool isShared = false;
 	bool genMipmaps = false;
@@ -515,7 +513,6 @@ struct gs_texture_3d : gs_texture {
 	void InitSRD(vector<D3D11_SUBRESOURCE_DATA> &srd);
 	void InitTexture(const uint8_t *const *data);
 	void InitResourceView();
-	void InitRenderTargets();
 	void BackupTexture(const uint8_t *const *data);
 	void GetSharedHandle(IDXGIResource *dxgi_res);
 
@@ -527,8 +524,6 @@ struct gs_texture_3d : gs_texture {
 	inline void Release()
 	{
 		texture.Release();
-		for (auto &rt : renderTarget)
-			rt.Release();
 		shaderRes.Release();
 	}
 

--- a/libobs-opengl/gl-texture3d.c
+++ b/libobs-opengl/gl-texture3d.c
@@ -139,7 +139,7 @@ gs_texture_t *device_voltexture_create(gs_device_t *device, uint32_t width,
 	tex->base.gl_type = get_gl_format_type(color_format);
 	tex->base.gl_target = GL_TEXTURE_3D;
 	tex->base.is_dynamic = (flags & GS_DYNAMIC) != 0;
-	tex->base.is_render_target = (flags & GS_RENDER_TARGET) != 0;
+	tex->base.is_render_target = false;
 	tex->base.is_dummy = (flags & GS_GL_DUMMYTEX) != 0;
 	tex->base.gen_mipmaps = (flags & GS_BUILD_MIPMAPS) != 0;
 	tex->width = width;


### PR DESCRIPTION
### Description
Remove support for binding 3D textures as render targets.

### Motivation and Context
Noticed the D3D path wasn't written correctly, and there's not really a sensible "default" for this, so it's probably better to remove support, and not bother.

### How Has This Been Tested?
SRV usage still works (Apply LUT) on Windows (D3D) and Mac (GL).

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.