### PR TITLE
UI: Make all preview/program sources active

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -681,9 +681,9 @@ void OBSBasic::SetCurrentScene(OBSSource scene, bool force)
 		OBSSource actualLastScene = OBSGetStrongRef(lastScene);
 		if (actualLastScene != scene) {
 			if (scene)
-				obs_source_inc_showing(scene);
+				obs_source_inc_active(scene);
 			if (actualLastScene)
-				obs_source_dec_showing(actualLastScene);
+				obs_source_dec_active(actualLastScene);
 			lastScene = OBSGetWeakRef(scene);
 		}
 	}
@@ -1339,7 +1339,7 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 		if (curScene) {
 			obs_source_t *source = obs_scene_get_source(curScene);
-			obs_source_inc_showing(source);
+			obs_source_inc_active(source);
 			lastScene = OBSGetWeakRef(source);
 			programScene = OBSGetWeakRef(source);
 		}


### PR DESCRIPTION
### Description
Makes it so users can control media that is in the preview as well. If the user pauses the media in the preview, when transitioning to program, it will still be paused, instead of restarting.

### Motivation and Context
Users have requested this in #2380.

### How Has This Been Tested?
Controlled media in studio mode. Not sure if their is any unintended consequences to this, so more testing is needed.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
