### PR TITLE
obs-plugins: Check if sources are showing for media hotkeys

### DIFF
--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -529,7 +529,7 @@ static void play_pause_hotkey(void *data, obs_hotkey_id id,
 
 	struct slideshow *ss = data;
 
-	if (pressed && obs_source_active(ss->source))
+	if (pressed && obs_source_showing(ss->source))
 		ss_play_pause(ss);
 }
 
@@ -541,7 +541,7 @@ static void restart_hotkey(void *data, obs_hotkey_id id, obs_hotkey_t *hotkey,
 
 	struct slideshow *ss = data;
 
-	if (pressed && obs_source_active(ss->source))
+	if (pressed && obs_source_showing(ss->source))
 		ss_restart(ss);
 }
 
@@ -553,7 +553,7 @@ static void stop_hotkey(void *data, obs_hotkey_id id, obs_hotkey_t *hotkey,
 
 	struct slideshow *ss = data;
 
-	if (pressed && obs_source_active(ss->source))
+	if (pressed && obs_source_showing(ss->source))
 		ss_stop(ss);
 }
 
@@ -568,7 +568,7 @@ static void next_slide_hotkey(void *data, obs_hotkey_id id,
 	if (!ss->manual)
 		return;
 
-	if (pressed && obs_source_active(ss->source))
+	if (pressed && obs_source_showing(ss->source))
 		ss_next_slide(ss);
 }
 
@@ -583,7 +583,7 @@ static void previous_slide_hotkey(void *data, obs_hotkey_id id,
 	if (!ss->manual)
 		return;
 
-	if (pressed && obs_source_active(ss->source))
+	if (pressed && obs_source_showing(ss->source))
 		ss_previous_slide(ss);
 }
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -391,7 +391,7 @@ static void restart_hotkey(void *data, obs_hotkey_id id, obs_hotkey_t *hotkey,
 		return;
 
 	struct ffmpeg_source *s = data;
-	if (obs_source_active(s->source))
+	if (obs_source_showing(s->source))
 		obs_source_media_restart(s->source);
 }
 
@@ -460,7 +460,7 @@ static bool ffmpeg_source_play_hotkey(void *data, obs_hotkey_pair_id id,
 	struct ffmpeg_source *s = data;
 
 	if (s->state == OBS_MEDIA_STATE_PLAYING ||
-	    !obs_source_active(s->source))
+	    !obs_source_showing(s->source))
 		return false;
 
 	obs_source_media_play_pause(s->source, false);
@@ -479,7 +479,7 @@ static bool ffmpeg_source_pause_hotkey(void *data, obs_hotkey_pair_id id,
 	struct ffmpeg_source *s = data;
 
 	if (s->state != OBS_MEDIA_STATE_PLAYING ||
-	    !obs_source_active(s->source))
+	    !obs_source_showing(s->source))
 		return false;
 
 	obs_source_media_play_pause(s->source, true);
@@ -497,7 +497,7 @@ static void ffmpeg_source_stop_hotkey(void *data, obs_hotkey_id id,
 
 	struct ffmpeg_source *s = data;
 
-	if (obs_source_active(s->source))
+	if (obs_source_showing(s->source))
 		obs_source_media_stop(s->source);
 }
 
@@ -599,7 +599,7 @@ static void ffmpeg_source_restart(void *data)
 {
 	struct ffmpeg_source *s = data;
 
-	if (obs_source_active(s->source))
+	if (obs_source_showing(s->source))
 		ffmpeg_source_start(s);
 
 	set_media_state(s, OBS_MEDIA_STATE_PLAYING);

--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -779,7 +779,7 @@ static void vlcs_play_pause_hotkey(void *data, obs_hotkey_id id,
 
 	enum obs_media_state state = obs_source_media_get_state(c->source);
 
-	if (pressed && obs_source_active(c->source)) {
+	if (pressed && obs_source_showing(c->source)) {
 		if (state == OBS_MEDIA_STATE_PLAYING)
 			obs_source_media_play_pause(c->source, true);
 		else if (state == OBS_MEDIA_STATE_PAUSED)
@@ -795,7 +795,7 @@ static void vlcs_restart_hotkey(void *data, obs_hotkey_id id,
 
 	struct vlc_source *c = data;
 
-	if (pressed && obs_source_active(c->source))
+	if (pressed && obs_source_showing(c->source))
 		obs_source_media_restart(c->source);
 }
 
@@ -807,7 +807,7 @@ static void vlcs_stop_hotkey(void *data, obs_hotkey_id id, obs_hotkey_t *hotkey,
 
 	struct vlc_source *c = data;
 
-	if (pressed && obs_source_active(c->source))
+	if (pressed && obs_source_showing(c->source))
 		obs_source_media_stop(c->source);
 }
 
@@ -819,7 +819,7 @@ static void vlcs_playlist_next_hotkey(void *data, obs_hotkey_id id,
 
 	struct vlc_source *c = data;
 
-	if (pressed && obs_source_active(c->source))
+	if (pressed && obs_source_showing(c->source))
 		obs_source_media_next(c->source);
 }
 
@@ -831,7 +831,7 @@ static void vlcs_playlist_prev_hotkey(void *data, obs_hotkey_id id,
 
 	struct vlc_source *c = data;
 
-	if (pressed && obs_source_active(c->source))
+	if (pressed && obs_source_showing(c->source))
 		obs_source_media_previous(c->source);
 }
 


### PR DESCRIPTION
### Description
Make media hotkeys work with studio mode preview.

### Motivation and Context
Better solution than #2805.

### How Has This Been Tested?
Used media hotkeys in studio mode.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
