### PR TITLE
obs-plugins: Change defaults of various plugins

### DIFF
--- a/plugins/image-source/color-source.c
+++ b/plugins/image-source/color-source.c
@@ -99,22 +99,49 @@ static uint32_t color_source_getheight(void *data)
 	return context->height;
 }
 
-static void color_source_defaults(obs_data_t *settings)
+static void color_source_defaults_v1(obs_data_t *settings)
 {
 	obs_data_set_default_int(settings, "color", 0xFFFFFFFF);
 	obs_data_set_default_int(settings, "width", 400);
 	obs_data_set_default_int(settings, "height", 400);
 }
 
-struct obs_source_info color_source_info = {
+static void color_source_defaults_v2(obs_data_t *settings)
+{
+	struct obs_video_info ovi;
+	obs_get_video_info(&ovi);
+
+	obs_data_set_default_int(settings, "color", 0xFFFFFFFF);
+	obs_data_set_default_int(settings, "width", ovi.base_width);
+	obs_data_set_default_int(settings, "height", ovi.base_width);
+}
+
+struct obs_source_info color_source_info_v1 = {
 	.id = "color_source",
+	.type = OBS_SOURCE_TYPE_INPUT,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
+			OBS_SOURCE_CAP_OBSOLETE,
+	.create = color_source_create,
+	.destroy = color_source_destroy,
+	.update = color_source_update,
+	.get_name = color_source_get_name,
+	.get_defaults = color_source_defaults_v1,
+	.get_width = color_source_getwidth,
+	.get_height = color_source_getheight,
+	.video_render = color_source_render,
+	.get_properties = color_source_properties,
+	.icon_type = OBS_ICON_TYPE_COLOR,
+};
+
+struct obs_source_info color_source_info_v2 = {
+	.id = "color_source_v2",
 	.type = OBS_SOURCE_TYPE_INPUT,
 	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW,
 	.create = color_source_create,
 	.destroy = color_source_destroy,
 	.update = color_source_update,
 	.get_name = color_source_get_name,
-	.get_defaults = color_source_defaults,
+	.get_defaults = color_source_defaults_v2,
 	.get_width = color_source_getwidth,
 	.get_height = color_source_getheight,
 	.video_render = color_source_render,

--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -277,12 +277,14 @@ MODULE_EXPORT const char *obs_module_description(void)
 }
 
 extern struct obs_source_info slideshow_info;
-extern struct obs_source_info color_source_info;
+extern struct obs_source_info color_source_info_v1;
+extern struct obs_source_info color_source_info_v2;
 
 bool obs_module_load(void)
 {
 	obs_register_source(&image_source_info);
-	obs_register_source(&color_source_info);
+	obs_register_source(&color_source_info_v1);
+	obs_register_source(&color_source_info_v2);
 	obs_register_source(&slideshow_info);
 	return true;
 }

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -35,8 +35,25 @@ MODULE_EXPORT const char *obs_module_description(void)
 
 uint32_t texbuf_w = 2048, texbuf_h = 2048;
 
-static struct obs_source_info freetype2_source_info = {
+static struct obs_source_info freetype2_source_info_v1 = {
 	.id = "text_ft2_source",
+	.type = OBS_SOURCE_TYPE_INPUT,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CAP_OBSOLETE |
+			OBS_SOURCE_CUSTOM_DRAW,
+	.get_name = ft2_source_get_name,
+	.create = ft2_source_create_v1,
+	.destroy = ft2_source_destroy,
+	.update = ft2_source_update,
+	.get_width = ft2_source_get_width,
+	.get_height = ft2_source_get_height,
+	.video_render = ft2_source_render,
+	.video_tick = ft2_video_tick,
+	.get_properties = ft2_source_properties,
+	.icon_type = OBS_ICON_TYPE_TEXT,
+};
+
+static struct obs_source_info freetype2_source_info_v2 = {
+	.id = "text_ft2_source_v2",
 	.type = OBS_SOURCE_TYPE_INPUT,
 	.output_flags = OBS_SOURCE_VIDEO |
 #ifdef _WIN32
@@ -44,7 +61,7 @@ static struct obs_source_info freetype2_source_info = {
 #endif
 			OBS_SOURCE_CUSTOM_DRAW,
 	.get_name = ft2_source_get_name,
-	.create = ft2_source_create,
+	.create = ft2_source_create_v2,
 	.destroy = ft2_source_destroy,
 	.update = ft2_source_update,
 	.get_width = ft2_source_get_width,
@@ -83,7 +100,8 @@ bool obs_module_load()
 		bfree(config_dir);
 	}
 
-	obs_register_source(&freetype2_source_info);
+	obs_register_source(&freetype2_source_info_v1);
+	obs_register_source(&freetype2_source_info_v2);
 
 	return true;
 }
@@ -469,7 +487,8 @@ error:
 #define DEFAULT_FACE "Sans Serif"
 #endif
 
-static void *ft2_source_create(obs_data_t *settings, obs_source_t *source)
+static void *ft2_source_create(obs_data_t *settings, obs_source_t *source,
+			       int ver)
 {
 	struct ft2_source *srcdata = bzalloc(sizeof(struct ft2_source));
 	obs_data_t *font_obj = obs_data_create();
@@ -477,10 +496,12 @@ static void *ft2_source_create(obs_data_t *settings, obs_source_t *source)
 
 	init_plugin();
 
-	srcdata->font_size = 32;
+	const uint16_t font_size = ver == 1 ? 32 : 256;
+
+	srcdata->font_size = font_size;
 
 	obs_data_set_default_string(font_obj, "face", DEFAULT_FACE);
-	obs_data_set_default_int(font_obj, "size", 32);
+	obs_data_set_default_int(font_obj, "size", font_size);
 	obs_data_set_default_obj(settings, "font", font_obj);
 
 	obs_data_set_default_int(settings, "log_lines", 6);
@@ -493,4 +514,14 @@ static void *ft2_source_create(obs_data_t *settings, obs_source_t *source)
 	obs_data_release(font_obj);
 
 	return srcdata;
+}
+
+static void *ft2_source_create_v1(obs_data_t *settings, obs_source_t *source)
+{
+	return ft2_source_create(settings, source, 1);
+}
+
+static void *ft2_source_create_v2(obs_data_t *settings, obs_source_t *source)
+{
+	return ft2_source_create(settings, source, 2);
 }

--- a/plugins/text-freetype2/text-freetype2.h
+++ b/plugins/text-freetype2/text-freetype2.h
@@ -69,7 +69,8 @@ struct ft2_source {
 
 extern FT_Library ft2_lib;
 
-static void *ft2_source_create(obs_data_t *settings, obs_source_t *source);
+static void *ft2_source_create_v1(obs_data_t *settings, obs_source_t *source);
+static void *ft2_source_create_v2(obs_data_t *settings, obs_source_t *source);
 static void ft2_source_destroy(void *data);
 static void ft2_source_update(void *data, obs_data_t *settings);
 static void ft2_source_render(void *data, gs_effect_t *effect);


### PR DESCRIPTION
### Description
Color Source: change default to size of canvas
Text: change default size to 256

This also adds fallbacks for when the user didn't change the defaults in a previous version.

### Motivation and Context
Provides better defaults for these sources.

This is a combination of #2073, #2112 and #1921.

The previous issues of why those weren't merged are fixed with this.

### How Has This Been Tested?
I've tested the color source and text-freetype2 on Linux. The gdi text source needs testing on Windows.

### Types of changes
- New feature (non-breaking change which adds functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested (gdi source needs testing on Windows).
- [x] All commit messages are properly formatted and commits squashed where appropriate.
