### PR TITLE
UI: Detect other instances of obs on Linux

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1939,6 +1939,8 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		RunOnceMutex rom = GetRunOnceMutex(already_running);
 #elif defined(__APPLE__)
 		CheckAppWithSameBundleID(already_running);
+#elif defined (__linux__)
+		RunningInstanceCheck(already_running);
 #endif
 
 		if (!already_running) {

--- a/UI/platform-x11.cpp
+++ b/UI/platform-x11.cpp
@@ -46,8 +46,8 @@ void RunningInstanceCheck(bool &already_running)
 	}
 
 	struct sockaddr bindInfo = {0};
-    bindInfo.sa_family = AF_LOCAL;
-    memmove(bindInfo.sa_data+1, "obs", strlen("obs"));
+	bindInfo.sa_family = AF_LOCAL;
+	memmove(bindInfo.sa_data+1, "obs", strlen("obs"));
 
 	int bindErr = bind(uniq, &bindInfo, sizeof(struct sockaddr));
 

--- a/UI/platform-x11.cpp
+++ b/UI/platform-x11.cpp
@@ -27,7 +27,33 @@
 #include <locale.h>
 
 #include "platform.hpp"
+
+#ifdef __linux__
+#include <sys/socket.h>
+#include <string.h>
+#endif
+
 using namespace std;
+
+
+#ifdef __linux__
+void RunningInstanceCheck(bool &already_running)
+{
+	int uniq = socket(AF_LOCAL, SOCK_DGRAM, 0);
+
+	if (uniq == -1) {
+		blog(LOG_ERROR, "socket: %i", errno);
+	}
+
+	struct sockaddr bindInfo = {0};
+    bindInfo.sa_family = AF_LOCAL;
+    memmove(bindInfo.sa_data+1, "obs", strlen("obs"));
+
+	int bindErr = bind(uniq, &bindInfo, sizeof(struct sockaddr));
+
+	already_running = bindErr == 0 ? 0 : 1;
+}
+#endif
 
 static inline bool check_path(const char *data, const char *path,
 			      string &output)

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -70,3 +70,6 @@ void InstallNSApplicationSubclass();
 void disableColorSpaceConversion(QWidget *window);
 void CheckAppWithSameBundleID(bool &already_running);
 #endif
+#ifdef __linux
+void RunningInstanceCheck(bool &already_running);
+#endif


### PR DESCRIPTION
fixes: https://github.com/obsproject/obs-studio/issues/3053

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This patch implements multiple instance detection on linux, by binding an
anonymous local socket. Additional instances will fail to bind. An advantage
to using a anonymous socket is that it will never be written to disk namespace
and the socket is automatically destroyed if OBS crashes. The drawback of
this approach is that it is not portable to FreeBSD.
 
### Motivation and Context
This patch allows obs to detect multiple instances on linux
https://github.com/obsproject/obs-studio/issues/3053

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tried to open multiple copies of OBS on computer, without patch the warning prompt does not appear.
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
Intel(R) Core(TM) i5-2520M
AMD CAICOS (DRM 2.50.0 / 5.9.0, LLVM 5.0.2)
Fedora 23

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
