### PR TITLE
win-capture: Reset WGC fail flag for new window

### DIFF
--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -421,6 +421,7 @@ static void wc_tick(void *data, float seconds)
 			return;
 		}
 
+		wc->previously_failed = false;
 		reset_capture = true;
 
 	} else if (IsIconic(wc->window)) {


### PR DESCRIPTION
### Description
WGC will give up on a window that it fails to capture, but that
shouldn't stop it from attempting to capture new windows.

Fixes #2928.

### Motivation and Context
WGC was failing to capture relaunched applications.

### How Has This Been Tested?
Relaunched calculator as outlined in the issue.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.