### PR TITLE
UI: fix build on older FreeBSD versions

### DIFF
--- a/UI/platform-x11.cpp
+++ b/UI/platform-x11.cpp
@@ -41,6 +41,7 @@
 #include <sys/sysctl.h>
 #include <sys/user.h>
 #include <libprocstat.h>
+#include <pthread_np.h>
 
 #include <condition_variable>
 #include <mutex>
@@ -114,7 +115,7 @@ struct RunOnce {
 	void thr_proc()
 	{
 		std::unique_lock<std::mutex> lk(mtx);
-		pthread_setname_np(pthread_self(), thr_name);
+		pthread_set_name_np(pthread_self(), thr_name);
 		name_changed = true;
 		wait_cv.notify_all();
 		cv.wait(lk, [this]() { return exiting; });


### PR DESCRIPTION
### Description
Include pthread_np.h header and use pthread_set_name_np to fix build
on FreeBSD 12.1.  The Linux-compatible pthread_setname_np alias was
added later.

### Motivation and Context
Fix build on older FreeBSD releases that are still supported by the FreeBSD project.

### How Has This Been Tested?
Build tested on FreeBSD 13 locally and on FreeBSD 12.1 in Cirrus-CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
