### PR TITLE
UI: Don't stretch server field in Qt 5.14

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -958,6 +958,12 @@
              </item>
              <item row="0" column="1">
               <widget class="QStackedWidget" name="serverStackedWidget">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
                <property name="currentIndex">
                 <number>1</number>
                </property>


### PR DESCRIPTION
### Description
On versions prior to 5.14, this field renders correctly. in 5.14, it stretches to fit the dialog.

Incorrect:
![image](https://user-images.githubusercontent.com/941350/78465218-f5db8d80-7735-11ea-87bc-fd400331fd8c.png)

Correct (with this PR):
![image](https://user-images.githubusercontent.com/941350/78465215-eceabc00-7735-11ea-8881-a616540a7063.png)

### Motivation and Context

As we're now using Qt 5.14 on macOS and newer versions of Linux, this is worth fixing.

### How Has This Been Tested?
Open the Stream Settings page

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
