### PR TITLE
UI: Fix always on top w/ projectors on Linux

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -8269,6 +8269,15 @@ void OBSBasic::UpdateProjectorAlwaysOnTop(bool top)
 		SetAlwaysOnTop(projectors[i], top);
 }
 
+void OBSBasic::ResetProjectors()
+{
+	obs_data_array_t *savedProjectorList = SaveProjectors();
+	ClearProjectors();
+	LoadSavedProjectors(savedProjectorList);
+	OpenSavedProjectors();
+	obs_data_array_release(savedProjectorList);
+}
+
 void OBSBasic::on_sourcePropertiesButton_clicked()
 {
 	on_actionSourceProperties_triggered();

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4076,6 +4076,16 @@ void OBSBasic::EnumDialogs()
 	}
 }
 
+void OBSBasic::ClearProjectors()
+{
+	for (size_t i = 0; i < projectors.size(); i++) {
+		if (projectors[i])
+			delete projectors[i];
+	}
+
+	projectors.clear();
+}
+
 void OBSBasic::ClearSceneData()
 {
 	disableSaving++;
@@ -4088,12 +4098,7 @@ void OBSBasic::ClearSceneData()
 	ClearQuickTransitions();
 	ui->transitions->clear();
 
-	for (size_t i = 0; i < projectors.size(); i++) {
-		if (projectors[i])
-			delete projectors[i];
-	}
-
-	projectors.clear();
+	ClearProjectors();
 
 	obs_set_output_source(0, nullptr);
 	obs_set_output_source(1, nullptr);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -347,6 +347,7 @@ private:
 
 	void CloseDialogs();
 	void ClearSceneData();
+	void ClearProjectors();
 
 	void Nudge(int dist, MoveDir dir);
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -531,6 +531,7 @@ private:
 
 	void UpdateProjectorHideCursor();
 	void UpdateProjectorAlwaysOnTop(bool top);
+	void ResetProjectors();
 
 	QPointer<QObject> screenshotData;
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2958,8 +2958,12 @@ void OBSBasicSettings::SaveGeneralSettings()
 		config_set_bool(GetGlobalConfig(), "BasicWindow",
 				"ProjectorAlwaysOnTop",
 				ui->projectorAlwaysOnTop->isChecked());
+#if defined(_WIN32) || defined(__APPLE__)
 		main->UpdateProjectorAlwaysOnTop(
 			ui->projectorAlwaysOnTop->isChecked());
+#else
+		main->ResetProjectors();
+#endif
 	}
 
 	if (WidgetChanged(ui->recordWhenStreaming))


### PR DESCRIPTION
### Description
Fixes an issue on Linux where updating the projector always on top setting wouldn't work.

### Motivation and Context
Apparently, on Linux, you cannot update the window flags while it is still open, so just close the projectors and reopen them again when the setting changes.

### How Has This Been Tested?
Created projector and changed the always on top setting.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
