### PR TITLE
CI: Disable Python for Mac PR automation

### DIFF
--- a/CI/before-deploy-osx.sh
+++ b/CI/before-deploy-osx.sh
@@ -23,8 +23,8 @@ mv ./rundir/RelWithDebInfo/data/obs-scripting/obslua.so ./rundir/RelWithDebInfo/
 
 # Move obspython
 hr "Moving OBS Python"
-mv ./rundir/RelWithDebInfo/data/obs-scripting/_obspython.so ./rundir/RelWithDebInfo/bin/
-mv ./rundir/RelWithDebInfo/data/obs-scripting/obspython.py ./rundir/RelWithDebInfo/bin/
+# mv ./rundir/RelWithDebInfo/data/obs-scripting/_obspython.so ./rundir/RelWithDebInfo/bin/
+# mv ./rundir/RelWithDebInfo/data/obs-scripting/obspython.py ./rundir/RelWithDebInfo/bin/
 
 # Package everything into a nice .app
 hr "Packaging .app"

--- a/CI/before-script-osx.sh
+++ b/CI/before-script-osx.sh
@@ -6,7 +6,8 @@ git fetch --tags
 mkdir build
 cd build
 cmake -DENABLE_SPARKLE_UPDATER=ON \
--DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 \
+-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 \
+-DDISABLE_PYTHON=ON \
 -DQTDIR=/usr/local/Cellar/qt/5.14.1 \
 -DDepsPath=/tmp/obsdeps \
 -DVLCPath=$PWD/../../vlc-3.0.8 \


### PR DESCRIPTION
### Description
Attempt to disable Python to fix Mac PR automation. See #3172 for details.

### Motivation and Context
Mac PR automation is failing.

### How Has This Been Tested?
Azure will let us know...

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.