### PR TITLE
mac-capture: Add several virtual audio drivers to Desktop audio

### DIFF
--- a/plugins/mac-capture/audio-device-enum.c
+++ b/plugins/mac-capture/audio-device-enum.c
@@ -11,7 +11,10 @@ static inline bool device_is_input(char *device)
 {
 	return astrstri(device, "soundflower") == NULL &&
 	       astrstri(device, "wavtap") == NULL &&
-	       astrstri(device, "soundsiphon") == NULL;
+	       astrstri(device, "soundsiphon") == NULL &&
+	       astrstri(device, "ishowu") == NULL &&
+	       astrstri(device, "blackhole") == NULL &&
+	       astrstri(device, "loopback") == NULL;
 }
 
 static inline bool enum_success(OSStatus stat, const char *msg)


### PR DESCRIPTION
### Description
This allows the following virtual audio devices to be listed as Desktop Audio devices:
- loopback;
- iShowU;
- BlackHole.

### Motivation and Context
These devices were not listed while they should be.

### How Has This Been Tested?
Tested on macOs 15 (Catalina)

### Types of changes
 - Bug fix (non-breaking change which fixes an issue) 
 - New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
