### PR TITLE
UI: Fix transtions not enabled

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1413,6 +1413,8 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		if (!previewEnabled)
 			EnablePreviewDisplay(false);
 
+		ui->transitions->setEnabled(true);
+
 		if (api)
 			api->on_event(OBS_FRONTEND_EVENT_STUDIO_MODE_DISABLED);
 


### PR DESCRIPTION
### Description
If a user is in a middle of a transition and exits studio mode, the transitions wouldn't be re-enabled.

### Motivation and Context
Fixing bugs.

### How Has This Been Tested?
Exited studio mode while using transition.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
