### PR TITLE
UI: Fix rec time left not showing in stats

### DIFF
--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -182,6 +182,9 @@ OBSBasicStats::OBSBasicStats(QWidget *parent, bool closeable)
 	}
 
 	obs_frontend_add_event_callback(OBSFrontendEvent, this);
+
+	if (obs_frontend_recording_active())
+		StartRecTimeLeft();
 }
 
 void OBSBasicStats::closeEvent(QCloseEvent *event)
@@ -412,15 +415,20 @@ void OBSBasicStats::Update()
 
 void OBSBasicStats::StartRecTimeLeft()
 {
+	if (recTimeLeft.isActive())
+		ResetRecTimeLeft();
+
 	recordTimeLeft->setText(QTStr("Calculating"));
 	recTimeLeft.start();
 }
 
 void OBSBasicStats::ResetRecTimeLeft()
 {
-	bitrates.clear();
-	recTimeLeft.stop();
-	recordTimeLeft->setText(QTStr(""));
+	if (recTimeLeft.isActive()) {
+		bitrates.clear();
+		recTimeLeft.stop();
+		recordTimeLeft->setText(QTStr(""));
+	}
 }
 
 void OBSBasicStats::RecordingTimeLeft()


### PR DESCRIPTION
### Description
If a user would start recording, then open the stats dialog,
the recording time left would be blank

### Motivation and Context
Fixes bug.

### How Has This Been Tested?
Made sure the recording time left displayed correctly when opening the stats dialog.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
