### PR TITLE
libobs: Allow wrapping D3D11 object with gs_texture_t

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -2670,6 +2670,23 @@ extern "C" EXPORT uint32_t device_texture_get_shared_handle(gs_texture_t *tex)
 	return tex2d->isShared ? tex2d->sharedHandle : GS_INVALID_HANDLE;
 }
 
+extern "C" EXPORT gs_texture_t *device_texture_wrap_obj(gs_device_t *device,
+							void *obj)
+{
+	gs_texture *texture = nullptr;
+	try {
+		texture = new gs_texture_2d(device, (ID3D11Texture2D *)obj);
+	} catch (const HRError &error) {
+		blog(LOG_ERROR, "gs_texture_wrap_obj (D3D11): %s (%08lX)",
+		     error.str, error.hr);
+		LogD3D11ErrorDetails(error, device);
+	} catch (const char *error) {
+		blog(LOG_ERROR, "gs_texture_wrap_obj (D3D11): %s", error);
+	}
+
+	return texture;
+}
+
 int device_texture_acquire_sync(gs_texture_t *tex, uint64_t key, uint32_t ms)
 {
 	gs_texture_2d *tex2d = reinterpret_cast<gs_texture_2d *>(tex);

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -490,6 +490,7 @@ struct gs_texture_2d : gs_texture {
 	gs_texture_2d(gs_device_t *device, ID3D11Texture2D *nv12,
 		      uint32_t flags);
 	gs_texture_2d(gs_device_t *device, uint32_t handle);
+	gs_texture_2d(gs_device_t *device, ID3D11Texture2D *obj);
 };
 
 struct gs_texture_3d : gs_texture {

--- a/libobs-d3d11/d3d11-texture2d.cpp
+++ b/libobs-d3d11/d3d11-texture2d.cpp
@@ -311,3 +311,30 @@ gs_texture_2d::gs_texture_2d(gs_device_t *device, uint32_t handle)
 	if (FAILED(hr))
 		throw HRError("Failed to create shader resource view", hr);
 }
+
+gs_texture_2d::gs_texture_2d(gs_device_t *device, ID3D11Texture2D *obj)
+	: gs_texture(device, gs_type::gs_texture_2d, GS_TEXTURE_2D)
+{
+	texture = obj;
+
+	texture->GetDesc(&td);
+
+	this->type = GS_TEXTURE_2D;
+	this->format = ConvertDXGITextureFormat(td.Format);
+	this->levels = 1;
+	this->device = device;
+
+	this->width = td.Width;
+	this->height = td.Height;
+	this->dxgiFormat = td.Format;
+
+	memset(&resourceDesc, 0, sizeof(resourceDesc));
+	resourceDesc.Format = td.Format;
+	resourceDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+	resourceDesc.Texture2D.MipLevels = 1;
+
+	HRESULT hr = device->device->CreateShaderResourceView(
+		texture, &resourceDesc, shaderRes.Assign());
+	if (FAILED(hr))
+		throw HRError("Failed to create shader resource view", hr);
+}

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -210,6 +210,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT_OPTIONAL(gs_texture_release_dc);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_open_shared);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_get_shared_handle);
+	GRAPHICS_IMPORT_OPTIONAL(device_texture_wrap_obj);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_acquire_sync);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_release_sync);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_create_nv12);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -299,6 +299,8 @@ struct gs_exports {
 	gs_texture_t *(*device_texture_open_shared)(gs_device_t *device,
 						    uint32_t handle);
 	uint32_t (*device_texture_get_shared_handle)(gs_texture_t *tex);
+	gs_texture_t *(*device_texture_wrap_obj)(gs_device_t *device,
+						 void *obj);
 	int (*device_texture_acquire_sync)(gs_texture_t *tex, uint64_t key,
 					   uint32_t ms);
 	int (*device_texture_release_sync)(gs_texture_t *tex, uint64_t key);

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -2885,6 +2885,18 @@ uint32_t gs_texture_get_shared_handle(gs_texture_t *tex)
 	return GS_INVALID_HANDLE;
 }
 
+gs_texture_t *gs_texture_wrap_obj(void *obj)
+{
+	graphics_t *graphics = thread_graphics;
+	if (!gs_valid("gs_texture_wrap_obj"))
+		return NULL;
+
+	if (graphics->exports.device_texture_wrap_obj)
+		return graphics->exports.device_texture_wrap_obj(
+			graphics->device, obj);
+	return NULL;
+}
+
 int gs_texture_acquire_sync(gs_texture_t *tex, uint64_t key, uint32_t ms)
 {
 	graphics_t *graphics = thread_graphics;

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -867,6 +867,8 @@ EXPORT gs_texture_t *gs_texture_open_shared(uint32_t handle);
 #define GS_INVALID_HANDLE (uint32_t) - 1
 EXPORT uint32_t gs_texture_get_shared_handle(gs_texture_t *tex);
 
+EXPORT gs_texture_t *gs_texture_wrap_obj(void *obj);
+
 #define GS_WAIT_INFINITE (uint32_t) - 1
 
 /**


### PR DESCRIPTION
### Description
This can be useful for reading from textures provided by middleware.

### Motivation and Context
I'm working on game capture library, and this will allow cleaner integration.

See:
Library: https://github.com/LagFreeGames/LfgGameCapture
Plugin: https://github.com/jpark37/obs-studio/tree/lfg-game-capture

### How Has This Been Tested?
Textures are successfully wrapped and display correctly as part of game capture plugin.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.