### PR TITLE
Add ability to control transition volume

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -139,6 +139,8 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	balance->setTickPosition(QSlider::TicksAbove);
 	balance->setTickInterval(50);
 
+	enum obs_source_type type = obs_source_get_type(source);
+
 	const char *speakers =
 		config_get_string(main->Config(), "Audio", "ChannelSetup");
 
@@ -168,6 +170,8 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	int mt = (int)obs_source_get_monitoring_type(source);
 	idx = monitoringType->findData(mt);
 	monitoringType->setCurrentIndex(idx);
+	if (type == OBS_SOURCE_TYPE_TRANSITION)
+		monitoringType->setDisabled(true);
 #endif
 
 	mixer1->setText("1");
@@ -192,12 +196,14 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 		balanceContainer->setMaximumWidth(170);
 	}
 
-	mixerContainer->layout()->addWidget(mixer1);
-	mixerContainer->layout()->addWidget(mixer2);
-	mixerContainer->layout()->addWidget(mixer3);
-	mixerContainer->layout()->addWidget(mixer4);
-	mixerContainer->layout()->addWidget(mixer5);
-	mixerContainer->layout()->addWidget(mixer6);
+	if (type != OBS_SOURCE_TYPE_TRANSITION) {
+		mixerContainer->layout()->addWidget(mixer1);
+		mixerContainer->layout()->addWidget(mixer2);
+		mixerContainer->layout()->addWidget(mixer3);
+		mixerContainer->layout()->addWidget(mixer4);
+		mixerContainer->layout()->addWidget(mixer5);
+		mixerContainer->layout()->addWidget(mixer6);
+	}
 
 	QWidget::connect(volume, SIGNAL(valueChanged(double)), this,
 			 SLOT(volumeChanged(double)));

--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -119,6 +119,9 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 
 	/* enum user scene/sources */
 	obs_enum_sources(EnumSources, this);
+	obs_source_t *tr = obs_frontend_get_current_transition();
+	EnumSources(this, tr);
+	obs_source_release(tr);
 
 	resize(1100, 340);
 	setWindowTitle(QTStr("Basic.AdvAudio"));
@@ -147,8 +150,10 @@ bool OBSBasicAdvAudio::EnumSources(void *param, obs_source_t *source)
 {
 	OBSBasicAdvAudio *dialog = reinterpret_cast<OBSBasicAdvAudio *>(param);
 	uint32_t flags = obs_source_get_output_flags(source);
+	enum obs_source_type type = obs_source_get_type(source);
+	bool showAnyway = type == OBS_SOURCE_TYPE_TRANSITION;
 
-	if ((flags & OBS_SOURCE_AUDIO) != 0 &&
+	if (((flags & OBS_SOURCE_AUDIO) != 0 || showAnyway) &&
 	    (dialog->showInactive || obs_source_active(source)))
 		dialog->AddAudioSource(source);
 
@@ -252,6 +257,9 @@ void OBSBasicAdvAudio::SetShowInactive(bool show)
 					    this);
 
 		obs_enum_sources(EnumSources, this);
+		obs_source_t *tr = obs_frontend_get_current_transition();
+		EnumSources(this, tr);
+		obs_source_release(tr);
 
 		SetIconsVisible(showVisible);
 	} else {


### PR DESCRIPTION
### Description
This adds the current transition to the "Advanced Audio Properties" (AAP) dialog.
This adds the ability to 
* set the volume 
* set the transition to mono
* set the sync offset
* see (not set) the monitoring status

![Advanced Audio Properties with Stinger](http://scr.wzd.li/scr/2020-01-25_19-22-52.png)

Questions/unknowns **(feedback needed!)**:
* [x] ~~Should Sync Offset also be modifiable? This should be relatively easy & would be consistent with other sources, I'm just not sure it's needed.~~
* [ ] Should this be hardcoded to only work for Stingers, or is there a better way to determine if it is a transition that supports audio? Currently it'll show the active transition, regardless of whether it supports audio.
* [ ] Currently I hide the Tracks section. Is it worth providing track selection capabilities for a stinger, allowing for more control & a cleaner recorded feed?
* [ ] Only the active transition is listed. Would it be worth listing all non-active transitions too? May be dependent on detecting audio capability of each transition to avoid clogging up the list.
* [ ] Would it be worth adding a monitoring signal that'd allow for changing the stinger's monitoring device from within Advanced Audio Properties? Once possible, would it be worth phasing out the property?
* [ ] Should "Preview Transition" respect the selected volume, as it does the monitoring mode?

Known issues (potentially not actual issues)
* [ ] If both Advanced Audio Properties and a stinger's Properties window are open at the same time, modifying and saving the monitoring properties does not update the AAP list. As far as I can tell, there's no real solution for this.
* [ ] I have been able to cause a crash on shutdown once. Not sure how/why, as I've been unable to reproduce it.

### Motivation and Context
Stinger transitions usually contain audio. However, there is no way within OBS to set their volume, as they're not within a scene. This exposes that capability, while also adding a couple other enhancements.

### How Has This Been Tested?
* Add a Stinger to your scene collection and configure it
* Enable monitoring for the stinger
* Run the stinger once by switching scenes
* Change the volume in AAP
* Run the stinger again, notice the volume has changed

Download the [build artifacts](https://dev.azure.com/obsjim/1437b187-9c54-400d-a378-3dff67a18804/_apis/build/builds/2453/artifacts?artifactName=winbuild&api-version=5.1&%24format=zip).

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
