### PR TITLE
obs-qsv11: memory leaks + minor tweaks

### DIFF
--- a/CI/util/build-package-deps-osx.sh
+++ b/CI/util/build-package-deps-osx.sh
@@ -21,7 +21,7 @@ fi
 CURDIR=$(pwd)
 
 # the temp directory
-WORK_DIR=`mktemp -d`
+WORK_DIR=$(mktemp -d)
 
 # deletes the temp directory
 function cleanup {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
     vmImage: 'ubuntu-18.04'
   steps:
   - bash: |
-     if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Seeking Testers"'
+     if curl -s "https://api.github.com/repos/${BUILD_REPOSITORY_ID}/issues/${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER}/labels" | grep '"name": "Seeking Testers"'
      then
        echo "##vso[task.setvariable variable=prHasCILabel;isOutput=true]true"
      fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
     displayName: 'Download / Setup Deps / Run CMake'
   - task: MSBuild@1
     displayName: 'Build 32-bit'
-    inputs: 
+    inputs:
       msbuildArguments: '/m /p:Configuration=RelWithDebInfo'
       solution: .\build32\obs-studio.sln
   - script: ./CI/before-deploy-win.cmd
@@ -97,7 +97,7 @@ jobs:
     displayName: 'Download / Setup Deps / Run CMake'
   - task: MSBuild@1
     displayName: 'Build 64-bit'
-    inputs: 
+    inputs:
       msbuildArguments: '/m /p:Configuration=RelWithDebInfo'
       solution: .\build64\obs-studio.sln
   - script: ./CI/before-deploy-win.cmd

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -709,7 +709,7 @@ mfxStatus QSV_Encoder_Internal::ClearData()
 	}
 
 	if (m_outBitstream.Data) {
-		delete m_outBitstream.Data;
+		delete[] m_outBitstream.Data;
 		m_outBitstream.Data = NULL;
 	}
 

--- a/plugins/obs-qsv11/common_directx9.cpp
+++ b/plugins/obs-qsv11/common_directx9.cpp
@@ -393,6 +393,7 @@ mfxStatus _dx9_simple_alloc(mfxFrameAllocRequest *request,
 			if (FAILED(hr)) {
 				_dx9_simple_free(response);
 				MSDK_SAFE_FREE(dxMids);
+				MSDK_SAFE_FREE(dxMidPtrs);
 				return MFX_ERR_MEMORY_ALLOC;
 			}
 			dxMidPtrs[i] = &dxMids[i];
@@ -402,6 +403,7 @@ mfxStatus _dx9_simple_alloc(mfxFrameAllocRequest *request,
 			new IDirect3DSurface9 *[request->NumFrameSuggested]);
 		if (!dxSrf.get()) {
 			MSDK_SAFE_FREE(dxMids);
+			MSDK_SAFE_FREE(dxMidPtrs);
 			return MFX_ERR_MEMORY_ALLOC;
 		}
 		hr = videoService->CreateSurface(
@@ -410,6 +412,7 @@ mfxStatus _dx9_simple_alloc(mfxFrameAllocRequest *request,
 			m_surfaceUsage, target, dxSrf.get(), NULL);
 		if (FAILED(hr)) {
 			MSDK_SAFE_FREE(dxMids);
+			MSDK_SAFE_FREE(dxMidPtrs);
 			return MFX_ERR_MEMORY_ALLOC;
 		}
 


### PR DESCRIPTION
### Description
I've recently started testing some code quality tooling for other projects and completed a run using OBS as a sample.

### Motivation and Context
Hopefully should have a few issues in here of merit to be worth investigating. At least 1-2 memleaks fixed.
Note: This is my first PR for OBS.

### How Has This Been Tested?
Not yet. Draft is just more commits until I'm happy to have it reviewed.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
