### PR TITLE
mac-capture: Use window id to identify windows on MacOS

### DIFF
--- a/plugins/mac-capture/window-utils.h
+++ b/plugins/mac-capture/window-utils.h
@@ -6,6 +6,7 @@
 
 struct cocoa_window {
 	CGWindowID window_id;
+	NSNumber *owner_pid;
 
 	pthread_mutex_t name_lock;
 	NSString *owner_name;

--- a/plugins/mac-capture/window-utils.h
+++ b/plugins/mac-capture/window-utils.h
@@ -6,7 +6,7 @@
 
 struct cocoa_window {
 	CGWindowID window_id;
-	NSNumber *owner_pid;
+	int owner_pid;
 
 	pthread_mutex_t name_lock;
 	NSString *owner_name;

--- a/plugins/mac-capture/window-utils.m
+++ b/plugins/mac-capture/window-utils.m
@@ -60,8 +60,10 @@ bool find_window(cocoa_window_t cw, obs_data_t *settings, bool force)
 
 		NSNumber *window_id = (NSNumber *)dict[WINDOW_NUMBER];
 		cw->window_id = window_id.intValue;
+		cw->owner_pid = (NSNumber *)dict[OWNER_PID];
 
 		obs_data_set_int(settings, "window", cw->window_id);
+		obs_data_set_int(settings, "owner_pid", cw->owner_pid.intValue);
 		return true;
 	}
 
@@ -76,10 +78,43 @@ void init_window(cocoa_window_t cw, obs_data_t *settings)
 
 	cw->owner_name = @(obs_data_get_string(settings, "owner_name"));
 	cw->window_name = @(obs_data_get_string(settings, "window_name"));
-	cw->window_id = obs_data_get_int(settings, "window");
 	[cw->owner_name retain];
 	[cw->window_name retain];
-	find_window(cw, settings, true);
+
+	// Find initial window.
+	pthread_mutex_lock(&cw->name_lock);
+
+	if (!cw->window_name.length && !cw->owner_name.length)
+		goto invalid_name;
+
+	NSNumber *owner_pid = @(obs_data_get_int(settings, "owner_pid"));
+	NSNumber *window_id = @(obs_data_get_int(settings, "window"));
+	for (NSDictionary *dict in enumerate_windows()) {
+		bool owner_names_match =
+			[cw->owner_name isEqualToString:dict[OWNER_NAME]];
+		bool ids_match =
+			[owner_pid isEqualToNumber:dict[OWNER_PID]] &&
+			[window_id isEqualToNumber:dict[WINDOW_NUMBER]];
+		bool window_names_match =
+			[cw->window_name isEqualToString:dict[WINDOW_NAME]];
+
+		if (owner_names_match && (ids_match || window_names_match)) {
+			pthread_mutex_unlock(&cw->name_lock);
+
+			NSNumber *window_id = (NSNumber *)dict[WINDOW_NUMBER];
+			cw->window_id = window_id.intValue;
+			cw->owner_pid = (NSNumber *)dict[OWNER_PID];
+
+			obs_data_set_int(settings, "window", cw->window_id);
+			obs_data_set_int(settings, "owner_pid",
+					 cw->owner_pid.intValue);
+			return;
+		}
+	}
+
+invalid_name:
+	pthread_mutex_unlock(&cw->name_lock);
+	return;
 }
 
 void destroy_window(cocoa_window_t cw)

--- a/plugins/mac-capture/window-utils.m
+++ b/plugins/mac-capture/window-utils.m
@@ -76,6 +76,7 @@ void init_window(cocoa_window_t cw, obs_data_t *settings)
 
 	cw->owner_name = @(obs_data_get_string(settings, "owner_name"));
 	cw->window_name = @(obs_data_get_string(settings, "window_name"));
+	cw->window_id = obs_data_get_int(settings, "window");
 	[cw->owner_name retain];
 	[cw->window_name retain];
 	find_window(cw, settings, true);

--- a/plugins/mac-capture/window-utils.m
+++ b/plugins/mac-capture/window-utils.m
@@ -60,10 +60,11 @@ bool find_window(cocoa_window_t cw, obs_data_t *settings, bool force)
 
 		NSNumber *window_id = (NSNumber *)dict[WINDOW_NUMBER];
 		cw->window_id = window_id.intValue;
-		cw->owner_pid = (NSNumber *)dict[OWNER_PID];
+		NSNumber *owner_pid = (NSNumber *)dict[OWNER_PID];
+		cw->owner_pid = owner_pid.intValue;
 
 		obs_data_set_int(settings, "window", cw->window_id);
-		obs_data_set_int(settings, "owner_pid", cw->owner_pid.intValue);
+		obs_data_set_int(settings, "owner_pid", cw->owner_pid);
 		return true;
 	}
 
@@ -103,11 +104,11 @@ void init_window(cocoa_window_t cw, obs_data_t *settings)
 
 			NSNumber *window_id = (NSNumber *)dict[WINDOW_NUMBER];
 			cw->window_id = window_id.intValue;
-			cw->owner_pid = (NSNumber *)dict[OWNER_PID];
+			NSNumber *owner_pid = (NSNumber *)dict[OWNER_PID];
+			cw->owner_pid = owner_pid.intValue;
 
 			obs_data_set_int(settings, "window", cw->window_id);
-			obs_data_set_int(settings, "owner_pid",
-					 cw->owner_pid.intValue);
+			obs_data_set_int(settings, "owner_pid", cw->owner_pid);
 			return;
 		}
 	}

--- a/plugins/mac-capture/window-utils.m
+++ b/plugins/mac-capture/window-utils.m
@@ -136,6 +136,7 @@ void update_window(cocoa_window_t cw, obs_data_t *settings)
 	[cw->window_name retain];
 	pthread_mutex_unlock(&cw->name_lock);
 
+	cw->owner_pid = obs_data_get_int(settings, "owner_pid");
 	cw->window_id = obs_data_get_int(settings, "window");
 }
 


### PR DESCRIPTION
Use a window's id in init_window in the mac window capture plugin.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This is a one-line change that resolves https://github.com/obsproject/obs-studio/issues/2642.
By using a window's ID to identify it, we can find windows even if their name has been changed.
Note that a window's name is still used first, so if a window ID is changed or recycled (I don't know if this can happen) it will still have at least as good behavior as it used to have. In my experience, this change improves things considerably, and I no longer need to reselect all the windows in the window capture settings every time I reopen OBS, which saves me a bunch of time :).

### Motivation and Context
Solves https://github.com/obsproject/obs-studio/issues/2642: the issue that OBS wouldn't be able to find a window if its name changed while OBS was closed.

### How Has This Been Tested?
Manual testing following the reproduction steps in https://github.com/obsproject/obs-studio/issues/2642
Operating system and version: macOS 10.14.6 (18G3020)
OBS Studio version: 25.0.3

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested. (Manual testing only)
- [x] All commit messages are properly formatted and commits squashed where appropriate.
