### PR TITLE
libobs: Don't allow duplicating scene sources/nested scenes

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1166,7 +1166,7 @@ const struct obs_source_info scene_info = {
 	.id = "scene",
 	.type = OBS_SOURCE_TYPE_SCENE,
 	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-			OBS_SOURCE_COMPOSITE,
+			OBS_SOURCE_COMPOSITE | OBS_SOURCE_DO_NOT_DUPLICATE,
 	.get_name = scene_getname,
 	.create = scene_create,
 	.destroy = scene_destroy,


### PR DESCRIPTION
### Description

Explicitly disables the ability to "Paste (Duplicate)" for a nested scene. Does not affect "Duplicate Scene" capabilities.

### Motivation and Context

Fixes #2736

### How Has This Been Tested?
* Try to paste a Duplicate of a nested scene.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
