### PR TITLE
frontend-tools: Auto detect Python on Windows

### DIFF
--- a/UI/frontend-plugins/frontend-tools/data/locale/en-US.ini
+++ b/UI/frontend-plugins/frontend-tools/data/locale/en-US.ini
@@ -46,3 +46,6 @@ ScriptDescriptionLink.OpenURL="Open URL"
 
 FileFilter.ScriptFiles="Script Files"
 FileFilter.AllFiles="All Files"
+
+PythonNotInstalled="Python not Installed"
+PythonWarning="Python %1 %2 is not installed. Please install and restart OBS, if you want to use Python scripts."

--- a/UI/frontend-plugins/frontend-tools/forms/scripts.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/scripts.ui
@@ -15,235 +15,171 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTabWidget" name="tabWidget">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <property name="tabBarAutoHide">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scriptsTab">
-      <attribute name="title">
-       <string>Scripts</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout_4">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_3">
-         <item>
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>LoadedScripts</string>
-           </property>
-           <property name="buddy">
-            <cstring>scripts</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QListWidget" name="scripts">
-           <property name="contextMenuPolicy">
-            <enum>Qt::CustomContextMenu</enum>
-           </property>
-           <property name="sortingEnabled">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="QPushButton" name="addScripts">
-             <property name="maximumSize">
-              <size>
-               <width>22</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>AddScripts</string>
-             </property>
-             <property name="accessibleName">
-              <string>AddScripts</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="flat">
-              <bool>true</bool>
-             </property>
-             <property name="themeID" stdset="0">
-              <string notr="true">addIconSmall</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="removeScripts">
-             <property name="maximumSize">
-              <size>
-               <width>22</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>RemoveScripts</string>
-             </property>
-             <property name="accessibleName">
-              <string>RemoveScripts</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="flat">
-              <bool>true</bool>
-             </property>
-             <property name="themeID" stdset="0">
-              <string notr="true">removeIconSmall</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="reloadScripts">
-             <property name="maximumSize">
-              <size>
-               <width>22</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>ReloadScripts</string>
-             </property>
-             <property name="accessibleName">
-              <string>ReloadScripts</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="flat">
-              <bool>true</bool>
-             </property>
-             <property name="themeID" stdset="0">
-              <string notr="true">refreshIconSmall</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_2">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QPushButton" name="defaults">
-             <property name="text">
-              <string>Defaults</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="scriptLog">
-             <property name="text">
-              <string>ScriptLogWindow</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="propertiesLayout">
-         <item>
-          <widget class="QLabel" name="label_3">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Description</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="description">
-           <property name="text">
-            <string notr="true"/>
-           </property>
-           <property name="openExternalLinks">
-            <bool>false</bool>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-           <property name="margin">
-            <number>12</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pythonSettingsTab">
-      <attribute name="title">
-       <string>PythonSettings</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QLabel" name="pythonPathLabel">
+        <widget class="QLabel" name="label_2">
          <property name="text">
-          <string notr="true"/>
+          <string>LoadedScripts</string>
          </property>
          <property name="buddy">
-          <cstring>pythonPath</cstring>
+          <cstring>scripts</cstring>
          </property>
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <widget class="QListWidget" name="scripts">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
-          <widget class="QLineEdit" name="pythonPath">
-           <property name="readOnly">
+          <widget class="QPushButton" name="addScripts">
+           <property name="maximumSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>AddScripts</string>
+           </property>
+           <property name="accessibleName">
+            <string>AddScripts</string>
+           </property>
+           <property name="text">
+            <string notr="true"/>
+           </property>
+           <property name="flat">
             <bool>true</bool>
+           </property>
+           <property name="themeID" stdset="0">
+            <string notr="true">addIconSmall</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="pythonPathBrowse">
+          <widget class="QPushButton" name="removeScripts">
+           <property name="maximumSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>RemoveScripts</string>
+           </property>
            <property name="accessibleName">
-            <string>PythonSettings.BrowsePythonPath</string>
+            <string>RemoveScripts</string>
            </property>
            <property name="text">
-            <string>Browse</string>
+            <string notr="true"/>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+           <property name="themeID" stdset="0">
+            <string notr="true">removeIconSmall</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="reloadScripts">
+           <property name="maximumSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>ReloadScripts</string>
+           </property>
+           <property name="accessibleName">
+            <string>ReloadScripts</string>
+           </property>
+           <property name="text">
+            <string notr="true"/>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+           <property name="themeID" stdset="0">
+            <string notr="true">refreshIconSmall</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="defaults">
+           <property name="text">
+            <string>Defaults</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="scriptLog">
+           <property name="text">
+            <string>ScriptLogWindow</string>
            </property>
           </widget>
          </item>
         </layout>
        </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="propertiesLayout">
        <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+        <widget class="QLabel" name="label_3">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>510</width>
-           <height>306</height>
-          </size>
+         <property name="text">
+          <string>Description</string>
          </property>
-        </spacer>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="description">
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="margin">
+          <number>12</number>
+         </property>
+         <property name="openExternalLinks">
+          <bool>false</bool>
+         </property>
+        </widget>
        </item>
       </layout>
-     </widget>
-    </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
@@ -272,10 +208,7 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>tabWidget</tabstop>
   <tabstop>close</tabstop>
-  <tabstop>pythonPath</tabstop>
-  <tabstop>pythonPathBrowse</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/UI/frontend-plugins/frontend-tools/scripts.hpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.hpp
@@ -52,8 +52,6 @@ public slots:
 
 	void on_scripts_currentRowChanged(int row);
 
-	void on_pythonPathBrowse_clicked();
-
 private slots:
 	void on_description_linkActivated(const QString &link);
 	void on_scripts_customContextMenuRequested(const QPoint &pos);


### PR DESCRIPTION
### Description
This automatically detects Python on Windows. If Python is
not installed, a message box will tell the users to install
Python and restart OBS, when they open the scripts dialog

### Motivation and Context
I found it annoying to find the Python path manually.

### How Has This Been Tested?
Needs more testing,  as I couldn't get COMPILE_PYTHON flag to work in cmake.

### Types of changes
- New feature (non-breaking change which adds functionality) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
