### PR TITLE
libobs: Fix os_get_executable_path_ptr on Linux

### DIFF
--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -287,7 +287,10 @@ char *os_get_executable_path_ptr(const char *name)
 	}
 	count = pathlen;
 #else
-	ssize_t count = readlink("/proc/self/exe", exe, PATH_MAX);
+	ssize_t count = readlink("/proc/self/exe", exe, PATH_MAX - 1);
+	if (count >= 0) {
+		exe[count] = '\0';
+	}
 #endif
 	const char *path_out = NULL;
 	struct dstr path;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix os_get_executable_path_ptr on Linux.

Terminate a non-terminated string generated by readlink() to pass to dirname() that needs terminated string as a parameter.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #2973 

I think this fix prevents a possibility of buffer overflow.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I tested this fix on Ubuntu 19.10.
I can start and stop recording while streaming with no error.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
