### PR TITLE
UI: Don't set remux filename in filename generator

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1671,9 +1671,6 @@ string GenerateSpecifiedFilename(const char *extension, bool noSpace,
 	BPtr<char> filename =
 		os_generate_formatted_filename(extension, !noSpace, format);
 
-	remuxFilename = string(filename);
-	remuxAfterRecord = autoRemux;
-
 	return string(filename);
 }
 

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -955,6 +955,11 @@ bool SimpleOutput::ConfigureRecording(bool updateReplayBuffer)
 				    strPath.c_str());
 	}
 
+	bool autoRemux = config_get_bool(main->Config(), "Video", "AutoRemux");
+	remuxFilename = string(GenerateSpecifiedFilename(
+		ffmpegOutput ? "avi" : format, noSpace, f.c_str()));
+	remuxAfterRecord = autoRemux;
+
 	obs_data_set_string(settings, "muxer_settings", mux);
 
 	if (updateReplayBuffer)


### PR DESCRIPTION
### Description

Rather than unexpectedly updating the `remuxFilename` in the filename generator, ensure it's only done when configuring the recording. This ensures it's not updated when other tasks (like screenshots) generate a filename.

### Motivation and Context

Fixes #3497

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
