### PR TITLE
UI: Hide script tabs if no python settings

### DIFF
--- a/UI/frontend-plugins/frontend-tools/forms/scripts.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/scripts.ui
@@ -19,6 +19,9 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
+     <property name="tabBarAutoHide">
+      <bool>true</bool>
+     </property>
      <widget class="QWidget" name="scriptsTab">
       <attribute name="title">
        <string>Scripts</string>

--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -192,6 +192,7 @@ ScriptsTool::ScriptsTool() : QWidget(nullptr), ui(new Ui_ScriptsTool)
 #else
 	delete ui->pythonSettingsTab;
 	ui->pythonSettingsTab = nullptr;
+	ui->tabWidget->setStyleSheet("QTabWidget::pane {border: 0;}");
 #endif
 
 	delete propertiesView;


### PR DESCRIPTION
### Description
Hide script tab bar when there are no Python settings.

Before:
![Screenshot_20200518_025215](https://user-images.githubusercontent.com/19962531/82187989-ced6b680-98b2-11ea-8896-d62188f88841.png)

After:
![Screenshot_20200518_024427](https://user-images.githubusercontent.com/19962531/82188011-d7c78800-98b2-11ea-8a8b-c6f20b033cab.png)

### Motivation and Context
Makes the dialog visually look better.

### How Has This Been Tested?
Opened scripts dialog to see if tab were hidden as expected.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
