### PR TITLE
deps/media-playback: Rewrite to use queue and states

### DIFF
--- a/deps/media-playback/media-playback/media.h
+++ b/deps/media-playback/media-playback/media.h
@@ -42,6 +42,64 @@ typedef void (*mp_video_cb)(void *opaque, struct obs_source_frame *frame);
 typedef void (*mp_audio_cb)(void *opaque, struct obs_source_audio *audio);
 typedef void (*mp_stop_cb)(void *opaque);
 
+typedef struct mp_media_queue_node mp_media_queue_node_t;
+typedef struct mp_media_state_message mp_media_state_message_t;
+typedef struct mp_media_queue mp_media_queue_t;
+typedef struct mp_media mp_media_t;
+
+typedef bool (*mp_state_handler)(mp_media_t *m);
+
+/* Used internally by mp_media to track current state.
+ * to add new event:
+ * 1. Declare event in mp_media_state enumerator
+ * 2. Define event handler function.
+ * 3. Register event handler reference to queue.
+ * 4. Register any transition actions to the state change method.
+ * Then use an invoke function to push the message to queue.
+ * Note: States must be a power of 2 in order to map properly to
+ * the flag table.
+ */
+enum mp_media_state {
+	mstate_uninit = 1,
+	mstate_playing = 2,
+	mstate_paused = 4,
+	mstate_resume = 8,
+	mstate_seeking = 16,
+	mstate_resetting = 32,
+	mstate_setloop = 64,
+	mstate_setreconnect = 128,
+	mstate_stopping = 256,
+	mstate_stopped = 512,
+	mstate_killing = 1024
+};
+
+/* Queued messages from event handlers to change media state. */
+struct mp_media_state_message {
+	/* Function for media loop to process. */
+	mp_state_handler state_handler;
+	/* State representation of the invoked function.
+	 * Generally, this is the state the media will change to.
+	 */
+	enum mp_media_state state;
+};
+
+/* Queue node. */
+ struct mp_media_queue_node {
+	/* The message object. */
+	mp_media_state_message_t message;
+	/* Pointer to the next message in queue. */
+	mp_media_queue_node_t *next;
+};
+
+/* Standard queue object, EXCEPT we include a bit flag integer.
+ * The flag allows us to ensure any given message only appears once.
+ */
+struct mp_media_queue {
+	mp_media_queue_node_t *first;
+	mp_media_queue_node_t *last;
+	int flags;
+};
+
 struct mp_media {
 	AVFormatContext *fmt;
 
@@ -88,23 +146,18 @@ struct mp_media {
 
 	pthread_mutex_t mutex;
 	os_sem_t *sem;
-	bool stopping;
 	bool looping;
-	bool active;
-	bool reset;
-	bool kill;
+	bool killing;
+
+	enum mp_media_state mp_state;
+	mp_media_queue_t mp_queue;
 
 	bool thread_valid;
 	pthread_t thread;
 
-	bool pause;
-	bool reset_ts;
-	bool seek;
 	bool seek_next_ts;
 	int64_t seek_pos;
 };
-
-typedef struct mp_media mp_media_t;
 
 struct mp_media_info {
 	void *opaque;
@@ -128,15 +181,17 @@ struct mp_media_info {
 
 extern bool mp_media_init(mp_media_t *media, const struct mp_media_info *info);
 extern void mp_media_free(mp_media_t *media);
-
 extern void mp_media_play(mp_media_t *media, bool loop, bool reconnecting);
 extern void mp_media_stop(mp_media_t *media);
 extern void mp_media_play_pause(mp_media_t *media, bool pause);
-extern int64_t mp_get_current_time(mp_media_t *m);
 extern void mp_media_seek_to(mp_media_t *m, int64_t pos);
 
-/* #define DETAILED_DEBUG_INFO */
+extern int64_t mp_get_current_time(mp_media_t *m);
 
+static bool mp_media_push_message(mp_media_t *m, enum mp_media_state state);
+static bool mp_media_pop_message(mp_media_t *m);
+
+/* #define DETAILED_DEBUG_INFO */
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
 #define USE_NEW_FFMPEG_DECODE_API
 #endif


### PR DESCRIPTION
 Media source object is rewritten in to use states and a message queue.
 By moving to a state enumerator, the state can be guaranteed through
 each iteration of the message loop. This should greatly reduce race
 condition concerns. Also broke each message into its own function that
 can be logically modified to change behavior later.

 Additionally, a message queue is created to handle events from other
 threads. A function pointer allows new states to be added easily. The
 queue also features a bit flag to ensure any given state only appears
 once.

 Makes code more readable, will make future feature implementation
 easier, and provides a more efficient execution loop.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This PR includes two key changes to the media source file:
First, states are changed from being a bunch of flags to a discrete state enumerator. This makes it easy to understand what is happening at any given time, and makes code much more readable.
Second, events are now handled by a message queue. This queue is fairly standard, but has the unique feature of providing a flag table to ensure any given message is pushed only once. 

### Motivation and Context
Seeks to improve code readability and efficiency of media source loop.

### How Has This Been Tested?
Tested any combination of media events, and provided properties in the media source settings panel. Tested multiple sources and scenes. 

Tested with Windows 10 18363 on a AMD Ryzen 3900x.

Changes should be encapsulated to the media file, but the event signalers may be relevant to obs-ffmpeg-source if the new structure changes the logic in an unanticipated way.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 - Performance enhancement (non-breaking change which improves efficiency)
 - Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
