### PR TITLE
CI: Make processor count consistent

### DIFF
--- a/formatcode.sh
+++ b/formatcode.sh
@@ -14,10 +14,8 @@ set -o nounset
 # Get CPU count
 OS=$(uname)
 NPROC=1
-if [[ $OS = "Linux" ]] ; then
-    NPROC=$(nproc)
-elif [[ ${OS} = "Darwin" ]] ; then
-    NPROC=$(sysctl -n hw.physicalcpu)
+if [[ $OS = "Linux" || $OS = "Darwin" ]] ; then
+    NPROC=$(getconf _NPROCESSORS_ONLN)
 fi
 
 # Discover clang-format


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Code formatting script was using `sysctl -n hw.physicalcpu` on macOS 
machines to get the CPU count. This command returns the physical CPUs. 
`nproc`, however, returns logical CPU count on Linux machines. It 
should be `sysctl -n hw.logicalcpu` to make it consistent with its 
Linux counterpart. But there also another way. 
`getconf _NPROCESSORS_ONLN` gives the number of logical CPUs on both Linux and 
macOS.

### Motivation and Context
Script was getting the CPU count inconsistently across platforms. 

### How Has This Been Tested?
I've tested my modifications on separate macOS and Linux machines to see it gets the correct CPU count.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
