### PR TITLE
libobs/util: Add FreeBSD and Dragonfly support in os_get_executable_path_ptr()

### DIFF
--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -275,7 +275,20 @@ char *os_get_program_data_path_ptr(const char *name)
 char *os_get_executable_path_ptr(const char *name)
 {
 	char exe[PATH_MAX];
+#if defined(__FreeBSD__) || defined(__DragonFly__)
+	int sysctlname[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+	size_t pathlen = PATH_MAX;
+	ssize_t count;
+	if (sysctl(sysctlname, nitems(sysctlname), exe, &pathlen, NULL, 0) ==
+	    -1) {
+		blog(LOG_ERROR, "sysctl(KERN_PROC_PATHNAME) failed, errno %d",
+		     errno);
+		return NULL;
+	}
+	count = pathlen;
+#else
 	ssize_t count = readlink("/proc/self/exe", exe, PATH_MAX);
+#endif
 	const char *path_out = NULL;
 	struct dstr path;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
FreeBSD and Dragonfly uses sysctl(3) for querying system information such as process stats. This change implements FreeBSD and Dragonfly support for os_get_executable_path_ptr().  

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
To implement proper FreeBSD supports.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on FreeBSD by checking if issue mentioned in https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=245299 goes away. Not tested on Dragonfly.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
