### PR TITLE
Fix compile warning

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -114,7 +114,8 @@ void OBSPropertiesView::RefreshProperties()
 	widget->setLayout(layout);
 
 	QSizePolicy mainPolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-	QSizePolicy policy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+
+	//QSizePolicy policy(QSizePolicy::Preferred, QSizePolicy::Preferred);
 	//widget->setSizePolicy(policy);
 
 	layout->setLabelAlignment(Qt::AlignRight);


### PR DESCRIPTION
```
[ 99%] Building CXX object UI/CMakeFiles/obs.dir/obs_autogen/mocs_compilation.cpp.o
/src/obs/obs-studio/UI/properties-view.cpp:117:14: warning: unused variable 'policy' [-Wunused-variable]
        QSizePolicy policy(QSizePolicy::Preferred, QSizePolicy::Preferred);
                    ^
1 warning generated.
```