### PR TITLE
Fix build for armhf and powerpc

### DIFF
--- a/plugins/linux-v4l2/v4l2-controls.c
+++ b/plugins/linux-v4l2/v4l2-controls.c
@@ -24,14 +24,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define blog(level, msg, ...) blog(level, "v4l2-controls: " msg, ##__VA_ARGS__)
 
-#if defined(__i386__)
-#define UINT_TO_POINTER(val) ((void *)(unsigned int)(val))
-#define POINTER_TO_UINT(p) ((unsigned int)(unsigned int)(p))
-#elif defined(__x86_64__) || defined(__aarch64__) || (_MIPS_SIM == _ABI64)
+#if defined(__LP64__)
 #define UINT_TO_POINTER(val) ((void *)(unsigned long)(val))
 #define POINTER_TO_UINT(p) ((unsigned int)(unsigned long)(p))
 #else
-#error "unknown platform, this code won't work"
+#define UINT_TO_POINTER(val) ((void *)(unsigned int)(val))
+#define POINTER_TO_UINT(p) ((unsigned int)(unsigned int)(p))
 #endif
 
 static bool v4l2_control_changed(void *data, obs_properties_t *props,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Use LP64 macro to determine pointer size in linux-v4l2 plugin.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
"unknown platform, this code won't work" buildtime error happens when
building for armhf. It should also effect powerpc.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Build & run test on armhf & amd64.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
