### PR TITLE
obs-outputs: Use FLV codec IDs for videocodecid/audiocodecid

### DIFF
--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -30,6 +30,8 @@
 //#define WRITE_FLV_HEADER
 
 #define VIDEO_HEADER_SIZE 5
+#define VIDEODATA_AVCVIDEOPACKET 7.0
+#define AUDIODATA_AAC 10.0
 
 static inline double encoder_bitrate(obs_encoder_t *encoder)
 {
@@ -85,14 +87,15 @@ static bool build_flv_meta_data(obs_output_t *context, uint8_t **output,
 		enc_num_val(&enc, end, "height",
 			    (double)obs_encoder_get_height(vencoder));
 
-		enc_str_val(&enc, end, "videocodecid", "avc1");
+		enc_num_val(&enc, end, "videocodecid",
+			    VIDEODATA_AVCVIDEOPACKET);
 		enc_num_val(&enc, end, "videodatarate",
 			    encoder_bitrate(vencoder));
 		enc_num_val(&enc, end, "framerate",
 			    video_output_get_frame_rate(video));
 	}
 
-	enc_str_val(&enc, end, "audiocodecid", "mp4a");
+	enc_num_val(&enc, end, "audiocodecid", AUDIODATA_AAC);
 	enc_num_val(&enc, end, "audiodatarate", encoder_bitrate(aencoder));
 	enc_num_val(&enc, end, "audiosamplerate",
 		    (double)obs_encoder_get_sample_rate(aencoder));


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
modify "audiocodecid" and "videocodecid" data types: string->number
reference: https://github.com/obsproject/obs-studio/issues/3131

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The spec says the metadata for codecid are double. 
I have problems writing rtmpclient and parsing metada. It's just a suggestion.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
push and pull video stream.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix (non-breaking change which fixes an issue) 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.