### PR TITLE
UI: Use OBS dock menu instead of Qt dock context menu

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -206,6 +206,10 @@ OBSBasic::OBSBasic(QWidget *parent)
 
 	setAcceptDrops(true);
 
+	setContextMenuPolicy(Qt::CustomContextMenu);
+	connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this,
+		SLOT(on_customContextMenuRequested(const QPoint &)));
+
 	api = InitializeAPIInterface(this);
 
 	ui->setupUi(this);
@@ -7772,4 +7776,15 @@ void OBSBasic::ResetStatsHotkey()
 	QList<OBSBasicStats *> list = findChildren<OBSBasicStats *>();
 
 	foreach(OBSBasicStats * s, list) s->Reset();
+}
+
+void OBSBasic::on_customContextMenuRequested(const QPoint &pos)
+{
+	QWidget *widget = childAt(pos);
+	const char *className = nullptr;
+	if (widget != nullptr)
+		className = widget->metaObject()->className();
+
+	if (!className || strstr(className, "Dock") != nullptr)
+		ui->viewMenuDocks->exec(mapToGlobal(pos));
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -834,6 +834,8 @@ private slots:
 	void on_actionVerticalCenter_triggered();
 	void on_actionHorizontalCenter_triggered();
 
+	void on_customContextMenuRequested(const QPoint &pos);
+
 	void on_scenes_currentItemChanged(QListWidgetItem *current,
 					  QListWidgetItem *prev);
 	void on_scenes_customContextMenuRequested(const QPoint &pos);


### PR DESCRIPTION
### Description
This overrides the default context menu provided by Qt's docking system, and instead displays the View->Docks menu.

![Dock context menu](http://scr.wzd.li/scr/2020-02-15_10-35-38.png)

**Note**: Without the specific check for null/dock widgets, this would "add" the context menu anywhere in the main window where a context menu isn't defined (including within the Controls dock).

### Motivation and Context

* The default context menu greys out any entries that have the close buttons hidden, while the Docks menu does not
* The default context menu is ordered differently than the Docks menu
* The docks menu provides Lock & Reset UI options, plus a link to add custom browser docks
* General consistency

### How Has This Been Tested?

* Right click on a docked panel's title area
* Right click on the separator/grip between docks

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
