### PR TITLE
UI: Adjust height of scenes/sources toolbars

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -526,6 +526,18 @@
         </item>
         <item>
          <widget class="QToolBar" name="scenesToolbar">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>22</height>
+           </size>
+          </property>
           <property name="iconSize">
            <size>
             <width>16</width>
@@ -661,6 +673,18 @@
         </item>
         <item>
          <widget class="QToolBar" name="sourcesToolbar">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>22</height>
+           </size>
+          </property>
           <property name="iconSize">
            <size>
             <width>16</width>


### PR DESCRIPTION
### Description
Makes toolbars smaller.

Before:
![Screenshot_20200430_123225](https://user-images.githubusercontent.com/19962531/80741745-ca06ba00-8adf-11ea-85c9-a5b03ae2ef31.png)

After:
![Screenshot_20200430_123751](https://user-images.githubusercontent.com/19962531/80741771-d854d600-8adf-11ea-835b-0e6d721b7030.png)

### Motivation and Context
These were out of proportion with the rest of the UI.

### How Has This Been Tested?
Ran OBS as normal.

### Types of changes
- UI tweak

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
