### PR TITLE
UI: Remove duplicate media timer code

### DIFF
--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -120,7 +120,7 @@ void MediaControls::MediaSliderClicked()
 	} else if (state == OBS_MEDIA_STATE_PLAYING) {
 		prevPaused = false;
 		PauseMedia();
-		mediaTimer.stop();
+		StopMediaTimer();
 	}
 
 	seek = ui->slider->value();
@@ -145,7 +145,7 @@ void MediaControls::MediaSliderReleased()
 
 	if (!prevPaused) {
 		PlayMedia();
-		mediaTimer.start(1000);
+		StartMediaTimer();
 	}
 }
 


### PR DESCRIPTION
### Description
This removes duplicate code that is already in the
start/stop timer functions.

### Motivation and Context
Code cleanup.

### How Has This Been Tested?
Played and paused media to make sure it still worked.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
