### PR TITLE
UI: Don't clip meters when resizing with no input

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -875,7 +875,7 @@ void VolumeMeter::paintHMeter(QPainter &painter, int x, int y, int width,
 		painter.fillRect(peakPosition, y,
 				 maximumPosition - peakPosition, height,
 				 backgroundErrorColor);
-	} else {
+	} else if (int(magnitude) != 0) {
 		if (!clipping) {
 			QTimer::singleShot(CLIP_FLASH_DURATION_MS, this,
 					   SLOT(ClipEnding()));


### PR DESCRIPTION
### Description
When dragging a dock in/around the Audio Mixer dock, the Volume Meter would assume the sudden change in size was caused by audio clipping, but only when no audio was being played. This seems to be specific to the horizontal meters.

Before this fix:
![2020-03-21_23-27-16](https://user-images.githubusercontent.com/941350/77226336-a3459180-6bcb-11ea-8b4e-5e3487de2015.gif)

### Motivation and Context
The clipping indicator should only be visible when the audio is **actually** clipping.

### How Has This Been Tested?
Undock Sources, and drag it in/around the mixer dock. Make sure no audio is playing. You may need to first play audio, then wait for the meters to settle, then drag Sources.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
