### PR TITLE
libobs-winrt: win-capture: BOOL fixes and WGC support check

### DIFF
--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -12,12 +12,12 @@ struct __declspec(uuid("A9B3D012-3DF2-4EE3-B8D1-8695F457D3C1"))
 					       void **object) = 0;
 };
 
-extern "C" EXPORT bool winrt_capture_supported()
+extern "C" EXPORT BOOL winrt_capture_supported()
 {
-	/* no contract for IGraphicsCaptureItemInterop, verify 10.0.18362.0 */
-	return winrt::Windows::Foundation::Metadata::ApiInformation::
-		IsApiContractPresent(L"Windows.Foundation.UniversalApiContract",
-				     8);
+	return winrt::Windows::Foundation::Metadata::ApiInformation::IsTypePresent(
+		       L"Windows.Graphics.Capture.GraphicsCaptureSession") &&
+	       winrt::Windows::Graphics::Capture::GraphicsCaptureSession::
+		       IsSupported();
 }
 
 template<typename T>
@@ -236,7 +236,7 @@ static void winrt_capture_device_loss_rebuild(void *device_void, void *data)
 thread_local bool initialized_tls;
 
 extern "C" EXPORT struct winrt_capture *
-winrt_capture_init(bool cursor, HWND window, bool client_area)
+winrt_capture_init(BOOL cursor, HWND window, BOOL client_area)
 {
 	ID3D11Device *const d3d_device = (ID3D11Device *)gs_get_device_obj();
 	ComPtr<IDXGIDevice> dxgi_device;

--- a/libobs-winrt/winrt-capture.h
+++ b/libobs-winrt/winrt-capture.h
@@ -9,9 +9,9 @@
 extern "C" {
 #endif
 
-EXPORT bool winrt_capture_supported();
-EXPORT struct winrt_capture *winrt_capture_init(bool cursor, HWND window,
-						bool client_area);
+EXPORT BOOL winrt_capture_supported();
+EXPORT struct winrt_capture *winrt_capture_init(BOOL cursor, HWND window,
+						BOOL client_area);
 EXPORT void winrt_capture_free(struct winrt_capture *capture);
 
 EXPORT void winrt_capture_render(struct winrt_capture *capture,

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -26,9 +26,9 @@
 #define WC_CHECK_TIMER 1.0f
 
 struct winrt_exports {
-	bool *(*winrt_capture_supported)();
-	struct winrt_capture *(*winrt_capture_init)(bool cursor, HWND window,
-						    bool client_area);
+	BOOL *(*winrt_capture_supported)();
+	struct winrt_capture *(*winrt_capture_init)(BOOL cursor, HWND window,
+						    BOOL client_area);
 	void (*winrt_capture_free)(struct winrt_capture *capture);
 	void (*winrt_capture_render)(struct winrt_capture *capture,
 				     gs_effect_t *effect);


### PR DESCRIPTION
### Description
C and C++ have different ideas of what bool is, so use BOOL instead.
Also use better logic for detecting WGC support.

These fixes were pulled out of PR #2469 to make them easier to merge.

### Motivation and Context
Noticed C++ clearing AL for the return value, but C testing RAX when using bool.

### How Has This Been Tested?
False is now interpreted as false instead of true. WGC continues to work.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.