### PR TITLE
audio-monitoring: Fix Pulse Audio crash

### DIFF
--- a/libobs/audio-monitoring/pulse/pulseaudio-wrapper.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-wrapper.c
@@ -48,10 +48,16 @@ void get_default_id(char **id)
 		bzalloc(sizeof(struct pulseaudio_default_output));
 	pulseaudio_get_server_info(
 		(pa_server_info_cb_t)pulseaudio_default_devices, (void *)pdo);
-	*id = bzalloc(strlen(pdo->default_sink_name) + 9);
-	strcat(*id, pdo->default_sink_name);
-	strcat(*id, ".monitor");
-	bfree(pdo->default_sink_name);
+
+	if (!pdo->default_sink_name || !*pdo->default_sink_name) {
+		*id = NULL;
+	} else {
+		*id = bzalloc(strlen(pdo->default_sink_name) + 9);
+		strcat(*id, pdo->default_sink_name);
+		strcat(*id, ".monitor");
+		bfree(pdo->default_sink_name);
+	}
+
 	bfree(pdo);
 	pulseaudio_unref();
 }


### PR DESCRIPTION
### Description
This fixes a crash where the default audio monitoring device would be returned as null. This happens when I build OBS in portable mode on Linux, where the pulse server for some reason can't be connected to. This has only happens to me on Ubuntu 19.10. Audio monitoring still doesn't work here, but at least it doesn't crash anymore.

### Motivation and Context
Fix annoying crash.

### How Has This Been Tested?
Created audio monitoring with default device.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
