### PR TITLE
UI: Fix Qt 5.14 deprecation warnings

### DIFF
--- a/UI/frontend-plugins/frontend-tools/output-timer.cpp
+++ b/UI/frontend-plugins/frontend-tools/output-timer.cpp
@@ -180,8 +180,8 @@ void OutputTimer::UpdateStreamTimerDisplay()
 	int minutes = (remainingTime % 3600) / 60;
 	int hours = remainingTime / 3600;
 
-	QString text;
-	text.sprintf("%02d:%02d:%02d", hours, minutes, seconds);
+	QString text =
+		QString::asprintf("%02d:%02d:%02d", hours, minutes, seconds);
 	ui->streamTime->setText(text);
 }
 
@@ -199,8 +199,8 @@ void OutputTimer::UpdateRecordTimerDisplay()
 	int minutes = (remainingTime % 3600) / 60;
 	int hours = remainingTime / 3600;
 
-	QString text;
-	text.sprintf("%02d:%02d:%02d", hours, minutes, seconds);
+	QString text =
+		QString::asprintf("%02d:%02d:%02d", hours, minutes, seconds);
 	ui->recordTime->setText(text);
 }
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -898,7 +898,7 @@ void OBSBasicSettings::LoadFormats()
 					audio ? AUDIO_STR : VIDEO_STR);
 
 			ui->advOutFFFormat->addItem(
-				itemText, qVariantFromValue(formatDesc));
+				itemText, QVariant::fromValue(formatDesc));
 		}
 
 		format = ff_format_desc_next(format);
@@ -921,7 +921,7 @@ static void AddCodec(QComboBox *combo, const ff_codec_desc *codec_desc)
 	CodecDesc cd(ff_codec_desc_name(codec_desc),
 		     ff_codec_desc_id(codec_desc));
 
-	combo->addItem(itemText, qVariantFromValue(cd));
+	combo->addItem(itemText, QVariant::fromValue(cd));
 }
 
 #define AV_ENCODER_DEFAULT_STR \
@@ -937,7 +937,7 @@ static void AddDefaultCodec(QComboBox *combo, const ff_format_desc *formatDesc,
 		combo->removeItem(existingIdx);
 
 	combo->addItem(QString("%1 (%2)").arg(cd.name, AV_ENCODER_DEFAULT_STR),
-		       qVariantFromValue(cd));
+		       QVariant::fromValue(cd));
 }
 
 #define AV_ENCODER_DISABLE_STR \
@@ -984,7 +984,7 @@ void OBSBasicSettings::ReloadCodecs(const ff_format_desc *formatDesc)
 	ui->advOutFFAEncoder->model()->sort(0);
 	ui->advOutFFVEncoder->model()->sort(0);
 
-	QVariant disable = qVariantFromValue(CodecDesc());
+	QVariant disable = QVariant::fromValue(CodecDesc());
 
 	ui->advOutFFAEncoder->insertItem(0, AV_ENCODER_DISABLE_STR, disable);
 	ui->advOutFFVEncoder->insertItem(0, AV_ENCODER_DISABLE_STR, disable);

--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -437,9 +437,9 @@ void OBSBasicStats::RecordingTimeLeft()
 	int minutes = totalMinutes % 60;
 	int hours = totalMinutes / 60;
 
-	QString text;
-	text.sprintf("%d %s, %d %s", hours, QT_TO_UTF8(QTStr("Hours")), minutes,
-		     QT_TO_UTF8(QTStr("Minutes")));
+	QString text = QString::asprintf("%d %s, %d %s", hours,
+					 QT_TO_UTF8(QTStr("Hours")), minutes,
+					 QT_TO_UTF8(QTStr("Minutes")));
 	recordTimeLeft->setText(text);
 	recordTimeLeft->setMinimumWidth(recordTimeLeft->width());
 }

--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -215,8 +215,8 @@ void OBSBasicStatusBar::UpdateStreamTime()
 	int minutes = totalMinutes % 60;
 	int hours = totalMinutes / 60;
 
-	QString text;
-	text.sprintf("LIVE: %02d:%02d:%02d", hours, minutes, seconds);
+	QString text = QString::asprintf("LIVE: %02d:%02d:%02d", hours, minutes,
+					 seconds);
 	streamTime->setText(text);
 	streamTime->setMinimumWidth(streamTime->width());
 
@@ -260,7 +260,8 @@ void OBSBasicStatusBar::UpdateRecordTime()
 		int minutes = totalMinutes % 60;
 		int hours = totalMinutes / 60;
 
-		text.sprintf("REC: %02d:%02d:%02d", hours, minutes, seconds);
+		text = QString::asprintf("REC: %02d:%02d:%02d", hours, minutes,
+					 seconds);
 	}
 
 	recordTime->setText(text);


### PR DESCRIPTION
### Description
Replace QString sprintf member function with non-member asprintf, and qVariantFromValue with QVariant::fromValue.

### Motivation and Context
Clean up build output.

### How Has This Been Tested?
Tested one of the asprintf replacements to validate the pattern. qVariantFromValue itself is implemented as QVariant::fromValue, so that's unlikely to fail, but I verified the FFmpeg advanced settings still work.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.