### PR TITLE
libobs: Pump graphics loop one final time for cleanup

### DIFF
--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -844,7 +844,11 @@ void *obs_graphics_thread(void *param)
 
 	srand((unsigned int)time(NULL));
 
-	while (!video_output_stopped(obs->video.video)) {
+	for (;;) {
+		/* defer loop break to clean up sources */
+		const bool stop_requested =
+			video_output_stopped(obs->video.video);
+
 		uint64_t frame_start = os_gettime_ns();
 		uint64_t frame_time_ns;
 		bool raw_active = obs->video.raw_active > 0;
@@ -920,6 +924,9 @@ void *obs_graphics_thread(void *param)
 			fps_total_ns = 0;
 			fps_total_frames = 0;
 		}
+
+		if (stop_requested)
+			break;
 	}
 
 	UNUSED_PARAMETER(param);


### PR DESCRIPTION
### Description
winrt-capture needs to clean up some objects on the render thread, and we need this one final pump to ensure wc_hide gets calls.

### Motivation and Context
OBS can crash or leak on exit.

### How Has This Been Tested?
Breakpoint thread freeze/thaw inspection on Windows. Ran Linux build 10 times in a row without leaking.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.