### PR TITLE
UI: Fix scene switcher not detecting some windows

### DIFF
--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher-nix.cpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher-nix.cpp
@@ -174,6 +174,14 @@ void GetCurrentWindowTitle(string &title)
 	if (status >= Success && name != nullptr) {
 		std::string str(name);
 		title = str;
+	} else {
+		XTextProperty xtp_new_name;
+		if (XGetWMName(disp(), data[0], &xtp_new_name) != 0 &&
+		    xtp_new_name.value != nullptr) {
+			std::string str((const char *)xtp_new_name.value);
+			title = str;
+			XFree(xtp_new_name.value);
+		}
 	}
 
 	XFree(name);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
The automatic scene switcher in linux is not picking up some windows during the running proccess, even when the getting the list works fine. 

### Motivation and Context
Using for recording notice that was not working for me for some windows and since was no issue start investigating and found a solution.

### How Has This Been Tested?
This has been tested manually, OS: Linux, Distribution: Manjaro.
I configure automatic scene switch for windows that was not being able to trigger the change, and confirm that with the fix they are working now.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ x] My code is not on the master branch.
- [ x] The code has been tested.
- [ x] All commit messages are properly formatted and commits squashed where appropriate.
- [ x] I have included updates to all appropriate documentation.
