### PR TITLE
linux-v4l2: avoid OOB write

### DIFF
--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -97,15 +97,12 @@ static bool try_connect(void *data, int device)
 	struct obs_video_info ovi;
 	obs_get_video_info(&ovi);
 
+	memset(&parm, 0, sizeof(parm));
 	parm.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
 
 	parm.parm.output.capability = V4L2_CAP_TIMEPERFRAME;
 	parm.parm.output.timeperframe.numerator = ovi.fps_den;
 	parm.parm.output.timeperframe.denominator = ovi.fps_num;
-	parm.parm.output.outputmode = 0;
-	parm.parm.output.writebuffers = 0;
-	parm.parm.output.extendedmode = 0;
-	parm.parm.output.reserved[4] = 0;
 
 	if (ioctl(vcam->device, VIDIOC_S_PARM, &parm) < 0)
 		return false;


### PR DESCRIPTION
### Description
v4l2_outputparm includes unused fields, defined as
```
	__u32		reserved[4]
```

Accesses to reserved[4] was out of bounds.  Fix this and simplify by
just zeroing the entire struct v4l2_streamparm instead.

### Motivation and Context
Issue was reported as a Clang warning compiling on FreeBSD

### How Has This Been Tested?
So far, compile-tested on FreeBSD -CURRENT

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
