### PR TITLE
UI: Prevent disabling replay buffer if it's active

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4458,9 +4458,13 @@ void OBSBasicSettings::UpdateAutomaticReplayBufferCheckboxes()
 	switch (ui->outputMode->currentIndex()) {
 	case 0:
 		state = ui->simpleReplayBuf->isChecked();
+		ui->simpleReplayBuf->setEnabled(
+			!obs_frontend_replay_buffer_active());
 		break;
 	case 1:
 		state = ui->advReplayBuf->isChecked();
+		ui->advReplayBuf->setEnabled(
+			!obs_frontend_replay_buffer_active());
 		break;
 	}
 	ui->replayWhileStreaming->setEnabled(state);


### PR DESCRIPTION
### Description
Alters the settings window to prevent the user from disabling the Replay Buffer when it's currently active

### Motivation and Context
I noticed that I could alter this, and it would not be reflected in the UI at all. This added some confusion to whether the application would still function as normal. While the replay buffer was still functioning, it was weird to see granted I had disabled it in settings.
By disabling the checkbox from being altered when it's active, it removes a source of confusion to the end-user

### How Has This Been Tested?
I have tested this in both Simple and Advanced recording mode. The checkbox remained locked when the replaybuffer was active, and returned to a modifiable state when it had been disabled

### Types of changes
- Bug fix (non-breaking change which fixes an issue)


### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
