### PR TITLE
libobs: Add util/sse2neon.h to CMakeLists.txt

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -362,6 +362,7 @@ set(libobs_util_SOURCES
 set(libobs_util_HEADERS
 	util/curl/curl-helper.h
 	util/sse-intrin.h
+	util/sse2neon.h
 	util/array-serializer.h
 	util/file-serializer.h
 	util/utf8.h


### PR DESCRIPTION

### Description:

Add util/sse2neon.h to libobs_util_HEADERS in libobs/CMakeLists.txt

### Motivation and Context

Plugins fail to compile on arm/rpi due to missing header install
The previous patch #3180 for arm/rpi missed this addition to CMakeLists

### How Has This Been Tested?

Fresh build on Raspberry Pi 4B 4Gb without changes:
* obs-studio will compile and install
* obs-websocket & obs-ndi will fail due to missing sse3neon.h

Fresh build on Raspberry Pi 4B 4Gb with changes: 
* obs-studio, obs-websocket & obs-ndi compile and install

Operating System: Raspbian GNU/Linux 10 (buster)  
Kernel: Linux 5.4.51-v7l+  
Architecture: arm  

### Types of changes

*  Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
