### PR TITLE
UI: Add informative messages to auto-config dialog

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -194,6 +194,8 @@ Basic.AutoConfig.TestPage.Result.StreamingEncoder="Streaming Encoder"
 Basic.AutoConfig.TestPage.Result.RecordingEncoder="Recording Encoder"
 Basic.AutoConfig.TestPage.Result.Header="The program has determined that these estimated settings are the most ideal for you:"
 Basic.AutoConfig.TestPage.Result.Footer="To use these settings, click Apply Settings. To reconfigure the wizard and try again, click Back. To manually configure settings yourself, click Cancel and open Settings."
+Basic.AutoConfig.Info="The auto-configuration wizard will determine the best settings based on your computer specs and internet speed."
+Basic.AutoConfig.RunAnytime="This can be run at any time by going to the Tools menu."
 
 # stats
 Basic.Stats="Stats"

--- a/UI/forms/AutoConfigStartPage.ui
+++ b/UI/forms/AutoConfigStartPage.ui
@@ -32,9 +32,76 @@
     </widget>
    </item>
    <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Basic.AutoConfig.Info</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>5</width>
+       <height>5</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Basic.AutoConfig.RunAnytime</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>


### PR DESCRIPTION
### Description
Add messages to describe what the wizard is for and how it can be run at any time.

![Screenshot from 2020-06-25 05-04-27](https://user-images.githubusercontent.com/19962531/85699926-85dc0400-b6a1-11ea-9243-a1f092326b35.png)

### Motivation and Context
Since #2744 removed the prompts, this adds those messages to the auto-config dialog itself.

### How Has This Been Tested?
Opened auto-config dialog.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
