### PR TITLE
UI: Enable sps/pps (video headers) repetition (for srt/mpegts)

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1278,6 +1278,15 @@ inline void AdvancedOutput::SetupStreaming()
 	obs_output_set_audio_encoder(streamOutput, streamAudioEnc, 0);
 	obs_encoder_set_scaled_size(h264Streaming, cx, cy);
 	obs_encoder_set_video(h264Streaming, obs_get_video());
+
+	const char *id = obs_service_get_id(main->GetService());
+	if (strcmp(id, "rtmp_custom") == 0) {
+		obs_data_t *settings = obs_data_create();
+		obs_service_apply_encoder_settings(main->GetService(), settings,
+						   nullptr);
+		obs_encoder_update(h264Streaming, settings);
+		obs_data_release(settings);
+	}
 }
 
 inline void AdvancedOutput::SetupRecording()

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -426,6 +426,14 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 	config->gopLength = gop_size;
 	config->frameIntervalP = 1 + bf;
 	h264_config->idrPeriod = gop_size;
+
+	bool repeat_headers = obs_data_get_bool(settings, "repeat_headers");
+	if (repeat_headers) {
+		h264_config->repeatSPSPPS = 1;
+		h264_config->disableSPSPPS = 0;
+		h264_config->outputAUD = 1;
+	}
+
 	vui_params->videoSignalTypePresentFlag = 1;
 	vui_params->videoFullRangeFlag = (voi->range == VIDEO_RANGE_FULL);
 	vui_params->colourDescriptionPresentFlag = 1;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -477,6 +477,7 @@ void nvenc_defaults(obs_data_t *settings)
 	obs_data_set_default_bool(settings, "psycho_aq", true);
 	obs_data_set_default_int(settings, "gpu", 0);
 	obs_data_set_default_int(settings, "bf", 2);
+	obs_data_set_default_bool(settings, "repeat_headers", false);
 }
 
 static bool rate_control_modified(obs_properties_t *ppts, obs_property_t *p,
@@ -576,6 +577,9 @@ obs_properties_t *nvenc_properties_internal(bool ffmpeg)
 			obs_module_text("NVENC.PsychoVisualTuning"));
 		obs_property_set_long_description(
 			p, obs_module_text("NVENC.PsychoVisualTuning.ToolTip"));
+		p = obs_properties_add_bool(props, "repeat_headers",
+					    "repeat_headers");
+		obs_property_set_visible(p, false);
 	}
 
 	obs_properties_add_int(props, "gpu", obs_module_text("GPU"), 0, 8, 1);

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -110,6 +110,7 @@ static void obs_x264_defaults(obs_data_t *settings)
 	obs_data_set_default_string(settings, "profile", "");
 	obs_data_set_default_string(settings, "tune", "");
 	obs_data_set_default_string(settings, "x264opts", "");
+	obs_data_set_default_bool(settings, "repeat_headers", false);
 }
 
 static inline void add_strings(obs_property_t *list, const char *const *strings)
@@ -172,6 +173,7 @@ static obs_properties_t *obs_x264_props(void *unused)
 	obs_properties_t *props = obs_properties_create();
 	obs_property_t *list;
 	obs_property_t *p;
+	obs_property_t *headers;
 
 	list = obs_properties_add_list(props, "rate_control", TEXT_RATE_CONTROL,
 				       OBS_COMBO_TYPE_LIST,
@@ -221,6 +223,10 @@ static obs_properties_t *obs_x264_props(void *unused)
 
 	obs_properties_add_text(props, "x264opts", TEXT_X264_OPTS,
 				OBS_TEXT_DEFAULT);
+
+	headers = obs_properties_add_bool(props, "repeat_headers",
+					  "repeat_headers");
+	obs_property_set_visible(headers, false);
 
 	return props;
 }
@@ -583,6 +589,7 @@ static bool update_settings(struct obs_x264 *obsx264, obs_data_t *settings,
 	char *tune = bstrdup(obs_data_get_string(settings, "tune"));
 	struct obs_x264_options options = obs_x264_parse_options(
 		obs_data_get_string(settings, "x264opts"));
+	bool repeat_headers = obs_data_get_bool(settings, "repeat_headers");
 
 	bool success = true;
 
@@ -603,6 +610,12 @@ static bool update_settings(struct obs_x264 *obsx264, obs_data_t *settings,
 		success = reset_x264_params(obsx264, preset, tune);
 	}
 
+	if (repeat_headers) {
+		obsx264->params.b_repeat_headers = 1;
+		obsx264->params.b_annexb = 1;
+		obsx264->params.b_aud = 1;
+	}
+
 	if (success) {
 		update_params(obsx264, settings, &options, update);
 		if (!update) {
@@ -612,8 +625,6 @@ static bool update_settings(struct obs_x264 *obsx264, obs_data_t *settings,
 		if (!obsx264->context)
 			apply_x264_profile(obsx264, profile);
 	}
-
-	obsx264->params.b_repeat_headers = false;
 
 	obs_x264_free_options(options);
 	bfree(preset);

--- a/plugins/rtmp-services/rtmp-custom.c
+++ b/plugins/rtmp-services/rtmp-custom.c
@@ -1,4 +1,5 @@
 #include <obs-module.h>
+#include <util/dstr.h>
 
 struct rtmp_custom {
 	char *server, *key;
@@ -109,6 +110,19 @@ static const char *rtmp_custom_password(void *data)
 	return service->password;
 }
 
+#define RTMP_PROTOCOL "rtmp"
+
+static void rtmp_custom_apply_settings(void *data, obs_data_t *video_settings,
+				       obs_data_t *audio_settings)
+{
+	struct rtmp_custom *service = data;
+	if (service->server != NULL && video_settings != NULL &&
+	    strncmp(service->server, RTMP_PROTOCOL, strlen(RTMP_PROTOCOL)) !=
+		    0) {
+		obs_data_set_bool(video_settings, "repeat_headers", true);
+	}
+}
+
 struct obs_service_info rtmp_custom_service = {
 	.id = "rtmp_custom",
 	.get_name = rtmp_custom_name,
@@ -120,4 +134,5 @@ struct obs_service_info rtmp_custom_service = {
 	.get_key = rtmp_custom_key,
 	.get_username = rtmp_custom_username,
 	.get_password = rtmp_custom_password,
+	.apply_encoder_settings = rtmp_custom_apply_settings,
 };


### PR DESCRIPTION
### Description
Also changes obs-x264, obs-ffmpeg, rtmp-services.
Repetition of sps/pps and AUDs are mandatory for mpegts live streams per spec.
This PR enables that for srt streams with mpegts container. In addition it enables AUDs (x264/nvenc) and annex B option (x264).

For obs-x264, the repeat-headers option had previously been hard-coded to false; we set it to false on default to keep previous behaviour. But we now allow it to be settable in x264 options.
For obs-ffmpeg/jim-nvenc, we add a setting for video headers repetition.
Since srt is dealt with rtmp-custom service, when x264 or jim-nvenc is used with mpegts, we automatically enable the repeat-headers option.

**This fixes some connection issues for srt streams.** (i should have opened an issue to document the bug but I confess I've been a bit lazy)
For instance, the following workflow is currently broken: obs ==> srt-live-transmit ==> ffplay , unless ffplay catches the initial video headers. If obs is started earlier than ffplay, no video will be displayed since sps/pps headers are not delivered.
Another broken case is : obs ==> srt server (wowza, nimble, srt-live-server) ==> client ; in case of a network disconnection, reconnection fails to produce a playable stream because the video headers are missing.

### Motivation and Context
This supersedes https://github.com/obsproject/obs-studio/pull/2725 
For live broadcasts (with mpegts container), repetition of sps/pps is necessary because there's no reason the broadcast catches headers at start of transmission; or in case of interruptions.
Mpeg-ts spec requires such a repetition (couldn't find exact spec refs, which are behind paywalls; this was told to me on slack #video-dev).

### How Has This Been Tested?
Tested against wowza, nimble server, makito X decoder, vlc, ffmpeg/ffplay, srt live server.

### Types of changes
 - New feature (non-breaking change which adds functionality)
 - Performance enhancement (non-breaking change which improves efficiency) 
 - Bugfix

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
