### PR TITLE
UI: Fix scene removal bug

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -149,7 +149,6 @@ void SourceTreeItem::paintEvent(QPaintEvent *event)
 
 void SourceTreeItem::DisconnectSignals()
 {
-	sceneRemoveSignal.Disconnect();
 	itemRemoveSignal.Disconnect();
 	selectSignal.Disconnect();
 	deselectSignal.Disconnect();
@@ -180,13 +179,8 @@ void SourceTreeItem::ReconnectSignals()
 		obs_sceneitem_t *curItem =
 			(obs_sceneitem_t *)calldata_ptr(cd, "item");
 
-		if (curItem == this_->sceneitem) {
-			QMetaObject::invokeMethod(this_->tree, "Remove",
-						  Q_ARG(OBSSceneItem, curItem));
-			curItem = nullptr;
-		}
-		if (!curItem)
-			QMetaObject::invokeMethod(this_, "Clear");
+		QMetaObject::invokeMethod(this_->tree, "Remove",
+					  Q_ARG(OBSSceneItem, curItem));
 	};
 
 	auto itemVisible = [](void *data, calldata_t *cd) {
@@ -243,7 +237,6 @@ void SourceTreeItem::ReconnectSignals()
 	obs_source_t *sceneSource = obs_scene_get_source(scene);
 	signal_handler_t *signal = obs_source_get_signal_handler(sceneSource);
 
-	sceneRemoveSignal.Connect(signal, "remove", removeItem, this);
 	itemRemoveSignal.Connect(signal, "item_remove", removeItem, this);
 	visibleSignal.Connect(signal, "item_visible", itemVisible, this);
 	lockedSignal.Connect(signal, "item_locked", itemLocked, this);

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -67,7 +67,6 @@ private:
 
 	SourceTree *tree;
 	OBSSceneItem sceneitem;
-	OBSSignal sceneRemoveSignal;
 	OBSSignal itemRemoveSignal;
 	OBSSignal groupReorderSignal;
 	OBSSignal selectSignal;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2766,23 +2766,27 @@ void OBSBasic::RemoveScene(OBSSource source)
 {
 	obs_scene_t *scene = obs_scene_from_source(source);
 
-	QListWidgetItem *sel = nullptr;
 	int count = ui->scenes->count();
 
+	auto remove_items = [](obs_scene_t *, obs_sceneitem_t *item, void *) {
+		if (item)
+			obs_sceneitem_remove(item);
+
+		return true;
+	};
+
 	for (int i = 0; i < count; i++) {
-		auto item = ui->scenes->item(i);
-		auto cur_scene = GetOBSRef<OBSScene>(item);
+		QListWidgetItem *item = ui->scenes->item(i);
+		OBSScene cur_scene = GetOBSRef<OBSScene>(item);
 		if (cur_scene != scene)
 			continue;
 
-		sel = item;
-		break;
-	}
+		obs_scene_enum_items(cur_scene, remove_items, nullptr);
 
-	if (sel != nullptr) {
-		if (sel == ui->scenes->currentItem())
-			ui->sources->Clear();
+		QListWidgetItem *sel = ui->scenes->takeItem(i);
 		delete sel;
+		sel = nullptr;
+		break;
 	}
 
 	SaveProject();
@@ -4118,8 +4122,6 @@ void OBSBasic::ClearSceneData()
 	CloseDialogs();
 
 	ClearVolumeControls();
-	ClearListItems(ui->scenes);
-	ui->sources->Clear();
 	ClearQuickTransitions();
 	ui->transitions->clear();
 


### PR DESCRIPTION
### Description
This removes code that is already handled when calling obs_enum_scenes. This
also fixes a bug where the scene list item isn't cleared properly when
removing scene. Also scene items were never actually deleted when removing
scene, so delete them.

### Motivation and Context
Cleaner code.

### How Has This Been Tested?
Ran OBS, everything worked as normal.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
