### PR TITLE
UI: Use absolute path for portable mode multi-instance check

### DIFF
--- a/UI/platform-windows.cpp
+++ b/UI/platform-windows.cpp
@@ -300,10 +300,13 @@ RunOnceMutex GetRunOnceMutex(bool &already_running)
 		name = "OBSStudioCore";
 	} else {
 		char path[500];
+		char absPath[512];
 		*path = 0;
+		*absPath = 0;
 		GetConfigPath(path, sizeof(path), "");
+		os_get_abs_path(path, absPath, sizeof(absPath));
 		name = "OBSStudioPortable";
-		name += path;
+		name += absPath;
 	}
 
 	BPtr<wchar_t> wname;


### PR DESCRIPTION
### Description
Uses an absolute path to determine whether the current portable OBS config directory is in use.

### Motivation and Context
Currently this uses a relative path, which means every portable instance is assumed to be using the same config directory.

### How Has This Been Tested?
Load two different portable installations of OBS at the same time. Previously a warning would appear when opening the second instance.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
