### PR TITLE
linux-v4l2: Save device by path

### DIFF
--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -276,10 +276,12 @@ static void v4l2_device_list(obs_property_t *prop, obs_data_t *settings)
 	const char *cur_device_name;
 
 #ifdef __FreeBSD__
-	dirp = opendir("/dev");
+	const char *basedir = "/dev/";
 #else
-	dirp = opendir("/sys/class/video4linux");
+	const char *basedir = "/dev/v4l/by-path/";
 #endif
+
+	dirp = opendir(basedir);
 	if (!dirp)
 		return;
 
@@ -288,7 +290,7 @@ static void v4l2_device_list(obs_property_t *prop, obs_data_t *settings)
 
 	obs_property_list_clear(prop);
 
-	dstr_init_copy(&device, "/dev/");
+	dstr_init(&device);
 
 	while ((dp = readdir(dirp)) != NULL) {
 		int fd;
@@ -303,8 +305,16 @@ static void v4l2_device_list(obs_property_t *prop, obs_data_t *settings)
 		if (dp->d_type == DT_DIR)
 			continue;
 
-		dstr_resize(&device, 5);
-		dstr_cat(&device, dp->d_name);
+		char *dev_path = dp->d_name;
+
+		char buf[1024];
+		ssize_t len;
+		if ((len = readlink(dp->d_name, buf, sizeof(buf) - 1)) != -1) {
+			buf[len] = '\0';
+			dev_path = &buf[0];
+		}
+		dstr_copy(&device, basedir);
+		dstr_cat(&device, dev_path);
 
 		if ((fd = v4l2_open(device.array, O_RDWR | O_NONBLOCK)) == -1) {
 			blog(LOG_INFO, "Unable to open %s", device.array);


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This adjusts device listing to be by /dev/v4l/by-path which is based
on where the device is plugged in instead of when it is initialized.
This should help people with multiple devices across restarts.

Old plugin data will still work unchanged, when users modify settings
the new options will be transparently backed by the new keys but names
presented remain consistent.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
/dev/videoX is not consistent across reboots. This fixes #3003 for users with multiple devices.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Works with my devices. Seems it should also work with the freeBSD assuming they have readlink. Manually editing scene to have the previous config works fine.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
