### PR TITLE
UI: Redesign transitions dock

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -203,7 +203,7 @@
      <x>0</x>
      <y>0</y>
      <width>1079</width>
-     <height>22</height>
+     <height>30</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -753,7 +753,7 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>71</width>
+           <width>82</width>
            <height>16</height>
           </rect>
          </property>
@@ -807,7 +807,7 @@
            <x>0</x>
            <y>0</y>
            <width>16</width>
-           <height>28</height>
+           <height>16</height>
           </rect>
          </property>
          <property name="sizePolicy">
@@ -883,106 +883,20 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QComboBox" name="transitions">
-          <property name="minimumSize">
-           <size>
-            <width>120</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="accessibleName">
-           <string>Transition</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_4">
           <property name="spacing">
            <number>4</number>
           </property>
           <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Expanding</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
+           <widget class="QComboBox" name="transitions">
+            <property name="minimumSize">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>120</width>
+              <height>0</height>
              </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="transitionAdd">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>22</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Basic.AddTransition</string>
             </property>
             <property name="accessibleName">
-             <string>Basic.AddTransition</string>
-            </property>
-            <property name="text">
-             <string notr="true"/>
-            </property>
-            <property name="icon">
-             <iconset>
-              <normaloff>:/res/images/add.png</normaloff>:/res/images/add.png</iconset>
-            </property>
-            <property name="flat">
-             <bool>true</bool>
-            </property>
-            <property name="themeID" stdset="0">
-             <string notr="true">addIconSmall</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="transitionRemove">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>22</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Basic.RemoveTransition</string>
-            </property>
-            <property name="accessibleName">
-             <string>Basic.RemoveTransition</string>
-            </property>
-            <property name="text">
-             <string notr="true"/>
-            </property>
-            <property name="icon">
-             <iconset>
-              <normaloff>:/res/images/list_remove.png</normaloff>:/res/images/list_remove.png</iconset>
-            </property>
-            <property name="flat">
-             <bool>true</bool>
-            </property>
-            <property name="themeID" stdset="0">
-             <string notr="true">removeIconSmall</string>
+             <string>Transition</string>
             </property>
            </widget>
           </item>

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -50,6 +50,7 @@ static inline QString MakeQuickTransitionText(QuickTransition *qt)
 
 void OBSBasic::InitDefaultTransitions()
 {
+	ui->transitions->blockSignals(true);
 	std::vector<OBSSource> transitions;
 	size_t idx = 0;
 	const char *id;
@@ -57,9 +58,9 @@ void OBSBasic::InitDefaultTransitions()
 	/* automatically add transitions that have no configuration (things
 	 * such as cut/fade/etc) */
 	while (obs_enum_transition_types(idx++, &id)) {
-		if (!obs_is_source_configurable(id)) {
-			const char *name = obs_source_get_display_name(id);
+		const char *name = obs_source_get_display_name(id);
 
+		if (!obs_is_source_configurable(id)) {
 			obs_source_t *tr =
 				obs_source_create_private(id, name, NULL);
 			InitTransition(tr);
@@ -69,13 +70,21 @@ void OBSBasic::InitDefaultTransitions()
 				fadeTransition = tr;
 
 			obs_source_release(tr);
+		} else {
+			ui->transitions->addItem(
+				QTStr("Add ") + QT_UTF8(name),
+				QVariant::fromValue(QString(QT_UTF8(id))));
 		}
 	}
+
+	if (ui->transitions->count())
+		ui->transitions->insertSeparator(ui->transitions->count());
 
 	for (OBSSource &tr : transitions) {
 		ui->transitions->addItem(QT_UTF8(obs_source_get_name(tr)),
 					 QVariant::fromValue(OBSSource(tr)));
 	}
+	ui->transitions->blockSignals(false);
 }
 
 void OBSBasic::AddQuickTransitionHotkey(QuickTransition *qt)
@@ -248,7 +257,7 @@ obs_source_t *OBSBasic::FindTransition(const char *name)
 		OBSSource tr = ui->transitions->itemData(i).value<OBSSource>();
 
 		const char *trName = obs_source_get_name(tr);
-		if (strcmp(trName, name) == 0)
+		if (trName && *trName && strcmp(trName, name) == 0)
 			return tr;
 	}
 
@@ -408,6 +417,10 @@ static inline void SetComboTransition(QComboBox *combo, obs_source_t *tr)
 void OBSBasic::SetTransition(OBSSource transition)
 {
 	obs_source_t *oldTransition = obs_get_output_source(0);
+	obs_source_release(oldTransition);
+
+	if (transition == oldTransition)
+		return;
 
 	if (oldTransition && transition) {
 		obs_transition_swap_begin(transition, oldTransition);
@@ -419,16 +432,14 @@ void OBSBasic::SetTransition(OBSSource transition)
 		obs_set_output_source(0, transition);
 	}
 
-	if (oldTransition)
-		obs_source_release(oldTransition);
-
 	bool fixed = transition ? obs_transition_fixed(transition) : false;
 	ui->transitionDurationLabel->setVisible(!fixed);
 	ui->transitionDuration->setVisible(!fixed);
 
 	bool configurable = obs_source_configurable(transition);
-	ui->transitionRemove->setEnabled(configurable);
 	ui->transitionProps->setEnabled(configurable);
+
+	SetComboTransition(ui->transitions, transition);
 
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_TRANSITION_CHANGED);
@@ -442,17 +453,21 @@ OBSSource OBSBasic::GetCurrentTransition()
 void OBSBasic::on_transitions_currentIndexChanged(int)
 {
 	OBSSource transition = GetCurrentTransition();
-	SetTransition(transition);
+
+	if (transition)
+		SetTransition(transition);
+	else
+		AddTransition(ui->transitions->currentData().value<QString>());
 }
 
-void OBSBasic::AddTransition()
+void OBSBasic::AddTransition(QString id)
 {
-	QAction *action = reinterpret_cast<QAction *>(sender());
-	QString idStr = action->property("id").toString();
+	if (id.isEmpty())
+		return;
 
 	string name;
 	QString placeHolderText =
-		QT_UTF8(obs_source_get_display_name(QT_TO_UTF8(idStr)));
+		QT_UTF8(obs_source_get_display_name(QT_TO_UTF8(id)));
 	QString format = placeHolderText + " (%1)";
 	obs_source_t *source = nullptr;
 	int i = 1;
@@ -471,7 +486,7 @@ void OBSBasic::AddTransition()
 			OBSMessageBox::warning(this,
 					       QTStr("NoNameEntered.Title"),
 					       QTStr("NoNameEntered.Text"));
-			AddTransition();
+			AddTransition(id);
 			return;
 		}
 
@@ -480,12 +495,12 @@ void OBSBasic::AddTransition()
 			OBSMessageBox::warning(this, QTStr("NameExists.Title"),
 					       QTStr("NameExists.Text"));
 
-			AddTransition();
+			AddTransition(id);
 			return;
 		}
 
-		source = obs_source_create_private(QT_TO_UTF8(idStr),
-						   name.c_str(), NULL);
+		source = obs_source_create_private(QT_TO_UTF8(id), name.c_str(),
+						   NULL);
 		InitTransition(source);
 		ui->transitions->addItem(
 			QT_UTF8(name.c_str()),
@@ -500,32 +515,11 @@ void OBSBasic::AddTransition()
 
 		ClearQuickTransitionWidgets();
 		RefreshQuickTransitions();
+	} else {
+		obs_source_t *transition = obs_get_output_source(0);
+		SetComboTransition(ui->transitions, transition);
+		obs_source_release(transition);
 	}
-}
-
-void OBSBasic::on_transitionAdd_clicked()
-{
-	bool foundConfigurableTransitions = false;
-	QMenu menu(this);
-	size_t idx = 0;
-	const char *id;
-
-	while (obs_enum_transition_types(idx++, &id)) {
-		if (obs_is_source_configurable(id)) {
-			const char *name = obs_source_get_display_name(id);
-			QAction *action = new QAction(name, this);
-			action->setProperty("id", id);
-
-			connect(action, SIGNAL(triggered()), this,
-				SLOT(AddTransition()));
-
-			menu.addAction(action);
-			foundConfigurableTransitions = true;
-		}
-	}
-
-	if (foundConfigurableTransitions)
-		menu.exec(QCursor::pos());
 }
 
 void OBSBasic::on_transitionRemove_clicked()
@@ -622,6 +616,11 @@ void OBSBasic::on_transitionProps_clicked()
 	QAction *action = new QAction(QTStr("Rename"), &menu);
 	connect(action, SIGNAL(triggered()), this, SLOT(RenameTransition()));
 	action->setProperty("transition", QVariant::fromValue(source));
+	menu.addAction(action);
+
+	action = new QAction(QTStr("Remove"), &menu);
+	connect(action, SIGNAL(triggered()), this,
+		SLOT(on_transitionRemove_clicked()));
 	menu.addAction(action);
 
 	action = new QAction(QTStr("Properties"), &menu);
@@ -1519,8 +1518,6 @@ void OBSBasic::LoadTransitions(obs_data_array_t *transitions)
 			ui->transitions->addItem(
 				QT_UTF8(name),
 				QVariant::fromValue(OBSSource(source)));
-			ui->transitions->setCurrentIndex(
-				ui->transitions->count() - 1);
 		}
 
 		obs_data_release(settings);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -608,7 +608,7 @@ private slots:
 
 	void ProcessHotkey(obs_hotkey_id id, bool pressed);
 
-	void AddTransition();
+	void AddTransition(QString id);
 	void RenameTransition();
 	void TransitionClicked();
 	void TransitionStopped();
@@ -934,7 +934,6 @@ private slots:
 	void on_toggleSourceIcons_toggled(bool visible);
 
 	void on_transitions_currentIndexChanged(int index);
-	void on_transitionAdd_clicked();
 	void on_transitionRemove_clicked();
 	void on_transitionProps_clicked();
 	void on_transitionDuration_valueChanged(int value);


### PR DESCRIPTION
### Description
Remove the plus and minus icons and move the selection of adding configurable transitions to the combo box. The remove ability has been moved to the config button menu.

![Screenshot_20200520_155745](https://user-images.githubusercontent.com/19962531/82497164-6d316a80-9ab3-11ea-81c3-0daa1970ded6.png)

### Motivation and Context
Before users might not have known the extra transitions existed because they would have to click the plus button to find them.

### How Has This Been Tested?
Added transitions via the combo box and clicked different transitions and everything worked as expected.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)
- UI tweak

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
