### PR TITLE
UI: Fix vcam button not changing colors when checked

### DIFF
--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -962,7 +962,8 @@ QPushButton:checked[themeID="replayBufferButton"],
 QPushButton:checked#modeSwitch,
 QPushButton:checked#settingsButton,
 QPushButton:checked#exitButton,
-QPushButton:checked[themeID="pauseIconSmall"] {
+QPushButton:checked[themeID="pauseIconSmall"],
+QPushButton:checked[themeID="vcamButton"] {
 	background-color: rgba(240, 98, 146, 0.5); /* Pink (Secondary) */
 	border: 1px solid rgba(240, 98, 146, 0.5); /* Pink (Secondary) */
 }


### PR DESCRIPTION
### Description
This fixes a bug with the Rachni theme in which the virtual
camera button wouldn't change colors when active.

### Motivation and Context
Bug mentioned on Discord.

### How Has This Been Tested?
Enabled virtual camera button to made sure it changed colors.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
