### PR TITLE
obs-ffmpeg: Add error detection to ffmpeg-mux network streams

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -803,8 +803,13 @@ static inline bool ffmpeg_mux_packet(struct ffmpeg_mux *ffm, uint8_t *buf,
 	int ret = av_interleaved_write_frame(ffm->output, &packet);
 
 	if (ret < 0) {
-		fprintf(stderr, "av_interleaved_write_frame failed: %s\n",
-			av_err2str(ret));
+		fprintf(stderr, "av_interleaved_write_frame failed: %d: %s\n",
+			ret, av_err2str(ret));
+	}
+
+	/* Treat "Invalid data found when processing input" as non-fatal */
+	if (ret == AVERROR_INVALIDDATA) {
+		return true;
 	}
 
 	return ret >= 0;


### PR DESCRIPTION
### Description

ffmpeg-mux does not notice if ffmpeg returns an error from
av_interleaved_write_frame() which means that OBS never knows if there is a
problem in ffmpeg.

This is the biggest issue for cases like srt:// or tcp:// streams that can
regularly fail. Without this change OBS never knows that something went wrong.

Only network streams are checked to prevent impacting potential transient
errors in recordings.

Also ignores the error "Invalid data found when processing input" (AVERROR_INVALIDDATA) to prevent transient errors.

### Motivation and Context

This is a re-implementation of #3460 with more limited impact to only report errors for network streams.

I noticed that when using an `srt://` custom stream endpoint OBS, if there is an issue with the SRT connection, a message is printed in the logs saying the SRT connection has failed but OBS never notices it. OBS noticing when the stream has failed is the first step in being able to do the auto-reconnection of SRT streams.

### How Has This Been Tested?

I created recordings and `srt://` streams and found that they worked successfully and that an error was displayed when I forcefully stopped the remote SRT receiver.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
