### PR TITLE
CI: Add LAME/MP3 to ffmpeg

### DIFF
--- a/CI/util/build-package-deps-osx.sh
+++ b/CI/util/build-package-deps-osx.sh
@@ -132,13 +132,22 @@ cd $WORK_DIR
 export LDFLAGS="-L/tmp/obsdeps/lib"
 export CFLAGS="-I/tmp/obsdeps/include"
 
+curl -L -O https://kent.dl.sourceforge.net/project/lame/lame/3.99/lame-3.99.5.tar.gz
+tar -xf ./lame-3.99.5.tar.gz
+cd ./lame*
+./configure --disable-shared --prefix="/tmp/obsdeps" --libdir="/tmp/obsdeps/lib"
+make -j4
+find . -name \*.dylib -exec cp \{\} $DEPS_DEST/bin/ \;
+rsync -avh --include="*/" --include="*.h" --exclude="*" ../* $DEPS_DEST/include/
+rsync -avh --include="*/" --include="*.h" --exclude="*" ./* $DEPS_DEST/include/
+
 # FFMPEG
 curl -L -O https://github.com/FFmpeg/FFmpeg/archive/n4.0.2.zip
 unzip ./n4.0.2.zip
 cd ./FFmpeg-n4.0.2
 mkdir build
 cd ./build
-../configure --pkg-config-flags="--static" --extra-ldflags="-mmacosx-version-min=10.11" --enable-shared --disable-static --shlibdir="/tmp/obsdeps/bin" --enable-gpl --disable-doc --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --disable-outdev=sdl
+../configure --pkg-config-flags="--static" --extra-ldflags="-mmacosx-version-min=10.11" --enable-shared --disable-static --shlibdir="/tmp/obsdeps/bin" --enable-gpl --disable-doc --enable-libx264 --enable-libopus --enable-libvorbis --enable-libvpx --enable-libmp3lame --disable-outdev=sdl
 make -j 12
 find . -name \*.dylib -exec cp \{\} $DEPS_DEST/bin/ \;
 rsync -avh --include="*/" --include="*.h" --exclude="*" ../* $DEPS_DEST/include/


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This change includes the LAME/MP3 codec. All patents relevant to this codec expired in April 2017, so I don't believe there should be any issue including MP3 codecs in builds of OBS. 

### Motivation and Context
I work with many small and not-for-profit radio broadcasters, who are adapting to work from home. In particular, a lot of these users are Mac users, and the majority of radio broadcasting software (especially free ones) are Windows specific. Currently, OBS doesn't build the LAME encoder in its embedded ffmpeg build. As a result, it's not possible to use ffmpeg in OBS to stream up to, for example, an Icecast server. Indeed one can achieve it with other formats, but compatibility issues with older internet radios, which are (annoyingly) still very common, mean that Icecast and MP3 are very much still the living standard. 

### How Has This Been Tested?
I have tested this on macOS, but I don't currently have the capacity to test this on Windows or other platforms. This PR adds codecs to those build scripts, I'd appreciate any changes/help mirroring these on Windows and other platforms. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
