### PR TITLE
UI: Make links in updater dialog clickable

### DIFF
--- a/UI/forms/OBSUpdate.ui
+++ b/UI/forms/OBSUpdate.ui
@@ -22,7 +22,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QTextEdit" name="text">
+    <widget class="QTextBrowser" name="text">
      <property name="readOnly">
       <bool>true</bool>
      </property>
@@ -32,6 +32,9 @@
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="openExternalLinks">
+        <bool>true</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
### Description
While `QTextEdit` can have links, they aren't clickable by default. This changes it to a `QTextBrowser` and forces the links to open externally (in a web browser).

![image](https://user-images.githubusercontent.com/941350/77219410-9ef88480-6b89-11ea-950c-95013d096ca7.png)

### Motivation and Context

As part of 25.0, the updater message had links to informative webpages, but were not clickable in the updater.

### How Has This Been Tested?

* Disabled `CheckDataSignature()` and set `WIN_MANIFEST_URL` to my own
* Clicked the links in the 25.0.1 update dialog.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
