### PR TITLE
obs-filters: Fix LUT file extension filter on Linux

### DIFF
--- a/plugins/obs-filters/color-grade-filter.c
+++ b/plugins/obs-filters/color-grade-filter.c
@@ -329,7 +329,7 @@ static obs_properties_t *color_grade_filter_properties(void *data)
 	obs_properties_t *props = obs_properties_create();
 	struct dstr filter_str = {0};
 
-	dstr_cat(&filter_str, "(*.cube;*.png)");
+	dstr_cat(&filter_str, "(*.cube *.png)");
 
 	if (s && s->file && *s->file) {
 		dstr_copy(&path, s->file);


### PR DESCRIPTION
### Description
Make LUT file selection filter match expected format. FIxes #2532.

### Motivation and Context
LUT file selection filter doesn't work on Linux.

### How Has This Been Tested?
LUT file selection filter works on Linux now, and still on Windows.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
