### PR TITLE
deps/media-playback: Fix fast-forward after reset

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -691,6 +691,8 @@ static inline bool mp_media_thread(mp_media_t *m)
 		if (!is_active || pause) {
 			if (os_sem_wait(m->sem) < 0)
 				return false;
+			if (pause)
+				reset_ts(m);
 		} else {
 			timeout = mp_media_sleepto(m);
 		}


### PR DESCRIPTION
Fixes #3341 by ensuring timestamps are reset after pausing.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a reset_ts call after waiting for semaphore if the media source was paused to ensure the timestamp is properly reset.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
fixes the fast-forward component of #3341. The other component is agreed by the issue opener to be by design, so this issue can be considered resolved with this PR.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Verified that other state changes still function as expected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
