### PR TITLE
win-capture: Improve Vulkan hook stability

### DIFF
--- a/plugins/win-capture/graphics-hook/vulkan-capture.h
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.h
@@ -7,6 +7,7 @@ struct vk_inst_funcs {
 	DEF_FUNC(DestroyInstance);
 	DEF_FUNC(CreateWin32SurfaceKHR);
 	DEF_FUNC(DestroySurfaceKHR);
+	DEF_FUNC(GetPhysicalDeviceQueueFamilyProperties);
 	DEF_FUNC(GetPhysicalDeviceMemoryProperties);
 	DEF_FUNC(GetPhysicalDeviceImageFormatProperties2);
 	DEF_FUNC(EnumerateDeviceExtensionProperties);


### PR DESCRIPTION
### Description
Make fixes mostly to stabilize CTS. Tested on Windows with RTX 2080 Ti.

Use separate linked-list maps for devices and queues.

Process queues upfront in OBS_CreateDevice, and not lazily in
OBS_GetDeviceQueue.

Handle failed node allocation for OBS_CreateInstance, OBS_CreateDevice,
and OBS_CreateSwapchainKHR.

Handle VK_NULL_HANDLE for OBS_DestroySurfaceKHR and
OBS_DestroySwapchainKHR.

Add temporary code path CTS_WORKAROUND to deal with CTS sharing surfaces
between instances.

Fix return value for OBS_DestroyInstance.

Add missing _freea calls, required for _malloca.

Make sure the queue passed to OBS_QueuePresentKHR supports transfer to
safely call vkCmdCopyImage.

Update GetInstanceProcAddr/GetDeviceProcAddr to conform closer to spec.

Remove extra macros because I dislike indirection more than verbosity.

### Motivation and Context
Vulkan hook should be a good citizen because it impacts all Vulkan titles even when OBS isn't running.

### How Has This Been Tested?
Tested on Windows with RTX 2080 Ti.

vkcube 32/64, Doom (2016), CTS deqp-vk mustpass

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.