### PR TITLE
UI: Fix projector not working on secondary monitors

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -24,10 +24,13 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 	  removedSignal(obs_source_get_signal_handler(source), "remove",
 			OBSSourceRemoved, this)
 {
-	type = type_;
+	isAlwaysOnTop = config_get_bool(GetGlobalConfig(), "BasicWindow",
+					"ProjectorAlwaysOnTop");
 
-	SetAlwaysOnTop(this, config_get_bool(GetGlobalConfig(), "BasicWindow",
-					     "ProjectorAlwaysOnTop"));
+	if (isAlwaysOnTop)
+		setWindowFlags(Qt::WindowStaysOnTopHint);
+
+	type = type_;
 
 	setWindowIcon(QIcon::fromTheme("obs", QIcon(":/res/images/obs.png")));
 
@@ -42,10 +45,6 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 	action->setShortcut(Qt::Key_Escape);
 	addAction(action);
 	connect(action, SIGNAL(triggered()), this, SLOT(EscapeTriggered()));
-
-	isAlwaysOnTop = config_get_bool(GetGlobalConfig(), "BasicWindow",
-					"ProjectorAlwaysOnTop");
-	SetAlwaysOnTop(this, isAlwaysOnTop);
 
 	setAttribute(Qt::WA_DeleteOnClose, true);
 


### PR DESCRIPTION
### Description
This fixes a bug where the projector wouldn't work on secondary
monitors on Windows.

### Motivation and Context
Bug mentioned on Discord.

### How Has This Been Tested?
Will need confirmation by others that the bug is fixed, as I only tested this on Linux.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
