### PR TITLE
UI: Reorganise control dock buttons

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1201,19 +1201,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="exitButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Exit</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <spacer name="expVSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -1888,22 +1875,6 @@
     <hint type="destinationlabel">
      <x>463</x>
      <y>351</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>exitButton</sender>
-   <signal>clicked()</signal>
-   <receiver>OBSBasic</receiver>
-   <slot>close()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>976</x>
-     <y>601</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>862</x>
-     <y>-11</y>
     </hint>
    </hints>
   </connection>

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1178,6 +1178,19 @@
       </layout>
      </item>
      <item>
+      <spacer name="expVSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <widget class="QPushButton" name="modeSwitch">
        <property name="text">
         <string>Basic.TogglePreviewProgramMode</string>
@@ -1199,19 +1212,6 @@
         <string>Settings</string>
        </property>
       </widget>
-     </item>
-     <item>
-      <spacer name="expVSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-      </spacer>
      </item>
     </layout>
    </widget>


### PR DESCRIPTION
### Description
Removes the exit button per #2751 and also separates the studio and settings buttons from the output controls per feedback in #2751.

<img width="1322" alt="Screenshot 2020-04-24 at 23 20 49" src="https://user-images.githubusercontent.com/147143/80261974-e8099000-8683-11ea-8477-ee473c8d75b1.png">

### Motivation and Context
- The button is redundant because this is available through the file menu, title bar and system hotkeys.
- Users might accidentally click the exit button.
- The new layout separates the remaining functions as:
  1. Output controls
  2. Settings

### How Has This Been Tested?
Built and ran OBS on macOS Catalina.

### Types of changes
UI tweaks

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
