### PR TITLE
rtmp-services: Add Mixcloud service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 132,
+	"version": 133,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 132
+			"version": 133
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1403,6 +1403,21 @@
             ]
         },
         {
+            "name": "Mixcloud",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://rtmp.mixcloud.com/broadcast"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 6000,
+                "max audio bitrate": 320,
+                "x264opts": "scenecut=0"
+            }
+        },
+        {
             "name": "SermonAudio Cloud",
             "alt_names": [
                 "SermonAudio.com"


### PR DESCRIPTION
### Description
Adding Mixcloud as a Streaming Service

### Motivation and Context
Enables users to stream to Mixcloud with minimum configuration changes.

### How Has This Been Tested?
Followed convention, these are also known endpoints provided by Mixcloud (I work there and lead that team)

### Types of changes
New Streaming Service

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
