### PR TITLE
linux-capture: Use RandR monitors for screen information

### DIFF
--- a/plugins/linux-capture/xhelpers.h
+++ b/plugins/linux-capture/xhelpers.h
@@ -94,7 +94,7 @@ int randr_screen_count(xcb_connection_t *xcb);
  */
 int randr_screen_geo(xcb_connection_t *xcb, int_fast32_t screen,
 		     int_fast32_t *x, int_fast32_t *y, int_fast32_t *w,
-		     int_fast32_t *h, xcb_screen_t **rscreen);
+		     int_fast32_t *h, xcb_screen_t **rscreen, char **name);
 
 /**
  * Get screen geometry for a X11 screen


### PR DESCRIPTION
### Description
RandR has two sets of screen geometry information:

 1. CRTC. These are the physical scanout engines in the hardware

 2. Monitors. These are the logical partitions of the screen.

By default, each CRTC gets mapped to a Monitor. However, some monitors
actually require two CRTCs to drive them due to limitations in the
scanout hardware. Users can also create 'virtual' monitors to support
VNC or other systems.

This patch makes the RandR code prefer the Monitor mechanism to the
older CRTC mechanism. If the server doesn't support a new enough RandR
version, the existing CRTC code is used instead.

The name of the monitor is also provided in place of the arbitrary
number to help users select the desired source.

### Motivation and Context
This updates the RandR code in obs-studio to use current best practices for
identifying screen geometry information on an X display. It fixes incorrect geometry information
for DP MST monitors which appear as two 'outputs' when using the current code, and also makes it
possible for users to configure virtual screens.

### How Has This Been Tested?
I've tested this by creating virtual monitors using xrandr:

    $ xrandr --setmonitor virtual0 1024/400x768/300+0+0 none

This virtual monitor is now shown in the list of available screens, and when selected,
the 1024x768 subset of the X display is captured.

### Types of changes
This is a Bug fix for systems using DP MST monitors, and a New feature for people
wanting to use virtual monitors.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
