### PR TITLE
linux-v4l2: Fix build with Clang 10.0

### DIFF
--- a/plugins/linux-v4l2/v4l2-controls.c
+++ b/plugins/linux-v4l2/v4l2-controls.c
@@ -95,7 +95,7 @@ static inline bool valid_control(struct v4l2_queryctrl *qctrl)
 	return (qctrl->flags & INVALID_CONTROL_FLAGS) == 0;
 }
 
-static inline bool add_control_property(obs_properties_t *props,
+static inline void add_control_property(obs_properties_t *props,
 					obs_data_t *settings, int_fast32_t dev,
 					struct v4l2_queryctrl *qctrl)
 {


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
add_control_property() was previously static inline bool, but did not return a
value and failed to build on FreeBSD-CURRENT with Clang 10.0, with

`error: non-void function 'add_control_property' should return a value [-Wreturn-type]`

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Fixes build on FreeBSD-CURRENT with Clang 10.0.

### How Has This Been Tested?
Build was successful.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
