### PR TITLE
UI: Add ability to reset entire UI

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -740,11 +740,12 @@ Basic.MainMenu.View.SceneTransitions="S&cene Transitions"
 Basic.MainMenu.View.SourceIcons="Source &Icons"
 Basic.MainMenu.View.StatusBar="&Status Bar"
 Basic.MainMenu.View.Fullscreen.Interface="Fullscreen Interface"
+Basic.MainMenu.View.ResetUI="&Reset UI"
 
 #basic mode docks menu
 Basic.MainMenu.Docks="&Docks"
-Basic.MainMenu.Docks.ResetUI="&Reset UI"
-Basic.MainMenu.Docks.LockUI="&Lock UI"
+Basic.MainMenu.Docks.ResetDocks="&Reset Docks"
+Basic.MainMenu.Docks.LockDocks="&Lock Docks"
 Basic.MainMenu.Docks.CustomBrowserDocks="&Custom Browser Docks..."
 
 # basic mode profile/scene collection menus

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -657,6 +657,11 @@
     <property name="title">
      <string>Basic.MainMenu.View</string>
     </property>
+    <action name="resetUI">
+     <property name="text">
+      <string>Basic.MainMenu.View.ResetUI</string>
+     </property>
+    </action>
     <action name="actionFullscreenInterface">
      <property name="text">
       <string>Basic.MainMenu.View.Fullscreen.Interface</string>
@@ -665,6 +670,7 @@
       <string>F11</string>
      </property>
     </action>
+    <addaction name="resetUI"/>
     <addaction name="actionFullscreenInterface"/>
     <addaction name="separator"/>
     <addaction name="toggleListboxToolbars"/>
@@ -685,8 +691,8 @@
     <property name="title">
      <string>Basic.MainMenu.Docks</string>
     </property>
-    <addaction name="lockUI"/>
-    <addaction name="resetUI"/>
+    <addaction name="lockDocks"/>
+    <addaction name="resetDocks"/>
     <addaction name="separator"/>
     <addaction name="toggleScenes"/>
     <addaction name="toggleSources"/>
@@ -1966,12 +1972,12 @@
     <string>Basic.Stats</string>
    </property>
   </action>
-  <action name="resetUI">
+  <action name="resetDocks">
    <property name="text">
-    <string>Basic.MainMenu.Docks.ResetUI</string>
+    <string>Basic.MainMenu.Docks.ResetDocks</string>
    </property>
   </action>
-  <action name="lockUI">
+  <action name="lockDocks">
    <property name="checkable">
     <bool>true</bool>
    </property>
@@ -1979,7 +1985,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Basic.MainMenu.Docks.LockUI</string>
+    <string>Basic.MainMenu.Docks.LockDocks</string>
    </property>
   </action>
   <action name="toggleScenes">

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1980,12 +1980,12 @@ void OBSBasic::OBSInit()
 		App()->GlobalConfig(), "BasicWindow", "DockState");
 
 	if (!dockStateStr) {
-		on_resetUI_triggered();
+		on_resetDocks_triggered();
 	} else {
 		QByteArray dockState =
 			QByteArray::fromBase64(QByteArray(dockStateStr));
 		if (!restoreState(dockState))
-			on_resetUI_triggered();
+			on_resetDocks_triggered();
 	}
 
 	bool pre23Defaults = config_get_bool(App()->GlobalConfig(), "General",
@@ -2004,10 +2004,10 @@ void OBSBasic::OBSInit()
 
 	bool docksLocked = config_get_bool(App()->GlobalConfig(), "BasicWindow",
 					   "DocksLocked");
-	on_lockUI_toggled(docksLocked);
-	ui->lockUI->blockSignals(true);
-	ui->lockUI->setChecked(docksLocked);
-	ui->lockUI->blockSignals(false);
+	on_lockDocks_toggled(docksLocked);
+	ui->lockDocks->blockSignals(true);
+	ui->lockDocks->setChecked(docksLocked);
+	ui->lockDocks->blockSignals(false);
 
 	SystemTray(true);
 
@@ -2692,7 +2692,7 @@ OBSBasic::~OBSBasic()
 	config_set_bool(App()->GlobalConfig(), "BasicWindow",
 			"PreviewProgramMode", IsPreviewProgramMode());
 	config_set_bool(App()->GlobalConfig(), "BasicWindow", "DocksLocked",
-			ui->lockUI->isChecked());
+			ui->lockDocks->isChecked());
 	config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
 
 #ifdef _WIN32
@@ -8805,7 +8805,7 @@ int OBSBasic::GetProfilePath(char *path, size_t size, const char *file) const
 	return snprintf(path, size, "%s/%s/%s", profiles_path, profile, file);
 }
 
-void OBSBasic::on_resetUI_triggered()
+void OBSBasic::on_resetDocks_triggered()
 {
 	/* prune deleted extra docks */
 	for (int i = extraDocks.size() - 1; i >= 0; i--) {
@@ -8867,7 +8867,7 @@ void OBSBasic::on_resetUI_triggered()
 	activateWindow();
 }
 
-void OBSBasic::on_lockUI_toggled(bool lock)
+void OBSBasic::on_lockDocks_toggled(bool lock)
 {
 	QDockWidget::DockWidgetFeatures features =
 		lock ? QDockWidget::NoDockWidgetFeatures
@@ -8892,6 +8892,16 @@ void OBSBasic::on_lockUI_toggled(bool lock)
 			extraDocks[i]->setFeatures(features);
 		}
 	}
+}
+
+void OBSBasic::on_resetUI_triggered()
+{
+	on_resetDocks_triggered();
+
+	ui->toggleListboxToolbars->setChecked(true);
+	ui->toggleContextBar->setChecked(true);
+	ui->toggleSourceIcons->setChecked(true);
+	ui->toggleStatusBar->setChecked(true);
 }
 
 void OBSBasic::on_toggleListboxToolbars_toggled(bool visible)
@@ -9668,7 +9678,7 @@ QAction *OBSBasic::AddDockWidget(QDockWidget *dock)
 	assignDockToggle(dock, action);
 	extraDocks.push_back(dock);
 
-	bool lock = ui->lockUI->isChecked();
+	bool lock = ui->lockDocks->isChecked();
 	QDockWidget::DockWidgetFeatures features =
 		lock ? QDockWidget::NoDockWidgetFeatures
 		     : (QDockWidget::DockWidgetClosable |

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1087,7 +1087,8 @@ private slots:
 	void on_stats_triggered();
 
 	void on_resetUI_triggered();
-	void on_lockUI_toggled(bool lock);
+	void on_resetDocks_triggered();
+	void on_lockDocks_toggled(bool lock);
 
 	void PauseToggled();
 


### PR DESCRIPTION
### Description
This adds the ability to reset to whole UI, instead of just
the docks.

The 'Reset UI' and 'Lock UI' in the dock view menu, are now
renamed to 'Reset Docks' and 'Lock Docks'.

### Motivation and Context
Users were confused before because the 'Reset UI' action in the docks view menu would only reset the docks.
The 'Reset UI' has been moved now to the view menu, with the action in the docks view menu being renamed.

### How Has This Been Tested?
Items in the UI were hidden and then reset to made sure it worked properly.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
