### PR TITLE
UI: Remove exit button from controls dock

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1201,19 +1201,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="exitButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Exit</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <spacer name="expVSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -1888,22 +1875,6 @@
     <hint type="destinationlabel">
      <x>463</x>
      <y>351</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>exitButton</sender>
-   <signal>clicked()</signal>
-   <receiver>OBSBasic</receiver>
-   <slot>close()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>976</x>
-     <y>601</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>862</x>
-     <y>-11</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
### Description
Remove exit button from controls dock.

![Screenshot from 2020-04-23 22-24-36](https://user-images.githubusercontent.com/19962531/80172046-88db4b00-85b1-11ea-8f54-92025f2baed5.png)

### Motivation and Context

- This button is redundant because these are also in the file menu
- This button made the UI feel cluttered
- Users might accidentally click the exit button

### How Has This Been Tested?
Ran OBS as normal.

### Types of changes
- UI tweak

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
