### PR TITLE
UI: Fix filter rename crash

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -738,6 +738,9 @@ void OBSBasicFilters::CustomContextMenu(const QPoint &pos, bool async)
 
 void OBSBasicFilters::EditItem(QListWidgetItem *item, bool async)
 {
+	if (editActive)
+		return;
+
 	Qt::ItemFlags flags = item->flags();
 	OBSSource filter = item->data(Qt::UserRole).value<OBSSource>();
 	const char *name = obs_source_get_name(filter);
@@ -748,6 +751,7 @@ void OBSBasicFilters::EditItem(QListWidgetItem *item, bool async)
 	list->removeItemWidget(item);
 	list->editItem(item);
 	item->setFlags(flags);
+	editActive = true;
 }
 
 void OBSBasicFilters::on_asyncFilters_customContextMenuRequested(
@@ -814,6 +818,7 @@ void OBSBasicFilters::FilterNameEdited(QWidget *editor, QListWidget *list)
 
 	listItem->setText(QString());
 	SetupVisibilityItem(list, listItem, filter);
+	editActive = false;
 }
 
 void OBSBasicFilters::AsyncFilterNameEdited(

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -74,6 +74,8 @@ private:
 
 	int noPreviewMargin;
 
+	bool editActive = false;
+
 private slots:
 	void AddFilter(OBSSource filter);
 	void RemoveFilter(OBSSource filter);


### PR DESCRIPTION
### Description
Fixes crash when pressing F2 to rename filter twice.

### Motivation and Context
Fix crash reported on Discord.

### How Has This Been Tested?
Renamed filters.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
