### PR TITLE
libobs, obs-x264: Fix compiler warnings

### DIFF
--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -177,7 +177,8 @@ static inline const char *get_video_colorspace_name(enum video_colorspace cs)
 	case VIDEO_CS_709:
 		return "709";
 	case VIDEO_CS_601:
-	case VIDEO_CS_DEFAULT:;
+	case VIDEO_CS_DEFAULT:
+	case VIDEO_CS_SRGB:;
 	}
 
 	return "601";

--- a/libobs/media-io/video-scaler-ffmpeg.c
+++ b/libobs/media-io/video-scaler-ffmpeg.c
@@ -94,9 +94,9 @@ static inline const int *get_ffmpeg_coeffs(enum video_colorspace cs)
 		return sws_getCoefficients(SWS_CS_ITU601);
 	case VIDEO_CS_709:
 		return sws_getCoefficients(SWS_CS_ITU709);
+	default:
+		return sws_getCoefficients(SWS_CS_ITU601);
 	}
-
-	return sws_getCoefficients(SWS_CS_ITU601);
 }
 
 static inline int get_ffmpeg_range_type(enum video_range_type type)

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -367,6 +367,7 @@ static inline const char *get_x264_colorspace_name(enum video_colorspace cs)
 	switch (cs) {
 	case VIDEO_CS_DEFAULT:
 	case VIDEO_CS_601:
+	case VIDEO_CS_SRGB:
 		return "undef";
 	case VIDEO_CS_709:;
 	}


### PR DESCRIPTION
# Description
Fixes enum not handled in case switch.

### Motivation and Context
Compiler warnings are annoying.

### How Has This Been Tested?
Compiled program.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
