### PR TITLE
More win-capture warnings

### DIFF
--- a/libobs-winrt/winrt-capture.h
+++ b/libobs-winrt/winrt-capture.h
@@ -15,7 +15,7 @@ EXPORT struct winrt_capture *winrt_capture_init(BOOL cursor, HWND window,
 						BOOL client_area);
 EXPORT void winrt_capture_free(struct winrt_capture *capture);
 
-EXPORT BOOL winrt_capture_supported(const struct winrt_capture *capture);
+EXPORT BOOL winrt_capture_active(const struct winrt_capture *capture);
 EXPORT void winrt_capture_show_cursor(struct winrt_capture *capture,
 				      BOOL visible);
 EXPORT void winrt_capture_render(struct winrt_capture *capture,

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -273,9 +273,10 @@ static inline HMODULE kernel32(void)
 static inline HANDLE open_process(DWORD desired_access, bool inherit_handle,
 				  DWORD process_id)
 {
-	static HANDLE(WINAPI * open_process_proc)(DWORD, BOOL, DWORD) = NULL;
+	typedef HANDLE(WINAPI * PFN_OpenProcess)(DWORD, BOOL, DWORD);
+	PFN_OpenProcess open_process_proc = NULL;
 	if (!open_process_proc)
-		open_process_proc = get_obfuscated_func(
+		open_process_proc = (PFN_OpenProcess)get_obfuscated_func(
 			kernel32(), "NuagUykjcxr", 0x1B694B59451ULL);
 
 	return open_process_proc(desired_access, inherit_handle, process_id);
@@ -457,6 +458,9 @@ static inline bool capture_needs_reset(struct game_capture_config *cfg1,
 static bool hotkey_start(void *data, obs_hotkey_pair_id id,
 			 obs_hotkey_t *hotkey, bool pressed)
 {
+	UNUSED_PARAMETER(id);
+	UNUSED_PARAMETER(hotkey);
+
 	struct game_capture *gc = data;
 
 	if (pressed && gc->config.mode == CAPTURE_MODE_HOTKEY) {
@@ -473,6 +477,9 @@ static bool hotkey_start(void *data, obs_hotkey_pair_id id,
 static bool hotkey_stop(void *data, obs_hotkey_pair_id id, obs_hotkey_t *hotkey,
 			bool pressed)
 {
+	UNUSED_PARAMETER(id);
+	UNUSED_PARAMETER(hotkey);
+
 	struct game_capture *gc = data;
 
 	if (pressed && gc->config.mode == CAPTURE_MODE_HOTKEY) {


### PR DESCRIPTION
### Description
Fix various issues around warnings that I've noticed in win-capture.

### Motivation and Context
Don't like warnings.

### How Has This Been Tested?
Debugger inspection through modified areas. WGC and DX11 game capture both verified to still work.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.