### PR TITLE
UI: Fix memory leak when dropping files

### DIFF
--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -51,8 +51,11 @@ static string GenerateSourceName(const char *base)
 		}
 
 		obs_source_t *source = obs_get_source_by_name(name.c_str());
+
 		if (!source)
 			return name;
+		else
+			obs_source_release(source);
 	}
 }
 


### PR DESCRIPTION
### Description
This fixes a memory leak when dropping files when the name
is the same as other sources.

### Motivation and Context
Inspired by #3393, I went to look in other places where the source is not getting released after calling obs_get_source_by_name.

### How Has This Been Tested?
Dropped same file multiple times and noticed leaks didn't happen like before.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
