### PR TITLE
libobs-opengl: Fix Mac VAO created without context

### DIFF
--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -93,7 +93,6 @@ struct gl_platform *gl_platform_create(gs_device_t *device, uint32_t adapter)
 	GLint interval = 0;
 	[context setValues:&interval forParameter:NSOpenGLCPSwapInterval];
 	const bool success = gladLoadGL() != 0;
-	[NSOpenGLContext clearCurrentContext];
 
 	if (!success) {
 		blog(LOG_ERROR, "gladLoadGL failed");


### PR DESCRIPTION
### Description
Make sure context is current while empty VAO is created on Mac. Draws that used the invalid empty VAO were failing.

### Motivation and Context
Fix video capture failing to draw on Mac.

### How Has This Been Tested?
Video capture now succeeds on Mac.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.