### PR TITLE
CI: Update macOS build script to support alternative build configs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,15 @@ jobs:
       - name: 'Install prerequisites (Homebrew)'
         shell: bash
         run: |
-          brew update --preinstall
+          if [ -d /usr/local/opt/openssl@1.0.2t ]; then
+              brew uninstall openssl@1.0.2t
+              brew untap local/openssl
+          fi
+
+          if [ -d /usr/local/opt/python@2.7.17 ]; then
+              brew uninstall python@2.7.17
+              brew untap local/python2
+          fi
           brew bundle --file ./CI/scripts/macos/Brewfile
       - name: 'Restore Chromium Embedded Framework from cache'
         id: cef-cache


### PR DESCRIPTION
### Description
When generating a build environment that supports multiple build configurations (e.g. Xcode) the directory structure assumed by the build script for bundling might not exist.

This change introduces an additional environment parameter `BUILD_CONFIG` that allows to specify the build dir and falls back to `RelWithDebInfo` if not supplied.

Additionally the `brew update` command before `brew bundle` is now in sync with GitHub Actions and _might_ also fix current Azure CI issues with macOS.

### Motivation and Context
When building/debugging OBS with Xcode, this change allows quick and easy bundling of the project e.g. by specifying the `Debug` build directory.

### How Has This Been Tested?
* Tested with an Xcode project and multiple build configs as well as no specific build config

### Types of changes
- New feature (non-breaking change which adds functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
