### PR TITLE
CI: Bump macOS-deps version to include rnnoise

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     name: 'macOS 64-bit'
     runs-on: [macos-latest]
     env:
-      MACOS_DEPS_VERSION: '2020-08-27'
+      MACOS_DEPS_VERSION: '2020-08-30'
       VLC_VERSION: '3.0.8'
       SPARKLE_VERSION: '1.23.0'
       QT_VERSION: '5.14.1'


### PR DESCRIPTION
### Description
Updates macOS deps version to include most recent version, enabling `rnnoise` support on macOS.

### Motivation and Context
Enable this enhanced noise reduction method on macOS.

### How Has This Been Tested?
* Build created on macOS
* `rnnoise` availability checked in filter options

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
