### PR TITLE
UI: Don't strip directories from file formatting when auto-remuxing

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5841,6 +5841,10 @@ void OBSBasic::AutoRemux()
 
 	QString output;
 	output += path;
+	if (fi.path().length() > 0) {
+		output += "/";
+		output += fi.path();
+	}
 	output += "/";
 	output += fi.completeBaseName();
 	output += ".mp4";


### PR DESCRIPTION
### Description

As `path` contains the Output directory and `completeBaseName` only returns the filename, any defined subdirectories in the Filename Formatting were stripped, dumping the file in the output directory unexpectedly.

### Motivation and Context

While file path generation was significantly improved in all other instances (replay buffer, etc), Auto Remux was accidentially stripping out subdirectories when generating the final filename.

### How Has This Been Tested?

* Enable auto-remux
* Set Recording Filename Formatting to include a "Folder/" prefix. Even '../' works
* Start a recording, wait a few seconds, stop the recording
* File should be in the correctly defined "Folder/" subdirectory

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
