### PR TITLE
libobs: Return default obj and array rather than current

### DIFF
--- a/libobs/obs-data.c
+++ b/libobs/obs-data.c
@@ -1762,12 +1762,12 @@ bool obs_data_item_get_default_bool(obs_data_item_t *item)
 
 obs_data_t *obs_data_item_get_default_obj(obs_data_item_t *item)
 {
-	return data_item_get_obj(item, get_item_obj);
+	return data_item_get_obj(item, get_item_default_obj);
 }
 
 obs_data_array_t *obs_data_item_get_default_array(obs_data_item_t *item)
 {
-	return data_item_get_array(item, get_item_array);
+	return data_item_get_array(item, get_item_default_array);
 }
 
 const char *obs_data_item_get_autoselect_string(obs_data_item_t *item)


### PR DESCRIPTION
### Description

Makes the return function's second parameter provide the `default` data. Ensured consistency with other \_get\_default\_ functions.

### Motivation and Context

Fixes #3357

### How Has This Been Tested?

Call the API. Ensure returned data matches the default values.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
