### PR TITLE
obs-ffmpeg: Fix VAAPI bug on systems with hotplugged GPUs.

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -539,8 +539,6 @@ static obs_properties_t *vaapi_properties(void *unused)
 			char card[128] = "Card: ";
 			sprintf(card, "Card%d: %s", i - 28, path);
 			obs_property_list_add_string(list, card, path);
-		} else {
-			break;
 		}
 	}
 


### PR DESCRIPTION
So it's totally valid to have no /dev/dri/renderD128 after removing a GPU. OBS shouldn't stop looking through possible devices.

Example of bug in action:

```
[AVHWDeviceContext @ 0x55a326941080] No VA display found for device: /dev/dri/renderD128.
```