### PR TITLE
support custom ffmpeg_mux path

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -249,7 +249,16 @@ static void build_command_line(struct ffmpeg_muxer *stream, struct dstr *cmd,
 		num_tracks++;
 	}
 
-	dstr_init_move_array(cmd, os_get_executable_path_ptr(FFMPEG_MUX));
+	obs_data_t *settings = obs_output_get_settings(stream->output);
+	const char *exec_path = obs_data_get_string(settings, "exec_path");
+
+	if (exec_path && strlen(exec_path) != 0) {
+		dstr_init_copy(cmd, exec_path);
+	} else {
+		dstr_init_move_array(cmd,
+				     os_get_executable_path_ptr(FFMPEG_MUX));
+	}
+
 	dstr_insert_ch(cmd, 0, '\"');
 	dstr_cat(cmd, "\" \"");
 
@@ -272,6 +281,7 @@ static void build_command_line(struct ffmpeg_muxer *stream, struct dstr *cmd,
 
 	add_stream_key(cmd, stream);
 	add_muxer_params(cmd, stream);
+	obs_data_release(settings);
 }
 
 void start_pipe(struct ffmpeg_muxer *stream, const char *path)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Support custom obs-ffmpeg-mux executable path

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We are implementing a cloud switcher application, which depends on libobs both on cloud side (linux) and desktop (windows/macos).  We found ffmpeg_mux executable path always related to the app executable path which is not fit in our case. (we are a nodejs application, and app executable path always be /usr/local/bin/node). This PR is to customize the ffmpeg_mux executable path. It may not useful for obs-studio, but a lot applications depends on libobs will be benifit it. 

Thank you for your excellent job.

### How Has This Been Tested?
Tested in local machine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
