### PR TITLE
UI / Log Viewer: Bring to front rather than close, add minimize/maximize buttons

### DIFF
--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -14,7 +14,8 @@
 
 OBSLogViewer::OBSLogViewer(QWidget *parent) : QDialog(parent)
 {
-	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+	setWindowFlags(windowFlags() & Qt::WindowMaximizeButtonHint &
+		       ~Qt::WindowContextHelpButtonHint);
 
 	QVBoxLayout *layout = new QVBoxLayout();
 	layout->setContentsMargins(0, 0, 0, 0);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5302,6 +5302,9 @@ void OBSBasic::on_actionViewCurrentLog_triggered()
 	if (!logView->isVisible()) {
 		logView->setVisible(true);
 	} else {
+		logView->setWindowState(logView->windowState() &
+						~Qt::WindowMinimized |
+					Qt::WindowActive);
 		logView->activateWindow();
 		logView->raise();
 	}

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5299,7 +5299,12 @@ void OBSBasic::on_actionUploadLastLog_triggered()
 
 void OBSBasic::on_actionViewCurrentLog_triggered()
 {
-	logView->setVisible(!logView->isVisible());
+	if (!logView->isVisible()) {
+		logView->setVisible(true);
+	} else {
+		logView->activateWindow();
+		logView->raise();
+	}
 }
 
 void OBSBasic::on_actionShowCrashLogs_triggered()


### PR DESCRIPTION
### Description

Rather than closing the Log Viewer when "View Current Log" is clicked, bring it to the front rather than closing it.

Also add minimize/maximize buttons for better UX.

### Motivation and Context

It is not common for a menu item to toggle a window. Instead, bring it to the front and focus it.

Additionally, a log can be quite verbose. Providing a maximize button allows for faster viewing of a larger log, and being able to minimize means less visual clutter when not focusing on the log.

This also makes the Log Viewer match the Script Log in behaviour.

### How Has This Been Tested?

Click Help -> View Current Log
Place the Log Viewer elsewhere on the screen
Click Help -> View Current Log again
See the log viewer

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
