### PR TITLE
UI: Add percent checkbox to advanced audio dialog

### DIFF
--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -26,6 +26,27 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 	QWidget *widget;
 	QLabel *label;
 
+	QLabel *volLabel = new QLabel(QTStr("Basic.AdvAudio.Volume"));
+	volLabel->setStyleSheet("font-weight: bold;");
+
+	usePercent = new QCheckBox();
+	usePercent->setStyleSheet("font-weight: bold;");
+	usePercent->setText("%");
+	connect(usePercent, SIGNAL(toggled(bool)), this,
+		SLOT(SetVolumeType(bool)));
+
+	VolumeType volType = (VolumeType)config_get_int(
+		GetGlobalConfig(), "BasicWindow", "AdvAudioVolumeType");
+
+	if (volType == VolumeType::Percent)
+		usePercent->setChecked(true);
+
+	QHBoxLayout *volLayout = new QHBoxLayout();
+	volLayout->setContentsMargins(0, 0, 0, 0);
+	volLayout->addWidget(volLabel);
+	volLayout->addStretch();
+	volLayout->addWidget(usePercent);
+
 	int idx = 0;
 	mainLayout = new QGridLayout;
 	mainLayout->setContentsMargins(0, 0, 0, 0);
@@ -37,9 +58,7 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 	label = new QLabel(QTStr("Basic.Stats.Status"));
 	label->setStyleSheet("font-weight: bold;");
 	mainLayout->addWidget(label, 0, idx++);
-	label = new QLabel(QTStr("Basic.AdvAudio.Volume"));
-	label->setStyleSheet("font-weight: bold;");
-	mainLayout->addWidget(label, 0, idx++);
+	mainLayout->addLayout(volLayout, 0, idx++);
 	label = new QLabel(QTStr("Basic.AdvAudio.Mono"));
 	label->setStyleSheet("font-weight: bold;");
 	mainLayout->addWidget(label, 0, idx++);
@@ -193,48 +212,20 @@ void OBSBasicAdvAudio::SourceRemoved(OBSSource source)
 	}
 }
 
-void OBSBasicAdvAudio::SetVolumeType()
+void OBSBasicAdvAudio::SetVolumeType(bool percent)
 {
-	QAction *action = reinterpret_cast<QAction *>(sender());
-	VolumeType type = (VolumeType)action->property("volumeType").toInt();
+	VolumeType type;
+
+	if (percent)
+		type = VolumeType::Percent;
+	else
+		type = VolumeType::dB;
 
 	for (size_t i = 0; i < controls.size(); i++)
 		controls[i]->SetVolumeWidget(type);
 
 	config_set_int(GetGlobalConfig(), "BasicWindow", "AdvAudioVolumeType",
 		       (int)type);
-}
-
-void OBSBasicAdvAudio::ShowContextMenu(const QPoint &pos)
-{
-	VolumeType type = (VolumeType)config_get_int(
-		GetGlobalConfig(), "BasicWindow", "AdvAudioVolumeType");
-
-	QMenu *contextMenu = new QMenu(this);
-
-	QAction *percent = new QAction(QTStr("Percent"), this);
-	QAction *dB = new QAction(QTStr("dB"), this);
-
-	percent->setProperty("volumeType", (int)VolumeType::Percent);
-	dB->setProperty("volumeType", (int)VolumeType::dB);
-
-	connect(percent, SIGNAL(triggered()), this, SLOT(SetVolumeType()),
-		Qt::DirectConnection);
-	connect(dB, SIGNAL(triggered()), this, SLOT(SetVolumeType()),
-		Qt::DirectConnection);
-
-	percent->setCheckable(true);
-	dB->setCheckable(true);
-
-	if (type == VolumeType::Percent)
-		percent->setChecked(true);
-	else if (type == VolumeType::dB)
-		dB->setChecked(true);
-
-	contextMenu->addAction(dB);
-	contextMenu->addAction(percent);
-
-	contextMenu->exec(mapToGlobal(pos));
 }
 
 void OBSBasicAdvAudio::ActiveOnlyChanged(bool checked)

--- a/UI/window-basic-adv-audio.hpp
+++ b/UI/window-basic-adv-audio.hpp
@@ -18,6 +18,7 @@ private:
 	QWidget *controlArea;
 	QGridLayout *mainLayout;
 	QPointer<QCheckBox> activeOnly;
+	QPointer<QCheckBox> usePercent;
 	OBSSignal sourceAddedSignal;
 	OBSSignal sourceRemovedSignal;
 	bool showInactive;
@@ -36,8 +37,7 @@ public slots:
 	void SourceAdded(OBSSource source);
 	void SourceRemoved(OBSSource source);
 
-	void ShowContextMenu(const QPoint &pos);
-	void SetVolumeType();
+	void SetVolumeType(bool percent);
 	void ActiveOnlyChanged(bool checked);
 
 public:


### PR DESCRIPTION
### Description
Add percent checkbox to advanced audio dialog.

![Screenshot from 2020-05-23 01-03-41](https://user-images.githubusercontent.com/19962531/82723070-b2ab8e80-9c91-11ea-922c-ad06b31ea79d.png)

### Motivation and Context
Before, the user would have to right click in the dialog to change the audio volume type, and this was hard to find.

### How Has This Been Tested?
Toggled percent.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)
- UI tweak

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
