### PR TITLE
libobs-winrt: Move project to core VS filter

### DIFF
--- a/libobs-winrt/CMakeLists.txt
+++ b/libobs-winrt/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(libobs-winrt MODULE
 	${libobs-winrt_HEADERS})
 set_target_properties(libobs-winrt
 	PROPERTIES
-		FOLDER "plugins/win-capture"
+		FOLDER "core"
 		OUTPUT_NAME libobs-winrt
 		PREFIX "")
 target_precompile_headers(libobs-winrt


### PR DESCRIPTION
### Description
This module houses more WinRT functionality than just window capture.

### Motivation and Context
Better project organization.

### How Has This Been Tested?
OBS still builds and runs. WGC still works.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.