### PR TITLE
UI: Override shortcuts that are also hotkeys

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -192,7 +192,9 @@ QObject *CreateShortcutFilter()
 			hotkey.modifiers = TranslateQtKeyboardEventModifiers(
 				event->modifiers());
 
-			obs_hotkey_inject_event(hotkey, pressed);
+			if (obs_hotkey_inject_event2(hotkey, pressed))
+				event->accept();
+
 			return true;
 		};
 
@@ -203,8 +205,7 @@ QObject *CreateShortcutFilter()
 
 		/*case QEvent::MouseButtonDblClick:
 		case QEvent::Wheel:*/
-		case QEvent::KeyPress:
-		case QEvent::KeyRelease:
+		case QEvent::ShortcutOverride:
 			return key_event(static_cast<QKeyEvent *>(event));
 
 		default:

--- a/libobs/obs-hotkey.h
+++ b/libobs/obs-hotkey.h
@@ -274,6 +274,8 @@ EXPORT void obs_enum_hotkey_bindings(obs_hotkey_binding_enum_func func,
 /* hotkey event control */
 
 EXPORT void obs_hotkey_inject_event(obs_key_combination_t hotkey, bool pressed);
+EXPORT bool obs_hotkey_inject_event2(obs_key_combination_t hotkey,
+				     bool pressed);
 
 EXPORT void obs_hotkey_enable_background_press(bool enable);
 


### PR DESCRIPTION
### Description
If user sets hotkey to Ctrl + F, this will ignore the 'fit to screen' shortcut.

### Motivation and Context
Makes it so hotkeys don't also trigger shortcuts.

### How Has This Been Tested?
Created Ctrl + F hotkey and made sure the fit to screen wasn't triggered.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
