### PR TITLE
UI: Allow adjusting media slider with arrow buttons

### DIFF
--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -39,6 +39,7 @@ MediaControls::MediaControls(QWidget *parent)
 	ui->previousButton->setProperty("themeID", "previousIcon");
 	ui->nextButton->setProperty("themeID", "nextIcon");
 	ui->stopButton->setProperty("themeID", "stopIcon");
+	setFocusPolicy(Qt::StrongFocus);
 
 	connect(&mediaTimer, SIGNAL(timeout()), this,
 		SLOT(SetSliderPosition()));
@@ -59,6 +60,20 @@ MediaControls::MediaControls(QWidget *parent)
 	restartAction->setShortcut({Qt::Key_R});
 	connect(restartAction, SIGNAL(triggered()), this, SLOT(RestartMedia()));
 	addAction(restartAction);
+
+	QAction *sliderFoward = new QAction(this);
+	sliderFoward->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+	connect(sliderFoward, SIGNAL(triggered()), this,
+		SLOT(MoveSliderFoward()));
+	sliderFoward->setShortcut({Qt::Key_Right});
+	addAction(sliderFoward);
+
+	QAction *sliderBack = new QAction(this);
+	sliderBack->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+	connect(sliderBack, SIGNAL(triggered()), this,
+		SLOT(MoveSliderBackwards()));
+	sliderBack->setShortcut({Qt::Key_Left});
+	addAction(sliderBack);
 }
 
 MediaControls::~MediaControls()
@@ -425,4 +440,32 @@ void MediaControls::on_durationLabel_clicked()
 
 	if (MediaPaused())
 		SetSliderPosition();
+}
+
+void MediaControls::MoveSliderFoward(int seconds)
+{
+	OBSSource source = OBSGetStrongRef(weakSource);
+
+	if (!source)
+		return;
+
+	int ms = obs_source_media_get_time(source);
+	ms += seconds * 1000;
+
+	obs_source_media_set_time(source, ms);
+	SetSliderPosition();
+}
+
+void MediaControls::MoveSliderBackwards(int seconds)
+{
+	OBSSource source = OBSGetStrongRef(weakSource);
+
+	if (!source)
+		return;
+
+	int ms = obs_source_media_get_time(source);
+	ms -= seconds * 1000;
+
+	obs_source_media_set_time(source, ms);
+	SetSliderPosition();
 }

--- a/UI/media-controls.hpp
+++ b/UI/media-controls.hpp
@@ -58,6 +58,9 @@ private slots:
 
 	void SeekTimerCallback();
 
+	void MoveSliderFoward(int seconds = 5);
+	void MoveSliderBackwards(int seconds = 5);
+
 public slots:
 	void PlayMedia();
 	void PauseMedia();

--- a/UI/media-slider.cpp
+++ b/UI/media-slider.cpp
@@ -2,7 +2,7 @@
 #include "media-slider.hpp"
 #include <QStyleFactory>
 
-MediaSlider::MediaSlider(QWidget *parent) : QSlider(parent)
+MediaSlider::MediaSlider(QWidget *parent) : SliderIgnoreScroll(parent)
 {
 	setMouseTracking(true);
 

--- a/UI/media-slider.hpp
+++ b/UI/media-slider.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <QSlider>
 #include <QMouseEvent>
+#include "slider-ignorewheel.hpp"
 
-class MediaSlider : public QSlider {
+class MediaSlider : public SliderIgnoreScroll {
 	Q_OBJECT
 
 public:


### PR DESCRIPTION
### Description
This allows the user to adjust the media slider with the left
and right keyboard arrows. It is currently set to adjust
by 5 second increments.

### Motivation and Context
User mentioned on Discord they wanted this feature.

### How Has This Been Tested?
Used keyboard arrows to change media time.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
