### PR TITLE
obs-x264: Log when options are ignored

### DIFF
--- a/plugins/obs-x264/CMakeLists.txt
+++ b/plugins/obs-x264/CMakeLists.txt
@@ -4,6 +4,18 @@ find_package(Libx264 REQUIRED)
 include_directories(${LIBX264_INCLUDE_DIRS})
 add_definitions(${LIBX264_DEFINITIONS})
 
+set(obs-x264-util_HEADERS
+	obs-x264-options.h)
+
+set(obs-x264-util_SOURCES
+	obs-x264-options.c)
+
+add_library(obs-x264-util STATIC
+	${obs-x264-util_HEADERS}
+	${obs-x264-util_SOURCES})
+target_link_libraries(obs-x264-util PRIVATE libobs)
+set_target_properties(obs-x264-util PROPERTIES FOLDER "plugins")
+
 set(obs-x264_SOURCES
 	obs-x264.c
 	obs-x264-plugin-main.c)
@@ -16,10 +28,17 @@ if(WIN32)
 endif()
 
 add_library(obs-x264 MODULE
+	${obs-x264_HEADERS}
 	${obs-x264_SOURCES})
 target_link_libraries(obs-x264
 	libobs
+	obs-x264-util
 	${LIBX264_LIBRARIES})
 set_target_properties(obs-x264 PROPERTIES FOLDER "plugins")
 
 install_obs_plugin_with_data(obs-x264 data)
+
+add_executable(obs-x264-test obs-x264-test.c)
+set_target_properties(obs-x264-test PROPERTIES FOLDER "plugins")
+target_link_libraries(obs-x264-test PRIVATE libobs obs-x264-util)
+add_test(NAME obs-x264-test COMMAND obs-x264-test)

--- a/plugins/obs-x264/obs-x264-options.c
+++ b/plugins/obs-x264/obs-x264-options.c
@@ -1,0 +1,60 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <util/bmem.h>
+#include <util/dstr.h>
+#include "obs-x264-options.h"
+
+static bool getparam(const char *param, char **name, const char **value)
+{
+	const char *assign;
+
+	if (!param || !*param || (*param == '='))
+		return false;
+
+	assign = strchr(param, '=');
+	if (!assign || !*assign || !*(assign + 1))
+		return false;
+
+	*name = bstrdup_n(param, assign - param);
+	*value = assign + 1;
+	return true;
+}
+
+struct obs_x264_options obs_x264_parse_options(const char *options_string)
+{
+	char **input_words = strlist_split(options_string, ' ', false);
+	if (!input_words) {
+		return (struct obs_x264_options){
+			.count = 0,
+			.options = NULL,
+			.input_words = NULL,
+		};
+	}
+	size_t input_option_count = 0;
+	for (char **input_word = input_words; *input_word; ++input_word)
+		input_option_count += 1;
+	struct obs_x264_option *out_options =
+		bmalloc(input_option_count * sizeof(*out_options));
+	struct obs_x264_option *out_option = out_options;
+	for (char **input_word = input_words; *input_word; ++input_word) {
+		if (getparam(*input_word, &out_option->name,
+			     &out_option->value)) {
+			++out_option;
+		}
+	}
+	return (struct obs_x264_options){
+		.count = out_option - out_options,
+		.options = out_options,
+		.input_words = input_words,
+	};
+}
+
+void obs_x264_free_options(struct obs_x264_options options)
+{
+	for (size_t i = 0; i < options.count; ++i) {
+		bfree(options.options[i].name);
+	}
+	strlist_free(options.input_words);
+}

--- a/plugins/obs-x264/obs-x264-options.h
+++ b/plugins/obs-x264/obs-x264-options.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stddef.h>
+
+struct obs_x264_option {
+	char *name;
+	char *value;
+};
+
+struct obs_x264_options {
+	size_t count;
+	struct obs_x264_option *options;
+	char **input_words;
+};
+
+struct obs_x264_options obs_x264_parse_options(const char *options_string);
+void obs_x264_free_options(struct obs_x264_options options);

--- a/plugins/obs-x264/obs-x264-options.h
+++ b/plugins/obs-x264/obs-x264-options.h
@@ -10,6 +10,8 @@ struct obs_x264_option {
 struct obs_x264_options {
 	size_t count;
 	struct obs_x264_option *options;
+	size_t ignored_word_count;
+	char **ignored_words;
 	char **input_words;
 };
 

--- a/plugins/obs-x264/obs-x264-test.c
+++ b/plugins/obs-x264/obs-x264-test.c
@@ -1,0 +1,65 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "obs-x264-options.h"
+
+#define CHECK(condition)                                                    \
+	do {                                                                \
+		if (!(condition)) {                                         \
+			fprintf(stderr, "%s:%d: error: check failed: %s\n", \
+				__FILE__, __LINE__, #condition);            \
+			exit(1);                                            \
+		}                                                           \
+	} while (0)
+
+static void test_obs_x264_parse_options()
+{
+	struct obs_x264_options options;
+
+	options = obs_x264_parse_options(NULL);
+	CHECK(options.count == 0);
+	obs_x264_free_options(options);
+
+	options = obs_x264_parse_options("");
+	CHECK(options.count == 0);
+	obs_x264_free_options(options);
+
+	options = obs_x264_parse_options("ref=3");
+	CHECK(options.count == 1);
+	CHECK(strcmp(options.options[0].name, "ref") == 0);
+	CHECK(strcmp(options.options[0].value, "3") == 0);
+	obs_x264_free_options(options);
+
+	options = obs_x264_parse_options("ref=3 bframes=8");
+	CHECK(options.count == 2);
+	CHECK(strcmp(options.options[0].name, "ref") == 0);
+	CHECK(strcmp(options.options[0].value, "3") == 0);
+	CHECK(strcmp(options.options[1].name, "bframes") == 0);
+	CHECK(strcmp(options.options[1].value, "8") == 0);
+	obs_x264_free_options(options);
+
+	// Invalid options are dropped.
+	options = obs_x264_parse_options(
+		"ref=3 option_with_no_equal_sign bframes=8");
+	CHECK(options.count == 2);
+	CHECK(strcmp(options.options[0].name, "ref") == 0);
+	CHECK(strcmp(options.options[0].value, "3") == 0);
+	CHECK(strcmp(options.options[1].name, "bframes") == 0);
+	CHECK(strcmp(options.options[1].value, "8") == 0);
+	obs_x264_free_options(options);
+
+	// Extra whitespace is ignored between and around options.
+	options = obs_x264_parse_options("  ref=3   bframes=8  ");
+	CHECK(options.count == 2);
+	CHECK(strcmp(options.options[0].name, "ref") == 0);
+	CHECK(strcmp(options.options[0].value, "3") == 0);
+	CHECK(strcmp(options.options[1].name, "bframes") == 0);
+	CHECK(strcmp(options.options[1].value, "8") == 0);
+	obs_x264_free_options(options);
+}
+
+int main()
+{
+	test_obs_x264_parse_options();
+	return 0;
+}

--- a/plugins/obs-x264/obs-x264-test.c
+++ b/plugins/obs-x264/obs-x264-test.c
@@ -18,16 +18,19 @@ static void test_obs_x264_parse_options()
 
 	options = obs_x264_parse_options(NULL);
 	CHECK(options.count == 0);
+	CHECK(options.ignored_word_count == 0);
 	obs_x264_free_options(options);
 
 	options = obs_x264_parse_options("");
 	CHECK(options.count == 0);
+	CHECK(options.ignored_word_count == 0);
 	obs_x264_free_options(options);
 
 	options = obs_x264_parse_options("ref=3");
 	CHECK(options.count == 1);
 	CHECK(strcmp(options.options[0].name, "ref") == 0);
 	CHECK(strcmp(options.options[0].value, "3") == 0);
+	CHECK(options.ignored_word_count == 0);
 	obs_x264_free_options(options);
 
 	options = obs_x264_parse_options("ref=3 bframes=8");
@@ -36,16 +39,21 @@ static void test_obs_x264_parse_options()
 	CHECK(strcmp(options.options[0].value, "3") == 0);
 	CHECK(strcmp(options.options[1].name, "bframes") == 0);
 	CHECK(strcmp(options.options[1].value, "8") == 0);
+	CHECK(options.ignored_word_count == 0);
 	obs_x264_free_options(options);
 
-	// Invalid options are dropped.
+	// Invalid options are ignored.
 	options = obs_x264_parse_options(
-		"ref=3 option_with_no_equal_sign bframes=8");
+		"ref=3 option_with_no_equal_sign bframes=8 1234");
 	CHECK(options.count == 2);
 	CHECK(strcmp(options.options[0].name, "ref") == 0);
 	CHECK(strcmp(options.options[0].value, "3") == 0);
 	CHECK(strcmp(options.options[1].name, "bframes") == 0);
 	CHECK(strcmp(options.options[1].value, "8") == 0);
+	CHECK(options.ignored_word_count == 2);
+	CHECK(strcmp(options.ignored_words[0], "option_with_no_equal_sign") ==
+	      0);
+	CHECK(strcmp(options.ignored_words[1], "1234") == 0);
 	obs_x264_free_options(options);
 
 	// Extra whitespace is ignored between and around options.
@@ -55,6 +63,7 @@ static void test_obs_x264_parse_options()
 	CHECK(strcmp(options.options[0].value, "3") == 0);
 	CHECK(strcmp(options.options[1].name, "bframes") == 0);
 	CHECK(strcmp(options.options[1].value, "8") == 0);
+	CHECK(options.ignored_word_count == 0);
 	obs_x264_free_options(options);
 }
 

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -510,6 +510,9 @@ static void update_params(struct obs_x264 *obsx264, obs_data_t *settings,
 	else
 		obsx264->params.i_csp = X264_CSP_NV12;
 
+	for (size_t i = 0; i < options->ignored_word_count; ++i)
+		warn("ignoring invalid x264 option: %s",
+		     options->ignored_words[i]);
 	for (size_t i = 0; i < options->count; ++i)
 		set_param(obsx264, options->options[i]);
 


### PR DESCRIPTION
### Description

OBS' x264 plugin has a text field for entering x264 options. The error reporting for this text field is bad. These patches improve the error reporting by printing more useful messages to the log file.

Before:

    15:25:30.435: [x264 encoder: 'streaming_h264'] preset: veryslow
    15:25:30.435: [x264 encoder: 'streaming_h264'] tune: zerolatency
    15:25:30.435: [x264 encoder: 'streaming_h264'] x264 param: --bad=stuff failed
    15:25:30.435: [x264 encoder: 'streaming_h264'] settings:
    15:25:30.435:       rate_control: CBR
    15:25:30.435:       bitrate:      1050
    15:25:30.435:       buffer size:  1050
    15:25:30.435:       crf:          0
    15:25:30.435:       fps_num:      15
    15:25:30.435:       fps_den:      1
    15:25:30.435:       width:        1920
    15:25:30.435:       height:       1080
    15:25:30.435:       keyint:       60
    15:25:30.435: 
    15:25:30.435: [x264 encoder: 'streaming_h264'] custom settings: ref=4 --bad=stuff sliced-threads

After:

    15:15:50.311: [x264 encoder: 'streaming_h264'] preset: veryslow
    15:15:50.311: [x264 encoder: 'streaming_h264'] tune: zerolatency
    15:15:50.312: [x264 encoder: 'streaming_h264'] ignoring invalid x264 option: sliced-threads
    15:15:50.312: [x264 encoder: 'streaming_h264'] x264 param: --bad=stuff failed
    15:15:50.312: [x264 encoder: 'streaming_h264'] settings:
    15:15:50.312:       rate_control: CBR
    15:15:50.312:       bitrate:      1050
    15:15:50.312:       buffer size:  1050
    15:15:50.312:       crf:          0
    15:15:50.312:       fps_num:      15
    15:15:50.312:       fps_den:      1
    15:15:50.312:       width:        1920
    15:15:50.312:       height:       1080
    15:15:50.312:       keyint:       60
    15:15:50.312: 
    15:15:50.313: [x264 encoder: 'streaming_h264'] custom settings: 
    15:15:50.313:       ref = 4
    15:15:50.313:       --bad = stuff

### Motivation and Context

Editing x264 options is error-prone. Improving the user experience will prevent some mistakes from happening.

### How Has This Been tested?

On Windows 10, x64, Debug:

* Run obs-x264-test. Ensure it exits with an exit code of 0.
* Stream to Twitch.tv with a mix of good and bad x264 options: "ref=4 --bad=stuff sliced-threads". Ensure the good option (ref=4) is used [1] and the bad options (--bad=stuff and sliced-threads) are logged to the log file (see description above).

[1] On my Amazon Fire TV with the Twitch app, streaming with preset=veryslow with no other options shows a black screen. With ref=4, the stream is visible on my Fire TV. (Both of these behaviors do not change with this patch.)

### Types of changes

* New feature (non-breaking change which adds functionality)
* Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
