### PR TITLE
Github: Add new bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Crashes or reproducible bugs (For feature requests, see ideas.obsproject.com)
+title: "[BUG] <bug description>"
+labels: ''
+assignees: ''
+
+---
+
+<!-- READ THIS FIRST -->
+<!-- The OBS Studio GitHub issue tracker is **ONLY** to be -->
+<!-- used for reporting Bugs that have replication steps. -->
+
+<!-- You can post Feature Requests here: https://ideas.obsproject.com/ -->
+<!-- Get help for Support Issues here: https://obsproject.com/help -->
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Platform
+<!-- Please fill out the following information about your bug report. -->
+<!-- If you are on Linux and installed using a package, please list the package type. -->
+Operating system and version:
+OBS Studio version:
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior. -->
+<!--- Please include a log file here if possible. -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant. -->
+<!--- Screenshots and video are encouraged if applicable. -->
+1.
+2.
+3.
+4.
+
+## Additional information
+<!--- Not obligatory, but provide any additional details or information -->
+<!--- that you feel might be relevant to the issue -->


### PR DESCRIPTION
Github uses a new issue template format instead
of the old .github repo format. This updates to the
new format, and includes some new additions.