### PR TITLE
libobs-winrt: win-capture: Clean up error handling

### DIFF
--- a/libobs-winrt/winrt-capture.h
+++ b/libobs-winrt/winrt-capture.h
@@ -12,8 +12,7 @@ extern "C" {
 EXPORT BOOL winrt_capture_supported();
 EXPORT BOOL winrt_capture_cursor_toggle_supported();
 EXPORT struct winrt_capture *winrt_capture_init(BOOL cursor, HWND window,
-						BOOL client_area, char **error,
-						HRESULT *hr);
+						BOOL client_area);
 EXPORT void winrt_capture_free(struct winrt_capture *capture);
 
 EXPORT void winrt_capture_show_cursor(struct winrt_capture *capture,


### PR DESCRIPTION
### Description
Use proper check to fix false positive on 1809, and rework error spew to
remove output parameters from winrt_capture_init.

### Motivation and Context
Clean up unnecessary error message for 1809, and remove general grossness of returning an allocated output parameter.

### How Has This Been Tested?
- 1809 successfully fails, and never calls winrt_capture_init to begin with.
- Verified new log lines output correctly by adding in temporary throws.
- WGC still works fine on Windows 10 20H1.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.