### PR TITLE
UI: Delete existing fullscreen projector

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6715,6 +6715,15 @@ OBSProjector *OBSBasic::OpenProjector(obs_source_t *source, int monitor,
 	if (monitor > 9 || monitor > QGuiApplication::screens().size() - 1)
 		return nullptr;
 
+	if (monitor > -1) {
+		for (size_t i = 0; i < projectors.size(); i++) {
+			if (projectors[i]->GetMonitor() == monitor) {
+				DeleteProjector(projectors[i]);
+				break;
+			}
+		}
+	}
+
 	OBSProjector *projector =
 		new OBSProjector(nullptr, source, monitor, type);
 


### PR DESCRIPTION
### Description 
Fixes issue when opening a fullscreen projector, the existing projector on the same monitor wouldn't be deleted.

### Motivation and Context
Found it annoying when extra projectors would be open.

### How Has This Been Tested?
Opening fullscreen projectors on the same screen multiple times.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
