### PR TITLE
UI: Add source coordinates tooltip

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -92,6 +92,7 @@ Calculating="Calculating..."
 Fullscreen="Fullscreen"
 Windowed="Windowed"
 Percent="Percent"
+SourcePosition="Top: %1 px\nBottom: %2 px\nRight: %3 px\nLeft: %4 px"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6471,6 +6471,8 @@ void OBSBasic::Nudge(int dist, MoveDir dir)
 	}
 
 	obs_scene_enum_items(GetCurrentScene(), nudge_callback, &offset);
+
+	ui->preview->SetPositionTooltip();
 }
 
 void OBSBasic::NudgeUp()

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -1,5 +1,6 @@
 #include <QGuiApplication>
 #include <QMouseEvent>
+#include <QToolTip>
 
 #include <algorithm>
 #include <cmath>
@@ -908,6 +909,8 @@ void OBSBasicPreview::MoveItems(const vec2 &pos)
 	vec2_add(&lastMoveOffset, &lastMoveOffset, &moveOffset);
 
 	obs_scene_enum_items(scene, move_items, &moveOffset);
+
+	SetPositionTooltip();
 }
 
 static bool CounterClockwise(float x1, float x2, float x3, float y1, float y2,
@@ -1942,4 +1945,34 @@ void OBSBasicPreview::SetScalingAmount(float newScalingAmountVal)
 OBSBasicPreview *OBSBasicPreview::Get()
 {
 	return OBSBasic::Get()->ui->preview;
+}
+
+void OBSBasicPreview::SetPositionTooltip()
+{
+	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+
+	obs_transform_info oti;
+	obs_video_info ovi;
+
+	OBSSceneItem item = main->GetCurrentSceneItem();
+	obs_sceneitem_get_info(main->GetCurrentSceneItem(), &oti);
+	obs_get_video_info(&ovi);
+
+	OBSSource source = obs_sceneitem_get_source(item);
+
+	int width = std::max(obs_source_get_width(source) * oti.scale.x,
+			     oti.bounds.x);
+	int height = std::max(obs_source_get_height(source) * oti.scale.y,
+			      oti.bounds.y);
+
+	int top = oti.pos.y;
+	int bottom = ovi.base_height - height - top;
+	int left = oti.pos.x;
+	int right = ovi.base_width - width - left;
+
+	QToolTip::showText(QCursor::pos(), QTStr("SourcePosition")
+						   .arg(QString::number(top),
+							QString::number(bottom),
+							QString::number(right),
+							QString::number(left)));
 }

--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -152,4 +152,6 @@ public:
 	 * byte boundary. */
 	static inline void *operator new(size_t size) { return bmalloc(size); }
 	static inline void operator delete(void *ptr) { bfree(ptr); }
+
+	void SetPositionTooltip();
 };


### PR DESCRIPTION
### Description
This displays the source coordinates in a tooltip.

![Screenshot from 2020-01-10 00-20-00](https://user-images.githubusercontent.com/19962531/72130527-6a717c80-333f-11ea-906f-aafe8562a370.png)

### Motivation and Context
This is a simpler version of #1144. One advantage of using a tooltip is that negative coordinates can be shown.

### How Has This Been Tested?
Moving sources around the preview.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
