### PR TITLE
UI: Open add source menu on double click

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -1030,8 +1030,17 @@ Q_DECLARE_METATYPE(OBSSceneItem);
 
 void SourceTree::mouseDoubleClickEvent(QMouseEvent *event)
 {
-	if (event->button() == Qt::LeftButton)
+	if (event->button() == Qt::LeftButton) {
 		QListView::mouseDoubleClickEvent(event);
+
+		QModelIndex idx = indexAt(event->pos());
+
+		if (idx.row() == -1) {
+			OBSBasic *main = reinterpret_cast<OBSBasic *>(
+				App()->GetMainWindow());
+			main->AddSourcePopupMenu(QCursor::pos());
+		}
+	}
 }
 
 void SourceTree::dropEvent(QDropEvent *event)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -673,7 +673,6 @@ private:
 
 	void AddSource(const char *id);
 	QMenu *CreateAddSourcePopupMenu();
-	void AddSourcePopupMenu(const QPoint &pos);
 	void copyActionsDynamicProperties();
 
 	static void HotkeyTriggered(void *data, obs_hotkey_id id, bool pressed);
@@ -790,6 +789,8 @@ public:
 	QIcon GetSourceIcon(const char *id) const;
 	QIcon GetGroupIcon() const;
 	QIcon GetSceneIcon() const;
+
+	void AddSourcePopupMenu(const QPoint &pos);
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;


### PR DESCRIPTION
### Description
This will open the add source menu, when the empty area of the sources dock is double clicked.

### Motivation and Context
Another way to add source.

### How Has This Been Tested?
Double clicking source area.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
