### PR TITLE
UI: Add duplicate filter

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -732,12 +732,18 @@ void OBSBasicFilters::CustomContextMenu(const QPoint &pos, bool async)
 		popup.addMenu(addMenu);
 
 	if (item) {
+		const char *dulpicateSlot =
+			async ? SLOT(DuplicateAsyncFilter())
+			      : SLOT(DuplicateEffectFilter());
+
 		const char *renameSlot = async ? SLOT(RenameAsyncFilter())
 					       : SLOT(RenameEffectFilter());
 		const char *removeSlot =
 			async ? SLOT(on_removeAsyncFilter_clicked())
 			      : SLOT(on_removeEffectFilter_clicked());
 
+		popup.addSeparator();
+		popup.addAction(QTStr("Duplicate"), this, dulpicateSlot);
 		popup.addSeparator();
 		popup.addAction(QTStr("Rename"), this, renameSlot);
 		popup.addAction(QTStr("Remove"), this, removeSlot);
@@ -764,6 +770,58 @@ void OBSBasicFilters::EditItem(QListWidgetItem *item, bool async)
 	editActive = true;
 }
 
+void OBSBasicFilters::DuplicateItem(QListWidgetItem *item)
+{
+	OBSSource filter = item->data(Qt::UserRole).value<OBSSource>();
+	string name = obs_source_get_name(filter);
+	obs_source_t *existing_filter;
+
+	QString placeholder = QString::fromStdString(name);
+	QString text{placeholder};
+	int i = 2;
+	while ((existing_filter = obs_source_get_filter_by_name(
+			source, QT_TO_UTF8(text)))) {
+		obs_source_release(existing_filter);
+		text = QString("%1 %2").arg(placeholder).arg(i++);
+	}
+
+	bool success = NameDialog::AskForName(
+		this, QTStr("Basic.Filters.AddFilter.Title"),
+		QTStr("Basic.Filters.AddFilter.Text"), name, text);
+	if (!success)
+		return;
+
+	if (name.empty()) {
+		OBSMessageBox::warning(this, QTStr("NoNameEntered.Title"),
+				       QTStr("NoNameEntered.Text"));
+		DuplicateItem(item);
+		return;
+	}
+
+	existing_filter = obs_source_get_filter_by_name(source, name.c_str());
+	if (existing_filter) {
+		OBSMessageBox::warning(this, QTStr("NameExists.Title"),
+				       QTStr("NameExists.Text"));
+		obs_source_release(existing_filter);
+		DuplicateItem(item);
+		return;
+	}
+	bool enabled = obs_source_enabled(filter);
+	obs_source_t *new_filter =
+		obs_source_duplicate(filter, name.c_str(), false);
+	if (new_filter) {
+		const char *sourceName = obs_source_get_name(source);
+		const char *id = obs_source_get_id(new_filter);
+		blog(LOG_INFO,
+		     "User duplicated filter '%s' (%s) from '%s' "
+		     "to source '%s'",
+		     name.c_str(), id, name.c_str(), sourceName);
+		obs_source_set_enabled(new_filter, enabled);
+		obs_source_filter_add(source, new_filter);
+		obs_source_release(new_filter);
+	}
+}
+
 void OBSBasicFilters::on_asyncFilters_customContextMenuRequested(
 	const QPoint &pos)
 {
@@ -784,6 +842,16 @@ void OBSBasicFilters::RenameAsyncFilter()
 void OBSBasicFilters::RenameEffectFilter()
 {
 	EditItem(ui->effectFilters->currentItem(), false);
+}
+
+void OBSBasicFilters::DuplicateAsyncFilter()
+{
+	DuplicateItem(ui->asyncFilters->currentItem());
+}
+
+void OBSBasicFilters::DuplicateEffectFilter()
+{
+	DuplicateItem(ui->effectFilters->currentItem());
 }
 
 void OBSBasicFilters::FilterNameEdited(QWidget *editor, QListWidget *list)

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -67,6 +67,7 @@ private:
 
 	void CustomContextMenu(const QPoint &pos, bool async);
 	void EditItem(QListWidgetItem *item, bool async);
+	void DuplicateItem(QListWidgetItem *item);
 
 	void FilterNameEdited(QWidget *editor, QListWidget *list);
 
@@ -82,6 +83,8 @@ private slots:
 	void ReorderFilters();
 	void RenameAsyncFilter();
 	void RenameEffectFilter();
+	void DuplicateAsyncFilter();
+	void DuplicateEffectFilter();
 	void ResetFilters();
 
 	void AddFilterFromAction();


### PR DESCRIPTION
### Description
Add option to duplicate a filter
![image](https://user-images.githubusercontent.com/5457024/95549991-7b533980-0a08-11eb-899c-4f700e52e106.png)


### Motivation and Context
If you want multiple filters with almost the same settings you have to copy all properties of the filter 1 by 1, now you can duplicate the filter and only set the properties that are different in the new filter.

### How Has This Been Tested?
On windows 64 bit by duplicating multiple filters and testing you can not create 2 filters with the same name.

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
 - New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
