### PR TITLE
libobs: Rename DEPRECATED to OBS_DEPRECATED

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -1309,12 +1309,14 @@ void obs_encoder_packet_create_instance(struct encoder_packet *dst,
 	memcpy(dst->data, src->data, src->size);
 }
 
+/* OBS_DEPRECATED */
 void obs_duplicate_encoder_packet(struct encoder_packet *dst,
 				  const struct encoder_packet *src)
 {
 	obs_encoder_packet_create_instance(dst, src);
 }
 
+/* OBS_DEPRECATED */
 void obs_free_encoder_packet(struct encoder_packet *packet)
 {
 	obs_encoder_packet_release(packet);

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -397,7 +397,7 @@ EXPORT enum obs_group_type obs_property_group_type(obs_property_t *p);
 EXPORT obs_properties_t *obs_property_group_content(obs_property_t *p);
 
 #ifndef SWIG
-DEPRECATED
+OBS_DEPRECATED
 EXPORT enum obs_text_type obs_proprety_text_type(obs_property_t *p);
 #endif
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1656,7 +1656,7 @@ gs_effect_t *obs_get_base_effect(enum obs_base_effect effect)
 	return NULL;
 }
 
-/* DEPRECATED */
+/* OBS_DEPRECATED */
 gs_effect_t *obs_get_default_rect_effect(void)
 {
 	if (!obs)
@@ -1678,6 +1678,7 @@ proc_handler_t *obs_get_proc_handler(void)
 	return obs->procs;
 }
 
+/* OBS_DEPRECATED */
 void obs_render_main_view(void)
 {
 	if (!obs)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -630,7 +630,7 @@ EXPORT gs_effect_t *obs_get_base_effect(enum obs_base_effect effect);
 
 #ifndef SWIG
 /* DEPRECATED: gets texture_rect default effect */
-DEPRECATED
+OBS_DEPRECATED
 EXPORT gs_effect_t *obs_get_default_rect_effect(void);
 #endif
 
@@ -642,7 +642,7 @@ EXPORT proc_handler_t *obs_get_proc_handler(void);
 
 #ifndef SWIG
 /** Renders the main view */
-DEPRECATED
+OBS_DEPRECATED
 EXPORT void obs_render_main_view(void);
 #endif
 
@@ -2037,11 +2037,11 @@ EXPORT uint32_t obs_encoder_get_caps(const obs_encoder_t *encoder);
 
 #ifndef SWIG
 /** Duplicates an encoder packet */
-DEPRECATED
+OBS_DEPRECATED
 EXPORT void obs_duplicate_encoder_packet(struct encoder_packet *dst,
 					 const struct encoder_packet *src);
 
-DEPRECATED
+OBS_DEPRECATED
 EXPORT void obs_free_encoder_packet(struct encoder_packet *packet);
 #endif
 

--- a/libobs/util/c99defs.h
+++ b/libobs/util/c99defs.h
@@ -24,10 +24,10 @@
 #define UNUSED_PARAMETER(param) (void)param
 
 #ifdef _MSC_VER
-#define DEPRECATED __declspec(deprecated)
+#define OBS_DEPRECATED __declspec(deprecated)
 #define FORCE_INLINE __forceinline
 #else
-#define DEPRECATED __attribute__((deprecated))
+#define OBS_DEPRECATED __attribute__((deprecated))
 #define FORCE_INLINE inline __attribute__((always_inline))
 #endif
 


### PR DESCRIPTION
### Description
Rename DEPRECATED to OBS_DEPRECATED to avoid collisions with other libraries that define DEPRECATED.

### Motivation and Context
I use a library in my personal plugin that defines DEPRECATED differently.

### How Has This Been Tested?
Grep'd for all usages of DEPRECATED. Compiles without warning.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.