### PR TITLE
rtmp-services: update castr.io rtmp ingest list

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 125,
+	"version": 126,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 125
+			"version": 126
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -893,56 +893,60 @@
             "name": "Castr.io",
             "servers": [
                 {
-                    "name": "Chicago US",
+                    "name": "US-East (Chicago, IL)",
                     "url": "rtmp://cg.castr.io/static"
                 },
                 {
-                    "name": "Los Angeles US",
-                    "url": "rtmp://la.castr.io/static"
-                },
-                {
-                    "name": "New York US",
+                    "name": "US-East (New York, NY)",
                     "url": "rtmp://ny.castr.io/static"
                 },
                 {
-                    "name": "Miami US",
+                    "name": "US-East (Miami, FL)",
                     "url": "rtmp://mi.castr.io/static"
                 },
                 {
-                    "name": "Montreal CA",
+                    "name": "US-West (Seattle, WA)",
+                    "url": "rtmp://se.castr.io/static"
+                },
+                {
+                    "name": "US-West (Los Angeles, CA)",
+                    "url": "rtmp://la.castr.io/static"
+                },
+                {
+                    "name": "US-Central (Dallas, TX)",
+                    "url": "rtmp://da.castr.io/static"
+                },
+                {
+                    "name": "NA-East (Toronto, CA)",
                     "url": "rtmp://qc.castr.io/static"
                 },
                 {
-                    "name": "London UK",
-                    "url": "rtmp://uk.castr.io/static"
-                },
-                {
-                    "name": "Frankfurt DE",
-                    "url": "rtmp://de.castr.io/static"
-                },
-                {
-                    "name": "Frankfurt DE 2",
-                    "url": "rtmp://fr.castr.io/static"
-                },
-                {
-                    "name": "Moscow RU",
-                    "url": "rtmp://ru.castr.io/static"
-                },
-                {
-                    "name": "Singapore",
-                    "url": "rtmp://sg.castr.io/static"
-                },
-                {
-                    "name": "Sydney AU",
-                    "url": "rtmp://au.castr.io/static"
-                },
-                {
-                    "name": "Brazil",
+                    "name": "SA (Sao Paulo, BR)",
                     "url": "rtmp://br.castr.io/static"
                 },
                 {
-                    "name": "India",
+                    "name": "EU-West (London, UK)",
+                    "url": "rtmp://uk.castr.io/static"
+                },
+                {
+                    "name": "EU-Central (Frankfurt, DE)",
+                    "url": "rtmp://fr.castr.io/static"
+                },
+                {
+                    "name": "Russia (Moscow)",
+                    "url": "rtmp://ru.castr.io/static"
+                },
+                {
+                    "name": "Asia (Singapore)",
+                    "url": "rtmp://sg.castr.io/static"
+                },
+                {
+                    "name": "Asia (India)",
                     "url": "rtmp://in.castr.io/static"
+                },
+                {
+                    "name": "Australia (Sydney)",
+                    "url": "rtmp://au.castr.io/static"
                 },
                 {
                     "name": "US Central",
@@ -975,10 +979,6 @@
                 {
                     "name": "Singapore",
                     "url": "rtmp://sg-central.castr.io/static"
-                },
-                {
-                    "name": "India",
-                    "url": "rtmp://in.castr.io/static"
                 }
             ],
             "recommended": {


### PR DESCRIPTION
Update Castr.io ingest locations in RTMP service list:

- Adding new ingest locations in the US; Seattle, Dallas.
- Renaming & rearranging ingest list to reflect UX change, as in Castr dashboard.
- Incrementing rtmp-services version in `package.json`.

List of updated Castr.io ingest locations  
[developers.castr.io/apiv1/ingests/list](https://developers.castr.io/apiv1/ingests/list)

### Description
Updating the rtmp-services ingestion list to enable updated Castr.io ingests.

### Motivation and Context
Castr.io has added support for a few more ingest locations and to reflect labels/names changes in existing ingests locations.

### How Has This Been Tested?
Not required.

### Types of changes
Updating OBS RTMP Services Data

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ x] My code is not on the master branch.
- [ x] The code has been tested.
- [ x] All commit messages are properly formatted and commit squashed where appropriate.
