### PR TITLE
UI: Add optional auto crash reporting

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -93,6 +93,8 @@ Windowed="Windowed"
 Percent="Percent"
 AspectRatio="Aspect Ratio <b>%1:%2</b>"
 LockVolume="Lock Volume"
+Crashed="OBS has crashed"
+PreviouslyCrashed="Looks like OBS has previously crashed. Would you like to upload the crash log to the OBS developers?"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"
@@ -145,6 +147,8 @@ BandwidthTest.Region.Other="Other"
 # first time startup
 Basic.FirstStartup.RunWizard="Would you like to run the auto-configuration wizard? You can also manually configure your settings by clicking the Settings button in the main window."
 Basic.FirstStartup.RunWizard.NoClicked="If you change your mind, you can run the auto-configuration wizard any time again from the Tools menu."
+Basic.FirstStartup.AutoReportCrashes="Would you like to automatically send crash logs to the OBS developers?"
+Basic.FirstStartup.AutoReportCrashes.Title="Report Crashes"
 
 # auto config wizard
 Basic.AutoConfig="Auto-Configuration Wizard"
@@ -632,6 +636,7 @@ Basic.Settings.General="General"
 Basic.Settings.General.Theme="Theme"
 Basic.Settings.General.Language="Language"
 Basic.Settings.General.EnableAutoUpdates="Automatically check for updates on startup"
+Basic.Settings.General.CrashAutoUpload="Automatically send crash logs to OBS developers"
 Basic.Settings.General.OpenStatsOnStartup="Open stats dialog on startup"
 Basic.Settings.General.WarnBeforeStartingStream="Show confirmation dialog when starting streams"
 Basic.Settings.General.WarnBeforeStoppingStream="Show confirmation dialog when stopping streams"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -151,8 +151,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>803</width>
-              <height>1026</height>
+              <width>805</width>
+              <height>1349</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -238,10 +238,17 @@
                      </property>
                     </widget>
                    </item>
-                   <item row="3" column="1">
+                   <item row="4" column="1">
                     <widget class="QCheckBox" name="openStatsOnStartup">
                      <property name="text">
                       <string>Basic.Settings.General.OpenStatsOnStartup</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="1">
+                    <widget class="QCheckBox" name="crashAutoUpload">
+                     <property name="text">
+                      <string>Basic.Settings.General.CrashAutoUpload</string>
                      </property>
                     </widget>
                    </item>
@@ -1263,8 +1270,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>603</width>
-              <height>631</height>
+              <width>732</width>
+              <height>813</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -2395,7 +2402,7 @@
                                  <rect>
                                   <x>9</x>
                                   <y>0</y>
-                                  <width>236</width>
+                                  <width>249</width>
                                   <height>25</height>
                                  </rect>
                                 </property>
@@ -3758,8 +3765,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>555</width>
-              <height>469</height>
+              <width>682</width>
+              <height>657</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_50">
@@ -4567,8 +4574,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>98</width>
-           <height>28</height>
+           <width>96</width>
+           <height>26</height>
           </rect>
          </property>
          <layout class="QFormLayout" name="hotkeyLayout">
@@ -4614,8 +4621,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>596</width>
-              <height>781</height>
+              <width>718</width>
+              <height>1037</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_23">

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1891,6 +1891,27 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 	"Woops, OBS has crashed!\n\nWould you like to copy the crash log " \
 	"to the clipboard? The crash log will still be saved to:\n\n%s"
 
+// Make OBS know it has previously crashed when started up again
+static void generate_crash_file()
+{
+	string name = "obs-studio/crashes/obs-crashed.txt";
+	BPtr<char> path(GetConfigPathPtr(name.c_str()));
+
+	fstream file;
+
+#ifdef _WIN32
+	BPtr<wchar_t> wpath;
+	os_utf8_to_wcs_ptr(path, 0, &wpath);
+	file.open(wpath, ios_base::in | ios_base::out | ios_base::trunc |
+				 ios_base::binary);
+#else
+	file.open(path, ios_base::in | ios_base::out | ios_base::trunc |
+				ios_base::binary);
+#endif
+	file << "OBS has crashed";
+	file.close();
+}
+
 static void main_crash_handler(const char *format, va_list args, void *param)
 {
 	char *text = new char[MAX_CRASH_REPORT_SIZE];
@@ -1920,6 +1941,8 @@ static void main_crash_handler(const char *format, va_list args, void *param)
 #endif
 	file << text;
 	file.close();
+
+	generate_crash_file();
 
 	string pathString(path.Get());
 

--- a/UI/remote-text.cpp
+++ b/UI/remote-text.cpp
@@ -88,9 +88,9 @@ void RemoteTextThread::run()
 
 		code = curl_easy_perform(curl.get());
 		if (code != CURLE_OK) {
-			emit Result(QString(), QT_UTF8(error));
+			emit Result(QString(), QT_UTF8(error), automatic);
 		} else {
-			emit Result(QT_UTF8(str.c_str()), QString());
+			emit Result(QT_UTF8(str.c_str()), QString(), automatic);
 		}
 
 		curl_slist_free_all(header);

--- a/UI/remote-text.hpp
+++ b/UI/remote-text.hpp
@@ -31,21 +31,24 @@ class RemoteTextThread : public QThread {
 	std::vector<std::string> extraHeaders;
 
 	int timeoutSec = 0;
+	bool automatic = false;
 
 	void run() override;
 
 signals:
-	void Result(const QString &text, const QString &error);
+	void Result(const QString &text, const QString &error,
+		    const bool &automatic);
 
 public:
 	inline RemoteTextThread(std::string url_,
 				std::string contentType_ = std::string(),
 				std::string postData_ = std::string(),
-				int timeoutSec_ = 0)
+				bool automatic_ = false, int timeoutSec_ = 0)
 		: url(url_),
 		  contentType(contentType_),
 		  postData(postData_),
-		  timeoutSec(timeoutSec_)
+		  timeoutSec(timeoutSec_),
+		  automatic(automatic_)
 	{
 	}
 
@@ -53,12 +56,13 @@ public:
 				std::vector<std::string> &&extraHeaders_,
 				std::string contentType_ = std::string(),
 				std::string postData_ = std::string(),
-				int timeoutSec_ = 0)
+				bool automatic_ = false, int timeoutSec_ = 0)
 		: url(url_),
 		  contentType(contentType_),
 		  postData(postData_),
 		  extraHeaders(std::move(extraHeaders_)),
-		  timeoutSec(timeoutSec_)
+		  timeoutSec(timeoutSec_),
+		  automatic(automatic_)
 	{
 	}
 };

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -292,7 +292,9 @@ private:
 	void UpdateVolumeControlsPeakMeterType();
 	void ClearVolumeControls();
 
-	void UploadLog(const char *subdir, const char *file);
+	void UploadLog(const char *subdir, const char *file,
+		       bool automatic = false);
+	void UploadCrashLog();
 
 	void Save(const char *file);
 	void Load(const char *file);
@@ -922,7 +924,8 @@ private slots:
 
 	void PauseToggled();
 
-	void logUploadFinished(const QString &text, const QString &error);
+	void logUploadFinished(const QString &text, const QString &error,
+			       const bool &automatic);
 
 	void updateCheckFinished();
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -335,6 +335,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->language,             COMBO_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->theme, 		     COMBO_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->enableAutoUpdates,    CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->crashAutoUpload,      CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->openStatsOnStartup,   CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStart,CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStop, CHECK_CHANGED,  GENERAL_CHANGED);
@@ -604,6 +605,11 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	delete ui->resetOSXVSync;
 	ui->disableOSXVSync = nullptr;
 	ui->resetOSXVSync = nullptr;
+#endif
+
+#ifndef _WIN32
+	delete ui->crashAutoUpload;
+	ui->crashAutoUpload = nullptr;
 #endif
 
 	connect(ui->streamDelaySec, SIGNAL(valueChanged(int)), this,
@@ -1115,6 +1121,13 @@ void OBSBasicSettings::LoadGeneralSettings()
 						 "EnableAutoUpdates");
 	ui->enableAutoUpdates->setChecked(enableAutoUpdates);
 #endif
+
+#if defined(_WIN32)
+	bool crashAutoUpload = config_get_bool(GetGlobalConfig(), "General",
+					       "AutoReportCrashes");
+	ui->crashAutoUpload->setChecked(crashAutoUpload);
+#endif
+
 	bool openStatsOnStartup = config_get_bool(main->Config(), "General",
 						  "OpenStatsOnStartup");
 	ui->openStatsOnStartup->setChecked(openStatsOnStartup);
@@ -2842,6 +2855,14 @@ void OBSBasicSettings::SaveGeneralSettings()
 				"EnableAutoUpdates",
 				ui->enableAutoUpdates->isChecked());
 #endif
+
+#if defined(_WIN32)
+	if (WidgetChanged(ui->crashAutoUpload))
+		config_set_bool(GetGlobalConfig(), "General",
+				"AutoReportCrashes",
+				ui->crashAutoUpload->isChecked());
+#endif
+
 	if (WidgetChanged(ui->openStatsOnStartup))
 		config_set_bool(main->Config(), "General", "OpenStatsOnStartup",
 				ui->openStatsOnStartup->isChecked());


### PR DESCRIPTION
### Description
This is an opt-in feature to automatically upload crash logs to OBS developers. When OBS is started for the first time, there is a dialog to ask if the user would like to opt-in to the reporting. There is also an option in the settings to enable/disable.

### Motivation and Context
Makes it easier for developers to know about crashes that are happening.

### How Has This Been Tested?
Needs actual real world testing.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
