### PR TITLE
libobs: Fix deferred update sometimes using stale data

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -599,7 +599,7 @@ struct obs_source {
 	bool owns_info_id;
 
 	/* signals to call the source update in the video thread */
-	bool defer_update;
+	long defer_update_count;
 
 	/* ensures show/hide are only called once */
 	volatile long show_refs;


### PR DESCRIPTION
### Description

Currently we use a bool flag to signal the video thread that it should
call obs_source_deferred_update. This does not work correctly when the
update callback is slow and the update is triggered faster than the
callback can complete.

For example:
* the settings are set to state A
* defer_update is set
* obs_source_deferred_update is called and enters into the callback
* the callback starts making use of the settings in state A
* the settings are set to state B
* defer_update stays set
* the callback finishes
* defer_update is set to false

Now defer_update is false but the callback has only observed settings in
state A but not B.

This commit fixes this bug by keeping an update counter. If the counter
has changed while we were in the callback we know that we need to update
again.

The counter is atomic. The current version uses a plain bool which is a
data race as the value is written and read in parallel.

### Motivation and Context

Fixes #3236 .

### How Has This Been Tested?

Tested with the diff and reproduction steps in the issue. The callback is called until it has observed the most recent update.

### Types of changes

- Bug fix (non-breaking change which fixes an issue) -->

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch. (I'm assuming this refers to my branch but I don't understand why it's relevant.)
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
