### PR TITLE
CI: Add qt5-xml package for FreeBSD build task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ task:
     freetype2 jackit jansson luajit mbedtls pulseaudio speexdsp
     libsysinfo libudev-devd libv4l libx264 cmake ninja
     mesa-libs lua52 pkgconf
-    qt5-svg qt5-qmake qt5-buildtools qt5-x11extras
+    qt5-svg qt5-qmake qt5-buildtools qt5-x11extras qt5-xml
   script:
   - mkdir build
   - cd build


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Add qt5-xml package currently required to build on FreeBSD
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
FreeBSD CI build started failing some time ago with a cmake error that Qt5Xml was not found.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Successful Cirrus-CI run: https://cirrus-ci.com/build/4851080737587200
Note that the build fix from https://github.com/obsproject/obs-studio/pull/2667 is also required.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
