### PR TITLE
game-capture: reduce a gpu copy for d3d11 shmem capture

### DIFF
--- a/plugins/win-capture/graphics-hook/d3d11-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d11-capture.cpp
@@ -795,8 +795,6 @@ static inline void d3d11_shmem_capture(ID3D11Resource *backbuffer)
 		d3d11_copy_texture(data.scale_tex, backbuffer);
 		d3d11_scale_texture(data.render_targets[data.cur_tex],
 				    data.scale_resource);
-	} else {
-		d3d11_copy_texture(data.textures[data.cur_tex], backbuffer);
 	}
 
 	if (data.copy_wait < NUM_BUFFERS - 1) {
@@ -811,7 +809,12 @@ static inline void d3d11_shmem_capture(ID3D11Resource *backbuffer)
 			shmem_texture_data_unlock(next_tex);
 		}
 
-		d3d11_copy_texture(dst, src);
+		if (data.using_scale) {
+			d3d11_copy_texture(dst, src);
+		} else {
+			d3d11_copy_texture(data.copy_surfaces[next_tex],
+					   backbuffer);
+		}
 		data.texture_ready[next_tex] = true;
 	}
 


### PR DESCRIPTION
### Description
In shmem copy mode we can directly copy backbuffer to staging texture. This change can reduce gpu load slightly.

### Motivation and Context
Better performance

### How Has This Been Tested?
Enable `SLI/CrossFire Capture Mode (Slow)` , disable `Force Scaling`

### Types of changes
 Performance enhancement (non-breaking change which improves efficiency) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
