### PR TITLE
libobs: Reset audio data on timestamp jump

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1216,6 +1216,7 @@ static void handle_ts_jump(obs_source_t *source, uint64_t expected, uint64_t ts,
 
 	pthread_mutex_lock(&source->audio_buf_mutex);
 	reset_audio_timing(source, ts, os_time);
+	reset_audio_data(source, os_time);
 	pthread_mutex_unlock(&source->audio_buf_mutex);
 }
 


### PR DESCRIPTION
To prevent issues in audio mixing make sure the audio data is also cleared
when audio timing is reset.

### Description

Ensure the audio data is cleared when a timestamp jump has been detected.


### Motivation and Context

While streaming to twitch with a Media Source that is rtmp I have experienced issues where, after the Media Source has disconnected and reconnected, the audio for that source would no longer be passed along to twitch and any other audio channels would stutter for as long as the "problem" source was enabled.

When debug logging was enabled, I noticed this log message that pointed me towards the timestamp issues:

```
debug: Timestamp for source 'Remote Video' jumped by '49580127663', expected value 678824875200, input value 728405002863
```

This lead me to check out the `handle_ts_jump()` function and I looked for other functions that would clear out more audio context for the source and found `reset_audio_data()`. After testing with and without the change, it appeared to solve the issue I was running into and I could not hear any issues or artifacts.


### How Has This Been Tested?

I created a source (OBS-A) that fed to an nginx-rtmp proxy and a destination (OBS-B) that created a Media Source for the nginx-rtmp proxy that was being streamed. I streamed the output from OBS-B to twitch and listened to the twitch stream.

I created a script that ran on the computer that OBS-A was running on that would disable the network interface for 30 seconds and then enable the network interface for 60 seconds.

Running the test with the fix for 45 minutes did not produce any of these issues I had experienced. Running the test without the fix for 15 minutes produced the issue.


### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
