### PR TITLE
UI: Delete projector when monitor is disconnected

### DIFF
--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -77,12 +77,15 @@ private:
 	QRect prevGeometry;
 	void SetMonitor(int monitor);
 
+	QScreen *screen = nullptr;
+
 private slots:
 	void EscapeTriggered();
 	void OpenFullScreenProjector();
 	void ResizeToContent();
 	void OpenWindowedProjector();
 	void AlwaysOnTopToggled(bool alwaysOnTop);
+	void ScreenRemoved(QScreen *screen_);
 
 public:
 	OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,


### PR DESCRIPTION
### Description
This deletes the fullscreen projector when the monitor it is on is disconnected.

### Motivation and Context
Before, the projector would move to a different screen.

### How Has This Been Tested?
Created fullscreen projector and disconnected monitor.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
