### PR TITLE
libobs: Add ability for audio busses

### DIFF
--- a/libobs/audio-monitoring/win32/wasapi-output.c
+++ b/libobs/audio-monitoring/win32/wasapi-output.c
@@ -49,6 +49,9 @@ struct audio_monitor {
 
 	DARRAY(float) buf;
 	pthread_mutex_t playback_mutex;
+
+	int bus;
+	char *id;
 };
 
 /* #define DEBUG_AUDIO */
@@ -228,6 +231,7 @@ static inline void audio_monitor_free(struct audio_monitor *monitor)
 	audio_resampler_destroy(monitor->resampler);
 	circlebuf_free(&monitor->delay_buffer);
 	da_free(monitor->buf);
+	bfree(monitor->id);
 }
 
 static enum speaker_layout convert_speaker_layout(DWORD layout, WORD channels)
@@ -251,7 +255,7 @@ static enum speaker_layout convert_speaker_layout(DWORD layout, WORD channels)
 extern bool devices_match(const char *id1, const char *id2);
 
 static bool audio_monitor_init(struct audio_monitor *monitor,
-			       obs_source_t *source)
+			       obs_source_t *source, const char *id)
 {
 	IMMDeviceEnumerator *immde = NULL;
 	WAVEFORMATEX *wfex = NULL;
@@ -262,8 +266,8 @@ static bool audio_monitor_init(struct audio_monitor *monitor,
 	pthread_mutex_init_value(&monitor->playback_mutex);
 
 	monitor->source = source;
+	monitor->id = bstrdup(id);
 
-	const char *id = obs->audio.monitoring_device_id;
 	if (!id) {
 		warn("%s: No device ID set", __FUNCTION__);
 		return false;
@@ -406,16 +410,18 @@ static void audio_monitor_init_final(struct audio_monitor *monitor)
 					      on_audio_playback, monitor);
 }
 
-struct audio_monitor *audio_monitor_create(obs_source_t *source)
+struct audio_monitor *audio_monitor_create(obs_source_t *source, const char *id,
+					   int bus)
 {
 	struct audio_monitor monitor = {0};
 	struct audio_monitor *out;
 
-	if (!audio_monitor_init(&monitor, source)) {
+	if (!audio_monitor_init(&monitor, source, id)) {
 		goto fail;
 	}
 
 	out = bmemdup(&monitor, sizeof(monitor));
+	out->bus = bus;
 
 	pthread_mutex_lock(&obs->audio.monitoring_mutex);
 	da_push_back(obs->audio.monitors, &out);
@@ -429,13 +435,13 @@ fail:
 	return NULL;
 }
 
-void audio_monitor_reset(struct audio_monitor *monitor)
+void audio_monitor_reset(struct audio_monitor *monitor, const char *id)
 {
 	struct audio_monitor new_monitor = {0};
 	bool success;
 
 	pthread_mutex_lock(&monitor->playback_mutex);
-	success = audio_monitor_init(&new_monitor, monitor->source);
+	success = audio_monitor_init(&new_monitor, monitor->source, id);
 	pthread_mutex_unlock(&monitor->playback_mutex);
 
 	if (success) {
@@ -459,4 +465,20 @@ void audio_monitor_destroy(struct audio_monitor *monitor)
 
 		bfree(monitor);
 	}
+}
+
+int audio_monitor_get_bus(struct audio_monitor *monitor)
+{
+	if (!monitor)
+		return -1;
+
+	return monitor->bus;
+}
+
+const char *audio_monitor_get_id(struct audio_monitor *monitor)
+{
+	if (!monitor)
+		return NULL;
+
+	return monitor->id;
 }

--- a/libobs/media-io/audio-io.h
+++ b/libobs/media-io/audio-io.h
@@ -28,6 +28,7 @@ extern "C" {
 #define MAX_AUDIO_MIXES 6
 #define MAX_AUDIO_CHANNELS 8
 #define AUDIO_OUTPUT_FRAMES 1024
+#define MAX_AUDIO_BUSSES 4
 
 #define TOTAL_AUDIO_SIZE                                              \
 	(MAX_AUDIO_MIXES * MAX_AUDIO_CHANNELS * AUDIO_OUTPUT_FRAMES * \

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -320,6 +320,11 @@ struct obs_core_video {
 
 struct audio_monitor;
 
+struct obs_bus_info {
+	char *id;
+	int bus;
+};
+
 struct obs_core_audio {
 	audio_t *audio;
 
@@ -335,8 +340,7 @@ struct obs_core_audio {
 
 	pthread_mutex_t monitoring_mutex;
 	DARRAY(struct audio_monitor *) monitors;
-	char *monitoring_device_name;
-	char *monitoring_device_id;
+	DARRAY(struct obs_bus_info *) bus_info;
 };
 
 /* user sources, output channels, and displays */
@@ -751,10 +755,12 @@ struct obs_source {
 	enum obs_transition_scale_type transition_scale_type;
 	struct matrix4 transition_matrices[2];
 
-	struct audio_monitor *monitor;
+	DARRAY(struct audio_monitor *) monitors;
 	enum obs_monitoring_type monitoring_type;
 
 	obs_data_t *private_settings;
+
+	uint32_t audio_busses;
 };
 
 extern struct obs_source_info *get_source_info(const char *id);
@@ -773,8 +779,11 @@ extern void obs_transition_enum_sources(obs_source_t *transition,
 extern void obs_transition_save(obs_source_t *source, obs_data_t *data);
 extern void obs_transition_load(obs_source_t *source, obs_data_t *data);
 
-struct audio_monitor *audio_monitor_create(obs_source_t *source);
-void audio_monitor_reset(struct audio_monitor *monitor);
+struct audio_monitor *audio_monitor_create(obs_source_t *source, const char *id,
+					   int bus);
+void audio_monitor_reset(struct audio_monitor *monitor, const char *id);
+int audio_monitor_get_bus(struct audio_monitor *monitor);
+const char *audio_monitor_get_id(struct audio_monitor *monitor);
 extern void audio_monitor_destroy(struct audio_monitor *monitor);
 
 extern obs_source_t *obs_source_create_set_last_ver(const char *id,

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -214,6 +214,7 @@ static bool obs_source_init(struct obs_source *source)
 	source->deinterlace_top_first = true;
 	source->control->source = source;
 	source->audio_mixers = 0xFF;
+	source->audio_busses = 0xFF;
 
 	source->private_settings = obs_data_create();
 	return true;
@@ -536,6 +537,7 @@ obs_source_t *obs_source_duplicate(obs_source_t *source, const char *new_name,
 						 settings, NULL);
 
 	new_source->audio_mixers = source->audio_mixers;
+	new_source->audio_busses = source->audio_busses;
 	new_source->sync_offset = source->sync_offset;
 	new_source->user_volume = source->user_volume;
 	new_source->user_muted = source->user_muted;
@@ -618,8 +620,6 @@ void obs_source_destroy(struct obs_source *source)
 		source->context.data = NULL;
 	}
 
-	audio_monitor_destroy(source->monitor);
-
 	obs_hotkey_unregister(source->push_to_talk_key);
 	obs_hotkey_unregister(source->push_to_mute_key);
 	obs_hotkey_pair_unregister(source->mute_unmute_key);
@@ -653,11 +653,15 @@ void obs_source_destroy(struct obs_source *source)
 	if (source->info.type == OBS_SOURCE_TYPE_TRANSITION)
 		obs_transition_free(source);
 
+	for (int i = 0; i < MAX_AUDIO_BUSSES; i++)
+		obs_source_delete_audio_bus(source, i);
+
 	da_free(source->audio_actions);
 	da_free(source->audio_cb_list);
 	da_free(source->async_cache);
 	da_free(source->async_frames);
 	da_free(source->filters);
+	da_free(source->monitors);
 	pthread_mutex_destroy(&source->filter_mutex);
 	pthread_mutex_destroy(&source->audio_actions_mutex);
 	pthread_mutex_destroy(&source->audio_buf_mutex);
@@ -4764,6 +4768,72 @@ void obs_source_remove_audio_capture_callback(
 	pthread_mutex_unlock(&source->audio_cb_mutex);
 }
 
+void obs_source_create_audio_bus(obs_source_t *source, int bus)
+{
+	if (!obs_source_valid(source, "obs_source_create_audio_bus"))
+		return;
+
+	if (source->monitoring_type == OBS_MONITORING_TYPE_NONE)
+		return;
+
+	obs_source_delete_audio_bus(source, bus);
+
+	const char *id = obs_get_audio_monitoring_device(bus);
+
+	for (size_t i = 0; i < source->monitors.num; i++) {
+		struct audio_monitor *monitor = source->monitors.array[i];
+		if (strcmp(id, audio_monitor_get_id(monitor)) == 0)
+			return;
+	}
+
+	struct audio_monitor *monitor = audio_monitor_create(source, id, bus);
+
+	if (monitor)
+		da_push_back(source->monitors, &monitor);
+}
+
+void obs_source_delete_audio_bus(obs_source_t *source, int bus)
+{
+	if (!obs_source_valid(source, "obs_source_delete_audio_bus"))
+		return;
+
+	if (!source->monitors.num)
+		return;
+
+	for (size_t i = 0; i < source->monitors.num; i++) {
+		struct audio_monitor *monitor = source->monitors.array[i];
+		if (bus == audio_monitor_get_bus(monitor)) {
+			audio_monitor_destroy(monitor);
+			monitor = NULL;
+			da_erase(source->monitors, i);
+			break;
+		}
+	}
+}
+
+void obs_source_set_audio_busses(obs_source_t *source, uint32_t busses)
+{
+	if (!obs_source_valid(source, "obs_source_set_audio_busses"))
+		return;
+	if ((source->info.output_flags & OBS_SOURCE_AUDIO) == 0)
+		return;
+
+	if (source->audio_busses == busses)
+		return;
+
+	source->audio_busses = busses;
+}
+
+uint32_t obs_source_get_audio_busses(const obs_source_t *source)
+{
+	if (!obs_source_valid(source, "obs_source_get_audio_busses"))
+		return 0;
+	if ((source->info.output_flags & OBS_SOURCE_AUDIO) == 0)
+		return 0;
+
+	return source->audio_busses;
+}
+
 void obs_source_set_monitoring_type(obs_source_t *source,
 				    enum obs_monitoring_type type)
 {
@@ -4777,17 +4847,21 @@ void obs_source_set_monitoring_type(obs_source_t *source,
 
 	was_on = source->monitoring_type != OBS_MONITORING_TYPE_NONE;
 	now_on = type != OBS_MONITORING_TYPE_NONE;
+	source->monitoring_type = type;
+
+	uint32_t busses = obs_source_get_audio_busses(source);
 
 	if (was_on != now_on) {
 		if (!was_on) {
-			source->monitor = audio_monitor_create(source);
+			for (int i = 0; i < MAX_AUDIO_BUSSES; i++) {
+				if (busses & (1 << i))
+					obs_source_create_audio_bus(source, i);
+			}
 		} else {
-			audio_monitor_destroy(source->monitor);
-			source->monitor = NULL;
+			for (int i = 0; i < MAX_AUDIO_BUSSES; i++)
+				obs_source_delete_audio_bus(source, i);
 		}
 	}
-
-	source->monitoring_type = type;
 }
 
 enum obs_monitoring_type

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -722,7 +722,12 @@ EXPORT void obs_enum_audio_monitoring_devices(obs_enum_audio_device_cb cb,
 					      void *data);
 
 EXPORT bool obs_set_audio_monitoring_device(const char *name, const char *id);
-EXPORT void obs_get_audio_monitoring_device(const char **name, const char **id);
+EXPORT bool obs_set_audio_monitoring_device2(const char *id, int bus);
+EXPORT const char *obs_get_audio_monitoring_device(int bus);
+EXPORT void obs_source_create_audio_bus(obs_source_t *source, int bus);
+EXPORT void obs_source_delete_audio_bus(obs_source_t *source, int bus);
+EXPORT void obs_source_set_audio_busses(obs_source_t *source, uint32_t busses);
+EXPORT uint32_t obs_source_get_audio_busses(const obs_source_t *source);
 
 EXPORT void obs_add_tick_callback(void (*tick)(void *param, float seconds),
 				  void *param);


### PR DESCRIPTION
### Description
This adds the ability to libobs to have an unlimited amount
of audio monitoring busses. The new code is 100% backwards
compatible with the old code, so no changes have to be
made.

### Motivation and Context
The previous PR #2847, had UI changes also. This just adds the libobs code as the UI code is discussed in the RFC https://github.com/obsproject/rfcs/pull/9

### How Has This Been Tested?
Tested to make sure existing UI code still works with the new libobs code.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
