### PR TITLE
UI: Ensure tray icon is themed in all cases

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5592,10 +5592,13 @@ inline void OBSBasic::OnDeactivate()
 	} else if (outputHandler->Active() && trayIcon &&
 		   trayIcon->isVisible()) {
 		if (os_atomic_load_bool(&recording_paused))
-			trayIcon->setIcon(QIcon(":/res/images/obs_paused.png"));
+			trayIcon->setIcon(QIcon::fromTheme(
+				"obs-tray-paused",
+				QIcon(":/res/images/obs_paused.png")));
 		else
-			trayIcon->setIcon(
-				QIcon(":/res/images/tray_active.png"));
+			trayIcon->setIcon(QIcon::fromTheme(
+				"obs-tray-active",
+				QIcon(":/res/images/tray_active.png")));
 	}
 }
 
@@ -8084,7 +8087,9 @@ void OBSBasic::PauseRecording()
 		ui->statusbar->RecordingPaused();
 
 		if (trayIcon && trayIcon->isVisible())
-			trayIcon->setIcon(QIcon(":/res/images/obs_paused.png"));
+			trayIcon->setIcon(QIcon::fromTheme(
+				"obs-tray-paused",
+				QIcon(":/res/images/obs_paused.png")));
 
 		os_atomic_set_bool(&recording_paused, true);
 
@@ -8113,8 +8118,9 @@ void OBSBasic::UnpauseRecording()
 		ui->statusbar->RecordingUnpaused();
 
 		if (trayIcon && trayIcon->isVisible())
-			trayIcon->setIcon(
-				QIcon(":/res/images/tray_active.png"));
+			trayIcon->setIcon(QIcon::fromTheme(
+				"obs-tray-active",
+				QIcon(":/res/images/tray_active.png")));
 
 		os_atomic_set_bool(&recording_paused, false);
 


### PR DESCRIPTION
### Description
Update code to use an icon theme every time the tray icon is updated.

### Motivation and Context
This is a follow up to #1736, which fixed only some instances of the tray being updated.
I like my icons neat and tidy so I just added the ones that remained.

### How Has This Been Tested?
Manually by running the app and checking the icon shows up and it's from the theme, basically

### Types of changes
Bug fix, I'd say

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
