### PR TITLE
rtmp-services: Add Uscreen

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 121,
+	"version": 122,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 121
+			"version": 122
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1055,6 +1055,15 @@
             }
         },
         {
+            "name": "Uscreen",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://live.uscreen.app/app"
+                }
+            ]
+        },
+        {
             "name": "Picarto",
             "servers": [
                 {


### PR DESCRIPTION
### Description
Added Uscreen to the list of steaming services. Uscreen which is a new VOD platform with Live Steaming support https://www.uscreen.tv/live-streaming-platform/

### Types of changes
New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
