### PR TITLE
libobs-d3d11: Default to Intel IGPU on IGPU+DGPU systems

### DIFF
--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -478,7 +478,8 @@ try {
 
 	/* ----------------------------------------------------------------- */
 
-	InitFactory(adpIdx);
+	InitFactory();
+	InitAdapter(adpIdx);
 
 	uint32_t createFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
 	hr = D3D11CreateDevice(adapter, D3D_DRIVER_TYPE_UNKNOWN, nullptr,

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -232,7 +232,7 @@ void gs_device::InitCompiler()
 	      "DirectX components</a> that OBS Studio requires.";
 }
 
-void gs_device::InitFactory(uint32_t adapterIdx)
+void gs_device::InitFactory()
 {
 	HRESULT hr;
 	IID factoryIID = (GetWinVer() >= 0x602) ? dxgiFactory2
@@ -241,8 +241,11 @@ void gs_device::InitFactory(uint32_t adapterIdx)
 	hr = CreateDXGIFactory1(factoryIID, (void **)factory.Assign());
 	if (FAILED(hr))
 		throw UnsupportedHWError("Failed to create DXGIFactory", hr);
+}
 
-	hr = factory->EnumAdapters1(adapterIdx, &adapter);
+void gs_device::InitAdapter(uint32_t adapterIdx)
+{
+	HRESULT hr = factory->EnumAdapters1(adapterIdx, &adapter);
 	if (FAILED(hr))
 		throw UnsupportedHWError("Failed to enumerate DXGIAdapter", hr);
 }
@@ -787,7 +790,8 @@ gs_device::gs_device(uint32_t adapterIdx)
 	}
 
 	InitCompiler();
-	InitFactory(adapterIdx);
+	InitFactory();
+	InitAdapter(adapterIdx);
 	InitDevice(adapterIdx);
 	device_set_render_target(this, NULL, NULL);
 }

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -243,6 +243,45 @@ void gs_device::InitFactory()
 		throw UnsupportedHWError("Failed to create DXGIFactory", hr);
 }
 
+#define VENDOR_ID_INTEL 0x8086
+#define IGPU_MEM (512 * 1024 * 1024)
+
+void gs_device::ReorderAdapters(uint32_t &adapterIdx)
+{
+	std::vector<uint32_t> adapterOrder;
+	ComPtr<IDXGIAdapter> adapter;
+	DXGI_ADAPTER_DESC desc;
+	uint32_t iGPUIndex = 0;
+	bool hasIGPU = false;
+	bool hasDGPU = false;
+	int idx = 0;
+
+	while (SUCCEEDED(factory->EnumAdapters(idx, &adapter))) {
+		if (SUCCEEDED(adapter->GetDesc(&desc))) {
+			if (desc.VendorId == VENDOR_ID_INTEL) {
+				if (desc.DedicatedVideoMemory <= IGPU_MEM) {
+					hasIGPU = true;
+					iGPUIndex = (uint32_t)idx;
+				} else {
+					hasDGPU = true;
+				}
+			}
+		}
+
+		adapterOrder.push_back((uint32_t)idx++);
+	}
+
+	/* Intel specific adapter check for Intel integrated and Intel
+	 * dedicated. If both exist, then change adapter priority so that the
+	 * integrated comes first for the sake of improving overall
+	 * performance */
+	if (hasIGPU && hasDGPU) {
+		adapterOrder.erase(adapterOrder.begin() + iGPUIndex);
+		adapterOrder.insert(adapterOrder.begin(), iGPUIndex);
+		adapterIdx = adapterOrder[adapterIdx];
+	}
+}
+
 void gs_device::InitAdapter(uint32_t adapterIdx)
 {
 	HRESULT hr = factory->EnumAdapters1(adapterIdx, &adapter);
@@ -791,6 +830,7 @@ gs_device::gs_device(uint32_t adapterIdx)
 
 	InitCompiler();
 	InitFactory();
+	ReorderAdapters(adapterIdx);
 	InitAdapter(adapterIdx);
 	InitDevice(adapterIdx);
 	device_set_render_target(this, NULL, NULL);

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -1005,6 +1005,7 @@ struct gs_device {
 
 	void InitCompiler();
 	void InitFactory();
+	void ReorderAdapters(uint32_t &adapterIdx);
 	void InitAdapter(uint32_t adapterIdx);
 	void InitDevice(uint32_t adapterIdx);
 

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -1004,7 +1004,8 @@ struct gs_device {
 	gs_obj *first_obj = nullptr;
 
 	void InitCompiler();
-	void InitFactory(uint32_t adapterIdx);
+	void InitFactory();
+	void InitAdapter(uint32_t adapterIdx);
 	void InitDevice(uint32_t adapterIdx);
 
 	ID3D11DepthStencilState *AddZStencilState();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This update is for Intel systems with integrated and discrete graphics only. Windows 10 20H1 runs OBS on the dGPU by default due to Windows D-list setting. It would be better to run on the iGPU by default.  

### Motivation and Context
Better performance on systems with both Intel iGPU and dGPU

### How Has This Been Tested?
Tested on CFL system with non-Intel discrete graphics and CFL system with Intel discrete graphics. Works as expected. Only sets default to integrated graphics on systems with both iGPU and dGPU.

### Types of changes
Adds a check for Intel systems with both integrated and discrete graphics. If so, sets adapter to Intel integrated graphics.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
