### PR TITLE
UI: Add always on top checkbox to projector context menu

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -590,6 +590,7 @@ obs_data_array_t *OBSBasic::SaveProjectors()
 
 		obs_data_t *data = obs_data_create();
 		ProjectorType type = projector->GetProjectorType();
+
 		switch (type) {
 		case ProjectorType::Scene:
 		case ProjectorType::Source: {
@@ -601,11 +602,20 @@ obs_data_array_t *OBSBasic::SaveProjectors()
 		default:
 			break;
 		}
+
 		obs_data_set_int(data, "monitor", projector->GetMonitor());
 		obs_data_set_int(data, "type", static_cast<int>(type));
 		obs_data_set_string(
 			data, "geometry",
 			projector->saveGeometry().toBase64().constData());
+
+		if (projector->IsAlwaysOnTopOverridden())
+			obs_data_set_bool(data, "alwaysOnTop",
+					  projector->IsAlwaysOnTop());
+
+		obs_data_set_bool(data, "alwaysOnTopOverridden",
+				  projector->IsAlwaysOnTopOverridden());
+
 		obs_data_array_push_back(savedProjectors, data);
 		obs_data_release(data);
 	};
@@ -792,6 +802,10 @@ void OBSBasic::LoadSavedProjectors(obs_data_array_t *array)
 		info->geometry =
 			std::string(obs_data_get_string(data, "geometry"));
 		info->name = std::string(obs_data_get_string(data, "name"));
+		info->alwaysOnTop = obs_data_get_bool(data, "alwaysOnTop");
+		info->alwaysOnTopOverridden =
+			obs_data_get_bool(data, "alwaysOnTopOverridden");
+
 		savedProjectorsArray.emplace_back(info);
 
 		obs_data_release(data);
@@ -6872,6 +6886,10 @@ void OBSBasic::OpenSavedProjector(SavedProjectorInfo *info)
 					Qt::LeftToRight, Qt::AlignCenter,
 					size(), rect));
 			}
+
+			if (info->alwaysOnTopOverridden)
+				projector->SetIsAlwaysOnTop(info->alwaysOnTop,
+							    true);
 		}
 	}
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -82,6 +82,8 @@ struct SavedProjectorInfo {
 	int monitor;
 	std::string geometry;
 	std::string name;
+	bool alwaysOnTop;
+	bool alwaysOnTopOverridden;
 };
 
 struct QuickTransition {

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -36,6 +36,8 @@ private:
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
 	void closeEvent(QCloseEvent *event) override;
 
+	bool isAlwaysOnTop;
+	bool isAlwaysOnTopOverridden = false;
 	int savedMonitor = -1;
 	ProjectorType type = ProjectorType::Source;
 	std::vector<OBSWeakSource> multiviewScenes;
@@ -80,6 +82,7 @@ private slots:
 	void OpenFullScreenProjector();
 	void ResizeToContent();
 	void OpenWindowedProjector();
+	void AlwaysOnTopToggled(bool alwaysOnTop);
 
 public:
 	OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
@@ -92,4 +95,8 @@ public:
 	static void UpdateMultiviewProjectors();
 	void RenameProjector(QString oldName, QString newName);
 	void SetHideCursor();
+
+	bool IsAlwaysOnTop() const;
+	bool IsAlwaysOnTopOverridden() const;
+	void SetIsAlwaysOnTop(bool isAlwaysOnTop, bool isOverridden);
 };


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Add a simple checkbox to the context menu of a projector or the multiview window.

![grafik](https://user-images.githubusercontent.com/8039939/80422647-d7088b00-88de-11ea-9b23-5f3b12edcd83.png)



### Motivation and Context
The projector windows (especially the multiview projector) are very useful. Having them always on top is useful and this checkbox provides a way to toggle this feature without opening the settings dialog.

Also reported on the idea page [here](https://ideas.obsproject.com/posts/848/always-on-top-option-for-multiview-window)

### How Has This Been Tested?
Tested it with multiple projectors (fullscreen and windowed) on Windows 10. This won't likely affect other areas of code or break other functionality.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
