### PR TITLE
UI: Fix scene corruption when dragging & dropping

### DIFF
--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -10,8 +10,6 @@
 SceneTree::SceneTree(QWidget *parent_) : QListWidget(parent_)
 {
 	installEventFilter(this);
-	setDragDropMode(InternalMove);
-	setMovement(QListView::Snap);
 }
 
 void SceneTree::SetGridMode(bool grid)


### PR DESCRIPTION
### Description
Fixes a bug where dragging and dropping scenes would
cause a crash on exit.

### Motivation and Context
These lines of code seem like they don't have to do with anything, but somehow this fixes the problem. My guess is that it is a QT bug where it corrupts the list item data. 

Fixes #3310 

### How Has This Been Tested?
Dragged and dropped scenes, exited and made sure there was no crash.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
