### PR TITLE
rtmp-services: Add Mixcloud

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 132,
+	"version": 133,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 132
+			"version": 133
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -492,6 +492,15 @@
             ]
         },
         {
+            "name": "Mixcloud",
+            "servers": [
+                {
+                    "name": "Primary",
+                    "url": "rtmp://rtmp.mixcloud.com/broadcast"
+                }
+            ]
+        },
+        {
             "name": "Vaughn Live / iNSTAGIB",
             "servers": [
                 {


### PR DESCRIPTION
### Description
A music-focused streaming service https://www.mixcloud.com/

### Motivation and Context
Their official stream setup guide suggests connecting via "Custom". https://help.mixcloud.com/hc/en-us/articles/360013022760

### How Has This Been Tested?

Verified the streaming URL matches the official Help page

### Types of changes

* New service

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
