### PR TITLE
CI: Fix Azure macOS pipeline to use new build script

### DIFF
--- a/CI/full-build-macos.sh
+++ b/CI/full-build-macos.sh
@@ -54,11 +54,20 @@ BUILD_DEPS=(
     "sparkle ${SPARKLE_VERSION:-${CI_SPARKLE_VERSION}}"
 )
 
-COLOR_RED=$(tput setaf 1)
-COLOR_GREEN=$(tput setaf 2)
-COLOR_BLUE=$(tput setaf 4)
-COLOR_ORANGE=$(tput setaf 3)
-COLOR_RESET=$(tput sgr0)
+if [ -n "${TERM-}" ]; then
+    COLOR_RED=$(tput setaf 1)
+    COLOR_GREEN=$(tput setaf 2)
+    COLOR_BLUE=$(tput setaf 4)
+    COLOR_ORANGE=$(tput setaf 3)
+    COLOR_RESET=$(tput sgr0)
+else
+    COLOR_RED=""
+    COLOR_GREEN=""
+    COLOR_BLUE=""
+    COLOR_ORANGE=""
+    COLOR_RESET=""
+fi
+
 
 MACOS_VERSION="$(sw_vers -productVersion)"
 MACOS_MAJOR="$(echo ${MACOS_VERSION} | cut -d '.' -f 1)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,23 +32,15 @@ jobs:
   steps:
   - script: git submodule update --init --recursive
     displayName: 'Checkout Submodules'
-  - script: ./CI/install-dependencies-osx.sh
-    displayName: 'Install Dependencies'
-
-  - script: ./CI/before-script-osx.sh
-    displayName: 'Cmake'
-
-  - bash: |
-      set -e
-      cd ./build
-      make -j4
-      cd -
-    displayName: 'Build'
-
-  - script: ./CI/before-deploy-osx.sh
+  - script: TERM="" ./CI/full-build-macos.sh
+    displayName: 'Install dependencies and build'
+  - script: TERM="" ./CI/full-build-macos.sh -s -d -b -p
     condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['prHasCILabel'], true))
     displayName: 'Before Deploy'
-
+  - bash: |
+      mkdir -p ./nightly
+      find ./build -name \*.dmg -exec cp -PR \{\} ./nightly/ \;
+    displayName: 'Copy disk image'
   - task: PublishBuildArtifacts@1
     condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['prHasCILabel'], true))
     inputs:
@@ -70,7 +62,7 @@ jobs:
     displayName: 'Download / Setup Deps / Run CMake'
   - task: MSBuild@1
     displayName: 'Build 32-bit'
-    inputs: 
+    inputs:
       msbuildArguments: '/m /p:Configuration=RelWithDebInfo'
       solution: .\build32\obs-studio.sln
   - script: ./CI/before-deploy-win.cmd
@@ -97,7 +89,7 @@ jobs:
     displayName: 'Download / Setup Deps / Run CMake'
   - task: MSBuild@1
     displayName: 'Build 64-bit'
-    inputs: 
+    inputs:
       msbuildArguments: '/m /p:Configuration=RelWithDebInfo'
       solution: .\build64\obs-studio.sln
   - script: ./CI/before-deploy-win.cmd


### PR DESCRIPTION
### Description
Fixes macOS builds failing on Azure by using new all-in-one script.

### Motivation and Context
Homebrew deprecated installations from remote URLs a while back. This was fixed for Github CI and the new all-in-one script a while ago, but not for Azure CI which still uses the old scripts. This fix utilises the new script which is actively maintained and was rewritten from scratch (and is kept in lockstep with Github CI).

### How Has This Been Tested?
* Azure CI steps executed locally

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
