### PR TITLE
win-capture: Restore Vulkan 1.1 version hack

### DIFF
--- a/plugins/win-capture/graphics-hook/vulkan-capture.c
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.c
@@ -1047,6 +1047,8 @@ static VkResult VKAPI OBS_CreateInstance(const VkInstanceCreateInfo *cinfo,
 		ai.apiVersion = VK_API_VERSION_1_1;
 	}
 
+	info.pApplicationInfo = &ai;
+
 	/* -------------------------------------------------------- */
 	/* create instance                                          */
 


### PR DESCRIPTION
### Description
Restore Vulkan 1.1 version hack for AMD drivers.

### Motivation and Context
Fix regression caused by null application info fix.

### How Has This Been Tested?
Vulkan works on AMD again after not working.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.