### PR TITLE
obs-scripting: Update text source IDs

### DIFF
--- a/UI/frontend-plugins/frontend-tools/data/scripts/countdown.lua
+++ b/UI/frontend-plugins/frontend-tools/data/scripts/countdown.lua
@@ -112,7 +112,7 @@ function script_properties()
 	if sources ~= nil then
 		for _, source in ipairs(sources) do
 			source_id = obs.obs_source_get_id(source)
-			if source_id == "text_gdiplus" or source_id == "text_ft2_source" then
+			if source_id == "text_gdiplus" or source_id == "text_ft2_source" or source_id == "text_gdiplus_v2" or source_id == "text_ft2_source_v2" then
 				local name = obs.obs_source_get_name(source)
 				obs.obs_property_list_add_string(p, name, name)
 			end

--- a/UI/frontend-plugins/frontend-tools/data/scripts/url-text.py
+++ b/UI/frontend-plugins/frontend-tools/data/scripts/url-text.py
@@ -67,7 +67,7 @@ def script_properties():
 	if sources is not None:
 		for source in sources:
 			source_id = obs.obs_source_get_id(source)
-			if source_id == "text_gdiplus" or source_id == "text_ft2_source":
+			if source_id == "text_gdiplus" or source_id == "text_ft2_source" or source_id == "text_gdiplus_v2" or source_id == "text_ft2_source_v2":
 				name = obs.obs_source_get_name(source)
 				obs.obs_property_list_add_string(p, name, name)
 


### PR DESCRIPTION
### Description
Fixes issue where the scripts wouldn't show text sources in the dropdowns.

### Motivation and Context
v25 updated the text source IDs.

### How Has This Been Tested?
Used script dialog.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
