### PR TITLE
libobs: Add helper to enter OBS graphics ctx with result

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1337,6 +1337,12 @@ void obs_enter_graphics(void)
 		gs_enter_context(obs->video.graphics);
 }
 
+bool obs_enter_graphics2(void)
+{
+	obs_enter_graphics();
+	return (gs_get_context() == obs->video.graphics);
+}
+
 void obs_leave_graphics(void)
 {
 	if (obs->video.graphics)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -549,6 +549,7 @@ EXPORT bool obs_enum_service_types(size_t idx, const char **id);
 
 /** Helper function for entering the OBS graphics context */
 EXPORT void obs_enter_graphics(void);
+EXPORT bool obs_enter_graphics2(void);
 
 /** Helper function for leaving the OBS graphics context */
 EXPORT void obs_leave_graphics(void);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Adds a helper function that enters the OBS graphics context, while also informing the caller if this action succeeded or failed. Internally checks 'gs_get_context()' against the known OBS graphics context.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
`obs_enter_graphics()` can fail without informing the caller of this issue, which is not ideal. Since there is no way (that I could find) to manually get the actual OBS graphics context and compare gs_get_context() against it, this is the current best solution for the issue.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Function returns true if the graphics context was entered, and returns false if it was not.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
