### PR TITLE
UI: Add ability to lock volume

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -93,6 +93,7 @@ Fullscreen="Fullscreen"
 Windowed="Windowed"
 Percent="Percent"
 AspectRatio="Aspect Ratio <b>%1:%2</b>"
+LockVolume="Lock Volume"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -276,6 +276,11 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 	VolumeChanged();
 }
 
+void VolControl::EnableSlider(bool enable)
+{
+	slider->setEnabled(enable);
+}
+
 VolControl::~VolControl()
 {
 	obs_fader_remove_callback(obs_fader, OBSVolumeChanged, this);

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -252,4 +252,6 @@ public:
 
 	void SetMeterDecayRate(qreal q);
 	void setPeakMeterType(enum obs_peak_meter_type peakMeterType);
+
+	void EnableSlider(bool enable);
 };

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -660,6 +660,8 @@ private slots:
 	void TBarChanged(int value);
 	void TBarReleased();
 
+	void LockVolumeControl(bool lock);
+
 private:
 	/* OBS Callbacks */
 	static void SceneReordered(void *data, calldata_t *params);


### PR DESCRIPTION
### Description
This adds an option the the volume control config menu to lock the volume slider.

### Motivation and Context
https://ideas.obsproject.com/posts/734/please-add-a-lock-to-the-volume-level

### How Has This Been Tested?
Locked/unlocked volume.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
