### PR TITLE
UI: Increment filter name automatically

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -444,10 +444,18 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 		obs_source_t *existing_filter;
 		string name = obs_source_get_display_name(id);
 
+		QString placeholder = QString::fromStdString(name);
+		QString text{placeholder};
+		int i = 2;
+		while ((existing_filter = obs_source_get_filter_by_name(
+				source, QT_TO_UTF8(text)))) {
+			obs_source_release(existing_filter);
+			text = QString("%1 %2").arg(placeholder).arg(i++);
+		}
+
 		bool success = NameDialog::AskForName(
 			this, QTStr("Basic.Filters.AddFilter.Title"),
-			QTStr("Basic.FIlters.AddFilter.Text"), name,
-			QT_UTF8(name.c_str()));
+			QTStr("Basic.Filters.AddFilter.Text"), name, text);
 		if (!success)
 			return;
 


### PR DESCRIPTION
### Description
When adding a duplicate filter, append an incrementing number after the default name.

![image](https://user-images.githubusercontent.com/941350/76679492-2c415380-6635-11ea-86a9-dd96aa0c420e.png)

### Motivation and Context
Consistency. Both Scene & Source creation auto-increment their names this way.

### How Has This Been Tested?
Add a filter with a default name. Add the same filter a second time.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
