### PR TITLE
deps/media-playback: Fix high cpu while paused

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -717,8 +717,13 @@ static inline bool mp_media_thread(mp_media_t *m)
 			continue;
 		}
 
-		if (pause)
+		if (pause) {
+			/*create a sleep timer to prevent continous loop execution*/
+			pthread_mutex_lock(&m->mutex);
+			m->next_ns += 200000000;
+			pthread_mutex_unlock(&m->mutex);
 			continue;
+		}
 
 		/* frames are ready */
 		if (is_active && !timeout) {


### PR DESCRIPTION
Paused media object were constantly executing their message loop. This
commit fixes this by sleeping the media thread for 200ms between loops
while paused.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This is to fix [3235](https://github.com/obsproject/obs-studio/issues/3235).
The issue was caused by the way the pause message was handled. Pause simply continued the loop, but since there is nothing to execute, the loop runs very quickly, eating up CPU time unnecessarily. Therefore, added a 200ms delay between message loop executions while a media thread is paused. This significantly reduces the number of loops executed while minimizing user impact.

### Motivation and Context
Fix for reported issue:
[3235](https://github.com/obsproject/obs-studio/issues/3235)

### How Has This Been Tested?
Tested on Windows 10 10.0.18363 using a Ryzen 9 3900x.
Before implementing the change, a paused media source would utilize up to 7% of CPU capacity. After the change, CPU usage is stable, and even somewhat drops.

Verified there was no loop blocking by successfully quitting the application while paused. Verified there was no notable latency due to the sleep. The modification properly locks and unlocks the mutex, so there should be no concerns of race conditions.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation. 
