### PR TITLE
cmake: Update Python to 3.7 for Windows builds

### DIFF
--- a/cmake/Modules/FindPythonDeps.cmake
+++ b/cmake/Modules/FindPythonDeps.cmake
@@ -38,7 +38,7 @@ FIND_PATH(PYTHON_INCLUDE_DIR
 		)
 
 find_library(PYTHON_LIB
-	NAMES ${_PYTHON_LIBRARIES} python36
+	NAMES ${_PYTHON_LIBRARIES} python37
 	HINTS
 		ENV PythonPath${_lib_suffix}
 		ENV PythonPath


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Updated the cmake script `FindPythonDeps.cmake` to make use of Python 3.7 for Windows builds. Also updated the files provided in `dependencies2017.zip` to the corresponding Python 3.7 files (removed the old Python 3.6 files), namely the header files under the `win32\include\python` / `win64\include\python` and the libraries under the `win32\bin` / `win64\bin`.

**Due to the way that Python is glued to OBS (using SWIG) this change will force users to upgrade their installed version of Python to 3.7.**

### Motivation and Context
I'm implementing a Python script that has dependencies that require Python 3.7 or newer. This has no link to the Ideas page or Mantis issue.

### How Has This Been Tested?
I tested this on a Windows 10 machine with 64 bits builds using. Installed both Python 3.7.0 and 3.7.6. Compiled OBS against Python 3.7.0 and ran tests using both versions by interchanging them on the `Scripts`configuration dialog.

### Types of changes
 - Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
