### PR TITLE
UI: Set restart state when there is no media

### DIFF
--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -253,6 +253,7 @@ void MediaControls::RefreshControls()
 	switch (state) {
 	case OBS_MEDIA_STATE_STOPPED:
 	case OBS_MEDIA_STATE_ENDED:
+	case OBS_MEDIA_STATE_NONE:
 		SetRestartState();
 		break;
 	case OBS_MEDIA_STATE_PLAYING:


### PR DESCRIPTION
### Description
When there is no media, set the media to the restart state.
Currently, this only affects the VLC source, as the media
source doesn't use the OBS_MEDIA_STATE_NONE, at this time.

### Motivation and Context
When VLC source is first loaded with no media, the media controls are enabled.

### How Has This Been Tested?
When creating the VLC source, I made sure the controls were in the correct state.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
