### PR TITLE
CI: Disable building OBS with Python scripting support on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           mkdir ./build
           cd ./build
-          cmake -DENABLE_UNIT_TESTS=YES -DENABLE_SPARKLE_UPDATER=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 -DQTDIR="/tmp/obsdeps" -DSWIGDIR="/tmp/obsdeps" -DDepsPath="/tmp/obsdeps" -DVLCPath="${{ github.workspace }}/cmbuild/vlc-${{ env.VLC_VERSION }}" -DENABLE_VLC=ON -DBUILD_BROWSER=ON -DBROWSER_DEPLOY=ON -DBUILD_CAPTIONS=ON -DWITH_RTMPS=ON -DCEF_ROOT_DIR="${{ github.workspace }}/cmbuild/cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64" ..
+          cmake -DENABLE_UNIT_TESTS=YES -DENABLE_SPARKLE_UPDATER=ON -DDISABLE_PYTHON=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 -DQTDIR="/tmp/obsdeps" -DSWIGDIR="/tmp/obsdeps" -DDepsPath="/tmp/obsdeps" -DVLCPath="${{ github.workspace }}/cmbuild/vlc-${{ env.VLC_VERSION }}" -DENABLE_VLC=ON -DBUILD_BROWSER=ON -DBROWSER_DEPLOY=ON -DBUILD_CAPTIONS=ON -DWITH_RTMPS=ON -DCEF_ROOT_DIR="${{ github.workspace }}/cmbuild/cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64" ..
       - name: 'Build'
         shell: bash
         working-directory: ${{ github.workspace }}/build
@@ -180,8 +180,8 @@ jobs:
 
           if [ -d ./OBS.app/Contents/Resources/data/obs-scripting ]; then
             mv ./OBS.app/Contents/Resources/data/obs-scripting/obslua.so ./OBS.app/Contents/MacOS/
-            mv ./OBS.app/Contents/Resources/data/obs-scripting/_obspython.so ./OBS.app/Contents/MacOS/
-            mv ./OBS.app/Contents/Resources/data/obs-scripting/obspython.py ./OBS.app/Contents/MacOS/
+            # mv ./OBS.app/Contents/Resources/data/obs-scripting/_obspython.so ./OBS.app/Contents/MacOS/
+            # mv ./OBS.app/Contents/Resources/data/obs-scripting/obspython.py ./OBS.app/Contents/MacOS/
             rm -rf ./OBS.app/Contents/Resources/data/obs-scripting/
           fi
 
@@ -208,7 +208,6 @@ jobs:
             -x ./OBS.app/Contents/PlugIns/rtmp-services.so \
             -x ./OBS.app/Contents/MacOS/obs-ffmpeg-mux \
             -x ./OBS.app/Contents/MacOS/obslua.so \
-            -x ./OBS.app/Contents/MacOS/_obspython.so \
             -x ./OBS.app/Contents/PlugIns/obs-x264.so \
             -x ./OBS.app/Contents/PlugIns/text-freetype2.so \
             -x ./OBS.app/Contents/PlugIns/obs-libfdk.so \

--- a/CI/full-build-macos.sh
+++ b/CI/full-build-macos.sh
@@ -231,7 +231,8 @@ configure_obs_build() {
 
     hr "Run CMAKE for OBS..."
     cmake -DENABLE_SPARKLE_UPDATER=ON \
-        -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 \
+        -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 \
+        -DDISABLE_PYTHON=ON  \
         -DQTDIR="/tmp/obsdeps" \
         -DSWIGDIR="/tmp/obsdeps" \
         -DDepsPath="/tmp/obsdeps" \
@@ -262,11 +263,6 @@ bundle_dylibs() {
 
     hr "Bundle dylibs for macOS application"
 
-    # step "Fix mbedtls for obs-outputs..."
-    # install_name_tool -change libmbedtls.12.dylib @executable_path/../Frameworks/libmbedtls.12.dylib ./OBS.app/Contents/Plugins/obs-outputs.so
-    # install_name_tool -change libmbedcrypto.3.dylib @executable_path/../Frameworks/libmbedcrypto.3.dylib ./OBS.app/Contents/Plugins/obs-outputs.so
-    # install_name_tool -change libmbedx509.0.dylib @executable_path/../Frameworks/libmbedx509.0.dylib ./OBS.app/Contents/Plugins/obs-outputs.so
-
     step "Run dylibBundler.."
     ${CI_SCRIPTS}/app/dylibBundler -cd -of -a ./OBS.app -q -f \
         -s ./OBS.app/Contents/MacOS \
@@ -291,7 +287,6 @@ bundle_dylibs() {
         -x ./OBS.app/Contents/PlugIns/rtmp-services.so \
         -x ./OBS.app/Contents/MacOS/obs-ffmpeg-mux \
         -x ./OBS.app/Contents/MacOS/obslua.so \
-        -x ./OBS.app/Contents/MacOS/_obspython.so \
         -x ./OBS.app/Contents/PlugIns/obs-x264.so \
         -x ./OBS.app/Contents/PlugIns/text-freetype2.so \
         -x ./OBS.app/Contents/PlugIns/obs-libfdk.so \
@@ -340,8 +335,8 @@ prepare_macos_bundle() {
     # Scripting plugins are required to be placed in same directory as binary
     if [ -d ./OBS.app/Contents/Resources/data/obs-scripting ]; then
         mv ./OBS.app/Contents/Resources/data/obs-scripting/obslua.so ./OBS.app/Contents/MacOS/
-        mv ./OBS.app/Contents/Resources/data/obs-scripting/_obspython.so ./OBS.app/Contents/MacOS/
-        mv ./OBS.app/Contents/Resources/data/obs-scripting/obspython.py ./OBS.app/Contents/MacOS/
+        # mv ./OBS.app/Contents/Resources/data/obs-scripting/_obspython.so ./OBS.app/Contents/MacOS/
+        # mv ./OBS.app/Contents/Resources/data/obs-scripting/obspython.py ./OBS.app/Contents/MacOS/
         rm -rf ./OBS.app/Contents/Resources/data/obs-scripting/
     fi
 


### PR DESCRIPTION
### Description
Disables Python scripting support for macOS builds on CI as well as in default builds using the macOS build script.

### Motivation and Context
Python scripting support is not in a working state on macOS and with Homebrew updating default Python to v3.8.3 there will be build issues if an updated Python is installed and prioritised over macOS' system Python (as OBS doesn't build successfully with newer Python versions present). Disabling Python scripting support for macOS builds for the time being avoids this issue.

### How Has This Been Tested?
OBS built and run with updated build script successfully on macOS 10.15 and Python 3.8.3 installed.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
