### PR TITLE
UI: Remove all scenes in ClearSceneData

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3921,6 +3921,7 @@ void OBSBasic::ClearSceneData()
 		return true;
 	};
 
+	obs_enum_scenes(cb, nullptr);
 	obs_enum_sources(cb, nullptr);
 
 	if (api)


### PR DESCRIPTION
### Description
Set scenes as removed on clearing scene data

### Motivation and Context
Helps prevent bugs on switching scene collections.
Was first in #2739, but made it separate pull request

### How Has This Been Tested?
On windows 64 combined with #2739, with the reproduction steps of #2724

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
