### PR TITLE
UI: After source rename, set focus back to label

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -354,6 +354,7 @@ void SourceTreeItem::ExitEditMode(bool save)
 	editor = nullptr;
 	setFocusPolicy(Qt::NoFocus);
 	boxLayout->insertWidget(index, label);
+	label->setFocus();
 
 	/* ----------------------------------------- */
 	/* check for empty string                    */


### PR DESCRIPTION
### Description
Fixes #3465
![obs-3568](https://user-images.githubusercontent.com/5983172/95267970-40c08580-07eb-11eb-8039-4617bde7ae58.gif)

### Motivation and Context
#3465

### How Has This Been Tested?
Manual tested on desktop PC Windows 10 and added asserts to test (removed before check-in but I can add them back if requested). Test steps in issue.

No expected impact on other areas of code, one-line change.

### Types of changes
Bug fix
Adds a setFocus() command when we re-insert the label after the QLineEdit editor has been removed. setFocusPolicy is only for editors so changing NoFocus to StrongFocus didn't work.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
