### PR TITLE
UI: Fix projector always on top not working on Linux

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -24,6 +24,9 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 {
 	type = type_;
 
+	SetAlwaysOnTop(this, config_get_bool(GetGlobalConfig(), "BasicWindow",
+					     "ProjectorAlwaysOnTop"));
+
 	setWindowIcon(QIcon::fromTheme("obs", QIcon(":/res/images/obs.png")));
 
 	if (monitor == -1)
@@ -37,9 +40,6 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 	action->setShortcut(Qt::Key_Escape);
 	addAction(action);
 	connect(action, SIGNAL(triggered()), this, SLOT(EscapeTriggered()));
-
-	SetAlwaysOnTop(this, config_get_bool(GetGlobalConfig(), "BasicWindow",
-					     "ProjectorAlwaysOnTop"));
 
 	setAttribute(Qt::WA_DeleteOnClose, true);
 


### PR DESCRIPTION
### Description
Fixes projector always on top setting with Linux.

### Motivation and Context
Fixes #2514

### How Has This Been Tested?
Made projector on top.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
