### PR TITLE
UI: Fix override transition not working

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -356,6 +356,7 @@ void OBSBasic::TransitionToScene(OBSSource source, bool force,
 		OBSSource trOverride = GetOverrideTransition(source);
 
 		if (trOverride && !overridingTransition && !quickTransition) {
+			transition = trOverride;
 			duration = GetOverrideTransitionDuration(source);
 			OverrideTransition(trOverride);
 			overridingTransition = true;


### PR DESCRIPTION
### Description
Fixes transition override not working as expected.

### Motivation and Context
Oversight in #2460

### How Has This Been Tested?
Used override transitions.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
