### PR TITLE
libobs: Use autoreleasepool for graphics thread

### DIFF
--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -1804,3 +1804,17 @@ bool obs_hotkeys_platform_is_pressed(obs_hotkeys_platform_t *plat,
 
 	return false;
 }
+
+void *obs_graphics_thread_autorelease(void *param)
+{
+	@autoreleasepool {
+		return obs_graphics_thread(param);
+	}
+}
+
+bool obs_graphics_thread_loop_autorelease(struct obs_graphics_context *context)
+{
+	@autoreleasepool {
+		return obs_graphics_thread_loop(context);
+	}
+}

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -434,7 +434,27 @@ struct obs_core {
 
 extern struct obs_core *obs;
 
+struct obs_graphics_context {
+	uint64_t last_time;
+	uint64_t interval;
+	uint64_t frame_time_total_ns;
+	uint64_t fps_total_ns;
+	uint32_t fps_total_frames;
+#ifdef _WIN32
+	bool gpu_was_active;
+#endif
+	bool raw_was_active;
+	bool was_active;
+	const char *video_thread_name;
+};
+
 extern void *obs_graphics_thread(void *param);
+extern bool obs_graphics_thread_loop(struct obs_graphics_context *context);
+#ifdef __APPLE__
+extern void *obs_graphics_thread_autorelease(void *param);
+extern bool
+obs_graphics_thread_loop_autorelease(struct obs_graphics_context *context);
+#endif
 
 extern gs_effect_t *obs_load_effect(gs_effect_t **effect, const char *file);
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -429,8 +429,13 @@ static int obs_init_video(struct obs_video_info *ovi)
 	if (pthread_mutex_init(&video->task_mutex, NULL) < 0)
 		return OBS_VIDEO_FAIL;
 
+#ifdef __APPLE__
+	errorcode = pthread_create(&video->video_thread, NULL,
+				   obs_graphics_thread_autorelease, obs);
+#else
 	errorcode = pthread_create(&video->video_thread, NULL,
 				   obs_graphics_thread, obs);
+#endif
 	if (errorcode != 0)
 		return OBS_VIDEO_FAIL;
 


### PR DESCRIPTION
### Description
Use autoreleasepool for graphics thread.

### Motivation and Context
Apparently necessary to clean up macOS leaks.

Fixes #2293

### How Has This Been Tested?
OBS still works on Mac and Windows. Used _CFAutoreleasePoolPrintPools() in debugger to verify leaky behavior before change, and good behavior after change. Not quite guaranteed to fix original issue, but hopefully it does.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.