### PR TITLE
UI: Check and fail when launched under ChromeOS

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -102,6 +102,9 @@ AlreadyRunning.Title="OBS is already running"
 AlreadyRunning.Text="OBS is already running! Unless you meant to do this, please shut down any existing instances of OBS before trying to run a new instance. If you have OBS set to minimize to the system tray, please check to see if it's still running there."
 AlreadyRunning.LaunchAnyway="Launch Anyway"
 
+ChromeOS.Title="Unsupported Platform"
+ChromeOS.Text="OBS appears to be running inside a ChromeOS container. This platform is unsupported"
+
 # warning when closing docks. it's frustrating that we actually need this.
 DockCloseWarning.Title="Closing Dockable Window"
 DockCloseWarning.Text="You just closed a dockable window. If you'd like to show it again, use the View → Docks menu on the menu bar."

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1987,6 +1987,22 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 	run:
 #endif
 
+#if !defined(_WIN32) && !defined(__APPLE__)
+		// Mounted by termina during chromeOS linux container startup
+		// https://chromium.googlesource.com/chromiumos/overlays/board-overlays/+/master/project-termina/chromeos-base/termina-lxd-scripts/files/lxd_setup.sh
+		os_dir_t *crosDir = os_opendir("/opt/google/cros-containers");
+		if (crosDir) {
+			QMessageBox::StandardButtons buttons(QMessageBox::Ok);
+			QMessageBox mb(QMessageBox::Critical,
+				       QTStr("ChromeOS.Title"),
+				       QTStr("ChromeOS.Text"), buttons,
+				       nullptr);
+
+			mb.exec();
+			return 0;
+		}
+#endif
+
 		if (!created_log) {
 			create_log_file(logFile);
 			created_log = true;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This adds a check when compiling for linux to check for a ChromeOS
container specific directory. If this directory exists OBS will fail to
start with an error that ChromeOS is unsupported. Its still unclear how
much this will help since these users are typically on debian stable so
this change wont reach them for another 4 years.

I also dont have a chromeos device to test this on. But it looks promising...
If anyone with a chromeos device could confirm id appreciate it.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Telling people on ChromeOS that OBS doesnt work is annoying. Now they will know as soon as they start up the program.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Manually creating the target folder works as intended. Removing it OBS works as intended. I find it highly unlikely people running on linuxes outside of chromeos or chromeos developers will have an `/opt/google/cros-containers`

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
