### PR TITLE
vlc-video: Add procedure to receive media metadata

### DIFF
--- a/plugins/vlc-video/vlc-video-plugin.c
+++ b/plugins/vlc-video/vlc-video-plugin.c
@@ -24,6 +24,7 @@ LIBVLC_MEDIA_NEW_LOCATION libvlc_media_new_location_;
 LIBVLC_MEDIA_ADD_OPTION libvlc_media_add_option_;
 LIBVLC_MEDIA_RELEASE libvlc_media_release_;
 LIBVLC_MEDIA_RELEASE libvlc_media_retain_;
+LIBVLC_MEDIA_GET_META libvlc_media_get_meta_;
 
 /* libvlc media player */
 LIBVLC_MEDIA_PLAYER_NEW libvlc_media_player_new_;
@@ -41,6 +42,7 @@ LIBVLC_VIDEO_GET_SIZE libvlc_video_get_size_;
 LIBVLC_MEDIA_PLAYER_EVENT_MANAGER libvlc_media_player_event_manager_;
 LIBVLC_MEDIA_PLAYER_GET_STATE libvlc_media_player_get_state_;
 LIBVLC_MEDIA_PLAYER_GET_LENGTH libvlc_media_player_get_length_;
+LIBVLC_MEDIA_PLAYER_GET_MEDIA libvlc_media_player_get_media_;
 
 /* libvlc media list */
 LIBVLC_MEDIA_LIST_NEW libvlc_media_list_new_;
@@ -99,6 +101,7 @@ static bool load_vlc_funcs(void)
 	LOAD_VLC_FUNC(libvlc_media_add_option);
 	LOAD_VLC_FUNC(libvlc_media_release);
 	LOAD_VLC_FUNC(libvlc_media_retain);
+	LOAD_VLC_FUNC(libvlc_media_get_meta);
 
 	/* libvlc media player */
 	LOAD_VLC_FUNC(libvlc_media_player_new);
@@ -116,6 +119,7 @@ static bool load_vlc_funcs(void)
 	LOAD_VLC_FUNC(libvlc_media_player_event_manager);
 	LOAD_VLC_FUNC(libvlc_media_player_get_state);
 	LOAD_VLC_FUNC(libvlc_media_player_get_length);
+	LOAD_VLC_FUNC(libvlc_media_player_get_media);
 
 	/* libvlc media list */
 	LOAD_VLC_FUNC(libvlc_media_list_new);

--- a/plugins/vlc-video/vlc-video-plugin.h
+++ b/plugins/vlc-video/vlc-video-plugin.h
@@ -35,6 +35,8 @@ typedef void (*LIBVLC_MEDIA_ADD_OPTION)(libvlc_media_t *p_md,
 					const char *options);
 typedef void (*LIBVLC_MEDIA_RETAIN)(libvlc_media_t *p_md);
 typedef void (*LIBVLC_MEDIA_RELEASE)(libvlc_media_t *p_md);
+typedef char *(*LIBVLC_MEDIA_GET_META)(libvlc_media_t *p_md,
+				       libvlc_meta_t e_meta);
 
 /* libvlc media player */
 typedef libvlc_media_player_t *(*LIBVLC_MEDIA_PLAYER_NEW)(
@@ -70,6 +72,8 @@ typedef libvlc_event_manager_t *(*LIBVLC_MEDIA_PLAYER_EVENT_MANAGER)(
 typedef libvlc_state_t (*LIBVLC_MEDIA_PLAYER_GET_STATE)(
 	libvlc_media_player_t *p_mi);
 typedef libvlc_time_t (*LIBVLC_MEDIA_PLAYER_GET_LENGTH)(
+	libvlc_media_player_t *p_mi);
+typedef libvlc_media_t *(*LIBVLC_MEDIA_PLAYER_GET_MEDIA)(
 	libvlc_media_player_t *p_mi);
 
 /* libvlc media list */
@@ -118,6 +122,7 @@ extern LIBVLC_MEDIA_NEW_LOCATION libvlc_media_new_location_;
 extern LIBVLC_MEDIA_ADD_OPTION libvlc_media_add_option_;
 extern LIBVLC_MEDIA_RELEASE libvlc_media_release_;
 extern LIBVLC_MEDIA_RETAIN libvlc_media_retain_;
+extern LIBVLC_MEDIA_GET_META libvlc_media_get_meta_;
 
 /* libvlc media player */
 extern LIBVLC_MEDIA_PLAYER_NEW libvlc_media_player_new_;
@@ -135,6 +140,7 @@ extern LIBVLC_VIDEO_GET_SIZE libvlc_video_get_size_;
 extern LIBVLC_MEDIA_PLAYER_EVENT_MANAGER libvlc_media_player_event_manager_;
 extern LIBVLC_MEDIA_PLAYER_GET_STATE libvlc_media_player_get_state_;
 extern LIBVLC_MEDIA_PLAYER_GET_LENGTH libvlc_media_player_get_length_;
+extern LIBVLC_MEDIA_PLAYER_GET_MEDIA libvlc_media_player_get_media_;
 
 /* libvlc media list */
 extern LIBVLC_MEDIA_LIST_NEW libvlc_media_list_new_;


### PR DESCRIPTION
### Description
This adds a procedure ``get_metadata`` to the VLC video source, which allows the retrieval of metadata about the currently playing media.

### Motivation and Context
Right now there's no safe way of getting this information for a [plugin](https://github.com/univrsal/tuna) I'm working on, so this would provide a proper interface.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I have called the procedure on Arch Linux and Windows 10  and the metadata was delivered fine.
The only thing I noticed is that it will return the metadata of the last played song when the queue is emptied, but ``obs_source_media_get_state`` should be enough to determine whether the returned metadata is for a currently playing song.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.

I ran formatcode.sh on Linux, but had to manually fix the indentation of a comment so I hope the formatting came out fine.