### PR TITLE
UI: Display resolution labels in video settings

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -94,6 +94,10 @@ Windowed="Windowed"
 Percent="Percent"
 AspectRatio="Aspect Ratio <b>%1:%2</b>"
 LockVolume="Lock Volume"
+Recommended="(Recommended)"
+Current="(Current)"
+Primary="primary"
+DisplayNumber="(Display %1%2)"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"


### PR DESCRIPTION
### Description
Display resolution labels in base resolution setting.

Example:
- 1280x720 (Current)
- 1920x1080 (Recommended)
- 2560x1440 (Display 1, primary)
- 1920x1080 (Display 2)

### Motivation and Context
Help users better determine what resolutions to use.

### How Has This Been Tested?
Checked resolutions in settings.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
