### PR TITLE
Allow hiding Preview even in Studio mode (useful for control via Multiview)

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1311,9 +1311,6 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 	os_atomic_set_bool(&previewProgramMode, enabled);
 
 	if (IsPreviewProgramMode()) {
-		if (!previewEnabled)
-			EnablePreviewDisplay(true);
-
 		CreateProgramDisplay();
 		CreateProgramOptions();
 
@@ -1375,6 +1372,10 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		ui->previewLayout->setAlignment(programOptions,
 						Qt::AlignCenter);
 
+		if (!previewEnabled) {
+			programWidget->setVisible(false);
+		}
+
 		if (api)
 			api->on_event(OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED);
 
@@ -1406,9 +1407,6 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 		for (QuickTransition &qt : quickTransitions)
 			qt.button = nullptr;
-
-		if (!previewEnabled)
-			EnablePreviewDisplay(false);
 
 		ui->transitions->setEnabled(true);
 		tBarActive = false;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4649,8 +4649,6 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		action->setCheckable(true);
 		action->setChecked(
 			obs_display_enabled(ui->preview->GetDisplay()));
-		if (IsPreviewProgramMode())
-			action->setEnabled(false);
 
 		popup.addAction(ui->actionLockPreview);
 		popup.addMenu(ui->scalingMenu);
@@ -6711,6 +6709,10 @@ void OBSBasic::EnablePreviewDisplay(bool enable)
 	obs_display_set_enabled(ui->preview->GetDisplay(), enable);
 	ui->preview->setVisible(enable);
 	ui->previewDisabledWidget->setVisible(!enable);
+	if (programWidget) {
+		programWidget->setVisible(enable);
+	}
+	UpdatePreviewProgramLabels();
 }
 
 void OBSBasic::TogglePreview()
@@ -8119,10 +8121,10 @@ void OBSBasic::UpdatePreviewProgramLabels()
 	bool labels = config_get_bool(GetGlobalConfig(), "BasicWindow",
 				      "StudioModeLabels");
 
-	if (!previewProgramMode)
+	if (!IsPreviewProgramMode())
 		ui->previewLabel->setHidden(true);
 	else
-		ui->previewLabel->setHidden(!labels);
+		ui->previewLabel->setHidden(!labels || !previewEnabled);
 
 	if (programLabel)
 		programLabel->setHidden(!labels);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -389,13 +389,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	ui->previewLabel->setProperty("themeID", "previewProgramLabels");
 	ui->previewLabel->style()->polish(ui->previewLabel);
 
-	bool labels = config_get_bool(GetGlobalConfig(), "BasicWindow",
-				      "StudioModeLabels");
-
-	if (!previewProgramMode)
-		ui->previewLabel->setHidden(true);
-	else
-		ui->previewLabel->setHidden(!labels);
+	UpdatePreviewProgramLabels();
 
 	ui->previewDisabledWidget->setContextMenuPolicy(Qt::CustomContextMenu);
 	connect(ui->previewDisabledWidget,
@@ -3711,19 +3705,12 @@ void OBSBasic::ResetUI()
 	bool studioPortraitLayout = config_get_bool(
 		GetGlobalConfig(), "BasicWindow", "StudioPortraitLayout");
 
-	bool labels = config_get_bool(GetGlobalConfig(), "BasicWindow",
-				      "StudioModeLabels");
-
 	if (studioPortraitLayout)
 		ui->previewLayout->setDirection(QBoxLayout::TopToBottom);
 	else
 		ui->previewLayout->setDirection(QBoxLayout::LeftToRight);
 
-	if (previewProgramMode)
-		ui->previewLabel->setHidden(!labels);
-
-	if (programLabel)
-		programLabel->setHidden(!labels);
+	UpdatePreviewProgramLabels();
 }
 
 int OBSBasic::ResetVideo()
@@ -8125,4 +8112,18 @@ void OBSBasic::UpdateProjectorAlwaysOnTop(bool top)
 {
 	for (size_t i = 0; i < projectors.size(); i++)
 		SetAlwaysOnTop(projectors[i], top);
+}
+
+void OBSBasic::UpdatePreviewProgramLabels()
+{
+	bool labels = config_get_bool(GetGlobalConfig(), "BasicWindow",
+				      "StudioModeLabels");
+
+	if (!previewProgramMode)
+		ui->previewLabel->setHidden(true);
+	else
+		ui->previewLabel->setHidden(!labels);
+
+	if (programLabel)
+		programLabel->setHidden(!labels);
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -717,6 +717,8 @@ private:
 	bool LowDiskSpace();
 	void DiskSpaceMessage();
 
+	void UpdatePreviewProgramLabels();
+
 	OBSSource prevFTBSource = nullptr;
 
 public:


### PR DESCRIPTION
Make it possible to hide both Preview and Program previews when running in the studio mode. This is useful when using Multiview as the main UI for switching between camera feeds -- aka a software-defined Atem Mini Pro :).

### Motivation and Context

I'm doing live event streaming, so I like the simplicity of the Multiview UI where it's easy to explain to the operator to "just click there and it switches". I also like the concept of two-phase switching -- hence the Studio mode. On my resource-constrained system (3-4 live streams from V4L2, 1080p@25, Skylake i5-6300U feeding to Zoom via V4L2-loopback), however, the Studio mode consumes additional resources, and I cannot meet my target of smooth 25 FPS.
    
Since I already have my Multiview, and I do not plan on editing my scenes, just switching, I do not need these previews in the main UI. That behavior is already supported when outside of the Studio mode, but a transition to the Studio mode currently hard-enables both Preview and Program, and the context menu for hiding Preview is disabled.
    
Fix this by keeping the Preview's and Program's visibility synced with each other and triggering them in lockstep. UI wise this just shows the transition panel at the right/bottom edge of the main widget when these previews are hidden:

![image](https://user-images.githubusercontent.com/2631925/87571389-444fdf00-c6ca-11ea-85b8-67088abe7c80.png)

The labels are hidden as well. I took the liberty of de-DRYing some bits in that first commit.

### How Has This Been Tested?

Tested by dogfooding with this change earlier today. It appears to do what I want to achieve.

Actual performance improvement varies strongly with a specific setup (not just HW, but window sizes as well). For example, it's about 40ms/frame -> 16ms/frame when the main UI runs as a maximized window on my 4k screen, with the Multiview fullscreen on another FHD display. When window sizes are smaller, the improvement is not that massive, but it's still there.

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
