### PR TITLE
win-capture Fix 32-bit Vulkan capture

### DIFF
--- a/plugins/win-capture/graphics-hook/vulkan-capture.c
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.c
@@ -1580,6 +1580,10 @@ static VkFunc VKAPI OBS_GetInstanceProcAddr(VkInstance inst, const char *name)
 
 #undef GETPROCADDR
 
+#ifndef _WIN64
+#pragma comment(linker, "/EXPORT:OBS_Negotiate=_OBS_Negotiate@4")
+#endif
+
 EXPORT VkResult VKAPI OBS_Negotiate(VkNegotiateLayerInterface *nli)
 {
 	if (nli->loaderLayerInterfaceVersion >= 2) {


### PR DESCRIPTION
### Description
Vulkan loader needs pure name, which needs manual fix-up on 32-bit.

### Motivation and Context
Just noticed Vulkan game capture doesn't work for 32-bit applications.

### How Has This Been Tested?
vkcube 32-bit works and 64-bit didn't regress.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.