### PR TITLE
libosbs: Bugfix Hotkey trigger (Mantis925)

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -1205,6 +1205,91 @@ static inline bool is_pressed(obs_key_t key)
 					       key);
 }
 
+static inline bool is_hotkey_pressed(obs_key_combination_t *hotkey)
+{
+	bool pressed = false;
+	if (is_pressed(hotkey->key)) {
+
+		pressed = true;
+	} else if (hotkey->modifiers != 0) {
+		switch (hotkey->modifiers) {
+		case 2:
+			pressed = is_pressed(OBS_KEY_SHIFT);
+			break;
+		case 4:
+			pressed = is_pressed(OBS_KEY_CONTROL);
+			break;
+		case 8:
+			pressed = is_pressed(OBS_KEY_ALT);
+			break;
+		case 128:
+			pressed = is_pressed(OBS_KEY_META);
+			break;
+		case 6:
+			if (is_pressed(OBS_KEY_SHIFT) ||
+			    is_pressed(OBS_KEY_CONTROL))
+				pressed = true;
+			break;
+		case 10:
+			if (is_pressed(OBS_KEY_SHIFT) ||
+			    is_pressed(OBS_KEY_ALT))
+				pressed = true;
+			break;
+		case 130:
+			if (is_pressed(OBS_KEY_SHIFT) ||
+			    is_pressed(OBS_KEY_META))
+				pressed = true;
+			break;
+		case 12:
+			if (is_pressed(OBS_KEY_CONTROL) ||
+			    is_pressed(OBS_KEY_ALT))
+				pressed = true;
+			break;
+		case 132:
+			if (is_pressed(OBS_KEY_CONTROL) ||
+			    is_pressed(OBS_KEY_META))
+				pressed = true;
+			break;
+		case 136:
+			if (is_pressed(OBS_KEY_ALT) || is_pressed(OBS_KEY_META))
+				pressed = true;
+			break;
+		case 14:
+			if (is_pressed(OBS_KEY_SHIFT) ||
+			    is_pressed(OBS_KEY_CONTROL) ||
+			    is_pressed(OBS_KEY_ALT))
+				pressed = true;
+			break;
+		case 134:
+			if (is_pressed(OBS_KEY_SHIFT) ||
+			    is_pressed(OBS_KEY_CONTROL) ||
+			    is_pressed(OBS_KEY_META))
+				pressed = true;
+			break;
+		case 140:
+			if (is_pressed(OBS_KEY_CONTROL) ||
+			    is_pressed(OBS_KEY_ALT) || is_pressed(OBS_KEY_META))
+				pressed = true;
+			break;
+
+		case 138:
+			if (is_pressed(OBS_KEY_SHIFT) ||
+			    is_pressed(OBS_KEY_ALT) || is_pressed(OBS_KEY_META))
+				pressed = true;
+			break;
+		case 142:
+			if (is_pressed(OBS_KEY_SHIFT) ||
+			    is_pressed(OBS_KEY_CONTROL) ||
+			    is_pressed(OBS_KEY_ALT) || is_pressed(OBS_KEY_META))
+				pressed = true;
+			break;
+		default:
+			break;
+		}
+	}
+	return pressed;
+}
+
 static inline void press_released_binding(obs_hotkey_binding_t *binding)
 {
 	binding->pressed = true;
@@ -1218,6 +1303,13 @@ static inline void press_released_binding(obs_hotkey_binding_t *binding)
 	else if (obs->hotkeys.router_func)
 		obs->hotkeys.router_func(obs->hotkeys.router_func_data,
 					 hotkey->id, true);
+
+	if (binding->key.modifiers != 0) {
+		bool pressed;
+		do {
+			pressed = is_hotkey_pressed(&binding->key);
+		} while (pressed);
+	}
 }
 
 static inline void release_pressed_binding(obs_hotkey_binding_t *binding)
@@ -1233,6 +1325,13 @@ static inline void release_pressed_binding(obs_hotkey_binding_t *binding)
 	else if (obs->hotkeys.router_func)
 		obs->hotkeys.router_func(obs->hotkeys.router_func_data,
 					 hotkey->id, false);
+
+		if (binding->key.modifiers != 0) {
+		bool pressed;
+		do {
+			pressed = is_hotkey_pressed(&binding->key);
+		} while (pressed);
+	}
 }
 
 static inline void handle_binding(obs_hotkey_binding_t *binding,
@@ -1261,16 +1360,16 @@ static inline void handle_binding(obs_hotkey_binding_t *binding,
 
 	if (binding->pressed || no_press)
 		return;
-
-	press_released_binding(binding);
+	if (binding->key.modifiers == modifiers)
+		press_released_binding(binding);
 	return;
 
 reset:
 	binding->modifiers_match = modifiers_match_;
 	if (!binding->pressed)
 		return;
-
-	release_pressed_binding(binding);
+	if (binding->key.modifiers == modifiers)
+		release_pressed_binding(binding);
 }
 
 struct obs_hotkey_internal_inject {

--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -1326,7 +1326,7 @@ static inline void release_pressed_binding(obs_hotkey_binding_t *binding)
 		obs->hotkeys.router_func(obs->hotkeys.router_func_data,
 					 hotkey->id, false);
 
-		if (binding->key.modifiers != 0) {
+	if (binding->key.modifiers != 0) {
 		bool pressed;
 		do {
 			pressed = is_hotkey_pressed(&binding->key);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix the problem that other hotkey also triggerd
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
If a hotkey trigger with a modifier the hotkey without the modifier will trigger too.
https://obsproject.com/mantis/view.php?id=925

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows 10

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Only let  hotkeys with the right modifier to handle the hotkey function. And then add the Function "is_hotkey_pressed" to prevent that the hotkey is triggerd when buttons from the previos hotkey are pressed 
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
