### PR TITLE
libobs: Don't save removed sources

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2108,7 +2108,8 @@ obs_data_array_t *obs_save_sources_filtered(obs_save_source_filter_cb cb,
 
 	while (source) {
 		if ((source->info.type != OBS_SOURCE_TYPE_FILTER) != 0 &&
-		    !source->context.private && cb(data_, source)) {
+		    !source->context.private && !source->removed &&
+		    cb(data_, source)) {
 			obs_data_t *source_data = obs_save_source(source);
 
 			obs_data_array_push_back(array, source_data);


### PR DESCRIPTION
### Description
Don't save removed sources

### Motivation and Context
Sources can keep references due to various problems like bad plugins.
If that is the case and the source is removed the source should still not be saved.
This does not fix the root problem of #2724 and #2709, but prevents the bad results.

### How Has This Been Tested?
With the steps in #2724

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
