### PR TITLE
UI: fix projector on other than primary display

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -166,8 +166,8 @@ void OBSProjector::SetMonitor(int monitor)
 {
 	savedMonitor = monitor;
 	QScreen *screen = QGuiApplication::screens()[monitor];
-	showFullScreen();
 	setGeometry(screen->geometry());
+	showFullScreen();
 	SetHideCursor();
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Calling showFullScreen after setGeometry puts the projector on the
expected monitor.

### Motivation and Context
On FreeBSD an attempt to open a projector on secondary monitor put it on the primary display instead, reported in #2670. Fixes #2670

This is my first experience with Qt so I am not sure of the canonical way to do this, but I looked at a [stackoverflow question about multiple monitors with Qt](https://stackoverflow.com/questions/3203095/display-window-full-screen-on-secondary-monitor-using-qt), tried moving the showFullScreen after setGeometry, and found that the issue was fixed.

### How Has This Been Tested?
Tested on FreeBSD 13 with qt5-5.13.2_3, View->Multiview (Full Screen)->2nd monitor now appears on the second monitor.

This definitely needs to be tested across operating systems.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
