### PR TITLE
ffmpeg-mux: Treat EINVAL as non-fatal and enable error checking for non-network streams

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -807,8 +807,8 @@ static inline bool ffmpeg_mux_packet(struct ffmpeg_mux *ffm, uint8_t *buf,
 			ret, av_err2str(ret));
 	}
 
-	/* Treat "Invalid data found when processing input" as non-fatal */
-	if (ret == AVERROR_INVALIDDATA) {
+	/* Treat "Invalid data found when processing input" and "Invalid argument" as non-fatal */
+	if (ret == AVERROR_INVALIDDATA || ret == EINVAL) {
 		return true;
 	}
 

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -857,15 +857,11 @@ int main(int argc, char *argv[])
 		return ret;
 	}
 
-	bool is_network = ffmpeg_mux_is_network(&ffm);
-
 	while (!fail && safe_read(&info, sizeof(info)) == sizeof(info)) {
 		resize_buf_resize(&rb, info.size);
 
 		if (safe_read(rb.buf, info.size) == info.size) {
-			bool packet_fail =
-				ffmpeg_mux_packet(&ffm, rb.buf, &info);
-			fail = is_network && packet_fail;
+			fail = ffmpeg_mux_packet(&ffm, rb.buf, &info);
 		} else {
 			fail = true;
 		}


### PR DESCRIPTION
### Description

Allow the `EINVAL` error from ffmpeg to be treated as non-fatal and also enable error checking for non-network streams. This is a follow-up to #3737 and #3460.

### Motivation and Context

After reviewing submitted log messages containing `av_interleaved_write_frame failed:` a pattern emerged of a few kinds of errors:

Invalid data coming from OBS:

```
08:49:14.392: [ffmpeg muxer: 'simple_file_output'] ffmpeg-mux: av_interleaved_write_frame failed: Invalid argument
08:49:14.392: [matroska @ 007a7840] Application provided invalid, non monotonically increasing dts to muxer in stream 0: -100 >= -300
```

```
14:46:51.550: [ffmpeg muxer: 'simple_file_output'] ffmpeg-mux: av_interleaved_write_frame failed: Invalid data found when processing input
14:46:51.550: [mpegts @ 00000230992b48c0] H.264 bitstream malformed, no startcode found, use the video bitstream filter 'h264_mp4toannexb' to fix it ('-bsf:v h264_mp4toannexb' option with ffmpeg)
```

Fatal errors from recordings:

```
20:16:13.429: [ffmpeg muxer: 'adv_file_output'] ffmpeg-mux: av_interleaved_write_frame failed: No space left on device
```

The `Invalid argument` errors were by far the most prevalent in the logs and it appears that there is something about how recordings are started that aren't giving a clean stream to ffmpeg-mux every time. It seems the best course of action is to just treat those as non-fatal errors and continue on.

The `No space left on device` would be a good one to actually fail the recording instead of making OBS think that it is writing when it isn't.

### How Has This Been Tested?

I haven't tested this, just reviewed the logs.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
