### PR TITLE
obs-x264: Fix memory leak

### DIFF
--- a/plugins/obs-x264/obs-x264-options.c
+++ b/plugins/obs-x264/obs-x264-options.c
@@ -66,6 +66,7 @@ void obs_x264_free_options(struct obs_x264_options options)
 	for (size_t i = 0; i < options.count; ++i) {
 		bfree(options.options[i].name);
 	}
+	bfree(options.options);
 	bfree(options.ignored_words);
 	strlist_free(options.input_words);
 }


### PR DESCRIPTION

### Description
bmalloc'ed array was not freed when freeing options.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Brings memory leaks after recording back down to 0.

### How Has This Been Tested?
Bisected to find, and recording afterwards worked as expected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
