### PR TITLE
Vulkan instance fallback, and uninitialized member fix

### DIFF
--- a/plugins/win-capture/graphics-hook/vulkan-capture.c
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.c
@@ -1604,6 +1604,9 @@ static VkResult VKAPI_CALL OBS_CreateDevice(VkPhysicalDevice phy_device,
 	_freea(queue_family_properties);
 
 	init_obj_list(&data->swaps);
+	data->cur_swap = NULL;
+	data->d3d11_device = NULL;
+	data->d3d11_context = NULL;
 
 	data->valid = true;
 
@@ -1674,8 +1677,14 @@ OBS_CreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *cinfo,
 			swap_data->format = cinfo->imageFormat;
 			swap_data->hwnd =
 				find_surf_hwnd(data->inst_data, cinfo->surface);
+			swap_data->export_image = VK_NULL_HANDLE;
+			swap_data->layout_initialized = false;
+			swap_data->export_mem = VK_NULL_HANDLE;
 			swap_data->image_count = count;
+			swap_data->handle = INVALID_HANDLE_VALUE;
+			swap_data->shtex_info = NULL;
 			swap_data->d3d11_tex = NULL;
+			swap_data->captured = false;
 		}
 	}
 


### PR DESCRIPTION
### Description
Two changes: one to support 1.0 API applications/drivers, and another to set uninitialized members that can lead to a crash.

### Motivation and Context
Be robust when creating instances. Crashes are bad.

### How Has This Been Tested?
Fallback path faked with debugger. Crash when restoring vkCube from minimize is gone. Lots of debugger inspection. Also tested Doom (2016) capture.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.