### PR TITLE
libobs-winrt: win-capture: Detect GraphicsCaptureItem closure

### DIFF
--- a/libobs-winrt/winrt-capture.h
+++ b/libobs-winrt/winrt-capture.h
@@ -15,6 +15,7 @@ EXPORT struct winrt_capture *winrt_capture_init(BOOL cursor, HWND window,
 						BOOL client_area);
 EXPORT void winrt_capture_free(struct winrt_capture *capture);
 
+EXPORT BOOL winrt_capture_supported(const struct winrt_capture *capture);
 EXPORT void winrt_capture_show_cursor(struct winrt_capture *capture,
 				      BOOL visible);
 EXPORT void winrt_capture_render(struct winrt_capture *capture,


### PR DESCRIPTION
### Description
Make WGC window capture recover from GraphicsCaptureItem closure, which
can occur when following links in fullscreen Chrome for example.

### Motivation and Context
Window capture was stuck in a state where the capture was severed, but it didn't know.

### How Has This Been Tested?
Following links in fullscreen Chrome now work, albeit with a black hiccup.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.