### PR TITLE
libobs: Fix undefined behavior

### DIFF
--- a/libobs/util/utf8.c
+++ b/libobs/util/utf8.c
@@ -110,7 +110,7 @@ static int utf8_forbidden(unsigned char octet)
  *
  *	It takes the following arguments:
  *	in	- input UTF-8 string. It can be null-terminated.
- *	insize	- size of input string in bytes.  If insize is 0, 
+ *	insize	- size of input string in bytes.  If insize is 0,
  *	        function continues until a null terminator is reached.
  *	out	- result buffer for UCS-4 string. If out is NULL,
  *		function returns size of result buffer.
@@ -143,7 +143,7 @@ size_t utf8_to_wchar(const char *in, size_t insize, wchar_t *out,
 	total = 0;
 	p = (unsigned char *)in;
 	lim = (insize != 0) ? (p + insize) : (unsigned char *)-1;
-	wlim = out + outsize;
+	wlim = out == NULL ? NULL : out + outsize;
 
 	for (; p < lim; p += n) {
 		if (!*p)
@@ -272,7 +272,7 @@ size_t wchar_to_utf8(const wchar_t *in, size_t insize, char *out,
 	w = (wchar_t *)in;
 	wlim = (insize != 0) ? (w + insize) : (wchar_t *)-1;
 	p = (unsigned char *)out;
-	lim = p + outsize;
+	lim = out == NULL ? NULL : p + outsize;
 	total = 0;
 
 	for (; w < wlim; w++) {


### PR DESCRIPTION
### Description
It is undefined behavior to apply an offset to a null pointer. I would
have liked to reference cppreference but best I found was the PR that
added this check to clang's undefined behavior sanitizer:
https://reviews.llvm.org/D67122 .

### Motivation and Context
We should not have undefined behavior.

### How Has This Been Tested?
We can observe the undefined behavior by compiling with `-fsanitize=undefined`. I do this with clang-10 on Linux. Create a text source. When typing the first character for the source we see the following message. Note that there is earlier undefined behavior already which this PR does not fix.

```
obs-studio/libobs/util/utf8.c:147:13: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/e/programming/obs/obs-studio/libobs/util/utf8.c:146
```

With this PR we no longer see the message.

### Types of changes
 - Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
