### PR TITLE
UI: Update volmeters at 60hz

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -562,7 +562,8 @@ VolumeMeter::VolumeMeter(QWidget *parent, obs_volmeter_t *obs_volmeter,
 	updateTimerRef = updateTimer.toStrongRef();
 	if (!updateTimerRef) {
 		updateTimerRef = QSharedPointer<VolumeMeterTimer>::create();
-		updateTimerRef->start(34);
+		updateTimerRef->setTimerType(Qt::PreciseTimer);
+		updateTimerRef->start(16);
 		updateTimer = updateTimerRef;
 	}
 


### PR DESCRIPTION
### Description
Update volume meters at 60Hz (technically 62.5Hz). Reimplementation of #3068.

EDIT: **[Here is a demo](https://streamable.com/ypd6uo)** (30Hz on top, 60Hz on bottom)

### Motivation and Context
The volmeter update rate essentially determines the volmeters' "frame rate". Volmeters that update more frequently are more responsive and more accurate, and also give the program a much-improved feeling of snappy performance.

Performance increase of this change appears to be less than 1% CPU usage increase on average.

### How Has This Been Tested?
Built on Windows 10 and visually inspected. Monitored CPU usage with OBS's built-in CPU usage monitor.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
