### PR TITLE
UI: Add ability to toggle studio mode controls

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -609,6 +609,7 @@ Basic.MainMenu.View.SceneTransitions="S&cene Transitions"
 Basic.MainMenu.View.SourceIcons="Source &Icons"
 Basic.MainMenu.View.StatusBar="&Status Bar"
 Basic.MainMenu.View.Fullscreen.Interface="Fullscreen Interface"
+Basic.MainMenu.View.StudioModeControls="Studio Mode Controls"
 
 # basic mode profile/scene collection menus
 Basic.MainMenu.SceneCollection="&Scene Collection"

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -628,6 +628,7 @@
     <addaction name="toggleContextBar"/>
     <addaction name="toggleSourceIcons"/>
     <addaction name="toggleStatusBar"/>
+    <addaction name="toggleStudioModeControls"/>
     <addaction name="separator"/>
     <addaction name="stats"/>
    </widget>
@@ -2003,6 +2004,17 @@
    </property>
    <property name="text">
     <string>Basic.MainMenu.View.ContextBar</string>
+   </property>
+  </action>
+  <action name="toggleStudioModeControls">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Basic.MainMenu.View.StudioModeControls</string>
    </property>
   </action>
  </widget>

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -448,6 +448,8 @@ bool OBSApp::InitGlobalConfigDefaults()
 				true);
 	config_set_default_bool(globalConfig, "BasicWindow", "StudioModeLabels",
 				true);
+	config_set_default_bool(globalConfig, "BasicWindow",
+				"ShowStudioModeControls", true);
 
 	if (!config_get_bool(globalConfig, "General", "Pre21Defaults")) {
 		config_set_default_string(globalConfig, "General",

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1444,6 +1444,11 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		ui->previewLayout->setAlignment(programOptions,
 						Qt::AlignCenter);
 
+		bool visible = config_get_bool(App()->GlobalConfig(),
+					       "BasicWindow",
+					       "ShowStudioModeControls");
+		programOptions->setVisible(visible);
+
 		if (api)
 			api->on_event(OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED);
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1748,6 +1748,10 @@ void OBSBasic::OBSInit()
 		GetGlobalConfig(), "BasicWindow", "ShowSourceIcons");
 	ui->toggleSourceIcons->setChecked(sourceIconsVisible);
 
+	bool studioModeControlsVisible = config_get_bool(
+		GetGlobalConfig(), "BasicWindow", "ShowStudioModeControls");
+	ui->toggleStudioModeControls->setChecked(studioModeControlsVisible);
+
 	if (config_has_user_value(App()->GlobalConfig(), "BasicWindow",
 				  "ShowContextToolbars")) {
 		bool visible = config_get_bool(App()->GlobalConfig(),
@@ -7380,6 +7384,15 @@ void OBSBasic::on_toggleSourceIcons_toggled(bool visible)
 
 	config_set_bool(App()->GlobalConfig(), "BasicWindow", "ShowSourceIcons",
 			visible);
+}
+
+void OBSBasic::on_toggleStudioModeControls_toggled(bool visible)
+{
+	if (programOptions)
+		programOptions->setVisible(visible);
+
+	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+			"ShowStudioModeControls", visible);
 }
 
 void OBSBasic::on_actionLockPreview_triggered()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -949,6 +949,7 @@ private slots:
 	void on_toggleContextBar_toggled(bool visible);
 	void on_toggleStatusBar_toggled(bool visible);
 	void on_toggleSourceIcons_toggled(bool visible);
+	void on_toggleStudioModeControls_toggled(bool visible);
 
 	void on_transitions_currentIndexChanged(int index);
 	void on_transitionRemove_clicked();


### PR DESCRIPTION
### Description
This adds the ability to toggle the view of the studio
mode controls.

### Motivation and Context
https://ideas.obsproject.com/posts/1129/studio-mode-ability-to-hide-transition-panel

### How Has This Been Tested?
Toggled the option in the view menu and made sure the controls were hidden/shown as expected.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
