### PR TITLE
linux-jack: Fix conversion from channels to speaker layout

### DIFF
--- a/plugins/linux-jack/jack-wrapper.c
+++ b/plugins/linux-jack/jack-wrapper.c
@@ -43,6 +43,8 @@ static enum speaker_layout jack_channels_to_obs_speakers(uint_fast32_t channels)
 		return SPEAKERS_STEREO;
 	case 3:
 		return SPEAKERS_2POINT1;
+	case 4:
+		return SPEAKERS_4POINT0;
 	case 5:
 		return SPEAKERS_4POINT1;
 	case 6:


### PR DESCRIPTION
### Description
Failed to initialize FFmpeg resampler when setup 4 channels in `Jack Input Client` source. And the volume meter in audio mixer would fallback to 1 channel.


### Motivation and Context
To successfully initialize `Jack Input Client` after setting 4 channels in properties for ambisonics inputs.

### How Has This Been Tested?
Create `Jack Input Client` source and setup 4 channels

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
