### PR TITLE
UI: Add TBar controls to obs-frontend-api

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -151,6 +151,17 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 					  "setValue", Q_ARG(int, duration));
 	}
 
+	void obs_frontend_release_tbar(void) override
+	{
+		QMetaObject::invokeMethod(main, "TBarReleased");
+	}
+
+	void obs_frontend_set_tbar_position(int position) override
+	{
+		QMetaObject::invokeMethod(main, "TBarChanged",
+					  Q_ARG(int, position));
+	}
+
 	void obs_frontend_get_scene_collections(
 		std::vector<std::string> &strings) override
 	{

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -142,6 +142,18 @@ void obs_frontend_set_transition_duration(int duration)
 		c->obs_frontend_set_transition_duration(duration);
 }
 
+void obs_frontend_release_tbar(void)
+{
+	if (callbacks_valid())
+		c->obs_frontend_release_tbar();
+}
+
+void obs_frontend_set_tbar_position(int position)
+{
+	if (callbacks_valid())
+		c->obs_frontend_set_tbar_position(position);
+}
+
 char **obs_frontend_get_scene_collections(void)
 {
 	if (!callbacks_valid())

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -100,6 +100,8 @@ EXPORT obs_source_t *obs_frontend_get_current_transition(void);
 EXPORT void obs_frontend_set_current_transition(obs_source_t *transition);
 EXPORT int obs_frontend_get_transition_duration(void);
 EXPORT void obs_frontend_set_transition_duration(int duration);
+EXPORT void obs_frontend_release_tbar(void);
+EXPORT void obs_frontend_set_tbar_position(int position);
 
 EXPORT char **obs_frontend_get_scene_collections(void);
 EXPORT char *obs_frontend_get_current_scene_collection(void);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -23,6 +23,8 @@ struct obs_frontend_callbacks {
 	obs_frontend_set_current_transition(obs_source_t *transition) = 0;
 	virtual int obs_frontend_get_transition_duration(void) = 0;
 	virtual void obs_frontend_set_transition_duration(int duration) = 0;
+	virtual void obs_frontend_release_tbar(void) = 0;
+	virtual void obs_frontend_set_tbar_position(int position) = 0;
 
 	virtual void obs_frontend_get_scene_collections(
 		std::vector<std::string> &strings) = 0;

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -915,6 +915,8 @@ void OBSBasic::TBarChanged(int value)
 	OBSSource transition = obs_get_output_source(0);
 	obs_source_release(transition);
 
+	tBar->setValue(value);
+
 	if (!tBarActive) {
 		OBSSource sceneSource = GetCurrentSceneSource();
 		OBSSource tBarTr = GetOverrideTransition(sceneSource);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds `obs_frontend_set_tbar_position` and `obs_frontend_release_tbar`, which allow plugins and scripts to control the tbar in OBS. This specific change is required for the `SetTBarPosition` request to be added to obs-websocket.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
There is a draft PR for obs-websocket to add a TBar control request to the plugin, and adding that request is impossible without modifying OBS.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Opened studio mode and played with software slider, works just as expected.
- Loaded an obs-websocket test script with the modified obs-websocket plugin and used it to set the TBar position
- The transition should start and the on-screen TBar should move according to the values sent to obs-websocket

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
