### PR TITLE
win-capture: Handle vkCreateSwapchainKHR errors

### DIFF
--- a/plugins/win-capture/graphics-hook-ver.h
+++ b/plugins/win-capture/graphics-hook-ver.h
@@ -13,7 +13,7 @@
 
 #define HOOK_VER_MAJOR 1
 #define HOOK_VER_MINOR 1
-#define HOOK_VER_PATCH 1
+#define HOOK_VER_PATCH 2
 
 #define STRINGIFY(s) #s
 #define MAKE_VERSION_NAME(major, minor, patch) \


### PR DESCRIPTION
### Description
Handle vkCreateSwapchainKHR errors instead of ignoring them.

### Motivation and Context
Hopefully fixes behavior for an application reported by AMD, fixes #2485.

### How Has This Been Tested?
OBS is still able to capture vkcube. Used breakpoint inspection to verify new code behaves as expected. Contrived failure leads to NULL dereference caused by sample code ignoring the return value.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.