### PR TITLE
oss-audio: Use util_mul_div64() to do time scaling

### DIFF
--- a/plugins/oss-audio/oss-input.c
+++ b/plugins/oss-audio/oss-input.c
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define blog(level, msg, ...) blog(level, "oss-audio: " msg, ##__VA_ARGS__)
 
-#define NSEC_PER_SEC 1000000000LL
+#define NSEC_PER_SEC 1000000000ULL
 
 #define OSS_MAX_CHANNELS 8
 
@@ -255,9 +255,9 @@ static void *oss_reader_thr(void *vptr)
 				oss_channels_to_obs_speakers(handle->channels);
 			out.samples_per_sec = handle->rate;
 			out.frames = nbytes / framesize;
-			out.timestamp =
-				os_gettime_ns() -
-				((out.frames * NSEC_PER_SEC) / handle->rate);
+			out.timestamp = os_gettime_ns() -
+					util_mul_div64(out.frames, NSEC_PER_SEC,
+						       handle->rate);
 			obs_source_output_audio(handle->source, &out);
 		}
 		if (fds[1].revents & POLLIN) {


### PR DESCRIPTION
util_mul_div64() is a new helper to do scaling introduced in https://github.com/obsproject/obs-studio/pull/2657. This commit sweeps the
oss-audio plugin code to generalize the way of doing scaling.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This commit serves as an optimization to oss-audio's arithmetic operations.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
It's tested on FreeBSD by sending SIGSTOP and SIGCONT to the obs process during audio recording.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
