### PR TITLE
obs-scripting: Add Python functions for frontend events

### DIFF
--- a/deps/obs-scripting/obs-scripting-python-frontend.c
+++ b/deps/obs-scripting/obs-scripting-python-frontend.c
@@ -331,6 +331,77 @@ static PyObject *add_save_callback(PyObject *self, PyObject *args)
 	return python_none();
 }
 
+static void frontend_event_callback(enum obs_frontend_event *event_data,
+				    void *priv)
+{
+	struct python_obs_callback *cb = priv;
+
+	if (cb->base.removed) {
+		obs_frontend_remove_event_callback(frontend_event_callback, cb);
+		return;
+	}
+
+	lock_python();
+
+	PyObject *args = Py_BuildValue("(i)", event_data);
+
+	struct python_obs_callback *last_cb = cur_python_cb;
+	cur_python_cb = cb;
+	cur_python_script = (struct obs_python_script *)cb->base.script;
+
+	PyObject *py_ret = PyObject_CallObject(cb->func, args);
+	Py_XDECREF(py_ret);
+	py_error();
+
+	cur_python_script = NULL;
+	cur_python_cb = last_cb;
+
+	Py_XDECREF(args);
+
+	unlock_python();
+}
+
+static PyObject *remove_event_callback(PyObject *self, PyObject *args)
+{
+	struct obs_python_script *script = cur_python_script;
+	PyObject *py_cb = NULL;
+
+	UNUSED_PARAMETER(self);
+
+	if (!parse_args(args, "O", &py_cb))
+		return python_none();
+	if (!py_cb || !PyFunction_Check(py_cb))
+		return python_none();
+
+	struct python_obs_callback *cb =
+		find_python_obs_callback(script, py_cb);
+	if (cb)
+		remove_python_obs_callback(cb);
+	return python_none();
+}
+
+static void add_event_callback_defer(void *cb)
+{
+	obs_frontend_add_event_callback(frontend_event_callback, cb);
+}
+
+static PyObject *add_event_callback(PyObject *self, PyObject *args)
+{
+	struct obs_python_script *script = cur_python_script;
+	PyObject *py_cb = NULL;
+
+	UNUSED_PARAMETER(self);
+
+	if (!parse_args(args, "O", &py_cb))
+		return python_none();
+	if (!py_cb || !PyFunction_Check(py_cb))
+		return python_none();
+
+	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);
+	defer_call_post(add_event_callback_defer, cb);
+	return python_none();
+}
+
 /* ----------------------------------- */
 
 void add_python_frontend_funcs(PyObject *module)
@@ -353,6 +424,8 @@ void add_python_frontend_funcs(PyObject *module)
 		DEF_FUNC(set_current_profile),
 		DEF_FUNC(remove_save_callback),
 		DEF_FUNC(add_save_callback),
+		DEF_FUNC(remove_event_callback),
+		DEF_FUNC(add_event_callback),
 
 #undef DEF_FUNC
 		{0}};


### PR DESCRIPTION
### Description
Adds `obs_frontend_add_event_callback` and `obs_frontend_remove_event_callback` support for python scripting.
Code has been mostly reused from the `obs_frontend_add_save_callback` and related functions, I trust Jim's code and it shouldn't behave much differently.
https://github.com/obsproject/obs-studio/blob/master/deps/obs-scripting/obs-scripting-python-frontend.c#L258

### Motivation and Context
I implemented this because I needed it and it hadn't been implemented for reasons unknown.

> 14:57 <@​Jim> I wonder why it's not there
> did I just forget or was there another reason?  I can't remember

I couldn't find this on mantis/gh, but there was a thread covering it;
https://obsproject.com/forum/threads/python-scripting-missing-bindings-to-frontend-events-making-it-hard-to-trigger-on-stream-start-stop.82955/

### How Has This Been Tested?
I have created a simple python script that creates the callback, and prints the event integer.
It additionally checks for the change of Studio Mode to test against the `obs_frontend_event` enum,
if a change of Studio Mode is recognised, the callback is removed, testing removing the callback.

All my tests passed

![image](https://user-images.githubusercontent.com/12771982/71702478-c7db6a00-2e23-11ea-8dce-f5923f953752.png)
https://hastebin.com/rizaqicoga.py

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
