### PR TITLE
UI: Support Unicode for Windows fullscreen projectors

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4137,11 +4137,15 @@ void OBSBasic::AddProjectorMenuMonitors(QMenu *parent, QObject *target,
 		QRect screenGeometry = screen->geometry();
 		QString name = "";
 #ifdef _WIN32
-		DISPLAY_DEVICEA ddev;
+		DISPLAY_DEVICE ddev;
 		ddev.cb = sizeof(ddev);
-		EnumDisplayDevicesA(screen->name().toStdString().c_str(), 0,
-				    &ddev, 1);
-		name = ddev.DeviceString;
+		BPtr<wchar_t> wideName;
+		os_utf8_to_wcs_ptr(screen->name().toStdString().c_str(), 0,
+				   &wideName);
+		EnumDisplayDevices(wideName, 0, &ddev, 1);
+		BPtr<char> newName;
+		os_wcs_to_utf8_ptr(ddev.DeviceString, 0, &newName);
+		name = newName;
 #elif defined(__APPLE__)
 		name = screen->name();
 #elif QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)


### PR DESCRIPTION
### Description
Uses and then converts wide char for fullscreen projector names on Windows.

### Motivation and Context
If a display device doesn't report its model number, Windows localises "Generic PnP Monitor", which in Russian becomes a series of question marks.

### How Has This Been Tested?
Unfortunately, of the 5 displays I have access to, none display as "Generic PnP Monitor", so I cannot test this fix myself.
At the very least, I've tested this to ensure there's no regression for standard English characters.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
