### PR TITLE
libobs: Add VIDEO_CS_SRGB enum value

### DIFF
--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -74,6 +74,7 @@ enum video_colorspace {
 	VIDEO_CS_DEFAULT,
 	VIDEO_CS_601,
 	VIDEO_CS_709,
+	VIDEO_CS_SRGB,
 };
 
 enum video_range_type {


### PR DESCRIPTION
### Description
Add VIDEO_CS_SRGB enum value in preparation for sYCC support. Can't PR all at once because of the AMF submodule.

WIP AMF changes: https://github.com/jpark37/obs-amd-encoder/commits/srgb-support
WIP sYCC changes: https://github.com/jpark37/obs-studio/commits/sycc-color-space

### Motivation and Context
Most video applications handle 709 incorrectly and sYCC correctly. We also don't perform color transformation from sRGB to 709, so sRGB is a more accurate TRC to label our videos with.

See RFC for compatibility matrix: https://github.com/obsproject/rfcs/pull/7

### How Has This Been Tested?
OBS compiles and runs without crashing. At this point, it's just an unused enum value.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.