### PR TITLE
UI: Set media slider update rate to 60Hz

### DIFF
--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -40,6 +40,9 @@ MediaControls::MediaControls(QWidget *parent)
 	ui->nextButton->setProperty("themeID", "nextIcon");
 	ui->stopButton->setProperty("themeID", "stopIcon");
 
+	mediaTimer.setTimerType(Qt::PreciseTimer);
+	seekTimer.setTimerType(Qt::PreciseTimer);
+
 	connect(&mediaTimer, SIGNAL(timeout()), this,
 		SLOT(SetSliderPosition()));
 	connect(&seekTimer, SIGNAL(timeout()), this, SLOT(SeekTimerCallback()));
@@ -105,11 +108,11 @@ void MediaControls::MediaSliderClicked()
 	} else if (state == OBS_MEDIA_STATE_PLAYING) {
 		prevPaused = false;
 		PauseMedia();
-		mediaTimer.stop();
+		StopMediaTimer();
 	}
 
 	seek = ui->slider->value();
-	seekTimer.start(100);
+	seekTimer.start(16);
 }
 
 void MediaControls::MediaSliderReleased()
@@ -130,7 +133,7 @@ void MediaControls::MediaSliderReleased()
 
 	if (!prevPaused) {
 		PlayMedia();
-		mediaTimer.start(1000);
+		StartMediaTimer();
 	}
 }
 
@@ -164,7 +167,7 @@ void MediaControls::StartMediaTimer()
 		return;
 
 	if (!mediaTimer.isActive())
-		mediaTimer.start(1000);
+		mediaTimer.start(16);
 }
 
 void MediaControls::StopMediaTimer()


### PR DESCRIPTION
### Description
With the slider updating only every second, it looked very choppy.
Testing shows this change barely increases the CPU usage. This
is to make it consistent with the volume meters.

### Motivation and Context
Make media slider smoother.

### How Has This Been Tested?
Played media and tested to see CPU usage.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
