### PR TITLE
CI: Fix Brew Bundler breaking without prior brew update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
       - name: 'Install prerequisites (Homebrew)'
         shell: bash
         run: |
+          brew update --preinstall
           brew bundle --file ./CI/scripts/macos/Brewfile
       - name: 'Restore Chromium Embedded Framework from cache'
         id: cef-cache

--- a/CI/full-build-macos.sh
+++ b/CI/full-build-macos.sh
@@ -103,6 +103,7 @@ install_homebrew_deps() {
         exit 1
     fi
 
+    brew update
     brew bundle --file ${CI_SCRIPTS}/Brewfile
 }
 


### PR DESCRIPTION
### Description
Fixes Brew Bundler breaking on CI due to missing prior Homebrew update: https://github.com/Homebrew/homebrew-bundle/issues/751

### Motivation and Context
Issue prohibits macOS CI workflows from completing and could also lead to issues when using the macOS build script.

### How Has This Been Tested?
* Tested locally
* Successful fix will let macOS workflow finish

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
