### PR TITLE
UI: Use input validator on resolution line edit

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -793,6 +793,11 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 
 	channelIndex = ui->channelSetup->currentIndex();
 	sampleRateIndex = ui->sampleRate->currentIndex();
+
+	QRegExp rx("\\d{1,5}x\\d{1,5}");
+	QValidator *validator = new QRegExpValidator(rx, this);
+	ui->baseResolution->lineEdit()->setValidator(validator);
+	ui->outputResolution->lineEdit()->setValidator(validator);
 }
 
 OBSBasicSettings::~OBSBasicSettings()


### PR DESCRIPTION
### Description
Fix crash in resolution line edit.

### Motivation and Context
While https://github.com/obsproject/obs-studio/commit/818e3a364e5873e5e1cdb18dddf91733cf8dec83 prevents users from using large resolutions, a crash will still happen if 9999999999999999999 was put in as the resolution, for example.

### How Has This Been Tested?
Entered resolutions.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
