### PR TITLE
win-capture: Faster display / window capture updates

### DIFF
--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -58,7 +58,7 @@ static inline void update_settings(struct duplicator_capture *capture,
 	capture->x = 0;
 	capture->y = 0;
 	capture->rot = 0;
-	capture->reset_timeout = 0.0f;
+	capture->reset_timeout = RESET_INTERVAL_SEC;
 
 	obs_leave_graphics();
 }

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -16,6 +16,8 @@
 
 /* clang-format on */
 
+#define WC_CHECK_TIMER 1.0f
+
 struct window_capture {
 	obs_source_t *source;
 
@@ -103,6 +105,7 @@ static void wc_update(void *data, obs_data_t *settings)
 
 	/* forces a reset */
 	wc->window = NULL;
+	wc->check_window_timer = WC_CHECK_TIMER;
 }
 
 static uint32_t wc_width(void *data)
@@ -166,7 +169,7 @@ static void wc_tick(void *data, float seconds)
 
 		wc->check_window_timer += seconds;
 
-		if (wc->check_window_timer < 1.0f) {
+		if (wc->check_window_timer < WC_CHECK_TIMER) {
 			if (wc->capture.valid)
 				dc_capture_free(&wc->capture);
 			return;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This commit forces window and display capture to update immediately when their properties are changed instead of waiting for the next tick.

### Motivation and Context
This was requested in https://github.com/obsproject/obs-studio/issues/2322 and makes the UI feel more responsive.

### How Has This Been Tested?
I changed the target window / display in the settings and verified it updated immediately.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
