### PR TITLE
libobs: media-playback: UI: obs-x264: YUY2 output

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -4761,6 +4761,11 @@
                      </item>
                      <item>
                       <property name="text">
+                       <string notr="true">YUY2</string>
+                      </property>
+                     </item>
+                     <item>
+                      <property name="text">
                        <string>I444</string>
                       </property>
                      </item>

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -473,7 +473,8 @@ void SimpleOutput::Update()
 	video_t *video = obs_get_video();
 	enum video_format format = video_output_get_format(video);
 
-	if (format != VIDEO_FORMAT_NV12 && format != VIDEO_FORMAT_I420)
+	if (format != VIDEO_FORMAT_NV12 && format != VIDEO_FORMAT_I420 &&
+	    format != VIDEO_FORMAT_YUY2)
 		obs_encoder_set_preferred_video_format(h264Streaming,
 						       VIDEO_FORMAT_NV12);
 
@@ -1256,7 +1257,8 @@ void AdvancedOutput::UpdateStreamSettings()
 	video_t *video = obs_get_video();
 	enum video_format format = video_output_get_format(video);
 
-	if (format != VIDEO_FORMAT_NV12 && format != VIDEO_FORMAT_I420)
+	if (format != VIDEO_FORMAT_NV12 && format != VIDEO_FORMAT_I420 &&
+	    format != VIDEO_FORMAT_YUY2)
 		obs_encoder_set_preferred_video_format(h264Streaming,
 						       VIDEO_FORMAT_NV12);
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3588,6 +3588,8 @@ static inline enum video_format GetVideoFormatFromName(const char *name)
 		return VIDEO_FORMAT_I420;
 	else if (astrcmpi(name, "NV12") == 0)
 		return VIDEO_FORMAT_NV12;
+	else if (astrcmpi(name, "YUY2") == 0)
+		return VIDEO_FORMAT_YUY2;
 	else if (astrcmpi(name, "I444") == 0)
 		return VIDEO_FORMAT_I444;
 #if 0 //currently unsupported

--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -34,6 +34,8 @@ static inline enum video_format convert_pixel_format(int f)
 		return VIDEO_FORMAT_NONE;
 	case AV_PIX_FMT_YUV420P:
 		return VIDEO_FORMAT_I420;
+	case AV_PIX_FMT_YUV422P:
+		return VIDEO_FORMAT_I422;
 	case AV_PIX_FMT_NV12:
 		return VIDEO_FORMAT_NV12;
 	case AV_PIX_FMT_YUYV422:

--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -152,6 +152,24 @@ VertPosWide VSPosWide_Reverse(uint id : VERTEXID)
 	return vert_out;
 }
 
+VertTexPosWide VSPacked422(uint id : VERTEXID)
+{
+	float idHigh = float(id >> 1);
+	float idLow = float(id & uint(1));
+
+	float x = idHigh * 4.0 - 1.0;
+	float y = idLow * 4.0 - 1.0;
+
+	float u_right = idHigh * 2.0;
+	float u_left = u_right - width_i;
+	float v = obs_glsl_compile ? (idLow * 2.0) : (1.0 - idLow * 2.0);
+
+	VertTexPosWide vert_out;
+	vert_out.uuv = float3(u_left, u_right, v);
+	vert_out.pos = float4(x, y, 0.0, 1.0);
+	return vert_out;
+}
+
 float PS_Y(FragPos frag_in) : TARGET
 {
 	float3 rgb = image.Load(int3(frag_in.pos.xy, 0)).rgb;
@@ -199,6 +217,24 @@ float PS_V_Wide(FragTexWide frag_in) : TARGET
 	float3 rgb = (rgb_left + rgb_right) * 0.5;
 	float v = dot(color_vec2.xyz, rgb) + color_vec2.w;
 	return v;
+}
+
+float4 PSYUY2(VertTexPosWide frag_in) : TARGET
+{
+	float2 pos_y_left = float2(frag_in.pos.x * 2.0 - 0.5, frag_in.pos.y);
+	float2 pos_y_right = float2(pos_y_left.x + 1.0, frag_in.pos.y);
+	float3 rgb_y_left = image.Load(int3(pos_y_left, 0)).rgb;
+	float3 rgb_y_right = image.Load(int3(pos_y_right, 0)).rgb;
+	float y0 = dot(color_vec0.xyz, rgb_y_left) + color_vec0.w;
+	float y1 = dot(color_vec0.xyz, rgb_y_right) + color_vec0.w;
+
+	float3 rgb_uv_left = image.Sample(def_sampler, frag_in.uuv.xz).rgb;
+	float3 rgb_uv_right = image.Sample(def_sampler, frag_in.uuv.yz).rgb;
+	float3 rgb_uv = (rgb_uv_left + rgb_uv_right) * 0.5;
+	float u = dot(color_vec1.xyz, rgb_uv) + color_vec1.w;
+	float v = dot(color_vec2.xyz, rgb_uv) + color_vec2.w;
+
+	return float4(y0, u, y1, v);
 }
 
 float3 YUV_to_RGB(float3 yuv)
@@ -436,6 +472,15 @@ technique NV12_UV
 	{
 		vertex_shader = VSTexPos_Left(id);
 		pixel_shader  = PS_UV_Wide(frag_in);
+	}
+}
+
+technique YUY2
+{
+	pass
+	{
+		vertex_shader = VSPacked422(id);
+		pixel_shader  = PSYUY2(frag_in);
 	}
 }
 

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -322,23 +322,18 @@ static void render_convert_texture(struct obs_core_video *video,
 	if (video->convert_textures[0]) {
 		gs_effect_set_texture(image, texture);
 		gs_effect_set_vec4(color_vec0, &vec0);
+		gs_effect_set_vec4(color_vec1, &vec1);
+		gs_effect_set_vec4(color_vec2, &vec2);
+		gs_effect_set_vec4(color_vec2, &vec2);
+		gs_effect_set_float(width_i, video->conversion_width_i);
 		render_convert_plane(effect, video->convert_textures[0],
 				     video->conversion_techs[0]);
 
 		if (video->convert_textures[1]) {
-			gs_effect_set_texture(image, texture);
-			gs_effect_set_vec4(color_vec1, &vec1);
-			if (!video->convert_textures[2])
-				gs_effect_set_vec4(color_vec2, &vec2);
-			gs_effect_set_float(width_i, video->conversion_width_i);
 			render_convert_plane(effect, video->convert_textures[1],
 					     video->conversion_techs[1]);
 
 			if (video->convert_textures[2]) {
-				gs_effect_set_texture(image, texture);
-				gs_effect_set_vec4(color_vec2, &vec2);
-				gs_effect_set_float(width_i,
-						    video->conversion_width_i);
 				render_convert_plane(
 					effect, video->convert_textures[2],
 					video->conversion_techs[2]);
@@ -618,6 +613,18 @@ static void set_gpu_converted_data(struct obs_core_video *video,
 
 			break;
 		}
+		case VIDEO_FORMAT_YUY2: {
+			const uint32_t width = info->width;
+			const uint32_t height = info->height;
+
+			set_gpu_converted_plane(width * 2, height,
+						input->linesize[0],
+						output->linesize[0],
+						input->data[0],
+						output->data[0]);
+
+			break;
+		}
 		case VIDEO_FORMAT_I444: {
 			const uint32_t width = info->width;
 			const uint32_t height = info->height;
@@ -645,7 +652,6 @@ static void set_gpu_converted_data(struct obs_core_video *video,
 
 		case VIDEO_FORMAT_NONE:
 		case VIDEO_FORMAT_YVYU:
-		case VIDEO_FORMAT_YUY2:
 		case VIDEO_FORMAT_UYVY:
 		case VIDEO_FORMAT_RGBA:
 		case VIDEO_FORMAT_BGRA:

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -511,6 +511,10 @@ static void update_params(struct obs_x264 *obsx264, obs_data_t *settings,
 		obsx264->params.i_csp = X264_CSP_NV12;
 	else if (info.format == VIDEO_FORMAT_I420)
 		obsx264->params.i_csp = X264_CSP_I420;
+#ifdef X264_CSP_YUYV
+	else if (info.format == VIDEO_FORMAT_YUY2)
+		obsx264->params.i_csp = X264_CSP_YUYV;
+#endif
 	else if (info.format == VIDEO_FORMAT_I444)
 		obsx264->params.i_csp = X264_CSP_I444;
 	else
@@ -692,6 +696,10 @@ static inline void init_pic_data(struct obs_x264 *obsx264, x264_picture_t *pic,
 		pic->img.i_plane = 2;
 	else if (obsx264->params.i_csp == X264_CSP_I420)
 		pic->img.i_plane = 3;
+#ifdef X264_CSP_YUYV
+	else if (obsx264->params.i_csp == X264_CSP_YUYV)
+		pic->img.i_plane = 1;
+#endif
 	else if (obsx264->params.i_csp == X264_CSP_I444)
 		pic->img.i_plane = 3;
 
@@ -756,8 +764,13 @@ static bool obs_x264_sei(void *data, uint8_t **sei, size_t *size)
 
 static inline bool valid_format(enum video_format format)
 {
+#ifdef X264_CSP_YUYV
+	return format == VIDEO_FORMAT_I420 || format == VIDEO_FORMAT_NV12 ||
+	       format == VIDEO_FORMAT_I444 || format == VIDEO_FORMAT_YUY2;
+#else
 	return format == VIDEO_FORMAT_I420 || format == VIDEO_FORMAT_NV12 ||
 	       format == VIDEO_FORMAT_I444;
+#endif
 }
 
 static void obs_x264_video_info(void *data, struct video_scale_info *info)


### PR DESCRIPTION
### Description
Add YUY2 (packed 4:2:2) output support.

### Motivation and Context
ProRes, DNxHD, Blackmagic output

### How Has This Been Tested?
Tested with x264 (works), NVENC/AMF (silent NV12 fallback)

TODO (preferably not by me): ProRes, DNxHD, Blackmagic output

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.