### PR TITLE
UI:Show "Get Stream Key" to users of Facebook CDN

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -273,6 +273,10 @@ AutoConfigStreamPage::AutoConfigStreamPage(QWidget *parent)
 		SLOT(ServiceChanged()));
 	connect(ui->customServer, SIGNAL(textChanged(const QString &)), this,
 		SLOT(ServiceChanged()));
+	connect(ui->customServer, SIGNAL(textChanged(const QString &)), this,
+		SLOT(UpdateKeyLink()));
+	connect(ui->customServer, SIGNAL(editingFinished()), this,
+		SLOT(UpdateKeyLink()));
 	connect(ui->doBandwidthTest, SIGNAL(toggled(bool)), this,
 		SLOT(ServiceChanged()));
 
@@ -573,12 +577,8 @@ void AutoConfigStreamPage::ServiceChanged()
 
 void AutoConfigStreamPage::UpdateKeyLink()
 {
-	if (IsCustomService()) {
-		ui->doBandwidthTest->setEnabled(true);
-		return;
-	}
-
 	QString serviceName = ui->service->currentText();
+	QString customServer = ui->customServer->text();
 	bool isYoutube = false;
 	QString streamKeyLink;
 
@@ -591,7 +591,8 @@ void AutoConfigStreamPage::UpdateKeyLink()
 	} else if (serviceName.startsWith("Restream.io")) {
 		streamKeyLink =
 			"https://restream.io/settings/streaming-setup?from=OBS";
-	} else if (serviceName == "Facebook Live") {
+	} else if (serviceName == "Facebook Live" ||
+		   (customServer.contains("fbcdn.net") && IsCustomService())) {
 		streamKeyLink =
 			"https://www.facebook.com/live/producer?ref=OBS";
 	} else if (serviceName.startsWith("Twitter")) {

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -71,6 +71,10 @@ void OBSBasicSettings::InitStreamPage()
 		SLOT(UpdateServerList()));
 	connect(ui->service, SIGNAL(currentIndexChanged(int)), this,
 		SLOT(UpdateKeyLink()));
+	connect(ui->customServer, SIGNAL(textChanged(const QString &)), this,
+		SLOT(UpdateKeyLink()));
+	connect(ui->customServer, SIGNAL(editingFinished(const QString &)),
+		this, SLOT(UpdateKeyLink()));
 }
 
 void OBSBasicSettings::LoadStream1Settings()
@@ -208,12 +212,8 @@ void OBSBasicSettings::SaveStream1Settings()
 
 void OBSBasicSettings::UpdateKeyLink()
 {
-	if (IsCustomService()) {
-		ui->getStreamKeyButton->hide();
-		return;
-	}
-
 	QString serviceName = ui->service->currentText();
+	QString customServer = ui->customServer->text();
 	QString streamKeyLink;
 	if (serviceName == "Twitch") {
 		streamKeyLink =
@@ -223,7 +223,8 @@ void OBSBasicSettings::UpdateKeyLink()
 	} else if (serviceName.startsWith("Restream.io")) {
 		streamKeyLink =
 			"https://restream.io/settings/streaming-setup?from=OBS";
-	} else if (serviceName == "Facebook Live") {
+	} else if (serviceName == "Facebook Live" ||
+		   (customServer.contains("fbcdn.net") && IsCustomService())) {
 		streamKeyLink =
 			"https://www.facebook.com/live/producer?ref=OBS";
 	} else if (serviceName.startsWith("Twitter")) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Facebook provides CDN endpoints for users to optimize their bandwidth or latency using the speed test on facebook.com/live/ingests/. In this case streamers use a custom server endpoint that looks like "rtmps://edgetee-upload-fml.xx.fbcdn.net:443/rtmp/".

This diff adds detection to users using the custom field for CDN endpoints so we can show the stream key link button.

Screenshots of the button hiding and displaying only when a URL is available: 

![Screen Shot 2020-08-14 at 5 02 15 PM](https://user-images.githubusercontent.com/1580980/90301046-5bf9bf00-de52-11ea-9b25-0ecab40d5082.png)
![Screen Shot 2020-08-14 at 5 02 22 PM](https://user-images.githubusercontent.com/1580980/90301047-5d2aec00-de52-11ea-90c8-ff94068c4c28.png)
![Screen Shot 2020-08-14 at 5 10 28 PM](https://user-images.githubusercontent.com/1580980/90301049-5e5c1900-de52-11ea-814c-5611cebf194a.png)
![Screen Shot 2020-08-14 at 5 10 40 PM](https://user-images.githubusercontent.com/1580980/90301050-5e5c1900-de52-11ea-99f4-b0bbaa374ef9.png)


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Providing a similarly simple link to users targeting CDNs directly to match using the default endpoint

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

 - Tested that button hides and shows when expected
 - Button is correctly hidden/shown 
 - Works in settings page
 - Works in auto config page 

On MacOS Mojave 10.14.6 (18G1012)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality) 
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
