### PR TITLE
Decklink: Fix crash when no device selected

### DIFF
--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -46,6 +46,9 @@ static bool decklink_output_start(void *data)
 		return false;
 	}
 
+	if (!decklink->deviceHash || !*decklink->deviceHash)
+		return false;
+
 	decklink->audio_samplerate = aoi.samples_per_sec;
 	decklink->audio_planes = 2;
 	decklink->audio_size =


### PR DESCRIPTION
### Description
Fixes crash when starting Decklink output and no device is selected.

### Motivation and Context
Bug fixing.

### How Has This Been Tested?
Created Decklink output when device wasn't selected.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
