### PR TITLE
Add OpenBSD support

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1440,6 +1440,8 @@ string OBSApp::GetVersionString() const
 	ver << "windows)";
 #elif __APPLE__
 	ver << "mac)";
+#elif __OpenBSD__
+	ver << "openbsd)";
 #elif __FreeBSD__
 	ver << "freebsd)";
 #else /* assume linux for the time being */

--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -23,10 +23,12 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <sys/sysctl.h>
 #endif
+#if !defined(__OpenBSD__)
 #include <sys/sysinfo.h>
+#endif
 #include <sys/utsname.h>
 #include <xcb/xcb.h>
 #if USE_XINPUT
@@ -155,9 +157,10 @@ static void log_processor_info(void)
 	dstr_free(&proc_speed);
 	free(line);
 }
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 static void log_processor_speed(void)
 {
+#ifndef __OpenBSD__
 	char *line = NULL;
 	size_t linecap = 0;
 	FILE *fp;
@@ -187,6 +190,7 @@ static void log_processor_speed(void)
 	fclose(fp);
 	dstr_free(&proc_speed);
 	free(line);
+#endif
 }
 
 static void log_processor_name(void)
@@ -218,6 +222,19 @@ static void log_processor_info(void)
 
 static void log_memory_info(void)
 {
+#if defined(__OpenBSD__)
+	int mib[2];
+	size_t len;
+	int64_t mem;
+
+	mib[0] = CTL_HW;
+	mib[1] = HW_PHYSMEM64;
+	len = sizeof(mem);
+
+	if (sysctl(mib, 2, &mem, &len, NULL, 0) >= 0)
+		blog(LOG_INFO, "Physical Memory: %" PRIi64 "MB Total",
+		     mem / 1024 / 1024);
+#else
 	struct sysinfo info;
 	if (sysinfo(&info) < 0)
 		return;
@@ -227,6 +244,7 @@ static void log_memory_info(void)
 	     (uint64_t)info.totalram * info.mem_unit / 1024 / 1024,
 	     ((uint64_t)info.freeram + (uint64_t)info.bufferram) *
 		     info.mem_unit / 1024 / 1024);
+#endif
 }
 
 static void log_kernel_version(void)

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -34,14 +34,16 @@
 #include <sys/times.h>
 #include <sys/wait.h>
 #include <libgen.h>
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <sys/param.h>
 #include <sys/queue.h>
 #include <sys/socket.h>
 #include <sys/sysctl.h>
 #include <sys/user.h>
 #include <unistd.h>
+#if defined(__FreeBSD__)
 #include <libprocstat.h>
+#endif
 #else
 #include <sys/resource.h>
 #endif
@@ -272,6 +274,62 @@ char *os_get_program_data_path_ptr(const char *name)
 	return str;
 }
 
+#if defined(__OpenBSD__)
+// a bit modified version of https://stackoverflow.com/a/31495527
+ssize_t os_openbsd_get_executable_path(char *epath)
+{
+	int mib[4];
+	char **argv;
+	size_t len;
+	const char *comm;
+	int ok = 0;
+
+	mib[0] = CTL_KERN;
+	mib[1] = KERN_PROC_ARGS;
+	mib[2] = getpid();
+	mib[3] = KERN_PROC_ARGV;
+
+	if (sysctl(mib, 4, NULL, &len, NULL, 0) < 0)
+		abort();
+
+	if (!(argv = malloc(len)))
+		abort();
+
+	if (sysctl(mib, 4, argv, &len, NULL, 0) < 0)
+		abort();
+
+	comm = argv[0];
+
+	if (*comm == '/' || *comm == '.') {
+		if (realpath(comm, epath))
+			ok = 1;
+	} else {
+		char *sp;
+		char *xpath = strdup(getenv("PATH"));
+		char *path = strtok_r(xpath, ":", &sp);
+		struct stat st;
+
+		if (!xpath)
+			abort();
+
+		while (path) {
+			snprintf(epath, PATH_MAX, "%s/%s", path, comm);
+
+			if (!stat(epath, &st) && (st.st_mode & S_IXUSR)) {
+				ok = 1;
+				break;
+			}
+			path = strtok_r(NULL, ":", &sp);
+		}
+
+		free(xpath);
+	}
+
+	free(argv);
+	return ok ? (ssize_t)strlen(epath) : -1;
+}
+#endif
+
 char *os_get_executable_path_ptr(const char *name)
 {
 	char exe[PATH_MAX];
@@ -286,6 +344,8 @@ char *os_get_executable_path_ptr(const char *name)
 		return NULL;
 	}
 	count = pathlen;
+#elif defined(__OpenBSD__)
+	ssize_t count = os_openbsd_get_executable_path(exe);
 #else
 	ssize_t count = readlink("/proc/self/exe", exe, PATH_MAX - 1);
 	if (count >= 0) {

--- a/libobs/util/profiler.c
+++ b/libobs/util/profiler.c
@@ -1058,7 +1058,11 @@ bool profiler_snapshot_dump_csv_gz(const profiler_snapshot_t *snap,
 
 	profiler_snapshot_dump(snap, dump_csv_gzwrite, gz);
 
+#ifdef _WIN32
 	gzclose_w(gz);
+#else
+	gzclose(gz);
+#endif
 	return true;
 }
 

--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -348,6 +348,12 @@ RTMP_TLS_LoadCerts(RTMP *r) {
             "/etc/ssl/certs");
         goto error;
     }
+#elif defined(__OpenBSD__)
+    if (mbedtls_x509_crt_parse_file(chain, "/etc/ssl/cert.pem") < 0) {
+        RTMP_Log(RTMP_LOGERROR, "mbedtls_x509_crt_parse_file: Couldn't parse "
+            "/etc/ssl/cert.pem");
+        goto error;
+    }
 #endif
 
     mbedtls_ssl_conf_ca_chain(&r->RTMP_TLS_ctx->conf, chain, NULL);
@@ -814,8 +820,10 @@ add_addr_info(struct sockaddr_storage *service, socklen_t *addrlen, AVal *host, 
         *socket_error = WSANO_DATA;
 #elif __FreeBSD__
         *socket_error = ENOATTR;
-#else
+#elif defined(ENODATA)
         *socket_error = ENODATA;
+#else
+        *socket_error = EAFNOSUPPORT;
 #endif
 
         RTMP_Log(RTMP_LOGERROR, "Could not resolve server '%s': no valid address found", hostname);


### PR DESCRIPTION
### Description
This makes OBS compile and run on OpenBSD.

Note that audio&webcam input are available only via FFmpeg, since both JACK and PulseAudio do not work well, and V4L2 plugin contains a lot of Linux-specific code. This is subject to separate PRs.

### Motivation and Context
OBS is great, and OpenBSD is great. They must work together.

### How Has This Been Tested?
Compiles and runs on OpenBSD/amd64, both 6.8 and CURRENT. Regression tests pass.

### Types of changes
New-feature: OpenBSD support

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
