### PR TITLE
UI: Show help text for launch parameters on Windows

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2451,26 +2451,31 @@ int main(int argc, char *argv[])
 			opt_allow_opengl = true;
 
 		} else if (arg_is(argv[i], "--help", "-h")) {
-			std::cout
-				<< "--help, -h: Get list of available commands.\n\n"
-				<< "--startstreaming: Automatically start streaming.\n"
-				<< "--startrecording: Automatically start recording.\n"
-				<< "--startreplaybuffer: Start replay buffer.\n"
-				<< "--startvirtualcam: Start virtual camera (if available).\n\n"
-				<< "--collection <string>: Use specific scene collection."
-				<< "\n"
-				<< "--profile <string>: Use specific profile.\n"
-				<< "--scene <string>: Start with specific scene.\n\n"
-				<< "--studio-mode: Enable studio mode.\n"
-				<< "--minimize-to-tray: Minimize to system tray.\n"
-				<< "--portable, -p: Use portable mode.\n"
-				<< "--multi, -m: Don't warn when launching multiple instances.\n\n"
-				<< "--verbose: Make log more verbose.\n"
-				<< "--always-on-top: Start in 'always on top' mode.\n\n"
-				<< "--unfiltered_log: Make log unfiltered.\n\n"
-				<< "--allow-opengl: Allow OpenGL on Windows.\n\n"
-				<< "--version, -V: Get current version.\n";
+			std::string help =
+				"--help, -h: Get list of available commands.\n\n"
+				"--startstreaming: Automatically start streaming.\n"
+				"--startrecording: Automatically start recording.\n"
+				"--startreplaybuffer: Start replay buffer.\n"
+				"--startvirtualcam: Start virtual camera (if available).\n\n"
+				"--collection <string>: Use specific scene collection."
+				"\n"
+				"--profile <string>: Use specific profile.\n"
+				"--scene <string>: Start with specific scene.\n\n"
+				"--studio-mode: Enable studio mode.\n"
+				"--minimize-to-tray: Minimize to system tray.\n"
+				"--portable, -p: Use portable mode.\n"
+				"--multi, -m: Don't warn when launching multiple instances.\n\n"
+				"--verbose: Make log more verbose.\n"
+				"--always-on-top: Start in 'always on top' mode.\n\n"
+				"--unfiltered_log: Make log unfiltered.\n\n";
 
+#ifdef _WIN32
+			MessageBoxA(NULL, help.c_str(), "Help",
+				    MB_OK | MB_ICONASTERISK);
+#else
+			std::cout << help
+				  << "--version, -V: Get current version.\n";
+#endif
 			exit(0);
 
 		} else if (arg_is(argv[i], "--version", "-V")) {


### PR DESCRIPTION
### Description
Displays a native Windows dialog with help text when OBS is launched with `-h` or `--help`, similar to other applications (for example, Microsoft's own [Windows Terminal](https://github.com/microsoft/terminal)).

Once launched, the user can press Ctrl+C on the dialog to copy the contents for easy usage.

![image](https://user-images.githubusercontent.com/941350/82562274-3f821980-9bb8-11ea-825b-934a3dad4caa.png)

### Motivation and Context
While other operating systems allow GUI apps to print to the command line, Windows does not, so the `-h` parameter would not perform as intended.

This change also hides `--allow-opengl` on non-Windows platforms, and hides `-V` on Windows because it doesn't do anything.

### How Has This Been Tested?

On Windows:
* Launch OBS with the `-h` or `--help` flag
* See a help dialog
* Press OK to close the dialog and cancel the OBS launch

Also tested on Ubuntu to ensure the existing `-h` behaviour didn't break.

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
