### PR TITLE
tests: fix Windows compile error

### DIFF
--- a/test/win/test.cpp
+++ b/test/win/test.cpp
@@ -112,7 +112,7 @@ static DisplayContext CreateDisplay(HWND hwnd)
 	info.zsformat = GS_ZS_NONE;
 	info.window.hwnd = hwnd;
 
-	return obs_display_create(&info);
+	return obs_display_create(&info, 0);
 }
 
 static void AddTestItems(obs_scene_t *scene, obs_source_t *source)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Nothing fancy here: if one tries to build OBS Studio on Windows with `BUILD_TESTS` enabled, compile fails with a `no enough parameters` error on a call to `obs_display_create`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Not having to edit `test/win/test.cpp` whenever I want to build The Tests™ on Windows.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows 10 1903 64-bit with `BUILD_TESTS` enabled in CMake. Compiles OK.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
