### PR TITLE
obs-qsv11: Fix target usage values

### DIFF
--- a/plugins/obs-qsv11/QSV_Encoder.h
+++ b/plugins/obs-qsv11/QSV_Encoder.h
@@ -74,17 +74,10 @@ static const struct qsv_rate_control_info qsv_ratecontrols[] = {
 	{"AVBR", false},  {"ICQ", true},  {"LA_ICQ", true}, {"LA_CBR", true},
 	{"LA_VBR", true}, {0, false}};
 static const char *const qsv_profile_names[] = {"high", "main", "baseline", 0};
-static const char *const qsv_usage_names[] = {"quality",
-					      "balanced",
-					      "speed",
-					      "veryslow",
-					      "slower",
-					      "slow",
-					      "medium",
-					      "fast",
-					      "faster"
-					      "veryfast",
-					      0};
+static const char *const qsv_usage_names[] = {"quality",  "balanced", "speed",
+					      "veryslow", "slower",   "slow",
+					      "medium",   "fast",     "faster",
+					      "veryfast", 0};
 
 typedef struct qsv_t qsv_t;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
PR #1937 (commit b9ad1ce) added QSV target usage options, but there was a comma missing between two of the array entries. This resulted in "faster" and "veryfast" becoming "fasterveryfast", which is not valid.

Code style changes were required by .clang-format.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #2527.  The encoder doesn't complain, and the log doesn't indicate which usage target was selected, but this should be fixed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled on Windows 10 1903 (Build 18362.720) 64-bit using VS2017 (15.9.21) with latest OBS deps.  Confirmed that the target usage entries are listed correctly and that recordings work with either selected.
![image](https://user-images.githubusercontent.com/624931/77150532-79288e00-6a6a-11ea-8457-74dcda387902.png)


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
