### PR TITLE
Add Python 3.8+ support, restore scripting on macOS CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,7 @@ jobs:
           mkdir ./build
           cd ./build
           LEGACY_BROWSER="$(test "${{ env.CEF_BUILD_VERSION }}" -le 3770 && echo "ON" || echo "OFF")"
-          cmake -DENABLE_UNIT_TESTS=YES -DENABLE_SPARKLE_UPDATER=ON -DDISABLE_PYTHON=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ env.MIN_MACOS_VERSION }} -DQTDIR="/tmp/obsdeps" -DSWIGDIR="/tmp/obsdeps" -DDepsPath="/tmp/obsdeps" -DVLCPath="${{ github.workspace }}/cmbuild/vlc-${{ env.VLC_VERSION }}" -DENABLE_VLC=ON -DBUILD_BROWSER=ON -DBROWSER_LEGACY=$LEGACY_BROWSER -DWITH_RTMPS=ON -DCEF_ROOT_DIR="${{ github.workspace }}/cmbuild/cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64" ..
+          cmake -DENABLE_UNIT_TESTS=YES -DENABLE_SPARKLE_UPDATER=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ env.MIN_MACOS_VERSION }} -DQTDIR="/tmp/obsdeps" -DSWIGDIR="/tmp/obsdeps" -DDepsPath="/tmp/obsdeps" -DVLCPath="${{ github.workspace }}/cmbuild/vlc-${{ env.VLC_VERSION }}" -DENABLE_VLC=ON -DBUILD_BROWSER=ON -DBROWSER_LEGACY=$LEGACY_BROWSER -DWITH_RTMPS=ON -DCEF_ROOT_DIR="${{ github.workspace }}/cmbuild/cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64" ..
       - name: 'Build'
         shell: bash
         working-directory: ${{ github.workspace }}/build
@@ -188,8 +188,8 @@ jobs:
 
           if [ -d ./OBS.app/Contents/Resources/data/obs-scripting ]; then
             mv ./OBS.app/Contents/Resources/data/obs-scripting/obslua.so ./OBS.app/Contents/MacOS/
-            # mv ./OBS.app/Contents/Resources/data/obs-scripting/_obspython.so ./OBS.app/Contents/MacOS/
-            # mv ./OBS.app/Contents/Resources/data/obs-scripting/obspython.py ./OBS.app/Contents/MacOS/
+            mv ./OBS.app/Contents/Resources/data/obs-scripting/_obspython.so ./OBS.app/Contents/MacOS/
+            mv ./OBS.app/Contents/Resources/data/obs-scripting/obspython.py ./OBS.app/Contents/MacOS/
             rm -rf ./OBS.app/Contents/Resources/data/obs-scripting/
           fi
 
@@ -214,6 +214,7 @@ jobs:
             ./OBS.app/Contents/PlugIns/rtmp-services.so
             ./OBS.app/Contents/MacOS/obs-ffmpeg-mux
             ./OBS.app/Contents/MacOS/obslua.so
+            ./OBS.app/Contents/MacOS/_obspython.so
             ./OBS.app/Contents/PlugIns/obs-x264.so
             ./OBS.app/Contents/PlugIns/text-freetype2.so
             ./OBS.app/Contents/PlugIns/obs-libfdk.so

--- a/CI/full-build-macos.sh
+++ b/CI/full-build-macos.sh
@@ -272,7 +272,6 @@ configure_obs_build() {
     hr "Run CMAKE for OBS..."
     cmake -DENABLE_SPARKLE_UPDATER=ON \
         -DCMAKE_OSX_DEPLOYMENT_TARGET=${MIN_MACOS_VERSION:-${CI_MIN_MACOS_VERSION}} \
-        -DDISABLE_PYTHON=ON  \
         -DQTDIR="/tmp/obsdeps" \
         -DSWIGDIR="/tmp/obsdeps" \
         -DDepsPath="/tmp/obsdeps" \
@@ -326,6 +325,7 @@ bundle_dylibs() {
         ./OBS.app/Contents/PlugIns/rtmp-services.so
         ./OBS.app/Contents/MacOS/obs-ffmpeg-mux
         ./OBS.app/Contents/MacOS/obslua.so
+        ./OBS.app/Contents/MacOS/_obspython.so
         ./OBS.app/Contents/PlugIns/obs-x264.so
         ./OBS.app/Contents/PlugIns/text-freetype2.so
         ./OBS.app/Contents/PlugIns/obs-libfdk.so
@@ -410,8 +410,8 @@ prepare_macos_bundle() {
     # Scripting plugins are required to be placed in same directory as binary
     if [ -d ./OBS.app/Contents/Resources/data/obs-scripting ]; then
         mv ./OBS.app/Contents/Resources/data/obs-scripting/obslua.so ./OBS.app/Contents/MacOS/
-        # mv ./OBS.app/Contents/Resources/data/obs-scripting/_obspython.so ./OBS.app/Contents/MacOS/
-        # mv ./OBS.app/Contents/Resources/data/obs-scripting/obspython.py ./OBS.app/Contents/MacOS/
+        mv ./OBS.app/Contents/Resources/data/obs-scripting/_obspython.so ./OBS.app/Contents/MacOS/
+        mv ./OBS.app/Contents/Resources/data/obs-scripting/obspython.py ./OBS.app/Contents/MacOS/
         rm -rf ./OBS.app/Contents/Resources/data/obs-scripting/
     fi
 

--- a/deps/obs-scripting/obs-scripting-python-import.c
+++ b/deps/obs-scripting/obs-scripting-python-import.c
@@ -143,6 +143,13 @@ bool import_python(const char *python_path)
 	IMPORT_FUNC(_Py_NoneStruct);
 	IMPORT_FUNC(PyTuple_New);
 
+#if defined(Py_DEBUG) || PY_VERSION_HEX >= 0x030900b0
+	IMPORT_FUNC(_Py_Dealloc);
+#endif
+#if PY_VERSION_HEX >= 0x030900b0
+	IMPORT_FUNC(PyType_GetFlags);
+#endif
+
 #undef IMPORT_FUNC
 
 	success = true;

--- a/deps/obs-scripting/obs-scripting-python-import.h
+++ b/deps/obs-scripting/obs-scripting-python-import.h
@@ -39,6 +39,14 @@
 #include <Python.h>
 #endif
 
+#if defined(HAVE_ATTRIBUTE_UNUSED) || defined(__MINGW32__)
+#if !defined(UNUSED)
+#define UNUSED __attribute__((unused))
+#endif
+#else
+#define UNUSED
+#endif
+
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
@@ -135,11 +143,23 @@ PY_EXTERN PyObject *(*Import_PyLong_FromUnsignedLongLong)(unsigned long long);
 PY_EXTERN int (*Import_PyArg_VaParse)(PyObject *, const char *, va_list);
 PY_EXTERN PyObject(*Import__Py_NoneStruct);
 PY_EXTERN PyObject *(*Import_PyTuple_New)(Py_ssize_t size);
+#if PY_VERSION_HEX >= 0x030900b0
+PY_EXTERN int (*Import_PyType_GetFlags)(PyTypeObject *o);
+#endif
+#if defined(Py_DEBUG) || PY_VERSION_HEX >= 0x030900b0
+PY_EXTERN void (*Import__Py_Dealloc)(PyObject *obj);
+#endif
 
 extern bool import_python(const char *python_path);
 
 #ifndef NO_REDEFS
 #define PyType_Ready Import_PyType_Ready
+#if PY_VERSION_HEX >= 0x030900b0
+#define PyType_GetFlags Import_PyType_GetFlags
+#endif
+#if defined(Py_DEBUG) || PY_VERSION_HEX >= 0x030900b0
+#define _Py_Dealloc Import__Py_Dealloc
+#endif
 #define PyObject_GenericGetAttr Import_PyObject_GenericGetAttr
 #define PyObject_IsTrue Import_PyObject_IsTrue
 #define Py_DecRef Import_Py_DecRef
@@ -210,6 +230,44 @@ extern bool import_python(const char *python_path);
 #define PyArg_VaParse Import_PyArg_VaParse
 #define _Py_NoneStruct (*Import__Py_NoneStruct)
 #define PyTuple_New Import_PyTuple_New
+#if PY_VERSION_HEX >= 0x030800f0
+static inline void Import__Py_DECREF(const char *filename UNUSED,
+				     int lineno UNUSED, PyObject *op)
+{
+	if (--op->ob_refcnt != 0) {
+#ifdef Py_REF_DEBUG
+		if (op->ob_refcnt < 0) {
+			_Py_NegativeRefcount(filename, lineno, op);
+		}
+#endif
+	} else {
+		_Py_Dealloc(op);
+	}
+}
+
+#undef Py_DECREF
+#define Py_DECREF(op) Import__Py_DECREF(__FILE__, __LINE__, _PyObject_CAST(op))
+
+static inline void Import__Py_XDECREF(PyObject *op)
+{
+	if (op != NULL) {
+		Py_DECREF(op);
+	}
+}
+
+#undef Py_XDECREF
+#define Py_XDECREF(op) Import__Py_XDECREF(_PyObject_CAST(op))
+#endif
+
+#if PY_VERSION_HEX >= 0x030900b0
+static inline int Import_PyType_HasFeature(PyTypeObject *type,
+					   unsigned long feature)
+{
+	return ((PyType_GetFlags(type) & feature) != 0);
+}
+#define PyType_HasFeature(t, f) Import_PyType_HasFeature(t, f)
+#endif
+
 #endif
 
 #endif

--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -1654,7 +1654,9 @@ bool obs_scripting_load_python(const char *python_path)
 	/* ---------------------------------------------- */
 	/* Load main interface module                     */
 
-	add_to_python_path(SCRIPT_DIR);
+	char *absolute_script_path = os_get_abs_path_ptr(SCRIPT_DIR);
+	add_to_python_path(absolute_script_path);
+	bfree(absolute_script_path);
 
 #if __APPLE__
 	char *exec_path = os_get_executable_path_ptr("");


### PR DESCRIPTION
### Description
Due to internal changes of Python 3.8+ OBS could not be built with Python scripting support on macOS CI as Python 3.8 (and 3.9) have become the default Python 3 versions available via Homebrew (oldest available Python 3 on Homebrew is v3.7).

This PR adds necessary patches to make OBS compile with Python 3.8 as well as Python 3.9 again.

As an added bonus it adds a valid user agent to the contained test script to not be blocked by Cloudflare or comparable proxies.

### Motivation and Context
* Restores Python scripting support on macOS

### How Has This Been Tested?
* Tested building with Python 3.7, 3.8 and Python 3.9
* Tested each build iteration with Python 3.7, 3.8 and Python 3.9 frameworks respectively
* Tested using simple "Hello World" script that also sets a proper description via OBS Python API as well as fetch-url script.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
