### PR TITLE
UI: Disable hotkeys when a user is expected to type text

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -373,6 +373,7 @@ void SourceTreeItem::EnterEditMode()
 	editor->installEventFilter(this);
 	boxLayout->insertWidget(index, editor);
 	setFocusProxy(editor);
+	App()->DisableHotkeys();
 }
 
 void SourceTreeItem::ExitEditMode(bool save)
@@ -412,6 +413,7 @@ void SourceTreeItem::ExitEditModeInternal(bool save)
 	setFocusPolicy(Qt::NoFocus);
 	boxLayout->insertWidget(index, label);
 	label->setFocus();
+	App()->UpdateHotkeyFocusSetting();
 
 	/* ----------------------------------------- */
 	/* check for empty string                    */

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -936,6 +936,7 @@ void OBSBasicFilters::EditItem(QListWidgetItem *item, bool async)
 	list->editItem(item);
 	item->setFlags(flags);
 	editActive = true;
+	App()->DisableHotkeys();
 }
 
 void OBSBasicFilters::DuplicateItem(QListWidgetItem *item)
@@ -1107,6 +1108,7 @@ void OBSBasicFilters::FilterNameEdited(QWidget *editor, QListWidget *list)
 	listItem->setText(QString());
 	SetupVisibilityItem(list, listItem, filter);
 	editActive = false;
+	App()->UpdateHotkeyFocusSetting();
 }
 
 void OBSBasicFilters::AsyncFilterNameEdited(

--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -67,6 +67,7 @@ OBSBasicInteraction::OBSBasicInteraction(QWidget *parent, OBSSource source_)
 	};
 
 	connect(ui->preview, &OBSQTDisplay::DisplayCreated, addDrawCallback);
+	App()->DisableHotkeys();
 }
 
 OBSBasicInteraction::~OBSBasicInteraction()
@@ -74,6 +75,7 @@ OBSBasicInteraction::~OBSBasicInteraction()
 	// since QT fakes a mouse movement while destructing a widget
 	// remove our event filter
 	ui->preview->removeEventFilter(eventFilter.get());
+	App()->UpdateHotkeyFocusSetting();
 }
 
 OBSEventFilter *OBSBasicInteraction::BuildEventFilter()

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4701,6 +4701,7 @@ void OBSBasic::on_scenes_currentItemChanged(QListWidgetItem *current,
 
 void OBSBasic::EditSceneName()
 {
+	App()->DisableHotkeys();
 	ui->scenesDock->removeAction(renameScene);
 	QListWidgetItem *item = ui->scenes->currentItem();
 	Qt::ItemFlags flags = item->flags();
@@ -4931,7 +4932,9 @@ void OBSBasic::on_actionAddScene_triggered()
 
 void OBSBasic::on_actionRemoveScene_triggered()
 {
+	App()->DisableHotkeys();
 	RemoveSelectedScene();
+	App()->UpdateHotkeyFocusSetting();
 }
 
 void OBSBasic::ChangeSceneIndex(bool relative, int offset, int invalidIdx)
@@ -5621,6 +5624,8 @@ void OBSBasic::on_actionRemoveSource_triggered()
 	if (!confirmed)
 		return;
 
+	App()->DisableHotkeys();
+
 	/* ----------------------------------------------- */
 	/* save undo data                                  */
 
@@ -5651,6 +5656,7 @@ void OBSBasic::on_actionRemoveSource_triggered()
 	}
 
 	CreateSceneUndoRedoAction(action_name, undo_data, redo_data);
+	App()->UpdateHotkeyFocusSetting();
 }
 
 void OBSBasic::on_actionInteract_triggered()
@@ -5939,6 +5945,7 @@ static void RenameListItem(OBSBasic *parent, QListWidget *listWidget,
 void OBSBasic::SceneNameEdited(QWidget *editor,
 			       QAbstractItemDelegate::EndEditHint endHint)
 {
+	App()->UpdateHotkeyFocusSetting();
 	OBSScene scene = GetCurrentScene();
 	QLineEdit *edit = qobject_cast<QLineEdit *>(editor);
 	string text = QT_TO_UTF8(edit->text().trimmed());

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -214,6 +214,8 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 	} else {
 		preview->hide();
 	}
+
+	App()->DisableHotkeys();
 }
 
 OBSBasicProperties::~OBSBasicProperties()
@@ -224,6 +226,7 @@ OBSBasicProperties::~OBSBasicProperties()
 	obs_source_dec_showing(source);
 	main->SaveProject();
 	main->UpdateContextBar();
+	App()->UpdateHotkeyFocusSetting();
 }
 
 void OBSBasicProperties::AddPreviewButton()

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -297,11 +297,13 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 		obs_sceneitem_release(item);
 	}
 
+	App()->UpdateHotkeyFocusSetting();
 	done(DialogCode::Accepted);
 }
 
 void OBSBasicSourceSelect::on_buttonBox_rejected()
 {
+	App()->UpdateHotkeyFocusSetting();
 	done(DialogCode::Rejected);
 }
 
@@ -376,6 +378,8 @@ OBSBasicSourceSelect::OBSBasicSourceSelect(OBSBasic *parent, const char *id_,
 	} else {
 		obs_enum_sources(EnumSources, this);
 	}
+
+	App()->DisableHotkeys();
 }
 
 void OBSBasicSourceSelect::SourcePaste(const char *name, bool visible, bool dup)

--- a/UI/window-namedialog.cpp
+++ b/UI/window-namedialog.cpp
@@ -67,6 +67,7 @@ bool NameDialog::AskForName(QWidget *parent, const QString &title,
 			    const QString &text, std::string &userTextInput,
 			    const QString &placeHolder, int maxSize)
 {
+	App()->DisableHotkeys();
 	if (maxSize <= 0 || maxSize > 32767)
 		maxSize = 170;
 
@@ -84,6 +85,7 @@ bool NameDialog::AskForName(QWidget *parent, const QString &title,
 	}
 	userTextInput = dialog.userText->text().toUtf8().constData();
 	CleanWhitespace(userTextInput);
+	App()->UpdateHotkeyFocusSetting();
 	return true;
 }
 
@@ -94,6 +96,7 @@ bool NameDialog::AskForNameWithOption(QWidget *parent, const QString &title,
 				      bool &optionChecked,
 				      const QString &placeHolder)
 {
+	App()->DisableHotkeys();
 	NameDialog dialog(parent);
 	dialog.setWindowTitle(title);
 
@@ -110,5 +113,6 @@ bool NameDialog::AskForNameWithOption(QWidget *parent, const QString &title,
 	userTextInput = dialog.userText->text().toUtf8().constData();
 	CleanWhitespace(userTextInput);
 	optionChecked = dialog.checkbox->isChecked();
+	App()->UpdateHotkeyFocusSetting();
 	return true;
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Disable hotkeys when a user starts an interaction with the UI where they are expected to type text and re-enable hotkeys when the interaction is completed.

This PR disables OBS hotkeys during the following user interactions:
* renaming sources
* renaming scenes
* renaming audio sources in the mixer
* while in the source/scene deletion confirmation dialog
* adding a source (the add source dialog)
* the filters window
* the properties window
* source interact mode

OBS resumes listening for hotkeys after those user interactions end.

Not covered by this PR:
* typing in browser source docks (e.g., Twitch/Mixer Chat or Stream Information docks)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Extended discussion on [Idea 144: Better media source playback control](https://ideas.obsproject.com/posts/144/better-media-source-playback-control) motivated me to address this.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I built on Windows 10 1909 64-bit with the current source.  I tested by doing the following in OBS:

1. Create a color source
2. Set the source hotkeys for show and hide to space bar.
3. Tried pressing space bar in all user interactions described above.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
