### PR TITLE
libobs-opengl: Fix volume texture leak

### DIFF
--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -1407,12 +1407,6 @@ void gs_swapchain_destroy(gs_swapchain_t *swapchain)
 	bfree(swapchain);
 }
 
-void gs_voltexture_destroy(gs_texture_t *voltex)
-{
-	/* TODO */
-	UNUSED_PARAMETER(voltex);
-}
-
 uint32_t gs_voltexture_get_width(const gs_texture_t *voltex)
 {
 	/* TODO */

--- a/libobs-opengl/gl-texture3d.c
+++ b/libobs-opengl/gl-texture3d.c
@@ -179,3 +179,8 @@ fail:
 	blog(LOG_ERROR, "device_voltexture_create (GL) failed");
 	return NULL;
 }
+
+void gs_voltexture_destroy(gs_texture_t *voltex)
+{
+	gs_texture_destroy(voltex);
+}


### PR DESCRIPTION
### Description
Forgot to add clean-up path for volume textures in OpenGL.

### Motivation and Context
Leaks are bad.

### How Has This Been Tested?
2 leaks before change. 0 after.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.