### PR TITLE
Update FreeBSD CI for package name change

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ env:
 task:
   install_script:
   - pkg install -y
-    v4l_compat swig30 ffmpeg curl dbus fdk-aac fontconfig
+    v4l_compat swig ffmpeg curl dbus fdk-aac fontconfig
     freetype2 jackit jansson luajit mbedtls pulseaudio speexdsp
     libsysinfo libudev-devd libv4l libx264 cmake ninja
     mesa-libs lua52 pkgconf


### PR DESCRIPTION
#3103 # Description
Track FreeBSD package rename.

### Motivation and Context
FreeBSD removed the swig30 package and replaced it with just swig, currently version 4.0.
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=246613

### How Has This Been Tested?
Cirrus-CI build test run: https://cirrus-ci.com/task/5811192847400960

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
