### PR TITLE
UI: Auto update projector settings

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7965,3 +7965,15 @@ void OBSBasic::on_customContextMenuRequested(const QPoint &pos)
 	if (!className || strstr(className, "Dock") != nullptr)
 		ui->viewMenuDocks->exec(mapToGlobal(pos));
 }
+
+void OBSBasic::UpdateProjectorHideCursor()
+{
+	for (size_t i = 0; i < projectors.size(); i++)
+		projectors[i]->SetHideCursor();
+}
+
+void OBSBasic::UpdateProjectorAlwaysOnTop(bool top)
+{
+	for (size_t i = 0; i < projectors.size(); i++)
+		SetAlwaysOnTop(projectors[i], top);
+}

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -525,6 +525,9 @@ private:
 	OBSSource GetOverrideTransition(OBSSource source);
 	int GetOverrideTransitionDuration(OBSSource source);
 
+	void UpdateProjectorHideCursor();
+	void UpdateProjectorAlwaysOnTop(bool top);
+
 public slots:
 	void DeferSaveBegin();
 	void DeferSaveEnd();

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2900,11 +2900,20 @@ void OBSBasicSettings::SaveGeneralSettings()
 			"WarnBeforeStoppingRecord",
 			ui->warnBeforeRecordStop->isChecked());
 
-	config_set_bool(GetGlobalConfig(), "BasicWindow", "HideProjectorCursor",
-			ui->hideProjectorCursor->isChecked());
-	config_set_bool(GetGlobalConfig(), "BasicWindow",
-			"ProjectorAlwaysOnTop",
+	if (WidgetChanged(ui->hideProjectorCursor)) {
+		config_set_bool(GetGlobalConfig(), "BasicWindow",
+				"HideProjectorCursor",
+				ui->hideProjectorCursor->isChecked());
+		main->UpdateProjectorHideCursor();
+	}
+
+	if (WidgetChanged(ui->projectorAlwaysOnTop)) {
+		config_set_bool(GetGlobalConfig(), "BasicWindow",
+				"ProjectorAlwaysOnTop",
+				ui->projectorAlwaysOnTop->isChecked());
+		main->UpdateProjectorAlwaysOnTop(
 			ui->projectorAlwaysOnTop->isChecked());
+	}
 
 	if (WidgetChanged(ui->recordWhenStreaming))
 		config_set_bool(GetGlobalConfig(), "BasicWindow",

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -173,6 +173,9 @@ void OBSProjector::SetMonitor(int monitor)
 
 void OBSProjector::SetHideCursor()
 {
+	if (savedMonitor == -1)
+		return;
+
 	bool hideCursor = config_get_bool(GetGlobalConfig(), "BasicWindow",
 					  "HideProjectorCursor");
 

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -73,7 +73,6 @@ private:
 	void UpdateProjectorTitle(QString name);
 
 	QRect prevGeometry;
-	void SetHideCursor();
 	void SetMonitor(int monitor);
 
 private slots:
@@ -91,4 +90,5 @@ public:
 	int GetMonitor();
 	static void UpdateMultiviewProjectors();
 	void RenameProjector(QString oldName, QString newName);
+	void SetHideCursor();
 };


### PR DESCRIPTION
### Description
Automatically change projector settings.

### Motivation and Context
Before, the user would have to close and reopen projector when settings changed.

### How Has This Been Tested?
Changed projector settings and see if they were changed.

### Types of changes
- UI tweak

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
