### PR TITLE
CI: Remove clang format Mac check

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -30,20 +30,3 @@ jobs:
         run: |
           ./formatcode.sh
           ./CI/check-format.sh
-
-  macos64:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'
-
-      - name: Install clang-format
-        run: |
-          brew install clang-format
-
-      - name: Check the Formatting
-        run: |
-          ./formatcode.sh
-          ./CI/check-format.sh


### PR DESCRIPTION
### Description
It is kind of pointless to have the Mac clang format check
when there is already one on Linux.

### Motivation and Context
Remove unnecessary check.

### How Has This Been Tested?
No testing needed.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
