### PR TITLE
Don't update the source context bar when it is hidden

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -360,8 +360,6 @@ OBSBasic::OBSBasic(QWidget *parent)
 
 	QPoint curPos;
 
-	UpdateContextBar();
-
 	//restore parent window geometry
 	const char *geometry = config_get_string(App()->GlobalConfig(),
 						 "BasicWindow", "geometry");
@@ -1755,6 +1753,8 @@ void OBSBasic::OBSInit()
 					       "ShowContextToolbars");
 		ui->toggleContextBar->setChecked(visible);
 		ui->contextContainer->setVisible(visible);
+		if (visible)
+			UpdateContextBar(true);
 	} else {
 		ui->toggleContextBar->setChecked(true);
 		ui->contextContainer->setVisible(true);
@@ -2929,8 +2929,11 @@ static bool is_network_media_source(obs_source_t *source, const char *id)
 	return !is_local_file;
 }
 
-void OBSBasic::UpdateContextBar()
+void OBSBasic::UpdateContextBar(bool force)
 {
+	if (!ui->contextContainer->isVisible() && !force)
+		return;
+
 	OBSSceneItem item = GetCurrentSceneItem();
 
 	ClearContextBar();
@@ -7362,6 +7365,7 @@ void OBSBasic::on_toggleContextBar_toggled(bool visible)
 	config_set_bool(App()->GlobalConfig(), "BasicWindow",
 			"ShowContextToolbars", visible);
 	this->ui->contextContainer->setVisible(visible);
+	UpdateContextBar(true);
 }
 
 void OBSBasic::on_toggleStatusBar_toggled(bool visible)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1023,7 +1023,7 @@ public slots:
 	bool ReplayBufferActive();
 
 	void ClearContextBar();
-	void UpdateContextBar();
+	void UpdateContextBar(bool force = false);
 
 public:
 	explicit OBSBasic(QWidget *parent = 0);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
If the source toolbar is hidden, there doesn't seem to be any point in fetching and updating properties every time the source selection changes.

### Motivation and Context
A user [ran into an issue](https://github.com/obsproject/obs-studio/issues/3673#issuecomment-719996332) caused by a source toolbar interaction with display capture. Even after hiding the source toolbar, the issue persisted which is somewhat unexpected behavior.

### How Has This Been Tested?
Toggled source toolbar on and off at various times with various sources selected and deselected, toolbar remained accurate.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
