### PR TITLE
rtmp-services: Add api.video service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 144,
+	"version": 145,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 144
+			"version": 145
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1742,6 +1742,20 @@
                 "max video bitrate": 4000,
                 "max audio bitrate": 192
             }
-        }
+        },
+	{
+	    "name": "api.video",
+	    "servers": [
+		    {
+			    "name": "Default",
+			    "url": "rtmp://broadcast.api.video/s"
+		    }
+	    ],
+	    "recommended": {
+		    "keyint": 2,
+		    "max video bitrate": 20000,
+		    "max audio bitrate": 192
+	    }
+	}
     ]
 }


### PR DESCRIPTION
### Description
Add rtmp server for api.video streaming service
If this change includes UI elements, please include screenshots.

### Motivation and Context
 Ease of streaming to the service for users

### How Has This Been Tested?
Started and successfully connected with new build

### Types of changes
New Streaming Service 

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
