### PR TITLE
libobs: Translate F13-F24 hotkeys on Windows

### DIFF
--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -1040,6 +1040,9 @@ void obs_key_to_str(obs_key_t key, struct dstr *str)
 	if (key == OBS_KEY_NONE) {
 		return;
 
+	} else if (key >= OBS_KEY_F13 && key <= OBS_KEY_F24) {
+		dstr_printf(str, "F%d", (int)(key - OBS_KEY_F13 + 13));
+		return;
 	} else if (key >= OBS_KEY_MOUSE1 && key <= OBS_KEY_MOUSE29) {
 		if (obs->hotkeys.translations[key]) {
 			dstr_copy(str, obs->hotkeys.translations[key]);


### PR DESCRIPTION
# Description

Adds translation strings & a check on Windows to ensure F13 and above are correctly translated.

![image](https://user-images.githubusercontent.com/941350/87140100-4a1d7d00-c2e4-11ea-9ae0-b722e6200b22.png)

### Motivation and Context

Fixes #2377.

### How Has This Been Tested?

Map a key to F13 on a Stream Deck or using Logitech G HUB and press the key in Settings -> Hotkeys. Tested on Windows 10.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
