### PR TITLE
UI: Fix clickable text on boolean properties with tooltips

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -1443,28 +1443,42 @@ void OBSPropertiesView::AddProperty(obs_property_t *property,
 		return;
 
 	if (obs_property_long_description(property)) {
-		QString lStr = "<html>%1 <img src='%2' style=' \
-				vertical-align: bottom;  \
-				' /></html>";
 		bool lightTheme = palette().text().color().redF() < 0.5;
 		QString file = lightTheme ? ":/res/images/help.svg"
 					  : ":/res/images/help_light.svg";
 		if (label) {
+			QString lStr = "<html>%1 <img src='%2' style=' \
+				vertical-align: bottom;  \
+				' /></html>";
+
 			label->setText(lStr.arg(label->text(), file));
 			label->setToolTip(
 				obs_property_long_description(property));
 		} else if (type == OBS_PROPERTY_BOOL) {
+
+			QString bStr = "<html> <img src='%1' style=' \
+				vertical-align: bottom;  \
+				' /></html>";
+
+			const char *desc = obs_property_description(property);
+
 			QWidget *newWidget = new QWidget();
+
 			QHBoxLayout *boxLayout = new QHBoxLayout(newWidget);
 			boxLayout->setContentsMargins(0, 0, 0, 0);
 			boxLayout->setAlignment(Qt::AlignLeft);
+			boxLayout->setSpacing(0);
 
 			QCheckBox *check = qobject_cast<QCheckBox *>(widget);
-			QLabel *help =
-				new QLabel(lStr.arg(check->text(), file));
+			check->setText(desc);
+			check->setToolTip(
+				obs_property_long_description(property));
+
+			QLabel *help = new QLabel(check);
+			help->setText(bStr.arg(file));
 			help->setToolTip(
 				obs_property_long_description(property));
-			check->setText("");
+
 			boxLayout->addWidget(check);
 			boxLayout->addWidget(help);
 			widget = newWidget;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
I moved the text for the checkbox properties with tooltips into the QCheckBox, and made the label only contain the help.svg image. This allows the text to be a part of the checkbox, so when you click the text it fires the checkbox event. 
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change just makes the text of boolean properties with tooltips on the properties page clickable.
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I was trying to fix this issue: https://github.com/obsproject/obs-studio/issues/2698

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
Tested on Windows 10 with RTX 2060
Tested changes by checking properties UI functions properly
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
