### PR TITLE
UI: Add Launch Jumplists on Windows

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -57,6 +57,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 set(CMAKE_AUTOMOC TRUE)
 
 find_package(Qt5Svg ${FIND_MODE})
+if(WIN32)
+	find_package(Qt5WinExtras ${FIND_MODE})
+endif()
 find_package(Qt5Xml ${FIND_MODE})
 
 find_package(FFmpeg REQUIRED COMPONENTS avcodec avutil avformat)
@@ -385,6 +388,8 @@ if(WIN32)
 	set_target_properties(obs
 		PROPERTIES
 			OUTPUT_NAME "obs${_output_suffix}")
+	target_link_libraries(obs
+			Qt5::WinExtras)
 endif()
 
 target_link_libraries(obs

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -143,6 +143,12 @@ BandwidthTest.Region.EU="Europe"
 BandwidthTest.Region.Asia="Asia"
 BandwidthTest.Region.Other="Other"
 
+# Taskbar Actions
+Basic.Start.ReplayBuffer="Launch with Replay Buffer"
+Basic.Start.VirtualCam="Launch with Virtual Camera"
+Basic.Start.Minimised="Launch Minimised to Tray"
+Basic.Start.Top="Launch Always on Top"
+
 # auto config wizard
 Basic.AutoConfig="Auto-Configuration Wizard"
 Basic.AutoConfig.ApplySettings="Apply Settings"

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1839,6 +1839,34 @@ void OBSBasic::OBSInit()
 
 #ifdef _WIN32
 	taskBtn->setWindow(windowHandle());
+
+	QWinJumpList jumplist;
+	QWinJumpListCategory *tasks = jumplist.tasks();
+	QWinJumpListItem *jAction;
+
+#define resetJumpItem()                                         \
+	jAction = new QWinJumpListItem(QWinJumpListItem::Link); \
+	jAction->setWorkingDirectory(QDir::currentPath());      \
+	jAction->setFilePath(QDir::toNativeSeparators(          \
+		QCoreApplication::applicationFilePath()));
+
+	resetJumpItem();
+	jAction->setTitle(QTStr("Basic.Start.ReplayBuffer"));
+	jAction->setArguments(QStringList("--startreplaybuffer"));
+	tasks->addItem(jAction);
+	resetJumpItem();
+	jAction->setTitle(QTStr("Basic.Start.VirtualCam"));
+	jAction->setArguments(QStringList("--startvirtualcam"));
+	tasks->addItem(jAction);
+	resetJumpItem();
+	jAction->setTitle(QTStr("Basic.Start.Minimised"));
+	jAction->setArguments(QStringList("--minimize-to-tray"));
+	tasks->addItem(jAction);
+	resetJumpItem();
+	jAction->setTitle(QTStr("Basic.Start.Top"));
+	jAction->setArguments(QStringList("--always-on-top"));
+	tasks->addItem(jAction);
+	tasks->setVisible(true);
 #endif
 
 	bool has_last_version = config_has_user_value(App()->GlobalConfig(),

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1837,6 +1837,10 @@ void OBSBasic::OBSInit()
 	SystemTray(true);
 #endif
 
+#ifdef _WIN32
+	taskBtn->setWindow(windowHandle());
+#endif
+
 	bool has_last_version = config_has_user_value(App()->GlobalConfig(),
 						      "General", "LastVersion");
 	bool first_run =

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -21,6 +21,9 @@
 #include <QAction>
 #include <QWidgetAction>
 #include <QSystemTrayIcon>
+#ifdef _WIN32
+#include <QWinTaskbarButton>
+#endif
 #include <QStyledItemDelegate>
 #include <obs.hpp>
 #include <vector>
@@ -277,6 +280,10 @@ private:
 	QPointer<QMenu> deinterlaceMenu;
 	QPointer<QMenu> perSceneTransitionMenu;
 	QPointer<QObject> shortcutFilter;
+
+#ifdef _WIN32
+	QWinTaskbarButton *taskBtn = new QWinTaskbarButton(this);
+#endif
 
 	QPointer<QWidget> programWidget;
 	QPointer<QVBoxLayout> programLayout;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -23,6 +23,9 @@
 #include <QSystemTrayIcon>
 #ifdef _WIN32
 #include <QWinTaskbarButton>
+#include <QWinJumpList>
+#include <QWinJumpListCategory>
+#include <QWinJumpListItem>
 #endif
 #include <QStyledItemDelegate>
 #include <obs.hpp>

--- a/cmake/Modules/CopyMSVCBins.cmake
+++ b/cmake/Modules/CopyMSVCBins.cmake
@@ -158,6 +158,7 @@ file(GLOB QT_DEBUG_BIN_FILES
 	"${Qt5Core_DIR}/../../../bin/Qt5Guid.dll"
 	"${Qt5Core_DIR}/../../../bin/Qt5Widgetsd.dll"
 	"${Qt5Core_DIR}/../../../bin/Qt5Svgd.dll"
+	"${Qt5Core_DIR}/../../../bin/Qt5WinExtrasd.dll"
 	"${Qt5Core_DIR}/../../../bin/Qt5Xmld.dll"
 	"${Qt5Core_DIR}/../../../bin/libGLESv2d.dll"
 	"${Qt5Core_DIR}/../../../bin/libEGLd.dll")
@@ -176,6 +177,7 @@ file(GLOB QT_BIN_FILES
 	"${Qt5Core_DIR}/../../../bin/Qt5Gui.dll"
 	"${Qt5Core_DIR}/../../../bin/Qt5Widgets.dll"
 	"${Qt5Core_DIR}/../../../bin/Qt5Svg.dll"
+	"${Qt5Core_DIR}/../../../bin/Qt5WinExtras.dll"
 	"${Qt5Core_DIR}/../../../bin/Qt5Xml.dll"
 	"${Qt5Core_DIR}/../../../bin/libGLESv2.dll"
 	"${Qt5Core_DIR}/../../../bin/libEGL.dll")


### PR DESCRIPTION
### Description

This adds basic support for Windows Jumplists. This first iteration provides the ability to choose to launch OBS with replay buffer active, minimised, or always on top.

[A future version](http://scr.wzd.li/scr/2020-05-24_18-55-54.png) could even expose Scene Collections as pinnable files, links to secondary windows like Stats or Settings, or toggles for items like Studio Mode.

![image](https://user-images.githubusercontent.com/941350/86898473-17d91780-c14c-11ea-9c2a-47f3543cfc75.png)

### Motivation and Context

Jumplists on Windows are used primarily for three things: launching an application in various states, to trigger certain screens while the app is running, or to open recent/pinned files.

OBS' launch flags/modes are not particularly discoverable. This exposes them slightly.

### How Has This Been Tested?

* Launch OBS on Windows 8 or above
* Right click the application to see the jumplists. Note that these are designed to be used when the application *isn't* running, but first launch adds them to the taskbar entry. Pin the taskbar entry to test this once OBS is launched.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
