### PR TITLE
UI: Fix crash when entering large resolutions

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -95,6 +95,11 @@ struct CodecDesc {
 Q_DECLARE_METATYPE(FormatDesc)
 Q_DECLARE_METATYPE(CodecDesc)
 
+static inline bool ResTooHigh(uint32_t cx, uint32_t cy)
+{
+	return cx > 16384 || cy > 16384;
+}
+
 /* parses "[width]x[height]", string, i.e. 1024x768 */
 static bool ConvertResText(const char *res, uint32_t &cx, uint32_t &cy)
 {
@@ -128,6 +133,11 @@ static bool ConvertResText(const char *res, uint32_t &cx, uint32_t &cy)
 	/* shouldn't be any more tokens after this */
 	if (lexer_getbasetoken(lex, &token, IGNORE_WHITESPACE))
 		return false;
+
+	if (ResTooHigh(cx, cy)) {
+		cx = cy = 0;
+		return false;
+	}
 
 	return true;
 }


### PR DESCRIPTION
### Description
Fixes crash when entering very high numbers in the resolution line edits. I've now set the max lengths of the line edits to 9. Resolutions up to 9999x9999 can be entered.

### Motivation and Context
https://github.com/obsproject/obs-studio/issues/2343

### How Has This Been Tested?
Entered resolutions.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
