### PR TITLE
libobs: Fix da_reserve early return logic

### DIFF
--- a/libobs/util/darray.h
+++ b/libobs/util/darray.h
@@ -84,7 +84,7 @@ static inline void darray_reserve(const size_t element_size, struct darray *dst,
 				  const size_t capacity)
 {
 	void *ptr;
-	if (capacity == 0 || capacity <= dst->num)
+	if (capacity == 0 || capacity <= dst->capacity)
 		return;
 
 	ptr = bmalloc(element_size * capacity);


### PR DESCRIPTION
### Description
Test desired capacity against original capacity instead of size.

### Motivation and Context
Noticed a spot in code where the allocation was recreated unnecessarily.

### How Has This Been Tested?
Allocation was no longer being recreated.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.