### PR TITLE
UI: Fix audio restart message not hiding

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -761,6 +761,9 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	UpdateAutomaticReplayBufferCheckboxes();
 
 	App()->DisableHotkeys();
+
+	channelIndex = ui->channelSetup->currentIndex();
+	sampleRateIndex = ui->sampleRate->currentIndex();
 }
 
 OBSBasicSettings::~OBSBasicSettings()
@@ -3828,10 +3831,22 @@ void OBSBasicSettings::AudioChanged()
 void OBSBasicSettings::AudioChangedRestart()
 {
 	if (!loading) {
-		audioChanged = true;
-		ui->audioMsg->setText(QTStr("Basic.Settings.ProgramRestart"));
-		sender()->setProperty("changed", QVariant(true));
-		EnableApplyButton(true);
+		int currentChannelIndex = ui->channelSetup->currentIndex();
+		int currentSampleRateIndex = ui->sampleRate->currentIndex();
+
+		if (currentChannelIndex != channelIndex ||
+		    currentSampleRateIndex != sampleRateIndex) {
+			audioChanged = true;
+			ui->audioMsg->setText(
+				QTStr("Basic.Settings.ProgramRestart"));
+			sender()->setProperty("changed", QVariant(true));
+			EnableApplyButton(true);
+		} else {
+			audioChanged = false;
+			ui->audioMsg->setText("");
+			sender()->setProperty("changed", QVariant(false));
+			EnableApplyButton(false);
+		}
 	}
 }
 

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -117,6 +117,8 @@ private:
 	bool loading = true;
 	bool forceAuthReload = false;
 	std::string savedTheme;
+	int sampleRateIndex = 0;
+	int channelIndex = 0;
 
 	int lastSimpleRecQualityIdx = 0;
 	int lastChannelSetupIdx = 0;


### PR DESCRIPTION
### Description
If the user clicks 'no' on the stereo audio message or changes a audio setting and changes it back, the restart message is still shown. This fixes the issue by hiding the message again.

### Motivation and Context
Less confusing for user.

### How Has This Been Tested?
Changed audio stuff in settings.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
