### PR TITLE
docs/sphinx: Fix obs_property_list_item_disable entry

### DIFF
--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -562,7 +562,7 @@ Property Modification Functions
 
 ---------------------
 
-.. function:: void obs_property_list_item_disable(obs_property_t *p, size_t idx,
+.. function:: void obs_property_list_item_disable(obs_property_t *p, size_t idx, bool disabled)
 
 ---------------------
 


### PR DESCRIPTION
### Description

Minor fix of this definition not being complete
![image](https://user-images.githubusercontent.com/12771982/72113471-af73ce00-3394-11ea-8e6d-2c68512263a2.png)

### Motivation and Context
Want to have any one else avoid having to find the definition of this function back in source since it's incomplete. Simple fix, writing this PR is longer than the patch 

### Types of changes
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
