### PR TITLE
libobs/media-io: Remove unused code

### DIFF
--- a/libobs/media-io/audio-io.c
+++ b/libobs/media-io/audio-io.c
@@ -73,47 +73,6 @@ struct audio_output {
 };
 
 /* ------------------------------------------------------------------------- */
-/* the following functions are used to calculate frame offsets based upon
- * timestamps.  this will actually work accurately as long as you handle the
- * values correctly */
-
-static inline double ts_to_frames(const audio_t *audio, uint64_t ts)
-{
-	return util_mul_div64(ts, audio->info.samples_per_sec, 1000000000ULL);
-}
-
-static inline double positive_round(double val)
-{
-	return floor(val + 0.5);
-}
-
-static int64_t ts_diff_frames(const audio_t *audio, uint64_t ts1, uint64_t ts2)
-{
-	double diff = ts_to_frames(audio, ts1) - ts_to_frames(audio, ts2);
-	return (int64_t)positive_round(diff);
-}
-
-static int64_t ts_diff_bytes(const audio_t *audio, uint64_t ts1, uint64_t ts2)
-{
-	return ts_diff_frames(audio, ts1, ts2) * (int64_t)audio->block_size;
-}
-
-/* ------------------------------------------------------------------------- */
-
-static inline uint64_t min_uint64(uint64_t a, uint64_t b)
-{
-	return a < b ? a : b;
-}
-
-static inline size_t min_size(size_t a, size_t b)
-{
-	return a < b ? a : b;
-}
-
-#ifndef CLAMP
-#define CLAMP(val, minval, maxval) \
-	((val > maxval) ? maxval : ((val < minval) ? minval : val))
-#endif
 
 static bool resample_audio_output(struct audio_input *input,
 				  struct audio_data *data)


### PR DESCRIPTION
### Description
Remove unused code.

### Motivation and Context
Compiler warning about ts_to_frames() returning uint64_t instead of double, but the function isn't even used anyway.

### How Has This Been Tested?
OBS still compiles and runs.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.