### PR TITLE
deps/media-playback: Fix current time at not standard speed

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -907,8 +907,7 @@ void mp_media_stop(mp_media_t *m)
 
 int64_t mp_get_current_time(mp_media_t *m)
 {
-	int speed = (int)((float)m->speed / 100.0f);
-	return (mp_media_get_base_pts(m) / 1000000) * speed;
+	return mp_media_get_base_pts(m) * (int64_t)m->speed / 100000000LL;
 }
 
 void mp_media_seek_to(mp_media_t *m, int64_t pos)


### PR DESCRIPTION
### Description
Fix current time at not standard speed

### Motivation and Context
obs_source_media_get_time would give 0 for every speed lower than 100%

### How Has This Been Tested?
On windows 10 64 bit with time showing in the media controls

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
