### PR TITLE
linux-v4l2: Support for Motion-JPEG codec

### DIFF
--- a/plugins/linux-v4l2/CMakeLists.txt
+++ b/plugins/linux-v4l2/CMakeLists.txt
@@ -29,9 +29,13 @@ else()
 	endif()
 endif()
 
+find_package(FFmpeg REQUIRED
+        COMPONENTS avcodec avutil avformat)
+
 include_directories(
 	SYSTEM "${CMAKE_SOURCE_DIR}/libobs"
 	${LIBV4L2_INCLUDE_DIRS}
+	${FFMPEG_INCLUDE_DIRS}
 )
 
 set(linux-v4l2_SOURCES
@@ -40,6 +44,7 @@ set(linux-v4l2_SOURCES
 	v4l2-input.c
 	v4l2-helpers.c
 	v4l2-output.c
+	v4l2-mjpeg.c
 	${linux-v4l2-udev_SOURCES}
 )
 
@@ -50,6 +55,7 @@ target_link_libraries(linux-v4l2
 	libobs
 	${LIBV4L2_LIBRARIES}
 	${UDEV_LIBRARIES}
+	${FFMPEG_LIBRARIES}
 )
 set_target_properties(linux-v4l2 PROPERTIES FOLDER "plugins")
 

--- a/plugins/linux-v4l2/v4l2-helpers.h
+++ b/plugins/linux-v4l2/v4l2-helpers.h
@@ -79,6 +79,8 @@ static inline enum video_format v4l2_to_obs_video_format(uint_fast32_t format)
 #endif
 	case V4L2_PIX_FMT_BGR24:
 		return VIDEO_FORMAT_BGR3;
+	case V4L2_PIX_FMT_MJPEG:
+		return VIDEO_FORMAT_I422;
 	default:
 		return VIDEO_FORMAT_NONE;
 	}

--- a/plugins/linux-v4l2/v4l2-mjpeg.c
+++ b/plugins/linux-v4l2/v4l2-mjpeg.c
@@ -1,0 +1,98 @@
+/*
+Copyright (C) 2020 by Morten Bøgeskov <source@kosmisk.dk>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <obs-module.h>
+
+#include "v4l2-mjpeg.h"
+
+#define blog(level, msg, ...) \
+	blog(level, "v4l2-input: mjpeg: " msg, ##__VA_ARGS__)
+
+int v4l2_init_mjpeg(struct v4l2_mjpeg_decoder *decoder)
+{
+	decoder->codec = avcodec_find_decoder(AV_CODEC_ID_MJPEG);
+	if (!decoder->codec) {
+		return -1;
+	}
+
+	decoder->context = avcodec_alloc_context3(decoder->codec);
+	if (!decoder->context) {
+		return -1;
+	}
+
+	decoder->packet = av_packet_alloc();
+	if (!decoder->packet) {
+		return -1;
+	}
+
+	decoder->frame = av_frame_alloc();
+	if (!decoder->frame) {
+		return -1;
+	}
+
+	decoder->context->flags2 |= AV_CODEC_FLAG2_FAST;
+	decoder->context->pix_fmt = AV_PIX_FMT_YUVJ422P;
+
+	if (avcodec_open2(decoder->context, decoder->codec, NULL) < 0) {
+		blog(LOG_ERROR, "failed to open codec");
+		return -1;
+	}
+
+	blog(LOG_DEBUG, "initialized avcodec");
+
+	return 0;
+}
+
+void v4l2_destroy_mjpeg(struct v4l2_mjpeg_decoder *decoder)
+{
+	blog(LOG_DEBUG, "destroying avcodec");
+	if (decoder->frame) {
+		av_frame_free(&decoder->frame);
+	}
+
+	if (decoder->packet) {
+		av_packet_free(&decoder->packet);
+	}
+
+	if (decoder->context) {
+		avcodec_free_context(&decoder->context);
+	}
+}
+
+int v4l2_decode_mjpeg(struct obs_source_frame *out, uint8_t *data,
+		      size_t length, struct v4l2_mjpeg_decoder *decoder)
+{
+
+	decoder->packet->data = data;
+	decoder->packet->size = length;
+	if (avcodec_send_packet(decoder->context, decoder->packet) < 0) {
+		blog(LOG_ERROR, "failed to send jpeg to codec");
+		return -1;
+	}
+
+	if (avcodec_receive_frame(decoder->context, decoder->frame) < 0) {
+		blog(LOG_ERROR, "failed to recieve frame from codec");
+		return -1;
+	}
+
+	for (uint_fast32_t i = 0; i < MAX_AV_PLANES; ++i) {
+		out->data[i] = decoder->frame->data[i];
+		out->linesize[i] = decoder->frame->linesize[i];
+	}
+
+	return 0;
+}

--- a/plugins/linux-v4l2/v4l2-mjpeg.h
+++ b/plugins/linux-v4l2/v4l2-mjpeg.h
@@ -1,0 +1,68 @@
+/*
+Copyright (C) 2020 by Morten Bøgeskov <source@kosmisk.dk>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/pixfmt.h>
+
+/**
+ * Data structure for mjpeg decoding
+ */
+struct v4l2_mjpeg_decoder {
+	AVCodec *codec;
+	AVCodecContext *context;
+	AVPacket *packet;
+	AVFrame *frame;
+};
+
+/**
+ * Initialize the mjpeg decoder.
+ * The decoder must be destroyed on failure.
+ *
+ * @param props the decoder structure
+ * @return non-zero on failure
+ */
+int v4l2_init_mjpeg(struct v4l2_mjpeg_decoder *decoder);
+
+/**
+ * Free any data associated with the decoder.
+ *
+ * @param decoder the decoder structure
+ */
+void v4l2_destroy_mjpeg(struct v4l2_mjpeg_decoder *decoder);
+
+/**
+ * Decode a jpeg into an obs frame
+ *
+ * @param out the obs frame to decode into
+ * @param data the jpeg data
+ * @param length length of the data
+ * @param decoder the decoder as initialized by v4l2_init_mjpeg
+ * @return non-zero on failure
+ */
+int v4l2_decode_mjpeg(struct obs_source_frame *out, uint8_t *data,
+		      size_t length, struct v4l2_mjpeg_decoder *decoder);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Added support for format "MJPG" to capture from the linux-v4l2 plugin.
Added code to use avcodec to unpack jpegs from the camera.

### Motivation and Context
I would like to run 1920x1080@30 from my Logitech C290.

### How Has This Been Tested?
I've selected "Moition-JPEG" from the "Video Format" drop down
I've selected "1920x1080" from the "Resoution" drop down
I've selected "30.00" from the4 "Frame Rate" drop down
This produces log output like this:
```
info: v4l2-input: Start capture from /dev/video0
info: v4l2-input: Input: 0
info: v4l2-input: Resolution: 1920x1080
info: v4l2-input: Pixelformat: GPJM
info: v4l2-input: Linesize: 0 Bytes
info: v4l2-input: Framerate: 30.00 fps
```
And a smooth FullHD output

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
