### PR TITLE
UI: Add status icons for recording and streaming

### DIFF
--- a/UI/forms/images/recording-active.svg
+++ b/UI/forms/images/recording-active.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 2.1166666 2.1166667"
+   height="8"
+   width="8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-294.88332)"
+     id="layer1">
+    <circle
+       r="0.52916664"
+       cy="295.94165"
+       cx="1.0583333"
+       id="path4544"
+       style="fill:#d40000;fill-opacity:1;stroke:none;stroke-width:0.06614584;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+  </g>
+</svg>

--- a/UI/forms/images/recording-inactive.svg
+++ b/UI/forms/images/recording-inactive.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 2.1166666 2.1166667"
+   height="8"
+   width="8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-294.88332)"
+     id="layer1">
+    <circle
+       r="0.52916664"
+       cy="295.94165"
+       cx="1.0583333"
+       id="path4544"
+       style="fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.06614584;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+  </g>
+</svg>

--- a/UI/forms/images/recording-pause-inactive.svg
+++ b/UI/forms/images/recording-pause-inactive.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 5.2916665 5.2916668"
+   height="20"
+   width="20">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-291.70832)"
+     id="layer1">
+    <rect
+       y="293.03125"
+       x="1.3229166"
+       height="2.6458333"
+       width="1.0583333"
+       id="rect822"
+       style="fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.5020116;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <rect
+       y="293.03125"
+       x="2.9104166"
+       height="2.6458333"
+       width="1.0583333"
+       id="rect822-1"
+       style="fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.5020116;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+  </g>
+</svg>

--- a/UI/forms/images/recording-pause.svg
+++ b/UI/forms/images/recording-pause.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 5.2916665 5.2916668"
+   height="20"
+   width="20">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-291.70832)"
+     id="layer1">
+    <rect
+       y="293.03125"
+       x="1.3229166"
+       height="2.6458333"
+       width="1.0583333"
+       id="rect822"
+       style="fill:#d4ae00;fill-opacity:1;stroke:none;stroke-width:0.5020116;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <rect
+       y="293.03125"
+       x="2.9104166"
+       height="2.6458333"
+       width="1.0583333"
+       id="rect822-1"
+       style="fill:#d4ae00;fill-opacity:1;stroke:none;stroke-width:0.5020116;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+  </g>
+</svg>

--- a/UI/forms/images/streaming-active.svg
+++ b/UI/forms/images/streaming-active.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 2.1166666 2.1166667"
+   height="8"
+   width="8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-294.88332)"
+     id="layer1">
+    <circle
+       r="0.39687499"
+       cy="295.94165"
+       cx="1.0582843"
+       id="path4544-3"
+       style="fill:#5079cc;fill-opacity:1;stroke:none;stroke-width:0.13229169;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       d="M 0.41577997,296.5497 A 0.79374999,0.79374999 0 0 1 0.13224262,295.94165 0.79374999,0.79374999 0 0 1 0.41577996,295.3336"
+       id="path4546-7"
+       style="fill:none;fill-opacity:1;stroke:#5079cc;stroke-width:0.15875001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       transform="scale(-1,1)"
+       d="m -1.7008867,296.5497 a 0.79374999,0.79374999 0 0 1 -0.2835374,-0.60805 0.79374999,0.79374999 0 0 1 0.2835374,-0.60805"
+       id="path4546-1-3"
+       style="fill:none;fill-opacity:1;stroke:#5079cc;stroke-width:0.15875001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       d="M 0.63239977,296.41847 A 0.62244385,0.62244385 0 0 1 0.4100551,295.94165 0.62244385,0.62244385 0 0 1 0.63239977,295.46483"
+       id="path4546-5-7"
+       style="fill:none;fill-opacity:1;stroke:#5079cc;stroke-width:0.15875001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       transform="scale(-1,1)"
+       d="m -1.484193,296.41847 a 0.62244391,0.62244391 0 0 1 -0.2223447,-0.47682 0.62244391,0.62244391 0 0 1 0.2223447,-0.47682"
+       id="path4546-5-4-2"
+       style="fill:none;fill-opacity:1;stroke:#5079cc;stroke-width:0.15875001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+  </g>
+</svg>

--- a/UI/forms/images/streaming-inactive.svg
+++ b/UI/forms/images/streaming-inactive.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 2.1166666 2.1166667"
+   height="8"
+   width="8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-294.88332)"
+     id="layer1">
+    <circle
+       r="0.39687499"
+       cy="295.94165"
+       cx="1.0583333"
+       id="path4544"
+       style="fill:#7f7d7f;fill-opacity:1;stroke:none;stroke-width:0.13229167;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       d="M 0.41582902,296.5497 A 0.79374999,0.79374999 0 0 1 0.13229167,295.94165 0.79374999,0.79374999 0 0 1 0.41582902,295.3336"
+       id="path4546"
+       style="fill:none;fill-opacity:1;stroke:#7f7d7f;stroke-width:0.15875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       transform="scale(-1,1)"
+       d="m -1.7009357,296.5497 a 0.79374999,0.79374999 0 0 1 -0.2835373,-0.60805 0.79374999,0.79374999 0 0 1 0.2835373,-0.60805"
+       id="path4546-1"
+       style="fill:none;fill-opacity:1;stroke:#7f7d7f;stroke-width:0.15875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       d="M 0.6324488,296.41847 A 0.6224438,0.6224438 0 0 1 0.41010416,295.94165 0.6224438,0.6224438 0 0 1 0.6324488,295.46483"
+       id="path4546-5"
+       style="fill:none;fill-opacity:1;stroke:#7f7d7f;stroke-width:0.15875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       transform="scale(-1,1)"
+       d="m -1.484242,296.41847 a 0.62244385,0.62244385 0 0 1 -0.2223447,-0.47682 0.62244385,0.62244385 0 0 1 0.2223447,-0.47682"
+       id="path4546-5-4"
+       style="fill:none;fill-opacity:1;stroke:#7f7d7f;stroke-width:0.15875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+  </g>
+</svg>

--- a/UI/forms/obs.qrc
+++ b/UI/forms/obs.qrc
@@ -34,6 +34,12 @@
     <file>images/sources/text.svg</file>
     <file>images/sources/window.svg</file>
     <file>images/sources/default.svg</file>
+    <file>images/recording-active.svg</file>
+    <file>images/recording-inactive.svg</file>
+    <file>images/recording-pause.svg</file>
+    <file>images/recording-pause-inactive.svg</file>
+    <file>images/streaming-active.svg</file>
+    <file>images/streaming-inactive.svg</file>
   </qresource>
   <qresource prefix="/settings">
     <file>images/settings/output.svg</file>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7712,6 +7712,8 @@ void OBSBasic::PauseRecording()
 		pause->setChecked(true);
 		pause->blockSignals(false);
 
+		ui->statusbar->RecordingPaused();
+
 		if (trayIcon)
 			trayIcon->setIcon(QIcon(":/res/images/obs_paused.png"));
 
@@ -7738,6 +7740,8 @@ void OBSBasic::UnpauseRecording()
 		pause->blockSignals(true);
 		pause->setChecked(false);
 		pause->blockSignals(false);
+
+		ui->statusbar->RecordingUnpaused();
 
 		if (trayIcon)
 			trayIcon->setIcon(

--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -11,17 +11,35 @@ OBSBasicStatusBar::OBSBasicStatusBar(QWidget *parent)
 	: QStatusBar(parent),
 	  delayInfo(new QLabel),
 	  droppedFrames(new QLabel),
+	  streamIcon(new QLabel),
 	  streamTime(new QLabel),
+	  recordIcon(new QLabel),
 	  recordTime(new QLabel),
 	  cpuUsage(new QLabel),
 	  transparentPixmap(20, 20),
 	  greenPixmap(20, 20),
 	  grayPixmap(20, 20),
-	  redPixmap(20, 20)
+	  redPixmap(20, 20),
+	  recordingActivePixmap(QIcon(":/res/images/recording-active.svg")
+					.pixmap(QSize(20, 20))),
+	  recordingPausePixmap(QIcon(":/res/images/recording-pause.svg")
+				       .pixmap(QSize(20, 20))),
+	  recordingPauseInactivePixmap(
+		  QIcon(":/res/images/recording-pause-inactive.svg")
+			  .pixmap(QSize(20, 20))),
+	  recordingInactivePixmap(QIcon(":/res/images/recording-inactive.svg")
+					  .pixmap(QSize(20, 20))),
+	  streamingActivePixmap(QIcon(":/res/images/streaming-active.svg")
+					.pixmap(QSize(20, 20))),
+	  streamingInactivePixmap(QIcon(":/res/images/streaming-inactive.svg")
+					  .pixmap(QSize(20, 20)))
 {
 	streamTime->setText(QString("LIVE: 00:00:00"));
 	recordTime->setText(QString("REC: 00:00:00"));
 	cpuUsage->setText(QString("CPU: 0.0%, 0.00 fps"));
+
+	streamIcon->setPixmap(streamingInactivePixmap);
+	recordIcon->setPixmap(recordingInactivePixmap);
 
 	QWidget *brWidget = new QWidget(this);
 	QHBoxLayout *brLayout = new QHBoxLayout(brWidget);
@@ -39,8 +57,12 @@ OBSBasicStatusBar::OBSBasicStatusBar(QWidget *parent)
 	delayInfo->setAlignment(Qt::AlignVCenter);
 	droppedFrames->setAlignment(Qt::AlignRight);
 	droppedFrames->setAlignment(Qt::AlignVCenter);
+	streamIcon->setAlignment(Qt::AlignRight);
+	streamIcon->setAlignment(Qt::AlignVCenter);
 	streamTime->setAlignment(Qt::AlignRight);
 	streamTime->setAlignment(Qt::AlignVCenter);
+	recordIcon->setAlignment(Qt::AlignRight);
+	recordIcon->setAlignment(Qt::AlignVCenter);
 	recordTime->setAlignment(Qt::AlignRight);
 	recordTime->setAlignment(Qt::AlignVCenter);
 	cpuUsage->setAlignment(Qt::AlignRight);
@@ -50,13 +72,15 @@ OBSBasicStatusBar::OBSBasicStatusBar(QWidget *parent)
 
 	delayInfo->setIndent(20);
 	droppedFrames->setIndent(20);
-	streamTime->setIndent(20);
-	recordTime->setIndent(20);
+	streamIcon->setIndent(20);
+	recordIcon->setIndent(20);
 	cpuUsage->setIndent(20);
 	kbps->setIndent(10);
 
 	addPermanentWidget(droppedFrames);
+	addPermanentWidget(streamIcon);
 	addPermanentWidget(streamTime);
+	addPermanentWidget(recordIcon);
 	addPermanentWidget(recordTime);
 	addPermanentWidget(cpuUsage);
 	addPermanentWidget(delayInfo);
@@ -93,6 +117,14 @@ void OBSBasicStatusBar::Activate()
 			statusSquare->setPixmap(grayPixmap);
 		}
 	}
+
+	if (streamOutput) {
+		streamIcon->setPixmap(streamingActivePixmap);
+	}
+
+	if (recordOutput) {
+		recordIcon->setPixmap(recordingActivePixmap);
+	}
 }
 
 void OBSBasicStatusBar::Deactivate()
@@ -103,11 +135,13 @@ void OBSBasicStatusBar::Deactivate()
 
 	if (!streamOutput) {
 		streamTime->setText(QString("LIVE: 00:00:00"));
+		streamIcon->setPixmap(streamingInactivePixmap);
 		totalStreamSeconds = 0;
 	}
 
 	if (!recordOutput) {
 		recordTime->setText(QString("REC: 00:00:00"));
+		recordIcon->setPixmap(recordingInactivePixmap);
 		totalRecordSeconds = 0;
 	}
 
@@ -247,25 +281,26 @@ void OBSBasicStatusBar::UpdateRecordTime()
 {
 	bool paused = os_atomic_load_bool(&recording_paused);
 
-	if (!paused)
+	if (!paused) {
 		totalRecordSeconds++;
 
-	QString text;
-
-	if (paused) {
-		text = QStringLiteral("REC: PAUSED");
-	} else {
 		int seconds = totalRecordSeconds % 60;
 		int totalMinutes = totalRecordSeconds / 60;
 		int minutes = totalMinutes % 60;
 		int hours = totalMinutes / 60;
 
-		text = QString::asprintf("REC: %02d:%02d:%02d", hours, minutes,
-					 seconds);
-	}
+		QString text = QString::asprintf("REC: %02d:%02d:%02d", hours,
+						 minutes, seconds);
 
-	recordTime->setText(text);
-	recordTime->setMinimumWidth(recordTime->width());
+		recordTime->setText(text);
+		recordTime->setMinimumWidth(recordTime->width());
+	} else {
+		recordIcon->setPixmap(streamPauseIconToggle
+					      ? recordingPauseInactivePixmap
+					      : recordingPausePixmap);
+
+		streamPauseIconToggle = !streamPauseIconToggle;
+	}
 }
 
 void OBSBasicStatusBar::UpdateDroppedFrames()
@@ -482,4 +517,23 @@ void OBSBasicStatusBar::RecordingStopped()
 {
 	recordOutput = nullptr;
 	Deactivate();
+}
+
+void OBSBasicStatusBar::RecordingPaused()
+{
+	QString text = QStringLiteral("REC: PAUSED");
+	recordTime->setText(text);
+	recordTime->setMinimumWidth(recordTime->width());
+
+	if (recordOutput) {
+		recordIcon->setPixmap(recordingPausePixmap);
+		streamPauseIconToggle = true;
+	}
+}
+
+void OBSBasicStatusBar::RecordingUnpaused()
+{
+	if (recordOutput) {
+		recordIcon->setPixmap(recordingActivePixmap);
+	}
 }

--- a/UI/window-basic-status-bar.hpp
+++ b/UI/window-basic-status-bar.hpp
@@ -14,8 +14,10 @@ class OBSBasicStatusBar : public QStatusBar {
 private:
 	QLabel *delayInfo;
 	QLabel *droppedFrames;
+	QLabel *streamIcon;
 	QLabel *streamTime;
 	QLabel *recordTime;
+	QLabel *recordIcon;
 	QLabel *cpuUsage;
 	QLabel *kbps;
 	QLabel *statusSquare;
@@ -24,6 +26,7 @@ private:
 	obs_output_t *recordOutput = nullptr;
 	bool active = false;
 	bool overloadedNotify = true;
+	bool streamPauseIconToggle = false;
 
 	int retries = 0;
 	int totalStreamSeconds = 0;
@@ -47,6 +50,13 @@ private:
 	QPixmap greenPixmap;
 	QPixmap grayPixmap;
 	QPixmap redPixmap;
+
+	QPixmap recordingActivePixmap;
+	QPixmap recordingPausePixmap;
+	QPixmap recordingPauseInactivePixmap;
+	QPixmap recordingInactivePixmap;
+	QPixmap streamingActivePixmap;
+	QPixmap streamingInactivePixmap;
 
 	float lastCongestion = 0.0f;
 
@@ -81,6 +91,8 @@ public:
 	void StreamStopped();
 	void RecordingStarted(obs_output_t *output);
 	void RecordingStopped();
+	void RecordingPaused();
+	void RecordingUnpaused();
 
 	void ReconnectClear();
 };


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Add status icons for recording and streaming in the statusbar at the bottom of the window.

This is how the status bar looks like now:

![Screenshot_5](https://user-images.githubusercontent.com/8039939/79260377-7c0e7700-7e8e-11ea-9fde-4fd713d02de6.png)


#### Default dark theme
![Dark_inactive](https://user-images.githubusercontent.com/8039939/79259490-18d01500-7e8d-11ea-9342-df172d3046d9.png)

![Dark_active](https://user-images.githubusercontent.com/8039939/79259515-21c0e680-7e8d-11ea-800e-33ecbfb40ce1.png)

![Dark_paused](https://user-images.githubusercontent.com/8039939/79275429-74f36300-7ea6-11ea-9ba8-2c286c6bcfbc.png)


#### Rachni theme
![Rachni_inactive](https://user-images.githubusercontent.com/8039939/79259563-32715c80-7e8d-11ea-8476-e74742a6a7ef.png)

![Rachni_active](https://user-images.githubusercontent.com/8039939/79259503-1bcb0580-7e8d-11ea-86e2-4571ae052c2f.png)

![Rachni_paused](https://user-images.githubusercontent.com/8039939/79275441-7a50ad80-7ea6-11ea-8c0e-f70c2323bb78.png)


#### Acri theme
![Acri_inactive](https://user-images.githubusercontent.com/8039939/79259583-3ef5b500-7e8d-11ea-8c88-50e6a3fe2fbc.png)

![Acri_active](https://user-images.githubusercontent.com/8039939/79259589-41580f00-7e8d-11ea-8b88-21111cbf909e.png)

![Acri_paused](https://user-images.githubusercontent.com/8039939/79275451-7fadf800-7ea6-11ea-95a8-d2bb788ab06c.png)


<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
This PR implements [this](https://ideas.obsproject.com/posts/131/status-icons-for-recording-and-streaming) idea from the ideas page.

It makes the current recording/streaming status more visible.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
This has been tested on Windows 10 with the available themes (Dark, Rachni, and Acri).
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
