### PR TITLE
linux-v4l2: Fix boolean and menu control types

### DIFF
--- a/plugins/linux-v4l2/v4l2-controls.c
+++ b/plugins/linux-v4l2/v4l2-controls.c
@@ -46,7 +46,26 @@ static bool v4l2_control_changed(void *data, obs_properties_t *props,
 
 	struct v4l2_control control;
 	control.id = POINTER_TO_UINT(data);
-	control.value = obs_data_get_int(settings, obs_property_name(prop));
+
+	switch (obs_property_get_type(prop)) {
+	case OBS_PROPERTY_BOOL:
+		control.value =
+			obs_data_get_bool(settings, obs_property_name(prop));
+		break;
+	case OBS_PROPERTY_INT:
+		control.value =
+			obs_data_get_int(settings, obs_property_name(prop));
+		break;
+	case OBS_PROPERTY_LIST:
+		control.value =
+			obs_data_get_int(settings, obs_property_name(prop));
+		break;
+	default:
+		blog(LOG_ERROR, "unknown property type for %s",
+		     obs_property_name(prop));
+		v4l2_close(dev);
+		return ret;
+	}
 
 	if (0 != v4l2_ioctl(dev, VIDIOC_S_CTRL, &control)) {
 		ret = true;
@@ -79,7 +98,7 @@ static int_fast32_t v4l2_update_controls_menu(int_fast32_t dev,
 	     qmenu.index += qctrl->step) {
 		if (0 == v4l2_ioctl(dev, VIDIOC_QUERYMENU, &qmenu)) {
 			obs_property_list_add_int(prop, (char *)qmenu.name,
-						  qmenu.value);
+						  qmenu.index);
 		}
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Previously, changing boolean or menu settings would send incorrect values to the ioctl. This configuring cameras properly impossible.
This change fixes the support.

### Motivation and Context
Cameras on Linux look bad since they can't be configured properly.

### How Has This Been Tested?
To check if settings are updated I used `v4l2-ctl -d /dev/video0 --all`
Before this change, boolean and menu values would not update.
I'm on `Linux manjaro 5.4.58-1-MANJARO #1 SMP PREEMPT Tue Aug 11 15:46:30 UTC 2020 x86_64 GNU/Linux`

### Types of changes
Code fixes for `v4l2_control_changed`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
