### PR TITLE
obs-ffmpeg: Signal a remote disconnect for network streams from ffmpeg-mux

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -440,7 +440,11 @@ static void signal_failure(struct ffmpeg_muxer *stream)
 		code = OBS_OUTPUT_UNSUPPORTED;
 		break;
 	default:
-		code = OBS_OUTPUT_ERROR;
+		if (stream->is_network) {
+			code = OBS_OUTPUT_DISCONNECTED;
+		} else {
+			code = OBS_OUTPUT_ENCODE_ERROR;
+		}
 	}
 
 	obs_output_signal_stop(stream->output, code);


### PR DESCRIPTION

### Description

If using ffmpeg-mux to send a network stream, signal a disconnect error code
on error to allow reconnections to take place.

### Motivation and Context

`srt://` custom destinations do not reconnect like `rtmp://` streams do, and as I added #3460 to report errors I found that the error that was returned wasn't the right one to cause reconnections to happen.


### How Has This Been Tested?

I streamed to an `srt://` custom destination, killed the remote destination, restart it, and OBS reconnected.


### Types of changes
 - Bug fix (non-breaking change which fixes an issue)
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
