### PR TITLE
libobs/util: Fix loading Python binary modules on *nix

### DIFF
--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -71,7 +71,8 @@ void *os_dlopen(const char *path)
 #ifdef __APPLE__
 	void *res = dlopen(dylib_name.array, RTLD_LAZY | RTLD_FIRST);
 #else
-	void *res = dlopen(dylib_name.array, RTLD_LAZY);
+	void *res = dlopen(dylib_name.array,
+			   RTLD_LAZY | RTLD_DEEPBIND | RTLD_GLOBAL);
 #endif
 	if (!res)
 		blog(LOG_ERROR, "os_dlopen(%s->%s): %s\n", path,


### PR DESCRIPTION
# Description

Someone with more experience can confirm why this works, but this PR simply applies the code change discussed in #2222.

### Motivation and Context

Fixes #2222

Fixes #2851

### How Has This Been Tested?

Load a python script on Linux which `import`s a binary module like `termios`, `ssl` or `math`

**Would love more people on a variety of Linux distros to test this fix further** before I mark this as ready.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
