### PR TITLE
UI: Report detailed output errors for Replay Buffer

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1788,9 +1788,15 @@ bool AdvancedOutput::StartReplayBuffer()
 	}
 
 	if (!obs_output_start(replayBuffer)) {
+		QString error_reason;
+		const char *error = obs_output_get_last_error(replayBuffer);
+		if (error)
+			error_reason = QT_UTF8(error);
+		else
+			error_reason = QTStr("Output.StartFailedGeneric");
 		QMessageBox::critical(main,
 				      QTStr("Output.StartRecordingFailed"),
-				      QTStr("Output.StartFailedGeneric"));
+				      error_reason);
 		return false;
 	}
 


### PR DESCRIPTION
### Description

Same changes as 0c0ffb341cfb521473479cdcd391c3507b05cf46

**Before:**
![image](https://user-images.githubusercontent.com/941350/92218467-87654c00-eedc-11ea-8145-74221873b299.png)

**After:**
![image](https://user-images.githubusercontent.com/941350/92218439-7caab700-eedc-11ea-8e59-cc1cbd81f68b.png)


### Motivation and Context

Consistency & usefulness. The Replay Buffer message remained generic while Recording and Streaming displayed informative errors.

### How Has This Been Tested?

* Switch to Advanced output mode
* Switch to NVENC and set GPU to 1
* Try starting the Replay Buffer

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
