### PR TITLE
UI: Make color display, don't show alpha value in color label

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -657,14 +657,15 @@ void OBSPropertiesView::AddColor(obs_property_t *prop, QFormLayout *layout,
 
 	QPalette palette = QPalette(color);
 	colorLabel->setFrameStyle(QFrame::Sunken | QFrame::Panel);
+	// The picker doesn't have an alpha option, show only RGB
 	colorLabel->setText(color.name(QColor::HexRgb));
 	colorLabel->setPalette(palette);
 	colorLabel->setStyleSheet(
 		QString("background-color :%1; color: %2;")
 			.arg(palette.color(QPalette::Window)
-				     .name(QColor::HexArgb))
+				     .name(QColor::HexRgb))
 			.arg(palette.color(QPalette::WindowText)
-				     .name(QColor::HexArgb)));
+				     .name(QColor::HexRgb)));
 	colorLabel->setAutoFillBackground(true);
 	colorLabel->setAlignment(Qt::AlignCenter);
 	colorLabel->setToolTip(QT_UTF8(obs_property_long_description(prop)));
@@ -1710,14 +1711,14 @@ bool WidgetInfo::ColorChanged(const char *setting)
 		return false;
 
 	QLabel *label = static_cast<QLabel *>(widget);
-	label->setText(color.name(QColor::HexArgb));
+	label->setText(color.name(QColor::HexRgb));
 	QPalette palette = QPalette(color);
 	label->setPalette(palette);
 	label->setStyleSheet(QString("background-color :%1; color: %2;")
 				     .arg(palette.color(QPalette::Window)
-						  .name(QColor::HexArgb))
+						  .name(QColor::HexRgb))
 				     .arg(palette.color(QPalette::WindowText)
-						  .name(QColor::HexArgb)));
+						  .name(QColor::HexRgb)));
 
 	obs_data_set_int(view->settings, setting, color_to_int(color));
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

UI: Make color display, don't show alpha value in color label

The color picker loads the label not showing alpha hex value but on
color change then shows the alpha level in the hex value (which is
hardcoded to 255).

This changes so the label always shows only RGB value.

Of course, can be easily changed back to ::Arbg later if an alpha 
picker is added.

On first load and open palette:
![Screen Shot 2020-07-08 at 4 20 51 PM](https://user-images.githubusercontent.com/1580980/86981957-e147d080-c13c-11ea-9041-06ee7b52a270.png)

Wrong behavior removed by this diff; saving new color would show the FF alpha value in the hex value: 

![Screen Shot 2020-07-08 at 4 21 00 PM](https://user-images.githubusercontent.com/1580980/86982005-0d635180-c13d-11ea-994c-1faba63779a8.png)


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

UI consistency, fixes. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

MacbookPro 2019. MacOS Catalina. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
