### PR TITLE
CI: Add QtNetwork to bundle to restore Streamdeck support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,6 +216,14 @@ jobs:
 
           mv ./libobs-opengl/libobs-opengl.so ./OBS.app/Contents/Frameworks
 
+          cp -R /tmp/obsdeps/lib/QtNetwork.framework ./OBS.app/Contents/Frameworks
+          chmod -R +w ./OBS.app/Contents/Frameworks/QtNetwork.framework
+          rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/Headers
+          rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/Headers/
+          chmod 644 ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/Resources/Info.plist
+          install_name_tool -id @executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
+          install_name_tool -change /tmp/obsdeps/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
+
           sudo cp -R "${{ github.workspace }}/cmbuild/cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64/Release/Chromium Embedded Framework.framework" ./OBS.app/Contents/Frameworks/
           sudo chown -R $(whoami) ./OBS.app/Contents/Frameworks/
 

--- a/CI/full-build-macos.sh
+++ b/CI/full-build-macos.sh
@@ -294,6 +294,15 @@ bundle_dylibs() {
         -x ./OBS.app/Contents/PlugIns/obs-outputs.so
     step "Move libobs-opengl to final destination"
     cp ./libobs-opengl/libobs-opengl.so ./OBS.app/Contents/Frameworks
+
+    step "Copy QtNetwork for plugin support"
+    cp -R /tmp/obsdeps/lib/QtNetwork.framework ./OBS.app/Contents/Frameworks
+    chmod -R +w ./OBS.app/Contents/Frameworks/QtNetwork.framework
+    rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/Headers
+    rm -r ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/Headers/
+    chmod 644 ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/Resources/Info.plist
+    install_name_tool -id @executable_path/../Frameworks/QtNetwork.framework/Versions/5/QtNetwork ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
+    install_name_tool -change /tmp/obsdeps/lib/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore ./OBS.app/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
 }
 
 install_frameworks() {


### PR DESCRIPTION
### Description
Adds `QtNetwork` from obs-deps to application bundle to restore support for plugins that expect it to be shipped as part of OBS' own bundle.

### Motivation and Context
Currently the Streamdeck OBS plugin requires `QtNetwork` and is linked against the Framework inside OBS' application bundle (using the `@executable_path` dylib variable). OBS and its included plugins do not require `QtNetwork` and hence it wasn't bundled automatically.

This fix adds the framework manually and fixes up identity and `QtCore` references to restore this support.

### How Has This Been Tested?
* OBS compiled locally with fixes to build script
* OBS bundled locally
* QtNetwork framework found inside bundle with correct identity/paths

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
