### PR TITLE
libobs: Only manipulate input source ref counts

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -958,7 +958,8 @@ static void deactivate_source(obs_source_t *source)
 
 static void show_source(obs_source_t *source)
 {
-	obs_source_addref(source);
+	if (source->info.type == OBS_SOURCE_TYPE_INPUT)
+		obs_source_addref(source);
 
 	if (source->context.data && source->info.show)
 		source->info.show(source->context.data);
@@ -971,7 +972,8 @@ static void hide_source(obs_source_t *source)
 		source->info.hide(source->context.data);
 	obs_source_dosignal(source, "source_hide", "hide");
 
-	obs_source_release(source);
+	if (source->info.type == OBS_SOURCE_TYPE_INPUT)
+		obs_source_release(source);
 }
 
 static void activate_tree(obs_source_t *parent, obs_source_t *child,


### PR DESCRIPTION
### Description
Filters can be hidden without being shown, which can unbalance the ref
count and destroys them prematurely. We really only care about input
sources having a chance to clean up from the render thread from the hide
handler, Windows 10 window capture specifically.

### Motivation and Context
Filters were disappearing on scene switches.

### How Has This Been Tested?
Filters stick around when scenes are being switched. WGC capture successfully cleaned up 5/5 times.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.