### PR TITLE
libobs-winrt: win-capture: HDC cursor capture for WGC

### DIFF
--- a/libobs-winrt/winrt-capture.h
+++ b/libobs-winrt/winrt-capture.h
@@ -9,11 +9,14 @@
 extern "C" {
 #endif
 
-EXPORT bool winrt_capture_supported();
-EXPORT struct winrt_capture *winrt_capture_init(bool cursor, HWND window,
-						bool client_area);
+EXPORT BOOL winrt_capture_supported();
+EXPORT BOOL winrt_capture_cursor_toggle_supported();
+EXPORT struct winrt_capture *winrt_capture_init(BOOL cursor, HWND window,
+						BOOL client_area);
 EXPORT void winrt_capture_free(struct winrt_capture *capture);
 
+EXPORT void winrt_capture_show_cursor(struct winrt_capture *capture,
+				      BOOL visible);
 EXPORT void winrt_capture_render(struct winrt_capture *capture,
 				 gs_effect_t *effect);
 EXPORT uint32_t winrt_capture_width(const struct winrt_capture *capture);


### PR DESCRIPTION
### Description
Starting with Windows 10 2004, we can disable WGC cursor capture, and
provide a user toggle. We swap out WGC support for our own though
because ours does not break hardware cursor support.

### Motivation and Context
Being able to disable cursor capture is good. WGC cursor capture is also apparently detrimental to mouse cursor performance.

### How Has This Been Tested?
BitBlt and WGC cursor captures work according to user setting and window focus. Mouse cursor offset appears to be good for both sides of client area toggle.

Older Windows 10 works as expected on builds made with old and new Windows SDK.

### Types of changes
- New feature (non-breaking change which adds functionality)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.