### PR TITLE
win-capture: Handle NULL VkApplicationInfo

### DIFF
--- a/plugins/win-capture/graphics-hook/vulkan-capture.c
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.c
@@ -1091,9 +1091,18 @@ static VkResult VKAPI OBS_CreateInstance(const VkInstanceCreateInfo *cinfo,
 	/* (HACK) Set api version to 1.1 if set to 1.0              */
 	/* We do this to get our extensions working properly        */
 
-	VkApplicationInfo ai = *info.pApplicationInfo;
-	if (ai.apiVersion < VK_API_VERSION_1_1) {
-		info.pApplicationInfo = &ai;
+	VkApplicationInfo ai;
+	if (info.pApplicationInfo) {
+		ai = *info.pApplicationInfo;
+		if (ai.apiVersion < VK_API_VERSION_1_1)
+			ai.apiVersion = VK_API_VERSION_1_1;
+	} else {
+		ai.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+		ai.pNext = NULL;
+		ai.pApplicationName = NULL;
+		ai.applicationVersion = 0;
+		ai.pEngineName = NULL;
+		ai.engineVersion = 0;
 		ai.apiVersion = VK_API_VERSION_1_1;
 	}
 


### PR DESCRIPTION
### Description
Fix crash in Vulkan game capture if VkApplicationInfo is NULL.

### Motivation and Context
mpv passes NULL, and that's valid.

### How Has This Been Tested?
mpv works now.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.