### PR TITLE
rtmp-services: Add getloconow

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 124,
+	"version": 125,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 124
+			"version": 125
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1030,7 +1030,7 @@
                 },
                 {
                     "name": "North America : US West",
-                    "url": "rtmp://rtmpmanager-aws-en-west.afreeca.tv/live"
+                     "url": "rtmp://rtmpmanager-aws-en-west.afreeca.tv/live"
                 },
                 {
                     "name": "Asia : Singapore",
@@ -1048,8 +1048,8 @@
             "name": "아프리카TV",
             "servers": [
                 {
-                    "name": "Korea",
-                    "url": "rtmp://rtmpmanager-freecat.afreeca.tv/app/"
+                "name": "Korea",
+                "url": "rtmp://rtmpmanager-freecat.afreeca.tv/app/"
                 }
             ],
             "recommended": {

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1724,7 +1724,6 @@
         },
         {
             "name": "LOCO",
-            "common": true,
             "servers": [
                 {
                     "name": "Default",

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1030,7 +1030,7 @@
                 },
                 {
                     "name": "North America : US West",
-                     "url": "rtmp://rtmpmanager-aws-en-west.afreeca.tv/live"
+                    "url": "rtmp://rtmpmanager-aws-en-west.afreeca.tv/live"
                 },
                 {
                     "name": "Asia : Singapore",
@@ -1048,8 +1048,8 @@
             "name": "아프리카TV",
             "servers": [
                 {
-                "name": "Korea",
-                "url": "rtmp://rtmpmanager-freecat.afreeca.tv/app/"
+                    "name": "Korea",
+                    "url": "rtmp://rtmpmanager-freecat.afreeca.tv/app/"
                 }
             ],
             "recommended": {
@@ -1721,6 +1721,19 @@
                     "url": "rtmp://us-west.live.whalebone.tv/live"
                 }
             ]
+        },
+        {
+            "name": "LOCO",
+            "common": true,
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://ivory-ingest.getloconow.com:1935/stream"
+                }
+            ],
+            "recommended": {
+                "keyint": 2
+            }
         }
     ]
 }


### PR DESCRIPTION

### Description
Added LOCO to services dropdown.

### Motivation and Context
Loco is the latest streaming platform for streamers from India. Adding it to the list would make
OBS easier to use for those streamers.

### How Has This Been Tested?
ran make package and dmg distributed to internal streamers

### Types of changes
Added loco services to the list and updated versioning.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commit squashed where appropriate.
