### PR TITLE
UI: Add default label to audio monitoring devices

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4344,18 +4344,24 @@ void OBSBasicSettings::FillSimpleStreamingValues()
 void OBSBasicSettings::FillAudioMonitoringDevices()
 {
 	QComboBox *cb = ui->monitoringDevice;
+	char *defaultId = obs_get_default_audio_monitoring_device();
+	cb->setProperty("defaultId", QT_UTF8(defaultId));
 
 	auto enum_devices = [](void *param, const char *name, const char *id) {
 		QComboBox *cb = (QComboBox *)param;
-		cb->addItem(name, id);
+		QString defaultId = cb->property("defaultId").value<QString>();
+
+		if (defaultId == QT_UTF8(id))
+			cb->addItem(QT_UTF8(name) + " " + QTStr("Default"),
+				    "default");
+		else
+			cb->addItem(name, id);
+
 		return true;
 	};
 
-	cb->addItem(QTStr("Basic.Settings.Advanced.Audio.MonitoringDevice"
-			  ".Default"),
-		    "default");
-
 	obs_enum_audio_monitoring_devices(enum_devices, cb);
+	bfree(defaultId);
 }
 
 void OBSBasicSettings::SimpleRecordingQualityChanged()

--- a/libobs/audio-monitoring/osx/coreaudio-enum-devices.c
+++ b/libobs/audio-monitoring/osx/coreaudio-enum-devices.c
@@ -187,3 +187,10 @@ bool devices_match(const char *id1, const char *id2)
 
 	return match;
 }
+
+char *obs_get_default_audio_monitoring_device()
+{
+	char *id = NULL;
+	get_default_id(&id);
+	return id;
+}

--- a/libobs/audio-monitoring/pulse/pulseaudio-enum-devices.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-enum-devices.c
@@ -30,3 +30,10 @@ void obs_enum_audio_monitoring_devices(obs_enum_audio_device_cb cb, void *data)
 
 	bfree(ecb);
 }
+
+char *obs_get_default_audio_monitoring_device()
+{
+	char *id = NULL;
+	get_default_id(&id);
+	return id;
+}

--- a/libobs/audio-monitoring/win32/wasapi-enum-devices.c
+++ b/libobs/audio-monitoring/win32/wasapi-enum-devices.c
@@ -177,3 +177,10 @@ bool devices_match(const char *id1, const char *id2)
 
 	return match;
 }
+
+char *obs_get_default_audio_monitoring_device()
+{
+	char *id = NULL;
+	get_default_id(&id);
+	return id;
+}

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -713,6 +713,8 @@ EXPORT void obs_enum_audio_monitoring_devices(obs_enum_audio_device_cb cb,
 EXPORT bool obs_set_audio_monitoring_device(const char *name, const char *id);
 EXPORT void obs_get_audio_monitoring_device(const char **name, const char **id);
 
+EXPORT char *obs_get_default_audio_monitoring_device();
+
 EXPORT void obs_add_tick_callback(void (*tick)(void *param, float seconds),
 				  void *param);
 EXPORT void obs_remove_tick_callback(void (*tick)(void *param, float seconds),


### PR DESCRIPTION
### Description
Add default label to audio monitoring device names, instead of just "Default."

I plan to also do this to the desktop and mic/aux sources as well in the future, but that is a more difficult task.

![Screenshot from 2020-04-21 20-17-08](https://user-images.githubusercontent.com/19962531/79930265-b091ae00-840d-11ea-99a3-6b6873a26270.png)

### Motivation and Context
Display name of default device, so users know what it is.

### How Has This Been Tested?
Opened settings to see if the label was added to the correct device. Only tested this on Linux, but it should work just fine on other OSs as well

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
