### PR TITLE
Color space refinements

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -4824,6 +4824,11 @@
                       <widget class="QComboBox" name="colorSpace">
                        <item>
                         <property name="text">
+                         <string notr="true">sRGB</string>
+                        </property>
+                       </item>
+                       <item>
+                        <property name="text">
                          <string notr="true">709</string>
                         </property>
                        </item>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3760,8 +3760,11 @@ int OBSBasic::ResetVideo()
 	ovi.output_height =
 		(uint32_t)config_get_uint(basicConfig, "Video", "OutputCY");
 	ovi.output_format = GetVideoFormatFromName(colorFormat);
-	ovi.colorspace = astrcmpi(colorSpace, "601") == 0 ? VIDEO_CS_601
-							  : VIDEO_CS_709;
+	ovi.colorspace = astrcmpi(colorSpace, "601") == 0
+				 ? VIDEO_CS_601
+				 : (astrcmpi(colorSpace, "709") == 0
+					    ? VIDEO_CS_709
+					    : VIDEO_CS_SRGB);
 	ovi.range = astrcmpi(colorRange, "Full") == 0 ? VIDEO_RANGE_FULL
 						      : VIDEO_RANGE_PARTIAL;
 	ovi.adapter =

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1383,7 +1383,7 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_uint(basicConfig, "Video", "FPSDen", 1);
 	config_set_default_string(basicConfig, "Video", "ScaleType", "bicubic");
 	config_set_default_string(basicConfig, "Video", "ColorFormat", "NV12");
-	config_set_default_string(basicConfig, "Video", "ColorSpace", "601");
+	config_set_default_string(basicConfig, "Video", "ColorSpace", "sRGB");
 	config_set_default_string(basicConfig, "Video", "ColorRange",
 				  "Partial");
 

--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -109,9 +109,15 @@ static inline enum speaker_layout convert_speaker_layout(uint8_t channels)
 	}
 }
 
-static inline enum video_colorspace convert_color_space(enum AVColorSpace s)
+static inline enum video_colorspace
+convert_color_space(enum AVColorSpace s, enum AVColorTransferCharacteristic trc)
 {
-	return s == AVCOL_SPC_BT709 ? VIDEO_CS_709 : VIDEO_CS_DEFAULT;
+	if (s == AVCOL_SPC_BT709) {
+		return (trc == AVCOL_TRC_IEC61966_2_1) ? VIDEO_CS_SRGB
+						       : VIDEO_CS_709;
+	}
+
+	return VIDEO_CS_DEFAULT;
 }
 
 static inline enum video_range_type convert_color_range(enum AVColorRange r)
@@ -365,7 +371,7 @@ static void mp_media_next_video(mp_media_t *m, bool preload)
 		frame->data[0] -= frame->linesize[0] * (f->height - 1);
 
 	new_format = convert_pixel_format(m->scale_format);
-	new_space = convert_color_space(f->colorspace);
+	new_space = convert_color_space(f->colorspace, f->color_trc);
 	new_range = m->force_range == VIDEO_RANGE_DEFAULT
 			    ? convert_color_range(f->color_range)
 			    : m->force_range;

--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -176,9 +176,10 @@ static inline const char *get_video_colorspace_name(enum video_colorspace cs)
 	switch (cs) {
 	case VIDEO_CS_709:
 		return "709";
+	case VIDEO_CS_SRGB:
+		return "sRGB";
 	case VIDEO_CS_601:
-	case VIDEO_CS_DEFAULT:
-	case VIDEO_CS_SRGB:;
+	case VIDEO_CS_DEFAULT:;
 	}
 
 	return "601";

--- a/libobs/media-io/video-matrices.c
+++ b/libobs/media-io/video-matrices.c
@@ -173,6 +173,8 @@ bool video_format_get_parameters(enum video_colorspace color_space,
 #endif
 	if (color_space == VIDEO_CS_DEFAULT)
 		color_space = VIDEO_CS_601;
+	else if (color_space == VIDEO_CS_SRGB)
+		color_space = VIDEO_CS_709;
 
 	for (size_t i = 0; i < NUM_FORMATS; i++) {
 		if (format_info[i].color_space != color_space)

--- a/libobs/media-io/video-scaler-ffmpeg.c
+++ b/libobs/media-io/video-scaler-ffmpeg.c
@@ -92,12 +92,11 @@ static inline int get_ffmpeg_scale_type(enum video_scale_type type)
 static inline const int *get_ffmpeg_coeffs(enum video_colorspace cs)
 {
 	switch (cs) {
-	case VIDEO_CS_DEFAULT:
-		return sws_getCoefficients(SWS_CS_ITU601);
-	case VIDEO_CS_601:
-		return sws_getCoefficients(SWS_CS_ITU601);
 	case VIDEO_CS_709:
+	case VIDEO_CS_SRGB:
 		return sws_getCoefficients(SWS_CS_ITU709);
+	case VIDEO_CS_DEFAULT:
+	case VIDEO_CS_601:
 	default:
 		return sws_getCoefficients(SWS_CS_ITU601);
 	}

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -79,6 +79,10 @@ struct main_params {
 	int height;
 	int fps_num;
 	int fps_den;
+	int color_primaries;
+	int color_trc;
+	int colorspace;
+	int color_range;
 	char *acodec;
 	char *muxer_settings;
 };
@@ -249,6 +253,18 @@ static bool init_params(int *argc, char ***argv, struct main_params *params,
 			return false;
 		if (!get_opt_int(argc, argv, &params->height, "video height"))
 			return false;
+		if (!get_opt_int(argc, argv, &params->color_primaries,
+				 "video color primaries"))
+			return false;
+		if (!get_opt_int(argc, argv, &params->color_trc,
+				 "video color trc"))
+			return false;
+		if (!get_opt_int(argc, argv, &params->colorspace,
+				 "video colorspace"))
+			return false;
+		if (!get_opt_int(argc, argv, &params->color_range,
+				 "video color range"))
+			return false;
 		if (!get_opt_int(argc, argv, &params->fps_num, "video fps num"))
 			return false;
 		if (!get_opt_int(argc, argv, &params->fps_den, "video fps den"))
@@ -327,6 +343,10 @@ static void create_video_stream(struct ffmpeg_mux *ffm)
 	context->height = ffm->params.height;
 	context->coded_width = ffm->params.width;
 	context->coded_height = ffm->params.height;
+	context->color_primaries = ffm->params.color_primaries;
+	context->color_trc = ffm->params.color_trc;
+	context->colorspace = ffm->params.colorspace;
+	context->color_range = ffm->params.color_range;
 	context->extradata = extradata;
 	context->extradata_size = ffm->video_header.size;
 	context->time_base =

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -429,9 +429,25 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 	vui_params->videoSignalTypePresentFlag = 1;
 	vui_params->videoFullRangeFlag = (voi->range == VIDEO_RANGE_FULL);
 	vui_params->colourDescriptionPresentFlag = 1;
-	vui_params->colourMatrix = (voi->colorspace == VIDEO_CS_709) ? 1 : 5;
-	vui_params->colourPrimaries = 1;
-	vui_params->transferCharacteristics = 1;
+
+	switch (voi->colorspace) {
+	case VIDEO_CS_DEFAULT:
+	case VIDEO_CS_601:
+		vui_params->colourPrimaries = 6;
+		vui_params->transferCharacteristics = 6;
+		vui_params->colourMatrix = 6;
+		break;
+	case VIDEO_CS_709:
+		vui_params->colourPrimaries = 1;
+		vui_params->transferCharacteristics = 1;
+		vui_params->colourMatrix = 1;
+		break;
+	case VIDEO_CS_SRGB:
+		vui_params->colourPrimaries = 1;
+		vui_params->transferCharacteristics = 13;
+		vui_params->colourMatrix = 1;
+		break;
+	}
 
 	enc->bframes = bf > 0;
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -235,13 +235,29 @@ static bool nvenc_update(void *data, obs_data_t *settings)
 	enc->context->height = obs_encoder_get_height(enc->encoder);
 	enc->context->time_base = (AVRational){voi->fps_den, voi->fps_num};
 	enc->context->pix_fmt = obs_to_ffmpeg_video_format(info.format);
-	enc->context->colorspace = info.colorspace == VIDEO_CS_709
-					   ? AVCOL_SPC_BT709
-					   : AVCOL_SPC_BT470BG;
 	enc->context->color_range = info.range == VIDEO_RANGE_FULL
 					    ? AVCOL_RANGE_JPEG
 					    : AVCOL_RANGE_MPEG;
 	enc->context->max_b_frames = bf;
+
+	switch (info.colorspace) {
+	case VIDEO_CS_DEFAULT:
+	case VIDEO_CS_601:
+		enc->context->color_trc = AVCOL_TRC_SMPTE170M;
+		enc->context->color_primaries = AVCOL_PRI_SMPTE170M;
+		enc->context->colorspace = AVCOL_SPC_SMPTE170M;
+		break;
+	case VIDEO_CS_709:
+		enc->context->color_trc = AVCOL_TRC_BT709;
+		enc->context->color_primaries = AVCOL_PRI_BT709;
+		enc->context->colorspace = AVCOL_SPC_BT709;
+		break;
+	case VIDEO_CS_SRGB:
+		enc->context->color_trc = AVCOL_TRC_IEC61966_2_1;
+		enc->context->color_primaries = AVCOL_PRI_BT709;
+		enc->context->colorspace = AVCOL_SPC_BT709;
+		break;
+	}
 
 	if (keyint_sec)
 		enc->context->gop_size =

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.h
@@ -23,7 +23,9 @@ struct ffmpeg_cfg {
 	int audio_tracks;
 	enum AVPixelFormat format;
 	enum AVColorRange color_range;
-	enum AVColorSpace color_space;
+	enum AVColorPrimaries color_primaries;
+	enum AVColorTransferCharacteristic color_trc;
+	enum AVColorSpace colorspace;
 	int scale_width;
 	int scale_height;
 	int width;


### PR DESCRIPTION
### Description
Several changes:

- Solidify support for sRGB video format.
- Add color metadata to file containers for playback libraries that ignore the metadata in the video stream.
- Base 601 support around SMPTE 170M, which is the expected definition of 601 for applications such as Chromium.
- Switch default video format from 601 to sRGB.

Based on this RFC: https://github.com/obsproject/rfcs/pull/7

### Motivation and Context
709/1886 is a weird pair, and most PC applications are sRGB, so make sRGB the default video color space for simplicity.

Chrome on Mac using sRGB is straightforward, whereas midtones are raised for 709, which may not have been desired.

Android ExoPlayer library is known to look at container metadata and not stream metadata for playback.

### How Has This Been Tested?
Inspected all diffs with debugger breakpoints. Various 601/709/sRGB files and streams were tested for the RFC.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.