### PR TITLE
rtmp-services: Remove offline servers/services

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 137,
+	"version": 138,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 137
+			"version": 138
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -571,19 +571,6 @@
             }
         },
         {
-            "name": "CyberGame.TV",
-            "servers": [
-                {
-                    "name": "RU Origin",
-                    "url": "rtmp://st.cybergame.tv:1953/live"
-                },
-                {
-                    "name": "RU Premium",
-                    "url": "rtmp://premium.cybergame.tv:1953/premium"
-                }
-            ]
-        },
-        {
             "name": "Facebook Live",
             "common": true,
             "servers": [
@@ -992,10 +979,6 @@
                     "url": "rtmp://eu-central.castr.io/static"
                 },
                 {
-                    "name": "AU South",
-                    "url": "rtmp://au-central.castr.io/static"
-                },
-                {
                     "name": "Singapore",
                     "url": "rtmp://sg-central.castr.io/static"
                 }
@@ -1012,21 +995,6 @@
                     "url": "rtmp://live.boomstream.com/live"
                 }
             ]
-        },
-        {
-            "name": "Stream.live",
-            "servers": [
-                {
-                    "name": "Default",
-                    "url": "rtmp://media.stream.live:1935/live"
-                }
-            ],
-            "recommended": {
-                "keyint": 2,
-                "profile": "main",
-                "max video bitrate": 2500,
-                "max audio bitrate": 160
-            }
         },
         {
             "name": "Meridix Live Sports Platform",


### PR DESCRIPTION
### Description
* cybergame.tv - Servers and website gone (defunct)
* castr AU - DNS resolution fails
* stream.live - Defunct by the looks of it (dns fail, website broken)

### Motivation and Context
Offline services should be removed to keep the list clean.

### How Has This Been Tested?
JSON has been checked for validity.

### Types of changes
 - Services update

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [N/A] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [N/A] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [N/A] I have included updates to all appropriate documentation.
