### PR TITLE
UI: Mac fix — remove wizard background padding

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -745,7 +745,7 @@ AutoConfig::AutoConfig(QWidget *parent) : QWizard(parent)
 
 	std::string serviceType;
 	GetServiceInfo(serviceType, serviceName, server, key);
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 	setWizardStyle(QWizard::ModernStyle);
 #endif
 	streamPage = new AutoConfigStreamPage();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

If style is not set it default's to Mac's style on Mac which adds
padding for a background. Looks like wasted space on Mac because there
is no background. Matches windows. Does not affect Linux.

https://doc.qt.io/qt-5/qwizard.html#elements-of-a-wizard-page


BEFORE:
<img width="680" alt="Screen Shot 2020-08-03 at 4 51 45 PM" src="https://user-images.githubusercontent.com/1580980/89238995-cbe38c00-d5ac-11ea-9545-6f06843bf70f.png">
<img width="807" alt="Screen Shot 2020-08-03 at 4 51 50 PM" src="https://user-images.githubusercontent.com/1580980/89239001-cede7c80-d5ac-11ea-974e-563ecd8e9b77.png">

AFTER: 

<img width="529" alt="Screen Shot 2020-08-03 at 5 06 20 PM" src="https://user-images.githubusercontent.com/1580980/89239010-d3a33080-d5ac-11ea-97d8-13875db15d09.png">
<img width="613" alt="Screen Shot 2020-08-03 at 5 06 25 PM" src="https://user-images.githubusercontent.com/1580980/89239013-d6058a80-d5ac-11ea-8ee6-e416725112e5.png">


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fixes outstanding mac issue with wizard layout. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
MacOS Mojave v10.14.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
