### PR TITLE
obs-ffmpeg: Add detection of stream stalls

### DIFF
--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -31,6 +31,12 @@ void MediaControls::OBSMediaStarted(void *data, calldata_t *)
 	QMetaObject::invokeMethod(media, "SetPlayingState");
 }
 
+void MediaControls::OBSMediaStalled(void *data, calldata_t *)
+{
+	MediaControls *media = static_cast<MediaControls *>(data);
+	QMetaObject::invokeMethod(media, "SetStalledState");
+}
+
 MediaControls::MediaControls(QWidget *parent)
 	: QWidget(parent), ui(new Ui::MediaControls)
 {
@@ -214,6 +220,11 @@ void MediaControls::SetRestartState()
 	StopMediaTimer();
 }
 
+void MediaControls::SetStalledState()
+{
+	// TODO a1rwulf: Not sure what to do yet
+}
+
 void MediaControls::RefreshControls()
 {
 	OBSSource source;
@@ -261,6 +272,8 @@ void MediaControls::RefreshControls()
 	case OBS_MEDIA_STATE_PAUSED:
 		SetPausedState();
 		break;
+	case OBS_MEDIA_STATE_STALLED:
+		SetStalledState();
 	default:
 		break;
 	}
@@ -286,6 +299,7 @@ void MediaControls::SetSource(OBSSource source)
 		sigs.emplace_back(sh, "media_stopped", OBSMediaStopped, this);
 		sigs.emplace_back(sh, "media_started", OBSMediaStarted, this);
 		sigs.emplace_back(sh, "media_ended", OBSMediaStopped, this);
+		sigs.emplace_back(sh, "media_stalled", OBSMediaStalled, this);
 	} else {
 		weakSource = nullptr;
 	}

--- a/UI/media-controls.hpp
+++ b/UI/media-controls.hpp
@@ -33,6 +33,7 @@ private:
 	static void OBSMediaPlay(void *data, calldata_t *calldata);
 	static void OBSMediaPause(void *data, calldata_t *calldata);
 	static void OBSMediaStarted(void *data, calldata_t *calldata);
+	static void OBSMediaStalled(void *data, calldata_t *calldata);
 
 	Ui_MediaControls *ui;
 
@@ -55,6 +56,7 @@ private slots:
 	void StopMedia();
 	void PlaylistNext();
 	void PlaylistPrevious();
+	void SetStalledState();
 
 	void SeekTimerCallback();
 

--- a/deps/media-playback/media-playback/media.h
+++ b/deps/media-playback/media-playback/media.h
@@ -41,6 +41,7 @@ extern "C" {
 typedef void (*mp_video_cb)(void *opaque, struct obs_source_frame *frame);
 typedef void (*mp_audio_cb)(void *opaque, struct obs_source_audio *audio);
 typedef void (*mp_stop_cb)(void *opaque);
+typedef void (*mp_ir_cb)(void *opaque);
 
 struct mp_media {
 	AVFormatContext *fmt;
@@ -101,6 +102,9 @@ struct mp_media {
 	bool seek;
 	bool seek_next_ts;
 	int64_t seek_pos;
+
+	mp_ir_cb ir_cb;
+	uint64_t last_frameread_ts;
 };
 
 typedef struct mp_media mp_media_t;
@@ -122,6 +126,8 @@ struct mp_media_info {
 	bool hardware_decoding;
 	bool is_local_file;
 	bool reconnecting;
+
+	mp_ir_cb ir_cb;
 };
 
 extern bool mp_media_init(mp_media_t *media, const struct mp_media_info *info);

--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -638,6 +638,10 @@ Source Signals
 
    Called when the media source switches to the previous media.
 
+**media_stalled**
+
+   Called when media has stalled during playback.
+
 General Source Functions
 ------------------------
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -102,6 +102,7 @@ static const char *source_signals[] = {
 	"void media_previous(ptr source)",
 	"void media_started(ptr source)",
 	"void media_ended(ptr source)",
+	"void media_stalled(ptr source)",
 	NULL,
 };
 
@@ -5039,4 +5040,12 @@ void obs_source_media_ended(obs_source_t *source)
 		return;
 
 	obs_source_dosignal(source, NULL, "media_ended");
+}
+
+void obs_source_media_stalled(obs_source_t *source)
+{
+	if (!obs_source_valid(source, "obs_source_media_stalled"))
+		return;
+
+	obs_source_dosignal(source, NULL, "media_stalled");
 }

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -69,6 +69,7 @@ enum obs_media_state {
 	OBS_MEDIA_STATE_STOPPED,
 	OBS_MEDIA_STATE_ENDED,
 	OBS_MEDIA_STATE_ERROR,
+	OBS_MEDIA_STATE_STALLED,
 };
 
 /**
@@ -523,6 +524,7 @@ struct obs_source_info {
 	int64_t (*media_get_time)(void *data);
 	void (*media_set_time)(void *data, int64_t miliseconds);
 	enum obs_media_state (*media_get_state)(void *data);
+	void (*media_ir_handler)(void *data);
 
 	/* version-related stuff */
 	uint32_t version; /* increment if needed to specify a new version */

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1372,6 +1372,7 @@ EXPORT void obs_source_media_set_time(obs_source_t *source, int64_t ms);
 EXPORT enum obs_media_state obs_source_media_get_state(obs_source_t *source);
 EXPORT void obs_source_media_started(obs_source_t *source);
 EXPORT void obs_source_media_ended(obs_source_t *source);
+EXPORT void obs_source_media_stalled(obs_source_t *source);
 
 /* ------------------------------------------------------------------------- */
 /* Transition-specific functions */

--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -68,3 +68,5 @@ NVENC.TooManySessions="NVENC Error: Too many concurrent sessions. Try closing ot
 NVENC.CheckDrivers="Please check your video drivers are up to date."
 
 ReconnectDelayTime="Reconnect Delay"
+
+DataReadTimeOut="Timeout"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Please see this PR as a request for comments:

It adds ability to detect stream stalls for the ffmpeg source.
When the stream starts to play again, the already existing
media play event will be triggered.

A stream is considered stalled if it did not get any data for a
configurable amount of time.
I've added this to the source settings:
![image](https://user-images.githubusercontent.com/5141257/91567410-5b2e5600-e945-11ea-996d-790ba694a622.png)


### Motivation and Context
The idea of the change is to allow automatic scene adaptions
when a live stream source fails to retrieve any data.
You might want to overlay, remove or change the affected stream
in this case.
Once the stream is available again, you could automatically restore
the scene.

### How Has This Been Tested?
I mostly tested the change in 2 ways:
* Using a live http tv stream and turning off the Wifi on my dev machine
* Livestreaming a videofile with ffmpeg and killing the stream process

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- New feature (non-breaking change which adds functionality)
- Documentation (a change to documentation pages)
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

As described above this is an RFC, so I'd be happy to get feedback on:
* wether such a change has a chance to be included
* if the implementation is kinda correct
* There is one TODO in the code, not sure if I need to call that method at all, comments welcome