### PR TITLE
Enhance Log dialog with description and Analyze button

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -333,6 +333,8 @@ Output.BadPath.Text="The configured file output path is invalid. Please check yo
 
 # log upload dialog text and messages
 LogReturnDialog="Log Upload Successful"
+LogReturnDialog.Description="Your log file has been uploaded. You can now share the URL for debugging or support purposes."
+LogReturnDialog.Description.Crash="Your crash report has been uploaded. You can now share the URL for debugging purposes."
 LogReturnDialog.CopyURL="Copy URL"
 LogReturnDialog.ErrorUploadingLog="Error uploading log file"
 

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -336,6 +336,7 @@ LogReturnDialog="Log Upload Successful"
 LogReturnDialog.Description="Your log file has been uploaded. You can now share the URL for debugging or support purposes."
 LogReturnDialog.Description.Crash="Your crash report has been uploaded. You can now share the URL for debugging purposes."
 LogReturnDialog.CopyURL="Copy URL"
+LogReturnDialog.AnalyzeURL="Analyze"
 LogReturnDialog.ErrorUploadingLog="Error uploading log file"
 
 # remux dialog

--- a/UI/forms/OBSLogReply.ui
+++ b/UI/forms/OBSLogReply.ui
@@ -40,6 +40,13 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QPushButton" name="analyzeURL">
+       <property name="text">
+        <string>LogReturnDialog.AnalyzeURL</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/UI/forms/OBSLogReply.ui
+++ b/UI/forms/OBSLogReply.ui
@@ -15,6 +15,13 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QLabel" name="description">
+     <property name="text">
+      <string>LogReturnDialog.Description</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLineEdit" name="urlEdit">

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5016,7 +5016,7 @@ static BPtr<char> ReadLogFile(const char *subdir, const char *log)
 	return file;
 }
 
-void OBSBasic::UploadLog(const char *subdir, const char *file)
+void OBSBasic::UploadLog(const char *subdir, const char *file, const bool crash)
 {
 	BPtr<char> fileString{ReadLogFile(subdir, file)};
 
@@ -5027,6 +5027,7 @@ void OBSBasic::UploadLog(const char *subdir, const char *file)
 		return;
 
 	ui->menuLogFiles->setEnabled(false);
+	ui->menuCrashLogs->setEnabled(false);
 
 	stringstream ss;
 	ss << "OBS " << App()->GetVersionString() << " log file uploaded at "
@@ -5042,8 +5043,13 @@ void OBSBasic::UploadLog(const char *subdir, const char *file)
 				     "text/plain", ss.str().c_str());
 
 	logUploadThread.reset(thread);
-	connect(thread, &RemoteTextThread::Result, this,
-		&OBSBasic::logUploadFinished);
+	if (crash) {
+		connect(thread, &RemoteTextThread::Result, this,
+			&OBSBasic::crashUploadFinished);
+	} else {
+		connect(thread, &RemoteTextThread::Result, this,
+			&OBSBasic::logUploadFinished);
+	}
 	logUploadThread->start();
 }
 
@@ -5059,12 +5065,12 @@ void OBSBasic::on_actionShowLogs_triggered()
 
 void OBSBasic::on_actionUploadCurrentLog_triggered()
 {
-	UploadLog("obs-studio/logs", App()->GetCurrentLog());
+	UploadLog("obs-studio/logs", App()->GetCurrentLog(), false);
 }
 
 void OBSBasic::on_actionUploadLastLog_triggered()
 {
-	UploadLog("obs-studio/logs", App()->GetLastLog());
+	UploadLog("obs-studio/logs", App()->GetLastLog(), false);
 }
 
 void OBSBasic::on_actionViewCurrentLog_triggered()
@@ -5095,7 +5101,7 @@ void OBSBasic::on_actionShowCrashLogs_triggered()
 
 void OBSBasic::on_actionUploadLastCrashLog_triggered()
 {
-	UploadLog("obs-studio/crashes", App()->GetLastCrashLog());
+	UploadLog("obs-studio/crashes", App()->GetLastCrashLog(), true);
 }
 
 void OBSBasic::on_actionCheckForUpdates_triggered()
@@ -5106,6 +5112,7 @@ void OBSBasic::on_actionCheckForUpdates_triggered()
 void OBSBasic::logUploadFinished(const QString &text, const QString &error)
 {
 	ui->menuLogFiles->setEnabled(true);
+	ui->menuCrashLogs->setEnabled(true);
 
 	if (text.isEmpty()) {
 		OBSMessageBox::critical(
@@ -5113,13 +5120,32 @@ void OBSBasic::logUploadFinished(const QString &text, const QString &error)
 			error);
 		return;
 	}
+	openLogDialog(text, false);
+}
+
+void OBSBasic::crashUploadFinished(const QString &text, const QString &error)
+{
+	ui->menuLogFiles->setEnabled(true);
+	ui->menuCrashLogs->setEnabled(true);
+
+	if (text.isEmpty()) {
+		OBSMessageBox::critical(
+			this, QTStr("LogReturnDialog.ErrorUploadingLog"),
+			error);
+		return;
+	}
+	openLogDialog(text, true);
+}
+
+void OBSBasic::openLogDialog(const QString &text, const bool crash)
+{
 
 	obs_data_t *returnData = obs_data_create_from_json(QT_TO_UTF8(text));
 	string resURL = obs_data_get_string(returnData, "url");
 	QString logURL = resURL.c_str();
 	obs_data_release(returnData);
 
-	OBSLogReply logDialog(this, logURL);
+	OBSLogReply logDialog(this, logURL, crash);
 	logDialog.exec();
 }
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -292,7 +292,7 @@ private:
 	void UpdateVolumeControlsPeakMeterType();
 	void ClearVolumeControls();
 
-	void UploadLog(const char *subdir, const char *file);
+	void UploadLog(const char *subdir, const char *file, const bool crash);
 
 	void Save(const char *file);
 	void Load(const char *file);
@@ -923,6 +923,8 @@ private slots:
 	void PauseToggled();
 
 	void logUploadFinished(const QString &text, const QString &error);
+	void crashUploadFinished(const QString &text, const QString &error);
+	void openLogDialog(const QString &text, const bool crash);
 
 	void updateCheckFinished();
 

--- a/UI/window-log-reply.cpp
+++ b/UI/window-log-reply.cpp
@@ -16,6 +16,9 @@
 ******************************************************************************/
 
 #include <QClipboard>
+#include <QUrl>
+#include <QUrlQuery>
+#include <QDesktopServices>
 #include "window-log-reply.hpp"
 #include "obs-app.hpp"
 
@@ -26,6 +29,7 @@ OBSLogReply::OBSLogReply(QWidget *parent, const QString &url, const bool crash)
 	ui->setupUi(this);
 	ui->urlEdit->setText(url);
 	if (crash) {
+		ui->analyzeURL->hide();
 		ui->description->setText(
 			Str("LogReturnDialog.Description.Crash"));
 	}
@@ -37,4 +41,14 @@ void OBSLogReply::on_copyURL_clicked()
 {
 	QClipboard *clipboard = QApplication::clipboard();
 	clipboard->setText(ui->urlEdit->text());
+}
+
+void OBSLogReply::on_analyzeURL_clicked()
+{
+	QUrlQuery param;
+	param.addQueryItem("log_url",
+			   QUrl::toPercentEncoding(ui->urlEdit->text()));
+	QUrl url("https://obsproject.com/tools/analyzer", QUrl::TolerantMode);
+	url.setQuery(param);
+	QDesktopServices::openUrl(url);
 }

--- a/UI/window-log-reply.cpp
+++ b/UI/window-log-reply.cpp
@@ -19,7 +19,7 @@
 #include "window-log-reply.hpp"
 #include "obs-app.hpp"
 
-OBSLogReply::OBSLogReply(QWidget *parent, const QString &url)
+OBSLogReply::OBSLogReply(QWidget *parent, const QString &url, const bool crash)
 	: QDialog(parent), ui(new Ui::OBSLogReply)
 {
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -27,6 +27,7 @@ OBSLogReply::OBSLogReply(QWidget *parent, const QString &url)
 	ui->urlEdit->setText(url);
 
 	installEventFilter(CreateShortcutFilter());
+	UNUSED_PARAMETER(crash);
 }
 
 void OBSLogReply::on_copyURL_clicked()

--- a/UI/window-log-reply.cpp
+++ b/UI/window-log-reply.cpp
@@ -22,6 +22,7 @@
 OBSLogReply::OBSLogReply(QWidget *parent, const QString &url)
 	: QDialog(parent), ui(new Ui::OBSLogReply)
 {
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 	ui->setupUi(this);
 	ui->urlEdit->setText(url);
 

--- a/UI/window-log-reply.cpp
+++ b/UI/window-log-reply.cpp
@@ -25,9 +25,12 @@ OBSLogReply::OBSLogReply(QWidget *parent, const QString &url, const bool crash)
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 	ui->setupUi(this);
 	ui->urlEdit->setText(url);
+	if (crash) {
+		ui->description->setText(
+			Str("LogReturnDialog.Description.Crash"));
+	}
 
 	installEventFilter(CreateShortcutFilter());
-	UNUSED_PARAMETER(crash);
 }
 
 void OBSLogReply::on_copyURL_clicked()

--- a/UI/window-log-reply.hpp
+++ b/UI/window-log-reply.hpp
@@ -27,7 +27,7 @@ private:
 	std::unique_ptr<Ui::OBSLogReply> ui;
 
 public:
-	OBSLogReply(QWidget *parent, const QString &url);
+	OBSLogReply(QWidget *parent, const QString &url, const bool crash);
 
 private slots:
 	void on_copyURL_clicked();

--- a/UI/window-log-reply.hpp
+++ b/UI/window-log-reply.hpp
@@ -31,4 +31,5 @@ public:
 
 private slots:
 	void on_copyURL_clicked();
+	void on_analyzeURL_clicked();
 };


### PR DESCRIPTION
### Description
* Removes the ? button in the Log Reply window (not sure how I missed it last time)
* Adds a basic description to the dialog. Improved wording suggestions welcome.
* Added a button to get basic troubleshooting via the Log Analyzer

**Before:**
![image](https://user-images.githubusercontent.com/941350/78554873-47c40680-784f-11ea-9a32-dc1324758a40.png)

**After:**
![image](https://user-images.githubusercontent.com/941350/78554917-5c080380-784f-11ea-9d1a-fc13c0d48dc7.png)
![image](https://user-images.githubusercontent.com/941350/78660571-a7ceb180-7910-11ea-8e1e-3c41f9791947.png)


**To Do:**
- [x] Use a different description & hide the button for Crash Reports

### Motivation and Context
Previously, the log dialog contained no context about what it was for.
As we now have an officially-hosted log analyzer, providing access to it from this dialog made sense. At the same time, such a button doesn't make sense for the crash dialog.

### How Has This Been Tested?
* Help -> Log Files -> Upload Last Log File
* Help -> Crash Reports -> Upload Last Crash Report

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
