### PR TITLE
CI: Fix Azure Pipelines macOS runs

### DIFF
--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -30,7 +30,9 @@ brew update
 #Base OBS Deps and ccache
 brew install jack speexdsp ccache mbedtls freetype fdk-aac
 brew install https://gist.githubusercontent.com/DDRBoxman/9c7a2b08933166f4b61ed9a44b242609/raw/ef4de6c587c6bd7f50210eccd5bd51ff08e6de13/qt.rb
-brew unlink swig
+if [ -d "$(brew --cellar)/swig" ]; then
+    brew unlink swig
+fi
 brew install https://gist.githubusercontent.com/DDRBoxman/4cada55c51803a2f963fa40ce55c9d3e/raw/572c67e908bfbc1bcb8c476ea77ea3935133f5b5/swig.rb
 
 pip install dmgbuild


### PR DESCRIPTION
### Description
Fixes the unlink step in the `install-dependencies-osx.sh` CI script for environments where Swig is not pre-installed.

### Motivation and Context
Should fix the failing macOS CI runs on Azure Pipelines starting on 2020-04-23.

In the current form the script assumes that a prior (more recent) version of Swig is present on the system, unlinks it (so it's not "visible" to the system), and then installs an older "pinned" version. If no Swig is pre-installed on the system, `brew unlink` will finish with a non-zero return code and due to `set -e` at the top of the script the whole step will fail as well.

By checking if any Swig installation exists on the system before unlinking, this should not happen anymore.

### How Has This Been Tested?
Tested script steps on macOS Catalina 10.15.4 with Homebrew 2.2.13-134-gd5ffb96.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
