### PR TITLE
CI: Remove caching of obs-deps for Github CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,22 +71,6 @@ jobs:
         with:
           path: ${{ github.workspace }}/cmbuild/cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64
           key: ${{ runner.os }}-pr-${{ env.CACHE_NAME }}-${{ env.CEF_BUILD_VERSION }}
-      - name: 'Restore pre-built dependencies from cache'
-        id: deps-cache
-        uses: actions/cache@v2.1.2
-        env:
-          CACHE_NAME: 'deps-cache'
-        with:
-          path: /tmp/obsdeps
-          key: ${{ runner.os }}-pr-${{ env.CACHE_NAME }}-${{ env.MACOS_DEPS_VERSION }}
-      - name: 'Restore pre-built Qt dependency from cache'
-        id: deps-qt-cache
-        uses: actions/cache@v2.1.2
-        env:
-          CACHE_NAME: 'deps-qt-cache'
-        with:
-          path: /tmp/obsdeps
-          key: ${{ runner.os }}-pr-${{ env.CACHE_NAME }}-${{ env.MACOS_DEPS_VERSION }}
       - name: 'Restore VLC dependency from cache'
         id: vlc-cache
         uses: actions/cache@v2.1.2


### PR DESCRIPTION
### Description
Removes caching/cache-restoration of prebuilt OBS-Deps and Qt. Apparently using `/tmp/obsdeps` as path for caching isn't entirely robust on CI, so extracting the cache failed in recent CI runs.

As both dependencies are available and downloaded from Github anyway, the caching for Github Action runs is unnecessary.

### Motivation and Context
* Removes possible incompatibility/issues with building on Github CI

### How Has This Been Tested?
* Needs to be tested on CI

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
