### PR TITLE
UI: Don't save invalid colors via Source Toolbar (Freetype 2 Source)

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -574,7 +574,12 @@ void TextSourceToolbar::on_selectColor_clicked()
 	color = newColor;
 
 	obs_data_t *settings = obs_data_create();
-	obs_data_set_int(settings, "color", color_to_int(color));
+	if (!strncmp(obs_source_get_id(source), "text_ft2_source", 15)) {
+		obs_data_set_int(settings, "color1", color_to_int(color));
+		obs_data_set_int(settings, "color2", color_to_int(color));
+	} else {
+		obs_data_set_int(settings, "color", color_to_int(color));
+	}
 	obs_source_update(source, settings);
 	obs_data_release(settings);
 }


### PR DESCRIPTION
# Description

This fixes an issue in the Freetype 2 Source where color changes were not applied at all.

### Motivation and Context

It's nice when buttons do what they say they do.

### How Has This Been Tested?

Add a Freetype 2 Text Source and try changing the Color via the Toolbar.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
