### PR TITLE
obs-filters: Add a user label to the LUT filter

### DIFF
--- a/plugins/obs-filters/color-grade-filter.c
+++ b/plugins/obs-filters/color-grade-filter.c
@@ -329,7 +329,7 @@ static obs_properties_t *color_grade_filter_properties(void *data)
 	obs_properties_t *props = obs_properties_create();
 	struct dstr filter_str = {0};
 
-	dstr_cat(&filter_str, "(*.cube *.png)");
+	dstr_cat(&filter_str, "PNG/Cube (*.cube *.png)");
 
 	if (s && s->file && *s->file) {
 		dstr_copy(&path, s->file);


### PR DESCRIPTION
### Description

While discussing the Flatpak RFC [1], it was spotted that the
LUT filter couldn't open the file selection dialog. It was
explained, then, that the proper formats were either composed
of "User Label (file extensions)", or "file extensions", and
the LUT filter was setting "(file extensions)" without the
actual user label.

While this works on a standard Qt file selection dialog, it
cannot be properly formatted as a set of D-Bus filters, thus
breaking the sandbox integration.

Add a simple user label to the LUT file filter.

[1] https://github.com/obsproject/rfcs/pull/21
### How Has This Been Tested?

Add the LUT filter to any image source when running OBS Studio either from Flatpak or a standard execution, and click the "Browse" button to select the LUT picture.

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
