### PR TITLE
mac-decklink: Fix C++ virtual function warnings

### DIFF
--- a/plugins/decklink/DecklinkBase.cpp
+++ b/plugins/decklink/DecklinkBase.cpp
@@ -15,4 +15,8 @@ bool DecklinkBase::Activate(DeckLinkDevice *, long long)
 	return false;
 }
 
-void DecklinkBase::Deactivate() {}
+bool DecklinkBase::Activate(DeckLinkDevice *, long long, BMDVideoConnection,
+			    BMDAudioConnection)
+{
+	return false;
+}

--- a/plugins/decklink/DecklinkBase.h
+++ b/plugins/decklink/DecklinkBase.h
@@ -27,7 +27,10 @@ protected:
 
 public:
 	virtual bool Activate(DeckLinkDevice *device, long long modeId);
-	virtual void Deactivate();
+	virtual bool Activate(DeckLinkDevice *device, long long modeId,
+			      BMDVideoConnection bmdVideoConnection,
+			      BMDAudioConnection bmdAudioConnection);
+	virtual void Deactivate() = 0;
 
 	DeckLinkDevice *GetDevice() const;
 };

--- a/plugins/decklink/DecklinkInput.hpp
+++ b/plugins/decklink/DecklinkInput.hpp
@@ -41,8 +41,8 @@ public:
 
 	bool Activate(DeckLinkDevice *device, long long modeId,
 		      BMDVideoConnection bmdVideoConnection,
-		      BMDAudioConnection bmdAudioConnection);
-	void Deactivate();
+		      BMDAudioConnection bmdAudioConnection) override;
+	void Deactivate() override;
 	bool Capturing();
 
 	bool buffering = false;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Created another virtual function to override and moves stubbed function to the header to remove three file warnings: `...hidden overloaded virtual function 'DecklinkBase::Activate' declared here...`


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Reduce warnings, more-correct code on mac. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
MacOS Mojave 10.14.16
 - Builds on mac
 - No longer flags errors: 
```
Scanning dependencies of target mac-decklink
[ 37%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/__/plugin-main.cpp.o
[ 38%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/__/decklink-devices.cpp.o
[ 38%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/__/decklink-output.cpp.o
[ 38%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/__/decklink-source.cpp.o
[ 38%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/__/DecklinkOutput.cpp.o
[ 39%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/__/DecklinkInput.cpp.o
[ 39%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/__/DecklinkBase.cpp.o
[ 39%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/__/decklink-device-instance.cpp.o
[ 39%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/__/decklink-device-discovery.cpp.o
[ 40%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/__/decklink-device.cpp.o
[ 40%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/__/decklink-device-mode.cpp.o
[ 40%] Building C object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/__/audio-repack.c.o
[ 41%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/platform.cpp.o
[ 41%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/__/util.cpp.o
[ 41%] Building CXX object plugins/decklink/mac/CMakeFiles/mac-decklink.dir/decklink-sdk/DeckLinkAPIDispatch.cpp.o
[ 41%] Linking CXX shared module mac-decklink.so
[ 41%] Built target mac-decklink
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Performance enhancement (non-breaking change which improves efficiency) 
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
