### PR TITLE
coreaudio-encoder: Fix path on windows

### DIFF
--- a/plugins/coreaudio-encoder/windows-imports.h
+++ b/plugins/coreaudio-encoder/windows-imports.h
@@ -404,6 +404,7 @@ static bool load_lib(void)
 	path_list_t path_list[] = {
 		{FOLDERID_ProgramFilesCommon,
 		 L"Apple\\Apple Application Support"},
+		{FOLDERID_ProgramFiles, L"iTunes"},
 	};
 
 	for (auto &val : path_list) {

--- a/plugins/coreaudio-encoder/windows-imports.h
+++ b/plugins/coreaudio-encoder/windows-imports.h
@@ -361,49 +361,57 @@ static HMODULE audio_toolbox = NULL;
 
 static void release_lib(void)
 {
-#define RELEASE_LIB(x)          \
-	if (x) {                \
-		FreeLibrary(x); \
-		x = NULL;       \
+	if (audio_toolbox) {
+		FreeLibrary(audio_toolbox);
+		audio_toolbox = NULL;
+	}
+}
+
+static bool load_from_shell_path(REFKNOWNFOLDERID rfid, const wchar_t *subpath)
+{
+	wchar_t *sh_path;
+	if (SHGetKnownFolderPath(rfid, 0, NULL, &sh_path) != S_OK) {
+		CA_LOG(LOG_WARNING, "Could not retrieve shell path");
+		return false;
 	}
 
-	RELEASE_LIB(audio_toolbox);
-#undef RELEASE_LIB
+	wchar_t path[MAX_PATH];
+	_snwprintf(path, MAX_PATH, L"%s\\%s\\%s", sh_path, subpath,
+		   L"CoreAudioToolbox.dll");
+	CoTaskMemFree(sh_path);
+
+	audio_toolbox = LoadLibraryW(path);
+	return !!audio_toolbox;
 }
 
 static bool load_lib(void)
 {
-	PWSTR common_path;
-	if (SHGetKnownFolderPath(FOLDERID_ProgramFilesCommon, 0, NULL,
-				 &common_path) != S_OK) {
-		CA_LOG(LOG_WARNING, "Could not retrieve common files path");
-		return false;
-	}
+	/* -------------------------------------------- */
+	/* attempt to load from path                    */
 
-	struct dstr path = {0};
-	dstr_printf(&path, "%S\\Apple\\Apple Application Support", common_path);
-	CoTaskMemFree(common_path);
-
-	wchar_t *w_path = dstr_to_wcs(&path);
-	dstr_free(&path);
-
-	SetDllDirectory(w_path);
-	bfree(w_path);
-
-#define LOAD_LIB(x, n)            \
-	x = LoadLibrary(TEXT(n)); \
-	if (!x)                   \
-		CA_LOG(LOG_DEBUG, "Failed loading library '" n "'");
-
-	LOAD_LIB(audio_toolbox, "CoreAudioToolbox.dll");
-#undef LOAD_LIB
-
-	SetDllDirectory(NULL);
-
-	if (audio_toolbox)
+	audio_toolbox = LoadLibraryW(L"CoreAudioToolbox.dll");
+	if (!!audio_toolbox)
 		return true;
 
-	release_lib();
+	/* -------------------------------------------- */
+	/* attempt to load from known install locations */
+
+	struct path_list_t {
+		REFKNOWNFOLDERID rfid;
+		const wchar_t *subpath;
+	};
+
+	path_list_t path_list[] = {
+		{FOLDERID_ProgramFilesCommon,
+		 L"Apple\\Apple Application Support"},
+	};
+
+	for (auto &val : path_list) {
+		if (load_from_shell_path(val.rfid, val.subpath)) {
+			return true;
+		}
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
### Description
Fixes issue https://github.com/obsproject/obs-studio/issues/3503
The path of coreaudio dll has changed in current versions of iTunes on windows.
The patch fixes the issue while keeping compatibility with previous path.

### Motivation and Context
Fixes an issue.
Tbf I haven't sought to factor as much code as possible so the code could probably be more elegant.
Note that this fixes path issues for the desktop iTunes app; not for UWP iTunes.

### How Has This Been Tested?
Tested on windows 10, visual studio 2019.
The new path from iTunes is found in obs-studio.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
