### PR TITLE
UI: Detect other instances of obs on Linux

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1939,6 +1939,8 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		RunOnceMutex rom = GetRunOnceMutex(already_running);
 #elif defined(__APPLE__)
 		CheckAppWithSameBundleID(already_running);
+#elif defined(__linux__)
+		RunningInstanceCheck(already_running);
 #endif
 
 		if (!already_running) {

--- a/UI/platform-x11.cpp
+++ b/UI/platform-x11.cpp
@@ -27,7 +27,69 @@
 #include <locale.h>
 
 #include "platform.hpp"
+
+#ifdef __linux__
+#include <sys/socket.h>
+#include <string.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <sys/un.h>
+#endif
+
 using namespace std;
+
+#ifdef __linux__
+void RunningInstanceCheck(bool &already_running)
+{
+	int uniq = socket(AF_LOCAL, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+
+	if (uniq == -1) {
+		blog(LOG_ERROR,
+		     "Failed to check for running instance, socket: %d", errno);
+		already_running = 0;
+		return;
+	}
+
+	struct sockaddr_un bindInfo;
+	memset(&bindInfo, 0, sizeof(sockaddr_un));
+	bindInfo.sun_family = AF_LOCAL;
+	char *abstactSockName = NULL;
+	asprintf(&abstactSockName, "%s %d %s", "/com/obsproject", getpid(),
+		 App()->GetVersionString().c_str());
+	memmove(bindInfo.sun_path + 1, abstactSockName,
+		strlen(abstactSockName));
+	free(abstactSockName);
+
+	int bindErr = bind(uniq, (struct sockaddr *)&bindInfo,
+			   sizeof(struct sockaddr_un));
+	already_running = bindErr == 0 ? 0 : 1;
+
+	if (already_running) {
+		return;
+	}
+
+	FILE *fp = fopen("/proc/net/unix", "re");
+
+	if (fp == NULL) {
+		return;
+	}
+
+	char *line = NULL;
+	size_t n = 0;
+	int obsCnt = 0;
+	while (getdelim(&line, &n, ' ', fp) != EOF) {
+		line[strcspn(line, "\n")] = '\0';
+		if (*line == '@') {
+			if (strstr(line, "@/com/obsproject") != NULL) {
+				++obsCnt;
+			}
+		}
+	}
+	already_running = obsCnt == 1 ? 0 : 1;
+	free(line);
+	fclose(fp);
+}
+#endif
 
 static inline bool check_path(const char *data, const char *path,
 			      string &output)

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -70,3 +70,6 @@ void InstallNSApplicationSubclass();
 void disableColorSpaceConversion(QWidget *window);
 void CheckAppWithSameBundleID(bool &already_running);
 #endif
+#ifdef __linux__
+void RunningInstanceCheck(bool &already_running);
+#endif


### PR DESCRIPTION
fixes: obsproject#3053

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Detect multiple instances of OBS using anonymous socket the first instance
will be able to bind, subsequent instances will not. An advantage of this approach
is that the socket will be automatically be deleted if OBS crashes and the
socket will never be saved to disk. This disadvantage of this approach is that is not
portable to FreeBSD.
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Include details of your testing environment (hardware, OS version, etc.)
Intel(R) Xeon(R) CPU E5-2697 
Fedora 23
<!--- and the tests you ran, including how it may affect other areas of code. -->
Opened multiple copies of OBS and received prompt about multiple instances which does
not happen on linux without this patch.
### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
        - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
