### PR TITLE
deps/glad: Fix build with GCC-10

### DIFF
--- a/deps/glad/src/glad_glx.c
+++ b/deps/glad/src/glad_glx.c
@@ -35,7 +35,7 @@ static void* libGL;
 
 #ifndef __APPLE__
 typedef void* (APIENTRYP PFNGLXGETPROCADDRESSPROC_PRIVATE)(const char*);
-PFNGLXGETPROCADDRESSPROC_PRIVATE gladGetProcAddressPtr;
+extern PFNGLXGETPROCADDRESSPROC_PRIVATE gladGetProcAddressPtr;
 #endif
 
 static


### PR DESCRIPTION
### Description
Use 'extern' to turn the first definition of 'gladGetProcAddressPtr' into a declaration.

### Motivation and Context
GCC-10 defaults to '-fno-common', which triggers issues with multiple definitions of global variables.

- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678

Without the changes, builds will fail like so:

```
FAILED: deps/glad/libobsglad.so.0 
: && /usr/bin/x86_64-pc-linux-gnu-gcc -fPIC -Wall -Wextra -Wvla -Wno-unused-function -Werror-implicit-function-declaration -Wno-missing-braces -Wno-missing-field-initializers -march=znver1 -O2 -fomit-frame-pointer -pipe -mindirect-branch=thunk -std=gnu99 -fno-strict-aliasing  -Wl,-O1 -Wl,--as-needed -shared -Wl,-soname,libobsglad.so.0 -o deps/glad/libobsglad.so.0 deps/glad/CMakeFiles/glad.dir/src/glad.c.o deps/glad/CMakeFiles/glad.dir/src/glad_glx.c.o  /usr/lib64/libX11.so  -ldl  /usr/lib64/libGL.so && :
/usr/lib/gcc/x86_64-pc-linux-gnu/10.0.1/../../../../x86_64-pc-linux-gnu/bin/ld: deps/glad/CMakeFiles/glad.dir/src/glad_glx.c.o:(.bss+0x4b8): multiple definition of `gladGetProcAddressPtr'; deps/glad/CMakeFiles/glad.dir/src/glad.c.o:(.bss+0x5008): first defined here
collect2: error: ld returned 1 exit status
```

### How Has This Been Tested?
Build tests ran with GCC 10.0.1 and 9.3.0 on Gentoo Linux.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
