### PR TITLE
UI: Restart when browser hardware acceleration changed

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2440,6 +2440,7 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	bool browserHWAccel = config_get_bool(App()->GlobalConfig(), "General",
 					      "BrowserHWAccel");
 	ui->browserHWAccel->setChecked(browserHWAccel);
+	prevBrowserAccel = ui->browserHWAccel->isChecked();
 #endif
 
 	SetComboByValue(ui->hotkeyFocusType, hotkeyFocusType);
@@ -3534,8 +3535,10 @@ void OBSBasicSettings::SaveSettings()
 	bool langChanged = (ui->language->currentIndex() != prevLangIndex);
 	bool audioRestart = (ui->channelSetup->currentIndex() != channelIndex ||
 			     ui->sampleRate->currentIndex() != sampleRateIndex);
+	bool browserHWAccelChanged =
+		(ui->browserHWAccel->isChecked() != prevBrowserAccel);
 
-	if (langChanged || audioRestart)
+	if (langChanged || audioRestart || browserHWAccelChanged)
 		restart = true;
 	else
 		restart = false;

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -235,6 +235,7 @@ private:
 	void OnAuthConnected();
 	QString lastService;
 	int prevLangIndex;
+	bool prevBrowserAccel;
 private slots:
 	void UpdateServerList();
 	void UpdateKeyLink();


### PR DESCRIPTION
### Description
Shows the newly introduced "Do you want to restart now?" dialog when browser hardware acceleration is toggled.

### Motivation and Context
As we removed the full Intel blacklist for browser hardware acceleration, a few users have come in with a need to disable it.

Users currently have to manually restart OBS when this setting is changed.

Continues changes from #2408

### How Has This Been Tested?
* Toggle the setting
* Save and close the Settings window
* Be asked to restart
* Click Yes

### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
