### PR TITLE
UI: Use QueuedConnection to reload audio sources

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2247,10 +2247,15 @@ void OBSBasicSettings::LoadAudioSources()
 		label->setMinimumSize(QSize(170, 0));
 		label->setAlignment(Qt::AlignRight | Qt::AlignTrailing |
 				    Qt::AlignVCenter);
-		connect(label, &OBSSourceLabel::Removed,
-			[=]() { LoadAudioSources(); });
-		connect(label, &OBSSourceLabel::Destroyed,
-			[=]() { LoadAudioSources(); });
+		connect(label, &OBSSourceLabel::Removed, [=]() {
+			QMetaObject::invokeMethod(this,
+						  "ReloadAudioSources",
+						  Qt::QueuedConnection);
+		});
+		connect(label, &OBSSourceLabel::Destroyed, [=]() {
+			QMetaObject::invokeMethod(this, "ReloadAudioSources",
+						  Qt::QueuedConnection);
+		});
 
 		layout->addRow(label, form);
 		return true;


### PR DESCRIPTION
### Description
When an audio source is removed, it signals its "destroy" callbacks. One of the callbacks is OBSSourceLabel::SourceDestroyed. When this fires its Qt destroyed signal, it causes a call to LoadAudioSources to refresh the source list. LoadAudioSources deletes the old layout, and so the QWidget that the OBSSourceLabel is based on is freed while it is still in the middle of running the signal callback, resulting in access to freed memory / crashes.

I am creating a PR instead of directly committing this as my knowledge of the OBS signalling system and Qt is not great, so there may be a more "correct" fix possible.

### Motivation and Context
Fixes a crash when audio sources are removed.

### How Has This Been Tested?
Tested under debug mode and observed no more crashing.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
