### PR TITLE
coreaudio-encoder: Fix encoding of 4.0 speaker layout

### DIFF
--- a/plugins/coreaudio-encoder/windows-imports.h
+++ b/plugins/coreaudio-encoder/windows-imports.h
@@ -61,6 +61,24 @@ struct AudioStreamPacketDescription {
 };
 typedef struct AudioStreamPacketDescription AudioStreamPacketDescription;
 
+typedef UInt32 AudioChannelLabel;
+typedef UInt32 AudioChannelLayoutTag;
+
+struct AudioChannelDescription {
+	AudioChannelLabel mChannelLabel;
+	UInt32 mChannelFlags;
+	float mCoordinates[3];
+};
+typedef struct AudioChannelDescription AudioChannelDescription;
+
+struct AudioChannelLayout {
+	AudioChannelLayoutTag mChannelLayoutTag;
+	UInt32 mChannelBitmap;
+	UInt32 mNumberChannelDescriptions;
+	AudioChannelDescription mChannelDescriptions[kVariableLengthArray];
+};
+typedef struct AudioChannelLayout AudioChannelLayout;
+
 typedef OSStatus (*AudioConverterComplexInputDataProc)(
 	AudioConverterRef inAudioConverter, UInt32 *ioNumberDataPackets,
 	AudioBufferList *ioData,


### PR DESCRIPTION
### Description
For four channels, CoreAudio aac encoder wrongly defaults to quad
(FL FR, BL BR) instead of 4.0 (FL FC FR, BC).
This goes against  the aac spec
(ISO/IEC 14496-3:2009.Amd.4:2013).
So 4.0 needs to be explicitly set for the CoreAudio encoder.

### Motivation and Context
This fixes an issue raised by @BtbN in PR 3174 where Twitch would 
silence channels when CoreAudio encoder is used.
The reason is because a quad channel layout is produced instead of 4.0.
The PR fixes the channel layout issue.

### How Has This Been Tested?
I've checked that recordings with CoreAudio encoder with 4.0 selected in audio settings
are indeed decoded as 4.0 (by FFmpeg native aac decoder).
I haven't checked directly with Twitch but @BtbN  reports this fixes the issue he reported. 

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
