### PR TITLE
linux-capture: Fix Problems with the Window-Selection of the XComposite Source

### DIFF
--- a/plugins/linux-capture/xcompcap-helper.cpp
+++ b/plugins/linux-capture/xcompcap-helper.cpp
@@ -32,22 +32,6 @@ void cleanupDisplay()
 	xdisplay = 0;
 }
 
-static void getAllWindows(Window parent, std::list<Window> &windows)
-{
-	UNUSED_PARAMETER(parent);
-	UNUSED_PARAMETER(windows);
-}
-
-std::list<Window> getAllWindows()
-{
-	std::list<Window> res;
-
-	for (int i = 0; i < ScreenCount(disp()); ++i)
-		getAllWindows(RootWindow(disp(), i), res);
-
-	return res;
-}
-
 // Specification for checking for ewmh support at
 // http://standards.freedesktop.org/wm-spec/wm-spec-latest.html#idm140200472693600
 
@@ -180,40 +164,6 @@ std::string getWindowAtom(Window win, const char *atom)
 	XFree(tp.value);
 
 	return res;
-}
-
-std::string getWindowCommand(Window win)
-{
-	Atom xi = XInternAtom(disp(), "WM_COMMAND", false);
-	int n;
-	char **list = 0;
-	XTextProperty tp;
-	std::string res = "error";
-
-	XGetTextProperty(disp(), win, &tp, xi);
-
-	if (!tp.nitems)
-		return std::string();
-
-	if (tp.encoding == XA_STRING) {
-		res = (char *)tp.value;
-	} else {
-		int ret = XmbTextPropertyToTextList(disp(), &tp, &list, &n);
-		if (ret >= Success && n > 0 && *list) {
-			res = *list;
-			XFreeStringList(list);
-		}
-	}
-
-	XFree(tp.value);
-
-	return res;
-}
-
-int getWindowPid(Window win)
-{
-	UNUSED_PARAMETER(win);
-	return 1234; //TODO
 }
 
 static std::map<XCompcapMain *, Window> windowForSource;

--- a/plugins/linux-capture/xcompcap-helper.hpp
+++ b/plugins/linux-capture/xcompcap-helper.hpp
@@ -70,6 +70,8 @@ public:
 	~ObsGsContextHolder();
 };
 
+class XCompcapMain;
+
 namespace XCompcap {
 Display *disp();
 void cleanupDisplay();
@@ -92,6 +94,8 @@ inline std::string getWindowClass(Window win)
 	return getWindowAtom(win, "WM_CLASS");
 }
 
+void registerSource(XCompcapMain *source, Window win);
+void unregisterSource(XCompcapMain *source);
 void processEvents();
-bool windowWasReconfigured(Window win);
+bool sourceWasReconfigured(XCompcapMain *source);
 }

--- a/plugins/linux-capture/xcompcap-helper.hpp
+++ b/plugins/linux-capture/xcompcap-helper.hpp
@@ -76,13 +76,10 @@ namespace XCompcap {
 Display *disp();
 void cleanupDisplay();
 
-std::string getWindowCommand(Window win);
 int getRootWindowScreen(Window root);
 std::string getWindowAtom(Window win, const char *atom);
-int getWindowPid(Window win);
 bool ewmhIsSupported();
 std::list<Window> getTopLevelWindows();
-std::list<Window> getAllWindows();
 
 inline std::string getWindowName(Window win)
 {

--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -104,7 +104,7 @@ void XCompcapMain::defaults(obs_data_t *settings)
 	obs_data_set_default_bool(settings, "exclude_alpha", false);
 }
 
-#define FIND_WINDOW_INTERVAL 2.0
+#define FIND_WINDOW_INTERVAL 0.5
 
 struct XCompcapMain_private {
 	XCompcapMain_private()


### PR DESCRIPTION
### Description
This PR fixes the **three Problems** reported in #3040 that have been found in the Window-Source (XComposite) of the linux-capture Plugin:

TL;DR Video: https://mazdermind.de/dl/github/obs/3040/2.mp4


#### Problem 1
When a selected Window is closed, OBS randomly chooses another Window of the same Application (for example any other Browser-Window) if the initial window is closed. Because of that restoring the, maybe accidentally closed Window, will not restore it in the Scene.

The reason for this is, that if no Window of the selected ID can be found, a search based on the Window-Title or the Window-Class is started (See [Lines 242-244 of xcompcap-main.cpp](https://github.com/obsproject/obs-studio/blob/fd66869/plugins/linux-capture/xcompcap-main.cpp#L242-L244) for the quite convoluted comparison). If no Window of the same Title is found, any window of the same Class is selected. This Search-Branch that checks the Window-Class has been removed in this PR.

#### Problem 2
Cannot capture two windows with the same title: Tough the Selection Dialog lists both Windows, only one of them can be actually selected. Selecting the other one behaves as if the first one had been selected.

The reason for this is a programming flaw in `getWindowFromString` where in [Lines 239-240 of xcompcap-main.cpp](https://github.com/obsproject/obs-studio/blob/fd66869/plugins/linux-capture/xcompcap-main.cpp#L239-L240) `wid` is never assigned and stays `0` for the entire function. Therefore `cwin == wid` is always  `false` and the only relevant condition is `wname == cwinname && wcls == ccls` which only matched Windows by Name & Class and completely ignoring the selected Window-ID.

The relevant selection Loop has been replaced with two Loops: One tries to find the exact window by ID, the second Loop does a further search by Name & Class, if the exact Window has not been found.

The relevant Code is not in the hot Path and only runs every 2 Seconds while a Window is not open, so the increased readability of the two distince loops outweighs the possibly reduced performance from the nearly unreadable original loop (which has hidden the above bug for quite some time).

#### Problem 3
Event-Handling-Problems when capturing the same Window more then once. When creating two or more sources which each capture the same Window, the Capture works on first glance, but when modifying the Window (ie. by simply resizing it) one can see, that only one of the sources correctly responds. As a followup problem, this breaks the image-capturing of the other source, that did not correctly receive the events.

This can also be observed, when the Window is closed: One of the Sources gets the `DESTROY`-Notification, while the other does not get notified of the destruction and continues to grab from the non-existing window, resulting in X-Errors being printed to the console:
```
error: X Error: BadWindow (invalid Window parameter), Major opcode: BadWindow (invalid Window parameter), Minor opcode: 0, Serial: 5332
```

The Reason for this is, that `XCompcap::processEvents` stores changed Window-IDs in an `std::unordered_set` which then contains one entry per changed Window. A following call to `XCompcap::windowWasReconfigured` returns for that specific window returns `true` but also removes the Window-ID from the set, so that the second call from the other Source incorrectly returns `false`. (See [Lines 250-262 of xcompcap-helper.cpp](https://github.com/obsproject/obs-studio/blob/fd668695db7ed5724888e71b4df34285fd72b495/plugins/linux-capture/xcompcap-helper.cpp#L250-L262)).

~~After trying various approaches, I decided to completely move the State into the Source, so that now each Source has its own `Display`-Reference and receives only Events for its own Window. All Helper-Functions have been extended with an `Display *xdisplay` parameter which makes them only dependent from the respective Source. Also the `pthread_mutex_t changeLock` could be removed, which also removes a possible congestion in the hot path.~~

After @kkartaltepe found issues with this approach I removed the offending change and implemented a different solution, which now uses [a combination of `map` and `unordered_set`](https://github.com/MaZderMind/obs-studio/commit/05bc26797a3f167a506cd2255b2dd31279bca0b8#diff-52b602eca61b7f1851c824aea05e4f6fR169-R170) to track which sources are interested in Events from which Window and handles subscribing and unsubscribing in the shared code, thus correctly handling multiple sources capturing the same window.

I also had to fix [a Problem with xcc_cleanup](https://github.com/MaZderMind/obs-studio/commit/05bc26797a3f167a506cd2255b2dd31279bca0b8#diff-73ba83f076f2731c616a0940f79f585bL373-R377) cleaning up the Window's Compositor-Redirection for one of the two sources when a captured Window re-appeard after it was closed before.

### Motivation and Context
I recently produced Remote-Conference-Talks with multiple Speakers and a Moderator, which all were present in a _Google Meet_ (Google Video-Conferencing System). I had 4 Chrome-Browser windows open, which all participated in the Meet. Each of them had one Source pinned and was switched to Fullscreen.

With the Window-Capture I was able to select them as individual "Camera" Sources and create a nice mix. Because all Browser-Windows have the same Title in this Scenario I hit _Problem 2_, which could be worked around by changing the Window-Title via the Browser-Developer-Console.

_Problem 1_ occured when I first started OBS without configuring the Meet-Windows first. OBS would just select any open Browser-Window and keep that way, even after correctly configuring the Meet-Windows.

_Problem 3_ only occured in the Lab after I fixed _Problem 1 & 2_.

### How Has This Been Tested?
I tested these Changes on an `Ubuntu 19.10` installation under Lab conditions; see Video linked at the top.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

Although that depends on whether the Logic to switch to another Window of the same Application when the original Window is closed county as Feature, but as it is totally uncontrollable which window the Source switches to, I rather see it as a fixed bug rather then functionality which has been removed.

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
