### PR TITLE
 UI: Add indicators for current preview/program scene

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -58,7 +58,7 @@
       <item>
        <layout class="QHBoxLayout" name="previewLayout">
         <property name="spacing">
-         <number>2</number>
+         <number>0</number>
         </property>
         <item>
          <widget class="QFrame" name="previewDisabledWidget">
@@ -157,14 +157,90 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="QLabel" name="previewLabel">
-            <property name="text">
-             <string>StudioMode.Preview</string>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <property name="spacing">
+             <number>10</number>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignBottom|Qt::AlignHCenter</set>
+            <property name="sizeConstraint">
+             <enum>QLayout::SetDefaultConstraint</enum>
             </property>
-           </widget>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>0</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLabel" name="previewLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>StudioMode.Preview</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignBottom|Qt::AlignHCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="previewIndicator">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="pixmap">
+               <pixmap resource="obs.qrc">:/res/images/preview-indicator.svg</pixmap>
+              </property>
+              <property name="scaledContents">
+               <bool>false</bool>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>0</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="OBSBasicPreview" name="preview">

--- a/UI/forms/images/preview-indicator.svg
+++ b/UI/forms/images/preview-indicator.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 8 8" fill="#00d000">
+  <path d="M0 0v6h6v-6h-6z" transform="translate(1 1)" />
+</svg>

--- a/UI/forms/images/program-indicator.svg
+++ b/UI/forms/images/program-indicator.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 8 8" fill="#d00000">
+  <path d="M0 0v6h6v-6h-6z" transform="translate(1 1)" />
+</svg>

--- a/UI/forms/obs.qrc
+++ b/UI/forms/obs.qrc
@@ -53,6 +53,8 @@
     <file>images/media/media_restart.svg</file>
     <file>images/media/media_stop.svg</file>
     <file>images/interact.svg</file>
+    <file>images/preview-indicator.svg</file>
+    <file>images/program-indicator.svg</file>
   </qresource>
   <qresource prefix="/settings">
     <file>images/settings/output.svg</file>

--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -13,6 +13,7 @@ SceneTree::SceneTree(QWidget *parent_) : QListWidget(parent_)
 	installEventFilter(this);
 	setDragDropMode(InternalMove);
 	setMovement(QListView::Snap);
+	setIconSize(QSize(16, 16));
 }
 
 void SceneTree::SetGridMode(bool grid)

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -743,6 +743,7 @@ void OBSBasic::SetCurrentScene(OBSSource scene, bool force)
 				ui->scenes->blockSignals(true);
 				ui->scenes->setCurrentItem(item);
 				ui->scenes->blockSignals(false);
+				SetPreviewProgramIndicators();
 				if (api)
 					api->on_event(
 						OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
@@ -1594,6 +1595,7 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		return;
 
 	ui->previewLabel->setHidden(!enabled);
+	ui->previewIndicator->setHidden(!enabled);
 
 	ui->modeSwitch->setChecked(enabled);
 	os_atomic_set_bool(&previewProgramMode, enabled);
@@ -1636,11 +1638,24 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 		RefreshQuickTransitions();
 
+		programLabelLayout = new QHBoxLayout(this);
+		programLabelLayout->setContentsMargins(0, 0, 0, 0);
+		programLabelLayout->setSpacing(10);
+
+		QIcon icon(":res/images/program-indicator.svg");
+		programIndicator = new QLabel(this);
+		programIndicator->setPixmap(icon.pixmap(QSize(18, 18)));
+
 		programLabel = new QLabel(QTStr("StudioMode.Program"), this);
 		programLabel->setSizePolicy(QSizePolicy::Preferred,
 					    QSizePolicy::Preferred);
 		programLabel->setAlignment(Qt::AlignHCenter | Qt::AlignBottom);
 		programLabel->setProperty("themeID", "previewProgramLabels");
+
+		programLabelLayout->addStretch();
+		programLabelLayout->addWidget(programLabel);
+		programLabelLayout->addWidget(programIndicator);
+		programLabelLayout->addStretch();
 
 		programWidget = new QWidget();
 		programLayout = new QVBoxLayout();
@@ -1648,13 +1663,8 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		programLayout->setContentsMargins(0, 0, 0, 0);
 		programLayout->setSpacing(0);
 
-		programLayout->addWidget(programLabel);
+		programLayout->addLayout(programLabelLayout);
 		programLayout->addWidget(program);
-
-		bool labels = config_get_bool(GetGlobalConfig(), "BasicWindow",
-					      "StudioModeLabels");
-
-		programLabel->setHidden(!labels);
 
 		programWidget->setLayout(programLayout);
 
@@ -1662,6 +1672,8 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		ui->previewLayout->addWidget(programWidget);
 		ui->previewLayout->setAlignment(programOptions,
 						Qt::AlignCenter);
+
+		SetPreviewProgramIndicators();
 
 		if (api)
 			api->on_event(OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED);
@@ -1680,7 +1692,10 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		delete programOptions;
 		delete program;
 		delete programLabel;
+		delete programIndicator;
 		delete programWidget;
+		delete programLabelLayout;
+		delete programLayout;
 
 		if (lastScene) {
 			OBSSource actualLastScene = OBSGetStrongRef(lastScene);
@@ -1701,6 +1716,8 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 		ui->transitions->setEnabled(true);
 		tBarActive = false;
+
+		ResetPreviewProgramIndicators();
 
 		if (api)
 			api->on_event(OBS_FRONTEND_EVENT_STUDIO_MODE_DISABLED);
@@ -1845,4 +1862,35 @@ int OBSBasic::GetOverrideTransitionDuration(OBSSource source)
 	obs_data_set_default_int(data, "transition_duration", 300);
 
 	return (int)obs_data_get_int(data, "transition_duration");
+}
+
+void OBSBasic::SetPreviewProgramIndicators()
+{
+	if (!IsPreviewProgramMode())
+		return;
+
+	for (int i = 0; i < ui->scenes->count(); i++) {
+		QListWidgetItem *item = ui->scenes->item(i);
+		OBSScene scene = GetOBSRef<OBSScene>(item);
+
+		obs_source_t *source = obs_scene_get_source(scene);
+
+		if (source == GetProgramSource()) {
+			item->setIcon(
+				QIcon(":res/images/program-indicator.svg"));
+		} else if (source == GetCurrentSceneSource()) {
+			item->setIcon(
+				QIcon(":res/images/preview-indicator.svg"));
+		} else {
+			item->setIcon(QIcon());
+		}
+	}
+}
+
+void OBSBasic::ResetPreviewProgramIndicators()
+{
+	for (int i = 0; i < ui->scenes->count(); i++) {
+		QListWidgetItem *item = ui->scenes->item(i);
+		item->setIcon(QIcon());
+	}
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -301,7 +301,9 @@ private:
 
 	QPointer<QWidget> programWidget;
 	QPointer<QVBoxLayout> programLayout;
+	QPointer<QHBoxLayout> programLabelLayout;
 	QPointer<QLabel> programLabel;
+	QPointer<QLabel> programIndicator;
 
 	QScopedPointer<QThread> patronJsonThread;
 	std::string patronJson;
@@ -578,6 +580,9 @@ private:
 
 	void UpdatePreviewSafeAreas();
 	bool drawSafeAreas = false;
+
+	void SetPreviewProgramIndicators();
+	void ResetPreviewProgramIndicators();
 
 public slots:
 	void DeferSaveBegin();
@@ -1116,13 +1121,16 @@ private:
 	std::unique_ptr<Ui::OBSBasic> ui;
 };
 
-class SceneRenameDelegate : public QStyledItemDelegate {
+class SceneDelegate : public QStyledItemDelegate {
 	Q_OBJECT
 
 public:
-	SceneRenameDelegate(QObject *parent);
+	SceneDelegate(QObject *parent);
 	virtual void setEditorData(QWidget *editor,
 				   const QModelIndex &index) const override;
+	virtual void paint(QPainter *painter,
+			   const QStyleOptionViewItem &option,
+			   const QModelIndex &index) const override;
 
 protected:
 	virtual bool eventFilter(QObject *editor, QEvent *event) override;


### PR DESCRIPTION
### Description
Add indicator for preview/program scene in studio mode.

![Screenshot from 2021-01-16 05-08-56](https://user-images.githubusercontent.com/19962531/104811499-81a04100-57c1-11eb-867d-0adf97538a7e.png)

### Motivation and Context
Makes it easier to know what scene is the preview or program scene.

### How Has This Been Tested?
Switched scenes in studio mode and made sure the icon was put in the right place.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
