### PR TITLE
Fix WGC minimize handling

### DIFF
--- a/plugins/win-capture/CMakeLists.txt
+++ b/plugins/win-capture/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(win-capture MODULE
 	${win-capture_HEADERS})
 target_link_libraries(win-capture
 	libobs
+	Dwmapi
 	ipc-util
 	psapi)
 

--- a/plugins/win-capture/window-helpers.c
+++ b/plugins/win-capture/window-helpers.c
@@ -2,8 +2,9 @@
 #include <obs.h>
 #include <util/dstr.h>
 
-#include <windows.h>
+#include <dwmapi.h>
 #include <psapi.h>
+#include <windows.h>
 #include "window-helpers.h"
 #include "obfuscate.h"
 
@@ -440,6 +441,12 @@ BOOL CALLBACK enum_windows_proc(HWND window, LPARAM lParam)
 	struct top_level_enum_data *data = (struct top_level_enum_data *)lParam;
 
 	if (!check_window_valid(window, data->mode))
+		return TRUE;
+
+	int cloaked;
+	if (SUCCEEDED(DwmGetWindowAttribute(window, DWMWA_CLOAKED, &cloaked,
+					    sizeof(cloaked))) &&
+	    cloaked)
 		return TRUE;
 
 	const int rating = window_rating(window, data->priority, data->class,


### PR DESCRIPTION
### Description
Illegal CopySubresourceRegion parameters were sometimes computed when
minimizing and restoring WGC window captures, leading to device loss.

Add robust safeties to ensure that doesn't happen.

Also prevent cloaked window handles from being selected for minimized UWP apps like Calculator because they will fail to capture even after uncloaking. For some reason, there is still an alternate uncloaked handle that can be latched onto.

Fixes #2932.

### Motivation and Context
Device loss is very bad.

### How Has This Been Tested?
Debugger breakpoint inspection. Minimized and restored window many times.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.