### PR TITLE
libobs: Do not repeat when hotkey is held down

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -1239,6 +1239,9 @@ static inline void handle_binding(obs_hotkey_binding_t *binding,
 				  uint32_t modifiers, bool no_press,
 				  bool strict_modifiers, bool *pressed)
 {
+	if (pressed && !*pressed)
+		return;
+
 	bool modifiers_match_ =
 		modifiers_match(binding, modifiers, strict_modifiers);
 	bool modifiers_only = binding->key.key == OBS_KEY_NONE;


### PR DESCRIPTION
### Description
If the user holds down a hotkey, the function it is tied to is repeatedly called.

### Motivation and Context
Fixing an annoyance.

### How Has This Been Tested?
Pressed down hotkeys, and the functions didn't repeat.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
