### PR TITLE
win-capture: Log duplicator display when updating properties

### DIFF
--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -51,6 +51,15 @@ static inline void update_settings(struct duplicator_capture *capture,
 
 	obs_enter_graphics();
 
+	struct gs_monitor_info info;
+	if (gs_get_duplicator_monitor_info(capture->monitor, &info)) {
+		info("update settings:\n"
+		     "\tdisplay: %d (%ldx%ld)\n"
+		     "\tcursor: %s",
+		     capture->monitor + 1, info.cx, info.cy,
+		     capture->capture_cursor ? "true" : "false");
+	}
+
 	gs_duplicator_destroy(capture->duplicator);
 	capture->duplicator = NULL;
 	capture->width = 0;


### PR DESCRIPTION
# Description

```
22:34:58.340: [duplicator-monitor-capture: 'Display Capture'] update settings:
22:34:58.340:     monitor: 1 (3440x1440)
22:34:58.340:     cursor: false
```
Logs the monitor number & its resolution when properties are changed (as the index can be different compared to the top of the log).

### Motivation and Context

Other sources log when properties are changed. Display Capture should too, as it's invaluable when debugging (especially dual-GPU).

### How Has This Been Tested?

Add a Display Capture source on Windows 8+. Change its properties. Hit OK.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
