### PR TITLE
UI: Show source icons in Advanced Audio Properties

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -33,6 +33,7 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	balanceContainer = new QWidget();
 	labelL = new QLabel();
 	labelR = new QLabel();
+	iconLabel = new QLabel();
 	nameLabel = new QLabel();
 	active = new QLabel();
 	stackedWidget = new QStackedWidget();
@@ -80,6 +81,14 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	labelL->setText("L");
 
 	labelR->setText("R");
+
+	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+
+	QIcon sourceIcon = main->GetSourceIcon(obs_source_get_id(source));
+	QPixmap pixmap = sourceIcon.pixmap(QSize(16, 16));
+	iconLabel->setPixmap(pixmap);
+	iconLabel->setFixedSize(16, 16);
+	iconLabel->setStyleSheet("background: none");
 
 	nameLabel->setText(QT_UTF8(sourceName));
 	nameLabel->setAlignment(Qt::AlignVCenter);
@@ -129,8 +138,6 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	balance->setMaximum(100);
 	balance->setTickPosition(QSlider::TicksAbove);
 	balance->setTickInterval(50);
-
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 
 	const char *speakers =
 		config_get_string(main->Config(), "Audio", "ChannelSetup");
@@ -226,6 +233,7 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 
 OBSAdvAudioCtrl::~OBSAdvAudioCtrl()
 {
+	iconLabel->deleteLater();
 	nameLabel->deleteLater();
 	activeContainer->deleteLater();
 	stackedWidget->deleteLater();
@@ -243,6 +251,7 @@ void OBSAdvAudioCtrl::ShowAudioControl(QGridLayout *layout)
 	int lastRow = layout->rowCount();
 	int idx = 0;
 
+	layout->addWidget(iconLabel, lastRow, idx++);
 	layout->addWidget(nameLabel, lastRow, idx++);
 	layout->addWidget(activeContainer, lastRow, idx++);
 	layout->addWidget(stackedWidget, lastRow, idx++);
@@ -494,4 +503,9 @@ void OBSAdvAudioCtrl::SetVolumeWidget(VolumeType type)
 		stackedWidget->setCurrentWidget(volume);
 		break;
 	}
+}
+
+void OBSAdvAudioCtrl::SetIconVisible(bool visible)
+{
+	visible ? iconLabel->show() : iconLabel->hide();
 }

--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -29,6 +29,7 @@ private:
 	QPointer<QWidget> mixerContainer;
 	QPointer<QWidget> balanceContainer;
 
+	QPointer<QLabel> iconLabel;
 	QPointer<QLabel> nameLabel;
 	QPointer<QLabel> active;
 	QPointer<QStackedWidget> stackedWidget;
@@ -69,6 +70,7 @@ public:
 	void ShowAudioControl(QGridLayout *layout);
 
 	void SetVolumeWidget(VolumeType type);
+	void SetIconVisible(bool visible);
 
 public slots:
 	void SourceActiveChanged(bool active);

--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -29,6 +29,8 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 	int idx = 0;
 	mainLayout = new QGridLayout;
 	mainLayout->setContentsMargins(0, 0, 0, 0);
+	label = new QLabel("");
+	mainLayout->addWidget(label, 0, idx++);
 	label = new QLabel(QTStr("Basic.AdvAudio.Name"));
 	label->setStyleSheet("font-weight: bold;");
 	mainLayout->addWidget(label, 0, idx++);
@@ -259,6 +261,8 @@ void OBSBasicAdvAudio::SetShowInactive(bool show)
 					    this);
 
 		obs_enum_sources(EnumSources, this);
+
+		SetIconsVisible(showVisible);
 	} else {
 		sourceAddedSignal.Connect(obs_get_signal_handler(),
 					  "source_activate", OBSSourceAdded,
@@ -275,5 +279,18 @@ void OBSBasicAdvAudio::SetShowInactive(bool show)
 				i--;
 			}
 		}
+	}
+}
+
+void OBSBasicAdvAudio::SetIconsVisible(bool visible)
+{
+	showVisible = visible;
+
+	QLayoutItem *item = mainLayout->itemAtPosition(0, 0);
+	QLabel *headerLabel = qobject_cast<QLabel *>(item->widget());
+	visible ? headerLabel->show() : headerLabel->hide();
+
+	for (int i = 0; i < controls.size(); i++) {
+		controls[i]->SetIconVisible(visible);
 	}
 }

--- a/UI/window-basic-adv-audio.hpp
+++ b/UI/window-basic-adv-audio.hpp
@@ -21,6 +21,7 @@ private:
 	OBSSignal sourceAddedSignal;
 	OBSSignal sourceRemovedSignal;
 	bool showInactive;
+	bool showVisible;
 
 	std::vector<OBSAdvAudioCtrl *> controls;
 
@@ -43,4 +44,5 @@ public:
 	OBSBasicAdvAudio(QWidget *parent);
 	~OBSBasicAdvAudio();
 	void SetShowInactive(bool showInactive);
+	void SetIconsVisible(bool visible);
 };

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3983,9 +3983,13 @@ void OBSBasic::on_actionAdvAudioProperties_triggered()
 		return;
 	}
 
+	bool iconsVisible = config_get_bool(App()->GlobalConfig(),
+					    "BasicWindow", "ShowSourceIcons");
+
 	advAudioWindow = new OBSBasicAdvAudio(this);
 	advAudioWindow->show();
 	advAudioWindow->setAttribute(Qt::WA_DeleteOnClose, true);
+	advAudioWindow->SetIconsVisible(iconsVisible);
 
 	connect(advAudioWindow, SIGNAL(destroyed()), this,
 		SLOT(on_advAudioProps_destroyed()));
@@ -6808,6 +6812,8 @@ void OBSBasic::on_toggleStatusBar_toggled(bool visible)
 void OBSBasic::on_toggleSourceIcons_toggled(bool visible)
 {
 	ui->sources->SetIconsVisible(visible);
+	if (advAudioWindow != nullptr)
+		advAudioWindow->SetIconsVisible(visible);
 
 	config_set_bool(App()->GlobalConfig(), "BasicWindow", "ShowSourceIcons",
 			visible);


### PR DESCRIPTION
### Description

Shows source icons next to the name of each source. Also controlled by the toggle in View.

![Example](http://scr.wzd.li/scr/2020-02-04_13-23-53.png)

### Motivation and Context

Consistent with the Sources list.

### How Has This Been Tested?
Open the AAP window. Toggle icons.

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
