### PR TITLE
UI: Fix compiler warning about needing parenthesis

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5319,9 +5319,9 @@ void OBSBasic::on_actionViewCurrentLog_triggered()
 	if (!logView->isVisible()) {
 		logView->setVisible(true);
 	} else {
-		logView->setWindowState(logView->windowState() &
-						~Qt::WindowMinimized |
-					Qt::WindowActive);
+		logView->setWindowState(
+			(logView->windowState() & ~Qt::WindowMinimized) |
+			Qt::WindowActive);
 		logView->activateWindow();
 		logView->raise();
 	}


### PR DESCRIPTION
### Description
Simply gets rid of a warning about needing parenthesis around bitwise operator

### Motivation and Context
It was the only thing between me and a perfect clean compile.

### How Has This Been Tested?
I tested it on my machine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
