### PR TITLE
CI: Improve formatcode.sh efficiency

### DIFF
--- a/formatcode.sh
+++ b/formatcode.sh
@@ -35,4 +35,4 @@ find . -type d \( -path ./deps \
 -o -path ./plugins/obs-outputs/ftl-sdk \
 -o -path ./plugins/obs-vst \
 -o -path ./build \) -prune -type f -o -name '*.h' -or -name '*.hpp' -or -name '*.m' -or -name '*.mm' -or -name '*.c' -or -name '*.cpp' \
-| xargs -I{} -P ${NPROC} ${CLANG_FORMAT} -i -style=file  -fallback-style=none {}
+| xargs -L100 -P${NPROC} ${CLANG_FORMAT} -i -style=file  -fallback-style=none


### PR DESCRIPTION
### Description
Batch files into clang-format to prevent needless processes. Now its
twice as fast in real time and uses 4x less resources. The old
implementation is also slower (but pretty close to) running a single
invocation of clang-format on all files.

before
time ./formatcode.sh
real	0m3.860s
user	0m20.975s
sys	0m6.694s

after
time ./formatcode.sh
real	0m1.486s
user	0m5.426s
sys	0m0.203s

(single threaded performance, all files on commandline)
real	0m3.511s
user	0m3.420s
sys	0m0.036s

### Motivation and Context
The old code was probably significantly slower on less beefy machines. This brings resource usage inline with running single threaded but actually runs faster with more cores. 100 was chosen arbitrarily but since we have about 800 files to format it should make good use of up to 8 cores. Going as low as 15 is also pretty reasonable with a bit more overhead but in either case we only get about twice as fast as single threaded so I chose to reduce overhead by going with a larger batch.

### How Has This Been Tested?
I ran it.

### Types of changes
Performance Enhancement for CI

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
