### PR TITLE
libobs/util: Retry pipe writes to avoid spurious failures on short write.

### DIFF
--- a/libobs/util/pipe-posix.c
+++ b/libobs/util/pipe-posix.c
@@ -93,5 +93,12 @@ size_t os_process_pipe_write(os_process_pipe_t *pp, const uint8_t *data,
 		return 0;
 	}
 
-	return fwrite(data, 1, len, pp->file);
+	size_t written = 0;
+	while (written < len) {
+		size_t ret = fwrite(data + written, 1, len - written, pp->file);
+		if (!ret)
+			return written;
+		written += ret;
+	}
+	return written;
 }


### PR DESCRIPTION
### Description
os_process_pipe_write now retries partial writes until it's written all the data, or it's unable to write anything at all.

### Motivation and Context
Saving the replay buffer twice would previously result in a crash where the pipe write got stuck in an infinite loop of failures (resulting in a wedged UI). The issue began with a large packet that was only partially written, which was deemed a failure, resulting in the pipe being prematurely closed and all future operations failing.


### How Has This Been Tested?
Tested on Debian Linux by manually firing up the replay buffer and saving it twice.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
