### PR TITLE
CI: Add freetype dep on osx

### DIFF
--- a/CI/before-script-osx.sh
+++ b/CI/before-script-osx.sh
@@ -10,6 +10,7 @@ cmake -DENABLE_SPARKLE_UPDATER=ON \
 -DQTDIR=/usr/local/Cellar/qt/5.14.1 \
 -DDepsPath=/tmp/obsdeps \
 -DVLCPath=$PWD/../../vlc-3.0.8 \
+-DFreetypePath=/tmp/obsdeps
 -DBUILD_BROWSER=ON \
 -DBROWSER_DEPLOY=ON \
 -DBUILD_CAPTIONS=ON \

--- a/CI/before-script-osx.sh
+++ b/CI/before-script-osx.sh
@@ -10,7 +10,6 @@ cmake -DENABLE_SPARKLE_UPDATER=ON \
 -DQTDIR=/usr/local/Cellar/qt/5.14.1 \
 -DDepsPath=/tmp/obsdeps \
 -DVLCPath=$PWD/../../vlc-3.0.8 \
--DFreetypePath=/tmp/obsdeps
 -DBUILD_BROWSER=ON \
 -DBROWSER_DEPLOY=ON \
 -DBUILD_CAPTIONS=ON \

--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -40,8 +40,8 @@ ccache -s || echo "CCache is not available."
 
 # Fetch and untar prebuilt OBS deps that are compatible with older versions of OSX
 hr "Downloading OBS deps"
-wget --quiet --retry-connrefused --waitretry=1 https://github.com/obsproject/obs-deps/releases/download/2020-04-07/osx-deps-2020-04-07.tar.gz
-tar -xf ./osx-deps-2020-04-07.tar.gz -C /tmp
+wget --quiet --retry-connrefused --waitretry=1 https://github.com/obsproject/obs-deps/releases/download/2020-04-15/osx-deps-2020-04-15.tar.gz
+tar -xf ./osx-deps-2020-04-15.tar.gz -C /tmp
 
 # Fetch vlc codebase
 hr "Downloading VLC repo"

--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -40,8 +40,8 @@ ccache -s || echo "CCache is not available."
 
 # Fetch and untar prebuilt OBS deps that are compatible with older versions of OSX
 hr "Downloading OBS deps"
-wget --quiet --retry-connrefused --waitretry=1 https://github.com/obsproject/obs-deps/releases/download/2020-04-15/osx-deps-2020-04-15.tar.gz
-tar -xf ./osx-deps-2020-04-15.tar.gz -C /tmp
+wget --quiet --retry-connrefused --waitretry=1 https://github.com/obsproject/obs-deps/releases/download/2020-4-16/osx-deps-2020-04-16.tar.gz
+tar -xf ./osx-deps-2020-04-16.tar.gz -C /tmp
 
 # Fetch vlc codebase
 hr "Downloading VLC repo"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
