### PR TITLE
UI: Add ability to reorder mixer by drag & drop

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -298,7 +298,8 @@ set(obs_SOURCES
 	locked-checkbox.cpp
 	visibility-checkbox.cpp
 	media-slider.cpp
-	undo-stack-obs.cpp)
+	undo-stack-obs.cpp
+	mixer-tree.cpp)
 
 set(obs_HEADERS
 	${obs_PLATFORM_HEADERS}
@@ -373,7 +374,8 @@ set(obs_HEADERS
 	obs-proxy-style.hpp
 	obs-proxy-style.hpp
 	media-slider.hpp
-	undo-stack-obs.hpp)
+	undo-stack-obs.hpp
+	mixer-tree.hpp)
 
 set(obs_importers_HEADERS
 	importers/importers.hpp)

--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -1288,3 +1288,7 @@ QCalendarWidget QAbstractItemView:enabled {
 QCalendarWidget QAbstractItemView:disabled {
     color: rgb(122,121,122);
 }
+
+MixerTree::item:selected {
+	border: 1px solid #d2d2d2;
+}

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -1007,3 +1007,7 @@ QCalendarWidget QAbstractItemView:enabled {
 QCalendarWidget QAbstractItemView:disabled {
     color: rgb(122,121,122);
 }
+
+MixerTree::item:selected {
+	border: 1px solid #d2d2d2;
+}

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -1613,3 +1613,7 @@ QCalendarWidget QAbstractItemView:enabled {
 QCalendarWidget QAbstractItemView:disabled {
     color: rgb(122,121,122);
 }
+
+MixerTree::item:selected {
+	border: 1px solid #d2d2d2;
+}

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -351,3 +351,7 @@ QCalendarWidget #qt_calendar_nextmonth {
     qproperty-icon: url(./Dark/expand.svg);
     icon-size: 16px, 16px;
 }
+
+MixerTree::item:selected {
+	border: 1px solid #000000;
+}

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1004,113 +1004,22 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="QStackedWidget" name="stackedMixerArea">
-       <widget class="VScrollArea" name="hMixerScrollArea">
-        <property name="contextMenuPolicy">
-         <enum>Qt::CustomContextMenu</enum>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Sunken</enum>
-        </property>
-        <property name="verticalScrollBarPolicy">
-         <enum>Qt::ScrollBarAlwaysOn</enum>
-        </property>
-        <property name="horizontalScrollBarPolicy">
-         <enum>Qt::ScrollBarAlwaysOff</enum>
-        </property>
-        <property name="widgetResizable">
-         <bool>true</bool>
-        </property>
-        <widget class="QWidget" name="hVolumeWidgets">
-         <property name="geometry">
-          <rect>
-           <x>0</x>
-           <y>0</y>
-           <width>67</width>
-           <height>16</height>
-          </rect>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <layout class="QVBoxLayout" name="hVolControlLayout">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-         </layout>
-        </widget>
-       </widget>
-       <widget class="HScrollArea" name="vMixerScrollArea">
-        <property name="contextMenuPolicy">
-         <enum>Qt::CustomContextMenu</enum>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Sunken</enum>
-        </property>
-        <property name="verticalScrollBarPolicy">
-         <enum>Qt::ScrollBarAlwaysOff</enum>
-        </property>
-        <property name="horizontalScrollBarPolicy">
-         <enum>Qt::ScrollBarAlwaysOn</enum>
-        </property>
-        <property name="widgetResizable">
-         <bool>true</bool>
-        </property>
-        <widget class="QWidget" name="vVolumeWidgets">
-         <property name="geometry">
-          <rect>
-           <x>0</x>
-           <y>0</y>
-           <width>16</width>
-           <height>28</height>
-          </rect>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <layout class="QHBoxLayout" name="vVolControlLayout">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-         </layout>
-        </widget>
-       </widget>
+      <widget class="MixerTree" name="mixer">
+       <property name="contextMenuPolicy">
+        <enum>Qt::CustomContextMenu</enum>
+       </property>
+       <property name="dragDropMode">
+        <enum>QAbstractItemView::InternalMove</enum>
+       </property>
+       <property name="defaultDropAction">
+        <enum>Qt::TargetMoveAction</enum>
+       </property>
+       <property name="uniformItemSizes">
+        <bool>false</bool>
+       </property>
+       <property name="sortingEnabled">
+        <bool>false</bool>
+       </property>
       </widget>
      </item>
     </layout>
@@ -2127,18 +2036,6 @@
    <header>window-basic-status-bar.hpp</header>
   </customwidget>
   <customwidget>
-   <class>HScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>horizontal-scroll-area.hpp</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>VScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>vertical-scroll-area.hpp</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>SourceTree</class>
    <extends>QListView</extends>
    <header>source-tree.hpp</header>
@@ -2158,6 +2055,11 @@
    <class>RecordButton</class>
    <extends>QPushButton</extends>
    <header>record-button.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>MixerTree</class>
+   <extends>QListWidget</extends>
+   <header>mixer-tree.hpp</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/UI/mixer-tree.cpp
+++ b/UI/mixer-tree.cpp
@@ -1,0 +1,19 @@
+#include "mixer-tree.hpp"
+
+MixerTree::MixerTree(QWidget *parent_) : QListWidget(parent_) {}
+
+void MixerTree::mousePressEvent(QMouseEvent *event)
+{
+	QListView::mousePressEvent(event);
+
+	QModelIndex idx = indexAt(event->pos());
+
+	if (idx.row() == -1)
+		clearSelection();
+}
+
+void MixerTree::focusOutEvent(QFocusEvent *event)
+{
+	QListView::focusOutEvent(event);
+	clearSelection();
+}

--- a/UI/mixer-tree.hpp
+++ b/UI/mixer-tree.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QListWidget>
+#include <QMouseEvent>
+#include <QFocusEvent>
+
+class MixerTree : public QListWidget {
+	Q_OBJECT
+
+public:
+	explicit MixerTree(QWidget *parent = nullptr);
+
+protected:
+	virtual void mousePressEvent(QMouseEvent *event) override;
+	virtual void focusOutEvent(QFocusEvent *event);
+};

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -234,8 +234,6 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 		mainLayout->addItem(controlLayout);
 
 		volMeter->setFocusProxy(slider);
-
-		setMaximumWidth(110);
 	} else {
 		QHBoxLayout *volLayout = new QHBoxLayout;
 		QHBoxLayout *textLayout = new QHBoxLayout;
@@ -267,6 +265,12 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 
 		volMeter->setFocusProxy(slider);
 	}
+
+	nameLabel->setStyleSheet("background: none");
+	volLabel->setStyleSheet("background: none");
+	mute->setStyleSheet("background: none");
+	slider->setStyleSheet("background: none");
+	config->setStyleSheet("background: none");
 
 	setLayout(mainLayout);
 

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -385,6 +385,13 @@ void OBSBasic::TransitionToScene(OBSSource source, bool force,
 		return;
 	}
 
+	if (prevSource) {
+		SaveMixerOrder(obs_scene_from_source(prevSource));
+		LoadMixerOrder();
+	}
+
+	prevSource = source;
+
 	float t = obs_transition_get_time(transition);
 	bool stillTransitioning = t < 1.0f && t > 0.0f;
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -207,8 +207,6 @@ private:
 
 	std::shared_ptr<Auth> auth;
 
-	std::vector<VolControl *> volumes;
-
 	std::vector<OBSSignal> signalHandlers;
 
 	QList<QPointer<QDockWidget>> extraDocks;
@@ -677,6 +675,12 @@ public slots:
 	void PauseRecording();
 	void UnpauseRecording();
 
+	void SaveMixerOrder(OBSScene scene);
+	void LoadMixerOrder();
+	void ActivateAudioSource(obs_source_t *source, bool addNew = false);
+	void DeactivateAudioSource(obs_source_t *source);
+	void SetSourceMixerHidden(obs_source_t *source, bool hidden);
+
 private slots:
 
 	void on_actionMainUndo_triggered();
@@ -686,9 +690,6 @@ private slots:
 	void AddScene(OBSSource source);
 	void RemoveScene(OBSSource source);
 	void RenameSources(OBSSource source, QString newName, QString prevName);
-
-	void ActivateAudioSource(OBSSource source);
-	void DeactivateAudioSource(OBSSource source);
 
 	void DuplicateSelectedScene();
 	void RemoveSelectedScene();
@@ -725,8 +726,7 @@ private slots:
 
 	void MixerRenameSource();
 
-	void on_vMixerScrollArea_customContextMenuRequested();
-	void on_hMixerScrollArea_customContextMenuRequested();
+	void on_mixer_customContextMenuRequested();
 
 	void on_actionCopySource_triggered();
 	void on_actionPasteRef_triggered();
@@ -785,10 +785,6 @@ private:
 	static void SceneItemAdded(void *data, calldata_t *params);
 	static void SourceCreated(void *data, calldata_t *params);
 	static void SourceRemoved(void *data, calldata_t *params);
-	static void SourceActivated(void *data, calldata_t *params);
-	static void SourceDeactivated(void *data, calldata_t *params);
-	static void SourceAudioActivated(void *data, calldata_t *params);
-	static void SourceAudioDeactivated(void *data, calldata_t *params);
 	static void SourceRenamed(void *data, calldata_t *params);
 	static void RenderMain(void *data, uint32_t cx, uint32_t cy);
 
@@ -813,11 +809,15 @@ private:
 	void DiskSpaceMessage();
 
 	OBSSource prevFTBSource = nullptr;
+	OBSSource prevSource = nullptr;
+
+	bool AudioSourceInMixer(obs_source_t *source);
 
 public:
 	undo_stack undo_s;
 	OBSSource GetProgramSource();
 	OBSScene GetCurrentScene();
+	VolControl *GetVolControlFromListItem(QListWidgetItem *item);
 
 	void SysTrayNotify(const QString &text, QSystemTrayIcon::MessageIcon n);
 
@@ -1119,8 +1119,6 @@ private slots:
 	void OpenSourceWindow();
 	void OpenMultiviewWindow();
 	void OpenSceneWindow();
-
-	void StackedMixerAreaContextMenuRequested();
 
 	void ResizeOutputSizeOfSource();
 


### PR DESCRIPTION
### Description
This adds the ability for users to drag and drop items in the audio mixer to reorder them. This changes the mixer to a QListWidget.

### Motivation and Context
https://ideas.obsproject.com/posts/117/add-the-ability-to-reorder-audio-mixer-items

### How Has This Been Tested?
Moving around mixer items.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
