### PR TITLE
Also disable CoreAudio_AAC for channels >= 3

### DIFF
--- a/UI/audio-encoders.cpp
+++ b/UI/audio-encoders.cpp
@@ -175,8 +175,9 @@ static void PopulateBitrateMap()
 			if (aac_ != GetCodec(encoder.c_str()))
 				continue;
 
-			// disable mf_aac if audio output is not stereo nor mono
-			if ((output_channels >= 3) && (encoder == "mf_aac"))
+			// disable mf_aac/coreaudio if audio output is not stereo nor mono
+			if ((output_channels >= 3) &&
+			    (encoder == "mf_aac" || encoder == "CoreAudio_AAC"))
 				continue;
 
 			HandleEncoderProperties(encoder.c_str());


### PR DESCRIPTION
### Description
CoreAudio just outputs silence when used for more than two channels, so add it to the check for that.

### Motivation and Context
To get rid of the silence I guess?

### How Has This Been Tested?
Encountered a weird issue where OBS in a 4.0 Audio Stream setup just streamed silence for some users, and worked fine for others.
Turned out those with iTunes installed got just silence.

### Types of changes
Bug fix

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
