### PR TITLE
UI: Fix silent scenes with imported SL scenes

### DIFF
--- a/UI/importers/sl.cpp
+++ b/UI/importers/sl.cpp
@@ -298,15 +298,8 @@ static int attempt_import(const Json &root, const string &name, Json &res)
 		Json::array filter_items = in_filters["items"].array_items();
 
 		Json in_settings = scene["settings"];
-		Json in_sync = scene["syncOffset"];
 
-		int sync = (int)(in_sync["sec"].number_value() * 1000000000 +
-				 in_sync["nsec"].number_value());
-
-		double vol = scene["volume"].number_value();
-		bool muted = scene["muted"].bool_value();
 		string name = scene["name"].string_value();
-		int monitoring = scene["monitoringType"].int_value();
 
 		Json::object out_hotkeys = Json::object{};
 		get_hotkey_bindings(out_hotkeys, hotkey_items, "");
@@ -336,11 +329,8 @@ static int attempt_import(const Json &root, const string &name, Json &res)
 				     {"id", "scene"},
 				     {"sl_id", sl_id},
 				     {"settings", in_settings},
-				     {"sync", sync},
-				     {"volume", vol},
-				     {"muted", muted},
+				     {"volume", 1.0},
 				     {"name", out_name},
-				     {"monitoring_type", monitoring},
 				     {"private_settings", Json::object{}}};
 
 		Json in_items = scene["sceneItems"];


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change gets rid of some fields that were assumed to exist in Streamlabs scene collections but don't, and explicitly sets the volume of imported scenes to 1.0.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Previously, the importer assumed scenes had fields that sources did for audio, namely volume, sync, mute and monitoring type. Streamlabs scenes do not have these fields. This resulted in mistakes in importing, such as imported scenes having a volume of 0.0. This prevented audio sources inside those scenes from being audible.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Imported a scene collection before and after the change, and verified that volume was correctly set to 1.0 after being saved in Studio.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
