### PR TITLE
libobs: Fix compiling warning

### DIFF
--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -392,7 +392,8 @@ struct os_dirent *os_readdir(os_dir_t *dir)
 	if (!dir->cur_dirent)
 		return NULL;
 
-	strncpy(dir->out.d_name, dir->cur_dirent->d_name, 255);
+	strncpy(dir->out.d_name, dir->cur_dirent->d_name,
+		sizeof(dir->out.d_name));
 
 	dstr_copy(&file_path, dir->path);
 	dstr_cat(&file_path, "/");


### PR DESCRIPTION
### Description
Fixes truncation warning of string.

### Motivation and Context
Compile warnings are annoying.

### How Has This Been Tested?
Made sure OBS compiled without the warning.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
