### PR TITLE
Fix compiling warnings

### DIFF
--- a/UI/forms/source-toolbar/device-select-toolbar.ui
+++ b/UI/forms/source-toolbar/device-select-toolbar.ui
@@ -57,7 +57,7 @@
       <string notr="true"/>
      </property>
      <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
      </property>
     </widget>
    </item>

--- a/UI/forms/source-toolbar/game-capture-toolbar.ui
+++ b/UI/forms/source-toolbar/game-capture-toolbar.ui
@@ -77,7 +77,7 @@
       <string notr="true"/>
      </property>
      <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
      </property>
     </widget>
    </item>

--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -361,7 +361,7 @@ static void flv_build_additional_meta_data(uint8_t **data, size_t *size)
 void flv_additional_meta_data(obs_output_t *context, uint8_t **data,
 			      size_t *size)
 {
-	obs_encoder_t *aencoder = obs_output_get_audio_encoder(context, 1);
+	UNUSED_PARAMETER(context);
 	struct array_output_data out;
 	struct serializer s;
 	uint8_t *meta_data = NULL;
@@ -414,6 +414,7 @@ static void flv_build_additional_audio(uint8_t **data, size_t *size,
 				       struct encoder_packet *packet,
 				       bool is_header, size_t index)
 {
+	UNUSED_PARAMETER(index);
 	struct array_output_data out;
 	struct serializer s;
 

--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -5277,13 +5277,11 @@ fail:
     return total;
 }
 
-static const AVal av_setDataFrame = AVC("@setDataFrame");
-
 int
 RTMP_Write(RTMP *r, const char *buf, int size, int streamIdx)
 {
     RTMPPacket *pkt = &r->m_write;
-    char *pend, *enc;
+    char *enc;
     int s2 = size, ret, num;
 
     pkt->m_nChannel = 0x04;	/* source channel */
@@ -5331,7 +5329,6 @@ RTMP_Write(RTMP *r, const char *buf, int size, int streamIdx)
                 return FALSE;
             }
             enc = pkt->m_body;
-            pend = enc + pkt->m_nBodySize;
         }
         else
         {

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -777,7 +777,6 @@ static void adjust_sndbuf_size(struct rtmp_stream *stream, int new_size)
 static int init_send(struct rtmp_stream *stream)
 {
 	int ret;
-	size_t idx = 0;
 	obs_output_t *context = stream->output;
 
 #if defined(_WIN32)

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -565,7 +565,7 @@ static void log_custom_options(struct obs_x264 *obsx264,
 					     options->options[i].name,
 					     options->options[i].value);
 		assert(chars_written >= 0);
-		assert(chars_written <= remaining_buffer_size);
+		assert((size_t)chars_written <= remaining_buffer_size);
 		p += chars_written;
 		remaining_buffer_size -= chars_written;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Clears GCC warnings on unused and deprecated vars

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Warnings are annoying.
Makes it easier to find more important warnings in logs.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

It still compiles and obs Open

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
