### PR TITLE
UI: Fix GetPreferredLocales locale detection

### DIFF
--- a/UI/platform-x11.cpp
+++ b/UI/platform-x11.cpp
@@ -72,6 +72,7 @@ string GetDefaultVideoSavePath()
 vector<string> GetPreferredLocales()
 {
 	setlocale(LC_ALL, "");
+	vector<string> matched;
 	string messages = setlocale(LC_MESSAGES, NULL);
 	if (!messages.size() || messages == "C" || messages == "POSIX")
 		return {};
@@ -85,10 +86,10 @@ vector<string> GetPreferredLocales()
 			return {locale};
 
 		if (locale.substr(0, 2) == messages.substr(0, 2))
-			return {locale};
+			matched.push_back(locale);
 	}
 
-	return {};
+	return matched;
 }
 
 bool IsAlwaysOnTop(QWidget *window)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When running obs on FreeBSD (and possibly on other *nix platforms), there might be a chance languages with the same family were prematurely picked over the desired one.

One can reproduce the issue by the following shell commands:
```
export LANG=zh_TW.UTF-8
obs
```
And we could observe that zh_CN was picked over zh_TW despite the existence of zh_TW locale files.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
To fix a bug when detecting preferred languages.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Re-run with
```
export LANG=zh_TW.UTF-8
obs
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
