### PR TITLE
image-source: Fix color source default size

### DIFF
--- a/plugins/image-source/color-source.c
+++ b/plugins/image-source/color-source.c
@@ -113,7 +113,7 @@ static void color_source_defaults_v2(obs_data_t *settings)
 
 	obs_data_set_default_int(settings, "color", 0xFFFFFFFF);
 	obs_data_set_default_int(settings, "width", ovi.base_width);
-	obs_data_set_default_int(settings, "height", ovi.base_width);
+	obs_data_set_default_int(settings, "height", ovi.base_height);
 }
 
 struct obs_source_info color_source_info_v1 = {


### PR DESCRIPTION
### Description
The color source default height was set to the canvas width.

### Motivation and Context
Bug fix.

### How Has This Been Tested?
Created color source.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
