### PR TITLE
docs/sphinx: Add obs_group_from_source and obs_enum_scenes

### DIFF
--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -228,6 +228,19 @@ Libobs Objects
 
 ---------------------
 
+.. function:: void obs_enum_scenes(bool (*enum_proc)(void*, obs_source_t*), void *param)
+
+   Enumerates all scenes.
+  
+   Callback function returns true to continue enumeration, or false to end
+   enumeration.
+  
+   Use :c:func:`obs_source_get_ref()` or
+   :c:func:`obs_source_get_weak_source()` if you want to retain a
+   reference after obs_enum_scenes finishes.
+ 
+---------------------
+
 .. function:: void obs_enum_outputs(bool (*enum_proc)(void*, obs_output_t*), void *param)
 
    Enumerates outputs.

--- a/docs/sphinx/reference-scenes.rst
+++ b/docs/sphinx/reference-scenes.rst
@@ -494,6 +494,13 @@ Scene Item Group Functions
 
 ---------------------
 
+.. function:: obs_scene_t *obs_group_from_source(const obs_source_t *source)
+
+   :return: The group context, or *NULL* if not a group.  Does not
+            increase the reference
+
+---------------------
+
 .. function:: bool obs_sceneitem_is_group(obs_sceneitem_t *item)
 
    :param item: Scene item


### PR DESCRIPTION
### Description
Add obs_group_from_source and obs_enum_scenes to the documentation

### Motivation and Context
It is missing from the documentation.

### How Has This Been Tested?


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
