### PR TITLE
UI: Always prompt when updates are available

### DIFF
--- a/UI/win-update/win-update.cpp
+++ b/UI/win-update/win-update.cpp
@@ -503,26 +503,6 @@ int AutoUpdateThread::queryUpdate(bool localManualUpdate, const char *text_utf8)
 	return ret;
 }
 
-static bool IsFileInUse(const wstring &file)
-{
-	WinHandle f = CreateFile(file.c_str(), GENERIC_WRITE, 0, nullptr,
-				 OPEN_EXISTING, 0, nullptr);
-	if (!f.Valid()) {
-		int err = GetLastError();
-		if (err == ERROR_SHARING_VIOLATION ||
-		    err == ERROR_LOCK_VIOLATION)
-			return true;
-	}
-
-	return false;
-}
-
-static bool IsGameCaptureInUse()
-{
-	wstring path = L"..\\..\\data\\obs-plugins\\win-capture\\graphics-hook";
-	return IsFileInUse(path + L"32.dll") || IsFileInUse(path + L"64.dll");
-}
-
 void AutoUpdateThread::run()
 try {
 	long responseCode;
@@ -545,29 +525,6 @@ try {
 
 	BPtr<char> manifestPath =
 		GetConfigPathPtr("obs-studio\\updates\\manifest.json");
-
-	auto ActiveOrGameCaptureLocked = [this]() {
-		if (obs_video_active()) {
-			if (manualUpdate)
-				info(QTStr("Updater.Running.Title"),
-				     QTStr("Updater.Running.Text"));
-			return true;
-		}
-		if (IsGameCaptureInUse()) {
-			if (manualUpdate)
-				info(QTStr("Updater.GameCaptureActive.Title"),
-				     QTStr("Updater.GameCaptureActive.Text"));
-			return true;
-		}
-
-		return false;
-	};
-
-	/* ----------------------------------- *
-	 * warn if running or gc locked        */
-
-	if (ActiveOrGameCaptureLocked())
-		return;
 
 	/* ----------------------------------- *
 	 * create signature provider           */
@@ -663,12 +620,6 @@ try {
 	int skipUpdateVer = config_get_int(GetGlobalConfig(), "General",
 					   "SkipUpdateVersion");
 	if (!manualUpdate && updateVer == skipUpdateVer)
-		return;
-
-	/* ----------------------------------- *
-	 * warn again if running or gc locked  */
-
-	if (ActiveOrGameCaptureLocked())
 		return;
 
 	/* ----------------------------------- *


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This PR makes the automatic update prompt on Windows appear regardless of whether any outputs are active or whether game capture is in use.

### Motivation and Context
OBS will stop prompting to update if the user has configured NDI or Virtualcam, since these plugins start outputs automatically, and users may be left on old OBS versions without realizing. Game capture hooks are also possible on startup, but given that the capture DLLs are infrequently updated it doesn't make sense to skip updates on this either.

### How Has This Been Tested?
It hasn't! But since this is straightforward deletion of the code to check and prompt, I don't see any issues...

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
 - Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
