### PR TITLE
UI: Make macOS 'always on top' more aggressive

### DIFF
--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -148,10 +148,18 @@ void SetAlwaysOnTop(QWidget *window, bool enable)
 {
 	Qt::WindowFlags flags = window->windowFlags();
 
-	if (enable)
+	if (enable) {
+		/* Force the level of the window high so it sits on top of
+		 * full-screen applications like Keynote */
+		NSView *nsv = (__bridge NSView *)reinterpret_cast<void *>(
+			window->winId());
+		NSWindow *nsw = nsv.window;
+		[nsw setLevel:1024];
+
 		flags |= Qt::WindowStaysOnTopHint;
-	else
+	} else {
 		flags &= ~Qt::WindowStaysOnTopHint;
+	}
 
 	window->setWindowFlags(flags);
 	window->show();


### PR DESCRIPTION
### Description

This change forces windows on Mac OS that have been set as 'always on top' to be more aggressively 'on top' by manipulating the underlying NSWindow's `level` attribute.


### Motivation and Context

I've been using OBS in conjunction with Apple Keynote. In full screen mode, Keynote covers OBS's windows even when 'always on top' has been set in preferences.

This change allows me to use a Windowed Projector to see previewed source even when Keynote is running in full screen mode.

I'm entirely new to Objective C and this type of projects, so I'm fully ready to hear that there was a much better way to do this.


### How Has This Been Tested?
Tested on Mac OS Catalina 10.15.6 on MacBook Pro (13-inch, 2020, Four Thunderbolt 3 ports)
Built locally, run from (unsigned, un-notorized) app bundle.
Set 'Make projectors always on top' in the preferences, opened a preview projector window, started Keynote in full screen mode. Observed projector window visible over the top of keynote.


### Types of changes
New feature (non-breaking change which adds/improves functionality)

### Checklist:

- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
