### PR TITLE
win-capture: Clean up remaining /W4 warnings

### DIFF
--- a/plugins/win-capture/app-helpers.c
+++ b/plugins/win-capture/app-helpers.c
@@ -2,8 +2,9 @@
 #include <stdio.h>
 #include "app-helpers.h"
 #include "nt-stuff.h"
+#include "util/base.h"
 
-WINADVAPI WINAPI ConvertSidToStringSidW(PSID sid, LPWSTR *str);
+WINADVAPI BOOL WINAPI ConvertSidToStringSidW(PSID sid, LPWSTR *str);
 
 bool is_app(HANDLE process)
 {
@@ -16,8 +17,10 @@ bool is_app(HANDLE process)
 						   &ret, sizeof(ret),
 						   &size_ret);
 		if (!success) {
-			DWORD error = GetLastError();
-			int test = 0;
+			const DWORD error = GetLastError();
+			blog(LOG_ERROR,
+			     "is_app GetTokenInformation failed: 0x%08lX",
+			     error);
 		}
 
 		CloseHandle(token);

--- a/plugins/win-capture/inject-library.c
+++ b/plugins/win-capture/inject-library.c
@@ -37,16 +37,16 @@ int inject_library_obf(HANDLE process, const wchar_t *dll,
 	virtual_free_ex_t virtual_free_ex;
 	FARPROC load_library_w;
 
-	create_remote_thread =
-		get_obfuscated_func(kernel32, create_remote_thread_obf, obf1);
-	write_process_memory =
-		get_obfuscated_func(kernel32, write_process_memory_obf, obf2);
-	virtual_alloc_ex =
-		get_obfuscated_func(kernel32, virtual_alloc_ex_obf, obf3);
-	virtual_free_ex =
-		get_obfuscated_func(kernel32, virtual_free_ex_obf, obf4);
-	load_library_w =
-		get_obfuscated_func(kernel32, load_library_w_obf, obf5);
+	create_remote_thread = (create_remote_thread_t)get_obfuscated_func(
+		kernel32, create_remote_thread_obf, obf1);
+	write_process_memory = (write_process_memory_t)get_obfuscated_func(
+		kernel32, write_process_memory_obf, obf2);
+	virtual_alloc_ex = (virtual_alloc_ex_t)get_obfuscated_func(
+		kernel32, virtual_alloc_ex_obf, obf3);
+	virtual_free_ex = (virtual_free_ex_t)get_obfuscated_func(
+		kernel32, virtual_free_ex_obf, obf4);
+	load_library_w = (FARPROC)get_obfuscated_func(kernel32,
+						      load_library_w_obf, obf5);
 
 	/* -------------------------------- */
 
@@ -108,7 +108,7 @@ int inject_library_safe_obf(DWORD thread_id, const wchar_t *dll,
 	HMODULE user32 = GetModuleHandleW(L"USER32");
 	set_windows_hook_ex_t set_windows_hook_ex;
 	HMODULE lib = LoadLibraryW(dll);
-	LPVOID proc;
+	HOOKPROC proc;
 	HHOOK hook;
 	size_t i;
 
@@ -117,17 +117,17 @@ int inject_library_safe_obf(DWORD thread_id, const wchar_t *dll,
 	}
 
 #ifdef _WIN64
-	proc = GetProcAddress(lib, "dummy_debug_proc");
+	proc = (HOOKPROC)GetProcAddress(lib, "dummy_debug_proc");
 #else
-	proc = GetProcAddress(lib, "_dummy_debug_proc@12");
+	proc = (HOOKPROC)GetProcAddress(lib, "_dummy_debug_proc@12");
 #endif
 
 	if (!proc) {
 		return INJECT_ERROR_UNLIKELY_FAIL;
 	}
 
-	set_windows_hook_ex =
-		get_obfuscated_func(user32, set_windows_hook_ex_obf, obf1);
+	set_windows_hook_ex = (set_windows_hook_ex_t)get_obfuscated_func(
+		user32, set_windows_hook_ex_obf, obf1);
 
 	hook = set_windows_hook_ex(WH_GETMESSAGE, proc, lib, thread_id);
 	if (!hook) {

--- a/plugins/win-capture/load-graphics-offsets.c
+++ b/plugins/win-capture/load-graphics-offsets.c
@@ -156,11 +156,12 @@ failed:
 	return !ver_mismatch;
 }
 
-bool load_graphics_offsets(bool is32bit, const char *config_path)
+bool load_graphics_offsets(bool is32bit, bool use_hook_address_cache,
+			   const char *config_path)
 {
 	char *offset_exe_path = NULL;
-	struct dstr offset_exe = {0};
 	struct dstr config_ini = {0};
+	struct dstr offset_exe = {0};
 	struct dstr str = {0};
 	os_process_pipe_t *pp;
 	bool success = false;
@@ -200,15 +201,14 @@ bool load_graphics_offsets(bool is32bit, const char *config_path)
 		goto error;
 	}
 
-	// uncomment this if you enable USE_HOOK_ADDRESS_CACHE
-	/*
-	dstr_copy(&config_ini, config_path);
-	dstr_cat(&config_ini, is32bit ? "32.ini" : "64.ini");
+	if (use_hook_address_cache) {
+		dstr_copy(&config_ini, config_path);
+		dstr_cat(&config_ini, is32bit ? "32.ini" : "64.ini");
 
-	os_quick_write_utf8_file_safe(config_ini.array, str.array, str.len, false,
-			"tmp", NULL);
-	dstr_free(&config_ini);
-*/
+		os_quick_write_utf8_file_safe(config_ini.array, str.array,
+					      str.len, false, "tmp", NULL);
+		dstr_free(&config_ini);
+	}
 
 	success = load_offsets_from_string(is32bit ? &offsets32 : &offsets64,
 					   str.array);
@@ -235,7 +235,7 @@ bool load_cached_graphics_offsets(bool is32bit, const char *config_path)
 	success = load_offsets_from_file(is32bit ? &offsets32 : &offsets64,
 					 config_ini.array);
 	if (!success)
-		success = load_graphics_offsets(is32bit, config_path);
+		success = load_graphics_offsets(is32bit, true, config_path);
 
 	dstr_free(&config_ini);
 	return success;

--- a/plugins/win-capture/plugin-main.c
+++ b/plugins/win-capture/plugin-main.c
@@ -19,7 +19,8 @@ static HANDLE init_hooks_thread = NULL;
 
 extern bool cached_versions_match(void);
 extern bool load_cached_graphics_offsets(bool is32bit, const char *config_path);
-extern bool load_graphics_offsets(bool is32bit, const char *config_path);
+extern bool load_graphics_offsets(bool is32bit, bool use_hook_address_cache,
+				  const char *config_path);
 
 /* temporary, will eventually be erased once we figure out how to create both
  * 32bit and 64bit versions of the helpers/hook */
@@ -29,22 +30,22 @@ extern bool load_graphics_offsets(bool is32bit, const char *config_path);
 #define IS32BIT true
 #endif
 
-/* note, need to enable cache writing in load-graphics-offsets.c if you turn
- * this back on*/
-#define USE_HOOK_ADDRESS_CACHE false
+static const bool use_hook_address_cache = false;
 
 static DWORD WINAPI init_hooks(LPVOID param)
 {
 	char *config_path = param;
 
-	if (USE_HOOK_ADDRESS_CACHE && cached_versions_match() &&
+	if (use_hook_address_cache && cached_versions_match() &&
 	    load_cached_graphics_offsets(IS32BIT, config_path)) {
 
 		load_cached_graphics_offsets(!IS32BIT, config_path);
 		obs_register_source(&game_capture_info);
 
-	} else if (load_graphics_offsets(IS32BIT, config_path)) {
-		load_graphics_offsets(!IS32BIT, config_path);
+	} else if (load_graphics_offsets(IS32BIT, use_hook_address_cache,
+					 config_path)) {
+		load_graphics_offsets(!IS32BIT, use_hook_address_cache,
+				      config_path);
 	}
 
 	bfree(config_path);

--- a/plugins/win-capture/window-helpers.c
+++ b/plugins/win-capture/window-helpers.c
@@ -58,9 +58,10 @@ static HMODULE kernel32(void)
 static inline HANDLE open_process(DWORD desired_access, bool inherit_handle,
 				  DWORD process_id)
 {
-	static HANDLE(WINAPI * open_process_proc)(DWORD, BOOL, DWORD) = NULL;
+	typedef HANDLE(WINAPI * PFN_OpenProcess)(DWORD, BOOL, DWORD);
+	static PFN_OpenProcess open_process_proc = NULL;
 	if (!open_process_proc)
-		open_process_proc = get_obfuscated_func(
+		open_process_proc = (PFN_OpenProcess)get_obfuscated_func(
 			kernel32(), "B}caZyah`~q", 0x2D5BEBAF6DDULL);
 
 	return open_process_proc(desired_access, inherit_handle, process_id);


### PR DESCRIPTION
### Description
Fix rest of warnings when win-capture is /W4.

### Motivation and Context
Don't like warnings.

### How Has This Been Tested?
Exercised game capture code paths: inject/direct, 32/64, anticheat on/off.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.