### PR TITLE
UI: Convert the filter dialog layout into a splitter

### DIFF
--- a/UI/forms/OBSBasicFilters.ui
+++ b/UI/forms/OBSBasicFilters.ui
@@ -393,10 +393,28 @@
       </layout>
      </item>
      <item>
-      <layout class="QVBoxLayout" name="rightContainerLayout">
-       <item>
-        <layout class="QVBoxLayout" name="rightLayout">
-         <item>
+      <widget class="QWidget" name="rightContainerLayout">
+       <layout class="QVBoxLayout" name="verticalLayout_6">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QSplitter" name="rightLayout">
+          <property name="lineWidth">
+           <number>1</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
           <widget class="OBSQTDisplay" name="preview">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -411,40 +429,40 @@
             </size>
            </property>
           </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <property name="spacing">
-          <number>4</number>
-         </property>
-         <property name="sizeConstraint">
-          <enum>QLayout::SetMaximumSize</enum>
-         </property>
-         <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QDialogButtonBox" name="buttonBox">
-           <property name="standardButtons">
-            <set>QDialogButtonBox::Reset|QDialogButtonBox::Close</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <property name="sizeConstraint">
+           <enum>QLayout::SetMaximumSize</enum>
+          </property>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QDialogButtonBox" name="buttonBox">
+            <property name="standardButtons">
+             <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
      </item>
     </layout>
    </item>

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -142,7 +142,8 @@ OBSBasicFilters::OBSBasicFilters(QWidget *parent, OBSSource source_)
 				addDrawCallback);
 	} else {
 		ui->rightLayout->setContentsMargins(0, noPreviewMargin, 0, 0);
-		ui->rightContainerLayout->insertStretch(1);
+		static_cast<QVBoxLayout *>(ui->rightContainerLayout->layout())
+			->insertStretch(1);
 		ui->preview->hide();
 	}
 
@@ -196,7 +197,8 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 {
 	if (view) {
 		updatePropertiesSignal.Disconnect();
-		ui->rightLayout->removeWidget(view);
+		//ui->rightLayout->removeWidget(view);
+		view->hide();
 		view->deleteLater();
 		view = nullptr;
 	}


### PR DESCRIPTION
### Description
Converts the rightLayout into a QSplitter in order to have more input area for filter settings. Implements [idea 898](https://ideas.obsproject.com/posts/898/assign-extra-vertical-space-in-resized-filter-window-to-showing-more-filter-parameters).

### Motivation and Context
Backporting some of my UI/UX redesign from my fork to mainline OBS Studio. Also because it is really annoying to have a super-sized filter preview and a tiny area for settings.

### How Has This Been Tested?
Tested on Windows 10 with the 27.x code base, based on Qt 5.15.2

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.