### PR TITLE
Fix return void in non-void function in plugins/linux-v4l2/v4l2-contr…

### DIFF
--- a/plugins/linux-v4l2/v4l2-controls.c
+++ b/plugins/linux-v4l2/v4l2-controls.c
@@ -102,7 +102,7 @@ static inline bool add_control_property(obs_properties_t *props,
 	obs_property_t *prop = NULL;
 
 	if (!valid_control(qctrl)) {
-		return;
+		return false;
 	}
 
 	switch (qctrl->type) {


### PR DESCRIPTION
…ols.c

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This function does not compile because it does not return a bool

### Motivation and Context
This file should actually compile. Non-void function shoud return `false`/`true`. `!valid_control(qctrl)` suggests that false may be appropiate.

```c
	if (!valid_control(qctrl)) {
		return false;
	}
```
The error message was
```
[5/11] Building C object plugins/linux-v4l2/CMakeFiles/linux-v4l2.dir/v4l2-controls.c.o
FAILED: plugins/linux-v4l2/CMakeFiles/linux-v4l2.dir/v4l2-controls.c.o
/usr/lib/ccache/clang-11 -DHAVE_OBSCONFIG_H -DHAVE_UDEV -DUSE_XDG -Dlinux_v4l2_EXPORTS -Iconfig -isystem ../libobs -Wall -Wextra -Wvla -Wno-unused-functio
n -Werror-implicit-function-declaration -Wno-missing-braces -Wno-missing-field-initializers -fcolor-diagnostics -std=gnu99 -fno-strict-aliasing -O3 -DNDEB
UG -fPIC   -mmmx -msse -msse2 -pthread -MD -MT plugins/linux-v4l2/CMakeFiles/linux-v4l2.dir/v4l2-controls.c.o -MF plugins/linux-v4l2/CMakeFiles/linux-v4l2
.dir/v4l2-controls.c.o.d -o plugins/linux-v4l2/CMakeFiles/linux-v4l2.dir/v4l2-controls.c.o   -c ../plugins/linux-v4l2/v4l2-controls.c
../plugins/linux-v4l2/v4l2-controls.c:105:3: error: non-void function 'add_control_property' should return a value [-Wreturn-type]
                return;
                ^
1 error generated.

```

### How Has This Been Tested?
Not at all. A maintainer should decide whether

### Types of changes
	if (!valid_control(qctrl)) {
		return false;
	}


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x ] My code is not on the master branch.
- [ ] The code has been tested.
- [x ] All commit messages are properly formatted and commits squashed where appropriate.
