### PR TITLE
cmake: Fix CMake package name warnings

### DIFF
--- a/cmake/Modules/FindLibVLC.cmake
+++ b/cmake/Modules/FindLibVLC.cmake
@@ -59,7 +59,9 @@ find_library(VLC_LIB
 		../bin${_lib_suffix} ../bin)
 
 include(FindPackageHandleStandardArgs)
+set(FPHSA_NAME_MISMATCHED 1)
 find_package_handle_standard_args(LibVLC_INCLUDES DEFAULT_MSG VLC_INCLUDE_DIR)
+unset(FPHSA_NAME_MISMATCHED)
 find_package_handle_standard_args(LibVLC DEFAULT_MSG VLC_LIB VLC_INCLUDE_DIR)
 mark_as_advanced(VLC_INCLUDE_DIR VLC_LIB)
 

--- a/cmake/Modules/FindMbedTLS.cmake
+++ b/cmake/Modules/FindMbedTLS.cmake
@@ -139,5 +139,7 @@ endif()
 
 # Now we've accounted for the 3-vs-1 library case:
 include(FindPackageHandleStandardArgs)
+set(FPHSA_NAME_MISMATCHED 1)
 find_package_handle_standard_args(Libmbedtls DEFAULT_MSG MBEDTLS_LIBRARIES MBEDTLS_INCLUDE_DIRS)
+unset(FPHSA_NAME_MISMATCHED)
 mark_as_advanced(MBEDTLS_INCLUDE_DIR MBEDTLS_LIBRARIES MBEDTLS_INCLUDE_DIRS)

--- a/cmake/Modules/FindVulkan.cmake
+++ b/cmake/Modules/FindVulkan.cmake
@@ -61,7 +61,7 @@ find_library(VULKAN_LIB
 		../bin${_lib_suffix} ../bin)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(vulkan DEFAULT_MSG VULKAN_LIB VULKAN_INCLUDE_DIR)
+find_package_handle_standard_args(Vulkan DEFAULT_MSG VULKAN_LIB VULKAN_INCLUDE_DIR)
 mark_as_advanced(VULKAN_INCLUDE_DIR VULKAN_LIB)
 
 if(VULKAN_FOUND)

--- a/cmake/Modules/FindZLIB.cmake
+++ b/cmake/Modules/FindZLIB.cmake
@@ -59,7 +59,7 @@ find_library(ZLIB_LIB
 		../bin${_lib_suffix} ../bin)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(zlib DEFAULT_MSG ZLIB_LIB ZLIB_INCLUDE_DIR)
+find_package_handle_standard_args(ZLIB DEFAULT_MSG ZLIB_LIB ZLIB_INCLUDE_DIR)
 mark_as_advanced(ZLIB_INCLUDE_DIR ZLIB_LIB)
 
 if(ZLIB_FOUND)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Since CMake 3.17, find_package_handle_standard_args (FPHSA) will emit a warning if the package name in the caller and in FPHSA do not match. This corrects names or suppresses the warning as needed.

For reference, see:
* [the CMake 3.17 documentation on FPHSA](https://cmake.org/cmake/help/v3.17/module/FindPackageHandleStandardArgs.html)
* [the commit to CMake that introduced this feature](https://gitlab.kitware.com/cmake/cmake/commit/ee4673c1ae1e4a1aa4687412717567c2ffbb501b)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Having less warnings makes it easier to notice real issues.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I built this on Windows 10 1903 64-bit.  I made a test recording and did a short bandwidth test stream to Twitch.  The previously shown CMake warnings did not appear during the CMake portion of the build process.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
