### PR TITLE
win-dshow: Set current working directory in VirtualCam scripts

### DIFF
--- a/plugins/win-dshow/virtualcam-install.bat.in
+++ b/plugins/win-dshow/virtualcam-install.bat.in
@@ -1,4 +1,5 @@
 @echo off
+@cd /d "%~dp0"
 goto checkAdmin
 
 :checkAdmin

--- a/plugins/win-dshow/virtualcam-uninstall.bat.in
+++ b/plugins/win-dshow/virtualcam-uninstall.bat.in
@@ -1,4 +1,5 @@
 @echo off
+@cd /d "%~dp0"
 goto checkAdmin
 
 :checkAdmin


### PR DESCRIPTION
# Description

Ensures the current working directory is set when running the VirtualCam install scripts to ensure they don't fail. Previously they'd silently fail, but removing the silent flag would return "Module not found".

Thanks to @ElectronicWar and @Gol-D-Ace on Discord for coming up with & verifying the fix.

### Motivation and Context

The scripts would fail if run by admin, as the default path was system32. Failing scripts are no good.

### How Has This Been Tested?

Build OBS. Right click "Run as admin" one of these scripts from within the win-dshow folder.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
