### PR TITLE
Vulkan hook COM clean up, and extension check

### DIFF
--- a/plugins/win-capture/graphics-hook/CMakeLists.txt
+++ b/plugins/win-capture/graphics-hook/CMakeLists.txt
@@ -53,7 +53,9 @@ target_include_directories(graphics-hook PUBLIC
 	"${CMAKE_BINARY_DIR}/plugins/win-capture/graphics-hook/config")
 
 target_link_libraries(graphics-hook
-	ipc-util psapi)
+	dxguid
+	ipc-util
+	psapi)
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
 	set(_output_suffix "64")

--- a/plugins/win-capture/graphics-hook/vulkan-capture.h
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.h
@@ -9,6 +9,7 @@ struct vk_inst_funcs {
 	DEF_FUNC(DestroySurfaceKHR);
 	DEF_FUNC(GetPhysicalDeviceMemoryProperties);
 	DEF_FUNC(GetPhysicalDeviceImageFormatProperties2);
+	DEF_FUNC(EnumerateDeviceExtensionProperties);
 };
 
 struct vk_device_funcs {


### PR DESCRIPTION
### Description
Cleaner COM usage.

Check for VK_KHR_external_memory_win32 support.

### Motivation and Context
Noticed minor things while making other changes. Reduce confusion, increase obviousness.

### How Has This Been Tested?
Debugger breakpoint inspection for all diffs.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.