### PR TITLE
UI: Test OBSPropertiesView

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -366,14 +366,39 @@ set(obs_QRC
 qt5_wrap_ui(obs_UI_HEADERS ${obs_UI})
 qt5_add_resources(obs_QRC_SOURCES ${obs_QRC})
 
-add_executable(obs WIN32
-	obs.manifest
+add_library(obs-lib STATIC
 	${obs_SOURCES}
 	${obs_HEADERS}
 	${obs_importers_SOURCES}
 	${obs_importers_HEADERS}
 	${obs_UI_HEADERS}
 	${obs_QRC_SOURCES})
+
+target_link_libraries(obs-lib
+	PUBLIC
+	libobs
+	Qt5::Widgets
+	Qt5::Svg
+	Qt5::Xml
+	obs-frontend-api
+	${FFMPEG_LIBRARIES}
+	${LIBCURL_LIBRARIES}
+	${obs_PLATFORM_LIBRARIES})
+
+if (APPLE)
+	target_link_libraries(obs-lib
+			PUBLIC
+			Qt5::MacExtras)
+endif()
+set_target_properties(obs-lib PROPERTIES FOLDER "frontend")
+define_graphic_modules(obs-lib)
+
+add_executable(obs WIN32
+	obs.manifest
+	obs-app-main.cpp)
+set_target_properties(obs PROPERTIES AUTOMOC FALSE)
+set_target_properties(obs PROPERTIES FOLDER "frontend")
+target_link_libraries(obs PRIVATE obs-lib)
 
 if(WIN32)
 	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -387,24 +412,9 @@ if(WIN32)
 			OUTPUT_NAME "obs${_output_suffix}")
 endif()
 
-target_link_libraries(obs
-	libobs
-	Qt5::Widgets
-	Qt5::Svg
-	Qt5::Xml
-	obs-frontend-api
-	${FFMPEG_LIBRARIES}
-	${LIBCURL_LIBRARIES}
-	${obs_PLATFORM_LIBRARIES})
-
 if (APPLE)
-	target_link_libraries(obs
-			Qt5::MacExtras)
 	set_target_properties(obs PROPERTIES LINK_FLAGS "-pagezero_size 10000 -image_base 100000000")
 endif()
-set_target_properties(obs PROPERTIES FOLDER "frontend")
-
-define_graphic_modules(obs)
 
 install_obs_core(obs)
 install_obs_data(obs data obs-studio)

--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -3,8 +3,10 @@ if(DISABLE_UI)
 	return()
 elseif(ENABLE_UI)
 	set(FIND_MODE REQUIRED)
+	set(TEST_FIND_MODE)
 else()
 	set(FIND_MODE QUIET)
+	set(TEST_FIND_MODE QUIET)
 endif()
 
 if(BROWSER_AVAILABLE_INTERNAL)
@@ -57,6 +59,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 set(CMAKE_AUTOMOC TRUE)
 
 find_package(Qt5Svg ${FIND_MODE})
+find_package(Qt5Test ${TEST_FIND_MODE})
 find_package(Qt5Xml ${FIND_MODE})
 
 find_package(FFmpeg REQUIRED COMPONENTS avcodec avutil avformat)
@@ -419,6 +422,17 @@ endif()
 install_obs_core(obs)
 install_obs_data(obs data obs-studio)
 install_obs_data_file(obs ../AUTHORS obs-studio/authors)
+
+if (TARGET Qt5::Test)
+	add_executable(obs-properties-view-test
+		properties-view-test.cpp)
+	target_link_libraries(obs-properties-view-test PRIVATE Qt5::Test obs-lib)
+	set_target_properties(obs-properties-view-test PROPERTIES FOLDER "frontend")
+	set(RUNDIR "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/bin/${OBS_OUTPUT_DIR_BIT_SUFFIX}")
+	set_target_properties(obs-properties-view-test PROPERTIES VS_DEBUGGER_ENVIRONMENT
+		"PATH=${Qt5Core_DIR}/../../../bin;${RUNDIR};$(PATH)
+QT_PLUGIN_PATH=${RUNDIR}")
+endif()
 
 if (UNIX AND UNIX_STRUCTURE AND NOT APPLE)
 	add_subdirectory(xdg-data)

--- a/UI/obs-app-main.cpp
+++ b/UI/obs-app-main.cpp
@@ -1,0 +1,6 @@
+#include "obs-app.hpp"
+
+int main(int argc, char *argv[])
+{
+	return obs_main(argc, argv);
+}

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2339,7 +2339,7 @@ void ctrlc_handler(int s)
 	main->close();
 }
 
-int main(int argc, char *argv[])
+int obs_main(int argc, char *argv[])
 {
 #ifndef _WIN32
 	signal(SIGPIPE, SIG_IGN);

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1111,19 +1111,23 @@ OBSApp::OBSApp(int &argc, char **argv, profiler_name_store_t *store)
 OBSApp::~OBSApp()
 {
 #ifdef _WIN32
-	bool disableAudioDucking =
-		config_get_bool(globalConfig, "Audio", "DisableAudioDucking");
-	if (disableAudioDucking)
-		DisableAudioDucking(false);
+	if (globalConfig) {
+		bool disableAudioDucking = config_get_bool(
+			globalConfig, "Audio", "DisableAudioDucking");
+		if (disableAudioDucking)
+			DisableAudioDucking(false);
+	}
 #endif
 
 #ifdef __APPLE__
-	bool vsyncDiabled =
-		config_get_bool(globalConfig, "Video", "DisableOSXVSync");
-	bool resetVSync =
-		config_get_bool(globalConfig, "Video", "ResetOSXVSyncOnExit");
-	if (vsyncDiabled && resetVSync)
-		EnableOSXVSync(true);
+	if (globalConfig) {
+		bool vsyncDiabled = config_get_bool(globalConfig, "Video",
+						    "DisableOSXVSync");
+		bool resetVSync = config_get_bool(globalConfig, "Video",
+						  "ResetOSXVSyncOnExit");
+		if (vsyncDiabled && resetVSync)
+			EnableOSXVSync(true);
+	}
 #endif
 
 	os_inhibit_sleep_set_active(sleepInhibitor, false);

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -182,6 +182,8 @@ signals:
 	void StyleChanged();
 };
 
+int obs_main(int argc, char *argv[]);
+
 int GetConfigPath(char *path, size_t size, const char *name);
 char *GetConfigPathPtr(const char *name);
 

--- a/UI/properties-view-test.cpp
+++ b/UI/properties-view-test.cpp
@@ -1,0 +1,167 @@
+#include <QtTest/QtTest>
+#include <qformlayout.h>
+#include <qlabel.h>
+#include <qlineedit.h>
+#include <qobject.h>
+#include "obs-app.hpp"
+#include "obs-data.h"
+#include "obs-properties.h"
+#include "properties-view.hpp"
+
+class TestPropertiesView : public QObject {
+	Q_OBJECT
+
+private slots:
+	void noPropertiesCreatesNoWidgets()
+	{
+		OBSPropertiesView view =
+			makeView(obs_data_create(), [](obs_properties_t *) {});
+		view.dumpObjectTree();
+
+		QFormLayout *form =
+			view.findChild<QFormLayout *>("properties-form");
+		QVERIFY(form);
+		QCOMPARE(form->rowCount(), 1);
+		QLabel *noPropertiesLabel =
+			qobject_cast<QLabel *>(form->itemAt(0)->widget());
+		QVERIFY(noPropertiesLabel);
+		QCOMPARE(noPropertiesLabel->text(),
+			 QTStr("Basic.PropertiesWindow.NoProperties"));
+	}
+
+	void textProperty()
+	{
+		OBSPropertiesView view = makeView(
+			obs_data_create(), [](obs_properties_t *properties) {
+				obs_properties_add_text(properties,
+							"test-text-option",
+							"Test Option",
+							OBS_TEXT_DEFAULT);
+			});
+		view.dumpObjectTree();
+
+		QFormLayout *form =
+			view.findChild<QFormLayout *>("properties-form");
+		QVERIFY(form);
+		QCOMPARE(form->rowCount(), 1);
+
+		QLabel *propertyLabel =
+			qobject_cast<QLabel *>(form->itemAt(0)->widget());
+		QVERIFY(propertyLabel);
+		QCOMPARE(propertyLabel->text(), QString("Test Option"));
+
+		QLineEdit *propertyEditor =
+			qobject_cast<QLineEdit *>(form->itemAt(1)->widget());
+		QVERIFY(propertyEditor);
+	}
+
+	void textPropertyLoadsValueFromSettings()
+	{
+		OBSData settings = obs_data_create_from_json(
+			R"({"test-option": "initial value"})");
+		OBSPropertiesView view =
+			makeView(settings, [](obs_properties_t *properties) {
+				obs_properties_add_text(properties,
+							"test-option",
+							"Test Option",
+							OBS_TEXT_DEFAULT);
+			});
+		view.dumpObjectTree();
+
+		QLineEdit *propertyEditor = view.findChild<QLineEdit *>();
+		QVERIFY(propertyEditor);
+		QCOMPARE(propertyEditor->text(), QString("initial value"));
+	}
+
+	void textPropertyReloadsValueFromSettings()
+	{
+		OBSData settings = obs_data_create_from_json(
+			R"({"test-option": "initial value"})");
+		OBSPropertiesView view =
+			makeView(settings, [](obs_properties_t *properties) {
+				obs_properties_add_text(properties,
+							"test-option",
+							"Test Option",
+							OBS_TEXT_DEFAULT);
+			});
+		view.dumpObjectTree();
+
+		obs_data_set_string(settings, "test-option", "updated value");
+		view.ReloadProperties();
+		view.dumpObjectTree();
+
+		QLineEdit *propertyEditor = view.findChild<QLineEdit *>();
+		QVERIFY(propertyEditor);
+		QCOMPARE(propertyEditor->text(), QString("updated value"));
+	}
+
+	void editingTextPropertySavesToSettings()
+	{
+		OBSData settings = obs_data_create_from_json(
+			R"({"test-option": "initial value"})");
+		OBSPropertiesView view =
+			makeView(settings, [](obs_properties_t *properties) {
+				obs_properties_add_text(properties,
+							"test-option",
+							"Test Option",
+							OBS_TEXT_DEFAULT);
+			});
+		view.dumpObjectTree();
+
+		QLineEdit *propertyEditor = view.findChild<QLineEdit *>();
+		QVERIFY(propertyEditor);
+		propertyEditor->selectAll();
+		QTest::keyClicks(propertyEditor, "updated value");
+		QCOMPARE(obs_data_get_string(settings, "test-option"),
+			 "updated value");
+	}
+
+	void cleanup() { viewClosures.clear(); }
+
+private:
+	struct ViewClosure {
+		virtual ~ViewClosure() = default;
+	};
+
+	template<class PropertiesBuilder>
+	OBSPropertiesView makeView(OBSData settings,
+				   PropertiesBuilder buildProperties)
+	{
+		struct Closure : public ViewClosure {
+			explicit Closure(PropertiesBuilder buildProperties)
+				: buildProperties(std::move(buildProperties))
+			{
+			}
+
+			static obs_properties_t *ReloadCallback(void *obj)
+			{
+				Closure *closure = static_cast<Closure *>(obj);
+				obs_properties_t *properties =
+					obs_properties_create();
+				closure->buildProperties(properties);
+				return properties;
+			}
+
+			static void UpdateCallback(void *, obs_data_t *) {}
+
+			PropertiesBuilder buildProperties;
+		};
+		viewClosures.emplace_back(
+			std::make_unique<Closure>(buildProperties));
+		return OBSPropertiesView(settings, viewClosures.back().get(),
+					 Closure::ReloadCallback,
+					 Closure::UpdateCallback);
+	}
+
+	std::vector<std::unique_ptr<ViewClosure>> viewClosures;
+};
+
+int main(int argc, char *argv[])
+{
+	QTEST_SET_MAIN_SOURCE_PATH
+	OBSApp app(argc, argv, nullptr);
+	TestPropertiesView test;
+	return QTest::qExec(&test, argc, argv);
+}
+
+#include "properties-view-test.moc"

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -110,6 +110,7 @@ void OBSPropertiesView::RefreshProperties()
 	widget = new QWidget();
 
 	QFormLayout *layout = new QFormLayout;
+	layout->setObjectName("properties-form");
 	layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
 	widget->setLayout(layout);
 

--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -12,6 +12,12 @@ else()
 	set(_struct_def TRUE)
 endif()
 
+if(APPLE)
+	set(OBS_OUTPUT_DIR_BIT_SUFFIX "")
+else()
+	set(OBS_OUTPUT_DIR_BIT_SUFFIX "/${_lib_suffix}bit")
+endif()
+
 option(INSTALLER_RUN "Build a multiarch installer, needs to run indenepdently after both archs have compiled" FALSE)
 option(UNIX_STRUCTURE "Build with standard unix filesystem structure" ${_struct_def})
 if(APPLE)
@@ -347,16 +353,10 @@ function(install_obs_pdb ttype target)
 		return()
 	endif()
 
-	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-		set(_bit_suffix "64bit")
-	else()
-		set(_bit_suffix "32bit")
-	endif()
-
 	obs_debug_copy_helper(${target} "${CMAKE_CURRENT_BINARY_DIR}/pdbs")
 
 	if("${ttype}" STREQUAL "PLUGIN")
-		obs_debug_copy_helper(${target} "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/obs-plugins/${_bit_suffix}")
+		obs_debug_copy_helper(${target} "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/obs-plugins${OBS_OUTPUT_DIR_BIT_SUFFIX}")
 
 		if(DEFINED ENV{obsInstallerTempDir})
 			obs_debug_copy_helper(${target} "$ENV{obsInstallerTempDir}/${OBS_PLUGIN_DESTINATION}")
@@ -366,7 +366,7 @@ function(install_obs_pdb ttype target)
 			DESTINATION "${OBS_PLUGIN_DESTINATION}"
 			CONFIGURATIONS Debug RelWithDebInfo)
 	else()
-		obs_debug_copy_helper(${target} "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/bin/${_bit_suffix}")
+		obs_debug_copy_helper(${target} "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/bin${OBS_OUTPUT_DIR_BIT_SUFFIX}")
 
 		if(DEFINED ENV{obsInstallerTempDir})
 			obs_debug_copy_helper(${target} "$ENV{obsInstallerTempDir}/${OBS_EXECUTABLE_DESTINATION}")
@@ -379,14 +379,6 @@ function(install_obs_pdb ttype target)
 endfunction()
 
 function(install_obs_core target)
-	if(APPLE)
-		set(_bit_suffix "")
-	elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-		set(_bit_suffix "64bit/")
-	else()
-		set(_bit_suffix "32bit/")
-	endif()
-
 	if("${ARGV1}" STREQUAL "EXPORT")
 		export_obs_core("${target}" "${ARGV2}")
 	else()
@@ -398,7 +390,7 @@ function(install_obs_core target)
 	add_custom_command(TARGET ${target} POST_BUILD
 		COMMAND "${CMAKE_COMMAND}" -E copy
 			"$<TARGET_FILE:${target}>"
-			"${OBS_OUTPUT_DIR}/$<CONFIGURATION>/bin/${_bit_suffix}$<TARGET_FILE_NAME:${target}>"
+			"${OBS_OUTPUT_DIR}/$<CONFIGURATION>/bin${OBS_OUTPUT_DIR_BIT_SUFFIX}/$<TARGET_FILE_NAME:${target}>"
 		VERBATIM)
 
 	if(DEFINED ENV{obsInstallerTempDir})
@@ -421,14 +413,6 @@ endfunction()
 
 function(install_obs_bin target mode)
 	foreach(bin ${ARGN})
-		if(APPLE)
-			set(_bit_suffix "")
-		elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-			set(_bit_suffix "64bit/")
-		else()
-			set(_bit_suffix "32bit/")
-		endif()
-
 		if(NOT IS_ABSOLUTE "${bin}")
 			set(bin "${CMAKE_CURRENT_SOURCE_DIR}/${bin}")
 		endif()
@@ -439,7 +423,7 @@ function(install_obs_bin target mode)
 			add_custom_command(TARGET ${target} POST_BUILD
 				COMMAND "${CMAKE_COMMAND}" -E copy
 					"${bin}"
-					"${OBS_OUTPUT_DIR}/$<CONFIGURATION>/bin/${_bit_suffix}${fname}"
+					"${OBS_OUTPUT_DIR}/$<CONFIGURATION>/bin${OBS_OUTPUT_DIR_BIT_SUFFIX}/${fname}"
 				VERBATIM)
 		endif()
 
@@ -457,14 +441,6 @@ function(install_obs_bin target mode)
 endfunction()
 
 function(install_obs_plugin target)
-	if(APPLE)
-		set(_bit_suffix "")
-	elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-		set(_bit_suffix "64bit/")
-	else()
-		set(_bit_suffix "32bit/")
-	endif()
-
 	set_target_properties(${target} PROPERTIES
 		PREFIX "")
 
@@ -474,7 +450,7 @@ function(install_obs_plugin target)
 	add_custom_command(TARGET ${target} POST_BUILD
 		COMMAND "${CMAKE_COMMAND}" -E copy
 			"$<TARGET_FILE:${target}>"
-			"${OBS_OUTPUT_DIR}/$<CONFIGURATION>/obs-plugins/${_bit_suffix}$<TARGET_FILE_NAME:${target}>"
+			"${OBS_OUTPUT_DIR}/$<CONFIGURATION>/obs-plugins${OBS_OUTPUT_DIR_BIT_SUFFIX}/$<TARGET_FILE_NAME:${target}>"
 		VERBATIM)
 
 	if(DEFINED ENV{obsInstallerTempDir})

--- a/cmake/external/ObsPluginHelpers.cmake
+++ b/cmake/external/ObsPluginHelpers.cmake
@@ -38,44 +38,20 @@ endfunction()
 # 'target' is the destination target project being installed to
 # 'data_loc' specifies the directory of the data being installed
 function(install_external_plugin_arch_data target data_loc)
-	if(APPLE)
-		set(_bit_suffix "")
-	elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-		set(_bit_suffix "/64bit")
-	else()
-		set(_bit_suffix "/32bit")
-	endif()
-
-	install_external_plugin_data_internal(${target} ${data_loc} "data${_bit_suffix}")
+	install_external_plugin_data_internal(${target} ${data_loc} "data${OBS_OUTPUT_DIR_BIT_SUFFIX}")
 endfunction()
 
 # Installs data in the target's bin directory
 # 'target' is the destination target project being installed to
 # 'data_loc' specifies the directory of the data being installed
 function(install_external_plugin_data_to_bin target data_loc)
-	if(APPLE)
-		set(_bit_suffix "")
-	elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-		set(_bit_suffix "/64bit")
-	else()
-		set(_bit_suffix "/32bit")
-	endif()
-
-	install_external_plugin_data_internal(${target} ${data_loc} "bin${_bit_suffix}")
+	install_external_plugin_data_internal(${target} ${data_loc} "bin${OBS_OUTPUT_DIR_BIT_SUFFIX}")
 endfunction()
 
 # Installs an additional binary to a target
 # 'target' is the destination target project being installed to
 # 'additional_target' specifies the additional binary
 function(install_external_plugin_additional target additional_target)
-	if(APPLE)
-		set(_bit_suffix "")
-	elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-		set(_bit_suffix "64bit/")
-	else()
-		set(_bit_suffix "32bit/")
-	endif()
-
 	set_target_properties(${additional_target} PROPERTIES
 		PREFIX "")
 
@@ -85,7 +61,7 @@ function(install_external_plugin_additional target additional_target)
 	add_custom_command(TARGET ${additional_target} POST_BUILD
 		COMMAND "${CMAKE_COMMAND}" -E copy
 			"$<TARGET_FILE:${additional_target}>"
-			"${EXTERNAL_PLUGIN_OUTPUT_DIR}/$<CONFIGURATION>/${target}/bin/${_bit_suffix}$<TARGET_FILE_NAME:${additional_target}>"
+			"${EXTERNAL_PLUGIN_OUTPUT_DIR}/$<CONFIGURATION>/${target}/bin${OBS_OUTPUT_DIR_BIT_SUFFIX}/$<TARGET_FILE_NAME:${additional_target}>"
 		VERBATIM)
 endfunction()
 
@@ -120,21 +96,13 @@ endfunction()
 # 'target' is the destination target project being installed to
 # 'additional_target' specifies the additional binary
 function(install_external_plugin_bin_to_arch_data target additional_target)
-	if(APPLE)
-		set(_bit_suffix "")
-	elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-		set(_bit_suffix "/64bit")
-	else()
-		set(_bit_suffix "/32bit")
-	endif()
-
 	install(TARGETS ${additional_target}
-		LIBRARY DESTINATION "data${_bit_suffix}"
-		RUNTIME DESTINATION "data${_bit_suffix}")
+		LIBRARY DESTINATION "data${OBS_OUTPUT_DIR_BIT_SUFFIX}"
+		RUNTIME DESTINATION "data${OBS_OUTPUT_DIR_BIT_SUFFIX}")
 	add_custom_command(TARGET ${additional_target} POST_BUILD
 		COMMAND "${CMAKE_COMMAND}" -E copy
 			"$<TARGET_FILE:${additional_target}>"
-			"${EXTERNAL_PLUGIN_OUTPUT_DIR}/$<CONFIGURATION>/${target}/data${_bit_suffix}/$<TARGET_FILE_NAME:${additional_target}>"
+			"${EXTERNAL_PLUGIN_OUTPUT_DIR}/$<CONFIGURATION>/${target}/data${OBS_OUTPUT_DIR_BIT_SUFFIX}/$<TARGET_FILE_NAME:${additional_target}>"
 		VERBATIM)
 endfunction()
 
@@ -142,22 +110,14 @@ endfunction()
 # 'target' is the destination target project being installed to
 # 'additional_target' specifies the additional binary
 function(install_external_plugin_data_file_to_arch_data target additional_target file_target)
-	if(APPLE)
-		set(_bit_suffix "")
-	elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-		set(_bit_suffix "/64bit")
-	else()
-		set(_bit_suffix "/32bit")
-	endif()
-
 	get_filename_component(file_target_name ${file_target} NAME)
 
 	install(TARGETS ${additional_target}
-		LIBRARY DESTINATION "data${_bit_suffix}"
-		RUNTIME DESTINATION "data${_bit_suffix}")
+		LIBRARY DESTINATION "data${OBS_OUTPUT_DIR_BIT_SUFFIX}"
+		RUNTIME DESTINATION "data${OBS_OUTPUT_DIR_BIT_SUFFIX}")
 	add_custom_command(TARGET ${additional_target} POST_BUILD
 		COMMAND "${CMAKE_COMMAND}" -E copy
 			"${file_target}"
-			"${EXTERNAL_PLUGIN_OUTPUT_DIR}/$<CONFIGURATION>/${target}/data${_bit_suffix}/${file_target_name}"
+			"${EXTERNAL_PLUGIN_OUTPUT_DIR}/$<CONFIGURATION>/${target}/data${OBS_OUTPUT_DIR_BIT_SUFFIX}/${file_target_name}"
 		VERBATIM)
 endfunction()


### PR DESCRIPTION
### Description

Add some basic tests for OBSPropertiesView using the QTest framework.

### Motivation and Context

I want to make some changes to OBSPropertiesView. (In particular, I want to have OBSPropertiesView reuse widgets instead of deleting them and recreating them on every property refresh.) I like having the safety net of a test suite to catch mistakes.

### How Has This Been Tested?

On Windows 10, x64, Debug:

* Build the solution and run obs64.exe. Ensure it launches. Click the "Settings" button. Ensure the Settings window appears.
* Build and run the "obs-property-view-test" target. Ensure all 7 tests pass and that the program exits with an exit code of 0.

On Linux Mint, x86_64:

* Build and run the "obs-property-view-test" target. Ensure all 7 tests pass and that the program exits with an exit code of 0.

### Types of changes

* New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.


