### PR TITLE
README.rst: Remove Mantis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,10 +37,7 @@ Quick Links
 
  - Donating/backing/sponsoring: https://obsproject.com/contribute
 
- - Bug Tracker: https://obsproject.com/mantis/
-
-   (Note: The bug tracker is linked to forum accounts.  To use the bug
-   tracker, log in to a forum account)
+ - Bug Tracker: https://github.com/obsproject/obs-studio/issues
 
 Contributing
 ------------


### PR DESCRIPTION
### Description
This removes the Mantis link in the readme and replaces it with the GitHub Issues one.

### Motivation and Context
Mantis isn't used anymore by the project.

### How Has This Been Tested?
Made sure the link showed up correctly when looking at the readme on the branch.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
