### PR TITLE
UI: Allow drag & drop reorder of property lists

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -594,6 +594,13 @@ void OBSPropertiesView::AddEditableList(obs_property_t *prop,
 
 	WidgetInfo *info = new WidgetInfo(this, prop, list);
 
+	list->setDragDropMode(QAbstractItemView::InternalMove);
+	connect(list->model(),
+		SIGNAL(rowsMoved(QModelIndex, int, int, QModelIndex, int)),
+		info,
+		SLOT(EditListReordered(const QModelIndex &, int, int,
+				       const QModelIndex &, int)));
+
 	QVBoxLayout *sideLayout = new QVBoxLayout();
 	NewButton(sideLayout, info, "addIconSmall", &WidgetInfo::EditListAdd);
 	NewButton(sideLayout, info, "removeIconSmall",
@@ -1772,6 +1779,19 @@ void WidgetInfo::GroupChanged(const char *setting)
 	obs_data_set_bool(view->settings, setting,
 			  groupbox->isCheckable() ? groupbox->isChecked()
 						  : true);
+}
+
+void WidgetInfo::EditListReordered(const QModelIndex &parent, int start,
+				   int end, const QModelIndex &destination,
+				   int row)
+{
+	UNUSED_PARAMETER(parent);
+	UNUSED_PARAMETER(start);
+	UNUSED_PARAMETER(end);
+	UNUSED_PARAMETER(destination);
+	UNUSED_PARAMETER(row);
+
+	EditableListChanged();
 }
 
 void WidgetInfo::EditableListChanged()

--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -58,6 +58,8 @@ public slots:
 	void EditListEdit();
 	void EditListUp();
 	void EditListDown();
+	void EditListReordered(const QModelIndex &parent, int start, int end,
+			       const QModelIndex &destination, int row);
 };
 
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
### Description
Allow drag & drop reordering of property lists.

### Motivation and Context
Motivation is to easily reorder items in VLC source playlist.

### How Has This Been Tested?
Reordered items in VLC source playlist.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
