### PR TITLE
rtmp-services: Update Uscreen service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 141,
+	"version": 142,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 141
+			"version": 142
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1096,9 +1096,14 @@
             "servers": [
                 {
                     "name": "Default",
-                    "url": "rtmp://live.uscreen.app/app"
+                    "url": "rtmp://global-live.uscreen.app:5222/app"
                 }
-            ]
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 8000,
+                "max audio bitrate": 192
+            }
         },
         {
             "name": "Stripchat",


### PR DESCRIPTION
### Description
Replaced ingest server and added recommended settings for the Uscreen service.

### Motivation and Context
It's a more stable ingest server.

### How Has This Been Tested?
Tested on Windows 10.

### Types of changes
Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
