### PR TITLE
deps/media-playback: Fix possible negative duration

### DIFF
--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -246,7 +246,7 @@ void mp_decode_push_packet(struct mp_decode *decode, AVPacket *packet)
 static inline int64_t get_estimated_duration(struct mp_decode *d,
 					     int64_t last_pts)
 {
-	if (last_pts)
+	if (last_pts && (d->frame_pts >= last_pts))
 		return d->frame_pts - last_pts;
 
 	if (d->audio) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Ensure that get_estimated_duration does not calculate a negative
duration based on pts, but instead falls back to other estimations.

### Motivation and Context
In cases where some frames have no pts but following frames again have a pts that
could be smaller than the current estimated one, the `get_estimated_duration` function
could calculate a negative duration, which breaks other calculations in media.c.

This does _not_ solve that some files can trigger the assert in `mp_media_calc_next_ns`,
this can still happen.

### How Has This Been Tested?
Tested on macOS with various media files with OBS linked against ffmpeg master.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
