### PR TITLE
UI: Fix warnings for Qt 5.15

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -431,7 +431,7 @@
   <widget class="OBSBasicStatusBar" name="statusbar"/>
   <widget class="OBSDock" name="scenesDock">
    <property name="features">
-    <set>QDockWidget::AllDockWidgetFeatures</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
    </property>
    <property name="windowTitle">
     <string>Basic.Main.Scenes</string>
@@ -566,7 +566,7 @@
   </widget>
   <widget class="OBSDock" name="sourcesDock">
    <property name="features">
-    <set>QDockWidget::AllDockWidgetFeatures</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
    </property>
    <property name="windowTitle">
     <string>Basic.Main.Sources</string>
@@ -702,7 +702,7 @@
   </widget>
   <widget class="OBSDock" name="mixerDock">
    <property name="features">
-    <set>QDockWidget::AllDockWidgetFeatures</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
    </property>
    <property name="windowTitle">
     <string>Mixer</string>
@@ -842,7 +842,7 @@
   </widget>
   <widget class="OBSDock" name="transitionsDock">
    <property name="features">
-    <set>QDockWidget::AllDockWidgetFeatures</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
    </property>
    <property name="windowTitle">
     <string>Basic.SceneTransitions</string>
@@ -1089,7 +1089,7 @@
   </widget>
   <widget class="OBSDock" name="controlsDock">
    <property name="features">
-    <set>QDockWidget::AllDockWidgetFeatures</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
    </property>
    <property name="windowTitle">
     <string>Basic.Main.Controls</string>

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -1686,7 +1686,7 @@ bool WidgetInfo::ColorChanged(const char *setting)
 	long long val = obs_data_get_int(view->settings, setting);
 	QColor color = color_from_int(val);
 
-	QColorDialog::ColorDialogOptions options = 0;
+	QColorDialog::ColorDialogOptions options;
 
 	/* The native dialog on OSX has all kinds of problems, like closing
 	 * other open QDialogs on exit, and

--- a/UI/qt-display.hpp
+++ b/UI/qt-display.hpp
@@ -24,7 +24,7 @@ signals:
 
 public:
 	OBSQTDisplay(QWidget *parent = nullptr,
-		     Qt::WindowFlags flags = nullptr);
+		     Qt::WindowFlags flags = Qt::WindowFlags());
 
 	virtual QPaintEngine *paintEngine() const override;
 

--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -264,7 +264,7 @@ void ExecuteFuncSafeBlockMsgBox(std::function<void()> func,
 	dlg.setWindowFlags(dlg.windowFlags() & ~Qt::WindowCloseButtonHint);
 	dlg.setWindowTitle(title);
 	dlg.setText(text);
-	dlg.setStandardButtons(0);
+	dlg.setStandardButtons(QMessageBox::StandardButtons());
 
 	auto wait = [&]() {
 		func();

--- a/UI/source-label.hpp
+++ b/UI/source-label.hpp
@@ -29,7 +29,7 @@ public:
 	OBSSignal destroyedSignal;
 
 	OBSSourceLabel(const obs_source_t *source, QWidget *parent = nullptr,
-		       Qt::WindowFlags f = 0)
+		       Qt::WindowFlags f = Qt::WindowFlags())
 		: QLabel(obs_source_get_name(source), parent, f),
 		  renamedSignal(obs_source_get_signal_handler(source), "rename",
 				&OBSSourceLabel::SourceRenamed, this),

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -830,7 +830,7 @@ AutoConfig::AutoConfig(QWidget *parent) : QWizard(parent)
 		streamPage->ui->preferHardware->setChecked(preferHardware);
 	}
 
-	setOptions(0);
+	setOptions(QWizard::WizardOptions());
 	setButtonText(QWizard::FinishButton,
 		      QTStr("Basic.AutoConfig.ApplySettings"));
 	setButtonText(QWizard::BackButton, QTStr("Back"));

--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -314,22 +314,32 @@ bool OBSBasicInteraction::HandleMouseWheelEvent(QWheelEvent *event)
 	int xDelta = 0;
 	int yDelta = 0;
 
+	const QPoint angleDelta = event->angleDelta();
 	if (!event->pixelDelta().isNull()) {
-		if (event->orientation() == Qt::Horizontal)
+		if (angleDelta.x())
 			xDelta = event->pixelDelta().x();
 		else
 			yDelta = event->pixelDelta().y();
 	} else {
-		if (event->orientation() == Qt::Horizontal)
-			xDelta = event->delta();
+		if (angleDelta.x())
+			xDelta = angleDelta.x();
 		else
-			yDelta = event->delta();
+			yDelta = angleDelta.y();
 	}
 
-	if (GetSourceRelativeXY(event->x(), event->y(), mouseEvent.x,
-				mouseEvent.y))
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+	const QPointF position = event->position();
+	const int x = position.x();
+	const int y = position.y();
+#else
+	const int x = event->x();
+	const int y = event->y();
+#endif
+
+	if (GetSourceRelativeXY(x, y, mouseEvent.x, mouseEvent.y)) {
 		obs_source_send_mouse_wheel(source, &mouseEvent, xDelta,
 					    yDelta);
+	}
 
 	return true;
 }

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -221,7 +221,9 @@ OBSBasic::OBSBasic(QWidget *parent)
 
 	statsDock = new OBSDock();
 	statsDock->setObjectName(QStringLiteral("statsDock"));
-	statsDock->setFeatures(QDockWidget::AllDockWidgetFeatures);
+	statsDock->setFeatures(QDockWidget::DockWidgetClosable |
+			       QDockWidget::DockWidgetMovable |
+			       QDockWidget::DockWidgetFloatable);
 	statsDock->setWindowTitle(QTStr("Basic.Stats"));
 	addDockWidget(Qt::BottomDockWidgetArea, statsDock);
 	statsDock->setVisible(false);
@@ -6982,7 +6984,9 @@ void OBSBasic::on_lockUI_toggled(bool lock)
 {
 	QDockWidget::DockWidgetFeatures features =
 		lock ? QDockWidget::NoDockWidgetFeatures
-		     : QDockWidget::AllDockWidgetFeatures;
+		     : (QDockWidget::DockWidgetClosable |
+			QDockWidget::DockWidgetMovable |
+			QDockWidget::DockWidgetFloatable);
 
 	QDockWidget::DockWidgetFeatures mainFeatures = features;
 	mainFeatures &= ~QDockWidget::QDockWidget::DockWidgetClosable;
@@ -7652,7 +7656,9 @@ QAction *OBSBasic::AddDockWidget(QDockWidget *dock)
 	bool lock = ui->lockUI->isChecked();
 	QDockWidget::DockWidgetFeatures features =
 		lock ? QDockWidget::NoDockWidgetFeatures
-		     : QDockWidget::AllDockWidgetFeatures;
+		     : (QDockWidget::DockWidgetClosable |
+			QDockWidget::DockWidgetMovable |
+			QDockWidget::DockWidgetFloatable);
 
 	dock->setFeatures(features);
 

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -495,13 +495,15 @@ void OBSBasicPreview::keyReleaseEvent(QKeyEvent *event)
 
 void OBSBasicPreview::wheelEvent(QWheelEvent *event)
 {
-	if (scrollMode && IsFixedScaling() &&
-	    event->orientation() == Qt::Vertical) {
-		if (event->delta() > 0)
-			SetScalingLevel(scalingLevel + 1);
-		else if (event->delta() < 0)
-			SetScalingLevel(scalingLevel - 1);
-		emit DisplayResized();
+	if (scrollMode && IsFixedScaling()) {
+		const int delta = event->angleDelta().y();
+		if (delta != 0) {
+			if (delta > 0)
+				SetScalingLevel(scalingLevel + 1);
+			else
+				SetScalingLevel(scalingLevel - 1);
+			emit DisplayResized();
+		}
 	}
 
 	OBSQTDisplay::wheelEvent(event);

--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -105,7 +105,8 @@ private:
 	void ProcessClick(const vec2 &pos);
 
 public:
-	OBSBasicPreview(QWidget *parent, Qt::WindowFlags flags = 0);
+	OBSBasicPreview(QWidget *parent,
+			Qt::WindowFlags flags = Qt::WindowFlags());
 	~OBSBasicPreview();
 
 	static OBSBasicPreview *Get();


### PR DESCRIPTION
### Description
AllDockWidgetFeatures is now deprecated. Use underlying values instead.

Use default QFlags constructor instead of nullptr/0.

Use QWheelEvent::angleDelta() in place of orientation() and delta(), and
position() in place of x() and y().

### Motivation and Context
Don't like warnings.

### How Has This Been Tested?
Breakpoint inspected every except two spots that I can't figure out how to reach, but I feel confident in the pattern change:
https://github.com/obsproject/obs-studio/blob/5687c5157c38a7b895fdd52a3f546816b168658d/UI/qt-wrappers.cpp#L267
https://github.com/obsproject/obs-studio/blob/5687c5157c38a7b895fdd52a3f546816b168658d/UI/window-basic-main.cpp#L7655

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.