### PR TITLE
UI: Remove unnecessary global variables

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -271,8 +271,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	connect(windowHandle(), &QWindow::screenChanged, displayResize);
 	connect(ui->preview, &OBSQTDisplay::DisplayResized, displayResize);
 
-	delete shortcutFilter;
-	shortcutFilter = CreateShortcutFilter();
+	QObject *shortcutFilter = CreateShortcutFilter();
 	installEventFilter(shortcutFilter);
 
 	stringstream name;
@@ -1822,12 +1821,10 @@ void OBSBasic::OBSInit()
 
 	ui->viewMenu->addSeparator();
 
-	multiviewProjectorMenu = new QMenu(QTStr("MultiviewProjector"));
+	QMenu *multiviewProjectorMenu = new QMenu(QTStr("MultiviewProjector"));
 	ui->viewMenu->addMenu(multiviewProjectorMenu);
 	AddProjectorMenuMonitors(multiviewProjectorMenu, this,
 				 SLOT(OpenMultiviewProjector()));
-	connect(ui->viewMenu->menuAction(), &QAction::hovered, this,
-		&OBSBasic::UpdateMultiviewProjectorMenu);
 	ui->viewMenu->addAction(QTStr("MultiviewWindowed"), this,
 				SLOT(OpenMultiviewWindow()));
 
@@ -2044,13 +2041,6 @@ void OBSBasic::ShowWhatsNew(const QString &url)
 #else
 	UNUSED_PARAMETER(url);
 #endif
-}
-
-void OBSBasic::UpdateMultiviewProjectorMenu()
-{
-	multiviewProjectorMenu->clear();
-	AddProjectorMenuMonitors(multiviewProjectorMenu, this,
-				 SLOT(OpenMultiviewProjector()));
 }
 
 void OBSBasic::InitHotkeys()
@@ -2309,21 +2299,6 @@ OBSBasic::~OBSBasic()
 	if (updateCheckThread && updateCheckThread->isRunning())
 		updateCheckThread->wait();
 
-	delete multiviewProjectorMenu;
-	delete previewProjector;
-	delete studioProgramProjector;
-	delete previewProjectorSource;
-	delete previewProjectorMain;
-	delete sourceProjector;
-	delete sceneProjectorMenu;
-	delete scaleFilteringMenu;
-	delete colorMenu;
-	delete colorWidgetAction;
-	delete colorSelect;
-	delete deinterlaceMenu;
-	delete perSceneTransitionMenu;
-	delete shortcutFilter;
-	delete trayMenu;
 	delete programOptions;
 	delete program;
 
@@ -4256,8 +4231,7 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 
 		popup.addSeparator();
 
-		delete sceneProjectorMenu;
-		sceneProjectorMenu = new QMenu(QTStr("SceneProjector"));
+		QMenu *sceneProjectorMenu = new QMenu(QTStr("SceneProjector"));
 		AddProjectorMenuMonitors(sceneProjectorMenu, this,
 					 SLOT(OpenSceneProjector()));
 		popup.addMenu(sceneProjectorMenu);
@@ -4272,8 +4246,7 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 
 		popup.addSeparator();
 
-		delete perSceneTransitionMenu;
-		perSceneTransitionMenu = CreatePerSceneTransitionMenu();
+		QMenu *perSceneTransitionMenu = CreatePerSceneTransitionMenu();
 		popup.addMenu(perSceneTransitionMenu);
 
 		/* ---------------------- */
@@ -4584,13 +4557,6 @@ ColorSelect::ColorSelect(QWidget *parent)
 void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 {
 	QMenu popup(this);
-	delete previewProjectorSource;
-	delete sourceProjector;
-	delete scaleFilteringMenu;
-	delete colorMenu;
-	delete colorWidgetAction;
-	delete colorSelect;
-	delete deinterlaceMenu;
 
 	if (preview) {
 		QAction *action = popup.addAction(
@@ -4605,7 +4571,8 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		popup.addAction(ui->actionLockPreview);
 		popup.addMenu(ui->scalingMenu);
 
-		previewProjectorSource = new QMenu(QTStr("PreviewProjector"));
+		QMenu *previewProjectorSource =
+			new QMenu(QTStr("PreviewProjector"));
 		AddProjectorMenuMonitors(previewProjectorSource, this,
 					 SLOT(OpenPreviewProjector()));
 
@@ -4662,9 +4629,9 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		bool hasAudio = (flags & OBS_SOURCE_AUDIO) == OBS_SOURCE_AUDIO;
 		QAction *action;
 
-		colorMenu = new QMenu(QTStr("ChangeBG"));
-		colorWidgetAction = new QWidgetAction(colorMenu);
-		colorSelect = new ColorSelect(colorMenu);
+		QMenu *colorMenu = new QMenu(QTStr("ChangeBG"));
+		QWidgetAction *colorWidgetAction = new QWidgetAction(colorMenu);
+		ColorSelect *colorSelect = new ColorSelect(colorMenu);
 		popup.addMenu(AddBackgroundColorMenu(
 			colorMenu, colorWidgetAction, colorSelect, sceneItem));
 		popup.addAction(QTStr("Rename"), this,
@@ -4687,7 +4654,7 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		ui->actionVerticalCenter->setEnabled(!lock);
 		ui->actionHorizontalCenter->setEnabled(!lock);
 
-		sourceProjector = new QMenu(QTStr("SourceProjector"));
+		QMenu *sourceProjector = new QMenu(QTStr("SourceProjector"));
 		AddProjectorMenuMonitors(sourceProjector, this,
 					 SLOT(OpenSourceProjector()));
 
@@ -4707,7 +4674,8 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		}
 
 		if (isAsyncVideo) {
-			deinterlaceMenu = new QMenu(QTStr("Deinterlacing"));
+			QMenu *deinterlaceMenu =
+				new QMenu(QTStr("Deinterlacing"));
 			popup.addMenu(
 				AddDeinterlacingMenu(deinterlaceMenu, source));
 			popup.addSeparator();
@@ -4725,7 +4693,7 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		if (width == 0 || height == 0)
 			resizeOutput->setEnabled(false);
 
-		scaleFilteringMenu = new QMenu(QTStr("ScaleFiltering"));
+		QMenu *scaleFilteringMenu = new QMenu(QTStr("ScaleFiltering"));
 		popup.addMenu(
 			AddScaleFilteringMenu(scaleFilteringMenu, sceneItem));
 		popup.addSeparator();
@@ -5385,10 +5353,7 @@ void OBSBasic::StreamDelayStarting(int sec)
 		sysTrayStream->setEnabled(true);
 	}
 
-	if (!startStreamMenu.isNull())
-		startStreamMenu->deleteLater();
-
-	startStreamMenu = new QMenu();
+	QMenu *startStreamMenu = new QMenu();
 	startStreamMenu->addAction(QTStr("Basic.Main.StopStreaming"), this,
 				   SLOT(StopStreaming()));
 	startStreamMenu->addAction(QTStr("Basic.Main.ForceStopStreaming"), this,
@@ -5411,10 +5376,7 @@ void OBSBasic::StreamDelayStopping(int sec)
 		sysTrayStream->setEnabled(true);
 	}
 
-	if (!startStreamMenu.isNull())
-		startStreamMenu->deleteLater();
-
-	startStreamMenu = new QMenu();
+	QMenu *startStreamMenu = new QMenu();
 	startStreamMenu->addAction(QTStr("Basic.Main.StartStreaming"), this,
 				   SLOT(StartStreaming()));
 	startStreamMenu->addAction(QTStr("Basic.Main.ForceStopStreaming"), this,
@@ -5537,11 +5499,7 @@ void OBSBasic::StreamingStop(int code, QString last_error)
 			      QSystemTrayIcon::Warning);
 	}
 
-	if (!startStreamMenu.isNull()) {
-		ui->streamButton->setMenu(nullptr);
-		startStreamMenu->deleteLater();
-		startStreamMenu = nullptr;
-	}
+	ui->streamButton->setMenu(nullptr);
 }
 
 void OBSBasic::AutoRemux()
@@ -6108,7 +6066,6 @@ void OBSBasic::on_program_customContextMenuRequested(const QPoint &)
 void OBSBasic::PreviewDisabledMenu(const QPoint &pos)
 {
 	QMenu popup(this);
-	delete previewProjectorMain;
 
 	QAction *action =
 		popup.addAction(QTStr("Basic.Main.PreviewConextMenu.Enable"),
@@ -6116,7 +6073,7 @@ void OBSBasic::PreviewDisabledMenu(const QPoint &pos)
 	action->setCheckable(true);
 	action->setChecked(obs_display_enabled(ui->preview->GetDisplay()));
 
-	previewProjectorMain = new QMenu(QTStr("PreviewProjector"));
+	QMenu *previewProjectorMain = new QMenu(QTStr("PreviewProjector"));
 	AddProjectorMenuMonitors(previewProjectorMain, this,
 				 SLOT(OpenPreviewProjector()));
 
@@ -7148,9 +7105,10 @@ void OBSBasic::SystemTrayInit()
 					  trayIcon.data());
 	exit = new QAction(QTStr("Exit"), trayIcon.data());
 
-	trayMenu = new QMenu;
-	previewProjector = new QMenu(QTStr("PreviewProjector"));
-	studioProgramProjector = new QMenu(QTStr("StudioProgramProjector"));
+	QMenu *trayMenu = new QMenu;
+	QMenu *previewProjector = new QMenu(QTStr("PreviewProjector"));
+	QMenu *studioProgramProjector =
+		new QMenu(QTStr("StudioProgramProjector"));
 	AddProjectorMenuMonitors(previewProjector, this,
 				 SLOT(OpenPreviewProjector()));
 	AddProjectorMenuMonitors(studioProgramProjector, this,
@@ -7183,14 +7141,6 @@ void OBSBasic::SystemTrayInit()
 
 void OBSBasic::IconActivated(QSystemTrayIcon::ActivationReason reason)
 {
-	// Refresh projector list
-	previewProjector->clear();
-	studioProgramProjector->clear();
-	AddProjectorMenuMonitors(previewProjector, this,
-				 SLOT(OpenPreviewProjector()));
-	AddProjectorMenuMonitors(studioProgramProjector, this,
-				 SLOT(OpenStudioProgramProjector()));
-
 	if (reason == QSystemTrayIcon::Trigger) {
 		EnablePreviewDisplay(previewEnabled && !isVisible());
 		ToggleShowHide();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -242,8 +242,6 @@ private:
 	QPointer<QWidget> extraBrowsers;
 	QPointer<QWidget> importer;
 
-	QPointer<QMenu> startStreamMenu;
-
 	QPointer<QPushButton> transitionButton;
 	QPointer<QPushButton> replayBufferButton;
 	QPointer<QHBoxLayout> replayLayout;
@@ -256,21 +254,6 @@ private:
 	QPointer<QAction> sysTrayReplayBuffer;
 	QPointer<QAction> showHide;
 	QPointer<QAction> exit;
-	QPointer<QMenu> trayMenu;
-	QPointer<QMenu> previewProjector;
-	QPointer<QMenu> studioProgramProjector;
-	QPointer<QMenu> multiviewProjectorMenu;
-	QPointer<QMenu> previewProjectorSource;
-	QPointer<QMenu> previewProjectorMain;
-	QPointer<QMenu> sceneProjectorMenu;
-	QPointer<QMenu> sourceProjector;
-	QPointer<QMenu> scaleFilteringMenu;
-	QPointer<QMenu> colorMenu;
-	QPointer<QWidgetAction> colorWidgetAction;
-	QPointer<ColorSelect> colorSelect;
-	QPointer<QMenu> deinterlaceMenu;
-	QPointer<QMenu> perSceneTransitionMenu;
-	QPointer<QObject> shortcutFilter;
 
 	QPointer<QWidget> programWidget;
 	QPointer<QVBoxLayout> programLayout;
@@ -278,8 +261,6 @@ private:
 
 	QScopedPointer<QThread> patronJsonThread;
 	std::string patronJson;
-
-	void UpdateMultiviewProjectorMenu();
 
 	void DrawBackdrop(float cx, float cy);
 


### PR DESCRIPTION
### Description
Remove unneeded global variables.

### Motivation and Context
There were a bunch of QMenus that didn't need to be global. Also removed global shortcut filter.

### How Has This Been Tested?
Everything ran as expected.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
