### PR TITLE
UI: Fix unreadable Connecting Stream button

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5259,6 +5259,7 @@ void OBSBasic::StartStreaming()
 	SaveProject();
 
 	ui->streamButton->setEnabled(false);
+	ui->streamButton->setChecked(false);
 	ui->streamButton->setText(QTStr("Basic.Main.Connecting"));
 
 	if (sysTrayStream) {


### PR DESCRIPTION
# Description

Fixes an issue where the Start Streaming button would still be checked while in a disabled state during `STREAMING_STARTING`, causing the text to be the same colour as the button.

Before:
![image](https://user-images.githubusercontent.com/941350/86509669-f36bfb00-be2c-11ea-8cd7-6e31aec2e3fb.png)

After:
![image](https://user-images.githubusercontent.com/941350/86509695-2d3d0180-be2d-11ea-93c8-cfaf1cfae0e6.png)


### Motivation and Context

This doesn't change behaviour when a stream fails due to:
https://github.com/obsproject/obs-studio/blob/0fff23d8e1cb715d0b2b117938c68b072419e22e/UI/window-basic-main.cpp#L5274-L5276

And will correctly go back to a checked state once the stream starts due to:
https://github.com/obsproject/obs-studio/blob/0fff23d8e1cb715d0b2b117938c68b072419e22e/UI/window-basic-main.cpp#L5496-L5500

I also checked relevant delay and stop functions, all correctly set the checked state when they run.

### How Has This Been Tested?

1. Put in an invalid stream key (tested with Twitch)
2. Click "Start Streaming"

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
