### PR TITLE
UI: Fix GetUnusedSceneCollectionFile filename creation

### DIFF
--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -92,7 +92,6 @@ static bool SceneCollectionExists(const char *findName)
 static bool GetUnusedSceneCollectionFile(std::string &name, std::string &file)
 {
 	char path[512];
-	size_t len;
 	int ret;
 
 	if (!GetFileSafeName(name.c_str(), file)) {
@@ -107,7 +106,6 @@ static bool GetUnusedSceneCollectionFile(std::string &name, std::string &file)
 		return false;
 	}
 
-	len = file.size();
 	file.insert(0, path);
 
 	if (!GetClosestUnusedFileName(file, "json")) {
@@ -117,7 +115,7 @@ static bool GetUnusedSceneCollectionFile(std::string &name, std::string &file)
 	}
 
 	file.erase(file.size() - 5, 5);
-	file.erase(0, file.size() - len);
+	file.erase(0, strlen(path));
 	return true;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
GetUnusedSceneCollectionFile tries to create a safe, unused filename for a new scene collection JSON file based on the user-specified scene collection name. It would check the length of the safe version of the user-specified name, but then it doesn't consider that the length may have changed when GetClosestUnusedFileName was called to alter the filename to prevent filename collisions by adding an incremented integer to the end of the filename. This could result in OBS thinking a filename was safe and available, but the resulting filename could be one that already exists. OBS could then overwrite a scene collection JSON file with this new file without any indication that the file previously existed.

Instead of trying to calculate a length based off of the returned filename, let's just use the length of the config path since it's a known string.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Prevent unexpected behavior and potential data loss.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
1. In OBS, make a new scene collection named "TEST 1/2".
OBS changes the name into a safe filename "TEST_12.json" and saves it.
2. Make another new scene collection named "TEST 1\2".
OBS will change the name into a safe filename "TEST_12.json", and then try to find a safe filename that is not already taken using GetClosestUnusedFileName, which resolves to "TEST_122.json".  But then GetUnusedSceneCollectionFile thinks the filename is still 7 character long instead of the now 8 characters, so it determines that the safe filename to use should be "EST_122.json".
3. Make a new scene collection named "TEST 1!2".
OBS will change the name to "TEST_12.json", and then GetClosestUnusedFileName determines that "TEST_122.json" is a safe filename to use.  GetUnusedSceneCollectionFile will then change that to "EST_122.json".  The filename checks have already passed, so OBS will just overwrite the existing "EST_122.json".

I compiled and tested this on Windows 10 1903 64-bit with VS2017.  I tested with the above steps before and after this commit to verify that I saw the "Actual Behavior" described below before this comment and that I saw the "Expected Behavior" after this commit.

#### Expected Behavior
Using the above steps, I'd expect to end up with "TEST_12.json", "TEST_122.json", and "TEST_123.json".

#### Actual Behavior
Using the above steps, OBS currently creates "TEST_12.json", then "EST_122.json", and then overwrites "EST_122.json".

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
