### PR TITLE
win-capture: Fix D3D leaks on swap chain release

### DIFF
--- a/plugins/win-capture/get-graphics-offsets/dxgi-offsets.cpp
+++ b/plugins/win-capture/get-graphics-offsets/dxgi-offsets.cpp
@@ -102,7 +102,8 @@ static inline void dxgi_free(dxgi_info &info)
 		DestroyWindow(info.hwnd);
 }
 
-void get_dxgi_offsets(struct dxgi_offsets *offsets)
+void get_dxgi_offsets(struct dxgi_offsets *offsets,
+		      struct dxgi_offsets2 *offsets2)
 {
 	dxgi_info info = {};
 	bool success = dxgi_init(info);
@@ -120,6 +121,8 @@ void get_dxgi_offsets(struct dxgi_offsets *offsets)
 				vtable_offset(info.module, swap1, 22);
 			swap1->Release();
 		}
+
+		offsets2->release = vtable_offset(info.module, info.swap, 2);
 	}
 
 	dxgi_free(info);

--- a/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.c
+++ b/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.c
@@ -8,6 +8,7 @@ int main(int argc, char *argv[])
 	struct d3d8_offsets d3d8 = {0};
 	struct d3d9_offsets d3d9 = {0};
 	struct dxgi_offsets dxgi = {0};
+	struct dxgi_offsets2 dxgi2 = {0};
 
 	WNDCLASSA wc = {0};
 	wc.style = CS_OWNDC;
@@ -24,7 +25,7 @@ int main(int argc, char *argv[])
 
 	get_d3d9_offsets(&d3d9);
 	get_d3d8_offsets(&d3d8);
-	get_dxgi_offsets(&dxgi);
+	get_dxgi_offsets(&dxgi, &dxgi2);
 
 	printf("[d3d8]\n");
 	printf("present=0x%" PRIx32 "\n", d3d8.present);
@@ -38,6 +39,7 @@ int main(int argc, char *argv[])
 	printf("present=0x%" PRIx32 "\n", dxgi.present);
 	printf("present1=0x%" PRIx32 "\n", dxgi.present1);
 	printf("resize=0x%" PRIx32 "\n", dxgi.resize);
+	printf("release=0x%" PRIx32 "\n", dxgi2.release);
 
 	(void)argc;
 	(void)argv;

--- a/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.h
+++ b/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.h
@@ -21,7 +21,8 @@ static inline uint32_t vtable_offset(HMODULE module, void *cls,
 	return (uint32_t)(vtable[offset] - (uintptr_t)module);
 }
 
-extern void get_dxgi_offsets(struct dxgi_offsets *offsets);
+extern void get_dxgi_offsets(struct dxgi_offsets *offsets,
+			     struct dxgi_offsets2 *offsets2);
 extern void get_d3d9_offsets(struct d3d9_offsets *offsets);
 extern void get_d3d8_offsets(struct d3d8_offsets *offsets);
 

--- a/plugins/win-capture/graphics-hook-info.h
+++ b/plugins/win-capture/graphics-hook-info.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
@@ -46,6 +47,10 @@ struct dxgi_offsets {
 	uint32_t present1;
 };
 
+struct dxgi_offsets2 {
+	uint32_t release;
+};
+
 struct ddraw_offsets {
 	uint32_t surface_create;
 	uint32_t surface_restore;
@@ -77,6 +82,7 @@ struct graphics_offsets {
 	struct d3d9_offsets d3d9;
 	struct dxgi_offsets dxgi;
 	struct ddraw_offsets ddraw;
+	struct dxgi_offsets2 dxgi2;
 };
 
 struct hook_info {
@@ -106,8 +112,9 @@ struct hook_info {
 	/* hook addresses */
 	struct graphics_offsets offsets;
 
-	uint32_t reserved[128];
+	uint32_t reserved[127];
 };
+static_assert(sizeof(struct hook_info) == 648, "ABI compatibility");
 
 #pragma pack(pop)
 

--- a/plugins/win-capture/load-graphics-offsets.c
+++ b/plugins/win-capture/load-graphics-offsets.c
@@ -40,6 +40,8 @@ static inline bool load_offsets_from_string(struct graphics_offsets *offsets,
 		(uint32_t)config_get_uint(config, "dxgi", "present1");
 	offsets->dxgi.resize =
 		(uint32_t)config_get_uint(config, "dxgi", "resize");
+	offsets->dxgi2.release =
+		(uint32_t)config_get_uint(config, "dxgi", "release");
 
 	config_close(config);
 	return true;


### PR DESCRIPTION
### Description
Hook DXGI release function to release D3D objects if the related swap
chain is also being destroyed.

An added bonus is that the game capture hook will handle swap chain
recreation for applications that don't use ResizeBuffers.

### Motivation and Context
User reported that swap chain recreation was not being handled properly.

In the process of reproducing the issue, decided to clean leaks.

When leaks were cleaned up, swap chain recreation was also fixed as a side effect.

### How Has This Been Tested?
- D3D10: Mega Man X Legacy Collection, windowed/fullscreen toggle
- D3D11: SimpleSample11, 32-bit and 64-bit, windowed/fullscreen toggle (swap chain recreate).
- D3D11: Mesen emulator, windowed/fullscreen toggle (ResizeBuffer and swap chain recreate paths).
- Verified ABI compatibility between old/new hook vs. new/old OBS using SimpleSample11.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.