### PR TITLE
UI: Keep showing time label when paused

### DIFF
--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -521,9 +521,8 @@ void OBSBasicStatusBar::RecordingStopped()
 
 void OBSBasicStatusBar::RecordingPaused()
 {
-	QString text = QStringLiteral("REC: PAUSED");
+	QString text = recordTime->text() + QStringLiteral(" (PAUSED)");
 	recordTime->setText(text);
-	recordTime->setMinimumWidth(recordTime->width());
 
 	if (recordOutput) {
 		recordIcon->setPixmap(recordingPausePixmap);


### PR DESCRIPTION
### Description
This shows the time with PAUSED label when recording is paused. Example: `00:05:21 (PAUSED)`.

### Motivation and Context
With there being a pause icon now, I believe that it is more useful to just show the record time.

### How Has This Been Tested?
Paused recording and made sure that the label was shown properly.

### Types of changes
- UI tweak

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
