### PR TITLE
mac-vth264: Manually mark priority bits for VideoToolbox frames

### DIFF
--- a/plugins/mac-vth264/encoder.c
+++ b/plugins/mac-vth264/encoder.c
@@ -1,5 +1,6 @@
 #include <obs-module.h>
 #include <util/darray.h>
+#include <obs-avc.h>
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <VideoToolbox/VideoToolbox.h>
@@ -671,6 +672,8 @@ static bool is_sample_keyframe(CMSampleBufferRef buffer)
 static bool parse_sample(struct vt_h264_encoder *enc, CMSampleBufferRef buffer,
 			 struct encoder_packet *packet, CMTime off)
 {
+	int type;
+
 	CMTime pts = CMSampleBufferGetPresentationTimeStamp(buffer);
 	CMTime dts = CMSampleBufferGetDecodeTimeStamp(buffer);
 
@@ -702,6 +705,37 @@ static bool parse_sample(struct vt_h264_encoder *enc, CMSampleBufferRef buffer,
 	packet->data = enc->packet_data.array;
 	packet->size = enc->packet_data.num;
 	packet->keyframe = keyframe;
+
+	// VideoToolbox produces packets with priority lower than the RTMP code
+	// expects, which causes it to be unable to recover from frame drops.
+	// Fix this by manually adjusting the priority.
+	uint8_t *start = enc->packet_data.array;
+	uint8_t *end = start + enc->packet_data.num;
+
+	start = (uint8_t *)obs_avc_find_startcode(start, end);
+	while (true) {
+		while (start < end && !*(start++))
+			;
+
+		if (start == end)
+			break;
+
+		type = start[0] & 0x1F;
+		if (type == OBS_NAL_SLICE_IDR || type == OBS_NAL_SLICE) {
+			uint8_t prev_type = (start[0] >> 5) & 0x3;
+			start[0] &= ~(3 << 5);
+
+			if (type == OBS_NAL_SLICE_IDR)
+				start[0] |= OBS_NAL_PRIORITY_HIGHEST << 5;
+			else if (type == OBS_NAL_SLICE &&
+				 prev_type != OBS_NAL_PRIORITY_DISPOSABLE)
+				start[0] |= OBS_NAL_PRIORITY_HIGH << 5;
+			else
+				start[0] |= prev_type << 5;
+		}
+
+		start = (uint8_t *)obs_avc_find_startcode(start, end);
+	}
 
 	CFRelease(buffer);
 	return true;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Reland of 30d29618, except actually tested this time.

### Motivation and Context
The VideoToolbox encoder gives I-frames and P-frames a priority of 1, but the RTMP output code expects I-frames to have priority 3 and P-frames to have priority 2. This causes RTMP to never stop dropping frames.

30d29618 changed the priority of all frames that aren't I-frames, but that included B-frames as well as P-frames. B-frames are given a priority of 0 by VideoToolbox and changing that priority causes artifacts for reasons I don't understand. So ignore the B-frames by ignoring slice packets with priority 0.

### How Has This Been Tested?
1. Did a bunch of recording and streaming with the hardware VT codec, confirmed that the corruption issues introduced by the previous incarnation are fixed.
2. Used Network Link Conditioner to artificially introduce congestion, confirmed that OBS was able to recover after turning off NLC, and that it couldn't recover and would infinitely drop frames without the patch.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
