### PR TITLE
win-capture: Reset command pool rather than buffer

### DIFF
--- a/plugins/win-capture/graphics-hook/vulkan-capture.h
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.h
@@ -27,6 +27,7 @@ struct vk_device_funcs {
 	DEF_FUNC(DestroyImage);
 	DEF_FUNC(GetImageMemoryRequirements);
 	DEF_FUNC(GetImageMemoryRequirements2);
+	DEF_FUNC(ResetCommandPool);
 	DEF_FUNC(BeginCommandBuffer);
 	DEF_FUNC(EndCommandBuffer);
 	DEF_FUNC(CmdCopyImage);


### PR DESCRIPTION
### Description
Reorganize data to avoid best practices layer warning. Sort of a false
positive in our case because we only have one buffer per pool now.

### Motivation and Context
Implicit layers should be clean citizens.

### How Has This Been Tested?
Opened and closed vkcube several times with OBS open. Opened and closed OBS several times with vkcube open. Best practices warning about VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT usage is gone now.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.