### PR TITLE
linux-v4l2: readonly controls cause infinite loop

### DIFF
--- a/plugins/linux-v4l2/v4l2-controls.c
+++ b/plugins/linux-v4l2/v4l2-controls.c
@@ -98,6 +98,8 @@ int_fast32_t v4l2_update_controls(int_fast32_t dev, obs_properties_t *props,
 	memset(&qctrl, 0, sizeof(qctrl));
 	qctrl.id = V4L2_CTRL_FLAG_NEXT_CTRL;
 	while (0 == v4l2_ioctl(dev, VIDIOC_QUERYCTRL, &qctrl)) {
+		qctrl.id |= V4L2_CTRL_FLAG_NEXT_CTRL;
+
 		if (qctrl.flags & V4L2_CTRL_FLAG_DISABLED) {
 			blog(LOG_INFO, "found control %s but it is disabled",
 			     qctrl.name);
@@ -145,8 +147,6 @@ int_fast32_t v4l2_update_controls(int_fast32_t dev, obs_properties_t *props,
 			     (char *)qctrl.name, qctrl.default_value);
 			break;
 		}
-
-		qctrl.id |= V4L2_CTRL_FLAG_NEXT_CTRL;
 	}
 
 	return 0;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
v4l2_ioctl will clear the V4L2_CTRL_FLAG_NEXT_CTRL flag resulting in
infinite loops for any driver that reported readonly, disabled, or
volitile controls.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Users whos drivers report these controls will have OBS hang. Reported in support with a device which infinitely logs readonly controls.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on c920 and it continues to work as expected. I dont have a device which reports these values.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Trivial reordering.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
