### PR TITLE
Fixes #3093 icon bug on macOS

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1106,7 +1106,9 @@ OBSApp::OBSApp(int &argc, char **argv, profiler_name_store_t *store)
 {
 	sleepInhibitor = os_inhibit_sleep_create("OBS Video/audio");
 
+#ifndef __APPLE__
 	setWindowIcon(QIcon::fromTheme("obs", QIcon(":/res/images/obs.png")));
+#endif
 }
 
 OBSApp::~OBSApp()

--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -145,7 +145,10 @@ OBSBasicStats::OBSBasicStats(QWidget *parent, bool closeable)
 	resize(800, 280);
 
 	setWindowTitle(QTStr("Basic.Stats"));
+
+#ifndef __APPLE__
 	setWindowIcon(QIcon::fromTheme("obs", QIcon(":/res/images/obs.png")));
+#endif
 
 	setWindowModality(Qt::NonModal);
 	setAttribute(Qt::WA_DeleteOnClose, true);

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -27,7 +27,9 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 	SetAlwaysOnTop(this, config_get_bool(GetGlobalConfig(), "BasicWindow",
 					     "ProjectorAlwaysOnTop"));
 
+#ifndef __APPLE__
 	setWindowIcon(QIcon::fromTheme("obs", QIcon(":/res/images/obs.png")));
+#endif
 
 	if (monitor == -1)
 		resize(480, 270);


### PR DESCRIPTION
### Description
OBS makes calls to `setWindowIcon` for the main window, stats window and multi-view window for operating systems like Windows where the window has an icon in the start bar and title bar, however on macOS this is not required as each application has only one icon on the Dock for all windows.

Due to the window icon typically rendering smaller it's a different icon to the macOS application icon and this causes the icon to suddenly change when the app launches.

### Motivation and Context
This fixes a subtle graphical glitch during the start up of OBS if you had the application saved in the Dock on macOS.

### How Has This Been Tested?
Tested on macOS Catalina 10.15.5 on a MacBook Pro 15" this shouldn't affect other operating systems.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
