### PR TITLE
Make it possible for Mac CI to fail on a PR

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,10 +40,7 @@ jobs:
   - script: ./CI/before-script-osx.sh
     displayName: 'Cmake'
 
-  - bash: |
-      cd ./build
-      make -j4
-      cd -
+  - script: make -C build -j4
     displayName: 'Build'
 
   - script: ./CI/before-deploy-osx.sh


### PR DESCRIPTION
Merge this once the CI fails :)

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Make it so an error in the make step of the Mac build will actually cause a pipeline failure, instead of being ignored.

### Motivation and Context
I made a PR (https://github.com/obsproject/obs-studio/pull/2386) that didn't build, and it was merged anyway because it had a green checkmark.

### How Has This Been Tested?
TODO

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
