### PR TITLE
obs-qsv11: Set preference for encode to iGPU in case of i+i

### DIFF
--- a/plugins/obs-qsv11/QSV_Encoder.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder.cpp
@@ -63,6 +63,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <atomic>
 #include <intrin.h>
+#include <d3d11.h>
+#include <dxgi1_2.h>
 
 #define do_log(level, format, ...) \
 	blog(level, "[qsv encoder: '%s'] " format, "msdk_impl", ##__VA_ARGS__)
@@ -70,6 +72,74 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 mfxIMPL impl = MFX_IMPL_HARDWARE_ANY;
 mfxVersion ver = {{0, 1}}; // for backward compatibility
 std::atomic<bool> is_active{false};
+
+bool prefer_igpu_enc(int *iGPUIndex)
+{
+	IDXGIAdapter *pAdapter;
+	int adapterIndex = 0;
+	bool hasIGPU = false;
+	bool hasDGPU = false;
+	bool isDG1Primary = false;
+
+	HMODULE hDXGI = LoadLibrary(L"dxgi.dll");
+	if (hDXGI == NULL) {
+		return false;
+	}
+
+	typedef HRESULT(WINAPI * LPCREATEDXGIFACTORY)(REFIID riid,
+						      void **ppFactory);
+
+	LPCREATEDXGIFACTORY pCreateDXGIFactory =
+		(LPCREATEDXGIFACTORY)GetProcAddress(hDXGI,
+						    "CreateDXGIFactory1");
+	if (pCreateDXGIFactory == NULL) {
+		pCreateDXGIFactory = (LPCREATEDXGIFACTORY)GetProcAddress(
+			hDXGI, "CreateDXGIFactory");
+
+		if (pCreateDXGIFactory == NULL) {
+			FreeLibrary(hDXGI);
+			return false;
+		}
+	}
+
+	IDXGIFactory *pFactory = NULL;
+	if (FAILED((*pCreateDXGIFactory)(__uuidof(IDXGIFactory),
+					 (void **)(&pFactory)))) {
+		FreeLibrary(hDXGI);
+		return false;
+	}
+
+	while (SUCCEEDED(pFactory->EnumAdapters(adapterIndex, &pAdapter))) {
+		DXGI_ADAPTER_DESC AdapterDesc = {};
+		if (SUCCEEDED(pAdapter->GetDesc(&AdapterDesc))) {
+			if (AdapterDesc.VendorId == 0x8086) {
+				if (AdapterDesc.DedicatedVideoMemory <=
+				    512 * 1024 * 1024) {
+					hasIGPU = true;
+					if (iGPUIndex != NULL) {
+						*iGPUIndex = adapterIndex;
+					}
+				} else {
+					hasDGPU = true;
+				}
+				if ((AdapterDesc.DeviceId == 0x4905) ||
+				    (AdapterDesc.DeviceId == 0x4906) ||
+				    (AdapterDesc.DeviceId == 0x4907)) {
+					if (adapterIndex == 0) {
+						isDG1Primary = true;
+					}
+				}
+			}
+		}
+		adapterIndex++;
+		pAdapter->Release();
+	}
+
+	pFactory->Release();
+	FreeLibrary(hDXGI);
+
+	return hasIGPU && hasDGPU && isDG1Primary;
+}
 
 void qsv_encoder_version(unsigned short *major, unsigned short *minor)
 {
@@ -79,6 +149,13 @@ void qsv_encoder_version(unsigned short *major, unsigned short *minor)
 
 qsv_t *qsv_encoder_open(qsv_param_t *pParams)
 {
+	mfxIMPL impl_list[4] = {MFX_IMPL_HARDWARE, MFX_IMPL_HARDWARE2,
+				MFX_IMPL_HARDWARE3, MFX_IMPL_HARDWARE4};
+	int igpu_index = -1;
+	if (prefer_igpu_enc(&igpu_index)) {
+		impl = impl_list[igpu_index];
+	}
+
 	QSV_Encoder_Internal *pEncoder = new QSV_Encoder_Internal(impl, ver);
 	mfxStatus sts = pEncoder->Open(pParams);
 	if (sts != MFX_ERR_NONE) {

--- a/plugins/obs-qsv11/QSV_Encoder.h
+++ b/plugins/obs-qsv11/QSV_Encoder.h
@@ -136,6 +136,7 @@ int qsv_encoder_encode_tex(qsv_t *, uint64_t, uint32_t, uint64_t, uint64_t *,
 int qsv_encoder_headers(qsv_t *, uint8_t **pSPS, uint8_t **pPPS,
 			uint16_t *pnSPS, uint16_t *pnPPS);
 enum qsv_cpu_platform qsv_get_cpu_platform();
+bool prefer_igpu_enc(int *iGPUIndex);
 
 #ifdef __cplusplus
 }

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -666,6 +666,12 @@ static void *obs_qsv_create_tex(obs_data_t *settings, obs_encoder_t *encoder)
 		return obs_encoder_create_rerouted(encoder, "obs_qsv11_soft");
 	}
 
+	if (prefer_igpu_enc(NULL)) {
+		blog(LOG_INFO,
+		     ">>> prefer iGPU encoding, fall back to old qsv encoder");
+		return obs_encoder_create_rerouted(encoder, "obs_qsv11_soft");
+	}
+
 	blog(LOG_INFO, ">>> new qsv encoder");
 	return obs_qsv_create(settings, encoder);
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change sets the preference for encoding to the integrated GPU over the discrete GPU on Intel systems with both iGPU and dGPU.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The motivation is to give streaming customers the best hardware encoding experience when there are both iGPU and dGPU options on Intel systems.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This patch has been tested with 3 different versions of graphics drivers (both internal and external) on 3 different platforms to verify HW encoding on the iGPU over the dGPU.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
