### PR TITLE
obs-ffmpeg: Fix play pause crash

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -649,6 +649,12 @@ static void ffmpeg_source_play_pause(void *data, bool pause)
 {
 	struct ffmpeg_source *s = data;
 
+	if (!s->media_valid)
+		ffmpeg_source_open(s);
+
+	if (!s->media_valid)
+		return;
+
 	mp_media_play_pause(&s->media, pause);
 
 	if (pause)


### PR DESCRIPTION
### Description
Fix play pause crash

### Motivation and Context
obs_source_media_play_pause called on a invalid ffmpeg source crashes OBS.

### How Has This Been Tested?
tested with obs media controls plugin: https://github.com/exeldro/obs-media-controls

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
