### PR TITLE
obs-scripting: Add missing symbols in -python-import.[ch]

### DIFF
--- a/deps/obs-scripting/obs-scripting-python-import.c
+++ b/deps/obs-scripting/obs-scripting-python-import.c
@@ -108,6 +108,7 @@ bool import_python(const char *python_path)
 	IMPORT_FUNC(PyExc_RuntimeError);
 	IMPORT_FUNC(PyObject_GetAttr);
 	IMPORT_FUNC(PyUnicode_FromString);
+	IMPORT_FUNC(PyDict_New);
 	IMPORT_FUNC(PyDict_GetItemString);
 	IMPORT_FUNC(PyDict_SetItemString);
 	IMPORT_FUNC(PyCFunction_NewEx);
@@ -140,6 +141,7 @@ bool import_python(const char *python_path)
 	IMPORT_FUNC(PyLong_FromUnsignedLongLong);
 	IMPORT_FUNC(PyArg_VaParse);
 	IMPORT_FUNC(_Py_NoneStruct);
+	IMPORT_FUNC(PyTuple_New);
 
 #undef IMPORT_FUNC
 

--- a/deps/obs-scripting/obs-scripting-python-import.h
+++ b/deps/obs-scripting/obs-scripting-python-import.h
@@ -92,6 +92,7 @@ PY_EXTERN PyObject *(*Import_PyExc_TypeError);
 PY_EXTERN PyObject *(*Import_PyExc_RuntimeError);
 PY_EXTERN PyObject *(*Import_PyObject_GetAttr)(PyObject *, PyObject *);
 PY_EXTERN PyObject *(*Import_PyUnicode_FromString)(const char *u);
+PY_EXTERN PyObject *(*Import_PyDict_New)(void);
 PY_EXTERN PyObject *(*Import_PyDict_GetItemString)(PyObject *dp,
 						   const char *key);
 PY_EXTERN int (*Import_PyDict_SetItemString)(PyObject *dp, const char *key,
@@ -133,6 +134,7 @@ PY_EXTERN PyObject *(*Import_PyUnicode_AsUTF8String)(PyObject *unicode);
 PY_EXTERN PyObject *(*Import_PyLong_FromUnsignedLongLong)(unsigned long long);
 PY_EXTERN int (*Import_PyArg_VaParse)(PyObject *, const char *, va_list);
 PY_EXTERN PyObject(*Import__Py_NoneStruct);
+PY_EXTERN PyObject *(*Import_PyTuple_New)(Py_ssize_t size);
 
 extern bool import_python(const char *python_path);
 
@@ -174,6 +176,7 @@ extern bool import_python(const char *python_path);
 #define PyExc_RuntimeError (*Import_PyExc_RuntimeError)
 #define PyObject_GetAttr Import_PyObject_GetAttr
 #define PyUnicode_FromString Import_PyUnicode_FromString
+#define PyDict_New Import_PyDict_New
 #define PyDict_GetItemString Import_PyDict_GetItemString
 #define PyDict_SetItemString Import_PyDict_SetItemString
 #define PyCFunction_NewEx Import_PyCFunction_NewEx
@@ -206,6 +209,7 @@ extern bool import_python(const char *python_path);
 #define PyLong_FromUnsignedLongLong Import_PyLong_FromUnsignedLongLong
 #define PyArg_VaParse Import_PyArg_VaParse
 #define _Py_NoneStruct (*Import__Py_NoneStruct)
+#define PyTuple_New Import_PyTuple_New
 #endif
 
 #endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Add PyDict_New and PyTuple_New to obs-scripting-python-import.[ch]; these functions are used by SWIG's generated code when I build OBS on macOS with SWIG 4.0.1.

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

obs-scripting-python-import is a wrapper used on Windows and macOS that dlopen()s Python instead of linking it directly.  It contains many pairs of definitions like
```c
PY_EXTERN void (*Import_PySys_SetArgv)(int, wchar_t **);
#define PySys_SetArgv Import_PySys_SetArgv
```

But it was missing two functions, causing OBS to fail to build.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

It builds.  I haven't tested further, but it seems like a straightforward fix.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
