### PR TITLE
UI: Always parse log contents for Log Viewer as UTF-8

### DIFF
--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -101,6 +101,7 @@ void OBSLogViewer::InitLog()
 
 	if (file.open(QIODevice::ReadOnly)) {
 		QTextStream in(&file);
+		in.setCodec("UTF-8");
 
 		while (!in.atEnd()) {
 			QString line = in.readLine();


### PR DESCRIPTION
# Description

Ensure log text (in non-English languages especially) in the Log Viewer is always treated as UTF-8 so that characters are always printed correctly.

### Motivation and Context

Source names in Japanese weren't rendering correctly. On English systems, it'd print incorrectly from the get-go. On Japanese systems, it'd print correctly on first log, but on reboot would show incorrectly.

### How Has This Been Tested?

* Name a source `デスクトップ音声`
* View the log
* Restart
* View the log again

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
