### PR TITLE
win-dshow: Fix virtual camera enable bug

### DIFF
--- a/plugins/win-dshow/dshow-plugin.cpp
+++ b/plugins/win-dshow/dshow-plugin.cpp
@@ -42,12 +42,12 @@ bool obs_module_load(void)
 	RegisterDShowEncoders();
 	obs_register_output(&virtualcam_info);
 
-	if (vcam_installed(false)) {
-		obs_data_t *obs_settings = obs_data_create();
-		obs_data_set_bool(obs_settings, "vcamEnabled", true);
-		obs_apply_private_data(obs_settings);
-		obs_data_release(obs_settings);
-	}
+	bool installed = vcam_installed(false);
+
+	obs_data_t *obs_settings = obs_data_create();
+	obs_data_set_bool(obs_settings, "vcamEnabled", installed);
+	obs_apply_private_data(obs_settings);
+	obs_data_release(obs_settings);
 
 	return true;
 }


### PR DESCRIPTION
### Description
If the user moves the OBS files to another computer without the virtual camera installed, it would still be enabled.

### Motivation and Context
Found this potential bug when coding the Linux virtual camera.

### How Has This Been Tested?
Has not been tested since I currently don't have Windows installed but should work.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
