### PR TITLE
fix ffmpeg source does not reconnect when source disconnect

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -584,6 +584,7 @@ static bool init_avformat(mp_media_t *m)
 
 	m->fmt = avformat_alloc_context();
 	if (!m->is_local_file) {
+		av_dict_set(&opts, "stimeout", "30000000", 0);
 		m->fmt->interrupt_callback.callback = interrupt_callback;
 		m->fmt->interrupt_callback.opaque = m;
 	}
@@ -811,8 +812,6 @@ void mp_media_free(mp_media_t *media)
 	os_sem_destroy(media->sem);
 	sws_freeContext(media->swscale);
 	av_freep(&media->scale_pic[0]);
-	bfree(media->path);
-	bfree(media->format_name);
 	memset(media, 0, sizeof(*media));
 	pthread_mutex_init_value(&media->mutex);
 }

--- a/deps/media-playback/media-playback/media.h
+++ b/deps/media-playback/media-playback/media.h
@@ -41,12 +41,14 @@ extern "C" {
 typedef void (*mp_video_cb)(void *opaque, struct obs_source_frame *frame);
 typedef void (*mp_audio_cb)(void *opaque, struct obs_source_audio *audio);
 typedef void (*mp_stop_cb)(void *opaque);
+typedef void (*mp_kill_cb)(void *opaque);
 
 struct mp_media {
 	AVFormatContext *fmt;
 
 	mp_video_cb v_preload_cb;
 	mp_stop_cb stop_cb;
+	mp_kill_cb kill_cb;
 	mp_video_cb v_cb;
 	mp_audio_cb a_cb;
 	void *opaque;
@@ -109,6 +111,7 @@ struct mp_media_info {
 	mp_video_cb v_preload_cb;
 	mp_audio_cb a_cb;
 	mp_stop_cb stop_cb;
+	mp_kill_cb kill_cb;
 
 	const char *path;
 	const char *format;


### PR DESCRIPTION
### Description
deps\media-playback\media-playback\media.c
add av_dict_set(&opts, "stimeout", "30000000", 0);
when connect ffmpeg source fail it will be closed

deps\media-playback\media-playback\media.c.h
add kill_cb in mp_media_info, when ffmpeg thread is killed it will be called

plugins\obs-ffmpeg\obs-ffmpeg-source.c
add ffpmeg_source_reconnect, when ffmpeg_source_tick found media thread has been destory it will start reconnect thread after 10000 ms


### Motivation and Context
ffmepg source does not reconnect when source disconnect

### How Has This Been Tested?
obs add a rtmp source or rtsp source test close the network and after a moment reconnect。
After 10000  ms it will be reconnect。

### Types of changes
New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
