### PR TITLE
Automatically fix the black screen problem with OBS running on the power saving GPU

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -231,6 +231,9 @@ set(obs_SOURCES
 	window-basic-transform.cpp
 	window-basic-preview.cpp
 	window-basic-about.cpp
+	helpwidget-gamecapturefailed.cpp
+	helpwidget-monitorcapturefailed.cpp
+	helpwidget.cpp
 	window-importer.cpp
 	window-namedialog.cpp
 	window-log-reply.cpp
@@ -286,6 +289,9 @@ set(obs_HEADERS
 	window-basic-adv-audio.hpp
 	window-basic-transform.hpp
 	window-basic-preview.hpp
+	helpwidget-gamecapturefailed.hpp
+	helpwidget-monitorcapturefailed.hpp
+	helpwidget.hpp
 	window-importer.hpp
 	window-namedialog.hpp
 	window-log-reply.hpp
@@ -347,6 +353,7 @@ set(obs_UI
 	forms/AutoConfigStreamPage.ui
 	forms/AutoConfigTestPage.ui
 	forms/ColorSelect.ui
+	forms/HelpWidget.ui
 	forms/OBSLogReply.ui
 	forms/OBSBasic.ui
 	forms/OBSBasicTransform.ui

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1022,3 +1022,16 @@ XSplitBroadcaster="XSplit Broadcaster"
 # OBS restart
 Restart="Restart"
 NeedsRestart="OBS Studio needs to be restarted. Do you want to restart now?"
+
+# Help dialog to fix game capture and display capture
+HelpWidget.HelpButtonText="More details"
+GameCaptureFailedHelpWidget.FixButtonText="Change GPU"
+
+GameCaptureFailedHelpWidget.FixedSuccessTitle="Successfully changed GPU"
+GameCaptureFailedHelpWidget.FixedSuccessMessage="Successfully changed the GPU, OBS needs to be restarted."
+GameCaptureFailedHelpWidget.FixedFailedTitle="Failed to change GPU!"
+GameCaptureFailedHelpWidget.FixedFailedMessage="Failed to change the GPU.\n\nOpen help to do the settings manually?"
+
+GameCaptureFailedHelpWidget.HelpText="OBS is not able to capture this application.\n\nThis may be because OBS Studio is not currently running on the same GPU as the application you are trying to capture."
+MonitorCaptureFailedHelpDialog.HelpText="OBS is not able to capture this display.\n\nThis may be because OBS Studio is not currently running on the same GPU the display is connected to."
+

--- a/UI/forms/HelpWidget.ui
+++ b/UI/forms/HelpWidget.ui
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>HelpWidget</class>
+ <widget class="QWidget" name="HelpWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
+    <number>9</number>
+   </property>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QLabel" name="icon">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="pixmap">
+          <pixmap>SP_MessageBoxWarning</pixmap>
+         </property>
+         <property name="margin">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>9</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelHelpText">
+         <property name="text">
+          <string>HelpDialog.HelpText</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Minimum</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Minimum</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="helpButton">
+         <property name="text">
+          <string>HelpDialog.HelpButtonText</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="fixButton">
+         <property name="text">
+          <string>HelpDialog.FixButtonText</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/UI/helpwidget-gamecapturefailed.cpp
+++ b/UI/helpwidget-gamecapturefailed.cpp
@@ -1,0 +1,114 @@
+/******************************************************************************
+    Copyright (C) 2020 by Hugh Bailey <obs.jim@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#include "helpwidget-gamecapturefailed.hpp"
+#include "obs-app.hpp"
+#include "platform.hpp"
+#include <QDesktopServices>
+#include <QUrlQuery>
+#include <QMessageBox>
+
+using namespace std;
+
+GameCaptureFailedHelpWidget::GameCaptureFailedHelpWidget(QWidget *parent)
+	: GameCaptureFailedHelpWidget(parent,
+				      "GameCaptureFailedHelpWidget.HelpText")
+{
+}
+
+GameCaptureFailedHelpWidget::GameCaptureFailedHelpWidget(QWidget *parent,
+							 const char *helpText)
+	: HelpWidget(parent, helpText,
+		     "GameCaptureFailedHelpWidget.FixButtonText")
+{
+#ifndef _WIN32
+	ui->fixButton->hide();
+#endif
+}
+
+void GameCaptureFailedHelpWidget::HelpButtonClicked()
+{
+	OpenManual();
+}
+
+void GameCaptureFailedHelpWidget::FixButtonClicked()
+{
+	TryFixAndDisplayResult();
+}
+
+bool GameCaptureFailedHelpWidget::ShouldDisplayHelp(int error)
+{
+	int gpuCount = 0;
+
+	obs_enter_graphics();
+
+	gs_enum_adapters(
+		[](void *param, const char *name, uint32_t id) {
+			int *counter = static_cast<int *>(param);
+			(*counter)++;
+
+			return true;
+		},
+		&gpuCount);
+
+	obs_leave_graphics();
+
+	return gpuCount > 1;
+}
+
+void GameCaptureFailedHelpWidget::OpenManual()
+{
+	QDesktopServices::openUrl(QUrl(
+		"https://obsproject.com/forum/threads/laptop-black-screen-when-capturing-read-here-first.5965/",
+		QUrl::TolerantMode));
+}
+
+void GameCaptureFailedHelpWidget::TryFixAndDisplayResult()
+{
+	const bool success = TryFix();
+
+	if (success) {
+		QMessageBox::information(
+			this,
+			QTStr("GameCaptureFailedHelpWidget.FixedSuccessTitle"),
+			QTStr("GameCaptureFailedHelpWidget.FixedSuccessMessage"),
+			QMessageBox::Ok);
+
+		ui->fixButton->setEnabled(false);
+	} else {
+		const bool openManual =
+			QMessageBox::warning(
+				this,
+				QTStr("GameCaptureFailedHelpWidget.FixedFailedTitle"),
+				QTStr("GameCaptureFailedHelpWidget.FixedFailedMessage"),
+				QMessageBox::Yes | QMessageBox::No) ==
+			QMessageBox::Yes;
+
+		if (openManual) {
+			OpenManual();
+		}
+	}
+}
+
+bool GameCaptureFailedHelpWidget::TryFix()
+{
+#ifdef _WIN32
+	return ToggleOBSGpuPowerProfile();
+#else
+	return false;
+#endif
+}

--- a/UI/helpwidget-gamecapturefailed.hpp
+++ b/UI/helpwidget-gamecapturefailed.hpp
@@ -1,0 +1,35 @@
+/******************************************************************************
+    Copyright (C) 2020 by Hugh Bailey <obs.jim@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#pragma once
+#include "helpwidget.hpp"
+
+class GameCaptureFailedHelpWidget : public HelpWidget {
+public:
+	GameCaptureFailedHelpWidget(QWidget *parent);
+	GameCaptureFailedHelpWidget(QWidget *parent, const char *helpText);
+
+	virtual void HelpButtonClicked() override;
+	virtual void FixButtonClicked() override;
+
+	bool ShouldDisplayHelp(int error) override;
+
+protected:
+	virtual void OpenManual();
+	virtual void TryFixAndDisplayResult();
+	virtual bool TryFix();
+};

--- a/UI/helpwidget-monitorcapturefailed.cpp
+++ b/UI/helpwidget-monitorcapturefailed.cpp
@@ -1,0 +1,33 @@
+/******************************************************************************
+    Copyright (C) 2020 by Hugh Bailey <obs.jim@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#include "helpwidget-monitorcapturefailed.hpp"
+
+using namespace std;
+
+#define ERROR_WRONG_GPU 2
+
+MonitorCaptureFailedHelpWidget::MonitorCaptureFailedHelpWidget(QWidget *parent)
+	: GameCaptureFailedHelpWidget(parent,
+				      "MonitorCaptureFailedHelpDialog.HelpText")
+{
+}
+
+bool MonitorCaptureFailedHelpWidget::ShouldDisplayHelp(int error)
+{
+	return error == ERROR_WRONG_GPU;
+}

--- a/UI/helpwidget-monitorcapturefailed.hpp
+++ b/UI/helpwidget-monitorcapturefailed.hpp
@@ -1,0 +1,28 @@
+/******************************************************************************
+    Copyright (C) 2020 by Hugh Bailey <obs.jim@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#pragma once
+#include "helpwidget-gamecapturefailed.hpp"
+#include "platform.hpp"
+#include "obs-app.hpp"
+
+class MonitorCaptureFailedHelpWidget : public GameCaptureFailedHelpWidget {
+public:
+	MonitorCaptureFailedHelpWidget(QWidget *parent);
+
+	bool ShouldDisplayHelp(int error) override;
+};

--- a/UI/helpwidget.cpp
+++ b/UI/helpwidget.cpp
@@ -1,0 +1,59 @@
+/******************************************************************************
+    Copyright (C) 2020 by Hugh Bailey <obs.jim@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#include "qt-wrappers.hpp"
+#include "ui_NameDialog.h"
+#include "obs-app.hpp"
+#include "helpwidget.hpp"
+#include <QStyleOptionFocusRect>
+
+using namespace std;
+
+HelpWidget::HelpWidget(QWidget *parent, const char *helpText,
+		       const char *fixButtonText, const char *helpButtonText)
+	: QWidget(parent),
+	  ui(new Ui::HelpWidget),
+	  helpText(helpText),
+	  fixButtonText(fixButtonText),
+	  helpButtonText(helpButtonText)
+{
+	ui->setupUi(this);
+
+	QPixmap pixmap = style()->standardIcon(QStyle::SP_MessageBoxWarning)
+				 .pixmap(QSize(60, 60));
+	ui->icon->setPixmap(pixmap);
+
+	ui->labelHelpText->setText(QTStr(helpText));
+	ui->fixButton->setText(QTStr(fixButtonText));
+	ui->helpButton->setText(QTStr(helpButtonText));
+
+	connect(ui->fixButton, &QAbstractButton::clicked, this,
+		&HelpWidget::FixButtonClicked);
+
+	connect(ui->helpButton, &QAbstractButton::clicked, this,
+		&HelpWidget::HelpButtonClicked);
+
+	adjustSize();
+	setFixedSize(geometry().width(), geometry().height());
+}
+
+HelpWidget::HelpWidget(QWidget *parent, const char *helpText,
+		       const char *fixButtonText)
+	: HelpWidget(parent, helpText, fixButtonText,
+		     "HelpWidget.HelpButtonText")
+{
+}

--- a/UI/helpwidget.hpp
+++ b/UI/helpwidget.hpp
@@ -1,0 +1,50 @@
+/******************************************************************************
+    Copyright (C) 2020 by Hugh Bailey <obs.jim@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#pragma once
+
+#include <QDialog>
+#include <string>
+#include <memory>
+
+#include "ui_HelpWidget.h"
+
+class HelpWidget : public QWidget {
+	Q_OBJECT
+
+protected:
+	std::unique_ptr<Ui::HelpWidget> ui;
+
+public:
+	const char *helpText;
+	const char *fixButtonText;
+	const char *helpButtonText;
+
+public:
+	HelpWidget(QWidget *parent, const char *helpText,
+		   const char *fixButtonText, const char *helpButtonText);
+
+	HelpWidget(QWidget *parent, const char *helpText,
+		   const char *fixButtonText);
+
+	virtual bool ShouldDisplayHelp(int error) { return true; }
+
+private slots:
+	virtual void HelpButtonClicked() {}
+
+	virtual void FixButtonClicked() {}
+};

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -61,6 +61,12 @@ public:
 
 RunOnceMutex GetRunOnceMutex(bool &already_running);
 QString GetMonitorName(const QString &id);
+
+enum GpuPowerProfiles { UseDefault, UsePowerSavingGpu, UseHighPerformanceGpu };
+
+bool ToggleOBSGpuPowerProfile();
+enum GpuPowerProfiles GetOBSGpuPowerProfile();
+bool SetOBSGpuPowerProfile(enum GpuPowerProfiles profile);
 #endif
 
 #ifdef __APPLE__

--- a/UI/window-basic-properties.hpp
+++ b/UI/window-basic-properties.hpp
@@ -23,6 +23,9 @@
 #include <QSplitter>
 #include "qt-display.hpp"
 #include <obs.hpp>
+#include <QLabel>
+#include <QHBoxLayout>
+#include "helpwidget.hpp"
 
 class OBSPropertiesView;
 class OBSBasic;
@@ -36,6 +39,8 @@ private:
 	OBSBasic *main;
 	bool acceptClicked;
 
+	bool didShowVideoHasErrorMessage = false;
+
 	OBSSource source;
 	OBSSignal removedSignal;
 	OBSSignal renamedSignal;
@@ -44,6 +49,9 @@ private:
 	OBSPropertiesView *view;
 	QDialogButtonBox *buttonBox;
 	QSplitter *windowSplitter;
+	QGridLayout *previewLayout;
+	QWidget *previewArea;
+	HelpWidget *helpWidget;
 
 	OBSSource sourceA;
 	OBSSource sourceB;
@@ -60,9 +68,15 @@ private:
 	int CheckSettings();
 	void Cleanup();
 
+signals:
+	void VideoHasError(int code);
+	void VideoClearError();
+
 private slots:
 	void on_buttonBox_clicked(QAbstractButton *button);
 	void AddPreviewButton();
+	void ShowVideoHasErrorMessage(int code);
+	void HideVideoHasErrorMessage();
 
 public:
 	OBSBasicProperties(QWidget *parent, OBSSource source_);

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -427,7 +427,7 @@ static bool set_priority(ID3D11Device *device)
 
 void gs_device::InitDevice(uint32_t adapterIdx)
 {
-	wstring adapterName;
+	wstring wideAdapterName;
 	DXGI_ADAPTER_DESC desc;
 	D3D_FEATURE_LEVEL levelUsed = D3D_FEATURE_LEVEL_10_0;
 	HRESULT hr = 0;
@@ -439,13 +439,14 @@ void gs_device::InitDevice(uint32_t adapterIdx)
 	//createFlags |= D3D11_CREATE_DEVICE_DEBUG;
 #endif
 
-	adapterName = (adapter->GetDesc(&desc) == S_OK) ? desc.Description
-							: L"<unknown>";
-
+	wideAdapterName = (adapter->GetDesc(&desc) == S_OK) ? desc.Description
+							    : L"<unknown>";
 	BPtr<char> adapterNameUTF8;
-	os_wcs_to_utf8_ptr(adapterName.c_str(), 0, &adapterNameUTF8);
+	os_wcs_to_utf8_ptr(wideAdapterName.c_str(), 0, &adapterNameUTF8);
 	blog(LOG_INFO, "Loading up D3D11 on adapter %s (%" PRIu32 ")",
 	     adapterNameUTF8.Get(), adapterIdx);
+
+	adapterName = adapterNameUTF8.Get();
 
 	hr = D3D11CreateDevice(adapter, D3D_DRIVER_TYPE_UNKNOWN, NULL,
 			       createFlags, featureLevels,
@@ -755,6 +756,11 @@ gs_device::~gs_device()
 const char *device_get_name(void)
 {
 	return "Direct3D 11";
+}
+
+const char *device_get_adapter_name(gs_device_t *device)
+{
+	return device->adapterName.c_str();
 }
 
 int device_get_type(void)

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -903,6 +903,7 @@ struct gs_device {
 	ComPtr<ID3D11Device> device;
 	ComPtr<ID3D11DeviceContext> context;
 	uint32_t adpIdx = 0;
+	string adapterName;
 	bool nv12Supported = false;
 
 	gs_texture_2d *curRenderTarget = nullptr;

--- a/libobs/graphics/device-exports.h
+++ b/libobs/graphics/device-exports.h
@@ -24,6 +24,7 @@ extern "C" {
 #endif
 
 EXPORT const char *device_get_name(void);
+EXPORT const char *device_get_adapter_name(gs_device_t *device);
 EXPORT int device_get_type(void);
 EXPORT bool device_enum_adapters(bool (*callback)(void *param, const char *name,
 						  uint32_t id),

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -43,6 +43,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	bool success = true;
 
 	GRAPHICS_IMPORT(device_get_name);
+	GRAPHICS_IMPORT_OPTIONAL(device_get_adapter_name);
 	GRAPHICS_IMPORT(device_get_type);
 	GRAPHICS_IMPORT_OPTIONAL(device_enum_adapters);
 	GRAPHICS_IMPORT(device_preprocessor_name);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -25,6 +25,7 @@
 
 struct gs_exports {
 	const char *(*device_get_name)(void);
+	const char *(*device_get_adapter_name)(gs_device_t *device);
 	int (*device_get_type)(void);
 	bool (*device_enum_adapters)(bool (*callback)(void *, const char *,
 						      uint32_t),

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -304,6 +304,20 @@ const char *gs_get_device_name(void)
 		       : NULL;
 }
 
+const char *gs_get_adapter_name(void)
+{
+	if (!gs_valid("gs_get_adapter_name"))
+		return NULL;
+
+	graphics_t *graphics = thread_graphics;
+
+	if (thread_graphics->exports.device_get_adapter_name)
+		return thread_graphics->exports.device_get_adapter_name(
+			graphics->device);
+
+	return NULL;
+}
+
 int gs_get_device_type(void)
 {
 	return gs_valid("gs_get_device_type")

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -494,6 +494,7 @@ struct gs_init_data {
 #define GS_DEVICE_DIRECT3D_11 2
 
 EXPORT const char *gs_get_device_name(void);
+EXPORT const char *gs_get_adapter_name(void);
 EXPORT int gs_get_device_type(void);
 EXPORT void gs_enum_adapters(bool (*callback)(void *param, const char *name,
 					      uint32_t id),

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2208,6 +2208,17 @@ void obs_source_video_render(obs_source_t *source)
 	obs_source_release(source);
 }
 
+int obs_source_video_get_error(obs_source_t *source)
+{
+	if (!obs_source_valid(source, "obs_source_video_get_error"))
+		return 0;
+
+	if (source->context.data != 0 && source->info.video_get_error != 0)
+		return source->info.video_get_error(source->context.data);
+
+	return 0;
+}
+
 static inline uint32_t get_async_width(const obs_source_t *source)
 {
 	return ((source->async_rotation % 180) == 0) ? source->async_width

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -330,6 +330,14 @@ struct obs_source_info {
 	void (*video_render)(void *data, gs_effect_t *effect);
 
 	/**
+	 * Called to ask the source if there was an error in the video_render() or in the video_tick() function.
+	 *
+	 * @param data    Source data
+	 * @return		  0, if there are no errors. Non zero return values indicate an error.
+	 */
+	int (*video_get_error)(void *data);
+
+	/**
 	 * Called to filter raw async video data.
 	 *
 	 * @note          This function is only used with filter sources.

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -906,6 +906,9 @@ EXPORT void obs_source_update(obs_source_t *source, obs_data_t *settings);
 /** Renders a video source. */
 EXPORT void obs_source_video_render(obs_source_t *source);
 
+/** Gets the error of a video source. Zero if no error occured or the source is invalid */
+EXPORT int obs_source_video_get_error(obs_source_t *source);
+
 /** Gets the width of a source (if it has video) */
 EXPORT uint32_t obs_source_get_width(obs_source_t *source);
 


### PR DESCRIPTION
### Description
Display an error message when the game capture doesn't work because OBS is running on a different GPU than the game. Provide a button to switch from the integrated GPU to the performance GPU from within OBS. 
Screenshots of this feature are in the PR comments.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
[Info message on laptop black screen issue](https://ideas.obsproject.com/posts/838/info-message-on-laptop-black-screen-issue)
It detects if game capture or monitor capture fails because OBS is running on the wrong GPU. Then a button is displayed which allows the user to do the windows settings to change the GPU as described [in the forum](https://obsproject.com/forum/threads/laptop-black-screen-when-capturing-read-here-first.5965/). 
The "laptop black screen issue" is very common and this feature helps the user to fix it. The support team will get fewer requests related to this issue.

### How Has This Been Tested?
I tested it on my PC (_Intel Core i7-8705G GPUs: Intel HD 630 / Radeon RX Vega M GL_)
Tried to capture a game running on the dedicated GPU while OBS is on the integrated GPU and vice versa. 
Tried to capture a display while OBS is running on the dedicated GPU. 
In all cases the error message was displayed and the button fixes the issue.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
  Added `video_get_error` to `obs_source_info`. Existing code is not affected but this is a struct in the core of OBS, thus I consider this as a breaking change.
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
