### PR TITLE
UI: Add ctrl + scroll to zoom scene items

### DIFF
--- a/frontend/widgets/OBSBasicPreview.cpp
+++ b/frontend/widgets/OBSBasicPreview.cpp
@@ -512,16 +512,15 @@ void OBSBasicPreview::GetStretchHandleData(const vec2 &pos, bool ignoreGroup)
 
 void OBSBasicPreview::keyPressEvent(QKeyEvent *event)
 {
-	if (!IsFixedScaling() || event->isAutoRepeat()) {
-		OBSQTDisplay::keyPressEvent(event);
-		return;
-	}
-
-	switch (event->key()) {
-	case Qt::Key_Space:
+	if (event->key() == Qt::Key_Space && !event->isAutoRepeat() && IsFixedScaling()) {
 		setCursor(Qt::OpenHandCursor);
 		scrollMode = true;
-		break;
+		return;
+	}
+	if (event->key() == Qt::Key_Control && !event->isAutoRepeat()) {
+		setCursor(Qt::SizeAllCursor);
+		zoomItemsMode = true;
+		return;
 	}
 
 	OBSQTDisplay::keyPressEvent(event);
@@ -529,16 +528,16 @@ void OBSBasicPreview::keyPressEvent(QKeyEvent *event)
 
 void OBSBasicPreview::keyReleaseEvent(QKeyEvent *event)
 {
-	if (event->isAutoRepeat()) {
-		OBSQTDisplay::keyReleaseEvent(event);
+	if (scrollMode && event->key() == Qt::Key_Space && !event->isAutoRepeat()) {
+		scrollMode = false;
+		setCursor(Qt::ArrowCursor);
 		return;
 	}
 
-	switch (event->key()) {
-	case Qt::Key_Space:
-		scrollMode = false;
+	if (zoomItemsMode && event->key() == Qt::Key_Control && !event->isAutoRepeat()) {
+		zoomItemsMode = false;
 		setCursor(Qt::ArrowCursor);
-		break;
+		return;
 	}
 
 	OBSQTDisplay::keyReleaseEvent(event);
@@ -555,6 +554,18 @@ void OBSBasicPreview::wheelEvent(QWheelEvent *event)
 				decreaseScalingLevel();
 			}
 		}
+	} else if (zoomItemsMode) {
+		QPoint numPixels = event->pixelDelta();
+		QPoint numDegrees = event->angleDelta();
+		float factor = 1.0f;
+		if (!numPixels.isNull()) {
+			factor = 1.0f + (0.0008f * numPixels.y());
+		} else if (!numDegrees.isNull()) {
+			factor = 1.0f + (0.0008f * numDegrees.y());
+		}
+		vec3 pos;
+		vec3_set(&pos, event->position().x(), event->position().y(), factor);
+		ZoomItems(pos);
 	}
 
 	OBSQTDisplay::wheelEvent(event);
@@ -573,6 +584,7 @@ void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 
 	if (event->button() == Qt::RightButton) {
 		scrollMode = false;
+		zoomItemsMode = false;
 		setCursor(Qt::ArrowCursor);
 	}
 
@@ -636,12 +648,13 @@ void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 
 void OBSBasicPreview::UpdateCursor(uint32_t &flags)
 {
-	if (!stretchItem || obs_sceneitem_locked(stretchItem)) {
+	if ((!stretchItem || obs_sceneitem_locked(stretchItem)) && !zoomItemsMode) {
 		unsetCursor();
 		return;
 	}
 
-	if (!flags && (cursor().shape() != Qt::OpenHandCursor || !scrollMode)) {
+	if (!flags && (cursor().shape() != Qt::OpenHandCursor || !scrollMode) &&
+	    (cursor().shape() != Qt::SizeAllCursor || !zoomItemsMode)) {
 		unsetCursor();
 	}
 	if ((cursor().shape() != Qt::ArrowCursor) || flags == 0) {
@@ -799,7 +812,9 @@ void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 		mouseMoved = false;
 		cropping = false;
 		selectionBox = false;
-		unsetCursor();
+		if (!zoomItemsMode) {
+			unsetCursor();
+		}
 
 		OBSSceneItem item = GetItemAtPos(pos, true);
 
@@ -1036,6 +1051,98 @@ void OBSBasicPreview::MoveItems(const vec2 &pos)
 	vec2_add(&lastMoveOffset, &lastMoveOffset, &moveOffset);
 
 	obs_scene_enum_items(scene, move_items, &moveOffset);
+}
+
+static bool zoom_items(obs_scene_t *scene, obs_sceneitem_t *item, void *param)
+{
+	if (obs_sceneitem_locked(item)) {
+		return true;
+	}
+
+	vec3 *mouseData = reinterpret_cast<vec3 *>(param);
+	vec2 mousePos;
+	vec2_set(&mousePos, mouseData->x, mouseData->y);
+
+	bool selected = obs_sceneitem_selected(item);
+	if (obs_sceneitem_is_group(item) && !selected) {
+		vec2 itemPos;
+		obs_sceneitem_get_pos(item, &itemPos);
+		vec2 size;
+		if (obs_sceneitem_get_bounds_type(item) == OBS_BOUNDS_NONE) {
+			auto source = obs_sceneitem_get_source(item);
+			auto width = obs_source_get_width(source);
+			auto height = obs_source_get_height(source);
+			vec2 scale;
+			obs_sceneitem_get_scale(item, &scale);
+			vec2_set(&size, width * scale.x, height * scale.y);
+		} else {
+			obs_sceneitem_get_bounds(item, &size);
+		}
+		auto alignment = obs_sceneitem_get_alignment(item);
+		if (alignment & OBS_ALIGN_LEFT) {
+			vec2_set(&itemPos, itemPos.x, itemPos.y);
+		} else if (alignment & OBS_ALIGN_RIGHT) {
+			vec2_set(&itemPos, itemPos.x - size.x, itemPos.y);
+		} else {
+			vec2_set(&itemPos, itemPos.x - (size.x / 2.0f), itemPos.y);
+		}
+
+		if (alignment & OBS_ALIGN_TOP) {
+			vec2_set(&itemPos, itemPos.x, itemPos.y);
+		} else if (alignment & OBS_ALIGN_BOTTOM) {
+			vec2_set(&itemPos, itemPos.x, itemPos.y - size.y);
+		} else {
+			vec2_set(&itemPos, itemPos.x, itemPos.y - -(size.y / 2.0f));
+		}
+		vec2 mid;
+		vec2_sub(&mid, &mousePos, &itemPos);
+		vec3 newMouseData;
+		vec3_set(&newMouseData, mid.x, mid.y, mouseData->z);
+		obs_sceneitem_group_enum_items(item, zoom_items, &newMouseData);
+	}
+	if (selected) {
+		vec2 itemPos;
+		obs_sceneitem_get_pos(item, &itemPos);
+		vec2 mid;
+		vec2_sub(&mid, &itemPos, &mousePos);
+		vec2 nmid;
+		vec2_mulf(&nmid, &mid, mouseData->z);
+		vec2 im;
+		vec2_sub(&im, &nmid, &mid);
+		vec2_add(&itemPos, &itemPos, &im);
+		obs_sceneitem_set_pos(item, &itemPos);
+		if (obs_sceneitem_get_bounds_type(item) == OBS_BOUNDS_NONE) {
+			vec2 scale;
+			obs_sceneitem_get_scale(item, &scale);
+
+			vec2_mulf(&scale, &scale, mouseData->z);
+			obs_sceneitem_set_scale(item, &scale);
+		} else {
+			vec2 bounds;
+			obs_sceneitem_get_bounds(item, &bounds);
+			vec2_mulf(&bounds, &bounds, mouseData->z);
+			obs_sceneitem_set_bounds(item, &bounds);
+		}
+	}
+	UNUSED_PARAMETER(scene);
+	return true;
+}
+
+void OBSBasicPreview::ZoomItems(const vec3 &mouseData)
+{
+	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+#ifdef SUPPORTS_FRACTIONAL_SCALING
+	float pixelRatio = main->devicePixelRatioF();
+#else
+	float pixelRatio = main->devicePixelRatio();
+#endif
+	float scale = pixelRatio / main->previewScale;
+	vec3 scaledMouseData;
+	vec3_set(&scaledMouseData, (mouseData.x - main->previewX / pixelRatio) * scale,
+		 (mouseData.y - main->previewY / pixelRatio) * scale, mouseData.z);
+
+	OBSScene scene = main->GetCurrentScene();
+	obs_scene_enum_items(scene, zoom_items, &scaledMouseData);
 }
 
 static bool CounterClockwise(float x1, float x2, float x3, float y1, float y2, float y3)

--- a/frontend/widgets/OBSBasicPreview.hpp
+++ b/frontend/widgets/OBSBasicPreview.hpp
@@ -69,6 +69,7 @@ private:
 	bool cropping = false;
 	bool locked = false;
 	bool scrollMode = false;
+	bool zoomItemsMode = false;
 	bool fixedScaling = false;
 	bool selectionBox = false;
 	bool overflowHidden = false;
@@ -112,6 +113,7 @@ private:
 	static void SnapItemMovement(vec2 &offset);
 	void MoveItems(const vec2 &pos);
 	void BoxItems(const vec2 &startPos, const vec2 &pos);
+	void ZoomItems(const vec3 &mouseData);
 
 	void ProcessClick(const vec2 &pos);
 


### PR DESCRIPTION
### Description
Add ctrl + scroll to zoom the selected scene items to the position of the mouse pointer
![2025-03-1708-56-54-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/863fe03f-feeb-4511-af57-336440427185)


### Motivation and Context
This makes zooming in to an interesting part much easier. Before you had to resize and move the scene items.

### How Has This Been Tested?
On windows 64 bit with different bounding box types and different positional alignments.

### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
