### PR TITLE
UI: sort audio sources by name locale aware

### DIFF
--- a/UI/item-widget-helpers.hpp
+++ b/UI/item-widget-helpers.hpp
@@ -34,7 +34,7 @@ void InsertQObjectByName(std::vector<QObjectPtr> &controls, QObjectPtr control)
 {
 	QString name = control->objectName();
 	auto finder = [name](QObjectPtr elem) {
-		return elem->objectName() > name;
+		return name.localeAwareCompare(elem->objectName()) < 0;
 	};
 	auto found_at = std::find_if(controls.begin(), controls.end(), finder);
 


### PR DESCRIPTION
### Description
Sort audio source by name locale aware

### Motivation and Context
The old sorting is based exclusively on the numeric Unicode values of the characters.
https://ideas.obsproject.com/posts/810/

### How Has This Been Tested?
On windows 64 bit see if sources in the advanced audio window are showing in the right order

### Types of changes
- Enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
