### PR TITLE
obs-outputs: Handle NetStream.Publish.BadName from rtmp server

### DIFF
--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -3379,6 +3379,14 @@ HandleInvoke(RTMP *r, const char *body, unsigned int nBodySize)
                 r->m_pausing = 3;
             }
         }
+
+        else
+        {
+            if (description.av_len)
+                RTMP_Log(RTMP_LOGWARNING, "Unhandled: %s:\n%s (%s)", r->Link.tcUrl.av_val, code.av_val, description.av_val);
+            else
+                RTMP_Log(RTMP_LOGWARNING, "Unhandled: %s:\n%s", r->Link.tcUrl.av_val, code.av_val);
+        }
     }
     else if (AVMATCH(&method, &av_playlist_ready))
     {

--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -3064,6 +3064,8 @@ static const AVal av_NetStream_Play_UnpublishNotify =
 static const AVal av_NetStream_Publish_Start = AVC("NetStream.Publish.Start");
 static const AVal av_NetStream_Publish_Rejected = AVC("NetStream.Publish.Rejected");
 static const AVal av_NetStream_Publish_Denied = AVC("NetStream.Publish.Denied");
+static const AVal av_NetStream_Publish_BadName = AVC("NetStream.Publish.BadName");
+
 
 /* Returns 0 for OK/Failed/error, 1 for 'Stop or Complete' */
 static int
@@ -3314,7 +3316,8 @@ HandleInvoke(RTMP *r, const char *body, unsigned int nBodySize)
                 || AVMATCH(&code, &av_NetStream_Play_StreamNotFound)
                 || AVMATCH(&code, &av_NetConnection_Connect_InvalidApp)
                 || AVMATCH(&code, &av_NetStream_Publish_Rejected)
-                || AVMATCH(&code, &av_NetStream_Publish_Denied))
+                || AVMATCH(&code, &av_NetStream_Publish_Denied)
+                || AVMATCH(&code, &av_NetStream_Publish_BadName))
         {
             r->m_stream_id = -1;
             RTMP_Close(r);


### PR DESCRIPTION
### Description

While streaming from OBS on an unstable connection, I have found instances where OBS will hang until it is force quit. During some testing with [arut/nginx-rtmp-module](https://github.com/arut/nginx-rtmp-module) proxying connections I found that when the OBS that was streaming to nginx-rtmp-module had network issues it would cause the OBS to hang and never recover.

I eventually identified that the server was sending a `NetStream.Publish.BadName` status message that was never handled.

More information from Adobe about that error can be found [on their site](https://helpx.adobe.com/adobe-media-server/kb/prevent-netstream-publish-badname-errors.html).

### Motivation and Context

I would like OBS to not hang when there are network glitches.

### How Has This Been Tested?

I tested this on macOS by making a build on my MacBook Pro and did the following:

From the nginx config:
```
        application stream {
            live on;
            publish_notify on;
            play_restart on;
        }
```

Steps:

1. Turn off WiFi and connect the MacBook Pro via ethernet
2. Start OBS via the command line
3. Start a custom stream to an nginx-rtmp server
4. Disconnect the ethernet
5. Plug it back in 10 seconds later

I checked the logs and status bar to see if the system reconnected. It would not reconnect when using OBS in master but would reconnect when using this branch.

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
