### PR TITLE
rtmp-services: updating castr.io rtmp ingests

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -4,7 +4,7 @@
 	"files": [
 		{
 			"name": "services.json",
-			"version": 122
+			"version": 123
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -894,71 +894,91 @@
             "servers": [
                 {
                     "name": "Chicago US",
-                    "url": "rtmp://cg.castr.io"
+                    "url": "rtmp://cg.castr.io/static"
                 },
                 {
                     "name": "Los Angeles US",
-                    "url": "rtmp://la.castr.io"
+                    "url": "rtmp://la.castr.io/static"
                 },
                 {
                     "name": "New York US",
-                    "url": "rtmp://ny.castr.io"
+                    "url": "rtmp://ny.castr.io/static"
+                },
+                {
+                    "name": "Miami US",
+                    "url": "rtmp://mi.castr.io/static"
                 },
                 {
                     "name": "Montreal CA",
-                    "url": "rtmp://qc.castr.io"
+                    "url": "rtmp://qc.castr.io/static"
                 },
                 {
                     "name": "London UK",
-                    "url": "rtmp://uk.castr.io"
+                    "url": "rtmp://uk.castr.io/static"
                 },
                 {
                     "name": "Frankfurt DE",
-                    "url": "rtmp://de.castr.io"
+                    "url": "rtmp://de.castr.io/static"
                 },
                 {
                     "name": "Frankfurt DE 2",
-                    "url": "rtmp://fr.castr.io"
+                    "url": "rtmp://fr.castr.io/static"
                 },
                 {
                     "name": "Moscow RU",
-                    "url": "rtmp://ru.castr.io"
+                    "url": "rtmp://ru.castr.io/static"
                 },
                 {
                     "name": "Singapore",
-                    "url": "rtmp://sg.castr.io"
+                    "url": "rtmp://sg.castr.io/static"
                 },
                 {
                     "name": "Sydney AU",
-                    "url": "rtmp://au.castr.io"
+                    "url": "rtmp://au.castr.io/static"
                 },
                 {
                     "name": "Brazil",
-                    "url": "rtmp://br.castr.io"
+                    "url": "rtmp://br.castr.io/static"
+                },
+                {
+                    "name": "India",
+                    "url": "rtmp://in.castr.io/static"
                 },
                 {
                     "name": "US Central",
-                    "url": "rtmp://us-central.castr.io"
+                    "url": "rtmp://us-central.castr.io/static"
                 },
                 {
                     "name": "US West",
-                    "url": "rtmp://us-west.castr.io"
+                    "url": "rtmp://us-west.castr.io/static"
                 },
                 {
                     "name": "US East",
-                    "url": "rtmp://us-east.castr.io"
+                    "url": "rtmp://us-east.castr.io/static"
                 },
                 {
                     "name": "US South",
-                    "url": "rtmp://us-south.castr.io"
+                    "url": "rtmp://us-south.castr.io/static"
                 },
                 {
                     "name": "South America",
-                    "url": "rtmp://south-am.castr.io"
+                    "url": "rtmp://south-am.castr.io/static"
                 },
                 {
                     "name": "EU Central",
-                    "url": "rtmp://eu-central.castr.io"
+                    "url": "rtmp://eu-central.castr.io/static"
+                },
+                {
+                    "name": "AU South",
+                    "url": "rtmp://au-central.castr.io/static"
+                },
+                {
+                    "name": "Singapore",
+                    "url": "rtmp://sg-central.castr.io/static"
+                },
+                {
+                    "name": "India",
+                    "url": "rtmp://in.castr.io/static"
                 }
             ],
             "recommended": {


### PR DESCRIPTION
Adding new Castr.io ingest locations to RTMP service list:

- Adding new ingest locations; Miami, Singapore, Australia, India.
- Updating pathnames in existing castr.io ingests in RTMP service list.
- Incrementing rtmp-services version in `package.json`.

List of updated Castr.io ingest locations  
[developers.castr.io/apiv1/ingests/list](https://developers.castr.io/apiv1/ingests/list)

### Description
Updating the rtmp-services ingestion list to enable updated Castr.io ingests.

### Motivation and Context
Castr.io has added support for a few more ingest locations and to reflect changes in rtmp pathnames for existing ingests locations.

### How Has This Been Tested?
Not required.

### Types of changes
Updating OBS RTMP Services Data

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ x] My code is not on the master branch.
- [ x] The code has been tested.
- [ x] All commit messages are properly formatted and commit squashed where appropriate.
