### PR TITLE
cmake: Update Windows SDK check to 19041

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 if(WIN32)
 	cmake_minimum_required(VERSION 3.16)
 
-	# Check for Win SDK version 10.0.18362 or above
+	# Check for Win SDK version 10.0.19041 or above
 	if(MSVC AND MSVC_VERSION LESS 1920)
 		message(STATUS "Windows API version is ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
 		string(REPLACE "." ";" WINAPI_VER "${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
@@ -26,7 +26,7 @@ if(WIN32)
 		set(WINAPI_COMPATIBLE FALSE)
 		if(WINAPI_VER_MAJOR EQUAL 10)
 			if (WINAPI_VER_MINOR EQUAL 0)
-				if (WINAPI_VER_BUILD GREATER_EQUAL 18362)
+				if (WINAPI_VER_BUILD GREATER_EQUAL 19041)
 					set(WINAPI_COMPATIBLE TRUE)
 				endif()
 			else()
@@ -37,7 +37,7 @@ if(WIN32)
 		endif()
 
 		if(NOT WINAPI_COMPATIBLE)
-			message(FATAL_ERROR "OBS requires Windows 10 SDK version 10.0.18362.0 and above to compile.\nPlease download the most recent Windows 10 SDK in order to compile (or update to Visual Studio 2019).")
+			message(FATAL_ERROR "OBS requires Windows 10 SDK version 10.0.19041.0 and above to compile.\nPlease download the most recent Windows 10 SDK in order to compile (or update to Visual Studio 2019).")
 		endif()
 	endif()
 


### PR DESCRIPTION

### Description
Update cmake to check for the latest (now required) Windows SDK 19041 to build against.

### Motivation and Context
We now require this version

### How Has This Been Tested?
Attempted to build against older SDK, watched cmake generate error.
Updated SDK to 19041, error no longer present.

TODO: Update build directions with this new requirement.

### Types of changes
- Fixup (non-breaking minor change or update)

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
