### PR TITLE
UI: Allow resizing docks when hotkeys are disabled

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -93,7 +93,8 @@ QObject *CreateShortcutFilter()
 {
 	return new OBSEventFilter([](QObject *obj, QEvent *event) {
 		auto mouse_event = [](QMouseEvent &event) {
-			if (!App()->HotkeysEnabledInFocus())
+			if (!App()->HotkeysEnabledInFocus() &&
+			    event.button() != Qt::LeftButton)
 				return true;
 
 			obs_key_combination_t hotkey = {0, OBS_KEY_NONE};


### PR DESCRIPTION
Fixes #2194

### Description
This ensures the UI doesn't block the left mouse click event.

### Motivation and Context
See #2194 for full details. Essentially, mouse events are blocked without determining if they're part of a hotkey.

### How Has This Been Tested?

1. Set "Hotkey Focus Behaviour" to "Disable hotkeys when main window is in focus"
2. Drag to resize a docked panel

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
