### PR TITLE
win-dshow: Fix upside-down RGB DIBs

### DIFF
--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -539,8 +539,13 @@ void DShowInput::OnVideoData(const VideoConfig &config, unsigned char *data,
 	frame.format = ConvertVideoFormat(config.format);
 	frame.flip = flip;
 
-	if (config.cy_flip)
-		frame.flip = !frame.flip;
+	/* YUV DIBS are always top-down */
+	if (config.format == VideoFormat::XRGB ||
+	    config.format == VideoFormat::ARGB) {
+		/* RGB DIBs are bottom-up by default */
+		if (!config.cy_flip)
+			frame.flip = !frame.flip;
+	}
 
 	if (videoConfig.format == VideoFormat::XRGB ||
 	    videoConfig.format == VideoFormat::ARGB) {


### PR DESCRIPTION
### Description
Fix regression to RGB DIB orientation caused by #2072.

### Motivation and Context
Re-read MSDN documentation, and saw misinterpretation.

### How Has This Been Tested?
YUY2 and XRGB are both upright on my capture card now.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.