### PR TITLE
UI: Theme case fix

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -155,8 +155,8 @@ QListWidget QLineEdit {
 
 /* Dock stuff */
 QDockWidget {
-	titlebar-close-icon: url('./Dark/Close.svg');
-	titlebar-normal-icon: url('./Dark/Popout.svg');
+	titlebar-close-icon: url('./Dark/close.svg');
+	titlebar-normal-icon: url('./Dark/popout.svg');
 }
 
 QDockWidget {

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -120,8 +120,8 @@ SourceTree QLineEdit {
 /* Dock Widget */
 
 QDockWidget {
-	titlebar-close-icon: url('./Dark/Close.svg');
-	titlebar-normal-icon: url('./Dark/Popout.svg');
+	titlebar-close-icon: url('./Dark/close.svg');
+	titlebar-normal-icon: url('./Dark/popout.svg');
 }
 
 QDockWidget::title {

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -189,8 +189,8 @@ QListWidget::item:hover:!active {
 /***********************/
 
 QDockWidget {
-	titlebar-close-icon: url('./Dark/Close.svg');
-	titlebar-normal-icon: url('./Dark/Popout.svg');
+	titlebar-close-icon: url('./Dark/close.svg');
+	titlebar-normal-icon: url('./Dark/popout.svg');
 }
 
 QDockWidget {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
The files on disk are lowercase whereas the qss was refrencing them in upper case. This is hidden on Windows due to the platform's case insensitivity, But would cause error messages and the icons not to render on case sensitive file systems like Linux's ext4 and Mac's HFS, and APFS*. It would be preferable if we could format check the theme files to ensure that they match the case on disk.

\* Depending on how the user has configured it

### Motivation and Context
Error messages and missing icons

### How Has This Been Tested?
Launching it on an archlinux running machine

uname -a
```
Linux 5.6.11-arch1-1 #1 SMP PREEMPT Wed, 06 May 2020 17:32:37 +0000 x86_64 GNU/Linux
```

### Types of changes
- Bug fix (non-breaking change which fixes an issue)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
