### PR TITLE
CI: Fix case of PlugIns directory

### DIFF
--- a/CI/install/osx/packageApp.sh
+++ b/CI/install/osx/packageApp.sh
@@ -3,43 +3,43 @@ rm -rf ./OBS.app
 mkdir OBS.app
 mkdir OBS.app/Contents
 mkdir OBS.app/Contents/MacOS
-mkdir OBS.app/Contents/Plugins
+mkdir OBS.app/Contents/PlugIns
 mkdir OBS.app/Contents/Resources
 
 cp -R rundir/RelWithDebInfo/bin/ ./OBS.app/Contents/MacOS
 cp -R rundir/RelWithDebInfo/data ./OBS.app/Contents/Resources
 cp ../CI/install/osx/obs.icns ./OBS.app/Contents/Resources
-cp -R rundir/RelWithDebInfo/obs-plugins/ ./OBS.app/Contents/Plugins
+cp -R rundir/RelWithDebInfo/obs-plugins/ ./OBS.app/Contents/PlugIns
 cp ../CI/install/osx/Info.plist ./OBS.app/Contents
 
 ../CI/install/osx/dylibBundler -b -cd -d ./OBS.app/Contents/Frameworks -p @executable_path/../Frameworks/ \
 -s ./OBS.app/Contents/MacOS \
 -s /usr/local/opt/mbedtls/lib/ \
--x ./OBS.app/Contents/Plugins/coreaudio-encoder.so \
--x ./OBS.app/Contents/Plugins/decklink-ouput-ui.so \
--x ./OBS.app/Contents/Plugins/frontend-tools.so \
--x ./OBS.app/Contents/Plugins/image-source.so \
--x ./OBS.app/Contents/Plugins/linux-jack.so \
--x ./OBS.app/Contents/Plugins/mac-avcapture.so \
--x ./OBS.app/Contents/Plugins/mac-capture.so \
--x ./OBS.app/Contents/Plugins/mac-decklink.so \
--x ./OBS.app/Contents/Plugins/mac-syphon.so \
--x ./OBS.app/Contents/Plugins/mac-vth264.so \
--x ./OBS.app/Contents/Plugins/obs-browser.so \
--x ./OBS.app/Contents/Plugins/obs-browser-page \
--x ./OBS.app/Contents/Plugins/obs-ffmpeg.so \
--x ./OBS.app/Contents/Plugins/obs-filters.so \
--x ./OBS.app/Contents/Plugins/obs-transitions.so \
--x ./OBS.app/Contents/Plugins/obs-vst.so \
--x ./OBS.app/Contents/Plugins/rtmp-services.so \
+-x ./OBS.app/Contents/PlugIns/coreaudio-encoder.so \
+-x ./OBS.app/Contents/PlugIns/decklink-ouput-ui.so \
+-x ./OBS.app/Contents/PlugIns/frontend-tools.so \
+-x ./OBS.app/Contents/PlugIns/image-source.so \
+-x ./OBS.app/Contents/PlugIns/linux-jack.so \
+-x ./OBS.app/Contents/PlugIns/mac-avcapture.so \
+-x ./OBS.app/Contents/PlugIns/mac-capture.so \
+-x ./OBS.app/Contents/PlugIns/mac-decklink.so \
+-x ./OBS.app/Contents/PlugIns/mac-syphon.so \
+-x ./OBS.app/Contents/PlugIns/mac-vth264.so \
+-x ./OBS.app/Contents/PlugIns/obs-browser.so \
+-x ./OBS.app/Contents/PlugIns/obs-browser-page \
+-x ./OBS.app/Contents/PlugIns/obs-ffmpeg.so \
+-x ./OBS.app/Contents/PlugIns/obs-filters.so \
+-x ./OBS.app/Contents/PlugIns/obs-transitions.so \
+-x ./OBS.app/Contents/PlugIns/obs-vst.so \
+-x ./OBS.app/Contents/PlugIns/rtmp-services.so \
 -x ./OBS.app/Contents/MacOS/obs \
 -x ./OBS.app/Contents/MacOS/obs-ffmpeg-mux \
 -x ./OBS.app/Contents/MacOS/obslua.so \
 -x ./OBS.app/Contents/MacOS/_obspython.so \
--x ./OBS.app/Contents/Plugins/obs-x264.so \
--x ./OBS.app/Contents/Plugins/text-freetype2.so \
--x ./OBS.app/Contents/Plugins/obs-libfdk.so
-# -x ./OBS.app/Contents/Plugins/obs-outputs.so \
+-x ./OBS.app/Contents/PlugIns/obs-x264.so \
+-x ./OBS.app/Contents/PlugIns/text-freetype2.so \
+-x ./OBS.app/Contents/PlugIns/obs-libfdk.so
+# -x ./OBS.app/Contents/PlugIns/obs-outputs.so \
 
 /usr/local/Cellar/qt/5.10.1/bin/macdeployqt ./OBS.app
 
@@ -57,17 +57,17 @@ install_name_tool -change /usr/local/Cellar/qt/5.10.1/lib/QtCore.framework/Versi
 
 
 # decklink ui qt
-install_name_tool -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui ./OBS.app/Contents/Plugins/decklink-ouput-ui.so
-install_name_tool -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./OBS.app/Contents/Plugins/decklink-ouput-ui.so
-install_name_tool -change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets ./OBS.app/Contents/Plugins/decklink-ouput-ui.so
+install_name_tool -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui ./OBS.app/Contents/PlugIns/decklink-ouput-ui.so
+install_name_tool -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./OBS.app/Contents/PlugIns/decklink-ouput-ui.so
+install_name_tool -change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets ./OBS.app/Contents/PlugIns/decklink-ouput-ui.so
 
 # frontend tools qt
-install_name_tool -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui ./OBS.app/Contents/Plugins/frontend-tools.so
-install_name_tool -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./OBS.app/Contents/Plugins/frontend-tools.so
-install_name_tool -change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets ./OBS.app/Contents/Plugins/frontend-tools.so
+install_name_tool -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui ./OBS.app/Contents/PlugIns/frontend-tools.so
+install_name_tool -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./OBS.app/Contents/PlugIns/frontend-tools.so
+install_name_tool -change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets ./OBS.app/Contents/PlugIns/frontend-tools.so
 
 # vst qt
-install_name_tool -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui ./OBS.app/Contents/Plugins/obs-vst.so
-install_name_tool -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./OBS.app/Contents/Plugins/obs-vst.so
-install_name_tool -change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets ./OBS.app/Contents/Plugins/obs-vst.so
-install_name_tool -change /usr/local/opt/qt/lib/QtMacExtras.framework/Versions/5/QtMacExtras @executable_path/../Frameworks/QtMacExtras.framework/Versions/5/QtMacExtras ./OBS.app/Contents/Plugins/obs-vst.so
+install_name_tool -change /usr/local/opt/qt/lib/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui ./OBS.app/Contents/PlugIns/obs-vst.so
+install_name_tool -change /usr/local/opt/qt/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./OBS.app/Contents/PlugIns/obs-vst.so
+install_name_tool -change /usr/local/opt/qt/lib/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets ./OBS.app/Contents/PlugIns/obs-vst.so
+install_name_tool -change /usr/local/opt/qt/lib/QtMacExtras.framework/Versions/5/QtMacExtras @executable_path/../Frameworks/QtMacExtras.framework/Versions/5/QtMacExtras ./OBS.app/Contents/PlugIns/obs-vst.so


### PR DESCRIPTION
### Description
'PlugIns' is normal for MacOS and whatever is generating qt.conf
(macdeployqt?) is using 'PlugIns', so this both builds and generates
an app that works on case insensitive filesystems but fails to load
on case sensitive filesystems.

### How Has This Been Tested?
I haven't tested building the installer, only modifying the
qt.conf in the installed copy of OBS.app which fixes my copy
of OBS so it loads.

Fixes https://github.com/obsproject/obs-studio/issues/2302

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Types of changes
Bugfix (https://github.com/obsproject/obs-studio/issues/2302)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format). (N/A)
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
