### PR TITLE
UI: Align Advanced Audio Percent toggle to Volume text

### DIFF
--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -28,6 +28,7 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 
 	QLabel *volLabel = new QLabel(QTStr("Basic.AdvAudio.Volume"));
 	volLabel->setStyleSheet("font-weight: bold;");
+	volLabel->setContentsMargins(0, 0, 6, 0);
 
 	usePercent = new QCheckBox();
 	usePercent->setStyleSheet("font-weight: bold;");
@@ -44,8 +45,8 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 	QHBoxLayout *volLayout = new QHBoxLayout();
 	volLayout->setContentsMargins(0, 0, 0, 0);
 	volLayout->addWidget(volLabel);
-	volLayout->addStretch();
 	volLayout->addWidget(usePercent);
+	volLayout->addStretch();
 
 	int idx = 0;
 	mainLayout = new QGridLayout;


### PR DESCRIPTION

### Description

Due to the placement of addStretch(), the checkbox was being attached to the Mono label when resizing the dialog.
This ensures it's aligned to the left, with some spacing.

**Before:**
![image](https://user-images.githubusercontent.com/941350/91133083-b74c6c80-e6f0-11ea-961b-61ac7baf3e48.png)

**After:**
![image](https://user-images.githubusercontent.com/941350/91133130-ba475d00-e6f0-11ea-85f9-5f15eff042bd.png)


### Motivation and Context

It makes no sense to show the toggle away from the volume column and may confuse users.

### How Has This Been Tested?

Resize the AAP dialog.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
