### PR TITLE
obs-ffmpeg: Fix crash when seeking with no media

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -714,6 +714,9 @@ static void ffmpeg_source_set_time(void *data, int64_t ms)
 {
 	struct ffmpeg_source *s = data;
 
+	if (!s->media_valid)
+		return;
+
 	mp_media_seek_to(&s->media, ms);
 }
 


### PR DESCRIPTION
### Description
This fixes a crash when seeking when there is no valid
media.

### Motivation and Context
Bug mentioned on Discord.

### How Has This Been Tested?
Created media source without media and then moved the seek slider.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
