### PR TITLE
UI: Auto generate mixer checkboxes in adv audio properties

### DIFF
--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -85,11 +85,6 @@ public slots:
 	void balanceChanged(int val);
 	void syncOffsetChanged(int milliseconds);
 	void monitoringTypeChanged(int index);
-	void mixer1Changed(bool checked);
-	void mixer2Changed(bool checked);
-	void mixer3Changed(bool checked);
-	void mixer4Changed(bool checked);
-	void mixer5Changed(bool checked);
-	void mixer6Changed(bool checked);
+	void mixerChanged(bool checked);
 	void ResetBalance();
 };


### PR DESCRIPTION
### Description
If somebody wants to change the number of audio tracks, all
they would have to do now is change one line with the MAX_AUDIO_MIXES
variable.

## TODO
- [ ] Add code to settings dialog

### Motivation and Context
People have asked to configure as many audio tracks as they want. Now they just have to change one line of code.

### How Has This Been Tested?
Checked / unchecked audio tracks in advanced audio properties.

### Types of changes
- New feature (non-breaking change which adds functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
