### PR TITLE
UI: Show success dialog when recording completed

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -98,6 +98,7 @@ LockVolume="Lock Volume"
 LogViewer="Log Viewer"
 ShowOnStartup="Show on startup"
 OpenFile="Open file"
+OpenFolder="Open folder"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"
@@ -309,6 +310,11 @@ Output.StartFailedGeneric="Starting the output failed. Please check the log for 
 # replay buffer + pause warning message
 Output.ReplayBuffer.PauseWarning.Title="Cannot save replays while paused"
 Output.ReplayBuffer.PauseWarning.Text="Warning: Replays cannot be saved while recording is paused."
+
+# recording complete dialog
+Output.Recording.DoneDialog.Title="Recording saved"
+Output.Recording.DoneDialog.Text="The recording has been saved successfully."
+Output.Recording.DoneDialog.DoNotShowAgain.ToolTip="Can be re-enabled in Settings -> General -> Output"
 
 # output connect messages
 Output.ConnectFail.Title="Failed to connect"
@@ -648,6 +654,7 @@ Basic.Settings.General.Theme="Theme"
 Basic.Settings.General.Language="Language"
 Basic.Settings.General.EnableAutoUpdates="Automatically check for updates on startup"
 Basic.Settings.General.OpenStatsOnStartup="Open stats dialog on startup"
+Basic.Settings.General.RecordingDoneDialog="Show dialog when recording is complete"
 Basic.Settings.General.WarnBeforeStartingStream="Show confirmation dialog when starting streams"
 Basic.Settings.General.WarnBeforeStoppingStream="Show confirmation dialog when stopping streams"
 Basic.Settings.General.WarnBeforeStoppingRecord="Show confirmation dialog when stopping recording"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -277,34 +277,41 @@
                     </spacer>
                    </item>
                    <item row="0" column="1">
+                    <widget class="QCheckBox" name="recordingDoneDialog">
+                     <property name="text">
+                      <string>Basic.Settings.General.RecordingDoneDialog</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="1">
                     <widget class="QCheckBox" name="warnBeforeStreamStart">
                      <property name="text">
                       <string>Basic.Settings.General.WarnBeforeStartingStream</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="1" column="1">
+                   <item row="2" column="1">
                     <widget class="QCheckBox" name="warnBeforeStreamStop">
                      <property name="text">
                       <string>Basic.Settings.General.WarnBeforeStoppingStream</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="2" column="1">
+                   <item row="3" column="1">
                     <widget class="QCheckBox" name="warnBeforeRecordStop">
                      <property name="text">
                       <string>Basic.Settings.General.WarnBeforeStoppingRecord</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="3" column="1">
+                   <item row="4" column="1">
                     <widget class="QCheckBox" name="recordWhenStreaming">
                      <property name="text">
                       <string>Basic.Settings.General.RecordWhenStreaming</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="4" column="1">
+                   <item row="5" column="1">
                     <widget class="QCheckBox" name="keepRecordStreamStops">
                      <property name="enabled">
                       <bool>false</bool>
@@ -314,14 +321,14 @@
                      </property>
                     </widget>
                    </item>
-                   <item row="5" column="1">
+                   <item row="6" column="1">
                     <widget class="QCheckBox" name="replayWhileStreaming">
                      <property name="text">
                       <string>Basic.Settings.General.ReplayBufferWhileStreaming</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="6" column="1">
+                   <item row="7" column="1">
                     <widget class="QCheckBox" name="keepReplayStreamStops">
                      <property name="enabled">
                       <bool>false</bool>

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -430,6 +430,8 @@ bool OBSApp::InitGlobalConfigDefaults()
 	config_set_default_double(globalConfig, "BasicWindow", "SnapDistance",
 				  10.0);
 	config_set_default_bool(globalConfig, "BasicWindow",
+				"RecordingDoneDialog", true);
+	config_set_default_bool(globalConfig, "BasicWindow",
 				"RecordWhenStreaming", false);
 	config_set_default_bool(globalConfig, "BasicWindow",
 				"KeepRecordingWhenStreamStops", false);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -554,6 +554,8 @@ public slots:
 	void RecordStopping();
 	void RecordingStop(int code, QString last_error);
 
+	void ShowRecordingDoneDialog(QString altPath);
+
 	void ShowReplayBufferPauseWarning();
 	void StartReplayBuffer();
 	void StopReplayBuffer();

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -387,6 +387,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->theme, 		     COMBO_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->enableAutoUpdates,    CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->openStatsOnStartup,   CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->recordingDoneDialog,  CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStart,CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStop, CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeRecordStop, CHECK_CHANGED,  GENERAL_CHANGED);
@@ -1222,6 +1223,10 @@ void OBSBasicSettings::LoadGeneralSettings()
 	double snapDistance = config_get_double(GetGlobalConfig(),
 						"BasicWindow", "SnapDistance");
 	ui->snapDistance->setValue(snapDistance);
+
+	bool recordingDoneDialog = config_get_bool(
+		GetGlobalConfig(), "BasicWindow", "RecordingDoneDialog");
+	ui->recordingDoneDialog->setChecked(recordingDoneDialog);
 
 	bool warnBeforeStreamStart = config_get_bool(
 		GetGlobalConfig(), "BasicWindow", "WarnBeforeStartingStream");
@@ -2937,6 +2942,8 @@ void OBSBasicSettings::SaveGeneralSettings()
 				"AutomaticCollectionSearch",
 				ui->automaticSearch->isChecked());
 
+	config_set_bool(GetGlobalConfig(), "BasicWindow", "RecordingDoneDialog",
+			ui->recordingDoneDialog->isChecked());
 	config_set_bool(GetGlobalConfig(), "BasicWindow",
 			"WarnBeforeStartingStream",
 			ui->warnBeforeStreamStart->isChecked());

--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -33,6 +33,7 @@
 #include <QTimer>
 
 #include "qt-wrappers.hpp"
+#include "window-basic-main.hpp"
 
 #include <memory>
 #include <cmath>
@@ -865,6 +866,7 @@ void OBSRemux::AutoRemux(QString inFile, QString outFile)
 	if (inFile != "" && outFile != "" && autoRemux) {
 		emit remux(inFile, outFile);
 		autoRemuxFile = inFile;
+		autoRemuxOut = outFile;
 	}
 }
 
@@ -927,6 +929,8 @@ void OBSRemux::remuxFinished(bool success)
 
 	if (autoRemux && autoRemuxFile != "") {
 		QTimer::singleShot(3000, this, SLOT(close()));
+		OBSBasic *main = qobject_cast<OBSBasic *>(parent());
+		main->ShowRecordingDoneDialog(autoRemuxOut);
 	}
 
 	remuxNextEntry();

--- a/UI/window-remux.hpp
+++ b/UI/window-remux.hpp
@@ -58,6 +58,7 @@ class OBSRemux : public QDialog {
 
 	bool autoRemux;
 	QString autoRemuxFile;
+	QString autoRemuxOut;
 
 public:
 	explicit OBSRemux(const char *recPath, QWidget *parent = nullptr,


### PR DESCRIPTION
# Description

Adds a dialog when a recording is completed with links to the file and the recording directory.

![image](https://user-images.githubusercontent.com/941350/90886553-f4191a80-e3f5-11ea-9f2c-8a63a70aff8d.png)

### Motivation and Context

When new users complete their first recording, they usually aren't sure whre to find their recordings. This provides an easy way to find them.

![image](https://user-images.githubusercontent.com/941350/90886786-6b4eae80-e3f6-11ea-8493-f9d6a299d3ed.png)

### How Has This Been Tested?

Start & stop a recording, with remux either on or off. Tested on Windows 10 and Ubuntu 20.04.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
