### PR TITLE
rtmp-services: Add Nimo TV auto server

### DIFF
--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -250,9 +250,10 @@ void AutoConfigTestPage::TestBandwidthThread()
 		GetServers(servers);
 
 	/* just use the first server if it only has one alternate server,
-	 * or if using Restream due to their "auto" servers */
+	 * or if using Restream or Nimo TV due to their "auto" servers */
 	if (servers.size() < 3 ||
-	    wiz->serviceName.substr(0, 11) == "Restream.io") {
+	    wiz->serviceName.substr(0, 11) == "Restream.io" ||
+	    wiz->serviceName == "Nimo TV") {
 		servers.resize(1);
 
 	} else if (wiz->service == AutoConfig::Service::Twitch &&

--- a/plugins/rtmp-services/CMakeLists.txt
+++ b/plugins/rtmp-services/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(${OBS_JANSSON_INCLUDE_DIRS})
 set(rtmp-services_SOURCES
 	twitch.c
 	younow.c
+	nimotv.c
 	rtmp-common.c
 	rtmp-custom.c
 	rtmp-services-main.c)
@@ -23,6 +24,7 @@ endif()
 set(rtmp-services_HEADERS
 	twitch.h
 	younow.h
+	nimotv.h
 	rtmp-format-ver.h)
 
 set(RTMP_SERVICES_URL

--- a/plugins/rtmp-services/nimotv.c
+++ b/plugins/rtmp-services/nimotv.c
@@ -1,0 +1,145 @@
+#include <util/curl/curl-helper.h>
+#include <stdlib.h>
+#include <string.h>
+#include <jansson.h>
+#include <util/dstr.h>
+#include "util/base.h"
+#include "nimotv.h"
+#include <time.h>
+
+struct nimotv_mem_struct {
+	char *memory;
+	size_t size;
+};
+static char *current_ingest = NULL;
+static time_t last_time = -1;
+
+static size_t nimotv_write_cb(void *contents, size_t size, size_t nmemb,
+			      void *userp)
+{
+	size_t realsize = size * nmemb;
+	struct nimotv_mem_struct *mem = (struct nimotv_mem_struct *)userp;
+
+	char *ptr = realloc(mem->memory, mem->size + realsize + 1);
+	if (ptr == NULL) {
+		blog(LOG_WARNING, "nimotv_write_cb: realloc returned NULL");
+		return 0;
+	}
+
+	mem->memory = ptr;
+	memcpy(&(mem->memory[mem->size]), contents, realsize);
+	mem->size += realsize;
+	mem->memory[mem->size] = 0;
+
+	return realsize;
+}
+
+static char *load_ingest(const char *json)
+{
+	json_t *root = json_loads(json, 0, NULL);
+	char *ingest = NULL;
+	if (!root)
+		return ingest;
+
+	json_t *recommended_ingests = json_object_get(root, "ingests");
+	if (recommended_ingests) {
+		json_t *recommended = json_array_get(recommended_ingests, 0);
+		if (recommended) {
+			json_t *item_url = json_object_get(recommended, "url");
+			if (item_url) {
+				const char *url = json_string_value(item_url);
+				ingest = bstrdup(url);
+			}
+		}
+	}
+
+	json_decref(root);
+	return ingest;
+}
+
+const char *nimotv_get_ingest(const char *key)
+{
+	if (current_ingest != NULL) {
+		time_t now = time(NULL);
+		double diff = difftime(now, last_time);
+		if (diff < 2) {
+			blog(LOG_INFO,
+			     "nimotv_get_ingest: returning ingest from cache: %s",
+			     current_ingest);
+			return current_ingest;
+		}
+	}
+
+	CURL *curl_handle;
+	CURLcode res;
+	struct nimotv_mem_struct chunk;
+	struct dstr uri;
+	long response_code;
+
+	curl_handle = curl_easy_init();
+	chunk.memory = malloc(1); /* will be grown as needed by realloc */
+	chunk.size = 0;           /* no data at this point */
+
+	char *encoded_key = curl_easy_escape(NULL, key, 0);
+	dstr_init(&uri);
+	dstr_copy(&uri, "https://globalcdnweb.nimo.tv/api/ingests/nimo?id=");
+	dstr_ncat(&uri, encoded_key, strlen(encoded_key));
+	curl_free(encoded_key);
+
+	curl_easy_setopt(curl_handle, CURLOPT_URL, uri.array);
+	curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYPEER, true);
+	curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYHOST, 2L);
+	curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT, 3L);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, nimotv_write_cb);
+	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
+	curl_obs_set_revoke_setting(curl_handle);
+
+#if LIBCURL_VERSION_NUM >= 0x072400
+	// A lot of servers don't yet support ALPN
+	curl_easy_setopt(curl_handle, CURLOPT_SSL_ENABLE_ALPN, 0);
+#endif
+
+	res = curl_easy_perform(curl_handle);
+	dstr_free(&uri);
+
+	if (res != CURLE_OK) {
+		blog(LOG_WARNING,
+		     "nimotv_get_ingest: curl_easy_perform() failed: %s",
+		     curl_easy_strerror(res));
+		curl_easy_cleanup(curl_handle);
+		free(chunk.memory);
+		return NULL;
+	}
+
+	curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &response_code);
+	if (response_code != 200) {
+		blog(LOG_WARNING,
+		     "nimotv_get_ingest: curl_easy_perform() returned code: %ld",
+		     response_code);
+		curl_easy_cleanup(curl_handle);
+		free(chunk.memory);
+		return NULL;
+	}
+
+	curl_easy_cleanup(curl_handle);
+
+	if (chunk.size == 0) {
+		blog(LOG_WARNING,
+		     "nimotv_get_ingest: curl_easy_perform() returned empty response");
+		free(chunk.memory);
+		return NULL;
+	}
+
+	if (current_ingest != NULL) {
+		bfree(current_ingest);
+	}
+
+	current_ingest = load_ingest(chunk.memory);
+	last_time = time(NULL);
+
+	free(chunk.memory);
+	blog(LOG_INFO, "nimotv_get_ingest: returning ingest: %s",
+	     current_ingest);
+
+	return current_ingest;
+}

--- a/plugins/rtmp-services/nimotv.h
+++ b/plugins/rtmp-services/nimotv.h
@@ -1,0 +1,3 @@
+#pragma once
+
+extern const char *nimotv_get_ingest(const char *key);

--- a/plugins/rtmp-services/rtmp-common.c
+++ b/plugins/rtmp-services/rtmp-common.c
@@ -6,6 +6,7 @@
 #include "rtmp-format-ver.h"
 #include "twitch.h"
 #include "younow.h"
+#include "nimotv.h"
 
 struct rtmp_common {
 	char *service;
@@ -345,6 +346,11 @@ static void fill_servers(obs_property_t *servers_prop, json_t *service,
 			return;
 	}
 
+	if (strcmp(name, "Nimo TV") == 0) {
+		obs_property_list_add_string(
+			servers_prop, obs_module_text("Server.Auto"), "auto");
+	}
+
 	json_array_foreach (servers, index, server) {
 		const char *server_name = get_string_val(server, "name");
 		const char *url = get_string_val(server, "url");
@@ -598,6 +604,12 @@ static const char *rtmp_common_url(void *data)
 	if (service->service && strcmp(service->service, "YouNow") == 0) {
 		if (service->server && service->key) {
 			return younow_get_ingest(service->server, service->key);
+		}
+	}
+
+	if (service->service && strcmp(service->service, "Nimo TV") == 0) {
+		if (service->server && strcmp(service->server, "auto") == 0) {
+			return nimotv_get_ingest(service->key);
 		}
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

- Add support for Nimo TV "Auto" server

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

- The ability to select a server based on user location.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on Windows 10 and Mac OS X 10.15.3.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
