### PR TITLE
UI: Dynamically set widget index when renaming sources

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -318,12 +318,13 @@ bool SourceTreeItem::IsEditing()
 void SourceTreeItem::EnterEditMode()
 {
 	setFocusPolicy(Qt::StrongFocus);
+	int index = boxLayout->indexOf(label);
 	boxLayout->removeWidget(label);
 	editor = new QLineEdit(label->text());
 	editor->setStyleSheet("background: none");
 	editor->selectAll();
 	editor->installEventFilter(this);
-	boxLayout->insertWidget(2, editor);
+	boxLayout->insertWidget(index, editor);
 	setFocusProxy(editor);
 }
 
@@ -338,11 +339,12 @@ void SourceTreeItem::ExitEditMode(bool save)
 	std::string newName = QT_TO_UTF8(editor->text());
 
 	setFocusProxy(nullptr);
+	int index = boxLayout->indexOf(editor);
 	boxLayout->removeWidget(editor);
 	delete editor;
 	editor = nullptr;
 	setFocusPolicy(Qt::NoFocus);
-	boxLayout->insertWidget(2, label);
+	boxLayout->insertWidget(index, label);
 
 	/* ----------------------------------------- */
 	/* check for empty string                    */


### PR DESCRIPTION
### Description
Instead of hard-coding an expected index, or assuming the index based on whether icons are enabled, this will dynamically read where the widget was previously.

### Motivation and Context
Bug reported [here](https://obsproject.com/forum/threads/obs-studio-25-0-release-candidate.116067/post-437794).
Long story short - when icons are disabled, widget indexes are different.

### How Has This Been Tested?
Disable source icons. Rename a source. Re-enable source icons. Rename a source.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
