### PR TITLE
obs-transitions: Halve stinger padding to 250ms

### DIFF
--- a/plugins/obs-transitions/transition-stinger.c
+++ b/plugins/obs-transitions/transition-stinger.c
@@ -231,7 +231,7 @@ static void stinger_transition_start(void *data)
 		proc_handler_call(ph, "get_duration", &cd);
 		proc_handler_call(ph, "get_nb_frames", &cd);
 		s->duration_ns =
-			(uint64_t)calldata_int(&cd, "duration") + 500000000ULL;
+			(uint64_t)calldata_int(&cd, "duration") + 250000000ULL;
 		s->duration_frames = (uint64_t)calldata_int(&cd, "num_frames");
 
 		if (s->transition_point_is_frame)


### PR DESCRIPTION

### Description
This is a modification to the change made in https://github.com/obsproject/obs-studio/commit/e023060afad105e59a07ac56499836b23182ae30

### Motivation and Context
Triggering a new transition too soon after a stinger would cause the wrong scene to be displayed. Jim suggested halving the padding which should mitigate this issue.

### How Has This Been Tested?
Attempted to transition after a stinger, ran into the issue significantly less often.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
