### PR TITLE
UI: Fix text clipping on non-English locales in certain locations

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -100,7 +100,7 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 		setThemeID(active, "error");
 	activeContainer->layout()->addWidget(active);
 	activeContainer->layout()->setAlignment(active, Qt::AlignVCenter);
-	activeContainer->setFixedWidth(50);
+	activeContainer->setFixedWidth(120);
 
 	volume->setMinimum(MIN_DB - 0.1);
 	volume->setMaximum(MAX_DB);


### PR DESCRIPTION
### Description
Fixes: #3514

<img width="579" alt="スクリーンショット 2020-10-12 21 02 41" src="https://user-images.githubusercontent.com/5316909/95744563-78896a80-0cce-11eb-955a-b40887ffee83.png">

### Motivation and Context
#3514

### How Has This Been Tested?
Manual tested on MacOS in all languages. No expected impact on other areas of code, one-line change. Test steps in issue.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
