### PR TITLE
libobs: Fix Mac linker error

### DIFF
--- a/libobs/graphics/half.h
+++ b/libobs/graphics/half.h
@@ -51,7 +51,7 @@ struct half {
 };
 
 /* adapted from DirectXMath XMConvertFloatToHalf */
-inline struct half half_from_float(float f)
+static struct half half_from_float(float f)
 {
 	uint32_t Result;
 
@@ -90,7 +90,7 @@ inline struct half half_from_float(float f)
 	return h;
 }
 
-inline struct half half_from_bits(uint16_t u)
+static struct half half_from_bits(uint16_t u)
 {
 	struct half h;
 	h.u = u;


### PR DESCRIPTION
### Description
Non-static inline functions don't work for some reason, so make them static.

### Motivation and Context
Couldn't build on Mac.

### How Has This Been Tested?
Mac builds. LUTs still work.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.