### PR TITLE
libobs: Fix reading memory past size of string

### DIFF
--- a/libobs/util/dstr.c
+++ b/libobs/util/dstr.c
@@ -218,7 +218,7 @@ char *strdepad(char *str)
 	while (is_padding(*temp))
 		++temp;
 
-	len = strlen(str);
+	len = strlen(temp);
 	if (temp != str)
 		memmove(str, temp, len + 1);
 
@@ -247,7 +247,7 @@ wchar_t *wcsdepad(wchar_t *str)
 	while (*temp == ' ' || *temp == '\t')
 		++temp;
 
-	len = wcslen(str);
+	len = wcslen(temp);
 	if (temp != str)
 		memmove(str, temp, (len + 1) * sizeof(wchar_t));
 

--- a/libobs/util/dstr.c
+++ b/libobs/util/dstr.c
@@ -197,7 +197,7 @@ wchar_t *wstrstri(const wchar_t *str, const wchar_t *find)
 	return NULL;
 }
 
-static inline bool is_padding(char ch)
+static inline bool is_padding(int ch)
 {
 	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
 }
@@ -244,7 +244,7 @@ wchar_t *wcsdepad(wchar_t *str)
 	temp = str;
 
 	/* remove preceding spaces/tabs */
-	while (*temp == ' ' || *temp == '\t')
+	while (is_padding(*temp))
 		++temp;
 
 	len = wcslen(temp);
@@ -253,7 +253,7 @@ wchar_t *wcsdepad(wchar_t *str)
 
 	if (len) {
 		temp = str + (len - 1);
-		while (*temp == ' ' || *temp == '\t')
+		while (is_padding(*temp))
 			*(temp--) = 0;
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

(edited by Jim)

Fixes a crash.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The depad functions haven't been tested with cases where the padding is at the front of the string, thus when padding at the front of the string, it could read more memory than it was supposed to, causing a possible crash.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested with a string that had spaces in the front.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
