### PR TITLE
obs-ffmpeg: Update error message in process_packet

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -952,7 +952,7 @@ static int process_packet(struct ffmpeg_output *output)
 	if (ret < 0) {
 		av_free_packet(&packet);
 		ffmpeg_log_error(LOG_WARNING, &output->ff_data,
-				 "receive_audio: Error writing packet: %s",
+				 "process_packet: Error writing packet: %s",
 				 av_err2str(ret));
 		return ret;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The error message in the process_packet function was prefixed with "receive_audio" because it was previously from code in the encode_audio function which was called from the receive_audio function. This is just a string change to avoid being misled to believe that the error is always audio related.

Previously, the logged error might be:
> receive_audio: Error writing packet: Invalid argument

Now the logged error will be:
> process_packet: Error writing packet: Invalid argument

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We should provide clearer error messages in the log.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I compiled OBS on Win10 1903 64-bit and caused an encoder failure to trigger this log line.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- Logging change (non-breaking change which does not change functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
