### PR TITLE
Set stinger media source's name

### DIFF
--- a/plugins/obs-transitions/transition-stinger.c
+++ b/plugins/obs-transitions/transition-stinger.c
@@ -1,4 +1,5 @@
 #include <obs-module.h>
+#include <util/dstr.h>
 
 #define TIMING_TIME 0
 #define TIMING_FRAME 1
@@ -46,8 +47,12 @@ static void stinger_update(void *data, obs_data_t *settings)
 	obs_data_set_string(media_settings, "local_file", path);
 
 	obs_source_release(s->media_source);
-	s->media_source = obs_source_create_private("ffmpeg_source", NULL,
+	struct dstr name;
+	dstr_init_copy(&name, obs_source_get_name(s->source));
+	dstr_cat(&name, " (Stinger)");
+	s->media_source = obs_source_create_private("ffmpeg_source", name.array,
 						    media_settings);
+	dstr_free(&name);
 	obs_data_release(media_settings);
 
 	int64_t point = obs_data_get_int(settings, "transition_point");


### PR DESCRIPTION
### Description
Populates the name of a stinger transition's media source to the name of the stinger itself.

### Motivation and Context
Occasionally when audio buffering is added and it's caused by a stinger, the log will not specify which stinger it's from - it'll instead say (null). This ensures the name will be displayed in such a scenario, which will help the user track down the issue.

### How Has This Been Tested?

Added a stinger transition, and checked the log to ensure the media source is named.
```
[Media Source 'MyCustomStinger']: settings:
    input:                   D:/User/Documents/OBS/Transition_Purple_wAudio.webm
```

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
