### PR TITLE
win-capture: Support VK_FORMAT_A8B8G8R8_UNORM_PACK32

### DIFF
--- a/plugins/win-capture/graphics-hook-ver.h
+++ b/plugins/win-capture/graphics-hook-ver.h
@@ -12,8 +12,8 @@
  * THIS IS YOUR ONLY WARNING. */
 
 #define HOOK_VER_MAJOR 1
-#define HOOK_VER_MINOR 0
-#define HOOK_VER_PATCH 3
+#define HOOK_VER_MINOR 1
+#define HOOK_VER_PATCH 0
 
 #define STRINGIFY(s) #s
 #define MAKE_VERSION_NAME(major, minor, patch) \

--- a/plugins/win-capture/graphics-hook/vulkan-capture.h
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.h
@@ -457,6 +457,7 @@ DXGI_FORMAT vk_format_to_dxgi(VkFormat format)
 		dxgi_format = DXGI_FORMAT_B8G8R8A8_UNORM;
 		break;
 	case VK_FORMAT_A8B8G8R8_UNORM_PACK32:
+		dxgi_format = DXGI_FORMAT_R8G8B8A8_UNORM;
 		break;
 	case VK_FORMAT_A8B8G8R8_SNORM_PACK32:
 		break;


### PR DESCRIPTION
### Description
Add support for VK_FORMAT_A8B8G8R8_UNORM_PACK32.

### Motivation and Context
Some programs use VK_FORMAT_A8B8G8R8_UNORM_PACK32 for their swap chains.

### How Has This Been Tested?
Vetted that Vulkan applications still capture, but I'm not in a position to test this specific format.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.