### PR TITLE
Remove weabook.live from services.json

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1727,32 +1727,6 @@
             }
         },
         {
-            "name": "weabook.live",
-            "servers": [
-                {
-                    "name": "N.Virgina, US",
-                    "url": "rtmp://us-api.weabook.live/live"
-                },
-                {
-                    "name": "Singapore, SG",
-                    "url": "rtmp://sg-api.weabook.live/live"
-                },
-                {
-                    "name": "Tokyo, JP",
-                    "url": "rtmp://jp-api.weabook.live/live"
-                },
-                {
-                    "name": "Premium Streaming",
-                    "url": "rtmp://premium.rtmp.weabook.live/live"
-                }
-            ],
-            "recommended": {
-                "keyint": 2,
-                "max audio bitrate": 256,
-                "max video bitrate": 20480
-            }
-        },
-        {
             "name": "Taryana - Apachat | تاریانا - آپاچت",
             "servers": [
                 {


### PR DESCRIPTION
### Description
I've been reviewing and integrating new services to my project https://streamon.app and it seems like weabook.live is now a recipe app - no longer a live streaming provider.

### Motivation and Context
If you try to use this service it will no longer work with OBS.

### How Has This Been Tested?
No changes to executable code

### Types of changes
 - Code cleanup (non-breaking change which makes code smaller or more readable) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
