### PR TITLE
UI: Don't open Studio Mode's "Program" label in a window

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1346,7 +1346,7 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 		RefreshQuickTransitions();
 
-		programLabel = new QLabel(QTStr("StudioMode.Program"));
+		programLabel = new QLabel(QTStr("StudioMode.Program"), this);
 		programLabel->setSizePolicy(QSizePolicy::Preferred,
 					    QSizePolicy::Preferred);
 		programLabel->setAlignment(Qt::AlignHCenter | Qt::AlignBottom);


### PR DESCRIPTION
### Description
When switching to Studio mode, a tiny window would appear for a split second, stealing focus. This is likely because the widget did not have a parent. This change ensures the window's parent is `OBSBasic`.

![image](https://user-images.githubusercontent.com/941350/77225331-2feb5200-6bc2-11ea-9de0-de567b23925c.png)

### Motivation and Context
Unnecessary and annoying. Potentially also caused accessibility issues for screen readers.

### How Has This Been Tested?
Toggle Studio mode on/off a few times, watching the taskbar for an extra `obs64` window.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
