### PR TITLE
obs-scripting: Expose platform functions to scripts

### DIFF
--- a/deps/obs-scripting/obslua/obslua.i
+++ b/deps/obs-scripting/obslua/obslua.i
@@ -24,6 +24,7 @@
 #include <util/base.h>
 #include "cstrcache.h"
 #include "obs-scripting-config.h"
+#include <util/platform.h>
 
 #if UI_ENABLED
 #include "obs-frontend-api.h"
@@ -100,6 +101,7 @@ static inline void wrap_blog(int log_level, const char *message)
 %include "callback/signal.h"
 %include "util/bmem.h"
 %include "util/base.h"
+%include "util/platform.h"
 
 #if UI_ENABLED
 %include "obs-frontend-api.h"

--- a/deps/obs-scripting/obspython/obspython.i
+++ b/deps/obs-scripting/obspython/obspython.i
@@ -24,6 +24,7 @@
 #include <util/bmem.h>
 #include <util/base.h>
 #include "obs-scripting-config.h"
+#include <util/platform.h>
 
 #if UI_ENABLED
 #include "obs-frontend-api.h"
@@ -98,6 +99,7 @@ static inline void wrap_blog(int log_level, const char *message)
 %include "callback/signal.h"
 %include "util/bmem.h"
 %include "util/base.h"
+%include "util/platform.h"
 
 #if UI_ENABLED
 %include "obs-frontend-api.h"


### PR DESCRIPTION
### Description
Expose platform functions to scripts.

### Motivation and Context
In my specific use case, I want to use the function os_gettime_ns() because Lua's current time function only has seconds precision.

### How Has This Been Tested?
Used functions in scripts.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
