### PR TITLE
docs/sphinx: add media controls and source icon

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -153,6 +153,9 @@ Source Definition Structure (obs_source_info)
      the problem of "I want to change the defaults of a source but I
      don't want to break people's configurations"
 
+   - **OBS_SOURCE_CONTROLLABLE_MEDIA** - This source has media that can
+     be controlled
+
 .. member:: const char *(*obs_source_info.get_name)(void *type_data)
 
    Get the translated name of the source type.
@@ -442,6 +445,51 @@ Source Definition Structure (obs_source_info)
    - **OBS_ICON_TYPE_BROWSER**         - Browser
    - **OBS_ICON_TYPE_CUSTOM**          - Custom (not implemented yet)
 
+.. member:: void (*obs_source_info.media_play_pause)(void *data, bool pause)
+
+   Called to pause or play media.
+
+.. member:: void (*obs_source_info.media_restart)(void *data)
+
+   Called to restart the media.
+
+.. member:: void (*obs_source_info.media_stop)(void *data)
+
+   Called to stop the media.
+
+.. member:: void (*obs_source_info.media_next)(void *data)
+
+   Called to go to the next media.
+
+.. member:: void (*obs_source_info.media_previous)(void *data)
+
+   Called to go to the previous media.
+
+.. member:: int64_t (*obs_source_info.media_get_duration)(void *data)
+
+   Called to get the media duration.
+
+.. member:: int64_t (*obs_source_info.media_get_time)(void *data)
+
+   Called to get the current time of the media.
+
+.. member:: void (*obs_source_info.media_set_time)(void *data, int64_t miliseconds)
+
+   Called to set the media time.
+
+.. member:: enum obs_media_state (*obs_source_info.media_get_state)(void *data)
+
+   Called to get the state of the media.
+
+   - **OBS_MEDIA_STATE_NONE**      - None
+   - **OBS_MEDIA_STATE_PLAYING**   - Playing
+   - **OBS_MEDIA_STATE_OPENING**   - Opening
+   - **OBS_MEDIA_STATE_BUFFERING** - Buffering
+   - **OBS_MEDIA_STATE_PAUSED**    - Paused
+   - **OBS_MEDIA_STATE_STOPPED**   - Stopped
+   - **OBS_MEDIA_STATE_ENDED**     - Ended
+   - **OBS_MEDIA_STATE_ERROR**     - Error
+
 
 .. _source_signal_handler_reference:
 
@@ -558,6 +606,37 @@ Source Signals
 
    Called when a transition has stopped.
 
+**media_started**
+
+   Called when media has started.
+
+**media_ended**
+
+   Called when media has ended.
+
+**media_pause**
+
+   Called when media has been paused.
+
+**media_play**
+
+   Called when media starts playing.
+
+**media_restart**
+
+   Called when the playing of media has been restarted.
+
+**media_stopped**
+
+   Called when the playing of media has been stopped.
+
+**media_next**
+
+   Called when the media source switches to the next media.
+
+**media_previous**
+
+   Called when the media source switches to the previous media.
 
 General Source Functions
 ------------------------

--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -423,6 +423,25 @@ Source Definition Structure (obs_source_info)
 
    (Optional)
 
+.. member:: enum obs_icon_type obs_source_info.icon_type
+
+   Icon used for the source.
+
+   - **OBS_ICON_TYPE_UNKNOWN**         - Unknown
+   - **OBS_ICON_TYPE_IMAGE**           - Image
+   - **OBS_ICON_TYPE_COLOR**           - Color
+   - **OBS_ICON_TYPE_SLIDESHOW**       - Slideshow
+   - **OBS_ICON_TYPE_AUDIO_INPUT**     - Audio Input
+   - **OBS_ICON_TYPE_AUDIO_OUTPUT**    - Audio Output
+   - **OBS_ICON_TYPE_DESKTOP_CAPTURE** - Desktop Capture
+   - **OBS_ICON_TYPE_WINDOW_CAPTURE**  - Window Capture
+   - **OBS_ICON_TYPE_GAME_CAPTURE**    - Game Capture
+   - **OBS_ICON_TYPE_CAMERA**          - Camera
+   - **OBS_ICON_TYPE_TEXT**            - Text
+   - **OBS_ICON_TYPE_MEDIA**           - Media
+   - **OBS_ICON_TYPE_BROWSER**         - Browser
+   - **OBS_ICON_TYPE_CUSTOM**          - Custom (not implemented yet)
+
 
 .. _source_signal_handler_reference:
 

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -521,7 +521,7 @@ struct obs_source_info {
 	void (*media_previous)(void *data);
 	int64_t (*media_get_duration)(void *data);
 	int64_t (*media_get_time)(void *data);
-	void (*media_set_time)(void *data, int64_t seconds);
+	void (*media_set_time)(void *data, int64_t miliseconds);
 	enum obs_media_state (*media_get_state)(void *data);
 };
 


### PR DESCRIPTION
### Description
Add media controls and source icon to the documentation

### Motivation and Context
It is add to OBS but not to the documentation.

### How Has This Been Tested?
Not

### Types of changes
- Documentation (a change to documentation pages)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
