### PR TITLE
vlc-video: Use case insensitive compare for valid extension check

### DIFF
--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -554,7 +554,7 @@ static bool valid_extension(const char *ext)
 		else
 			dstr_copy(&test, b);
 
-		if (dstr_cmp(&test, ext) == 0) {
+		if (dstr_cmpi(&test, ext) == 0) {
 			valid = true;
 			break;
 		}


### PR DESCRIPTION
### Description

The list of valid file extensions in the VLC Source was stored lowercase, and this check was being done with the assumption that filenames were too. This PR switches the check from case sensitive to case insensitive.

Fixes #3562

### Motivation and Context

It's possible for files to have some/all characters uppercase. Such files were being ignored by the "Add Directory" option.

### How Has This Been Tested?

Create a folder with a .MP4 file. In the VLC Source, add the directory and see the file doesn't play (even after saving the Properties). After applying this change, try again - this time the file will play.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
