### PR TITLE
UI: Detect other instances of obs on FreeBSD

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -132,6 +132,11 @@ elseif(UNIX)
 
         set(obs_PLATFORM_LIBRARIES
                 Qt5::X11Extras)
+
+	if("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
+		list(APPEND obs_PLATFORM_LIBRARIES
+			procstat)
+	endif()
 endif()
 
 if(BROWSER_AVAILABLE_INTERNAL)

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1943,6 +1943,8 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		CheckAppWithSameBundleID(already_running);
 #elif defined(__linux__)
 		RunningInstanceCheck(already_running);
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
+		PIDFileCheck(already_running);
 #endif
 
 		if (!already_running) {

--- a/UI/platform-x11.cpp
+++ b/UI/platform-x11.cpp
@@ -35,6 +35,17 @@
 #include <stdio.h>
 #include <sys/un.h>
 #endif
+#if defined(__FreeBSD__) || defined(__DragonFly__)
+#include <sys/param.h>
+#include <fcntl.h>
+#include <sys/sysctl.h>
+#include <sys/user.h>
+#include <libprocstat.h>
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#endif
 
 using namespace std;
 
@@ -88,6 +99,75 @@ void RunningInstanceCheck(bool &already_running)
 	already_running = obsCnt == 1 ? 0 : 1;
 	free(line);
 	fclose(fp);
+}
+#endif
+#if defined(__FreeBSD__) || defined(__DragonFly__)
+struct RunOnce {
+	std::thread thr;
+	static const char *thr_name;
+	std::condition_variable cv;
+	std::condition_variable wait_cv;
+	std::mutex mtx;
+	bool exiting = false;
+	bool name_changed = false;
+
+	void thr_proc()
+	{
+		std::unique_lock<std::mutex> lk(mtx);
+		pthread_setname_np(pthread_self(), thr_name);
+		name_changed = true;
+		wait_cv.notify_all();
+		cv.wait(lk, [this]() { return exiting; });
+	}
+
+	~RunOnce()
+	{
+		if (thr.joinable()) {
+			std::unique_lock<std::mutex> lk(mtx);
+			exiting = true;
+			cv.notify_one();
+			lk.unlock();
+			thr.join();
+		}
+	}
+} RO;
+const char *RunOnce::thr_name = "OBS runonce";
+
+void PIDFileCheck(bool &already_running)
+{
+	std::string tmpfile_name =
+		"/tmp/obs-studio.lock." + to_string(geteuid());
+	int fd = open(tmpfile_name.c_str(), O_RDWR | O_CREAT | O_EXLOCK, 0600);
+	if (fd == -1) {
+		already_running = true;
+		return;
+	}
+
+	already_running = false;
+
+	procstat *ps = procstat_open_sysctl();
+	unsigned int count;
+	auto procs = procstat_getprocs(ps, KERN_PROC_UID | KERN_PROC_INC_THREAD,
+				       geteuid(), &count);
+	for (unsigned int i = 0; i < count; i++) {
+		if (!strncmp(procs[i].ki_tdname, RunOnce::thr_name,
+			     sizeof(procs[i].ki_tdname))) {
+			already_running = true;
+			break;
+		}
+	}
+	procstat_freeprocs(ps, procs);
+	procstat_close(ps);
+
+	RO.thr = std::thread(std::mem_fn(&RunOnce::thr_proc), &RO);
+
+	{
+		std::unique_lock<std::mutex> lk(RO.mtx);
+		RO.wait_cv.wait(lk, []() { return RO.name_changed; });
+	}
+
+	unlink(tmpfile_name.c_str());
+	close(fd);
 }
 #endif
 

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -73,3 +73,6 @@ void CheckAppWithSameBundleID(bool &already_running);
 #ifdef __linux__
 void RunningInstanceCheck(bool &already_running);
 #endif
+#if defined(__FreeBSD__) || defined(__DragonFly__)
+void PIDFileCheck(bool &already_running);
+#endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change is an attempt to fix 3053 on FreeBSD. This change detects other instances of the obs by creating a dummy thread named `OBS runonce`. This should be usable on FreeBSD and possibly compile on DragonFly.

Since the td_name detection happens before thread spawning. To account for the case that multiple OBS instances started simultaneously and they fetched the thread list at the same time, an exclusive file advisory lock would be acquired in open(), so that only one instance is allowed to scan the threads list of the current user.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open Mantis issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
To fix #3053 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Running OBS in the same user more than one time.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
