### PR TITLE
oss-audio: Add en-US translation data file

### DIFF
--- a/plugins/oss-audio/CMakeLists.txt
+++ b/plugins/oss-audio/CMakeLists.txt
@@ -34,4 +34,4 @@ target_link_libraries(oss-audio
 )
 set_target_properties(oss-audio PROPERTIES FOLDER "plugins")
 
-install_obs_plugin(oss-audio)
+install_obs_plugin_with_data(oss-audio data)

--- a/plugins/oss-audio/data/locale/en-US.ini
+++ b/plugins/oss-audio/data/locale/en-US.ini
@@ -1,0 +1,8 @@
+OSSInput="Audio Input Capture (OSS)"
+DSP="DSP"
+CustomDSPPath="Custom DSP Path"
+SampleRate="Sample rate"
+Channels="Channels"
+SampleFormat="Sample format"
+Default="Default"
+Custom="Custom"

--- a/plugins/oss-audio/oss-input.c
+++ b/plugins/oss-audio/oss-input.c
@@ -322,7 +322,7 @@ static void oss_stop_reader(struct oss_input_data *handle)
 static const char *oss_getname(void *unused)
 {
 	UNUSED_PARAMETER(unused);
-	return obs_module_text("OSS Input");
+	return obs_module_text("OSSInput");
 }
 
 /**
@@ -630,16 +630,18 @@ static obs_properties_t *oss_properties(void *unused)
 					  OBS_COMBO_TYPE_LIST,
 					  OBS_COMBO_FORMAT_STRING);
 
-	obs_property_list_add_string(devices, "Default", OSS_DSP_DEFAULT);
-	obs_property_list_add_string(devices, "Custom", OBS_PATH_DSP_CUSTOM);
+	obs_property_list_add_string(devices, obs_module_text("Default"),
+				     OSS_DSP_DEFAULT);
+	obs_property_list_add_string(devices, obs_module_text("Custom"),
+				     OBS_PATH_DSP_CUSTOM);
 	obs_property_set_modified_callback(devices, oss_on_devices_changed);
 
 	obs_properties_add_text(props, OBS_PROPS_CUSTOM_DSP,
-				obs_module_text("Custom DSP Path"),
+				obs_module_text("CustomDSPPath"),
 				OBS_TEXT_DEFAULT);
 
 	rate = obs_properties_add_list(props, OBS_PROPS_RATE,
-				       obs_module_text("Sample rate"),
+				       obs_module_text("SampleRate"),
 				       OBS_COMBO_TYPE_LIST,
 				       OBS_COMBO_FORMAT_INT);
 	channels = obs_properties_add_list(props, OBS_PROPS_CHANNELS,
@@ -649,7 +651,7 @@ static obs_properties_t *oss_properties(void *unused)
 	oss_fill_device_info(rate, channels, OSS_DSP_DEFAULT);
 
 	sample_fmt = obs_properties_add_list(props, OBS_PROPS_SAMPLE_FMT,
-					     obs_module_text("Sample format"),
+					     obs_module_text("SampleFormat"),
 					     OBS_COMBO_TYPE_LIST,
 					     OBS_COMBO_FORMAT_INT);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR adds corresponding module text, and en-US translation file for oss-audio plugin.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
To prepare for support of languages other than English (US).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Run it with 
```
export LANG=en_US.UTF-8; obs
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
