### PR TITLE
frontend-tools: Add defaults button to script dialog

### DIFF
--- a/UI/frontend-plugins/frontend-tools/forms/scripts.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/scripts.ui
@@ -137,6 +137,13 @@
             </spacer>
            </item>
            <item>
+            <widget class="QPushButton" name="defaults">
+             <property name="text">
+              <string>Defaults</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QPushButton" name="scriptLog">
              <property name="text">
               <string>ScriptLogWindow</string>

--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -255,6 +255,22 @@ void ScriptsTool::RefreshLists()
 	}
 }
 
+void ScriptsTool::SetScriptDefaults(const char *path)
+{
+	for (OBSScript &script : scriptData->scripts) {
+		const char *script_path = obs_script_get_path(script);
+		if (strcmp(script_path, path) == 0) {
+			obs_data_t *settings = obs_script_get_settings(script);
+			obs_data_clear(settings);
+			obs_data_release(settings);
+
+			obs_script_update(script, nullptr);
+			on_reloadScripts_clicked();
+			break;
+		}
+	}
+}
+
 void ScriptsTool::on_close_clicked()
 {
 	close();
@@ -431,6 +447,16 @@ void ScriptsTool::on_scripts_currentRowChanged(int row)
 		(PropertiesUpdateCallback)obs_script_update);
 	ui->propertiesLayout->addWidget(propertiesView);
 	ui->description->setText(obs_script_get_description(script));
+}
+
+void ScriptsTool::on_defaults_clicked()
+{
+	QListWidgetItem *item = ui->scripts->currentItem();
+	if (!item)
+		return;
+
+	SetScriptDefaults(
+		item->data(Qt::UserRole).toString().toUtf8().constData());
 }
 
 /* ----------------------------------------------------------------- */

--- a/UI/frontend-plugins/frontend-tools/scripts.hpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.hpp
@@ -37,6 +37,7 @@ public:
 	void RemoveScript(const char *path);
 	void ReloadScript(const char *path);
 	void RefreshLists();
+	void SetScriptDefaults(const char *path);
 
 public slots:
 	void on_close_clicked();
@@ -45,6 +46,7 @@ public slots:
 	void on_removeScripts_clicked();
 	void on_reloadScripts_clicked();
 	void on_scriptLog_clicked();
+	void on_defaults_clicked();
 
 	void on_scripts_currentRowChanged(int row);
 


### PR DESCRIPTION
### Description
Add defaults button to script dialog.

![Screenshot_20200510_043323](https://user-images.githubusercontent.com/19962531/81495723-e4772b00-9277-11ea-82aa-fc52f55ff1d2.png)

### Motivation and Context
Makes it easier for users to reset script settings.

### How Has This Been Tested?
Changed script settings, then clicked defaults button, and then everything was reset as expected.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
