### PR TITLE
frontend-plugins: Refactor Decklink out UI

### DIFF
--- a/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.cpp
@@ -15,14 +15,6 @@ DecklinkOutputUI::DecklinkOutputUI(QWidget *parent)
 
 	propertiesView = nullptr;
 	previewPropertiesView = nullptr;
-
-	connect(ui->startOutput, SIGNAL(released()), this, SLOT(StartOutput()));
-	connect(ui->stopOutput, SIGNAL(released()), this, SLOT(StopOutput()));
-
-	connect(ui->startPreviewOutput, SIGNAL(released()), this,
-		SLOT(StartPreviewOutput()));
-	connect(ui->stopPreviewOutput, SIGNAL(released()), this,
-		SLOT(StopPreviewOutput()));
 }
 
 void DecklinkOutputUI::ShowHideDialog()
@@ -106,15 +98,10 @@ void DecklinkOutputUI::SavePreviewSettings()
 		obs_data_save_json_safe(settings, path, "tmp", "bak");
 }
 
-void DecklinkOutputUI::StartOutput()
+void DecklinkOutputUI::on_outputButton_clicked()
 {
 	SaveSettings();
-	output_start();
-}
-
-void DecklinkOutputUI::StopOutput()
-{
-	output_stop();
+	output_toggle();
 }
 
 void DecklinkOutputUI::PropertiesChanged()
@@ -126,24 +113,19 @@ void DecklinkOutputUI::OutputStateChanged(bool active)
 {
 	QString text;
 	if (active) {
-		text = QString(obs_module_text("OutputState.Active"));
+		text = QString(obs_module_text("Stop"));
 	} else {
-		text = QString(obs_module_text("OutputState.Idle"));
+		text = QString(obs_module_text("Start"));
 	}
 
-	QMetaObject::invokeMethod(ui->outputStatus, "setText",
-				  Q_ARG(QString, text));
+	ui->outputButton->setChecked(active);
+	ui->outputButton->setText(text);
 }
 
-void DecklinkOutputUI::StartPreviewOutput()
+void DecklinkOutputUI::on_previewOutputButton_clicked()
 {
 	SavePreviewSettings();
-	preview_output_start();
-}
-
-void DecklinkOutputUI::StopPreviewOutput()
-{
-	preview_output_stop();
+	preview_output_toggle();
 }
 
 void DecklinkOutputUI::PreviewPropertiesChanged()
@@ -155,11 +137,11 @@ void DecklinkOutputUI::PreviewOutputStateChanged(bool active)
 {
 	QString text;
 	if (active) {
-		text = QString(obs_module_text("OutputState.Active"));
+		text = QString(obs_module_text("Stop"));
 	} else {
-		text = QString(obs_module_text("OutputState.Idle"));
+		text = QString(obs_module_text("Start"));
 	}
 
-	QMetaObject::invokeMethod(ui->previewOutputStatus, "setText",
-				  Q_ARG(QString, text));
+	ui->previewOutputButton->setChecked(active);
+	ui->previewOutputButton->setText(text);
 }

--- a/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.h
+++ b/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.h
@@ -12,16 +12,12 @@ private:
 	OBSPropertiesView *previewPropertiesView;
 
 public slots:
-	void StartOutput();
-	void StopOutput();
+	void on_outputButton_clicked();
 	void PropertiesChanged();
-
 	void OutputStateChanged(bool);
 
-	void StartPreviewOutput();
-	void StopPreviewOutput();
+	void on_previewOutputButton_clicked();
 	void PreviewPropertiesChanged();
-
 	void PreviewOutputStateChanged(bool);
 
 public:

--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.h
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.h
@@ -1,8 +1,6 @@
 #pragma once
 
-void output_start();
-void output_stop();
+void output_toggle();
 OBSData load_settings();
-void preview_output_start();
-void preview_output_stop();
+void preview_output_toggle();
 OBSData load_preview_settings();

--- a/UI/frontend-plugins/decklink-output-ui/forms/output.ui
+++ b/UI/frontend-plugins/decklink-output-ui/forms/output.ui
@@ -58,23 +58,12 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="outputStatus">
-       <property name="text">
-        <string>OutputState.Idle</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="startOutput">
+      <widget class="QPushButton" name="outputButton">
        <property name="text">
         <string>Start</string>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="stopOutput">
-       <property name="text">
-        <string>Stop</string>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -106,27 +95,29 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="previewOutputStatus">
-       <property name="text">
-        <string>OutputState.Idle</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="startPreviewOutput">
+      <widget class="QPushButton" name="previewOutputButton">
        <property name="text">
         <string>Start</string>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="stopPreviewOutput">
-       <property name="text">
-        <string>Stop</string>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QLabel" name="keyerLabel">


### PR DESCRIPTION
### Description
This combines the stop and start buttons into a single toggle button. Instead of the status labels, the buttons are set checked if active. This also simplifies some of the code.

Before:
![Screenshot from 2020-02-26 20-51-13](https://user-images.githubusercontent.com/19962531/75408197-a904cb80-58da-11ea-8dba-8f863a083f41.png)

After:
![Screenshot from 2020-02-26 20-52-09](https://user-images.githubusercontent.com/19962531/75408217-b4f08d80-58da-11ea-98de-1d5b603f59f9.png)

### Motivation and Context
Simplifies the UI.

### How Has This Been Tested?
Started Decklink output.

### Types of changes
- Code cleanup
- UI change

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
