### PR TITLE
CI: Update macOS deps to fix crash from invalid linking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     name: 'macOS 64-bit'
     runs-on: [macos-latest]
     env:
-      MACOS_DEPS_VERSION: '2020-08-06'
+      MACOS_DEPS_VERSION: '2020-08-27'
       VLC_VERSION: '3.0.8'
       SPARKLE_VERSION: '1.23.0'
       QT_VERSION: '5.14.1'


### PR DESCRIPTION
### Description

https://github.com/obsproject/obs-deps/commit/e3cf394948352d8db49d830b3b0ee8cf2390efd7

### Motivation and Context

Crashes are bad, and up-to-date deps are good.

### How Has This Been Tested?

Built & ran OBS on macOS

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
