### PR TITLE
frontend-tools: Free xdisplay on Linux auto scene switcher

### DIFF
--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher-nix.cpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher-nix.cpp
@@ -27,7 +27,7 @@ Display *disp()
 	return xdisplay;
 }
 
-void cleanupDisplay()
+void CleanupSceneSwitcher()
 {
 	if (!xdisplay)
 		return;

--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher-osx.mm
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher-osx.mm
@@ -41,3 +41,5 @@ void GetCurrentWindowTitle(string &title)
 		}
 	}
 }
+
+void CleanupSceneSwitcher() {}

--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher-win.cpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher-win.cpp
@@ -67,3 +67,5 @@ void GetCurrentWindowTitle(string &title)
 	}
 	GetWindowTitle(window, title);
 }
+
+void CleanupSceneSwitcher() {}

--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher.cpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher.cpp
@@ -521,6 +521,8 @@ void SwitcherData::Stop()
 
 extern "C" void FreeSceneSwitcher()
 {
+	CleanupSceneSwitcher();
+
 	delete switcher;
 	switcher = nullptr;
 }

--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher.hpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher.hpp
@@ -45,3 +45,4 @@ public slots:
 
 void GetWindowList(std::vector<std::string> &windows);
 void GetCurrentWindowTitle(std::string &title);
+void CleanupSceneSwitcher();


### PR DESCRIPTION
### Description
The xdisplay in the Linux scene switcher was never closed
when OBS exits.

### Motivation and Context
Noticed the cleanup function was never being called.

### How Has This Been Tested?
Ran the auto scene switcher to make sure it still worked properly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
