### PR TITLE
CI: Quick fix to cover pre-installed Homebrew dependencies for macOS

### DIFF
--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -28,7 +28,14 @@ sudo installer -pkg ./Packages.pkg -target /
 brew update
 
 #Base OBS Deps and ccache
-brew install jack speexdsp ccache mbedtls freetype fdk-aac
+for DEPENDENCY in jack speexdsp ccache mbedtls freetype fdk-aac; do
+    if [ ! -d "$(brew --cellar)/${DEPENDENCY}" ]; then
+        brew install $DEPENDENCY
+    else
+        brew upgrade $DEPENDENCY
+    fi
+done
+
 brew install https://gist.githubusercontent.com/DDRBoxman/9c7a2b08933166f4b61ed9a44b242609/raw/ef4de6c587c6bd7f50210eccd5bd51ff08e6de13/qt.rb
 if [ -d "$(brew --cellar)/swig" ]; then
     brew unlink swig


### PR DESCRIPTION
# Description
This PR adds checks around each Homebrew dependency to only install if necessary and upgrade otherwise. Due to CI providers changing their default Homebrew setups, one cannot assume some packages to not exist already.

### Motivation and Context
Running `brew install` within a script that is set to abort on errors via `set -e` will break as Homebrew quits with a non-zero return value if one tries to install a formula already present. The proper fix is to use Homebrew bundle (see the GitHub Actions workflows), but this quick fix should be future proof as well.

### How Has This Been Tested?
Tested locally with pre-installed formulas

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
