### PR TITLE
CI: Remove explicit LANGUAGE flags for cmake 3.19+

### DIFF
--- a/libobs-opengl/CMakeLists.txt
+++ b/libobs-opengl/CMakeLists.txt
@@ -16,10 +16,6 @@ elseif(APPLE)
 	set(libobs-opengl_PLATFORM_SOURCES
 		gl-cocoa.m)
 
-	set_source_files_properties(${libobs-opengl_PLATFORM_SOURCES}
-		PROPERTIES
-			LANGUAGE C)
-
 	find_library(COCOA Cocoa)
 	include_directories(${COCOA})
 	mark_as_advanced(COCOA)

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -143,7 +143,6 @@ elseif(APPLE)
 
 	set_source_files_properties(${libobs_PLATFORM_SOURCES}
 		PROPERTIES
-			LANGUAGE C
 			COMPILE_FLAGS "-fobjc-arc")
 
 	find_library(COCOA Cocoa)

--- a/plugins/mac-capture/CMakeLists.txt
+++ b/plugins/mac-capture/CMakeLists.txt
@@ -24,11 +24,6 @@ set(mac-capture_SOURCES
 	mac-window-capture.m
 	window-utils.m)
 
-set_source_files_properties(mac-display-capture.m
-			    mac-window-capture.m
-			    window-utils.m
-	PROPERTIES LANGUAGE C)
-
 add_library(mac-capture MODULE
 	${mac-capture_SOURCES}
 	${mac-capture_HEADERS})

--- a/plugins/mac-syphon/CMakeLists.txt
+++ b/plugins/mac-syphon/CMakeLists.txt
@@ -65,9 +65,6 @@ set(mac-syphon_SOURCES
 	syphon.m
 	plugin-main.c)
 
-set_source_files_properties(${mac-syphon_SOURCES} ${syphon_SOURCES}
-	PROPERTIES LANGUAGE C)
-
 add_definitions(-DSYPHON_UNIQUE_CLASS_NAME_PREFIX=OBS_ -include
 	${PROJECT_SOURCE_DIR}/syphon-framework/Syphon_Prefix.pch)
 

--- a/plugins/text-freetype2/CMakeLists.txt
+++ b/plugins/text-freetype2/CMakeLists.txt
@@ -42,9 +42,6 @@ elseif(APPLE)
 	set(text-freetype2_PLATFORM_DEPS
 		${COCOA}
 		${ICONV_LIBRARIES})
-
-	set_source_files_properties(find-font-cocoa.m
-		PROPERTIES LANGUAGE C)
 else()
 	find_package(Fontconfig QUIET)
 	if(NOT FONTCONFIG_FOUND AND ENABLE_FREETYPE)


### PR DESCRIPTION
### Description
Removes the Cmake directives to explicitly set the language of some plugins to `C` on macOS which breaks most recent `cmake` versions.

### Motivation and Context
`Cmake` merged and released a change with version 3.19 that breaks building on macOS with our current `cmake` rules.

The change as explained in https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4780 now sets the language flag explicitly when `LANGUAGE` is set in `cmake` rules. This leads to the switch `-x c` being added to calls to `cc` or `clang` which then fails when the compiler meets an ObjectiveC file (as is the case in `libobs` and some other plugins.

According to one of `cmake`'s maintainers, the flag is supposed to _explicitly_ set the source code language, not which compiler is preferred. This PR removes all instances of setting the `LANGUAGE` for plugins that use ObjectiveC to enable compilation again.

Note that `Cmake` is not part of macOS default or development distribution, so it _has_ to be installed via Homebrew where 3.19 is the default version.

### How Has This Been Tested?
* OBS compiled and tested with cmake 3.19 

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
