### PR TITLE
CI: Add Sphinx Docs generator Github Action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Generate Documentation
+
+on:
+  push:
+    paths-ignore:
+      - "cmake/**"
+  pull_request:
+    paths:
+      - "docs/sphinx/**"
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Bump Version Number
+        shell: bash
+        if: github.event_name == 'push'
+        run: |
+          VERTEST="\#define\sLIBOBS_API_\w+_VER\s([0-9]{1,2})"
+          VER=""
+          MAJOR=""
+          while IFS= read -r l
+          do
+              if [[ $l =~ $VERTEST ]]; then
+                  if [[ $VER = '' ]]; then MAJOR="${BASH_REMATCH[1]}"; else VER+="."; fi
+                  VER+="${BASH_REMATCH[1]}"
+              fi
+          done < "libobs/obs-config.h"
+
+          SVER="version = '([0-9\.]+)'"
+          RVER="version = '$VER'"
+          SREL="release = '([0-9\.]+)'"
+          RREL="release = '$VER'"
+          SCOPY="copyright = '([A-Za-z0-9, ]+)'"
+          RCOPY="copyright = '2017-$(date +"%Y"), Hugh Bailey'"
+          sed -i -E -e "s/${SVER}/${RVER}/g" -e "s/${SREL}/${RREL}/g" -e "s/${SCOPY}/${RCOPY}/g" docs/sphinx/conf.py
+      - uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "docs/sphinx/"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: OBS Studio Documentation (HTML)
+          path: docs/sphinx/_build/html/


### PR DESCRIPTION
### Description

Performs a checkout of the OBS repo, updates the sphinx config with the latest libobs version & copyright year, generates the HTML documentation, and provides a zip with artifacts that can be uploaded to `obsproject.com/docs`.

Example run can be found here: https://github.com/WizardCM/obs-studio/runs/1024678780?check_suite_focus=true

For pull requests, this is only run for direct edits to the documentation, and skips the version bump.

![image](https://user-images.githubusercontent.com/941350/91119495-a989ed80-e6d6-11ea-9d6e-006b48718bad.png)


### Motivation and Context

There's no need for generating documentation to be a manual process.

Additionally, this includes warnings about formatting.

### How Has This Been Tested?

* Push to a branch and see it build
* Submit a PR with changes to the docs folder.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
