### PR TITLE
UI: Require selected source for Transform shortcut

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6225,6 +6225,9 @@ void OBSBasic::on_actionEditTransform_triggered()
 	if (transformWindow)
 		transformWindow->close();
 
+	if (!GetCurrentSceneItem())
+		return;
+
 	transformWindow = new OBSBasicTransform(this);
 	transformWindow->show();
 	transformWindow->setAttribute(Qt::WA_DeleteOnClose, true);


### PR DESCRIPTION
### Description

Currently, if you don't have a source selected and press Ctrl+E, a completely broken Edit Transform dialog will appear - as no source is selected, it doesn't have a defined scene, and therefore if you try clicking on another source in the scene, the dialog doesn't update.

This change requires that an item be selected before the dialog will open.

### Motivation and Context

Fixes #2468 

### How Has This Been Tested?
* With a source selected, press Ctrl+E. A window should appear. Close it manually.
* Deselect all sources, and press Ctrl+E. Nothing should happen. If a transform dialog is already open, it will close.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
