### PR TITLE
UI: Remove duplicate file generation code

### DIFF
--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -92,30 +92,12 @@ static bool SceneCollectionExists(const char *findName)
 static bool GetUnusedSceneCollectionFile(std::string &name, std::string &file)
 {
 	char path[512];
-	int ret;
 
-	if (!GetFileSafeName(name.c_str(), file)) {
-		blog(LOG_WARNING, "Failed to create safe file name for '%s'",
-		     name.c_str());
+	if (!GetConfigPath(path, sizeof(path), "obs-studio/basic/scenes/"))
 		return false;
-	}
 
-	ret = GetConfigPath(path, sizeof(path), "obs-studio/basic/scenes/");
-	if (ret <= 0) {
-		blog(LOG_WARNING, "Failed to get scene collection config path");
-		return false;
-	}
+	file = GetOutputFilename(path, "json", false, false, name.c_str());
 
-	file.insert(0, path);
-
-	if (!GetClosestUnusedFileName(file, "json")) {
-		blog(LOG_WARNING, "Failed to get closest file name for %s",
-		     file.c_str());
-		return false;
-	}
-
-	file.erase(file.size() - 5, 5);
-	file.erase(0, strlen(path));
 	return true;
 }
 

--- a/UI/window-importer.cpp
+++ b/UI/window-importer.cpp
@@ -517,19 +517,6 @@ void OBSImporter::dragEnterEvent(QDragEnterEvent *ev)
 		ev->accept();
 }
 
-static bool CheckConfigExists(const char *dir, QString name)
-{
-
-	QString dst = dir;
-	dst += "/";
-	dst += name;
-	dst += ".json";
-
-	dst.replace(" ", "_");
-
-	return os_file_exists(dst.toStdString().c_str());
-}
-
 void OBSImporter::browseImport()
 {
 	QString Pattern = "(*.json *.bpres *.xml *.xconfig)";
@@ -577,24 +564,10 @@ void OBSImporter::importCollections()
 			json11::Json::object out = res.object_items();
 			QString file = res["name"].string_value().c_str();
 
-			bool safe = !CheckConfigExists(dst, file);
-			int x = 1;
-			while (!safe) {
-				file = name;
-				file += " (";
-				file += QString::number(x);
-				file += ")";
-
-				safe = !CheckConfigExists(dst, file);
-				x++;
-			}
+			std::string save = GetOutputFilename(
+				dst, "json", false, false, QT_TO_UTF8(file));
 
 			out["name"] = file.toStdString();
-
-			std::string save = dst;
-			save += "/";
-			save += file.replace(" ", "_").toStdString();
-			save += ".json";
 
 			std::string out_str = json11::Json(out).dump();
 


### PR DESCRIPTION
### Description
This removes duplicate code when generating scene collection
filenames.

### Motivation and Context
Makes maintenance easier.

### How Has This Been Tested?
Created/imported scene collections to made sure they were named properly.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
