### PR TITLE
UI: Move program options in portrait mode

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -786,6 +786,7 @@ void OBSBasic::CreateProgramOptions()
 	programOptions = new QWidget();
 	QVBoxLayout *layout = new QVBoxLayout();
 	layout->setSpacing(4);
+	programOptions->setMaximumWidth(250);
 
 	QPushButton *configTransitions = new QPushButton();
 	configTransitions->setMaximumSize(22, 22);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3546,10 +3546,17 @@ void OBSBasic::ResetUI()
 	bool labels = config_get_bool(GetGlobalConfig(), "BasicWindow",
 				      "StudioModeLabels");
 
-	if (studioPortraitLayout)
+	if (studioPortraitLayout) {
 		ui->previewLayout->setDirection(QBoxLayout::TopToBottom);
-	else
+
+		if (programOptions)
+			ui->horizontalLayout_2->insertWidget(0, programOptions);
+	} else {
 		ui->previewLayout->setDirection(QBoxLayout::LeftToRight);
+
+		if (programOptions)
+			ui->previewLayout->insertWidget(2, programOptions);
+	}
 
 	if (previewProgramMode)
 		ui->previewLabel->setHidden(!labels);


### PR DESCRIPTION
### Description
This moves the program options to the left side in portrait mode.

Before:
![Screenshot from 2020-01-05 13-33-38](https://user-images.githubusercontent.com/19962531/71785033-8b914080-2fc0-11ea-92f3-120fdf9ba5cc.png)

After:
![Screenshot from 2020-01-05 13-26-59](https://user-images.githubusercontent.com/19962531/71785035-95b33f00-2fc0-11ea-8c37-e41f165e7759.png)

### Motivation and Context
With the addition of the t-bar, the preview/program areas became squished and small.

### How Has This Been Tested?
Switched studio mode to portrait.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
