### PR TITLE
image-source: allow upper case image extensions in image and slideshow

### DIFF
--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -209,13 +209,13 @@ static void image_source_tick(void *data, float seconds)
 }
 
 static const char *image_filter =
-	"All formats (*.bmp *.tga *.png *.jpeg *.jpg *.gif *.psd);;"
-	"BMP Files (*.bmp);;"
-	"Targa Files (*.tga);;"
-	"PNG Files (*.png);;"
-	"JPEG Files (*.jpeg *.jpg);;"
-	"GIF Files (*.gif);;"
-	"PSD Files (*.psd);;"
+	"All formats (*.bmp *.BMP *.tga *.TGA *.png *.PNG *.jpeg *.JPEG *.jpg *.JPG *.gif *.GIF *.psd *.PSD);;"
+	"BMP Files (*.bmp *.BMP);;"
+	"Targa Files (*.tga *.TGA);;"
+	"PNG Files (*.png *.PNG);;"
+	"JPEG Files (*.jpeg *.JPEG *.jpg *.JPG);;"
+	"GIF Files (*.gif *.GIF);;"
+	"PSD Files (*.psd *.PSD);;"
 	"All Files (*.*)";
 
 static obs_properties_t *image_source_properties(void *data)

--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -811,7 +811,7 @@ static void ss_defaults(obs_data_t *settings)
 }
 
 static const char *file_filter =
-	"Image files (*.bmp *.tga *.png *.jpeg *.jpg *.gif)";
+	"Image files (*.bmp *.BMP *.tga *.TGA *.png *.PNG *.jpeg *.JPEG *.jpg *.JPG *.gif *.GIF)";
 
 static const char *aspects[] = {"16:9", "16:10", "4:3", "1:1"};
 

--- a/plugins/obs-filters/mask-filter.c
+++ b/plugins/obs-filters/mask-filter.c
@@ -119,7 +119,8 @@ static void mask_filter_defaults(obs_data_t *settings)
 	obs_data_set_default_int(settings, SETTING_OPACITY, 100);
 }
 
-#define IMAGE_FILTER_EXTENSIONS " (*.bmp *.jpg *.jpeg *.tga *.gif *.png)"
+#define IMAGE_FILTER_EXTENSIONS \
+	" (*.bmp *.BMP *.jpg *.JPG *.jpeg *.JPEG *.tga *.TGA *.gif *.GIF *.png *.PNG)"
 
 static obs_properties_t *mask_filter_properties(void *data)
 {


### PR DESCRIPTION
### Description
Allow upper case image extensions in image and slideshow.

### Motivation and Context
Before obs only accepted lower case image extensions (*.bmp, *.jpeg, ...) in image and slideshow plugin. Now upper case (*.BMP, *.JPEG, ...) are allowed, too. This is necessary at least on linux file systems.

### How Has This Been Tested?
Compiled, tested functionality on: Ubuntu 18.04.4 LTS (bionic)
Kernel: Linux blank 4.15.0-91-generic #92-Ubuntu SMP Fri Feb 28 11:09:48 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux


### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
