### PR TITLE
UI: Fix transitions being disabled

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -267,9 +267,9 @@ void OBSBasic::TransitionStopped()
 		OBSSource scene = OBSGetStrongRef(swapScene);
 		if (scene)
 			SetCurrentScene(scene);
-
-		EnableTransitionWidgets(true);
 	}
+
+	EnableTransitionWidgets(true);
 
 	if (api) {
 		api->on_event(OBS_FRONTEND_EVENT_TRANSITION_STOPPED);


### PR DESCRIPTION
### Description
Fixes bug where transitions remained disabled when the scenes were not swapped.

### Motivation and Context
https://github.com/obsproject/obs-studio/issues/2368

### How Has This Been Tested?
Turned off swap mode and transitioned between scenes.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
