### PR TITLE
obs-ffmpeg: Fix VC++ warnings

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-encoded-output.c
+++ b/plugins/obs-ffmpeg/ffmpeg-encoded-output.c
@@ -502,10 +502,10 @@ static int get_audio_mix_count(int audio_mix_mask)
 	return mix_count;
 }
 
-static inline double encoder_bitrate(obs_encoder_t *encoder)
+static inline int encoder_bitrate(obs_encoder_t *encoder)
 {
 	obs_data_t *settings = obs_encoder_get_settings(encoder);
-	double bitrate = obs_data_get_double(settings, "bitrate");
+	const int bitrate = (int)obs_data_get_int(settings, "bitrate");
 
 	obs_data_release(settings);
 
@@ -542,7 +542,7 @@ static int proto_try_connect(struct ffmpeg_encoded_output *stream)
 	config.scale_height = 0;
 	config.width = obs_encoder_get_width(vencoder);
 	config.height = obs_encoder_get_height(vencoder);
-	config.audio_tracks = audio_output_get_channels(audio);
+	config.audio_tracks = (int)audio_output_get_channels(audio);
 	config.audio_mix_count = get_audio_mix_count(config.audio_tracks);
 	config.format =
 		obs_to_ffmpeg_video_format(video_output_get_format(video));

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -219,7 +219,7 @@ static bool create_video_stream(struct ffmpeg_data *data)
 		data->vcodec->pix_fmts, data->config.format, 0, NULL);
 
 	context = data->video->codec;
-	context->bit_rate = data->config.video_bitrate * 1000;
+	context->bit_rate = (int64_t)data->config.video_bitrate * 1000;
 	context->width = data->config.scale_width;
 	context->height = data->config.scale_height;
 	context->time_base = (AVRational){ovi.fps_den, ovi.fps_num};
@@ -313,7 +313,7 @@ static bool create_audio_stream(struct ffmpeg_data *data, int idx)
 
 	data->audio_streams[idx] = stream;
 	context = data->audio_streams[idx]->codec;
-	context->bit_rate = data->config.audio_bitrate * 1000;
+	context->bit_rate = (int64_t)data->config.audio_bitrate * 1000;
 	context->time_base = (AVRational){1, aoi.samples_per_sec};
 	context->channels = get_audio_channels(aoi.speakers);
 	context->sample_rate = aoi.samples_per_sec;


### PR DESCRIPTION
### Description
Clean up VC++ warnings from #1748.

### Motivation and Context
Don't like warning spam.

### How Has This Been Tested?
Breakpoint inspection on Windows for all diffs to ensure behavior is the same.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
