### PR TITLE
media-playback: Add functions to pause/seek media source

### DIFF
--- a/deps/media-playback/media-playback/media.h
+++ b/deps/media-playback/media-playback/media.h
@@ -93,6 +93,8 @@ struct mp_media {
 
 	bool thread_valid;
 	pthread_t thread;
+
+	bool pause;
 };
 
 typedef struct mp_media mp_media_t;
@@ -119,6 +121,10 @@ extern void mp_media_free(mp_media_t *media);
 
 extern void mp_media_play(mp_media_t *media, bool loop);
 extern void mp_media_stop(mp_media_t *media);
+extern void mp_media_play_pause(mp_media_t *media, bool pause);
+extern int64_t mp_get_current_time(mp_media_t *m);
+extern void mp_media_seek_to(mp_media_t *m, int64_t pos);
+
 
 /* #define DETAILED_DEBUG_INFO */
 


### PR DESCRIPTION
### Description
This adds functions to pause/seek media sources.

### Motivation and Context
This is another piece of #1803, in which I'm separating into different PRs.

### How Has This Been Tested?
As part of #1803, the media sources could be paused and seeked.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
