### PR TITLE
UI: Fix aspect ratio triggering settings change

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -247,6 +247,25 @@ static void PopulateAACBitrates(initializer_list<QComboBox *> boxes)
 	}
 }
 
+static int gcd(int a, int b)
+{
+	return b == 0 ? a : gcd(b, a % b);
+}
+
+static std::tuple<int, int> aspect_ratio(int cx, int cy)
+{
+	int common = gcd(cx, cy);
+	int newCX = cx / common;
+	int newCY = cy / common;
+
+	if (newCX == 8 && newCY == 5) {
+		newCX = 16;
+		newCY = 10;
+	}
+
+	return std::make_tuple(newCX, newCY);
+}
+
 void RestrictResetBitrates(initializer_list<QComboBox *> boxes, int maxbitrate);
 
 void OBSBasicSettings::HookWidget(QWidget *widget, const char *signal,
@@ -759,8 +778,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	SimpleRecordingQualityChanged();
 
 	UpdateAutomaticReplayBufferCheckboxes();
-
-	on_baseResolution_editTextChanged(ui->baseResolution->currentText());
 
 	App()->DisableHotkeys();
 
@@ -1406,6 +1423,13 @@ void OBSBasicSettings::LoadResolutionLists()
 	ResetDownscales(cx, cy);
 
 	ui->outputResolution->lineEdit()->setText(outputResString.c_str());
+
+	std::tuple<int, int> aspect = aspect_ratio(cx, cy);
+
+	ui->baseAspect->setText(
+		QTStr("AspectRatio")
+			.arg(QString::number(std::get<0>(aspect)),
+			     QString::number(std::get<1>(aspect))));
 }
 
 static inline void LoadFPSCommon(OBSBasic *main, Ui::OBSBasicSettings *ui)
@@ -3751,25 +3775,6 @@ static bool ValidResolutions(Ui::OBSBasicSettings *ui)
 
 	ui->videoMsg->setText("");
 	return true;
-}
-
-static int gcd(int a, int b)
-{
-	return b == 0 ? a : gcd(b, a % b);
-}
-
-static std::tuple<int, int> aspect_ratio(int cx, int cy)
-{
-	int common = gcd(cx, cy);
-	int newCX = cx / common;
-	int newCY = cy / common;
-
-	if (newCX == 8 && newCY == 5) {
-		newCX = 16;
-		newCY = 10;
-	}
-
-	return std::make_tuple(newCX, newCY);
 }
 
 void OBSBasicSettings::RecalcOutputResPixels(const char *resText)


### PR DESCRIPTION
### Description
This fixes an issue where loading the aspect ratio would cause the settings to change, causing the Apply button to be enabled.

### Motivation and Context
Bug mentioned on Discord by @jpark37

### How Has This Been Tested?
Opened settings.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
