### PR TITLE
rtmp-services: Update/remove services

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 119,
+	"version": 120,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 119
+			"version": 120
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -316,10 +316,6 @@
                     "url": "ingest-fra.mixer.com"
                 },
                 {
-                    "name": "EU: Oslo",
-                    "url": "ingest-osl.mixer.com"
-                },
-                {
                     "name": "Brazil: Sao Paulo",
                     "url": "ingest-sao.mixer.com"
                 },
@@ -405,10 +401,6 @@
                 {
                     "name": "EU: Frankfurt",
                     "url": "rtmp://ingest-fra.mixer.com:1935/beam"
-                },
-                {
-                    "name": "EU: Oslo",
-                    "url": "rtmp://ingest-osl.mixer.com:1935/beam"
                 },
                 {
                     "name": "Brazil: Sao Paulo",
@@ -628,6 +620,10 @@
                     "url": "rtmp://falkenstein.restream.io/live"
                 },
                 {
+                    "name": "EU-East (Prague, Czech)",
+                    "url": "rtmp://prague.restream.io/live"
+                },
+                {
                     "name": "EU-South (Madrid, Spain)",
                     "url": "rtmp://madrid.restream.io/live"
                 },
@@ -737,6 +733,10 @@
                     "url": "falkenstein.restream.io"
                 },
                 {
+                    "name": "EU-East (Prague, Czech)",
+                    "url": "prague.restream.io"
+                },
+                {
                     "name": "EU-South (Madrid, Spain)",
                     "url": "madrid.restream.io"
                 },
@@ -813,19 +813,6 @@
                 "profile": "main",
                 "bframes": 0
             }
-        },
-        {
-          "name": "GameTips.TV",
-          "servers": [
-              {
-                  "name": "Iran - Rasht",
-                  "url": "rtmp://rtmp.cdn.server1.gametips.tv:1935/hls"
-              },
-              {
-                  "name": "Germany - Falkenstein/Vogtland",
-                  "url": "rtmp://rtmp.cdn.server2.gametips.tv:1935/hls"
-              }
-          ]
         },
         {
             "name": "Nood",


### PR DESCRIPTION
- Mixer OSL removed (NXDOMAIN)
- Restream.io Prague added (FTL & RTMP)
- GameTips.tv removed (NXDOMAIN on all servers)

Twitch has made several updates as well, but since those are kinda messy (splitting single servers into multiple with inconsistent naming) and we fetch the Twitch server list from them anyway I skipped over that for now.

Gametips.tv *technically* still seems to exist, but all their servers we knew about are offline and  I can't find any information on their website indicating new ones, so remove them for now.

### Description
Update/Remove service information.

### Motivation and Context
Servers have been added, servers have been removed.

### How Has This Been Tested?
Really?

### Types of changes
- OBS Service Data Update

### Checklist:
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
