### PR TITLE
decklink: Fix crash when no outputs are available

### DIFF
--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -74,7 +74,9 @@ static bool decklink_output_start(void *data)
 	obs_output_set_video_conversion(decklink->GetOutput(), &to);
 
 	device->SetKeyerMode(decklink->keyerMode);
-	decklink->Activate(device, decklink->modeID);
+
+	if (!decklink->Activate(device, decklink->modeID))
+		return false;
 
 	struct audio_convert_info conversion = {};
 	conversion.format = AUDIO_FORMAT_16BIT;


### PR DESCRIPTION
### Description
When a user starts a Decklink output and there are none available (such as when the Decklink input is active), OBS would crash.

### Motivation and Context
https://obsproject.com/mantis/view.php?id=1298

### How Has This Been Tested?
Created Blackmagic source and then tried to start output.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
