### PR TITLE
obs-ffmpeg: Fix type conversion warning

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -599,7 +599,7 @@ static int64_t ffmpeg_source_get_duration(void *data)
 	int64_t dur = 0;
 
 	if (s->media.fmt)
-		dur = (float)s->media.fmt->duration / 1000.0f;
+		dur = s->media.fmt->duration / INT64_C(1000);
 
 	return dur;
 }


### PR DESCRIPTION
### Description
Remove implicit float to int64_t conversion by avoiding float entirely.

### Motivation and Context
Fixes VC++ warning.

### How Has This Been Tested?
No more warning. Calling code doesn't seem to exist yet, so didn't test functionality.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested. (kind of...)
- [x] All commit messages are properly formatted and commits squashed where appropriate.