### PR TITLE
UI: Split toggle preview program hotkey into hotkey pair

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -294,6 +294,8 @@ Basic.TransitionProperties="Transition Properties"
 Basic.SceneTransitions="Scene Transitions"
 Basic.TransitionDuration="Duration"
 Basic.TogglePreviewProgramMode="Studio Mode"
+Basic.EnablePreviewProgramMode="Enable Studio Mode"
+Basic.DisablePreviewProgramMode="Disable Studio Mode"
 
 # undo
 Undo.Undo="Undo"

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -498,7 +498,7 @@ private:
 	bool sceneDuplicationMode = true;
 	bool swapScenesMode = true;
 	volatile bool previewProgramMode = false;
-	obs_hotkey_id togglePreviewProgramHotkey = 0;
+	obs_hotkey_pair_id togglePreviewProgramHotkeys = 0;
 	obs_hotkey_id transitionHotkey = 0;
 	obs_hotkey_id statsHotkey = 0;
 	obs_hotkey_id screenshotHotkey = 0;
@@ -782,6 +782,9 @@ private slots:
 
 	void EnablePreview();
 	void DisablePreview();
+
+	void EnablePreviewProgram();
+	void DisablePreviewProgram();
 
 	void SceneCopyFilters();
 	void ScenePasteFilters();


### PR DESCRIPTION
### Description
Split toggle preview program hotkey into hotkey pair

### Motivation and Context
To be sure it is enabled or disabled when the hotkey is pressed.

### How Has This Been Tested?
set the same and different keys for enable and disable

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.