### PR TITLE
linux-capture: Fix unknown window names

### DIFF
--- a/plugins/linux-capture/xcompcap-helper.hpp
+++ b/plugins/linux-capture/xcompcap-helper.hpp
@@ -84,7 +84,7 @@ std::list<Window> getAllWindows();
 
 inline std::string getWindowName(Window win)
 {
-	return getWindowAtom(win, "_NET_WM_NAME");
+	return getWindowAtom(win, "WM_NAME");
 }
 
 inline std::string getWindowClass(Window win)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changed the XComposite Atom for getting window names from "_NET_WM_NAME" to "WM_NAME". [Source](https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/dix/BuiltInAtoms#L221)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When using a language combination like "en_DE.UTF8" all window names become "unknown" but should show the actual window names.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: Arch Linux
Kernel version: 5.5.10-arch1-1
XOrg server version: 1.20.7

Opened various windows an checked in the window capture settings for proper naming.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
