### PR TITLE
libobs: Add desktop session type to Linux log

### DIFF
--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -312,6 +312,14 @@ static void log_distribution_info(void)
 	dstr_free(&distro);
 	free(line);
 }
+
+static void log_desktop_session_info(void)
+{
+	char *session_ptr = getenv("XDG_SESSION_TYPE");
+	if (session_ptr) {
+		blog(LOG_INFO, "Session Type: %s", session_ptr);
+	}
+}
 #endif
 
 void log_system_info(void)
@@ -324,6 +332,7 @@ void log_system_info(void)
 	log_kernel_version();
 #if defined(__linux__)
 	log_distribution_info();
+	log_desktop_session_info();
 #endif
 	log_x_info();
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add the content of the XDG_SESSION_TYPE environment variable to
the output log if it is set. This is usually set on modern Linux
distributions and typically carry either "x11" or "wayland" when
run from a desktop environment.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This is independent from the QT_QPA_PLATFORM environment variable
which would allow OBS Studio to run inside a wayland session. The
session type it runs on does have an implication on the behavior of
some plugins like screen and window capture. So having this
information exposed here is extremely helpful for diagnosing
issues.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Build and run on Linux with x11 and wayland sessions as well as a negative, from inside docker.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
