### PR TITLE
UI: Change cursor when interacting with the preview

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -583,6 +583,25 @@ void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 	mousePos = startPos;
 }
 
+void OBSBasicPreview::UpdateCursor(uint32_t &flags)
+{
+	if (!flags && cursor().shape() != Qt::OpenHandCursor)
+		unsetCursor();
+	if (cursor().shape() != Qt::ArrowCursor)
+		return;
+
+	if ((flags & ITEM_LEFT && flags & ITEM_TOP) ||
+	    (flags & ITEM_RIGHT && flags & ITEM_BOTTOM))
+		setCursor(Qt::SizeFDiagCursor);
+	else if ((flags & ITEM_LEFT && flags & ITEM_BOTTOM) ||
+		 (flags & ITEM_RIGHT && flags & ITEM_TOP))
+		setCursor(Qt::SizeBDiagCursor);
+	else if (flags & ITEM_LEFT || flags & ITEM_RIGHT)
+		setCursor(Qt::SizeHorCursor);
+	else if (flags & ITEM_TOP || flags & ITEM_BOTTOM)
+		setCursor(Qt::SizeVerCursor);
+}
+
 static bool select_one(obs_scene_t *scene, obs_sceneitem_t *item, void *param)
 {
 	obs_sceneitem_t *selectedItem =
@@ -685,6 +704,7 @@ void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 		mouseMoved = false;
 		cropping = false;
 		selectionBox = false;
+		unsetCursor();
 
 		OBSSceneItem item = GetItemAtPos(pos, true);
 
@@ -1090,6 +1110,9 @@ void OBSBasicPreview::BoxItems(const vec2 &startPos, const vec2 &pos)
 	if (!scene)
 		return;
 
+	if (cursor().shape() != Qt::CrossCursor)
+		setCursor(Qt::CrossCursor);
+
 	SceneFindBoxData data(startPos, pos);
 	obs_scene_enum_items(scene, FindItemsInBox, &data);
 
@@ -1423,6 +1446,8 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 	if (locked)
 		return;
 
+	bool updateCursor = false;
+
 	if (mouseDown) {
 		vec2 pos = GetMouseEventPos(event);
 
@@ -1458,6 +1483,8 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 				StretchItem(pos);
 
 		} else if (mouseOverItems) {
+			if (cursor().shape() != Qt::SizeAllCursor)
+				setCursor(Qt::SizeAllCursor);
 			selectionBox = false;
 			MoveItems(pos);
 		} else {
@@ -1476,6 +1503,27 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 		std::lock_guard<std::mutex> lock(selectMutex);
 		hoveredPreviewItems.clear();
 		hoveredPreviewItems.push_back(item);
+
+		if (!mouseMoved && hoveredPreviewItems.size() > 0) {
+			mousePos = pos;
+			OBSBasic *main = reinterpret_cast<OBSBasic *>(
+				App()->GetMainWindow());
+#ifdef SUPPORTS_FRACTIONAL_SCALING
+			float scale = main->devicePixelRatioF();
+#else
+			float scale = main->devicePixelRatio();
+#endif
+			float x = float(event->x()) - main->previewX / scale;
+			float y = float(event->y()) - main->previewY / scale;
+			vec2_set(&startPos, x, y);
+			updateCursor = true;
+		}
+	}
+
+	if (updateCursor) {
+		GetStretchHandleData(startPos);
+		uint32_t stretchFlags = (uint32_t)stretchHandle;
+		UpdateCursor(stretchFlags);
 	}
 }
 

--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -92,6 +92,8 @@ private:
 
 	void GetStretchHandleData(const vec2 &pos);
 
+	void UpdateCursor(uint32_t &flags);
+
 	void SnapStretchingToScreen(vec3 &tl, vec3 &br);
 	void ClampAspect(vec3 &tl, vec3 &br, vec2 &size, const vec2 &baseSize);
 	vec3 CalculateStretchPos(const vec3 &tl, const vec3 &br);


### PR DESCRIPTION


### Description

Changes the cursor to match the action that's currently being performed by the user.

Includes move, resize, crop, stretch, and box select.

![2020-08-23_13-16-08](https://user-images.githubusercontent.com/941350/90970096-a5799680-e543-11ea-9c5f-eaece75ea271.gif)

I did attempt switching `selectMutex` to use a `recursive_mutex` instead of a manual `lock()`/`unlock()`, but it caused a deadlock.

### Motivation and Context

Consistent with other canvas-based applications like Adobe Photoshop, Krita and blender. Slightly improves UX, making it clearer what action a click/drag will perform (or is performing). Also adds consistency with an unscaled preview and space-to-move.

### How Has This Been Tested?

On Windows 10, use any manipulative action in the preview window: move, resize, crop, stretch and box select.

Also tested with Preview Scaling set to Canvas and using the Space key to drag the view.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
