### PR TITLE
Deps/CI: Update to Qt 5.14.2

### DIFF
--- a/CI/before-script-osx.sh
+++ b/CI/before-script-osx.sh
@@ -7,7 +7,7 @@ mkdir build
 cd build
 cmake -DENABLE_SPARKLE_UPDATER=ON \
 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 \
--DQTDIR=/usr/local/Cellar/qt/5.14.1 \
+-DQTDIR=/usr/local/Cellar/qt/5.14.2 \
 -DDepsPath=/tmp/obsdeps \
 -DVLCPath=$PWD/../../vlc-3.0.8 \
 -DBUILD_BROWSER=ON \

--- a/CI/install-qt-win.cmd
+++ b/CI/install-qt-win.cmd
@@ -1,4 +1,4 @@
-if exist Qt_5.10.1.7z (curl -kLO https://cdn-fastly.obsproject.com/downloads/Qt_5.10.1.7z -f --retry 5 -z Qt_5.10.1.7z) else (curl -kLO https://cdn-fastly.obsproject.com/downloads/Qt_5.10.1.7z -f --retry 5 -C -)
-7z x Qt_5.10.1.7z -oQt
+if exist Qt_5.14.2.7z (curl -kLO https://cdn-fastly.obsproject.com/downloads/Qt_5.14.2.7z -f --retry 5 -z Qt_5.14.2.7z) else (curl -kLO https://cdn-fastly.obsproject.com/downloads/Qt_5.14.2.7z -f --retry 5 -C -)
+7z x Qt_5.14.2.7z -oQt
 mv Qt C:\QtDep
 dir C:\QtDep

--- a/CI/install-script-win.cmd
+++ b/CI/install-script-win.cmd
@@ -9,8 +9,8 @@ if exist cef_binary_%CEF_VERSION%_windows64_minimal.zip (curl -kLO https://cdn-f
 set DepsPath32=%CD%\dependencies2017\win32
 set DepsPath64=%CD%\dependencies2017\win64
 set VLCPath=%CD%\vlc
-set QTDIR32=C:\QtDep\5.10.1\msvc2017
-set QTDIR64=C:\QtDep\5.10.1\msvc2017_64
+set QTDIR32=C:\QtDep\5.14.2\msvc2017
+set QTDIR64=C:\QtDep\5.14.2\msvc2017_64
 set CEF_32=%CD%\CEF_32\cef_binary_%CEF_VERSION%_windows32_minimal
 set CEF_64=%CD%\CEF_64\cef_binary_%CEF_VERSION%_windows64_minimal
 set build_config=RelWithDebInfo

--- a/CI/install/osx/packageApp.sh
+++ b/CI/install/osx/packageApp.sh
@@ -44,7 +44,7 @@ cp ../CI/install/osx/Info.plist ./OBS.app/Contents
 -x ./OBS.app/Contents/PlugIns/obs-libfdk.so
 # -x ./OBS.app/Contents/PlugIns/obs-outputs.so \
 
-/usr/local/Cellar/qt/5.14.1/bin/macdeployqt ./OBS.app
+/usr/local/Cellar/qt/5.14.2/bin/macdeployqt ./OBS.app
 
 mv ./OBS.app/Contents/MacOS/libobs-opengl.so ./OBS.app/Contents/Frameworks
 
@@ -57,7 +57,7 @@ rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/Headers
 rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/Headers/
 chmod 644 ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/Resources/Info.plist
 install_name_tool -id @executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
-install_name_tool -change /usr/local/Cellar/qt/5.14.1/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
+install_name_tool -change /usr/local/Cellar/qt/5.14.2/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
 
 
 # decklink ui qt


### PR DESCRIPTION
_This is a draft pull request for public review and CI testing._

### Description
- Updates Qt from 5.10.1 to 5.14.2 on Windows
- Updates Qt from 5.14.1 to 5.14.2 on macOS

### Motivation and Context
Unifies Qt version on macOS and Windows. For Windows the minor version jump also improves scaling behavior on high DPI displays, among other improvements

### How Has This Been Tested?
 - Waiting on some upstream uploads before proper testing can be done

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.

### To-do
 - [ ] Wait for updated `Qt_5.14.2.7z` package to be uploaded on https://cdn-fastly.obsproject.com/downloads/
 - [ ] Wait for update on [qt.rb](https://github.com/obsproject/obs-studio/blob/master/CI/install-dependencies-osx.sh#L32)
 - [ ] Perform testing

@DDRBoxman Could you review this PR and upload the necessary Qt packages if ok?