### PR TITLE
Fix QuickSync LA_ICQ encoder settings

### DIFF
--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -240,6 +240,7 @@ bool QSV_Encoder_Internal::InitParams(qsv_param_t *pParams)
 		break;
 	case MFX_RATECONTROL_LA_ICQ:
 		m_mfxEncParams.mfx.ICQQuality = pParams->nICQQuality;
+		break;
 	case MFX_RATECONTROL_LA_HRD:
 		m_mfxEncParams.mfx.TargetKbps = pParams->nTargetBitRate;
 		m_mfxEncParams.mfx.MaxKbps = pParams->nTargetBitRate;


### PR DESCRIPTION
Broken by https://github.com/obsproject/obs-studio/commit/2f62831a96dec0c79134d8eed125b57c03692671 when the break statement was forgotten.