### PR TITLE
UI: Allow the use of Esc key to quit settings window

### DIFF
--- a/UI/window-basic-interaction.hpp
+++ b/UI/window-basic-interaction.hpp
@@ -80,6 +80,6 @@ protected:
 		return filter(obj, event);
 	}
 
-private:
+public:
 	EventFilterFunc filter;
 };

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -55,6 +55,33 @@
 
 using namespace std;
 
+class SettingsEventFilter : public QObject {
+	QScopedPointer<OBSEventFilter> shortcutFilter;
+
+public:
+	inline SettingsEventFilter()
+		: shortcutFilter((OBSEventFilter *)CreateShortcutFilter())
+	{
+	}
+
+protected:
+	bool eventFilter(QObject *obj, QEvent *event) override
+	{
+		int key;
+
+		switch (event->type()) {
+		case QEvent::KeyPress:
+		case QEvent::KeyRelease:
+			key = static_cast<QKeyEvent *>(event)->key();
+			if (key == Qt::Key_Escape) {
+				return false;
+			}
+		}
+
+		return shortcutFilter->filter(obj, event);
+	}
+};
+
 // Used for QVariant in codec comboboxes
 namespace {
 static bool StringEquals(QString left, QString right)
@@ -656,7 +683,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	// Initialize libff library
 	ff_init();
 
-	installEventFilter(CreateShortcutFilter());
+	installEventFilter(new SettingsEventFilter());
 
 	LoadEncoderTypes();
 	LoadColorRanges();
@@ -3611,14 +3638,14 @@ bool OBSBasicSettings::QueryChanges()
 
 void OBSBasicSettings::closeEvent(QCloseEvent *event)
 {
-	if (Changed() && !QueryChanges())
+	if (!AskIfCanCloseSettings())
 		event->ignore();
+}
 
-	if (forceAuthReload) {
-		main->auth->Save();
-		main->auth->Load();
-		forceAuthReload = false;
-	}
+void OBSBasicSettings::reject()
+{
+	if (AskIfCanCloseSettings())
+		close();
 }
 
 void OBSBasicSettings::on_theme_activated(int idx)
@@ -3870,6 +3897,22 @@ void OBSBasicSettings::RecalcOutputResPixels(const char *resText)
 				.arg(QString::number(std::get<0>(aspect)),
 				     QString::number(std::get<1>(aspect))));
 	}
+}
+
+bool OBSBasicSettings::AskIfCanCloseSettings()
+{
+	bool canCloseSettings = false;
+
+	if (!Changed() || QueryChanges())
+		canCloseSettings = true;
+
+	if (forceAuthReload) {
+		main->auth->Save();
+		main->auth->Load();
+		forceAuthReload = false;
+	}
+
+	return canCloseSettings;
 }
 
 void OBSBasicSettings::on_filenameFormatting_textEdited(const QString &text)

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -289,6 +289,8 @@ private:
 
 	void RecalcOutputResPixels(const char *resText);
 
+	bool AskIfCanCloseSettings();
+
 	QIcon generalIcon;
 	QIcon streamIcon;
 	QIcon outputIcon;
@@ -376,6 +378,7 @@ private slots:
 
 protected:
 	virtual void closeEvent(QCloseEvent *event);
+	void reject() override;
 
 public:
 	OBSBasicSettings(QWidget *parent);


### PR DESCRIPTION
### Description
Allow the use of the ESC key to close the settings window.
When there are unsaved changes it prompts to save your settings (Same behavior like clicking on the [x] button in the upper right).

### Motivation and Context
This improves the workflow when the settings window is opened by accident by providing a fast way to close it. Moreover it implements the expected action when the esc key is pressed on a dialog or settings window (Visual Studio, Word, Discord, ... have the same behavior). 

It addresses this issue: #2166

### How Has This Been Tested?
Tested on Windows 10.

#### No changes were made: 
1. Open the settings window
2. Change nothing
3. Hit escape
-> closes the settings window

#### Changes were made: 
1. Open the settings window
2. Change something
3. Hit escape
-> shows a confirmation dialog to close the settings window  

#### Influence on configured hotkeys: 
1. Open the settings window
2. Hit some configured hotkeys (like show/hide a source)
-> hotkey action not executed (as expected)
3. Close the settings window
4. Hit some configured hotkeys (like show/hide a source)
-> hotkey action executed (as expected)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
