### PR TITLE
Fix non-void function 'add_control_property' in plugins/linux-v4l2

### DIFF
--- a/plugins/linux-v4l2/v4l2-controls.c
+++ b/plugins/linux-v4l2/v4l2-controls.c
@@ -102,7 +102,7 @@ static inline bool add_control_property(obs_properties_t *props,
 	obs_property_t *prop = NULL;
 
 	if (!valid_control(qctrl)) {
-		return;
+		return false;
 	}
 
 	switch (qctrl->type) {
@@ -131,7 +131,10 @@ static inline bool add_control_property(obs_properties_t *props,
 		blog(LOG_INFO, "setting default for %s to %d",
 		     (char *)qctrl->name, qctrl->default_value);
 		break;
+	default:
+		return false;
 	}
+	return true;
 }
 
 int_fast32_t v4l2_update_controls(int_fast32_t dev, obs_properties_t *props,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This commit fixing regresion in OBS-Studio 25.0.3 caused probably through this commit https://github.com/obsproject/obs-studio/commit/488e25fc3dfc7c49b1d017384999895aca1ae442

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Beginning with the release of OBS Studio 25.0.3 (25.0.2 was latest good), a compiling problem occurred when building OBS package for Linux OpenMandriva Cooker using the Clang 10 compiler and the lld linker.

```
../plugins/linux-v4l2/v4l2-controls.c:105:3: error: non-void function 'add_control_property' should return a value [-Wreturn-type]
DEBUG util.py:587:                  return;
DEBUG util.py:587:                  ^
DEBUG util.py:587:  1 error generated.

```
Full build log available here: https://file-store.openmandriva.org/api/v1/file_stores/edd808b24e4da4bd29053dda57b7590f4c591ca6.log?show=true

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
@berolinux created patch for OpenMandriva Cooker to fix above issue. Patch is available here: https://github.com/OpenMandrivaAssociation/obs-studio/commit/65d136894b3a13bd5a1b68a381c06a04a49b8801#diff-660c5c67e2085befbcf3ad5db5bb2613
After apply this patch OBS Studio 25.0.3 build without any issues on OpenMandriva with Clang 10.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
