### PR TITLE
Show friendly monitor names on Display Capture on Windows & Projectors

### DIFF
--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -181,6 +181,8 @@ struct gs_monitor_info {
 	long y;
 	long cx;
 	long cy;
+	char *monitor_name;
+	uint32_t flags;
 };
 
 struct gs_tvertarray {

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -273,13 +273,32 @@ static bool get_monitor_props(obs_property_t *monitor_list, int monitor_idx)
 	if (!gs_get_duplicator_monitor_info(monitor_idx, &info))
 		return false;
 
-	dstr_catf(&monitor_desc, "%s %d: %ldx%ld @ %ld,%ld", TEXT_MONITOR,
-		  monitor_idx + 1, info.cx, info.cy, info.x, info.y);
+	struct dstr format_str = {0};
+	dstr_copy(&format_str, "%s: %ldx%ld @ %ld,%ld");
+
+	struct dstr m = {0};
+	dstr_copy(&m, info.monitor_name);
+	if (dstr_is_empty(&m)) {
+		// Fallback
+		struct dstr d = {0};
+		dstr_catf(&d, "%s %d", TEXT_MONITOR, monitor_idx + 1);
+		dstr_free(&m);
+		dstr_copy_dstr(&m, &d);
+		dstr_free(&d);
+	}
+
+	if (info.flags & MONITORINFOF_PRIMARY)
+		dstr_catf(&format_str, " (%s)", TEXT_PRIMARY_MONITOR);
+
+	dstr_catf(&monitor_desc, format_str.array, m.array, info.cx, info.cy,
+		  info.x, info.y);
 
 	obs_property_list_add_int(monitor_list, monitor_desc.array,
 				  monitor_idx);
 
 	dstr_free(&monitor_desc);
+	dstr_free(&format_str);
+	dstr_free(&m);
 
 	return true;
 }

--- a/plugins/win-capture/monitor-capture.c
+++ b/plugins/win-capture/monitor-capture.c
@@ -1,4 +1,5 @@
 #include <util/dstr.h>
+#include <util/platform.h>
 #include "dc-capture.h"
 
 /* clang-format off */
@@ -176,7 +177,7 @@ static BOOL CALLBACK enum_monitor_props(HMONITOR handle, HDC hdc, LPRECT rect,
 	UNUSED_PARAMETER(rect);
 
 	obs_property_t *monitor_list = (obs_property_t *)param;
-	MONITORINFO mi;
+	MONITORINFOEX mi;
 	size_t monitor_id = 0;
 	struct dstr monitor_desc = {0};
 	struct dstr resolution = {0};
@@ -187,18 +188,40 @@ static BOOL CALLBACK enum_monitor_props(HMONITOR handle, HDC hdc, LPRECT rect,
 	mi.cbSize = sizeof(mi);
 	GetMonitorInfo(handle, &mi);
 
+	DISPLAY_DEVICE ddev;
+	ddev.cb = sizeof(ddev);
+	EnumDisplayDevices(mi.szDevice, 0, &ddev, 1);
+
+	char *devname = NULL;
+#ifdef UNICODE
+	os_wcs_to_utf8_ptr(ddev.DeviceString, 128, &devname);
+#else
+	devname = (char *)bstrdup(ddev.DeviceString);
+#endif
+
 	dstr_catf(&resolution, "%dx%d @ %d,%d",
 		  mi.rcMonitor.right - mi.rcMonitor.left,
 		  mi.rcMonitor.bottom - mi.rcMonitor.top, mi.rcMonitor.left,
 		  mi.rcMonitor.top);
 
-	dstr_copy(&format_string, "%s %d: %s");
+	dstr_copy(&format_string, "%s: %s");
 	if (mi.dwFlags == MONITORINFOF_PRIMARY) {
 		dstr_catf(&format_string, " (%s)", TEXT_PRIMARY_MONITOR);
 	}
 
-	dstr_catf(&monitor_desc, format_string.array, TEXT_MONITOR,
-		  monitor_id + 1, resolution.array);
+	struct dstr m = {0};
+	dstr_copy(&m, devname);
+	dstr_replace(&m, "(", " (");
+	if (dstr_is_empty(&m)) {
+		struct dstr d = {0};
+		dstr_catf(&d, "%s %d", TEXT_MONITOR, monitor_id + 1);
+		dstr_free(&m);
+		dstr_copy_dstr(&m, &d);
+		dstr_free(&d);
+	}
+
+	dstr_catf(&monitor_desc, format_string.array, m.array,
+		  resolution.array);
 
 	obs_property_list_add_int(monitor_list, monitor_desc.array,
 				  (int)monitor_id);
@@ -206,6 +229,8 @@ static BOOL CALLBACK enum_monitor_props(HMONITOR handle, HDC hdc, LPRECT rect,
 	dstr_free(&monitor_desc);
 	dstr_free(&resolution);
 	dstr_free(&format_string);
+	dstr_free(&m);
+	bfree(devname);
 
 	return TRUE;
 }


### PR DESCRIPTION
### Description
Replaces "Display X" in Fullscreen Projector lists on all platforms, and Display Capture on Windows, with the real display names. Falls back to Display X if a name is unavailable or blank.

Display Capture:
![image](https://user-images.githubusercontent.com/941350/76173495-1a564f80-61f4-11ea-84bd-4348a709446f.png)

Projectors (Windows):
![image](https://user-images.githubusercontent.com/941350/76173499-2510e480-61f4-11ea-9e49-8a69da3e0c81.png)

Projectors (Linux):
![image](https://user-images.githubusercontent.com/941350/76173509-2fcb7980-61f4-11ea-9f93-133b6c713cc8.png)

Projectors (macOS):
![image](https://user-images.githubusercontent.com/941350/76173521-3f4ac280-61f4-11ea-896d-7aaac5266198.png)

**Note;** If someone is able to get proper display names on macOS or Linux Screen Capture, feel free to PR to my branch, I'll happily combine the changes. I tried and failed.

### Motivation and Context
Improves UX: "Display X" isn't very descriptive, especially as it doesn't always match the display indexes in the system's Display properties. This makes it easier to find the right display at a glance.

### How Has This Been Tested?

* Right click on a scene, source, preview or program and select "Fullscreen Projector"

* Add a Display Capture source on Windows 7 or above. The dropdown should contain named displays.

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
