### PR TITLE
UI: Render tabs and spaces in Log Viewer

### DIFF
--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -133,7 +133,9 @@ void OBSLogViewer::AddLine(int type, const QString &str)
 
 	QTextCursor newCursor = textArea->textCursor();
 	newCursor.movePosition(QTextCursor::End);
-	newCursor.insertHtml(msg + QStringLiteral("<br>"));
+	newCursor.insertHtml(
+		QStringLiteral("<pre style=\"white-space: pre-wrap\">") + msg +
+		QStringLiteral("<br></pre>"));
 
 	if (bottomScrolled)
 		scroll->setValue(scroll->maximum());


### PR DESCRIPTION
# Description

Ensures tabs and spaces are rendered correctly by wrapping each line in a `<pre>` tag.

**Before:**
![image](https://user-images.githubusercontent.com/941350/90700640-ae5f3380-e2c9-11ea-9eb0-7e9d51baf195.png)

**After:**
![image](https://user-images.githubusercontent.com/941350/90700633-a901e900-e2c9-11ea-8452-e812d816aa3a.png)

### Motivation and Context

Logs are harder to read without the included tabs and spaces, plus this makes it consistent with Notepad and other tools.

### How Has This Been Tested?

Open the log viewer. Notice tabs and spaces are rendered.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
