### PR TITLE
win-dshow: Add installer scripts for manual Virtual Cam registration

### DIFF
--- a/plugins/win-dshow/CMakeLists.txt
+++ b/plugins/win-dshow/CMakeLists.txt
@@ -143,5 +143,8 @@ source_group("libdshowcapture\\Header Files" FILES ${libdshowcapture_HEADERS})
 install_obs_plugin_with_data(win-dshow data)
 
 if(VIRTUALCAM_ENABLED)
+	configure_file(virtualcam-install.bat.in "${CMAKE_CURRENT_BINARY_DIR}/data/virtualcam-install.bat")
+	configure_file(virtualcam-uninstall.bat.in "${CMAKE_CURRENT_BINARY_DIR}/data/virtualcam-uninstall.bat")
+	install_obs_data_from_abs_path(win-dshow "${CMAKE_CURRENT_BINARY_DIR}/data" "obs-plugins/win-dshow")
 	add_subdirectory(virtualcam-module)
 endif()

--- a/plugins/win-dshow/virtualcam-install.bat.in
+++ b/plugins/win-dshow/virtualcam-install.bat.in
@@ -1,0 +1,78 @@
+@echo off
+goto checkAdmin
+
+:checkAdmin
+	net session >nul 2>&1
+	if %errorLevel% == 0 (
+		echo.
+	) else (
+		echo Administrative rights are required, please re-run this script as Administrator.
+		goto end
+	)
+
+:checkDLL
+	echo Checking for 32-bit Virtual Cam registration...
+	reg query "HKLM\SOFTWARE\Classes\WOW6432Node\CLSID\{@VIRTUALCAM_GUID@}" >nul 2>&1
+	if %errorLevel% == 0 (
+		echo 32-bit Virtual Cam found, skipping install...
+		echo.
+	) else (
+		echo 32-bit Virtual Cam not found, installing...
+		goto install32DLL
+	)
+
+:CheckDLLContinue
+	echo Checking for 64-bit Virtual Cam registration...
+	reg query "HKLM\SOFTWARE\Classes\CLSID\{@VIRTUALCAM_GUID@}" >nul 2>&1
+	if %errorLevel% == 0 (
+		echo 64-bit Virtual Cam found, skipping install...
+		echo.
+	) else (
+		echo 64-bit Virtual Cam not found, installing...
+		goto install64DLL
+	)
+	goto endSuccess
+
+:install32DLL
+	echo Installing 32-bit Virtual Cam...
+	if exist "%~dp0\data\obs-plugins\win-dshow\obs-virtualcam-module32.dll" (
+		regsvr32.exe /i /s "%~dp0\data\obs-plugins\win-dshow\obs-virtualcam-module32.dll"
+	) else (
+		regsvr32.exe /i /s obs-virtualcam-module32.dll
+	)
+	reg query "HKLM\SOFTWARE\Classes\WOW6432Node\CLSID\{@VIRTUALCAM_GUID@}" >nul 2>&1
+	if %errorLevel% == 0 (
+		echo 32-bit Virtual Cam successfully installed
+		echo.
+	) else (
+		echo 32-bit Virtual Cam installation failed
+		echo.
+		goto end
+	)
+	goto checkDLLContinue
+
+:install64DLL
+	echo Installing 64-bit Virtual Cam...
+	if exist "%~dp0\data\obs-plugins\win-dshow\obs-virtualcam-module64.dll" (
+		regsvr32.exe /i /s "%~dp0\data\obs-plugins\win-dshow\obs-virtualcam-module64.dll"
+	) else (
+		regsvr32.exe /i /s obs-virtualcam-module64.dll
+	)
+	reg query "HKLM\SOFTWARE\Classes\CLSID\{@VIRTUALCAM_GUID@}" >nul 2>&1
+	if %errorLevel% == 0 (
+		echo 64-bit Virtual Cam successfully installed
+		echo.
+		goto endSuccess
+	) else (
+		echo 64-bit Virtual Cam installation failed
+		echo.
+		goto end
+	)
+
+:endSuccess
+	echo Virtual Cam installed!
+	echo.
+
+:end
+	pause
+	exit

--- a/plugins/win-dshow/virtualcam-uninstall.bat.in
+++ b/plugins/win-dshow/virtualcam-uninstall.bat.in
@@ -1,0 +1,31 @@
+@echo off
+goto checkAdmin
+
+:checkAdmin
+	net session >nul 2>&1
+	if %errorLevel% == 0 (
+		echo.
+	) else (
+		echo Administrative rights are required, please re-run this script as Administrator.
+		goto end
+	)
+
+:uninstallDLLs
+	if exist "%~dp0\data\obs-plugins\win-dshow\obs-virtualcam-module32.dll" (
+		regsvr32.exe /u /s "%~dp0\data\obs-plugins\win-dshow\obs-virtualcam-module32.dll"
+	) else (
+		regsvr32.exe /u /s obs-virtualcam-module32.dll
+	)
+	if exist "%~dp0\data\obs-plugins\win-dshow\obs-virtualcam-module64.dll" (
+		regsvr32.exe /u /s "%~dp0\data\obs-plugins\win-dshow\obs-virtualcam-module64.dll"
+	) else (
+		regsvr32.exe /u /s obs-virtualcam-module64.dll
+	)
+
+:endSuccess
+	echo Virtual Cam uninstalled!
+	echo.
+
+:end
+	pause
+	exit


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This adds two batch scripts to install and uninstall the virtual cam
devices for installations where the installer could not be useed.
Most commonly, this is for portable installations or those who prefer
the .zip file.

### Motivation and Context
We had several people ask how to register virtual camera on portable
installations with the RC for v26.

### How Has This Been Tested?
Tested the script logic for all scenarios on the installer:

- No cam registered
- Only 32bit registered
- Only 64bit registered
- Both already registered
- All the above in the root of the obs-studio folder
- All the above in the win-dshow plugin folder

Script functioned as expected. Tested uninstaller, devices were unregistered.
### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
