### PR TITLE
UI: Fix text handling for dialogs

### DIFF
--- a/UI/window-importer.cpp
+++ b/UI/window-importer.cpp
@@ -92,6 +92,9 @@ QWidget *ImporterEntryPathItemDelegate::createEditor(
 					QSizePolicy::ControlType::LineEdit));
 	layout->addWidget(text);
 
+	QObject::connect(text, SIGNAL(editingFinished()), this,
+			 SLOT(updateText()));
+
 	QToolButton *browseButton = new QToolButton();
 	browseButton->setText("...");
 	browseButton->setSizePolicy(buttonSizePolicy);
@@ -121,8 +124,6 @@ void ImporterEntryPathItemDelegate::setEditorData(
 {
 	QLineEdit *text = editor->findChild<QLineEdit *>();
 	text->setText(index.data().toString());
-	QObject::connect(text, SIGNAL(textEdited(QString)), this,
-			 SLOT(updateText()));
 	editor->setProperty(PATH_LIST_PROP, QVariant());
 }
 

--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -112,6 +112,9 @@ QWidget *RemuxEntryPathItemDelegate::createEditor(
 				    QSizePolicy::ControlType::LineEdit));
 		layout->addWidget(text);
 
+		QObject::connect(text, SIGNAL(editingFinished()), this,
+				 SLOT(updateText()));
+
 		QToolButton *browseButton = new QToolButton();
 		browseButton->setText("...");
 		browseButton->setSizePolicy(buttonSizePolicy);
@@ -143,8 +146,6 @@ void RemuxEntryPathItemDelegate::setEditorData(QWidget *editor,
 {
 	QLineEdit *text = editor->findChild<QLineEdit *>();
 	text->setText(index.data().toString());
-	QObject::connect(text, SIGNAL(textEdited(QString)), this,
-			 SLOT(updateText()));
 	editor->setProperty(PATH_LIST_PROP, QVariant());
 }
 


### PR DESCRIPTION
### Description
Signal only needs to be connected once, not every keystroke.

Also commit data only when text widget focus is lost to fix cursor
moving to the end of the string after every keystroke.

Fixes #2575.

### Motivation and Context
Wacky text entry behavior.

### How Has This Been Tested?
Text entry behavior good for both remux and scene import dialogs. Text is still committed when clicking button immediately after text entry.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.