### PR TITLE
obs-scripting: Fix script_path() python memory corruption

### DIFF
--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -147,8 +147,13 @@ void add_functions_to_py_module(PyObject *module, PyMethodDef *method_list)
 
 static PyObject *py_get_current_script_path(PyObject *self, PyObject *args)
 {
+	PyObject *dir;
+
 	UNUSED_PARAMETER(args);
-	return PyDict_GetItemString(PyModule_GetDict(self), "__script_dir__");
+
+	dir = PyDict_GetItemString(PyModule_GetDict(self), "__script_dir__");
+	Py_XINCREF(dir);
+	return dir;
 }
 
 static void get_defaults(struct obs_python_script *data, PyObject *get_defs)


### PR DESCRIPTION
Returning PyObject with borrowed reference will result in double free
and/or use after free issue.
Issue seen as crash when running Python script calling script_path().

### Description
Fixes a memory bug that happens to Python script using the function script_path()

### Motivation and Context
Fixes crashes and potentially nastier problems that are difficult for script developers to find.

### How Has This Been Tested?
Python script that previously would crash at reload and closing of OBS runs fine after change.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
