### PR TITLE
CMake: Fix build on ppc64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if(${CMAKE_C_COMPILER_ID} MATCHES "Clang" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "C
 	set(CMAKE_COMPILER_IS_CLANG TRUE)
 endif()
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64le")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64(le)?")
 	add_compile_definitions(NO_WARN_X86_INTRINSICS)
 endif()
 

--- a/deps/media-playback/CMakeLists.txt
+++ b/deps/media-playback/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(media-playback STATIC
 	${media-playback_SOURCES}
 	)
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64le")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64(le)?")
 	target_compile_options(media-playback
 			PUBLIC
 			-mvsx)

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -474,7 +474,7 @@ target_compile_definitions(libobs
 	PUBLIC
 		HAVE_OBSCONFIG_H)
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64le")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64(le)?")
 	target_compile_options(libobs
 		PUBLIC
 			-mvsx)


### PR DESCRIPTION
ppc64le was fixed before, but ppc64 (big-endian) was still failing.