### PR TITLE
libobs: Add Windows 10 release version to crash log

### DIFF
--- a/libobs/obs-win-crash-handler.c
+++ b/libobs/obs-win-crash-handler.c
@@ -246,6 +246,8 @@ static inline void init_module_info(struct exception_handler_data *data)
 		data);
 }
 
+extern const char *get_win_release_id();
+
 static inline void write_header(struct exception_handler_data *data)
 {
 	char date_time[80];
@@ -260,18 +262,20 @@ static inline void write_header(struct exception_handler_data *data)
 	else
 		obs_bitness = "32";
 
+	const char *release_id = get_win_release_id();
+
 	dstr_catf(&data->str,
 		  "Unhandled exception: %x\r\n"
 		  "Date/Time: %s\r\n"
 		  "Fault address: %" PRIX64 " (%s)\r\n"
 		  "libobs version: " OBS_VERSION " (%s-bit)\r\n"
-		  "Windows version: %d.%d build %d (revision: %d; "
+		  "Windows version: %d.%d build %d (release: %s; revision: %d; "
 		  "%s-bit)\r\n"
 		  "CPU: %s\r\n\r\n",
 		  data->exception->ExceptionRecord->ExceptionCode, date_time,
 		  data->main_trace.instruction_ptr, data->module_name.array,
 		  obs_bitness, data->win_version.major, data->win_version.minor,
-		  data->win_version.build, data->win_version.revis,
+		  data->win_version.build, release_id, data->win_version.revis,
 		  is_64_bit_windows() ? "64" : "32", data->cpu_info.array);
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Follow-up to eadb96f.  Add Windows 10 release version (e.g., 1809, 1903, 1909) to the crash log.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Make crash logs contain the same Windows version string as the regular log.  This makes it easier to determine the Windows 10 version at a glance from just the crash log header.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I built OBS on Win10 64-bit and induced a crash in a browser source to trigger the crash handler.  That resulted in OBS outputting a crash log with the following header:
> Unhandled exception: 80000003
Date/Time: 2020-04-30, 01:34:03
Fault address: 7FFBB4681562 (c:\users\rytoex\documents\code\obsproject\obs-studio\build64\rundir\relwithdebinfo\obs-plugins\64bit\libcef.dll)
libobs version: 25.0.7-61-gb20e71cd-modified (64-bit)
Windows version: 10.0 build 18362 (release: 1903; revision: 778; 64-bit)
CPU: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- Logging change (non-breaking change which does not change functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
