### PR TITLE
Expose more levels and profiles for FFmpeg VAAPI

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -561,12 +561,16 @@ static obs_properties_t *vaapi_properties(void *unused)
 	list = obs_properties_add_list(props, "level", "Level",
 				       OBS_COMBO_TYPE_LIST,
 				       OBS_COMBO_FORMAT_INT);
-	obs_property_list_add_int(list, "480p30 (3.0)", 30);
-	obs_property_list_add_int(list, "720p30/480p60  (3.1)", 31);
-	obs_property_list_add_int(list, "Compatibility mode  (4.0 default)",
+	obs_property_list_add_int(list, "Auto", FF_LEVEL_UNKNOWN);
+	obs_property_list_add_int(list, "3.0", 30);
+	obs_property_list_add_int(list, "3.1", 31);
+	obs_property_list_add_int(list, "4.0 (default) (Compatibility mode)",
 				  40);
-	obs_property_list_add_int(list, "720p60/1080p30 (4.1)", 41);
-	obs_property_list_add_int(list, "1080p60 (4.2)", 42);
+	obs_property_list_add_int(list, "4.1", 41);
+	obs_property_list_add_int(list, "4.2", 42);
+	obs_property_list_add_int(list, "5.0", 50);
+	obs_property_list_add_int(list, "5.1", 51);
+	obs_property_list_add_int(list, "5.2", 52);
 
 	list = obs_properties_add_list(props, "rate_control",
 				       obs_module_text("RateControl"),

--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -550,6 +550,14 @@ static obs_properties_t *vaapi_properties(void *unused)
 
 	obs_property_list_add_int(list, "H.264 (default)", AV_CODEC_ID_H264);
 
+	list = obs_properties_add_list(props, "profile", "Profile",
+				       OBS_COMBO_TYPE_LIST,
+				       OBS_COMBO_FORMAT_INT);
+	obs_property_list_add_int(list, "Constrained Baseline (default)",
+				  FF_PROFILE_H264_CONSTRAINED_BASELINE);
+	obs_property_list_add_int(list, "Main", FF_PROFILE_H264_MAIN);
+	obs_property_list_add_int(list, "High", FF_PROFILE_H264_HIGH);
+
 	list = obs_properties_add_list(props, "level", "Level",
 				       OBS_COMBO_TYPE_LIST,
 				       OBS_COMBO_FORMAT_INT);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This change adds Profile and Extra options to FFmpeg VAAPI output.
![Profile](https://user-images.githubusercontent.com/59268455/78279164-06f68580-750f-11ea-885b-6d23a2d0dbb7.jpg)
![Level](https://user-images.githubusercontent.com/59268455/78279190-1249b100-750f-11ea-9f3a-d67159956ad5.jpg)


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
With certain resolutions (such as 3440x1440), using an inappropriate level not only fails to produce output, it can trigger strange behavior on the kernel (witnessed with dmesg, using level 4.2, the highest supported before this patch).
FFmpeg allows specifying level -99 (defined by FF_LEVEL_UNKNOWN macro) which instructs it to decide the appropriate level automatically.
The level names were removed since they are not accurate representation of what the level means. This assumes that whoever decides to tune with it knows what they're doing.
Encoding profiles were also exposed to allow more flexibility (instead of being restricted to CONSTRAINED_BASELINE).


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Fedora 31, Mesa 20.0.1, AMD Fury X.
Recorded desktop and HDMI capture card.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- New feature

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
