### PR TITLE
mac-virtualcam: Update locales

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/data/locale/en-US.ini
+++ b/plugins/mac-virtualcam/src/obs-plugin/data/locale/en-US.ini
@@ -1,5 +1,1 @@
-UnsupportedResolution_Title="Unsupported resolution"
-UnsupportedResolution_Main="Your output resolution not supported. Please use one of the following:"
-VirtualCamera_Start="Start Virtual Camera"
-VirtualCamera_Stop="Stop Virtual Camera"
 Plugin_Name="macOS Virtual Webcam"

--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -108,7 +108,7 @@ static bool check_dal_plugin()
 static const char *virtualcam_output_get_name(void *type_data)
 {
 	(void)type_data;
-	return obs_module_text("macOS Virtual Webcam");
+	return obs_module_text("Plugin_Name");
 }
 
 // This is a dummy pointer so we have something to return from virtualcam_output_create


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The plugin only uses one of the locales defined, the other ones can be removed.
This also makes the plugin actually use the one remaining string.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
A discussion on Discord revealed that most of the locales aren't used and the one that should be used isn't actually called. 
This addresses these issues.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built successfully on my computer
macOS 11.0.1 Beta (20B5012d)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
I'm honest, I didn't, cause I don't know how (I don't see how anything should have changed though). Edit: Since the Clang Format Check says its ok I'm ticking this field as well.
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
