### PR TITLE
deps: lzma: also use .note.GNU-stack on FreeBSD

### DIFF
--- a/deps/lzma/liblzma/check/crc32_x86.S
+++ b/deps/lzma/liblzma/check/crc32_x86.S
@@ -299,6 +299,6 @@ LZMA_CRC32:
  * use __linux__ here, but I don't know a way to detect when
  * we are using GNU assembler.
  */
-#if defined(__ELF__) && defined(__linux__)
+#if defined(__ELF__) && (defined(__FreeBSD__) || defined(__linux__))
 	.section	.note.GNU-stack,"",@progbits
 #endif

--- a/deps/lzma/liblzma/check/crc64_x86.S
+++ b/deps/lzma/liblzma/check/crc64_x86.S
@@ -282,6 +282,6 @@ LZMA_CRC64:
  * use __linux__ here, but I don't know a way to detect when
  * we are using GNU assembler.
  */
-#if defined(__ELF__) && defined(__linux__)
+#if defined(__ELF__) && (defined(__FreeBSD__) || defined(__linux__))
 	.section	.note.GNU-stack,"",@progbits
 #endif


### PR DESCRIPTION
### Description
FreeBSD uses the same .note.GNU-stack section as Linux to indicate that the
stack should not be executable.

### Motivation and Context
With GNU and GNU-compatible toolchains binaries are tagged with a `GNU_STACK` program header with RW permissions to indicate that they should use a non-executable stack. Linkers emit this header when all input objects contain a .note.GNU-stack section with RW permissions. Add `__FreeBSD__` to the cases where we do this for Linux today.

### How Has This Been Tested?
Built and ran with this change on FreeBSD-CURRENT,
`FreeBSD nazar 13.0-CURRENT FreeBSD 13.0-CURRENT #0 r359488: Tue Mar 31 13:13:49 EDT 2020     emaste@nazar:/usr/obj/usr/home/emaste/src/freebsd-svn/head/amd64.amd64/sys/GENERIC  amd64`

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Small security cleanup?

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
