### PR TITLE
UI: Remove Desktop Audio fields on macOS

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -119,7 +119,7 @@
      <item>
       <widget class="QStackedWidget" name="settingsPages">
        <property name="currentIndex">
-        <number>0</number>
+        <number>3</number>
        </property>
        <widget class="QWidget" name="generalPage">
         <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -151,8 +151,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>803</width>
-              <height>1026</height>
+              <width>810</width>
+              <height>1087</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -1263,8 +1263,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>603</width>
-              <height>631</height>
+              <width>740</width>
+              <height>767</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -2395,7 +2395,7 @@
                                  <rect>
                                   <x>9</x>
                                   <y>0</y>
-                                  <width>236</width>
+                                  <width>250</width>
                                   <height>25</height>
                                  </rect>
                                 </property>
@@ -3758,8 +3758,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>555</width>
-              <height>469</height>
+              <width>810</width>
+              <height>610</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_50">
@@ -3909,7 +3909,7 @@
                     <widget class="QLabel" name="label_2">
                      <property name="minimumSize">
                       <size>
-                       <width>170</width>
+                       <width>0</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -3953,8 +3953,17 @@
                    </item>
                    <item row="2" column="0">
                     <widget class="QLabel" name="label_4">
+                     <property name="minimumSize">
+                      <size>
+                       <width>170</width>
+                       <height>0</height>
+                      </size>
+                     </property>
                      <property name="text">
                       <string>Basic.Settings.Audio.AuxDevice</string>
+                     </property>
+                     <property name="alignment">
+                      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                      </property>
                      <property name="buddy">
                       <cstring>auxAudioDevice1</cstring>
@@ -4614,8 +4623,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>596</width>
-              <height>781</height>
+              <width>755</width>
+              <height>930</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_23">

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -468,8 +468,10 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->sampleRate,           COMBO_CHANGED,  AUDIO_RESTART);
 	HookWidget(ui->meterDecayRate,       COMBO_CHANGED,  AUDIO_CHANGED);
 	HookWidget(ui->peakMeterType,        COMBO_CHANGED,  AUDIO_CHANGED);
+#ifndef __APPLE__
 	HookWidget(ui->desktopAudioDevice1,  COMBO_CHANGED,  AUDIO_CHANGED);
 	HookWidget(ui->desktopAudioDevice2,  COMBO_CHANGED,  AUDIO_CHANGED);
+#endif
 	HookWidget(ui->auxAudioDevice1,      COMBO_CHANGED,  AUDIO_CHANGED);
 	HookWidget(ui->auxAudioDevice2,      COMBO_CHANGED,  AUDIO_CHANGED);
 	HookWidget(ui->auxAudioDevice3,      COMBO_CHANGED,  AUDIO_CHANGED);
@@ -2112,11 +2114,21 @@ void OBSBasicSettings::LoadListValues(QComboBox *widget, obs_property_t *prop,
 
 void OBSBasicSettings::LoadAudioDevices()
 {
+#ifdef __APPLE__
+	ui->label_2->hide();
+	ui->desktopAudioDevice1->hide();
+	ui->formLayout_53->removeWidget(ui->label_2);
+	ui->formLayout_53->removeWidget(ui->desktopAudioDevice1);
+
+	ui->label_3->hide();
+	ui->desktopAudioDevice2->hide();
+	ui->formLayout_53->removeWidget(ui->label_3);
+	ui->formLayout_53->removeWidget(ui->desktopAudioDevice2);
+#endif
+
 	const char *input_id = App()->InputAudioSource();
-	const char *output_id = App()->OutputAudioSource();
 
 	obs_properties_t *input_props = obs_get_source_properties(input_id);
-	obs_properties_t *output_props = obs_get_source_properties(output_id);
 
 	if (input_props) {
 		obs_property_t *inputs =
@@ -2128,6 +2140,10 @@ void OBSBasicSettings::LoadAudioDevices()
 		obs_properties_destroy(input_props);
 	}
 
+#ifndef __APPLE__
+	const char *output_id = App()->OutputAudioSource();
+	obs_properties_t *output_props = obs_get_source_properties(output_id);
+
 	if (output_props) {
 		obs_property_t *outputs =
 			obs_properties_get(output_props, "device_id");
@@ -2135,6 +2151,7 @@ void OBSBasicSettings::LoadAudioDevices()
 		LoadListValues(ui->desktopAudioDevice2, outputs, 2);
 		obs_properties_destroy(output_props);
 	}
+#endif
 
 	if (obs_video_active()) {
 		ui->sampleRate->setEnabled(false);
@@ -3443,10 +3460,12 @@ void OBSBasicSettings::SaveAudioSettings()
 				       Str(name), index);
 	};
 
+#ifndef __APPLE__
 	UpdateAudioDevice(false, ui->desktopAudioDevice1,
 			  "Basic.DesktopDevice1", 1);
 	UpdateAudioDevice(false, ui->desktopAudioDevice2,
 			  "Basic.DesktopDevice2", 2);
+#endif
 	UpdateAudioDevice(true, ui->auxAudioDevice1, "Basic.AuxDevice1", 3);
 	UpdateAudioDevice(true, ui->auxAudioDevice2, "Basic.AuxDevice2", 4);
 	UpdateAudioDevice(true, ui->auxAudioDevice3, "Basic.AuxDevice3", 5);


### PR DESCRIPTION
# Description
Removes the Desktop Audio 1  & 2 fields on Apple devices.

<img width="1093" alt="Screenshot 2020-06-24 at 22 51 18" src="https://user-images.githubusercontent.com/147143/85632494-56ac9f00-b66f-11ea-83f4-df61e602348d.png">

### Motivation and Context
This feature hasn't been implemented on macOS versions of OBS thus far and it results in multiple daily questions asking why the Desktop Audio isn't showing up for them.

### How Has This Been Tested?
This has only been tested on macOS Catalina 10.15.5 on a MacBook Pro 15" 2019

### Types of changes
- Bug fix

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
