### PR TITLE
obs-text, text-freetype2: Add ability to directly set text

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -490,6 +490,10 @@ Source Definition Structure (obs_source_info)
    - **OBS_MEDIA_STATE_ENDED**     - Ended
    - **OBS_MEDIA_STATE_ERROR**     - Error
 
+.. member:: void (*obs_source_info.set_text)(void *data, const char *text)
+
+   Called to set text of text source.
+
 
 .. _source_signal_handler_reference:
 
@@ -1234,6 +1238,10 @@ Functions used by sources
    Removes an active child source.  Must be called by parent sources on child
    sources when the child is removed or inactive.  This ensures that the source
    is properly deactivated if the parent is no longer active.
+
+.. function:: void obs_source_set_text(obs_source_t *source, const char *text)
+
+   Set texts to text source.
 
 ---------------------
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -4953,3 +4953,12 @@ void obs_source_media_ended(obs_source_t *source)
 
 	obs_source_dosignal(source, NULL, "media_ended");
 }
+
+void obs_source_set_text(obs_source_t *source, const char *text)
+{
+	if (!obs_source_valid(source, "obs_source_set_text"))
+		return;
+
+	if (source->info.set_text)
+		source->info.set_text(source->context.data, text);
+}

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -527,6 +527,8 @@ struct obs_source_info {
 	/* version-related stuff */
 	uint32_t version; /* increment if needed to specify a new version */
 	const char *unversioned_id; /* set internally, don't set manually */
+
+	void (*set_text)(void *data, const char *text);
 };
 
 EXPORT void obs_register_source_s(const struct obs_source_info *info,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2230,6 +2230,9 @@ EXPORT void obs_source_frame_copy(struct obs_source_frame *dst,
 /* Get source icon type */
 EXPORT enum obs_icon_type obs_source_get_icon_type(const char *id);
 
+/* Set text of text source */
+EXPORT void obs_source_set_text(obs_source_t *source, const char *text);
+
 #ifdef __cplusplus
 }
 #endif

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -50,6 +50,7 @@ static struct obs_source_info freetype2_source_info_v1 = {
 	.video_tick = ft2_video_tick,
 	.get_properties = ft2_source_properties,
 	.icon_type = OBS_ICON_TYPE_TEXT,
+	.set_text = ft2_source_set_text,
 };
 
 static struct obs_source_info freetype2_source_info_v2 = {
@@ -71,6 +72,7 @@ static struct obs_source_info freetype2_source_info_v2 = {
 	.video_tick = ft2_video_tick,
 	.get_properties = ft2_source_properties,
 	.icon_type = OBS_ICON_TYPE_TEXT,
+	.set_text = ft2_source_set_text,
 };
 
 static bool plugin_initialized = false;
@@ -525,4 +527,20 @@ static void *ft2_source_create_v1(obs_data_t *settings, obs_source_t *source)
 static void *ft2_source_create_v2(obs_data_t *settings, obs_source_t *source)
 {
 	return ft2_source_create(settings, source, 2);
+}
+
+static void ft2_source_set_text(void *data, const char *text)
+{
+	struct ft2_source *srcdata = data;
+	bfree(srcdata->text);
+	os_utf8_to_wcs_ptr(text, strlen(text), &srcdata->text);
+	cache_glyphs(srcdata, srcdata->text);
+	set_up_vertex_buffer(srcdata);
+
+	obs_data_t *settings = obs_source_get_settings(srcdata->src);
+
+	if (settings) {
+		obs_data_set_string(settings, "text", text);
+		obs_data_release(settings);
+	}
 }

--- a/plugins/text-freetype2/text-freetype2.h
+++ b/plugins/text-freetype2/text-freetype2.h
@@ -75,6 +75,7 @@ static void ft2_source_destroy(void *data);
 static void ft2_source_update(void *data, obs_data_t *settings);
 static void ft2_source_render(void *data, gs_effect_t *effect);
 static void ft2_video_tick(void *data, float seconds);
+static void ft2_source_set_text(void *data, const char *text);
 
 void draw_outlines(struct ft2_source *srcdata);
 void draw_drop_shadow(struct ft2_source *srcdata);


### PR DESCRIPTION
### Description
Adds ability to set text of text sources directly.

### Motivation and Context
This should increase the performance and make it easier to set text, especially for scripts.

### How Has This Been Tested?
Only tested on Linux. Should work on Mac just fine because it also uses FreeType2. Needs testing on Windows.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
