### PR TITLE
CI: Fail osx and linux on build failures. Fix decklink clang-format

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,7 @@ jobs:
     displayName: 'Cmake'
 
   - bash: |
+      set -e
       cd ./build
       make -j4
       cd -
@@ -126,6 +127,7 @@ jobs:
     displayName: 'CMake'
 
   - bash: |
+      set -e
       cd ./build
       make -j4
       cd -

--- a/formatcode.sh
+++ b/formatcode.sh
@@ -29,9 +29,9 @@ fi
 
 find . -type d \( -path ./deps \
 -o -path ./cmake \
--o -path ./plugins/decklink/win \
--o -path ./plugins/decklink/mac \
--o -path ./plugins/decklink/linux \
+-o -path ./plugins/decklink/win/decklink-sdk \
+-o -path ./plugins/decklink/mac/decklink-sdk \
+-o -path ./plugins/decklink/linux/decklink-sdk \
 -o -path ./plugins/enc-amf \
 -o -path ./plugins/mac-syphon/syphon-framework \
 -o -path ./plugins/obs-outputs/ftl-sdk \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
