### PR TITLE
UI: Add flag/file to disable built-in updater

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -79,6 +79,7 @@ bool opt_start_virtualcam = false;
 bool opt_minimize_tray = false;
 bool opt_allow_opengl = false;
 bool opt_always_on_top = false;
+bool opt_disable_updater = false;
 string opt_starting_collection;
 string opt_starting_profile;
 string opt_starting_scene;
@@ -1424,6 +1425,11 @@ bool OBSApp::IsPortableMode()
 	return portable_mode;
 }
 
+bool OBSApp::IsUpdaterDisabled()
+{
+	return opt_disable_updater;
+}
+
 #ifdef __APPLE__
 #define INPUT_AUDIO_SOURCE "coreaudio_input_capture"
 #define OUTPUT_AUDIO_SOURCE "coreaudio_output_capture"
@@ -2450,6 +2456,9 @@ int main(int argc, char *argv[])
 		} else if (arg_is(argv[i], "--allow-opengl", nullptr)) {
 			opt_allow_opengl = true;
 
+		} else if (arg_is(argv[i], "--disable-updater", nullptr)) {
+			opt_disable_updater = true;
+
 		} else if (arg_is(argv[i], "--help", "-h")) {
 			std::string help =
 				"--help, -h: Get list of available commands.\n\n"
@@ -2467,7 +2476,8 @@ int main(int argc, char *argv[])
 				"--multi, -m: Don't warn when launching multiple instances.\n\n"
 				"--verbose: Make log more verbose.\n"
 				"--always-on-top: Start in 'always on top' mode.\n\n"
-				"--unfiltered_log: Make log unfiltered.\n\n";
+				"--unfiltered_log: Make log unfiltered.\n\n"
+				"--disable-updater: Disable built-in updater (Windows/Mac only)\n\n";
 
 #ifdef _WIN32
 			MessageBoxA(NULL, help.c_str(), "Help",
@@ -2492,6 +2502,12 @@ int main(int argc, char *argv[])
 			os_file_exists(BASE_PATH "/obs_portable_mode") ||
 			os_file_exists(BASE_PATH "/portable_mode.txt") ||
 			os_file_exists(BASE_PATH "/obs_portable_mode.txt");
+	}
+
+	if (!opt_disable_updater) {
+		opt_disable_updater =
+			os_file_exists(BASE_PATH "/disable_updater") ||
+			os_file_exists(BASE_PATH "/disable_updater.txt");
 	}
 #endif
 

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -144,6 +144,7 @@ public:
 
 	std::string GetVersionString() const;
 	bool IsPortableMode();
+	bool IsUpdaterDisabled();
 
 	const char *InputAudioSource() const;
 	const char *OutputAudioSource() const;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1894,6 +1894,9 @@ void OBSBasic::OBSInit()
 	ui->actionUploadLastCrashLog = nullptr;
 	ui->menuCrashLogs = nullptr;
 	ui->actionCheckForUpdates = nullptr;
+#elif _WIN32 || __APPLE__
+	if (App()->IsUpdaterDisabled())
+		ui->actionCheckForUpdates->setEnabled(false);
 #endif
 
 	OnFirstLoad();
@@ -3248,6 +3251,8 @@ void trigger_sparkle_update();
 
 void OBSBasic::TimedCheckForUpdates()
 {
+	if (App()->IsUpdaterDisabled())
+		return;
 	if (!config_get_bool(App()->GlobalConfig(), "General",
 			     "EnableAutoUpdates"))
 		return;


### PR DESCRIPTION
When distributing OBS via third party platforms that have their own update systems we want to be able to disable the OBS updater without having to resort to having a separate build entirely.

This is a PR for one of the changes proposed in RFC #⁠30: https://github.com/obsproject/rfcs/pull/30

### Description
This change adds a new `--disable-updater` command line options and `/disable_updater(.txt)` sentinel file to disable the built-in OBS updater.

### Motivation and Context
As per https://github.com/obsproject/rfcs/pull/30, when distributing OBS via third party platforms the built-in updater should be disabled to avoid conflicts with the platform's updater system.

To keep the maintenance effort to a minimum we'd like to re-use the existing build and simply include the sentinel file or start parameter in the platform configuration to disable the updater.

### How Has This Been Tested?
Compiled on Windows 10 and verified that the "Check for Updates" option is greyed out and the update check on startup does not happen.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
