### PR TITLE
linux-v4l2: Fix case of variables

### DIFF
--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -81,8 +81,8 @@ struct v4l2_data {
 	pthread_t thread;
 	os_event_t *event;
 
-	bool framerateUnchanged;
-	bool resolutionUnchanged;
+	bool framerate_unchanged;
+	bool resolution_unchanged;
 	int_fast32_t dev;
 	int width;
 	int height;
@@ -976,28 +976,28 @@ static bool v4l2_settings_changed(struct v4l2_data *data, obs_data_t *settings)
 		       obs_data_get_int(settings, "dv_timing");
 
 		if (obs_data_get_int(settings, "resolution") == -1 &&
-		    !data->resolutionUnchanged) {
-			data->resolutionUnchanged = true;
+		    !data->resolution_unchanged) {
+			data->resolution_unchanged = true;
 			res |= true;
 		} else if (obs_data_get_int(settings, "resolution") == -1 &&
-			   data->resolutionUnchanged) {
+			   data->resolution_unchanged) {
 			res |= false;
 		} else {
-			data->resolutionUnchanged = false;
+			data->resolution_unchanged = false;
 			res |= (data->resolution !=
 				obs_data_get_int(settings, "resolution")) &&
 			       (obs_data_get_int(settings, "resolution") != -1);
 		}
 
 		if (obs_data_get_int(settings, "framerate") == -1 &&
-		    !data->framerateUnchanged) {
-			data->framerateUnchanged = true;
+		    !data->framerate_unchanged) {
+			data->framerate_unchanged = true;
 			res |= true;
 		} else if (obs_data_get_int(settings, "framerate") == -1 &&
-			   data->framerateUnchanged) {
+			   data->framerate_unchanged) {
 			res |= false;
 		} else {
-			data->framerateUnchanged = false;
+			data->framerate_unchanged = false;
 			res |= (data->framerate !=
 				obs_data_get_int(settings, "framerate")) &&
 			       (obs_data_get_int(settings, "framerate") != -1);
@@ -1052,8 +1052,8 @@ static void *v4l2_create(obs_data_t *settings, obs_source_t *source)
 	struct v4l2_data *data = bzalloc(sizeof(struct v4l2_data));
 	data->dev = -1;
 	data->source = source;
-	data->resolutionUnchanged = false;
-	data->framerateUnchanged = false;
+	data->resolution_unchanged = false;
+	data->framerate_unchanged = false;
 
 	/* Bitch about build problems ... */
 #ifndef V4L2_CAP_DEVICE_CAPS


### PR DESCRIPTION
### Description
The PR #2978 which was merged a few days ago added the two struct members resolutionUnchanged and framerateUnchanged which are use in the newly added code which keeps track if the device must be restarted after a configuration change.

These two keys are using CamelCase despite all of the other code using snake_case. This PR fixes that.

### Motivation and Context
Code consistency

### How Has This Been Tested?
It compiled fine and I checked that the stream restart logic still works.

### Types of changes
Best match of list: Code cleanup

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
