### PR TITLE
libobs: Don't check filter compatibility on not loaded sources

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2368,7 +2368,7 @@ void obs_source_filter_add(obs_source_t *source, obs_source_t *filter)
 		return;
 	}
 
-	if (!filter_compatible(source, filter)) {
+	if (!source->owns_info_id && !filter_compatible(source, filter)) {
 		pthread_mutex_unlock(&source->filter_mutex);
 		return;
 	}


### PR DESCRIPTION
### Description
If a source is not loaded do not check filter compatibility for filters on that source.

### Motivation and Context
Fixes #2509

### How Has This Been Tested?
On windows 64 bit replicating the steps in #2509

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.