### PR TITLE
CI: Update macOS deps version to fix unmet Qt plugin dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     name: 'macOS 64-bit'
     runs-on: [macos-latest]
     env:
-      MACOS_DEPS_VERSION: '2020-07-06'
+      MACOS_DEPS_VERSION: '2020-08-06'
       VLC_VERSION: '3.0.8'
       SPARKLE_VERSION: '1.23.0'
       QT_VERSION: '5.14.1'


### PR DESCRIPTION
### Description
Update macOS deps for build script and Github CI to include updated Qt build. 

### Motivation and Context
Github Action runners contain `libtiff` and `webp` preinstalled via Homebrew. Building Qt on CI for re-distribution will lead to Qt's `imageformats` plugins to be linked against those Homebrew-provided libraries (instead of third-party code contained in Qt's repos).

This leads to a situation where the Qt distributed as part of `obs-deps` can not be bundled on a system without these libraries installed via Homebrew as well.

Fixes https://github.com/obsproject/obs-studio/issues/3242

### How Has This Been Tested?
* OBS built and bundled successfully with `libtiff` and `webp` not linked/available on build system
* OBS built and bundled successfully with `libtiff` and `webp` linked/available on build system
* Qt plugins checked for Homebrew library references after each build

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
