### PR TITLE
UI: Show warning when outputs are active with settings

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1022,3 +1022,7 @@ XSplitBroadcaster="XSplit Broadcaster"
 # OBS restart
 Restart="Restart"
 NeedsRestart="OBS Studio needs to be restarted. Do you want to restart now?"
+
+# Settings outputs active warning
+OutputsActive.Title="Outputs Active"
+OutputsActive.Text="Outputs are currently active. Video settings such as resolution and frame rate cannot be changed."

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -236,6 +236,9 @@ private:
 	QString lastService;
 	int prevLangIndex;
 	bool prevBrowserAccel;
+
+	void ShowOutputsWarning();
+
 private slots:
 	void UpdateServerList();
 	void UpdateKeyLink();


### PR DESCRIPTION
### Description
Show warning when outputs are active when the user opens the settings.

![Screenshot from 2020-04-19 20-54-11](https://user-images.githubusercontent.com/19962531/79707027-ba39db00-8280-11ea-924e-09ce76bee5a5.png)

### Motivation and Context
Better feedback for users.

### How Has This Been Tested?
Opened settings when output was active.

### Types of changes
- New feature (non-breaking change which adds functionality)
- UI enhancement

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
