### PR TITLE
UI: Rework TBar to replicate hardware video switchers

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -512,6 +512,7 @@ private:
 
 	QSlider *tBar;
 	bool tBarActive = false;
+	bool tBarSide = false;
 
 	OBSSource GetOverrideTransition(OBSSource source);
 	int GetOverrideTransitionDuration(OBSSource source);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
All hardware switchers that have a TBar function symmetrically. As in when you leave the TBar in the top position, it obviously stays there. This replicates that behavior.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This change is required in order to make #2927 (and indirectly [this](https://github.com/Palakis/obs-websocket/pull/439)) function properly. The old functionality of making it reset to position 0 after the transition completes makes external control incredibly difficult, since most control surfaces out there like MIDI return literal position data and not relative position data.

Video: https://gfycat.com/unluckyachingblackbuck

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with OBS 25.0.7 (nearly latest) on Ubuntu 20.04. Only affects TBar code.

- Did anything I could to break/desync the TBar by using the cursor, couldn't get anything to break. (Was using fix in #2930 )
- Used Behringer XTouch Mini, python script, and modified obs-websocket to control the TBar with the slider.  Functioned basically the same with no bugs found.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
