### PR TITLE
win-capture: Log window capture method

### DIFF
--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -122,6 +122,24 @@ choose_method(enum window_capture_method method, bool wgc_supported,
 	return METHOD_BITBLT;
 }
 
+static const char *get_method_name(int method)
+{
+	const char *method_name = "";
+	switch (method) {
+	case METHOD_AUTO:
+		method_name = "Automatic";
+		break;
+	case METHOD_BITBLT:
+		method_name = "BitBlt";
+		break;
+	case METHOD_WGC:
+		method_name = "WGC";
+		break;
+	}
+
+	return method_name;
+}
+
 static void update_settings(struct window_capture *wc, obs_data_t *s)
 {
 	int method = (int)obs_data_get_int(s, "method");
@@ -134,20 +152,23 @@ static void update_settings(struct window_capture *wc, obs_data_t *s)
 
 	build_window_strings(window, &wc->class, &wc->title, &wc->executable);
 
-	if (wc->title != NULL) {
-		blog(LOG_INFO,
-		     "[window-capture: '%s'] update settings:\n"
-		     "\texecutable: %s",
-		     obs_source_get_name(wc->source), wc->executable);
-		blog(LOG_DEBUG, "\tclass:      %s", wc->class);
-	}
-
 	wc->method = choose_method(method, wc->wgc_supported, wc->class);
 	wc->priority = (enum window_priority)priority;
 	wc->cursor = obs_data_get_bool(s, "cursor");
 	wc->use_wildcards = obs_data_get_bool(s, "use_wildcards");
 	wc->compatibility = obs_data_get_bool(s, "compatibility");
 	wc->client_area = obs_data_get_bool(s, "client_area");
+
+	if (wc->title != NULL) {
+		blog(LOG_INFO,
+		     "[window-capture: '%s'] update settings:\n"
+		     "\texecutable: %s\n"
+		     "\tmethod selected: %s\n"
+		     "\tmethod chosen: %s\n",
+		     obs_source_get_name(wc->source), wc->executable,
+		     get_method_name(method), get_method_name(wc->method));
+		blog(LOG_DEBUG, "\tclass:      %s", wc->class);
+	}
 }
 
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change adds the window capture method information to the log file.  With this change, the log file will include whether a user selected "Automatic" or directly selected a window capture method.  It will also include which method was ultimately used, whether the user select "Automatic" or not.

I moved the `blog` call to the end of the `update_settings` function so that I had access to both `method` and `wc->method`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
People providing support requested this change.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I compiled and ran OBS git master on Windows 10 1903 64-bit using VS2017.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- Logging change (non-breaking change which does not change functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
