### PR TITLE
UI: Adjust a few margins

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -38,6 +38,21 @@
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="spacing">
+     <number>0</number>
+    </property>
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
@@ -853,19 +868,19 @@
       <widget class="QWidget" name="transitionsContainer" native="true">
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="spacing">
-         <number>4</number>
+         <number>2</number>
         </property>
         <property name="leftMargin">
-         <number>1</number>
+         <number>0</number>
         </property>
         <property name="topMargin">
-         <number>1</number>
+         <number>0</number>
         </property>
         <property name="rightMargin">
-         <number>1</number>
+         <number>0</number>
         </property>
         <property name="bottomMargin">
-         <number>2</number>
+         <number>0</number>
         </property>
         <item>
          <widget class="QComboBox" name="transitions">


### PR DESCRIPTION
### Description
-Remove 9px margins around central widget. This saves 18px of vertical
space. This will be helpful when the source context menu is added,
which is 24px tall.

-Adjusts margins in transitions dock. The top of the transitions dock
wasn't lined up with the top of the controls dock, which made it look
bad.

Before:
![Screenshot from 2020-04-16 13-32-59](https://user-images.githubusercontent.com/19962531/79493437-1b468200-7fe7-11ea-8d2b-c1bb98bd812a.png)

After:
![Screenshot from 2020-04-16 13-47-42](https://user-images.githubusercontent.com/19962531/79494597-e5a29880-7fe8-11ea-9fc3-0c362671aa52.png)


### Motivation and Context
Make UI look better.

### How Has This Been Tested?
Looked and saw it looked better.

### Types of changes
- UI tweak

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
