### PR TITLE
UI: Fix Import Profile in Portable Mode

### DIFF
--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -505,10 +505,16 @@ void OBSBasic::on_actionImportProfile_triggered()
 		QFileInfo finfo(dir);
 		QString directory = finfo.fileName();
 		QString profileDir = inputPath + directory;
-		QDir folder(profileDir);
 
-		if (!folder.exists()) {
-			folder.mkpath(profileDir);
+		if (ProfileExists(directory.toStdString().c_str())) {
+			OBSMessageBox::warning(
+				this, QTStr("Basic.MainMenu.Profile.Import"),
+				QTStr("Basic.MainMenu.Profile.Exists"));
+		} else if (os_mkdir(profileDir.toStdString().c_str()) < 0) {
+			blog(LOG_WARNING,
+			     "Failed to create profile directory '%s'",
+			     directory.toStdString().c_str());
+		} else {
 			QFile::copy(dir + "/basic.ini",
 				    profileDir + "/basic.ini");
 			QFile::copy(dir + "/service.json",
@@ -518,10 +524,6 @@ void OBSBasic::on_actionImportProfile_triggered()
 			QFile::copy(dir + "/recordEncoder.json",
 				    profileDir + "/recordEncoder.json");
 			RefreshProfiles();
-		} else {
-			OBSMessageBox::warning(
-				this, QTStr("Basic.MainMenu.Profile.Import"),
-				QTStr("Basic.MainMenu.Profile.Exists"));
 		}
 	}
 }


### PR DESCRIPTION
### Description
QDir.mkpath seems broken with relative paths, which causes the import to silently fail because the parent directory is never created. This also adds a basic check to avoid accidentally overriding an existing profile.

### Motivation and Context
https://obsproject.com/mantis/view.php?id=1548

### How Has This Been Tested?

* Launch OBS in portable mode
* Export a profile
* Rename the profile within OBS
* Import the profile you just exported

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
