### PR TITLE
win-capture: Fix unused variables

### DIFF
--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -234,7 +234,6 @@ static void *wc_create(obs_data_t *settings, obs_source_t *source)
 
 	if (uses_d3d11) {
 		static const char *const module = "libobs-winrt";
-		bool use_winrt_capture = false;
 		wc->winrt_module = os_dlopen(module);
 		if (wc->winrt_module &&
 		    load_winrt_imports(&wc->exports, wc->winrt_module,
@@ -343,6 +342,8 @@ static void update_settings_visibility(obs_properties_t *props,
 static bool wc_capture_method_changed(obs_properties_t *props,
 				      obs_property_t *p, obs_data_t *settings)
 {
+	UNUSED_PARAMETER(p);
+
 	struct window_capture *wc = obs_properties_get_param(props);
 	update_settings(wc, settings);
 


### PR DESCRIPTION
### Description
Noticed a couple of unused variables, and removed them.

### Motivation and Context
Don't like compiler warnings.

### How Has This Been Tested?
Compiler warnings are gone.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.