### PR TITLE
Return real Windows 10 build number (incl. in logs)

### DIFF
--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -866,7 +866,17 @@ void get_win_ver(struct win_version_info *info)
 		return;
 
 	if (!got_version) {
-		get_dll_ver(L"kernel32", &ver);
+
+		OSVERSIONINFO osvi;
+
+		ZeroMemory(&osvi, sizeof(OSVERSIONINFO));
+		osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+
+		GetVersionEx(&osvi);
+		ver.build = osvi.dwBuildNumber;
+		ver.major = osvi.dwMajorVersion;
+		ver.minor = osvi.dwMinorVersion;
+		ver.revis = 0; // Not returned in osvi
 		got_version = true;
 
 		if (ver.major == 10) {


### PR DESCRIPTION
### Description
Rather than reading `kernel32.dll`'s version number, this uses the only relatively-supported API to fetch the Windows version number. This ensures accuracy.

### Motivation and Context
Windows 10 1909 was released late last year, and it used a new upgrade method - one that didn't require a super long reboot. It also didn't update the version number of `kernel32.dll`. This means _anyone_ running 1909 is currently reported as 1903 in the OBS logs.

Thanks to the change in #2282 the API now returns a version number that isn't Windows 8, opening the door to this PR.

Unfortunately, I couldn't find a way to get the revision number via an API. Likely because revision numbers are too recent, and therefore were never implemented. I'd love to use an API rather than the registry.

### How Has This Been Tested?
On Windows 10 build 2004. 

If possible, please test on **Windows 7, 8, and 8.1.** If you're running Windows 10 1909, please test that too!

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
