### PR TITLE
UI: Some settings changes

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -5408,7 +5408,7 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -482,10 +482,8 @@ void OBSBasicSettings::OnAuthConnected()
 		OnOAuthStreamKeyConnected();
 	}
 
-	if (!loading) {
+	if (!loading)
 		stream1Changed = true;
-		EnableApplyButton(true);
-	}
 }
 
 void OBSBasicSettings::on_connectAccount_clicked()

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -795,6 +795,16 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	QValidator *validator = new QRegExpValidator(rx, this);
 	ui->baseResolution->lineEdit()->setValidator(validator);
 	ui->outputResolution->lineEdit()->setValidator(validator);
+
+	QAction *action = new QAction(this);
+	action->setShortcut(Qt::Key_Escape);
+	ui->generalPage->addAction(action);
+	ui->outputPage->addAction(action);
+	ui->streamPage->addAction(action);
+	ui->audioPage->addAction(action);
+	ui->videoPage->addAction(action);
+	ui->advancedPage->addAction(action);
+	connect(action, SIGNAL(triggered()), this, SLOT(EscapeTriggered()));
 }
 
 OBSBasicSettings::~OBSBasicSettings()
@@ -805,6 +815,11 @@ OBSBasicSettings::~OBSBasicSettings()
 	App()->UpdateHotkeyFocusSetting();
 
 	EnableThreadedMessageBoxes(false);
+}
+
+void OBSBasicSettings::EscapeTriggered()
+{
+	close();
 }
 
 void OBSBasicSettings::SaveCombo(QComboBox *widget, const char *section,
@@ -3519,7 +3534,8 @@ bool OBSBasicSettings::QueryChanges()
 	button = OBSMessageBox::question(
 		this, QTStr("Basic.Settings.ConfirmTitle"),
 		QTStr("Basic.Settings.Confirm"),
-		QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+		QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
+		QMessageBox::Yes);
 
 	if (button == QMessageBox::Cancel) {
 		return false;

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -623,9 +623,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	connect(ui->advOutTrack6Bitrate, SIGNAL(currentIndexChanged(int)), this,
 		SLOT(UpdateStreamDelayEstimate()));
 
-	//Apply button disabled until change.
-	EnableApplyButton(false);
-
 	// Initialize libff library
 	ff_init();
 
@@ -782,7 +779,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 		SLOT(AdvOutRecCheckWarnings()));
 	AdvOutRecCheckWarnings();
 
-	ui->buttonBox->button(QDialogButtonBox::Apply)->setIcon(QIcon());
 	ui->buttonBox->button(QDialogButtonBox::Ok)->setIcon(QIcon());
 	ui->buttonBox->button(QDialogButtonBox::Cancel)->setIcon(QIcon());
 
@@ -3582,8 +3578,7 @@ void OBSBasicSettings::on_buttonBox_clicked(QAbstractButton *button)
 {
 	QDialogButtonBox::ButtonRole val = ui->buttonBox->buttonRole(button);
 
-	if (val == QDialogButtonBox::ApplyRole ||
-	    val == QDialogButtonBox::AcceptRole) {
+	if (val == QDialogButtonBox::AcceptRole) {
 		SaveSettings();
 		ClearChanged();
 	}
@@ -3865,7 +3860,6 @@ void OBSBasicSettings::GeneralChanged()
 	if (!loading) {
 		generalChanged = true;
 		sender()->setProperty("changed", QVariant(true));
-		EnableApplyButton(true);
 	}
 }
 
@@ -3874,7 +3868,6 @@ void OBSBasicSettings::Stream1Changed()
 	if (!loading) {
 		stream1Changed = true;
 		sender()->setProperty("changed", QVariant(true));
-		EnableApplyButton(true);
 	}
 }
 
@@ -3883,7 +3876,6 @@ void OBSBasicSettings::OutputsChanged()
 	if (!loading) {
 		outputsChanged = true;
 		sender()->setProperty("changed", QVariant(true));
-		EnableApplyButton(true);
 	}
 }
 
@@ -3892,7 +3884,6 @@ void OBSBasicSettings::AudioChanged()
 	if (!loading) {
 		audioChanged = true;
 		sender()->setProperty("changed", QVariant(true));
-		EnableApplyButton(true);
 	}
 }
 
@@ -3908,12 +3899,10 @@ void OBSBasicSettings::AudioChangedRestart()
 			ui->audioMsg->setText(
 				QTStr("Basic.Settings.ProgramRestart"));
 			sender()->setProperty("changed", QVariant(true));
-			EnableApplyButton(true);
 		} else {
 			audioChanged = false;
 			ui->audioMsg->setText("");
 			sender()->setProperty("changed", QVariant(false));
-			EnableApplyButton(false);
 		}
 	}
 }
@@ -4004,7 +3993,6 @@ void OBSBasicSettings::VideoChangedRestart()
 		videoChanged = true;
 		ui->videoMsg->setText(QTStr("Basic.Settings.ProgramRestart"));
 		sender()->setProperty("changed", QVariant(true));
-		EnableApplyButton(true);
 	}
 }
 
@@ -4015,7 +4003,6 @@ void OBSBasicSettings::AdvancedChangedRestart()
 		ui->advancedMsg->setText(
 			QTStr("Basic.Settings.ProgramRestart"));
 		sender()->setProperty("changed", QVariant(true));
-		EnableApplyButton(true);
 	}
 }
 
@@ -4024,7 +4011,6 @@ void OBSBasicSettings::VideoChangedResolution()
 	if (!loading && ValidResolutions(ui.get())) {
 		videoChanged = true;
 		sender()->setProperty("changed", QVariant(true));
-		EnableApplyButton(true);
 	}
 }
 
@@ -4033,7 +4019,6 @@ void OBSBasicSettings::VideoChanged()
 	if (!loading) {
 		videoChanged = true;
 		sender()->setProperty("changed", QVariant(true));
-		EnableApplyButton(true);
 	}
 }
 
@@ -4049,9 +4034,6 @@ void OBSBasicSettings::HotkeysChanged()
 			       const auto &hw = *hotkey.second;
 			       return hw.Changed();
 		       });
-
-	if (hotkeysChanged)
-		EnableApplyButton(true);
 }
 
 void OBSBasicSettings::ReloadHotkeys(obs_hotkey_id ignoreKey)
@@ -4064,7 +4046,6 @@ void OBSBasicSettings::AdvancedChanged()
 	if (!loading) {
 		advancedChanged = true;
 		sender()->setProperty("changed", QVariant(true));
-		EnableApplyButton(true);
 	}
 }
 

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -177,11 +177,6 @@ private:
 		       hotkeysChanged;
 	}
 
-	inline void EnableApplyButton(bool en)
-	{
-		ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(en);
-	}
-
 	inline void ClearChanged()
 	{
 		generalChanged = false;
@@ -191,7 +186,6 @@ private:
 		videoChanged = false;
 		hotkeysChanged = false;
 		advancedChanged = false;
-		EnableApplyButton(false);
 	}
 
 #ifdef _WIN32

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -237,6 +237,7 @@ private slots:
 	void on_disconnectAccount_clicked();
 	void on_useStreamKey_clicked();
 	void on_useAuth_toggled();
+	void EscapeTriggered();
 
 private:
 	/* output */


### PR DESCRIPTION
### Description

Changes:
- Remove the apply button (the settings are saved anyway when the dialog is closed, so is it necessary?)
- Close settings when escape is pressed (convenience for users)
- Users can still set the esc button as a hotkey

### Motivation and Context
Streamlining settings.

### How Has This Been Tested?
Changed settings. Settings saved correctly.

### Types of changes
- New feature (non-breaking change which adds functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
