### PR TITLE
UI: Make select/deselect signals work w/ group items

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -151,6 +151,7 @@ void SourceTreeItem::DisconnectSignals()
 {
 	sceneRemoveSignal.Disconnect();
 	itemRemoveSignal.Disconnect();
+	selectSignal.Disconnect();
 	deselectSignal.Disconnect();
 	visibleSignal.Disconnect();
 	lockedSignal.Disconnect();
@@ -212,6 +213,16 @@ void SourceTreeItem::ReconnectSignals()
 						  Q_ARG(bool, locked));
 	};
 
+	auto itemSelect = [](void *data, calldata_t *cd) {
+		SourceTreeItem *this_ =
+			reinterpret_cast<SourceTreeItem *>(data);
+		obs_sceneitem_t *curItem =
+			(obs_sceneitem_t *)calldata_ptr(cd, "item");
+
+		if (curItem == this_->sceneitem)
+			QMetaObject::invokeMethod(this_, "Select");
+	};
+
 	auto itemDeselect = [](void *data, calldata_t *cd) {
 		SourceTreeItem *this_ =
 			reinterpret_cast<SourceTreeItem *>(data);
@@ -236,6 +247,8 @@ void SourceTreeItem::ReconnectSignals()
 	itemRemoveSignal.Connect(signal, "item_remove", removeItem, this);
 	visibleSignal.Connect(signal, "item_visible", itemVisible, this);
 	lockedSignal.Connect(signal, "item_locked", itemLocked, this);
+	selectSignal.Connect(signal, "item_select", itemSelect, this);
+	deselectSignal.Connect(signal, "item_deselect", itemDeselect, this);
 
 	if (obs_sceneitem_is_group(sceneitem)) {
 		obs_source_t *source = obs_sceneitem_get_source(sceneitem);
@@ -244,10 +257,6 @@ void SourceTreeItem::ReconnectSignals()
 		groupReorderSignal.Connect(signal, "reorder", reorderGroup,
 					   this);
 	}
-
-	if (scene != GetCurrentScene())
-		deselectSignal.Connect(signal, "item_deselect", itemDeselect,
-				       this);
 
 	/* --------------------------------------------------------- */
 
@@ -514,6 +523,11 @@ void SourceTreeItem::ExpandClicked(bool checked)
 		tree->GetStm()->ExpandGroup(sceneitem);
 	else
 		tree->GetStm()->CollapseGroup(sceneitem);
+}
+
+void SourceTreeItem::Select()
+{
+	tree->SelectItem(sceneitem, true);
 }
 
 void SourceTreeItem::Deselect()

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -70,6 +70,7 @@ private:
 	OBSSignal sceneRemoveSignal;
 	OBSSignal itemRemoveSignal;
 	OBSSignal groupReorderSignal;
+	OBSSignal selectSignal;
 	OBSSignal deselectSignal;
 	OBSSignal visibleSignal;
 	OBSSignal lockedSignal;
@@ -90,6 +91,7 @@ private slots:
 
 	void ExpandClicked(bool checked);
 
+	void Select();
 	void Deselect();
 };
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2580,11 +2580,6 @@ void OBSBasic::AddScene(OBSSource source)
 	container.handlers.assign({
 		std::make_shared<OBSSignal>(handler, "item_add",
 					    OBSBasic::SceneItemAdded, this),
-		std::make_shared<OBSSignal>(handler, "item_select",
-					    OBSBasic::SceneItemSelected, this),
-		std::make_shared<OBSSignal>(handler, "item_deselect",
-					    OBSBasic::SceneItemDeselected,
-					    this),
 		std::make_shared<OBSSignal>(handler, "reorder",
 					    OBSBasic::SceneReordered, this),
 		std::make_shared<OBSSignal>(handler, "refresh",
@@ -2752,16 +2747,6 @@ void OBSBasic::RenameSources(OBSSource source, QString newName,
 	obs_scene_t *scene = obs_scene_from_source(source);
 	if (scene)
 		OBSProjector::UpdateMultiviewProjectors();
-}
-
-void OBSBasic::SelectSceneItem(OBSScene scene, OBSSceneItem item, bool select)
-{
-	SignalBlocker sourcesSignalBlocker(ui->sources);
-
-	if (scene != GetCurrentScene() || ignoreSelectionUpdate)
-		return;
-
-	ui->sources->SelectItem(item, select);
 }
 
 static inline bool SourceMixerHidden(obs_source_t *source)
@@ -3361,31 +3346,6 @@ void OBSBasic::SceneItemAdded(void *data, calldata_t *params)
 
 	QMetaObject::invokeMethod(window, "AddSceneItem",
 				  Q_ARG(OBSSceneItem, OBSSceneItem(item)));
-}
-
-void OBSBasic::SceneItemSelected(void *data, calldata_t *params)
-{
-	OBSBasic *window = static_cast<OBSBasic *>(data);
-
-	obs_scene_t *scene = (obs_scene_t *)calldata_ptr(params, "scene");
-	obs_sceneitem_t *item = (obs_sceneitem_t *)calldata_ptr(params, "item");
-
-	QMetaObject::invokeMethod(window, "SelectSceneItem",
-				  Q_ARG(OBSScene, scene),
-				  Q_ARG(OBSSceneItem, item), Q_ARG(bool, true));
-}
-
-void OBSBasic::SceneItemDeselected(void *data, calldata_t *params)
-{
-	OBSBasic *window = static_cast<OBSBasic *>(data);
-
-	obs_scene_t *scene = (obs_scene_t *)calldata_ptr(params, "scene");
-	obs_sceneitem_t *item = (obs_sceneitem_t *)calldata_ptr(params, "item");
-
-	QMetaObject::invokeMethod(window, "SelectSceneItem",
-				  Q_ARG(OBSScene, scene),
-				  Q_ARG(OBSSceneItem, item),
-				  Q_ARG(bool, false));
 }
 
 void OBSBasic::SourceCreated(void *data, calldata_t *params)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -226,7 +226,6 @@ private:
 	gs_vertbuffer_t *circle = nullptr;
 
 	bool sceneChanging = false;
-	bool ignoreSelectionUpdate = false;
 
 	int previewX = 0, previewY = 0;
 	int previewCX = 0, previewCY = 0;
@@ -573,8 +572,6 @@ private slots:
 	void RemoveScene(OBSSource source);
 	void RenameSources(OBSSource source, QString newName, QString prevName);
 
-	void SelectSceneItem(OBSScene scene, OBSSceneItem item, bool select);
-
 	void ActivateAudioSource(OBSSource source);
 	void DeactivateAudioSource(OBSSource source);
 
@@ -671,8 +668,6 @@ private:
 	static void SceneReordered(void *data, calldata_t *params);
 	static void SceneRefreshed(void *data, calldata_t *params);
 	static void SceneItemAdded(void *data, calldata_t *params);
-	static void SceneItemSelected(void *data, calldata_t *params);
-	static void SceneItemDeselected(void *data, calldata_t *params);
 	static void SourceCreated(void *data, calldata_t *params);
 	static void SourceRemoved(void *data, calldata_t *params);
 	static void SourceActivated(void *data, calldata_t *params);


### PR DESCRIPTION
### Description
Previously the item select and deselect signals wouldn't work with groups.

### Motivation and Context
Fixes #2794

### How Has This Been Tested?
Selecting and deselecting scene/group items to make sure the signals are fired.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
