### PR TITLE
UI: Fix windowed multiview title

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -979,7 +979,7 @@ void OBSProjector::UpdateProjectorTitle(QString name)
 		if (!window)
 			title = QTStr("MultiviewProjector");
 		else
-			title = QTStr("MultiviewWindow");
+			title = QTStr("MultiviewWindowed");
 		break;
 	default:
 		title = name;


### PR DESCRIPTION
### Description

Uses the correct translation key instead of the current one.

`MultiviewWindowed="Multiview (Windowed)"`

### Motivation and Context
Currently the window title is rendered as the key, not the string. This means it is not translated for users.

### How Has This Been Tested?
Open a windowed multiview. Note the window title.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
