### PR TITLE
deps/media-playback: Use more accurate seeking

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -840,16 +840,9 @@ void mp_media_seek_to(mp_media_t *m, int64_t pos)
 
 	int64_t seek_to = pos * 1000;
 
-	AVStream *stream = m->fmt->streams[0];
-
-	int64_t seek_target = AVSEEK_FLAG_BACKWARD == AVSEEK_FLAG_BACKWARD
-				      ? av_rescale_q(seek_to, AV_TIME_BASE_Q,
-						     stream->time_base)
-				      : seek_to;
-
 	if (m->is_local_file) {
-		int ret = av_seek_frame(m->fmt, 0, seek_target,
-					AVSEEK_FLAG_BACKWARD);
+		int ret = av_seek_frame(m->fmt, -1, seek_to,
+					AVSEEK_FLAG_ANY);
 		if (ret < 0) {
 			blog(LOG_WARNING, "MP: Failed to seek: %s",
 			     av_err2str(ret));


### PR DESCRIPTION
### Description
Previously the seeking would go to the nearest previous keyframe. Now it seeks to the nearest frame.

### Motivation and Context
Ironing out media controls.

### How Has This Been Tested?
Seeking with #2380 

### Types of changes
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
