### PR TITLE
libobs: Remove log entry for CoInitializeEx pass

### DIFF
--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -1264,9 +1264,7 @@ bool initialize_com(void)
 {
 	const HRESULT hr = CoInitializeEx(0, COINIT_APARTMENTTHREADED);
 	const bool success = SUCCEEDED(hr);
-	if (success)
-		blog(LOG_INFO, "CoInitializeEx succeeded: 0x%08X", hr);
-	else
+	if (!success)
 		blog(LOG_ERROR, "CoInitializeEx failed: 0x%08X", hr);
 	return success;
 }


### PR DESCRIPTION
### Description
Remove entry from the top of the log. Always returns S_FALSE, and that's
unlikely to change.

### Motivation and Context
Remove unhelpful log message.

### How Has This Been Tested?
Log no longer has success message in it.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.