### PR TITLE
image-source: change color source default color to d1d1d1

### DIFF
--- a/plugins/image-source/color-source.c
+++ b/plugins/image-source/color-source.c
@@ -113,6 +113,13 @@ static void color_source_defaults_v2(obs_data_t *settings)
 	obs_data_set_default_int(settings, "height", 1080);
 }
 
+static void color_source_defaults_v3(obs_data_t *settings)
+{
+	obs_data_set_default_int(settings, "color", 0xFFD1D1D1);
+	obs_data_set_default_int(settings, "width", 1920);
+	obs_data_set_default_int(settings, "height", 1080);
+}
+
 struct obs_source_info color_source_info_v1 = {
 	.id = "color_source",
 	.type = OBS_SOURCE_TYPE_INPUT,
@@ -134,12 +141,30 @@ struct obs_source_info color_source_info_v2 = {
 	.id = "color_source",
 	.version = 2,
 	.type = OBS_SOURCE_TYPE_INPUT,
-	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
+			OBS_SOURCE_CAP_OBSOLETE,
 	.create = color_source_create,
 	.destroy = color_source_destroy,
 	.update = color_source_update,
 	.get_name = color_source_get_name,
 	.get_defaults = color_source_defaults_v2,
+	.get_width = color_source_getwidth,
+	.get_height = color_source_getheight,
+	.video_render = color_source_render,
+	.get_properties = color_source_properties,
+	.icon_type = OBS_ICON_TYPE_COLOR,
+};
+
+struct obs_source_info color_source_info_v3 = {
+	.id = "color_source",
+	.version = 3,
+	.type = OBS_SOURCE_TYPE_INPUT,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW,
+	.create = color_source_create,
+	.destroy = color_source_destroy,
+	.update = color_source_update,
+	.get_name = color_source_get_name,
+	.get_defaults = color_source_defaults_v3,
 	.get_width = color_source_getwidth,
 	.get_height = color_source_getheight,
 	.video_render = color_source_render,

--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -281,12 +281,14 @@ MODULE_EXPORT const char *obs_module_description(void)
 extern struct obs_source_info slideshow_info;
 extern struct obs_source_info color_source_info_v1;
 extern struct obs_source_info color_source_info_v2;
+extern struct obs_source_info color_source_info_v3;
 
 bool obs_module_load(void)
 {
 	obs_register_source(&image_source_info);
 	obs_register_source(&color_source_info_v1);
 	obs_register_source(&color_source_info_v2);
+	obs_register_source(&color_source_info_v3);
 	obs_register_source(&slideshow_info);
 	return true;
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the default color for color source to #d1d1d1.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The default color can trigger photosensitivity in users suffering from it; the new color should reduce or avoid the trigger.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Flashed the new color in my own face, it not nearly as painful as flashing a full #ffffff white without precautions. I haven't actually compiled obs-studio with this change.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
 - Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
