### PR TITLE
win-capture: Fix format string warning

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -1252,7 +1252,7 @@ static inline enum capture_result init_capture_data(struct game_capture *gc)
 	CloseHandle(gc->hook_data_map);
 
 	wchar_t name[64];
-	_snwprintf(name, 64, L"%s_%d_", SHMEM_TEXTURE,
+	_snwprintf(name, 64, L"%s_%u_", SHMEM_TEXTURE,
 		   (uint32_t)(uintptr_t)gc->window);
 
 	gc->hook_data_map =

--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -505,7 +505,7 @@ static inline void unlock_shmem_tex(int id)
 static inline bool init_shared_info(size_t size, HWND window)
 {
 	wchar_t name[64];
-	_snwprintf(name, 64, L"%s_%d_%u", SHMEM_TEXTURE,
+	_snwprintf(name, 64, L"%s_%u_%u", SHMEM_TEXTURE,
 		   (uint32_t)(uintptr_t)window, ++shmem_id_counter);
 
 	shmem_file_handle = CreateFileMappingW(INVALID_HANDLE_VALUE, NULL,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Use correct format string for uint32_t (unsigned int)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Reduce warning

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
After this fix, warning dispears

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
