### PR TITLE
libobs: Use correct data pointer for hotkey pair

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -332,7 +332,7 @@ static void obs_hotkey_pair_second_func(void *data, obs_hotkey_id id,
 
 	if (pair->pressed1 && !pressed)
 		pair->pressed1 = false;
-	else if (pair->func[1](pair->data[0], pair->pair_id, hotkey, pressed))
+	else if (pair->func[1](pair->data[1], pair->pair_id, hotkey, pressed))
 		pair->pressed1 = pressed;
 }
 


### PR DESCRIPTION
### Description
Use correct data pointer for hotkey pair

### Motivation and Context
When registering a hotkey pair 2 different data pointers can be set, but only the first one is used for the pressed function call

### How Has This Been Tested?
On windows 64 bit by having different data pointers for data0 and data1

### Types of changes
 - Bug fix (non-breaking change which fixes an issue) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
