### PR TITLE
UI: Add Chromium-compatible NSApplication subclass

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1761,6 +1761,10 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 
 	QCoreApplication::addLibraryPath(".");
 
+#if __APPLE__
+	InstallNSApplicationSubclass();
+#endif
+
 	OBSApp program(argc, argv, profilerNameStore.get());
 	try {
 		bool created_log = false;

--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -196,3 +196,32 @@ void EnableOSXDockIcon(bool enable)
 		[NSApp setActivationPolicy:
 				NSApplicationActivationPolicyProhibited];
 }
+
+/*
+ * This custom NSApplication subclass makes the app compatible with CEF. Qt
+ * also has an NSApplication subclass, but it doesn't conflict thanks to Qt
+ * using arcane magic to hook into the NSApplication superclass itself if the
+ * program has its own NSApplication subclass.
+ */
+
+@protocol CrAppProtocol
+- (BOOL)isHandlingSendEvent;
+@end
+
+@interface OBSApplication : NSApplication <CrAppProtocol>
+@property (nonatomic, getter=isHandlingSendEvent) BOOL handlingSendEvent;
+@end
+
+@implementation OBSApplication
+- (void)sendEvent:(NSEvent *)event
+{
+	_handlingSendEvent = YES;
+	[super sendEvent:event];
+	_handlingSendEvent = NO;
+}
+@end
+
+void InstallNSApplicationSubclass()
+{
+	[OBSApplication sharedApplication];
+}


### PR DESCRIPTION
This fixes some crashes in browser panels on Mac, but it's also harmless
if browser panels aren't enabled.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Some parts of Chromium apparently can't live without knowing whether they're being called from the Mac event loop. To satisfy them, this PR implements the `isHandlingSendEvent` method on NSApp. 

### Motivation and Context
This fixes a crash led to a crash when you right click a browser panel.

### How Has This Been Tested?
Tested in combination with https://github.com/obsproject/obs-browser/pull/197, makes it crash less.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
