### PR TITLE
libobs: Log Windows 10 Hardware GPU Scheduler

### DIFF
--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -199,6 +199,8 @@ static void log_aero(void)
 	L"SOFTWARE\\Policies\\Microsoft\\Windows\\GameDVR"
 #define WIN10_GAME_DVR_REG_KEY L"System\\GameConfigStore"
 #define WIN10_GAME_MODE_REG_KEY L"Software\\Microsoft\\GameBar"
+#define WIN10_HAGS_REG_KEY \
+	L"SYSTEM\\CurrentControlSet\\Control\\GraphicsDrivers"
 
 static void log_gaming_features(void)
 {
@@ -210,6 +212,7 @@ static void log_gaming_features(void)
 	struct reg_dword game_dvr_enabled;
 	struct reg_dword game_dvr_bg_recording;
 	struct reg_dword game_mode_enabled;
+	struct reg_dword hags_enabled;
 
 	get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_BAR_REG_KEY,
 		      L"AppCaptureEnabled", &game_bar_enabled);
@@ -221,6 +224,9 @@ static void log_gaming_features(void)
 		      L"HistoricalCaptureEnabled", &game_dvr_bg_recording);
 	get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_MODE_REG_KEY,
 		      L"AllowAutoGameMode", &game_mode_enabled);
+	get_reg_dword(HKEY_LOCAL_MACHINE, WIN10_HAGS_REG_KEY, L"HwSchMode",
+		      &hags_enabled);
+
 	if (game_mode_enabled.status != ERROR_SUCCESS) {
 		get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_MODE_REG_KEY,
 			      L"AutoGameModeEnabled", &game_mode_enabled);
@@ -250,6 +256,11 @@ static void log_gaming_features(void)
 	if (game_mode_enabled.status == ERROR_SUCCESS) {
 		blog(LOG_INFO, "\tGame Mode: %s",
 		     (bool)game_mode_enabled.return_value ? "On" : "Off");
+	}
+
+	if (hags_enabled.status == ERROR_SUCCESS) {
+		blog(LOG_INFO, "\tHardware GPU Scheduler: %s",
+		     (hags_enabled.return_value == 2) ? "On" : "Off");
 	}
 }
 


### PR DESCRIPTION
This adds logging for the "Hardware-accelerated GPU Scheduler" (HAGS)
introduced with Windows 10 2004 which is known to cause issues with OBS
and game performance.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Adds a new line in the OBS log below Windows 10 Gaming Features named "Hardware GPU Scheduler" to indicate status of the Hardware-accelerated GPU Scheduler introduced with Windows 10 2004.

### Motivation and Context
HAGS is known to cause performance issues with OBS as well as game capture. Also some games do not work properly with it. Adding a log entry for it helps troubleshooting for users with latest Windows 10 as the option seems to be enabled by default for some users despite it being an experimental/early access feature.

### How Has This Been Tested?
- Visual Studio 2019 on Windows 10 Pro 20H2 (slow ring) with compatible RTX2080S and latest Nvidia driver.
- HAGS enabled and disabled via system config menu as well as regedit

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
