### PR TITLE
mac-capture: show actual windows in Window Capture sources

### DIFF
--- a/plugins/mac-capture/window-utils.h
+++ b/plugins/mac-capture/window-utils.h
@@ -18,6 +18,8 @@ typedef struct cocoa_window *cocoa_window_t;
 
 NSArray *enumerate_cocoa_windows(void);
 
+NSArray *filter_nonzero_kcgwindowlayer_sources(NSArray *windows_arr);
+
 bool find_window(cocoa_window_t cw, obs_data_t *settings, bool force);
 
 void init_window(cocoa_window_t cw, obs_data_t *settings);

--- a/plugins/mac-capture/window-utils.m
+++ b/plugins/mac-capture/window-utils.m
@@ -23,14 +23,25 @@ static NSComparator win_info_cmp = ^(NSDictionary *o1, NSDictionary *o2) {
 	return [o1[WINDOW_NUMBER] compare:o2[WINDOW_NUMBER]];
 };
 
+NSArray *filter_nonzero_kcgwindowlayer_sources(NSArray *windows_arr)
+{
+	NSPredicate *pred =
+		[NSPredicate predicateWithFormat:@"(kCGWindowLayer == 0)"];
+	NSArray *new_windows_arr =
+		[windows_arr filteredArrayUsingPredicate:pred];
+
+	return new_windows_arr;
+}
+
 NSArray *enumerate_windows(void)
 {
 	NSArray *arr = (NSArray *)CGWindowListCopyWindowInfo(
 		kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
+	NSArray *filtered_arr = filter_nonzero_kcgwindowlayer_sources(arr);
 
 	[arr autorelease];
 
-	return [arr sortedArrayUsingComparator:win_info_cmp];
+	return [filtered_arr sortedArrayUsingComparator:win_info_cmp];
 }
 
 #define WAIT_TIME_MS 500


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This pull request addresses the issue found [here](https://github.com/obsproject/obs-studio/issues/3146) where sources inside Windows Capture show system/icon windows as well. Upon investigating the issue, it appears that the problem is inside `plugins/mac-capture/window-utils.m`:
```
NSArray *enumerate_windows(void)
{
	NSArray *arr = (NSArray *)CGWindowListCopyWindowInfo(
		kCGWindowListOptionOnScreenOnly, kCGNullWindowID);
	[arr autorelease];

	return [arr sortedArrayUsingComparator:win_info_cmp];
}
```

The `CGWindowListCopyWindowInfo(option, relativeToWindow)` returns every single window that is onscreen. It just so happens that the icons such as those in the menu bar

![image](https://user-images.githubusercontent.com/35359774/91933807-c2d30100-ecb7-11ea-8baf-9fcb6fece318.png)

are also considered windows, which have different `kCGWindowLayer` levels. The ones we're concerned with are found at the standard window layer level, which is zero. In other words, we want to filter out the windows returned from `CGWindowListCopyWindowInfo` to only give us ones where their `kCGWindowLayer == 0`. The below snippet of code has been added to serve as the extra filtering step:
```
NSArray *filter_nonzero_kcgwindowlayer_sources(NSArray *windows_arr)
{
	NSPredicate *pred =
		[NSPredicate predicateWithFormat:@"(kCGWindowLayer == 0)"];
	NSArray *new_windows_arr =
		[windows_arr filteredArrayUsingPredicate:pred];

	return new_windows_arr;
}
```

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
This pull request addresses the issue found [here](https://github.com/obsproject/obs-studio/issues/3146) where sources inside Windows Capture show system/icon windows as well. These only cause clutter with their large numbers and we presumably only want actual windows to show, so there is extra logic added to the code to clean up the windows.

<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested this on macOS Catalina 10.15.4. More importantly, I tested what would happen to existing "garbage" windows if this change is made. For example, I added `SystemUIServer - BatteryExtra` as a source and applied the code changes.
![image](https://user-images.githubusercontent.com/35359774/91936226-74286580-ecbd-11ea-923b-d04786d57631.png)
Upon restarting OBS, the window no longer showed up as a valid window. This would certainly affect those who have added sources like `SystemUIServer - BatteryExtra`, but it's nothing that would cause the program to crash. For reference, this is the new list of windows that appears when selecting a source:

![image](https://user-images.githubusercontent.com/35359774/91938642-5f020580-ecc2-11ea-99d8-3f321566f45f.png)

As for how this could potentially affect other areas of code, it's pretty self-contained inside of `window-utils.m`. The only code that calls `enumerate_windows()` is code that needs to list out window candidates for a Window Capture source.

<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

Fixes #3146