### PR TITLE
obs-ffmpeg: Fix AVFrame handling in FFmpeg output

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -699,6 +699,15 @@ static void receive_video(void *param, struct video_data *frame)
 	if (!data->start_timestamp)
 		data->start_timestamp = frame->timestamp;
 
+	ret = av_frame_make_writable(data->vframe);
+	if (ret < 0) {
+		blog(LOG_WARNING,
+		     "receive_video: Error obtaining writable "
+		     "AVFrame: %s",
+		     av_err2str(ret));
+		//FIXME: stop the encode with an error
+		return;
+	}
 	if (!!data->swscale)
 		sws_scale(data->swscale, (const uint8_t *const *)frame->data,
 			  (const int *)frame->linesize, 0, data->config.height,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fix an issue in the way AVFrames were handled in the FFmpeg
encoder plugin, which could lead to tearing in the encoded
video due to data races in the AVFrame and AVBuffer.

This is fixed by calling av_frame_make_writable which ensures
the frame and its associated buffer are writable. If its not,
it will copy the AVFrame, create a new AVBuffer for it and
decrease the refcount of the old AVFrame and AVBuffer.
This way OBS always ends up with a usable buffer to write into
which is not still used by the encoder while avoiding a copy
when unnecessary.

### Motivation and Context
This issue was most noticeable with the ProRes encoder with a large output
bitrate as it caused severe tearing in the output.

### How Has This Been Tested?
Tested with a debug build on Windows 10, 64bit.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
