### PR TITLE
obs-ffmpeg: Expose old NVENC on Windows 7

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -240,6 +240,11 @@ bool obs_module_load(void)
 #ifdef _WIN32
 		if (get_win_ver_int() > 0x0601) {
 			jim_nvenc_load();
+		} else {
+			// if on Win 7, new nvenc isn't available so there's
+			// no nvenc encoder for the user to select, expose
+			// the old encoder directly
+			nvenc_encoder_info.caps &= ~OBS_ENCODER_CAP_INTERNAL;
 		}
 #endif
 		obs_register_encoder(&nvenc_encoder_info);


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Make NVENC available again to Windows 7 users in advanced output mode. Created as PR since this is a bit of a hacky solution to the problem.

### Motivation and Context
Since the old encoder was flagged internal, users can't choose it any more. However NVENC new depends on Windows 8 or higher, so Windows 7 users have no NVENC options at all.

Reported at https://obsproject.com/forum/threads/obs-25-0-1-nvenc-on-rtx-card-and-advanced-output-mode.117322/

### How Has This Been Tested?
Breakpoint to stop the call to `jim_nvenc_load` and verifying old encoder appeared.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
