### PR TITLE
plugins: Build ALSA plugin for FreeBSD

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -46,6 +46,7 @@ elseif("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
 	add_subdirectory(linux-pulseaudio)
 	add_subdirectory(linux-v4l2)
 	add_subdirectory(linux-jack)
+	add_subdirectory(linux-alsa)
 endif()
 
 option(BUILD_BROWSER "Build browser plugin" OFF)


### PR DESCRIPTION
### Description
Build ALSA plugin for FreeBSD

### Motivation and Context
The ALSA plugin sometimes works better than pulseaudio and JACK audio input depending on the setup.

### How Has This Been Tested?
Tested using FreeBSD.

### Types of changes
System build files.

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
