### PR TITLE
UI: Restart program when audio/locale changed

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1014,3 +1014,7 @@ OBSStudio="OBS Studio"
 OBSClassic="OBS Classic"
 Streamlabs="Streamlabs"
 XSplitBroadcaster="XSplit Broadcaster"
+
+# OBS restart
+Restart="Restart"
+NeedsRestart="OBS Studio needs to be restarted. Do you want to restart now?"

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -34,6 +34,7 @@
 #include <QGuiApplication>
 #include <QProxyStyle>
 #include <QScreen>
+#include <QProcess>
 
 #include "qt-wrappers.hpp"
 #include "obs-app.hpp"
@@ -82,6 +83,8 @@ string opt_starting_scene;
 
 bool remuxAfterRecord = false;
 string remuxFilename;
+
+bool restart = false;
 
 // GPU hint exports for AMD/NVIDIA laptops
 #ifdef _MSC_VER
@@ -1806,7 +1809,7 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		}
 
 		if (cancel_launch)
-			return 0;
+			ret = 0;
 
 		if (!created_log) {
 			create_log_file(logFile);
@@ -1844,16 +1847,20 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		}
 
 		if (!program.OBSInit())
-			return 0;
+			ret = 0;
 
 		prof.Stop();
 
-		return program.exec();
+		ret = program.exec();
 
 	} catch (const char *error) {
 		blog(LOG_ERROR, "%s", error);
 		OBSErrorBox(nullptr, "%s", error);
 	}
+
+	if (restart)
+		QProcess::startDetached(qApp->arguments()[0],
+					qApp->arguments());
 
 	return ret;
 }

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -230,3 +230,4 @@ extern bool opt_studio_mode;
 extern bool opt_allow_opengl;
 extern bool opt_always_on_top;
 extern std::string opt_starting_scene;
+extern bool restart;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3882,6 +3882,7 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 
 		if (button == QMessageBox::No) {
 			event->ignore();
+			restart = false;
 			return;
 		}
 	}
@@ -4012,6 +4013,16 @@ void OBSBasic::on_action_Settings_triggered()
 	SystemTray(false);
 
 	settings_already_executing = false;
+
+	if (restart) {
+		QMessageBox::StandardButton button = OBSMessageBox::question(
+			this, QTStr("Restart"), QTStr("NeedsRestart"));
+
+		if (button == QMessageBox::Yes)
+			close();
+		else
+			restart = false;
+	}
 }
 
 void OBSBasic::on_actionAdvAudioProperties_triggered()

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1248,6 +1248,11 @@ void OBSBasicSettings::LoadGeneralSettings()
 	ui->multiviewLayout->setCurrentIndex(config_get_int(
 		GetGlobalConfig(), "BasicWindow", "MultiviewLayout"));
 
+	prevLangIndex = ui->language->currentIndex();
+
+	if (obs_video_active())
+		ui->language->setEnabled(false);
+
 	loading = false;
 }
 
@@ -2120,6 +2125,11 @@ void OBSBasicSettings::LoadAudioDevices()
 		LoadListValues(ui->desktopAudioDevice1, outputs, 1);
 		LoadListValues(ui->desktopAudioDevice2, outputs, 2);
 		obs_properties_destroy(output_props);
+	}
+
+	if (obs_video_active()) {
+		ui->sampleRate->setEnabled(false);
+		ui->channelSetup->setEnabled(false);
 	}
 }
 
@@ -3514,6 +3524,15 @@ void OBSBasicSettings::SaveSettings()
 		blog(LOG_INFO, "Settings changed (%s)", changed.c_str());
 		blog(LOG_INFO, MINOR_SEPARATOR);
 	}
+
+	bool langChanged = (ui->language->currentIndex() != prevLangIndex);
+	bool audioRestart = (ui->channelSetup->currentIndex() != channelIndex ||
+			     ui->sampleRate->currentIndex() != sampleRateIndex);
+
+	if (langChanged || audioRestart)
+		restart = true;
+	else
+		restart = false;
 }
 
 bool OBSBasicSettings::QueryChanges()
@@ -3535,6 +3554,7 @@ bool OBSBasicSettings::QueryChanges()
 		if (toggleAero)
 			SetAeroEnabled(!aeroWasDisabled);
 #endif
+		restart = false;
 	}
 
 	ClearChanged();

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -234,6 +234,7 @@ private:
 	void OnOAuthStreamKeyConnected();
 	void OnAuthConnected();
 	QString lastService;
+	int prevLangIndex;
 private slots:
 	void UpdateServerList();
 	void UpdateKeyLink();


### PR DESCRIPTION
### Description
When the user closes the settings and changes audio or locale, ask them if they want to restart OBS.

### Motivation and Context
Users currently have to manually restart OBS.

Previous PR: #1701

### How Has This Been Tested?
Changed audio/language.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
