### PR TITLE
UI, libobs: Add downstream keyer

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -262,7 +262,8 @@ set(obs_SOURCES
 	source-label.cpp
 	remote-text.cpp
 	audio-encoders.cpp
-	qt-wrappers.cpp)
+	qt-wrappers.cpp
+	window-basic-main-dsk.cpp)
 
 set(obs_HEADERS
 	${obs_PLATFORM_HEADERS}

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -92,7 +92,7 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		if (main->IsPreviewProgramMode()) {
 			source = obs_weak_source_get_source(main->programScene);
 		} else {
-			source = main->GetCurrentSceneSource();
+			source = main->GetCurrentSceneListSource();
 			obs_source_addref(source);
 		}
 		return source;
@@ -505,7 +505,7 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		OBSSource source = nullptr;
 
 		if (main->IsPreviewProgramMode()) {
-			source = main->GetCurrentSceneSource();
+			source = main->GetCurrentSceneListSource();
 			obs_source_addref(source);
 		}
 
@@ -520,6 +520,34 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 						  Q_ARG(OBSSource,
 							OBSSource(scene)),
 						  Q_ARG(bool, false));
+		}
+	}
+
+	obs_source_t *obs_frontend_get_current_global_scene(void) override
+	{
+		OBSSource source = main->GetCurrentSceneListSource();
+		obs_source_addref(source);
+
+		return source;
+	}
+
+	void obs_frontend_set_current_global_scene(obs_source_t *scene) override
+	{
+		QMetaObject::invokeMethod(main, "SetDSKSource",
+					  Q_ARG(OBSSource, OBSSource(scene)),
+					  Q_ARG(bool, false));
+	}
+
+	void obs_frontend_get_global_scenes(
+		struct obs_frontend_source_list *sources) override
+	{
+		for (int i = 0; i < main->ui->dsk->count(); i++) {
+			QListWidgetItem *item = main->ui->dsk->item(i);
+			OBSScene scene = GetOBSRef<OBSScene>(item);
+			obs_source_t *source = obs_scene_get_source(scene);
+
+			obs_source_addref(source);
+			da_push_back(sources->sources, &source);
 		}
 	}
 

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -94,6 +94,7 @@ Windowed="Windowed"
 Percent="Percent"
 AspectRatio="Aspect Ratio <b>%1:%2</b>"
 LockVolume="Lock Volume"
+DownstreamKeyer="Global Scenes"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -7,7 +7,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1079</width>
+    <width>1191</width>
     <height>730</height>
    </rect>
   </property>
@@ -202,8 +202,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1079</width>
-     <height>22</height>
+     <width>1191</width>
+     <height>30</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -395,6 +395,7 @@
      <addaction name="toggleTransitions"/>
      <addaction name="toggleControls"/>
      <addaction name="toggleStats"/>
+     <addaction name="toggleDSK"/>
     </widget>
     <action name="actionFullscreenInterface">
      <property name="text">
@@ -429,6 +430,144 @@
    <addaction name="menuBasic_MainMenu_Help"/>
   </widget>
   <widget class="OBSBasicStatusBar" name="statusbar"/>
+  <widget class="OBSDock" name="dskDock">
+   <property name="autoFillBackground">
+    <bool>false</bool>
+   </property>
+   <property name="features">
+    <set>QDockWidget::AllDockWidgetFeatures</set>
+   </property>
+   <property name="windowTitle">
+    <string>DownstreamKeyer</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>8</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_2">
+    <layout class="QVBoxLayout" name="verticalLayout_6">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QFrame" name="dskFrame">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>160</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Sunken</enum>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_12">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="SceneTree" name="dsk">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="contextMenuPolicy">
+           <enum>Qt::CustomContextMenu</enum>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Plain</enum>
+          </property>
+          <property name="showDropIndicator" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="dragEnabled">
+           <bool>true</bool>
+          </property>
+          <property name="dragDropMode">
+           <enum>QAbstractItemView::InternalMove</enum>
+          </property>
+          <property name="defaultDropAction">
+           <enum>Qt::TargetMoveAction</enum>
+          </property>
+          <addaction name="actionRemoveScene"/>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolBar" name="dskToolbar">
+          <property name="iconSize">
+           <size>
+            <width>16</width>
+            <height>16</height>
+           </size>
+          </property>
+          <property name="floatable">
+           <bool>false</bool>
+          </property>
+          <addaction name="actionAddSceneDSK"/>
+          <addaction name="actionRemoveSceneDSK"/>
+          <addaction name="separator"/>
+          <addaction name="actionSceneUpDSK"/>
+          <addaction name="actionSceneDownDSK"/>
+         </widget>
+        </item>
+        <item>
+         <spacer name="scenesFixedSizeHSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>150</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
   <widget class="OBSDock" name="scenesDock">
    <property name="features">
     <set>QDockWidget::AllDockWidgetFeatures</set>
@@ -753,7 +892,7 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>71</width>
+           <width>76</width>
            <height>16</height>
           </rect>
          </property>
@@ -807,7 +946,7 @@
            <x>0</x>
            <y>0</y>
            <width>16</width>
-           <height>28</height>
+           <height>26</height>
           </rect>
          </property>
          <property name="sizePolicy">
@@ -1241,6 +1380,18 @@
     <string notr="true">addIconSmall</string>
    </property>
   </action>
+  <action name="actionAddSceneDSK">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/res/images/add.png</normaloff>:/res/images/add.png</iconset>
+   </property>
+   <property name="text">
+    <string>Add</string>
+   </property>
+   <property name="themeID" stdset="0">
+    <string notr="true">addIconSmall</string>
+   </property>
+  </action>
   <action name="actionAddSource">
    <property name="icon">
     <iconset>
@@ -1254,6 +1405,24 @@
    </property>
   </action>
   <action name="actionRemoveScene">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/res/images/list_remove.png</normaloff>:/res/images/list_remove.png</iconset>
+   </property>
+   <property name="text">
+    <string>Remove</string>
+   </property>
+   <property name="shortcut">
+    <string>Del</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetWithChildrenShortcut</enum>
+   </property>
+   <property name="themeID" stdset="0">
+    <string notr="true">removeIconSmall</string>
+   </property>
+  </action>
+  <action name="actionRemoveSceneDSK">
    <property name="icon">
     <iconset>
      <normaloff>:/res/images/list_remove.png</normaloff>:/res/images/list_remove.png</iconset>
@@ -1316,6 +1485,18 @@
     <string notr="true">upArrowIconSmall</string>
    </property>
   </action>
+  <action name="actionSceneUpDSK">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/res/images/up.png</normaloff>:/res/images/up.png</iconset>
+   </property>
+   <property name="text">
+    <string>MoveUp</string>
+   </property>
+   <property name="themeID" stdset="0">
+    <string notr="true">upArrowIconSmall</string>
+   </property>
+  </action>
   <action name="actionSourceUp">
    <property name="enabled">
     <bool>true</bool>
@@ -1332,6 +1513,18 @@
    </property>
   </action>
   <action name="actionSceneDown">
+   <property name="icon">
+    <iconset>
+     <normaloff>:/res/images/down.png</normaloff>:/res/images/down.png</iconset>
+   </property>
+   <property name="text">
+    <string>MoveDown</string>
+   </property>
+   <property name="themeID" stdset="0">
+    <string notr="true">downArrowIconSmall</string>
+   </property>
+  </action>
+  <action name="actionSceneDownDSK">
    <property name="icon">
     <iconset>
      <normaloff>:/res/images/down.png</normaloff>:/res/images/down.png</iconset>
@@ -1822,6 +2015,17 @@
    </property>
    <property name="text">
     <string>Basic.MainMenu.View.SourceIcons</string>
+   </property>
+  </action>
+  <action name="toggleDSK">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>DownstreamKeyer</string>
    </property>
   </action>
  </widget>

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -451,3 +451,21 @@ void obs_frontend_set_current_preview_scene(obs_source_t *scene)
 	if (callbacks_valid())
 		c->obs_frontend_set_current_preview_scene(scene);
 }
+
+obs_source_t *obs_frontend_get_current_global_scene(void)
+{
+	return !!callbacks_valid() ? c->obs_frontend_get_current_global_scene()
+				   : nullptr;
+}
+
+void obs_frontend_set_current_global_scene(obs_source_t *scene)
+{
+	if (callbacks_valid())
+		c->obs_frontend_set_current_global_scene(scene);
+}
+
+void obs_frontend_get_global_scenes(struct obs_frontend_source_list *sources)
+{
+	if (callbacks_valid())
+		c->obs_frontend_get_global_scenes(sources);
+}

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -49,6 +49,8 @@ enum obs_frontend_event {
 	OBS_FRONTEND_EVENT_RECORDING_UNPAUSED,
 
 	OBS_FRONTEND_EVENT_TRANSITION_DURATION_CHANGED,
+
+	OBS_FRONTEND_EVENT_GLOBAL_SCENE_CHANGED,
 };
 
 /* ------------------------------------------------------------------------- */
@@ -191,6 +193,11 @@ EXPORT bool obs_frontend_preview_enabled(void);
 
 EXPORT obs_source_t *obs_frontend_get_current_preview_scene(void);
 EXPORT void obs_frontend_set_current_preview_scene(obs_source_t *scene);
+
+EXPORT void
+obs_frontend_get_global_scenes(struct obs_frontend_source_list *sources);
+EXPORT obs_source_t *obs_frontend_get_current_global_scene(void);
+EXPORT void obs_frontend_set_current_global_scene(obs_source_t *scene);
 
 /* ------------------------------------------------------------------------- */
 

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -116,6 +116,12 @@ struct obs_frontend_callbacks {
 	virtual void on_preload(obs_data_t *settings) = 0;
 	virtual void on_save(obs_data_t *settings) = 0;
 	virtual void on_event(enum obs_frontend_event event) = 0;
+
+	virtual void obs_frontend_get_global_scenes(
+		struct obs_frontend_source_list *sources) = 0;
+	virtual obs_source_t *obs_frontend_get_current_global_scene(void) = 0;
+	virtual void
+	obs_frontend_set_current_global_scene(obs_source_t *scene) = 0;
 };
 
 EXPORT void

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -159,6 +159,8 @@ class SourceTree : public QListView {
 		return reinterpret_cast<SourceTreeModel *>(model());
 	}
 
+	obs_scene_t *scene = nullptr;
+
 public:
 	inline SourceTreeItem *GetItemWidget(int idx)
 	{
@@ -183,6 +185,9 @@ public:
 
 	void UpdateIcons();
 	void SetIconsVisible(bool visible);
+
+	obs_scene_t *GetScene();
+	void SetScene(OBSScene newScene);
 
 public slots:
 	inline void ReorderItems() { GetStm()->ReorderItems(); }

--- a/UI/window-basic-main-dsk.cpp
+++ b/UI/window-basic-main-dsk.cpp
@@ -1,0 +1,137 @@
+#include "window-basic-main.hpp"
+#include "qt-wrappers.hpp"
+
+void OBSBasic::on_actionAddSceneDSK_triggered()
+{
+	AddSceneQuery(true);
+}
+
+void OBSBasic::on_actionRemoveSceneDSK_triggered()
+{
+	on_actionRemoveScene_triggered();
+}
+
+void OBSBasic::on_actionSceneUpDSK_triggered()
+{
+	ChangeListIndex(ui->dsk, true, -1, 0);
+}
+
+void OBSBasic::on_actionSceneDownDSK_triggered()
+{
+	ChangeListIndex(ui->dsk, true, 1, ui->dsk->count() - 1);
+}
+
+void OBSBasic::MoveDSKToTop()
+{
+	ChangeListIndex(ui->dsk, false, 0, 0);
+}
+
+void OBSBasic::MoveDSKToBottom()
+{
+	ChangeListIndex(ui->dsk, false, ui->dsk->count() - 1,
+			ui->dsk->count() - 1);
+}
+
+void OBSBasic::on_dsk_customContextMenuRequested(const QPoint &pos)
+{
+	ShowScenesMenu(ui->dsk, pos);
+}
+
+void OBSBasic::SetDSKSource(OBSSource source)
+{
+	OBSSource prevSource = obs_get_output_source(7);
+	obs_source_release(prevSource);
+
+	if (prevSource == source)
+		return;
+
+	obs_set_output_source(7, source);
+
+	for (int i = 0; i < ui->dsk->count(); i++) {
+		QListWidgetItem *item = ui->dsk->item(i);
+		OBSScene scene = GetSceneFromListItem(item);
+
+		if (obs_dsk_from_source(source) == scene) {
+			ui->dsk->blockSignals(true);
+			ui->dsk->setCurrentItem(item);
+			ui->dsk->blockSignals(false);
+			break;
+		}
+	}
+
+	if (api)
+		api->on_event(OBS_FRONTEND_EVENT_GLOBAL_SCENE_CHANGED);
+
+	blog(LOG_INFO, "Switched to global scene '%s'",
+	     obs_source_get_name(source));
+}
+
+void OBSBasic::on_actionGridModeDSK_triggered()
+{
+	bool gridMode = !ui->dsk->GetGridMode();
+	ui->dsk->SetGridMode(gridMode);
+}
+
+obs_data_array_t *OBSBasic::SaveDSKListOrder()
+{
+	obs_data_array_t *dskOrder = obs_data_array_create();
+
+	for (int i = 0; i < ui->dsk->count(); i++) {
+		obs_data_t *data = obs_data_create();
+		obs_data_set_string(data, "name",
+				    QT_TO_UTF8(ui->dsk->item(i)->text()));
+		obs_data_array_push_back(dskOrder, data);
+		obs_data_release(data);
+	}
+
+	return dskOrder;
+}
+
+void OBSBasic::LoadDSKListOrder(obs_data_array_t *array)
+{
+	size_t num = obs_data_array_count(array);
+
+	for (size_t i = 0; i < num; i++) {
+		obs_data_t *data = obs_data_array_item(array, i);
+		const char *name = obs_data_get_string(data, "name");
+
+		ReorderItemByName(ui->dsk, name, (int)i);
+
+		obs_data_release(data);
+	}
+}
+
+void OBSBasic::on_dsk_currentItemChanged(QListWidgetItem *current,
+					 QListWidgetItem *prev)
+{
+	on_dsk_itemClicked(current);
+	UNUSED_PARAMETER(prev);
+}
+
+void OBSBasic::on_dsk_itemClicked(QListWidgetItem *item)
+{
+	if (!item)
+		return;
+
+	ui->dsk->blockSignals(true);
+	OBSScene scene = GetCurrentGlobalScene();
+	ui->sources->SetScene(scene);
+
+	SetDSKSource(obs_scene_get_source(scene));
+	ui->dsk->blockSignals(false);
+}
+
+void OBSBasic::EditDSKName()
+{
+	QListWidgetItem *item = ui->dsk->currentItem();
+	Qt::ItemFlags flags = item->flags();
+
+	item->setFlags(flags | Qt::ItemIsEditable);
+	ui->dsk->editItem(item);
+	item->setFlags(flags);
+}
+
+bool OBSBasic::IsDSKDockVisible()
+{
+	return ui->dskDock->isVisible();
+}

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -289,7 +289,7 @@ OBSBasicSourceSelect::OBSBasicSourceSelect(OBSBasic *parent, const char *id_)
 	if (strcmp(id_, "scene") == 0) {
 		OBSBasic *main =
 			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
-		OBSSource curSceneSource = main->GetCurrentSceneSource();
+		OBSSource curSceneSource = main->GetCurrentSceneListSource();
 
 		ui->selectExisting->setChecked(true);
 		ui->createNew->setChecked(false);

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -272,7 +272,7 @@ void OBSProjector::OBSRenderMultiview(void *data, uint32_t cx, uint32_t cy)
 
 	GetScaleAndCenterPos(targetCX, targetCY, cx, cy, x, y, scale);
 
-	OBSSource previewSrc = main->GetCurrentSceneSource();
+	OBSSource previewSrc = main->GetCurrentSceneListSource();
 	OBSSource programSrc = main->GetProgramSource();
 	bool studioMode = main->IsPreviewProgramMode();
 
@@ -641,7 +641,7 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 
 	if (window->type == ProjectorType::Preview &&
 	    main->IsPreviewProgramMode()) {
-		OBSSource curSource = main->GetCurrentSceneSource();
+		OBSSource curSource = main->GetCurrentSceneListSource();
 
 		if (source != curSource) {
 			obs_source_dec_showing(source);
@@ -845,7 +845,7 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 			return;
 
 		OBSBasic *main = (OBSBasic *)obs_frontend_get_main_window();
-		if (main->GetCurrentSceneSource() != src)
+		if (main->GetCurrentSceneListSource() != src)
 			main->SetCurrentScene(src, false);
 	}
 }

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -21,6 +21,7 @@
 #include "obs-scene.h"
 
 const struct obs_source_info group_info;
+const struct obs_source_info dsk_info;
 
 static void resize_group(obs_sceneitem_t *group);
 static void resize_scene(obs_scene_t *scene);
@@ -80,6 +81,12 @@ static const char *group_getname(void *unused)
 	return "Group";
 }
 
+static const char *dsk_getname(void *unused)
+{
+	UNUSED_PARAMETER(unused);
+	return "DSK";
+}
+
 static void *scene_create(obs_data_t *settings, struct obs_source *source)
 {
 	pthread_mutexattr_t attr;
@@ -91,6 +98,8 @@ static void *scene_create(obs_data_t *settings, struct obs_source *source)
 		scene->custom_size = true;
 		scene->cx = 0;
 		scene->cy = 0;
+	} else if (strcmp(source->info.id, dsk_info.id) == 0) {
+		scene->is_dsk = true;
 	}
 
 	signal_handler_add_array(obs_source_get_signal_handler(source),
@@ -1198,6 +1207,24 @@ const struct obs_source_info group_info = {
 	.enum_active_sources = scene_enum_active_sources,
 	.enum_all_sources = scene_enum_all_sources};
 
+const struct obs_source_info dsk_info = {
+	.id = "dsk",
+	.type = OBS_SOURCE_TYPE_SCENE,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
+			OBS_SOURCE_COMPOSITE,
+	.get_name = dsk_getname,
+	.create = scene_create,
+	.destroy = scene_destroy,
+	.video_tick = scene_video_tick,
+	.video_render = scene_video_render,
+	.audio_render = scene_audio_render,
+	.get_width = scene_getwidth,
+	.get_height = scene_getheight,
+	.load = scene_load,
+	.save = scene_save,
+	.enum_active_sources = scene_enum_active_sources,
+	.enum_all_sources = scene_enum_all_sources};
+
 static inline obs_scene_t *create_id(const char *id, const char *name)
 {
 	struct obs_source *source = obs_source_create(id, name, NULL, NULL);
@@ -1218,6 +1245,11 @@ obs_scene_t *obs_scene_create(const char *name)
 obs_scene_t *obs_scene_create_private(const char *name)
 {
 	return create_private_id("scene", name);
+}
+
+obs_scene_t *obs_dsk_create(const char *name)
+{
+	return create_id("dsk", name);
 }
 
 static obs_source_t *get_child_at_idx(obs_scene_t *scene, size_t idx)
@@ -1419,6 +1451,14 @@ obs_scene_t *obs_scene_from_source(const obs_source_t *source)
 obs_scene_t *obs_group_from_source(const obs_source_t *source)
 {
 	if (!source || strcmp(source->info.id, group_info.id) != 0)
+		return NULL;
+
+	return source->context.data;
+}
+
+obs_scene_t *obs_dsk_from_source(const obs_source_t *source)
+{
+	if (!source || strcmp(source->info.id, dsk_info.id) != 0)
 		return NULL;
 
 	return source->context.data;
@@ -2992,6 +3032,16 @@ bool obs_source_is_group(const obs_source_t *source)
 bool obs_scene_is_group(const obs_scene_t *scene)
 {
 	return scene ? scene->is_group : false;
+}
+
+bool obs_source_is_dsk(const obs_source_t *source)
+{
+	return source && strcmp(source->info.id, dsk_info.id) == 0;
+}
+
+bool obs_scene_is_dsk(const obs_scene_t *scene)
+{
+	return scene ? scene->is_dsk : false;
 }
 
 void obs_sceneitem_group_enum_items(obs_sceneitem_t *group,

--- a/libobs/obs-scene.h
+++ b/libobs/obs-scene.h
@@ -97,4 +97,6 @@ struct obs_scene {
 	pthread_mutex_t video_mutex;
 	pthread_mutex_t audio_mutex;
 	struct obs_scene_item *first_item;
+
+	bool is_dsk;
 };

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -510,6 +510,8 @@ obs_source_t *obs_source_duplicate(obs_source_t *source, const char *new_name,
 		if (!scene)
 			scene = obs_group_from_source(source);
 		if (!scene)
+			scene = obs_dsk_from_source(source);
+		if (!scene)
 			return NULL;
 
 		obs_scene_t *new_scene = obs_scene_duplicate(

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -823,6 +823,7 @@ static inline void obs_free_hotkeys(void)
 
 extern const struct obs_source_info scene_info;
 extern const struct obs_source_info group_info;
+extern const struct obs_source_info dsk_info;
 
 static const char *submix_name(void *unused)
 {
@@ -870,6 +871,7 @@ static bool obs_init(const char *locale, const char *module_config_path,
 	obs->locale = bstrdup(locale);
 	obs_register_source(&scene_info);
 	obs_register_source(&group_info);
+	obs_register_source(&dsk_info);
 	obs_register_source(&audio_line_info);
 	add_default_module_paths();
 	return true;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1455,6 +1455,8 @@ EXPORT void obs_transition_swap_end(obs_source_t *tr_dest,
  */
 EXPORT obs_scene_t *obs_scene_create(const char *name);
 
+EXPORT obs_scene_t *obs_dsk_create(const char *name);
+
 EXPORT obs_scene_t *obs_scene_create_private(const char *name);
 
 enum obs_scene_duplicate_type {
@@ -1657,6 +1659,12 @@ EXPORT obs_scene_t *obs_group_from_source(const obs_source_t *source);
 
 EXPORT void obs_sceneitem_defer_group_resize_begin(obs_sceneitem_t *item);
 EXPORT void obs_sceneitem_defer_group_resize_end(obs_sceneitem_t *item);
+
+/** Gets the dsk from its source, or NULL if not a group */
+EXPORT obs_scene_t *obs_dsk_from_source(const obs_source_t *source);
+
+EXPORT bool obs_source_is_dsk(const obs_source_t *source);
+EXPORT bool obs_scene_is_dsk(const obs_scene_t *scene);
 
 /* ------------------------------------------------------------------------- */
 /* Outputs */


### PR DESCRIPTION
### Description
Adds downstream keyer (global scenes), so users can have scenes that are always on top of other scenes. This PR allows for unlimited amount of DSK channels.

TODO:
- [ ] Transitions between DSK channels
- [ ] RFC finalized/merged

### Motivation and Context
Previous PR:
https://github.com/obsproject/obs-studio/pull/1321

Previous PR only allowed for one DSK channel.

RFC:
https://github.com/obsproject/rfcs/pull/11

### How Has This Been Tested?
Created DSK scenes and made sure that they were always on top.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
