### PR TITLE
UI: Provide Open button in the Log Viewer

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -96,6 +96,7 @@ AspectRatio="Aspect Ratio <b>%1:%2</b>"
 LockVolume="Lock Volume"
 LogViewer="Log Viewer"
 ShowOnStartup="Show on startup"
+OpenFile="Open file"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"

--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -6,6 +6,7 @@
 #include <QPushButton>
 #include <QCheckBox>
 #include <QLayout>
+#include <QDesktopServices>
 #include <string>
 
 #include "log-viewer.hpp"
@@ -29,6 +30,9 @@ OBSLogViewer::OBSLogViewer(QWidget *parent) : QDialog(parent)
 	QPushButton *clearButton = new QPushButton(QTStr("Clear"));
 	connect(clearButton, &QPushButton::clicked, this,
 		&OBSLogViewer::ClearText);
+	QPushButton *openButton = new QPushButton(QTStr("OpenFile"));
+	connect(openButton, &QPushButton::clicked, this,
+		&OBSLogViewer::OpenFile);
 	QPushButton *closeButton = new QPushButton(QTStr("Close"));
 	connect(closeButton, &QPushButton::clicked, this, &QDialog::hide);
 
@@ -40,6 +44,7 @@ OBSLogViewer::OBSLogViewer(QWidget *parent) : QDialog(parent)
 	buttonLayout->addSpacing(10);
 	buttonLayout->addWidget(showStartup);
 	buttonLayout->addStretch();
+	buttonLayout->addWidget(openButton);
 	buttonLayout->addWidget(clearButton);
 	buttonLayout->addWidget(closeButton);
 	buttonLayout->addSpacing(10);
@@ -142,4 +147,20 @@ void OBSLogViewer::AddLine(int type, const QString &str)
 void OBSLogViewer::ClearText()
 {
 	textArea->clear();
+}
+
+void OBSLogViewer::OpenFile()
+{
+	char logDir[512];
+	if (GetConfigPath(logDir, sizeof(logDir), "obs-studio/logs") <= 0)
+		return;
+
+	const char *log = App()->GetCurrentLog();
+
+	std::string path = logDir;
+	path += "/";
+	path += log;
+
+	QUrl url = QUrl::fromLocalFile(QT_UTF8(path.c_str()));
+	QDesktopServices::openUrl(url);
 }

--- a/UI/log-viewer.hpp
+++ b/UI/log-viewer.hpp
@@ -15,6 +15,7 @@ private slots:
 	void AddLine(int type, const QString &text);
 	void ClearText();
 	void ToggleShowStartup(bool checked);
+	void OpenFile();
 
 public:
 	OBSLogViewer(QWidget *parent = 0);


### PR DESCRIPTION
### Description

This restores the ability to open the log file itself from the OBS UI.

![image](https://user-images.githubusercontent.com/941350/90305935-3d0b3380-df0b-11ea-9513-752f308ade92.png)

I wasn't sure whether "Open" or "Open file" was more suitable.

### Motivation and Context

The new log viewer is awesome, but there are use cases to open the log file itself, such as viewing profiler information without launching OBS a second time. This provides a way to do that.

### How Has This Been Tested?

Launched on Windows 10, clicked the button which opened the file in Notepad.

### Types of changes

 - New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
