### PR TITLE
UI: Fix transition enumeration

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -119,6 +119,9 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 			OBSSource tr = main->ui->transitions->itemData(i)
 					       .value<OBSSource>();
 
+			if (!tr)
+				continue;
+
 			obs_source_addref(tr);
 			da_push_back(sources->sources, &tr);
 		}

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -68,6 +68,8 @@ void OBSBasic::InitDefaultTransitions()
 
 			if (strcmp(id, "fade_transition") == 0)
 				fadeTransition = tr;
+			else if (strcmp(id, "cut_transition") == 0)
+				cutTransition = tr;
 
 			obs_source_release(tr);
 		} else {
@@ -180,15 +182,12 @@ void OBSBasic::CreateDefaultQuickTransitions()
 {
 	/* non-configurable transitions are always available, so add them
 	 * to the "default quick transitions" list */
-	quickTransitions.emplace_back(GetTransitionComboItem(ui->transitions,
-							     0),
-				      300, quickTransitionIdCounter++);
-	quickTransitions.emplace_back(GetTransitionComboItem(ui->transitions,
-							     1),
-				      300, quickTransitionIdCounter++);
-	quickTransitions.emplace_back(GetTransitionComboItem(ui->transitions,
-							     1),
-				      300, quickTransitionIdCounter++, true);
+	quickTransitions.emplace_back(cutTransition, 300,
+				      quickTransitionIdCounter++);
+	quickTransitions.emplace_back(fadeTransition, 300,
+				      quickTransitionIdCounter++);
+	quickTransitions.emplace_back(fadeTransition, 300,
+				      quickTransitionIdCounter++, true);
 }
 
 void OBSBasic::LoadQuickTransitions(obs_data_array_t *array)
@@ -986,9 +985,11 @@ QMenu *OBSBasic::CreatePerSceneTransitionMenu()
 		}
 
 		OBSSource tr = GetTransitionComboItem(ui->transitions, idx);
-		const char *name = obs_source_get_name(tr);
 
-		obs_data_set_string(data, "transition", name);
+		if (tr) {
+			const char *name = obs_source_get_name(tr);
+			obs_data_set_string(data, "transition", name);
+		}
 	};
 
 	auto setDuration = [this](int duration) {
@@ -1008,6 +1009,8 @@ QMenu *OBSBasic::CreatePerSceneTransitionMenu()
 		if (i >= 0) {
 			OBSSource tr;
 			tr = GetTransitionComboItem(ui->transitions, i);
+			if (!tr)
+				continue;
 			name = obs_source_get_name(tr);
 		}
 
@@ -1063,10 +1066,9 @@ QMenu *OBSBasic::CreateTransitionMenu(QWidget *parent, QuickTransition *qt)
 			this, &OBSBasic::QuickTransitionChangeDuration);
 	}
 
-	tr = GetTransitionComboItem(ui->transitions, 1);
+	tr = fadeTransition;
 
 	action = menu->addAction(QTStr("FadeToBlack"));
-	action->setProperty("transition_index", 1);
 	action->setProperty("fadeToBlack", true);
 
 	if (qt) {
@@ -1082,6 +1084,9 @@ QMenu *OBSBasic::CreateTransitionMenu(QWidget *parent, QuickTransition *qt)
 
 	for (int i = 0; i < ui->transitions->count(); i++) {
 		tr = GetTransitionComboItem(ui->transitions, i);
+
+		if (!tr)
+			continue;
 
 		action = menu->addAction(obs_source_get_name(tr));
 		action->setProperty("transition_index", i);
@@ -1152,12 +1157,18 @@ void OBSBasic::AddQuickTransition()
 {
 	int trIdx = sender()->property("transition_index").toInt();
 	QSpinBox *duration = sender()->property("duration").value<QSpinBox *>();
-	bool toBlack = sender()->property("fadeToBlack").value<bool>();
-	OBSSource transition = GetTransitionComboItem(ui->transitions, trIdx);
+	bool fadeToBlack = sender()->property("fadeToBlack").value<bool>();
+	OBSSource transition =
+		fadeToBlack ? OBSSource(fadeTransition)
+			    : GetTransitionComboItem(ui->transitions, trIdx);
+
+	if (!transition)
+		return;
+
 	int id = quickTransitionIdCounter++;
 
 	quickTransitions.emplace_back(transition, duration->value(), id,
-				      toBlack);
+				      fadeToBlack);
 	AddQuickTransitionId(id);
 
 	int idx = (int)quickTransitions.size() - 1;
@@ -1203,11 +1214,18 @@ void OBSBasic::QuickTransitionChange()
 {
 	int id = sender()->property("id").toInt();
 	int trIdx = sender()->property("transition_index").toInt();
+	bool fadeToBlack = sender()->property("fadeToBlack").value<bool>();
 	QuickTransition *qt = GetQuickTransition(id);
 
 	if (qt) {
-		qt->source = GetTransitionComboItem(ui->transitions, trIdx);
-		ResetQuickTransitionText(qt);
+		OBSSource tr = fadeToBlack
+				       ? OBSSource(fadeTransition)
+				       : GetTransitionComboItem(ui->transitions,
+								trIdx);
+		if (tr) {
+			qt->source = tr;
+			ResetQuickTransitionText(qt);
+		}
 	}
 }
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -391,6 +391,7 @@ private:
 	void LoadTransitions(obs_data_array_t *transitions);
 
 	obs_source_t *fadeTransition;
+	obs_source_t *cutTransition;
 
 	void CreateProgramDisplay();
 	void CreateProgramOptions();


### PR DESCRIPTION
### Description
Fixes issue where sometimes the transition loop would return null transition.

### Motivation and Context
Bug mentioned on Discord.

### How Has This Been Tested?
Tested with transition override menu.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
