### PR TITLE
UI: Fix scene tree event handling

### DIFF
--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -6,6 +6,7 @@
 #include <QScrollBar>
 #include <QDropEvent>
 #include <QPushButton>
+#include <QTimer>
 
 SceneTree::SceneTree(QWidget *parent_) : QListWidget(parent_)
 {
@@ -67,8 +68,6 @@ bool SceneTree::eventFilter(QObject *obj, QEvent *event)
 
 void SceneTree::resizeEvent(QResizeEvent *event)
 {
-	QListWidget::resizeEvent(event);
-
 	if (gridMode) {
 		int scrollWid = verticalScrollBar()->sizeHint().width();
 		int h = visualItemRect(item(count() - 1)).bottom();
@@ -96,6 +95,8 @@ void SceneTree::resizeEvent(QResizeEvent *event)
 			item(i)->setData(Qt::SizeHintRole, QVariant());
 		}
 	}
+
+	QListWidget::resizeEvent(event);
 }
 
 void SceneTree::startDrag(Qt::DropActions supportedActions)
@@ -105,10 +106,10 @@ void SceneTree::startDrag(Qt::DropActions supportedActions)
 
 void SceneTree::dropEvent(QDropEvent *event)
 {
-	QListWidget::dropEvent(event);
-
-	if (event->source() != this)
+	if (event->source() != this) {
+		QListWidget::dropEvent(event);
 		return;
+	}
 
 	if (gridMode) {
 		int scrollWid = verticalScrollBar()->sizeHint().width();
@@ -136,7 +137,9 @@ void SceneTree::dropEvent(QDropEvent *event)
 		resize(size());
 	}
 
-	emit scenesReordered();
+	QListWidget::dropEvent(event);
+
+	QTimer::singleShot(100, [this]() { emit scenesReordered(); });
 }
 
 void SceneTree::dragMoveEvent(QDragMoveEvent *event)
@@ -181,15 +184,15 @@ void SceneTree::dragMoveEvent(QDragMoveEvent *event)
 			QPoint position(xPos * g.width(), yPos * g.height());
 			setPositionForIndex(position, index);
 		}
-	} else {
-		QListWidget::dragMoveEvent(event);
 	}
+
+	QListWidget::dragMoveEvent(event);
 }
 
 void SceneTree::rowsInserted(const QModelIndex &parent, int start, int end)
 {
-	QListWidget::rowsInserted(parent, start, end);
-
 	QResizeEvent event(size(), size());
 	SceneTree::resizeEvent(&event);
+
+	QListWidget::rowsInserted(parent, start, end);
 }


### PR DESCRIPTION
### Description
This fixes a bug where the same scene would show up in
the multiview more than once when reordering scenes.

### Motivation and Context
Bug fixing.

### How Has This Been Tested?
Reordered scenes by drag & drop and made sure the multiview looked normal.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
