### PR TITLE
UI: Return 0 when launch cancelled or failed

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1809,7 +1809,7 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		}
 
 		if (cancel_launch)
-			ret = 0;
+			return 0;
 
 		if (!created_log) {
 			create_log_file(logFile);
@@ -1847,7 +1847,7 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		}
 
 		if (!program.OBSInit())
-			ret = 0;
+			return 0;
 
 		prof.Stop();
 


### PR DESCRIPTION
### Description
The program would still launch if it failed to init or was cancelled.

### Motivation and Context
Bug mentioned on Discord.

### How Has This Been Tested?
Wasn't tested, but should work properly now.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
