### PR TITLE
UI: Support URL/web DnD in linuxbrowser

### DIFF
--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -91,6 +91,7 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 	obs_data_t *settings = obs_data_create();
 	obs_source_t *source = nullptr;
 	const char *type = nullptr;
+	std::vector<const char *> types;
 	QString name;
 
 	obs_video_info ovi;
@@ -133,15 +134,21 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 		obs_data_set_int(settings, "width", ovi.base_width);
 		obs_data_set_int(settings, "height", ovi.base_height);
 		name = QUrl::fromLocalFile(QString(data)).fileName();
-		type = "browser_source";
+		types = {"browser_source", "linuxbrowser-source"};
 		break;
 	case DropType_Url:
 		AddDropURL(data, name, settings, ovi);
-		type = "browser_source";
+		types = {"browser_source", "linuxbrowser-source"};
 		break;
 	}
 
-	if (!obs_source_get_display_name(type)) {
+	for (char const *t : types) {
+		if (obs_source_get_display_name(t)) {
+			type = t;
+			break;
+		}
+	}
+	if (type == nullptr || !obs_source_get_display_name(type)) {
 		obs_data_release(settings);
 		return;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add support for checking multiple source types in Drag n Drop callback
to support overlays for linuxbrowser users. Once the "browsersource" is
available on the platform it will have priority.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
It's trivial to support linuxbrowser-source in this case, so I think it's important for platform parity.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Worked on my machine. Im not sure if the original branch introduced a memory leak or I did, but I see ~1 leak per drag n drop.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
