### PR TITLE
vlc-video: Enable building the plugin on FreeBSD

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -47,6 +47,7 @@ elseif("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
 	add_subdirectory(linux-v4l2)
 	add_subdirectory(linux-jack)
 	add_subdirectory(linux-alsa)
+	add_subdirectory(vlc-video)
 endif()
 
 option(BUILD_BROWSER "Build browser plugin" OFF)


### PR DESCRIPTION
### Description
Enable vlc-video plugin on FreeBSD, as a1ec0ecee3 for Linux.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Plugin works fine on FreeBSD so enable it. Although it seems the VLC plugin is somewhat deprecated in favour of the media plugin it's reported to have some features not yet supported there.
 
### How Has This Been Tested?
Built and sanity tested on FreeBSD-current, creating a playlist with a few entries.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
