### PR TITLE
UI: Add configurable prefix/suffix for Screenshots

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -754,6 +754,7 @@ Basic.Settings.Output.EncoderPreset="Encoder Preset"
 Basic.Settings.Output.CustomEncoderSettings="Custom Encoder Settings"
 Basic.Settings.Output.CustomMuxerSettings="Custom Muxer Settings"
 Basic.Settings.Output.NoSpaceFileName="Generate File Name without Space"
+Basic.Settings.Output.Screenshot.Prefix="Screenshot Filename Prefix"
 
 # basic mode 'output' settings - advanced section
 Basic.Settings.Output.Adv.Rescale="Rescale Output"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -4940,6 +4940,38 @@
                      </item>
                     </layout>
                    </item>
+                   <item row="4" column="1">
+                    <layout class="QHBoxLayout" name="horizontalLayout_26">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLineEdit" name="simpleScrPrefix"/>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="label_69">
+                       <property name="text">
+                        <string>Basic.Settings.Output.ReplayBuffer.Suffix</string>
+                       </property>
+                       <property name="buddy">
+                        <cstring>simpleScrSuffix</cstring>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLineEdit" name="simpleScrSuffix"/>
+                     </item>
+                    </layout>
+                   </item>
                    <item row="3" column="0">
                     <widget class="QLabel" name="label_57">
                      <property name="text">
@@ -4947,6 +4979,16 @@
                      </property>
                      <property name="buddy">
                       <cstring>simpleRBPrefix</cstring>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="4" column="0">
+                    <widget class="QLabel" name="label_68">
+                     <property name="text">
+                      <string>Basic.Settings.Output.Screenshot.Prefix</string>
+                     </property>
+                     <property name="buddy">
+                      <cstring>simpleScrPrefix</cstring>
                      </property>
                     </widget>
                    </item>

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -918,6 +918,10 @@ bool SimpleOutput::ConfigureRecording(bool updateReplayBuffer)
 						 "RecRBPrefix");
 	const char *rbSuffix = config_get_string(main->Config(), "SimpleOutput",
 						 "RecRBSuffix");
+	const char *scrPrefix = config_get_string(
+		main->Config(), "SimpleOutput", "RecScrPrefix");
+	const char *scrSuffix = config_get_string(
+		main->Config(), "SimpleOutput", "RecScrSuffix");
 	int rbTime =
 		config_get_int(main->Config(), "SimpleOutput", "RecRBTime");
 	int rbSize =

--- a/UI/window-basic-main-screenshot.cpp
+++ b/UI/window-basic-main-screenshot.cpp
@@ -132,9 +132,14 @@ void ScreenshotObj::Save()
 	bool overwriteIfExists =
 		config_get_bool(config, "Output", "OverwriteIfExists");
 
+	const char *scrPrefix = config_get_string(
+		main->Config(), "SimpleOutput", "RecScrPrefix");
+	const char *scrSuffix = config_get_string(
+		main->Config(), "SimpleOutput", "RecScrSuffix");
+
 	path = GetOutputFilename(
 		rec_path, "png", false, overwriteIfExists,
-		GetFormatString(filenameFormat, "Screenshot", nullptr).c_str());
+		GetFormatString(filenameFormat, scrPrefix, scrSuffix).c_str());
 
 	th = std::thread([this] { MuxAndFinish(); });
 }

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1294,6 +1294,8 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_int(basicConfig, "SimpleOutput", "RecRBSize", 512);
 	config_set_default_string(basicConfig, "SimpleOutput", "RecRBPrefix",
 				  "Replay");
+	config_set_default_string(basicConfig, "SimpleOutput", "RecScrPrefix",
+				  "Screenshot");
 
 	config_set_default_bool(basicConfig, "AdvOut", "ApplyServiceSettings",
 				true);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -545,6 +545,8 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->overwriteIfExists,    CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->simpleRBPrefix,       EDIT_CHANGED,   ADV_CHANGED);
 	HookWidget(ui->simpleRBSuffix,       EDIT_CHANGED,   ADV_CHANGED);
+	HookWidget(ui->simpleScrPrefix,      EDIT_CHANGED,   ADV_CHANGED);
+	HookWidget(ui->simpleScrSuffix,      EDIT_CHANGED,   ADV_CHANGED);
 	HookWidget(ui->streamDelayEnable,    CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->streamDelaySec,       SCROLL_CHANGED, ADV_CHANGED);
 	HookWidget(ui->streamDelayPreserve,  CHECK_CHANGED,  ADV_CHANGED);
@@ -2412,6 +2414,10 @@ void OBSBasicSettings::LoadAdvancedSettings()
 						 "RecRBPrefix");
 	const char *rbSuffix = config_get_string(main->Config(), "SimpleOutput",
 						 "RecRBSuffix");
+	const char *scrPrefix = config_get_string(
+		main->Config(), "SimpleOutput", "RecScrPrefix");
+	const char *scrSuffix = config_get_string(
+		main->Config(), "SimpleOutput", "RecScrSuffix");
 	bool replayBuf = config_get_bool(main->Config(), "AdvOut", "RecRB");
 	int rbTime = config_get_int(main->Config(), "AdvOut", "RecRBTime");
 	int rbSize = config_get_int(main->Config(), "AdvOut", "RecRBSize");
@@ -2434,6 +2440,8 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	ui->overwriteIfExists->setChecked(overwriteIfExists);
 	ui->simpleRBPrefix->setText(rbPrefix);
 	ui->simpleRBSuffix->setText(rbSuffix);
+	ui->simpleScrPrefix->setText(scrPrefix);
+	ui->simpleScrSuffix->setText(scrSuffix);
 
 	ui->advReplayBuf->setChecked(replayBuf);
 	ui->advRBSecMax->setValue(rbTime);
@@ -3155,6 +3163,8 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	SaveEdit(ui->filenameFormatting, "Output", "FilenameFormatting");
 	SaveEdit(ui->simpleRBPrefix, "SimpleOutput", "RecRBPrefix");
 	SaveEdit(ui->simpleRBSuffix, "SimpleOutput", "RecRBSuffix");
+	SaveEdit(ui->simpleScrPrefix, "SimpleOutput", "RecScrPrefix");
+	SaveEdit(ui->simpleScrSuffix, "SimpleOutput", "RecScrSuffix");
 	SaveCheckBox(ui->overwriteIfExists, "Output", "OverwriteIfExists");
 	SaveCheckBox(ui->streamDelayEnable, "Output", "DelayEnable");
 	SaveSpinBox(ui->streamDelaySec, "Output", "DelaySec");


### PR DESCRIPTION
### Description

Provides prefix & suffix configuration fields for screenshots in Settings -> Advanced, alongside Replay Buffer.

![image](https://user-images.githubusercontent.com/941350/91968175-9969b200-ed57-11ea-88e2-026d6fa12a24.png)

![image](https://user-images.githubusercontent.com/941350/91968181-9b337580-ed57-11ea-8adf-e3516ca5f88d.png)


### Motivation and Context

Feature parity and better ability to organise files.

Additionally, as the OBS output defaults to the Videos folder on the system, it doesn't make sense to force the user to put screenshots in there too.

### How Has This Been Tested?

1. Set a screenshot hotkey
2. Change the prefix or suffix, Save & close the Settings dialog
3. Press the screenshot hotkey

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
