### PR TITLE
UI: Use non-native file dialog w/ Linux

### DIFF
--- a/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
@@ -9,10 +9,13 @@ if(UNIX AND NOT APPLE)
 	find_package(X11 REQUIRED)
 	link_libraries(${X11_LIBRARIES})
 	include_directories(${X11_INCLUDE_DIR})
+
+	find_package(Qt5X11Extras REQUIRED)
 endif()
 
 set(decklink-ouput-ui_HEADERS
 	${decklink-ouput-ui_HEADERS}
+	../../qt-wrappers.hpp
 	../../properties-view.hpp
 	../../properties-view.moc.hpp
 	../../vertical-scroll-area.hpp
@@ -25,6 +28,7 @@ set(decklink-ouput-ui_HEADERS
 	)
 set(decklink-ouput-ui_SOURCES
 	${decklink-ouput-ui_SOURCES}
+	../../qt-wrappers.cpp
 	../../properties-view.cpp
 	../../vertical-scroll-area.cpp
 	../../double-slider.cpp
@@ -64,6 +68,12 @@ target_link_libraries(decklink-ouput-ui
 	obs-frontend-api
 	Qt5::Widgets
 	libobs)
+
+if(UNIX AND NOT APPLE)
+	target_link_libraries(decklink-ouput-ui
+		Qt5::X11Extras)
+endif()
+
 set_target_properties(decklink-ouput-ui PROPERTIES FOLDER "frontend")
 
 install_obs_plugin_with_data(decklink-ouput-ui data)

--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -9,6 +9,8 @@ if(UNIX AND NOT APPLE)
 	find_package(X11 REQUIRED)
 	link_libraries(${X11_LIBRARIES})
 	include_directories(${X11_INCLUDE_DIR})
+
+	find_package(Qt5X11Extras REQUIRED)
 endif()
 
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/deps/obs-scripting")
@@ -31,6 +33,7 @@ set(frontend-tools_HEADERS
 	../../slider-ignorewheel.hpp
 	../../combobox-ignorewheel.hpp
 	../../spinbox-ignorewheel.hpp
+	../../qt-wrappers.hpp
 	)
 set(frontend-tools_SOURCES
 	${frontend-tools_SOURCES}
@@ -44,6 +47,7 @@ set(frontend-tools_SOURCES
 	../../slider-ignorewheel.cpp
 	../../combobox-ignorewheel.cpp
 	../../spinbox-ignorewheel.cpp
+	../../qt-wrappers.cpp
 	)
 set(frontend-tools_UI
 	${frontend-tools_UI}
@@ -122,6 +126,12 @@ target_link_libraries(frontend-tools
 	obs-frontend-api
 	Qt5::Widgets
 	libobs)
+
+if(UNIX AND NOT APPLE)
+	target_link_libraries(frontend-tools
+		Qt5::X11Extras)
+endif()
+
 set_target_properties(frontend-tools PROPERTIES FOLDER "frontend")
 
 install_obs_plugin_with_data(frontend-tools data)

--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -1,6 +1,7 @@
 #include "scripts.hpp"
 #include "frontend-tools-config.h"
 #include "../../properties-view.hpp"
+#include "../../qt-wrappers.hpp"
 
 #include <QFileDialog>
 #include <QPlainTextEdit>
@@ -319,19 +320,16 @@ void ScriptsTool::on_addScripts_clicked()
 		lastBrowsedDir = baseScriptPath;
 	}
 
-	QFileDialog dlg(this, obs_module_text("AddScripts"));
-	dlg.setFileMode(QFileDialog::ExistingFiles);
-	dlg.setDirectory(QDir(lastBrowsedDir.c_str()));
-	dlg.setNameFilter(filter);
-	dlg.exec();
-
-	QStringList files = dlg.selectedFiles();
+	QStringList files = OpenFiles(this,
+				      QT_UTF8(obs_module_text("AddScripts")),
+				      QT_UTF8(lastBrowsedDir.c_str()), filter);
 	if (!files.count())
 		return;
 
-	lastBrowsedDir = dlg.directory().path().toUtf8().constData();
-
 	for (const QString &file : files) {
+		lastBrowsedDir =
+			QFileInfo(file).absolutePath().toUtf8().constData();
+
 		QByteArray pathBytes = file.toUtf8();
 		const char *path = pathBytes.constData();
 
@@ -396,8 +394,8 @@ void ScriptsTool::on_scriptLog_clicked()
 void ScriptsTool::on_pythonPathBrowse_clicked()
 {
 	QString curPath = ui->pythonPath->text();
-	QString newPath = QFileDialog::getExistingDirectory(
-		this, ui->pythonPathLabel->text(), curPath);
+	QString newPath =
+		SelectDirectory(this, ui->pythonPathLabel->text(), curPath);
 
 	if (newPath.isEmpty())
 		return;

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -1631,18 +1631,14 @@ bool WidgetInfo::PathChanged(const char *setting)
 	QString path;
 
 	if (type == OBS_PATH_DIRECTORY)
-		path = QFileDialog::getExistingDirectory(
-			view, QT_UTF8(desc), QT_UTF8(default_path),
-			QFileDialog::ShowDirsOnly |
-				QFileDialog::DontResolveSymlinks);
+		path = SelectDirectory(view, QT_UTF8(desc),
+				       QT_UTF8(default_path));
 	else if (type == OBS_PATH_FILE)
-		path = QFileDialog::getOpenFileName(view, QT_UTF8(desc),
-						    QT_UTF8(default_path),
-						    QT_UTF8(filter));
+		path = OpenFile(view, QT_UTF8(desc), QT_UTF8(default_path),
+				QT_UTF8(filter));
 	else if (type == OBS_PATH_FILE_SAVE)
-		path = QFileDialog::getSaveFileName(view, QT_UTF8(desc),
-						    QT_UTF8(default_path),
-						    QT_UTF8(filter));
+		path = SaveFile(view, QT_UTF8(desc), QT_UTF8(default_path),
+				QT_UTF8(filter));
 
 	if (path.isEmpty())
 		return false;
@@ -1905,9 +1901,8 @@ class EditableItemDialog : public QDialog {
 		if (curPath.isEmpty())
 			curPath = default_path;
 
-		QString path = QFileDialog::getOpenFileName(
-			App()->GetMainWindow(), QTStr("Browse"), curPath,
-			filter);
+		QString path = OpenFile(App()->GetMainWindow(), QTStr("Browse"),
+					curPath, filter);
 		if (path.isEmpty())
 			return;
 
@@ -2026,9 +2021,8 @@ void WidgetInfo::EditListAddFiles()
 	QString title = QTStr("Basic.PropertiesWindow.AddEditableListFiles")
 				.arg(QT_UTF8(desc));
 
-	QStringList files = QFileDialog::getOpenFileNames(
-		App()->GetMainWindow(), title, QT_UTF8(default_path),
-		QT_UTF8(filter));
+	QStringList files = OpenFiles(App()->GetMainWindow(), title,
+				      QT_UTF8(default_path), QT_UTF8(filter));
 
 	if (files.count() == 0)
 		return;
@@ -2047,8 +2041,8 @@ void WidgetInfo::EditListAddDir()
 	QString title = QTStr("Basic.PropertiesWindow.AddEditableListDir")
 				.arg(QT_UTF8(desc));
 
-	QString dir = QFileDialog::getExistingDirectory(
-		App()->GetMainWindow(), title, QT_UTF8(default_path));
+	QString dir = SelectDirectory(App()->GetMainWindow(), title,
+				      QT_UTF8(default_path));
 
 	if (dir.isEmpty())
 		return;
@@ -2086,15 +2080,11 @@ void WidgetInfo::EditListEdit()
 		QString path;
 
 		if (pathDir.exists())
-			path = QFileDialog::getExistingDirectory(
-				App()->GetMainWindow(), QTStr("Browse"),
-				item->text(),
-				QFileDialog::ShowDirsOnly |
-					QFileDialog::DontResolveSymlinks);
+			path = SelectDirectory(App()->GetMainWindow(),
+					       QTStr("Browse"), item->text());
 		else
-			path = QFileDialog::getOpenFileName(
-				App()->GetMainWindow(), QTStr("Browse"),
-				item->text(), QT_UTF8(filter));
+			path = OpenFile(App()->GetMainWindow(), QTStr("Browse"),
+					item->text(), QT_UTF8(filter));
 
 		if (path.isEmpty())
 			return;

--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -25,6 +25,7 @@
 #include <QMessageBox>
 #include <QDataStream>
 #include <QKeyEvent>
+#include <QFileDialog>
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 #include <QX11Info>
@@ -334,4 +335,65 @@ void setThemeID(QWidget *widget, const QString &themeID)
 		widget->setStyleSheet("/* */");
 		widget->setStyleSheet(qss);
 	}
+}
+
+QString SelectDirectory(QWidget *parent, QString title, QString path)
+{
+#if defined(BROWSER_AVAILABLE) && defined(__linux__)
+	QString dir = QFileDialog::getExistingDirectory(
+		parent, title, path,
+		QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks |
+			QFileDialog::DontUseNativeDialog);
+#else
+	QString dir = QFileDialog::getExistingDirectory(
+		parent, title, path,
+		QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+#endif
+
+	return dir;
+}
+
+QString SaveFile(QWidget *parent, QString title, QString path,
+		 QString extensions)
+{
+#if defined(BROWSER_AVAILABLE) && defined(__linux__)
+	QString file = QFileDialog::getSaveFileName(
+		parent, title, path, extensions, nullptr,
+		QFileDialog::DontUseNativeDialog);
+#else
+	QString file =
+		QFileDialog::getSaveFileName(parent, title, path, extensions);
+#endif
+
+	return file;
+}
+
+QString OpenFile(QWidget *parent, QString title, QString path,
+		 QString extensions)
+{
+#if defined(BROWSER_AVAILABLE) && defined(__linux__)
+	QString file = QFileDialog::getOpenFileName(
+		parent, title, path, extensions, nullptr,
+		QFileDialog::DontUseNativeDialog);
+#else
+	QString file =
+		QFileDialog::getOpenFileName(parent, title, path, extensions);
+#endif
+
+	return file;
+}
+
+QStringList OpenFiles(QWidget *parent, QString title, QString path,
+		      QString extensions)
+{
+#if defined(BROWSER_AVAILABLE) && defined(__linux__)
+	QStringList files = QFileDialog::getOpenFileNames(
+		parent, title, path, extensions, nullptr,
+		QFileDialog::DontUseNativeDialog);
+#else
+	QStringList files =
+		QFileDialog::getOpenFileNames(parent, title, path, extensions);
+#endif
+
+	return files;
 }

--- a/UI/qt-wrappers.hpp
+++ b/UI/qt-wrappers.hpp
@@ -107,3 +107,11 @@ bool LineEditCanceled(QEvent *event);
 bool LineEditChanged(QEvent *event);
 
 void setThemeID(QWidget *widget, const QString &themeID);
+
+QString SelectDirectory(QWidget *parent, QString title, QString path);
+QString SaveFile(QWidget *parent, QString title, QString path,
+		 QString extensions);
+QString OpenFile(QWidget *parent, QString title, QString path,
+		 QString extensions);
+QStringList OpenFiles(QWidget *parent, QString title, QString path,
+		      QString extensions);

--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -496,9 +496,8 @@ void OBSBasic::on_actionImportProfile_triggered()
 		return;
 	}
 
-	QString dir = QFileDialog::getExistingDirectory(
-		this, QTStr("Basic.MainMenu.Profile.Import"), home,
-		QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+	QString dir = SelectDirectory(
+		this, QTStr("Basic.MainMenu.Profile.Import"), home);
 
 	if (!dir.isEmpty() && !dir.isNull()) {
 		QString inputPath = QString::fromUtf8(path);
@@ -543,9 +542,8 @@ void OBSBasic::on_actionExportProfile_triggered()
 		return;
 	}
 
-	QString dir = QFileDialog::getExistingDirectory(
-		this, QTStr("Basic.MainMenu.Profile.Export"), home,
-		QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+	QString dir = SelectDirectory(
+		this, QTStr("Basic.MainMenu.Profile.Export"), home);
 
 	if (!dir.isEmpty() && !dir.isNull()) {
 		QString outputDir = dir + "/" + currentProfile;

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -412,9 +412,9 @@ void OBSBasic::on_actionExportSceneCollection_triggered()
 		return;
 	}
 
-	QString exportFile = QFileDialog::getSaveFileName(
-		this, QTStr("Basic.MainMenu.SceneCollection.Export"),
-		home + "/" + currentFile, "JSON Files (*.json)");
+	QString exportFile =
+		SaveFile(this, QTStr("Basic.MainMenu.SceneCollection.Export"),
+			 home + "/" + currentFile, "JSON Files (*.json)");
 
 	string file = QT_TO_UTF8(exportFile);
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -27,7 +27,6 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QCloseEvent>
-#include <QFileDialog>
 #include <QDirIterator>
 #include <QVariant>
 #include <QTreeView>
@@ -3702,10 +3701,9 @@ void OBSBasicSettings::on_buttonBox_clicked(QAbstractButton *button)
 
 void OBSBasicSettings::on_simpleOutputBrowse_clicked()
 {
-	QString dir = QFileDialog::getExistingDirectory(
+	QString dir = SelectDirectory(
 		this, QTStr("Basic.Settings.Output.SelectDirectory"),
-		ui->simpleOutputPath->text(),
-		QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+		ui->simpleOutputPath->text());
 	if (dir.isEmpty())
 		return;
 
@@ -3714,10 +3712,9 @@ void OBSBasicSettings::on_simpleOutputBrowse_clicked()
 
 void OBSBasicSettings::on_advOutRecPathBrowse_clicked()
 {
-	QString dir = QFileDialog::getExistingDirectory(
+	QString dir = SelectDirectory(
 		this, QTStr("Basic.Settings.Output.SelectDirectory"),
-		ui->advOutRecPath->text(),
-		QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+		ui->advOutRecPath->text());
 	if (dir.isEmpty())
 		return;
 
@@ -3726,10 +3723,9 @@ void OBSBasicSettings::on_advOutRecPathBrowse_clicked()
 
 void OBSBasicSettings::on_advOutFFPathBrowse_clicked()
 {
-	QString dir = QFileDialog::getExistingDirectory(
+	QString dir = SelectDirectory(
 		this, QTStr("Basic.Settings.Output.SelectDirectory"),
-		ui->advOutRecPath->text(),
-		QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+		ui->advOutRecPath->text());
 	if (dir.isEmpty())
 		return;
 

--- a/UI/window-importer.cpp
+++ b/UI/window-importer.cpp
@@ -22,7 +22,6 @@
 #include <QPushButton>
 #include <QLineEdit>
 #include <QToolButton>
-#include <QFileDialog>
 #include <QMimeData>
 #include <QStyledItemDelegate>
 #include <QDirIterator>
@@ -169,7 +168,7 @@ void ImporterEntryPathItemDelegate::handleBrowse(QWidget *container)
 	QString currentPath = text->text();
 
 	bool isSet = false;
-	QStringList paths = QFileDialog::getOpenFileNames(
+	QStringList paths = OpenFiles(
 		container, QTStr("Importer.SelectCollection"), currentPath,
 		QTStr("Importer.Collection") + QString(" ") + Pattern);
 
@@ -535,7 +534,7 @@ void OBSImporter::browseImport()
 {
 	QString Pattern = "(*.json *.bpres *.xml *.xconfig)";
 
-	QStringList paths = QFileDialog::getOpenFileNames(
+	QStringList paths = OpenFiles(
 		this, QTStr("Importer.SelectCollection"), "",
 		QTStr("Importer.Collection") + QString(" ") + Pattern);
 

--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -21,7 +21,6 @@
 
 #include <QCloseEvent>
 #include <QDirIterator>
-#include <QFileDialog>
 #include <QItemDelegate>
 #include <QLineEdit>
 #include <QMessageBox>
@@ -216,9 +215,9 @@ void RemuxEntryPathItemDelegate::handleBrowse(QWidget *container)
 
 	bool isSet = false;
 	if (isOutput) {
-		QString newPath = QFileDialog::getSaveFileName(
-			container, QTStr("Remux.SelectTarget"), currentPath,
-			OutputPattern);
+		QString newPath = SaveFile(container,
+					   QTStr("Remux.SelectTarget"),
+					   currentPath, OutputPattern);
 
 		if (!newPath.isEmpty()) {
 			container->setProperty(PATH_LIST_PROP,
@@ -226,7 +225,7 @@ void RemuxEntryPathItemDelegate::handleBrowse(QWidget *container)
 			isSet = true;
 		}
 	} else {
-		QStringList paths = QFileDialog::getOpenFileNames(
+		QStringList paths = OpenFiles(
 			container, QTStr("Remux.SelectRecording"), currentPath,
 			QTStr("Remux.OBSRecording") + QString(" ") +
 				InputPattern);


### PR DESCRIPTION
### Description
Fixes crash when using Linux browser when opening file dialog.

### Motivation and Context
Workaround for https://github.com/obsproject/obs-browser/issues/219 until the actual issue is solved.

### How Has This Been Tested?
Opened file dialog to make they still work.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
