### PR TITLE
obs-ffmpeg: Use callbacks when starting/ending

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -261,6 +261,9 @@ static void media_stopped(void *opaque)
 		if (s->close_when_inactive && s->media_valid)
 			s->destroy_media = true;
 	}
+
+	set_media_state(s, OBS_MEDIA_STATE_ENDED);
+	obs_source_media_ended(s->source);
 }
 
 static void ffmpeg_source_open(struct ffmpeg_source *s)
@@ -308,6 +311,7 @@ static void ffmpeg_source_start(struct ffmpeg_source *s)
 		if (s->is_local_file)
 			obs_source_show_preloaded_video(s->source);
 		set_media_state(s, OBS_MEDIA_STATE_PLAYING);
+		obs_source_media_started(s->source);
 	}
 }
 


### PR DESCRIPTION
### Description
Callbacks when media starts/ends.

### Motivation and Context
Originally a commit in #2380. The media controls UI won't be put in until after v25.

### How Has This Been Tested?
Tested in #2380

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
