### PR TITLE
UI: Detect other instances of OBS on MacOS

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1929,13 +1929,17 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		OBSTranslator translator;
 		program.installTranslator(&translator);
 
-#ifdef _WIN32
 		/* --------------------------------------- */
 		/* check and warn if already running       */
 
 		bool cancel_launch = false;
 		bool already_running = false;
+
+#if defined(_WIN32)
 		RunOnceMutex rom = GetRunOnceMutex(already_running);
+#elif defined(__APPLE__)
+		CheckAppWithSameBundleID(already_running);
+#endif
 
 		if (!already_running) {
 			goto run;
@@ -1979,7 +1983,6 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 
 		/* --------------------------------------- */
 	run:
-#endif
 
 #if !defined(_WIN32) && !defined(__APPLE__) && !defined(__FreeBSD__)
 		// Mounted by termina during chromeOS linux container startup

--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -87,6 +87,29 @@ bool InitApplicationBundle()
 #endif
 }
 
+void CheckAppWithSameBundleID(bool &already_running)
+{
+	try {
+		NSBundle *bundle = [NSBundle mainBundle];
+		if (!bundle)
+			throw "Could not find main bundle";
+
+		NSString *bundleID = [bundle bundleIdentifier];
+		if (!bundleID)
+			throw "Could not find bundle identifier";
+
+		int app_count =
+			[NSRunningApplication
+				runningApplicationsWithBundleIdentifier:bundleID]
+				.count;
+
+		already_running = app_count > 1;
+
+	} catch (const char *error) {
+		blog(LOG_ERROR, "CheckAppWithSameBundleID: %s", error);
+	}
+}
+
 string GetDefaultVideoSavePath()
 {
 	NSFileManager *fm = [NSFileManager defaultManager];

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -68,4 +68,5 @@ void EnableOSXVSync(bool enable);
 void EnableOSXDockIcon(bool enable);
 void InstallNSApplicationSubclass();
 void disableColorSpaceConversion(QWidget *window);
+void CheckAppWithSameBundleID(bool &already_running);
 #endif


### PR DESCRIPTION
### Description
Added logic that checks on MacOS if there any other applications running with same [BundleID](https://developer.apple.com/documentation/appstoreconnectapi/bundle_ids).

### Motivation and Context

fixes: https://github.com/obsproject/obs-studio/issues/3053

### How Has This Been Tested?

One instance of the app was started by clicking on the application icon from Finder, second instance was started from the terminal. As a result "dialog" appear which stated that another instance is already running.
Also tested that flag "--multi" works as expected.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
