### PR TITLE
obs-scripting: Fix removing signal handlers in python

### DIFF
--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -595,7 +595,7 @@ static PyObject *obs_python_signal_handler_disconnect(PyObject *self,
 		const char *cb_signal =
 			calldata_string(&cb->base.extra, "signal");
 
-		if (cb_signal && strcmp(signal, cb_signal) != 0 &&
+		if (cb_signal && strcmp(signal, cb_signal) == 0 &&
 		    handler == cb_handler)
 			break;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
OBS currently does not remove signal handlers due to an invalid string comparison. While other checks on the operation passed, matching the title of the call-back was checking to see if the strings were not equal. Flipping the operation to an `== 0` will correct this.

### Motivation and Context
This solves issue #3218

### How Has This Been Tested?
Running the supplied script at https://gist.github.com/alexdean/87cb0c087b85cb529559086b319c832f provided a suitable test case. I was able to confirm that with these changes, the call-back was properly being removed.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
