### PR TITLE
UI: Fix replay buffer saved event in advanced mode

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1182,6 +1182,8 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 			replayBufferStopping.Connect(signal, "stopping",
 						     OBSReplayBufferStopping,
 						     this);
+			replayBufferSaved.Connect(signal, "saved",
+						  OBSReplayBufferSaved, this);
 		}
 
 		fileOutput = obs_output_create(


### PR DESCRIPTION


### Description

`AdvancedOutput::AdvancedOutput(OBSBasic *main_)` lacked a proper event handler connection which caused a bug where `OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED` wasn't emitted in the advanced output mode.

### Motivation and Context
A very simple bug-fix in the front-end API.

### How Has This Been Tested?
On Arch Linux VM with a plugin listening to the event.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
