### PR TITLE
UI: Add option to auto start virtual camera

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -676,6 +676,7 @@ Basic.Settings.General.MultiviewLayout.Horizontal.Bottom="Horizontal, Bottom (8 
 Basic.Settings.General.MultiviewLayout.Vertical.Left="Vertical, Left (8 Scenes)"
 Basic.Settings.General.MultiviewLayout.Vertical.Right="Vertical, Right (8 Scenes)"
 Basic.Settings.General.MultiviewLayout.Horizontal.Extended.Top="Horizontal, Top (24 Scenes)"
+Basic.Settings.General.VCamAutoStart="Automatically start virtual camera on startup"
 
 # basic mode 'stream' settings
 Basic.Settings.Stream="Stream"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -151,8 +151,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>803</width>
-              <height>1026</height>
+              <width>806</width>
+              <height>1349</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -328,6 +328,13 @@
                      </property>
                      <property name="text">
                       <string>Basic.Settings.General.KeepReplayBufferStreamStops</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="7" column="1">
+                    <widget class="QCheckBox" name="autoStartVcam">
+                     <property name="text">
+                      <string>Basic.Settings.General.VCamAutoStart</string>
                      </property>
                     </widget>
                    </item>
@@ -1263,8 +1270,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>603</width>
-              <height>631</height>
+              <width>813</width>
+              <height>739</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -3758,8 +3765,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>555</width>
-              <height>469</height>
+              <width>767</width>
+              <height>582</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_50">
@@ -4614,8 +4621,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>596</width>
-              <height>781</height>
+              <width>791</width>
+              <height>970</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_23">

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1930,6 +1930,12 @@ void OBSBasic::OnFirstLoad()
 #endif
 
 	Auth::Load();
+
+	bool autoVCam = config_get_bool(GetGlobalConfig(), "BasicWindow",
+					"AutoStartVirtualCam");
+
+	if (autoVCam && vcamEnabled)
+		VCamButtonClicked();
 }
 
 void OBSBasic::DeferredSysTrayLoad(int requeueCount)

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -399,6 +399,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->keepReplayStreamStops,CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->systemTrayEnabled,    CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->systemTrayWhenStarted,CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->autoStartVcam,        CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->systemTrayAlways,     CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->saveProjectors,       CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->snappingEnabled,      CHECK_CHANGED,  GENERAL_CHANGED);
@@ -855,6 +856,9 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	QValidator *validator = new QRegExpValidator(rx, this);
 	ui->baseResolution->lineEdit()->setValidator(validator);
 	ui->outputResolution->lineEdit()->setValidator(validator);
+
+	if (!main->vcamEnabled)
+		ui->autoStartVcam->hide();
 }
 
 OBSBasicSettings::~OBSBasicSettings()
@@ -1200,6 +1204,10 @@ void OBSBasicSettings::LoadGeneralSettings()
 	bool systemTrayAlways = config_get_bool(
 		GetGlobalConfig(), "BasicWindow", "SysTrayMinimizeToTray");
 	ui->systemTrayAlways->setChecked(systemTrayAlways);
+
+	bool autoVCam = config_get_bool(GetGlobalConfig(), "BasicWindow",
+					"AutoStartVirtualCam");
+	ui->autoStartVcam->setChecked(autoVCam);
 
 	bool saveProjectors = config_get_bool(GetGlobalConfig(), "BasicWindow",
 					      "SaveProjectors");
@@ -2996,6 +3004,11 @@ void OBSBasicSettings::SaveGeneralSettings()
 		config_set_bool(GetGlobalConfig(), "BasicWindow",
 				"SysTrayMinimizeToTray",
 				ui->systemTrayAlways->isChecked());
+
+	if (WidgetChanged(ui->autoStartVcam))
+		config_set_bool(GetGlobalConfig(), "BasicWindow",
+				"AutoStartVirtualCam",
+				ui->autoStartVcam->isChecked());
 
 	if (WidgetChanged(ui->saveProjectors))
 		config_set_bool(GetGlobalConfig(), "BasicWindow",


### PR DESCRIPTION
### Description
Add option to settings to automatically start virtual camera on startup.

### Motivation and Context
The original virtual camera plugin had an auto start feature, and users might be expecting it.

### How Has This Been Tested?
Enabled option in the settings and restarted OBS to see if it worked.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
