### PR TITLE
UI: Improve macOS performance by disabling Qt colourspace conversion

### DIFF
--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -144,6 +144,13 @@ bool IsAlwaysOnTop(QWidget *window)
 	return (window->windowFlags() & Qt::WindowStaysOnTopHint) != 0;
 }
 
+void disableColorSpaceConversion(QWidget *window)
+{
+	NSView *view =
+		(__bridge NSView *)reinterpret_cast<void *>(window->winId());
+	view.window.colorSpace = NSColorSpace.sRGBColorSpace;
+}
+
 void SetAlwaysOnTop(QWidget *window, bool enable)
 {
 	Qt::WindowFlags flags = window->windowFlags();

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -67,4 +67,5 @@ QString GetMonitorName(const QString &id);
 void EnableOSXVSync(bool enable);
 void EnableOSXDockIcon(bool enable);
 void InstallNSApplicationSubclass();
+void disableColorSpaceConversion(QWidget *window);
 #endif

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1867,6 +1867,10 @@ void OBSBasic::OBSInit()
 	SystemTray(true);
 #endif
 
+#ifdef __APPLE__
+	disableColorSpaceConversion(this);
+#endif
+
 	bool has_last_version = config_has_user_value(App()->GlobalConfig(),
 						      "General", "LastVersion");
 	bool first_run =


### PR DESCRIPTION
### Description
This patch reduces OBS' idle CPU usage by about 40-50% by removing the need to do expensive colourspace conversions for drawing the UI.

### Motivation and Context
Profiling on macOS showed a high amount of calls made to colour conversion methods by Qt. The underlying issue (according to comments made in a Qt ticket I found https://bugreports.qt.io/browse/QTBUG-47660) seems to be that each time "the Qt backingstore is pushed to macOS, each pixel is color-rescaled by macOS" and also "macOS converts the 32 bit/pixel pixmap supplied by the Qt backingstore to a 64 bit pixmap, each time the backingstore is flushed to the screen".

Due to retina screen resolutions being default on macOS (and 10-bit colour on 5k iMacs), the size and bit-depth of these bitmaps is effectively "damn big", hence high CPU usage for these operations.

The simple fix as suggested by the last comment was to make Qt use a default sRGB colourspace, disabling conversions altogether.

Do note that the issue identified in https://github.com/obsproject/obs-studio/issues/2841#issuecomment-630991956 still persists, even with the associated Qt fix applied (or alternative building OBS with Qt 5.15.1) - while the high CPU usage for colour conversions (quite probably the high usage of "syscalls" as mentioned in https://github.com/obsproject/obs-studio/issues/2841#issuecomment-701941696) should be removed, we're back to `QBackingStore::flush -> Qimage::copy` eating lots of CPU compared to Windows.

### How Has This Been Tested?
* OBS built on macOS via Xcode and profiled with and without fix to check if CPU usage actually went down consistently

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
