### PR TITLE
mac-capture: Use resize instead of reserve

### DIFF
--- a/plugins/mac-capture/mac-window-capture.m
+++ b/plugins/mac-capture/mac-window-capture.m
@@ -51,7 +51,7 @@ static inline void capture_frame(struct window_capture *wc)
 	size_t height = CGImageGetHeight(img);
 
 	CGRect rect = {{0, 0}, {width, height}};
-	da_reserve(wc->buffer, width * height * 4);
+	da_resize(wc->buffer, width * height * 4);
 	uint8_t *data = wc->buffer.array;
 
 	CGContextRef cg_context = CGBitmapContextCreate(


### PR DESCRIPTION
### Description
Better practice for the tracked size to be nonzero.

This does NOT speed up window capture significantly.

### Motivation and Context
Code inspection of Mac window capture found this minor issue.

### How Has This Been Tested?
Window capture on Mac still works.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.