### PR TITLE
obs-ffmpeg: Allow continuous network streaming

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -87,8 +87,6 @@ static bool is_local_file_modified(obs_properties_t *props,
 	obs_property_t *local_file = obs_properties_get(props, "local_file");
 	obs_property_t *looping = obs_properties_get(props, "looping");
 	obs_property_t *buffering = obs_properties_get(props, "buffering_mb");
-	obs_property_t *close =
-		obs_properties_get(props, "close_when_inactive");
 	obs_property_t *seekable = obs_properties_get(props, "seekable");
 	obs_property_t *speed = obs_properties_get(props, "speed_percent");
 	obs_property_t *reconnect_delay_sec =
@@ -96,7 +94,6 @@ static bool is_local_file_modified(obs_properties_t *props,
 	obs_property_set_visible(input, !enabled);
 	obs_property_set_visible(input_format, !enabled);
 	obs_property_set_visible(buffering, !enabled);
-	obs_property_set_visible(close, enabled);
 	obs_property_set_visible(local_file, enabled);
 	obs_property_set_visible(looping, enabled);
 	obs_property_set_visible(speed, enabled);
@@ -392,8 +389,6 @@ static void ffmpeg_source_update(void *data, obs_data_t *settings)
 		input = (char *)obs_data_get_string(settings, "local_file");
 		input_format = NULL;
 		s->is_looping = obs_data_get_bool(settings, "looping");
-		s->close_when_inactive =
-			obs_data_get_bool(settings, "close_when_inactive");
 	} else {
 		input = (char *)obs_data_get_string(settings, "input");
 		input_format =
@@ -404,7 +399,6 @@ static void ffmpeg_source_update(void *data, obs_data_t *settings)
 						 ? 10
 						 : s->reconnect_delay_sec;
 		s->is_looping = false;
-		s->close_when_inactive = true;
 
 		if (s->reconnect_thread_valid) {
 			s->stop_reconnect = true;
@@ -412,6 +406,9 @@ static void ffmpeg_source_update(void *data, obs_data_t *settings)
 			s->stop_reconnect = false;
 		}
 	}
+
+	s->close_when_inactive =
+		obs_data_get_bool(settings, "close_when_inactive");
 
 	s->input = input ? bstrdup(input) : NULL;
 	s->input_format = input_format ? bstrdup(input_format) : NULL;


### PR DESCRIPTION
# Description

This change breaks the tying of the 'close' option to the media source being a local file vs. network source. In doing so, it is possible to keep network sources streaming continuously, which fixes a few things when using network cameras as sources:

* The preview pane works in studio mode.
* There is no delay in switching scenes before video appears.
* The multiview works properly/normally.

This does introduce one bit of weirdness which could be easily fixed with sufficient knowledge of OBS to do it quickly: if a networked media source fails with both `Restart playback when source becomes active` and `Close file when inactive` disabled, it is slightly tricky to get it to restart the video stream. (It can be done by enabling those options and hiding the scene, though.) It would be nice to have a simple "restart stream" button somewhere to do this more easily.

<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context

At the moment using an IP camera as a Media Source, inactive cameras are not shown in previews or in multiview, making it difficult to use them in productions. Additionally there is a short delay (and risk of failure) when switching to a scene with an IP camera, while the video stream is started and buffers. Along with a companion change to minimize buffering from network sources which was merged as https://github.com/obsproject/obs-studio/pull/2384, this makes IP cameras completely usable for production.

### How Has This Been Tested?

I have streamed several FIRST Tech Challenge robotics state championships using this code, using a custom-patched OBS on Ubuntu 19, nginx, and Ubiquiti IP cameras as described in my [Stream Dream](https://jeremycole.github.io/stream_dream/) project page.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
