### PR TITLE
Warning pass 2020-03-19

### DIFF
--- a/UI/importers/importers.hpp
+++ b/UI/importers/importers.hpp
@@ -38,6 +38,7 @@ typedef std::vector<std::string> OBSImporterFiles;
 
 class Importer {
 public:
+	virtual ~Importer() {}
 	virtual std::string Prog() { return "Null"; };
 	virtual int ImportScenes(const std::string &path, std::string &name,
 				 json11::Json &res) = 0;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2600,12 +2600,13 @@ static inline void copy_frame_data_plane(struct obs_source_frame *dst,
 					 const struct obs_source_frame *src,
 					 uint32_t plane, uint32_t lines)
 {
-	if (dst->linesize[plane] != src->linesize[plane])
+	if (dst->linesize[plane] != src->linesize[plane]) {
 		for (uint32_t y = 0; y < lines; y++)
 			copy_frame_data_line(dst, src, plane, y);
-	else
+	} else {
 		memcpy(dst->data[plane], src->data[plane],
-		       dst->linesize[plane] * lines);
+		       (size_t)dst->linesize[plane] * (size_t)lines);
+	}
 }
 
 static void copy_frame_data(struct obs_source_frame *dst,

--- a/libobs/obs.hpp
+++ b/libobs/obs.hpp
@@ -236,7 +236,7 @@ public:
 	}
 
 	OBSSignal(const OBSSignal &) = delete;
-	OBSSignal(OBSSignal &&other)
+	OBSSignal(OBSSignal &&other) noexcept
 		: handler(other.handler),
 		  signal(other.signal),
 		  callback(other.callback),
@@ -249,7 +249,7 @@ public:
 	}
 
 	OBSSignal &operator=(const OBSSignal &) = delete;
-	OBSSignal &operator=(OBSSignal &&other)
+	OBSSignal &operator=(OBSSignal &&other) noexcept
 	{
 		Disconnect();
 

--- a/libobs/util/util.hpp
+++ b/libobs/util/util.hpp
@@ -20,6 +20,7 @@
 
 #include <string.h>
 #include <stdarg.h>
+#include <utility>
 
 #include "bmem.h"
 #include "config-file.h"
@@ -36,7 +37,7 @@ template<typename T> class BPtr {
 
 public:
 	inline BPtr(T *p = nullptr) : ptr(p) {}
-	inline BPtr(BPtr &&other) : ptr(other.ptr) { other.ptr = nullptr; }
+	inline BPtr(BPtr &&other) { *this = std::move(other); }
 	inline ~BPtr() { bfree(ptr); }
 
 	inline T *operator=(T *p)
@@ -45,6 +46,14 @@ public:
 		ptr = p;
 		return p;
 	}
+
+	inline BPtr &operator=(BPtr &&other)
+	{
+		ptr = other.ptr;
+		other.ptr = nullptr;
+		return *this;
+	}
+
 	inline operator T *() { return ptr; }
 	inline T **operator&()
 	{

--- a/libobs/util/util.hpp
+++ b/libobs/util/util.hpp
@@ -68,7 +68,7 @@ class ConfigFile {
 
 public:
 	inline ConfigFile() : config(NULL) {}
-	inline ConfigFile(ConfigFile &&other) : config(other.config)
+	inline ConfigFile(ConfigFile &&other) noexcept : config(other.config)
 	{
 		other.config = nullptr;
 	}
@@ -120,7 +120,7 @@ class TextLookup {
 
 public:
 	inline TextLookup(lookup_t *lookup = nullptr) : lookup(lookup) {}
-	inline TextLookup(TextLookup &&other) : lookup(other.lookup)
+	inline TextLookup(TextLookup &&other) noexcept : lookup(other.lookup)
 	{
 		other.lookup = nullptr;
 	}

--- a/libobs/util/windows/CoTaskMemPtr.hpp
+++ b/libobs/util/windows/CoTaskMemPtr.hpp
@@ -39,6 +39,7 @@ public:
 	{
 		Clear();
 		ptr = val;
+		return *this;
 	}
 
 	inline T **operator&()


### PR DESCRIPTION
### Description
Clean up warnings at HEAD on latest VS 2019.

### Motivation and Context
I hate warnings.

### How Has This Been Tested?
Debugger inspection for memcpy and destructor calls. Couldn't really test the noexcept changes because I don't think anything calls them, but c'mon.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.