### PR TITLE
UI: Fix output channels not being deleted

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4125,12 +4125,9 @@ void OBSBasic::ClearSceneData()
 
 	ClearProjectors();
 
-	obs_set_output_source(0, nullptr);
-	obs_set_output_source(1, nullptr);
-	obs_set_output_source(2, nullptr);
-	obs_set_output_source(3, nullptr);
-	obs_set_output_source(4, nullptr);
-	obs_set_output_source(5, nullptr);
+	for (int i = 0; i < MAX_CHANNELS; i++)
+		obs_set_output_source(i, nullptr);
+
 	lastScene = nullptr;
 	swapScene = nullptr;
 	programScene = nullptr;


### PR DESCRIPTION
### Description
Output channel 6 was not being deleted, so use for loop
to delete all possible channels.

### Motivation and Context
Bug fix and code cleanup.

### How Has This Been Tested?
Ran OBS to make sure nothing broke.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
