### PR TITLE
libobs-opengl: Lock Mac parent context during present

### DIFF
--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -292,8 +292,6 @@ void device_present(gs_device_t *device)
 	glFlush();
 	[NSOpenGLContext clearCurrentContext];
 
-	CGLUnlockContext([device->plat->context CGLContextObj]);
-
 	CGLLockContext([device->cur_swap->wi->context CGLContextObj]);
 
 	[device->cur_swap->wi->context makeCurrentContext];
@@ -308,8 +306,6 @@ void device_present(gs_device_t *device)
 	[NSOpenGLContext clearCurrentContext];
 
 	CGLUnlockContext([device->cur_swap->wi->context CGLContextObj]);
-
-	CGLLockContext([device->plat->context CGLContextObj]);
 
 	[device->plat->context makeCurrentContext];
 }


### PR DESCRIPTION
### Description
Parent context lock keeps GL commands serialized.

### Motivation and Context
Fixes race that causes crash when resizing multiview.

Fixes #2848

### How Has This Been Tested?
Spammed multiview resize, and OBS would normally crash much sooner, but it stayed alive.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.