### PR TITLE
mac-virtualcam: Fix global namespace issues in DAL plugin

### DIFF
--- a/plugins/mac-virtualcam/src/dal-plugin/CMakeLists.txt
+++ b/plugins/mac-virtualcam/src/dal-plugin/CMakeLists.txt
@@ -25,24 +25,24 @@ include_directories(${AVFOUNDATION}
 set(mac-dal-plugin_HEADERS
 	Defines.h
 	Logging.h
-	PlugInInterface.h
-	ObjectStore.h
-	PlugIn.h
-	Device.h
-	Stream.h
+	OBSDALPlugInInterface.h
+    OBSDALObjectStore.h
+	OBSDALPlugIn.h
+	OBSDALDevice.h
+    OBSDALStream.h
 	CMSampleBufferUtils.h
-	MachClient.h
+	OBSDALMachClient.h
 	../common/MachProtocol.h)
 
 set(mac-dal-plugin_SOURCES
-	PlugInMain.mm
-	PlugInInterface.mm
-	ObjectStore.mm
-	PlugIn.mm
-	Device.mm
-	Stream.mm
+	OBSDALPlugInMain.mm
+	OBSDALPlugInInterface.mm
+	OBSDALObjectStore.mm
+	OBSDALPlugIn.mm
+	OBSDALDevice.mm
+    OBSDALStream.mm
 	CMSampleBufferUtils.mm
-	MachClient.mm)
+	OBSDALMachClient.mm)
 
 add_library(mac-dal-plugin MODULE
 	${mac-dal-plugin_SOURCES}

--- a/plugins/mac-virtualcam/src/dal-plugin/Info.plist
+++ b/plugins/mac-virtualcam/src/dal-plugin/Info.plist
@@ -20,14 +20,14 @@
 	</array>
 	<key>CFPlugInFactories</key>
 	<dict>
-		<key>35FDFF29-BFCF-4644-AB77-B759DE932ABE</key>
+		<key>7E950B8C-5E49-4B9E-B7D0-B3608A08E8F6</key>
 		<string>PlugInMain</string>
 	</dict>
 	<key>CFPlugInTypes</key>
 	<dict>
 		<key>30010C1C-93BF-11D8-8B5B-000A95AF9C6A</key>
 		<array>
-			<string>35FDFF29-BFCF-4644-AB77-B759DE932ABE</string>
+			<string>7E950B8C-5E49-4B9E-B7D0-B3608A08E8F6</string>
 		</array>
 	</dict>
 	<key>LSMinimumSystemVersion</key>

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALDevice.h
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALDevice.h
@@ -1,8 +1,8 @@
 //
-//  PlugInMain.mm
+//  Device.h
 //  obs-mac-virtualcam
 //
-//  Created by John Boiles  on 4/9/20.
+//  Created by John Boiles  on 4/10/20.
 //
 //  obs-mac-virtualcam is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -17,21 +17,18 @@
 //  You should have received a copy of the GNU General Public License
 //  along with obs-mac-virtualcam. If not, see <http://www.gnu.org/licenses/>.
 
-#import <CoreMediaIO/CMIOHardwarePlugin.h>
+#import <Foundation/Foundation.h>
 
-#import "PlugInInterface.h"
-#import "Logging.h"
-#import "Defines.h"
+#import "OBSDALObjectStore.h"
 
-//! PlugInMain is the entrypoint for the plugin
-extern "C" {
-void *PlugInMain(CFAllocatorRef allocator, CFUUIDRef requestedTypeUUID)
-{
-	DLogFunc(@"version=%@", PLUGIN_VERSION);
-	if (!CFEqual(requestedTypeUUID, kCMIOHardwarePlugInTypeID)) {
-		return 0;
-	}
+NS_ASSUME_NONNULL_BEGIN
 
-	return PlugInRef();
-}
-}
+@interface OBSDALDevice : NSObject <CMIOObject>
+
+@property CMIOObjectID objectId;
+@property CMIOObjectID pluginId;
+@property CMIOObjectID streamId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALDevice.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALDevice.mm
@@ -17,20 +17,20 @@
 //  You should have received a copy of the GNU General Public License
 //  along with obs-mac-virtualcam. If not, see <http://www.gnu.org/licenses/>.
 
-#import "Device.h"
+#import "OBSDALDevice.h"
 
 #import <CoreFoundation/CoreFoundation.h>
 #include <IOKit/audio/IOAudioTypes.h>
 
-#import "PlugIn.h"
+#import "OBSDALPlugin.h"
 #import "Logging.h"
 
-@interface Device ()
+@interface OBSDALDevice ()
 @property BOOL excludeNonDALAccess;
 @property pid_t masterPid;
 @end
 
-@implementation Device
+@implementation OBSDALDevice
 
 // Note that the DAL's API calls HasProperty before calling GetPropertyDataSize. This means that it can be assumed that address is valid for the property involved.
 - (UInt32)getPropertyDataSizeWithAddress:(CMIOObjectPropertyAddress)address
@@ -87,7 +87,7 @@
 		return sizeof(pid_t);
 	default:
 		DLog(@"Device unhandled getPropertyDataSizeWithAddress for %@",
-		     [ObjectStore
+		     [OBSDALObjectStore
 			     StringFromPropertySelector:address.mSelector]);
 	};
 
@@ -192,7 +192,7 @@
 		break;
 	default:
 		DLog(@"Device unhandled getPropertyDataWithAddress for %@",
-		     [ObjectStore
+		     [OBSDALObjectStore
 			     StringFromPropertySelector:address.mSelector]);
 		*dataUsed = 0;
 		break;
@@ -228,7 +228,7 @@
 		return false;
 	default:
 		DLog(@"Device unhandled hasPropertyWithAddress for %@",
-		     [ObjectStore
+		     [OBSDALObjectStore
 			     StringFromPropertySelector:address.mSelector]);
 		return false;
 	};
@@ -263,7 +263,7 @@
 		return true;
 	default:
 		DLog(@"Device unhandled isPropertySettableWithAddress for %@",
-		     [ObjectStore
+		     [OBSDALObjectStore
 			     StringFromPropertySelector:address.mSelector]);
 		return false;
 	};
@@ -286,7 +286,7 @@
 		break;
 	default:
 		DLog(@"Device unhandled setPropertyDataWithAddress for %@",
-		     [ObjectStore
+		     [OBSDALObjectStore
 			     StringFromPropertySelector:address.mSelector]);
 		break;
 	};

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALMachClient.h
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALMachClient.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MachClient : NSObject
+@interface OBSDALMachClient : NSObject
 
 @property (nullable, weak) id<MachClientDelegate> delegate;
 

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALMachClient.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALMachClient.mm
@@ -5,16 +5,16 @@
 //  Created by John Boiles  on 5/5/20.
 //
 
-#import "MachClient.h"
+#import "OBSDALMachClient.h"
 #import "MachProtocol.h"
 #import "Logging.h"
 
-@interface MachClient () <NSPortDelegate> {
+@interface OBSDALMachClient () <NSPortDelegate> {
 	NSPort *_receivePort;
 }
 @end
 
-@implementation MachClient
+@implementation OBSDALMachClient
 
 - (void)dealloc
 {

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALObjectStore.h
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALObjectStore.h
@@ -43,9 +43,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface ObjectStore : NSObject
+@interface OBSDALObjectStore : NSObject
 
-+ (ObjectStore *)SharedObjectStore;
++ (OBSDALObjectStore *)SharedObjectStore;
 
 + (NSObject<CMIOObject> *)GetObjectWithId:(CMIOObjectID)objectId;
 

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALObjectStore.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALObjectStore.mm
@@ -17,13 +17,13 @@
 //  You should have received a copy of the GNU General Public License
 //  along with obs-mac-virtualcam. If not, see <http://www.gnu.org/licenses/>.
 
-#import "ObjectStore.h"
+#import "OBSDALObjectStore.h"
 
-@interface ObjectStore ()
+@interface OBSDALObjectStore ()
 @property NSMutableDictionary *objectMap;
 @end
 
-@implementation ObjectStore
+@implementation OBSDALObjectStore
 
 // 4-byte selectors to string for easy debugging
 + (NSString *)StringFromPropertySelector:(CMIOObjectPropertySelector)selector
@@ -245,9 +245,9 @@
 	}
 }
 
-+ (ObjectStore *)SharedObjectStore
++ (OBSDALObjectStore *)SharedObjectStore
 {
-	static ObjectStore *sObjectStore = nil;
+	static OBSDALObjectStore *sObjectStore = nil;
 	static dispatch_once_t sOnceToken;
 	dispatch_once(&sOnceToken, ^{
 		sObjectStore = [[self alloc] init];
@@ -257,7 +257,7 @@
 
 + (NSObject<CMIOObject> *)GetObjectWithId:(CMIOObjectID)objectId
 {
-	return [[ObjectStore SharedObjectStore] getObject:objectId];
+	return [[OBSDALObjectStore SharedObjectStore] getObject:objectId];
 }
 
 - (id)init

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugInInterface.h
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugInInterface.h
@@ -1,8 +1,8 @@
 //
-//  Stream.h
+//  PlugInInterface.h
 //  obs-mac-virtualcam
 //
-//  Created by John Boiles  on 4/10/20.
+//  Created by John Boiles  on 4/9/20.
 //
 //  obs-mac-virtualcam is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -17,32 +17,7 @@
 //  You should have received a copy of the GNU General Public License
 //  along with obs-mac-virtualcam. If not, see <http://www.gnu.org/licenses/>.
 
-#import <Foundation/Foundation.h>
+#import <CoreMediaIO/CMIOHardwarePlugIn.h>
 
-#import "ObjectStore.h"
-
-NS_ASSUME_NONNULL_BEGIN
-
-@interface Stream : NSObject <CMIOObject>
-
-@property CMIOStreamID objectId;
-
-- (instancetype _Nonnull)init;
-
-- (CMSimpleQueueRef)copyBufferQueueWithAlteredProc:
-			    (CMIODeviceStreamQueueAlteredProc)alteredProc
-				     alteredRefCon:(void *)alteredRefCon;
-
-- (void)startServingDefaultFrames;
-
-- (void)stopServingDefaultFrames;
-
-- (void)queueFrameWithSize:(NSSize)size
-		 timestamp:(uint64_t)timestamp
-	      fpsNumerator:(uint32_t)fpsNumerator
-	    fpsDenominator:(uint32_t)fpsDenominator
-		 frameData:(NSData *)frameData;
-
-@end
-
-NS_ASSUME_NONNULL_END
+// The static singleton of the plugin interface
+CMIOHardwarePlugInRef OBSDALPlugInRef();

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugin.h
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugin.h
@@ -1,5 +1,5 @@
 //
-//  PlugInInterface.h
+//  PlugIn.h
 //  obs-mac-virtualcam
 //
 //  Created by John Boiles  on 4/9/20.
@@ -17,7 +17,35 @@
 //  You should have received a copy of the GNU General Public License
 //  along with obs-mac-virtualcam. If not, see <http://www.gnu.org/licenses/>.
 
+#import <Foundation/Foundation.h>
 #import <CoreMediaIO/CMIOHardwarePlugIn.h>
 
-// The static singleton of the plugin interface
-CMIOHardwarePlugInRef PlugInRef();
+#import "OBSDALObjectStore.h"
+#import "OBSDALMachClient.h"
+#import "OBSDALStream.h"
+
+#define kTestCardWidthKey @"obs-mac-virtualcam-test-card-width"
+#define kTestCardHeightKey @"obs-mac-virtualcam-test-card-height"
+#define kTestCardFPSKey @"obs-mac-virtualcam-test-card-fps"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OBSDALPlugin : NSObject <CMIOObject>
+
+@property CMIOObjectID objectId;
+@property (readonly) OBSDALMachClient *machClient;
+@property OBSDALStream *stream;
+
++ (OBSDALPlugin *)SharedPlugIn;
+
+- (void)initialize;
+
+- (void)teardown;
+
+- (void)startStream;
+
+- (void)stopStream;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugin.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugin.mm
@@ -17,7 +17,7 @@
 //  You should have received a copy of the GNU General Public License
 //  along with obs-mac-virtualcam. If not, see <http://www.gnu.org/licenses/>.
 
-#import "PlugIn.h"
+#import "OBSDALPlugin.h"
 
 #import <CoreMediaIO/CMIOHardwarePlugin.h>
 
@@ -27,9 +27,9 @@ typedef enum {
 	PlugInStateNotStarted = 0,
 	PlugInStateWaitingForServer,
 	PlugInStateReceivingFrames,
-} PlugInState;
+} OBSDALPlugInState;
 
-@interface PlugIn () <MachClientDelegate> {
+@interface OBSDALPlugin () <MachClientDelegate> {
 	//! Serial queue for all state changes that need to be concerned with thread safety
 	dispatch_queue_t _stateQueue;
 
@@ -39,16 +39,16 @@ typedef enum {
 	//! Timeout timer when we haven't received frames for 5s
 	dispatch_source_t _timeoutTimer;
 }
-@property PlugInState state;
-@property MachClient *machClient;
+@property OBSDALPlugInState state;
+@property OBSDALMachClient *machClient;
 
 @end
 
-@implementation PlugIn
+@implementation OBSDALPlugin
 
-+ (PlugIn *)SharedPlugIn
++ (OBSDALPlugin *)SharedPlugIn
 {
-	static PlugIn *sPlugIn = nil;
+	static OBSDALPlugin *sPlugIn = nil;
 	static dispatch_once_t sOnceToken;
 	dispatch_once(&sOnceToken, ^{
 		sPlugIn = [[self alloc] init];
@@ -74,7 +74,7 @@ typedef enum {
 			}
 		});
 
-		_machClient = [[MachClient alloc] init];
+		_machClient = [[OBSDALMachClient alloc] init];
 		_machClient.delegate = self;
 
 		_machConnectTimer = dispatch_source_create(
@@ -140,7 +140,7 @@ typedef enum {
 		return true;
 	default:
 		DLog(@"PlugIn unhandled hasPropertyWithAddress for %@",
-		     [ObjectStore
+		     [OBSDALObjectStore
 			     StringFromPropertySelector:address.mSelector]);
 		return false;
 	};
@@ -153,7 +153,7 @@ typedef enum {
 		return false;
 	default:
 		DLog(@"PlugIn unhandled isPropertySettableWithAddress for %@",
-		     [ObjectStore
+		     [OBSDALObjectStore
 			     StringFromPropertySelector:address.mSelector]);
 		return false;
 	};
@@ -168,7 +168,7 @@ typedef enum {
 		return sizeof(CFStringRef);
 	default:
 		DLog(@"PlugIn unhandled getPropertyDataSizeWithAddress for %@",
-		     [ObjectStore
+		     [OBSDALObjectStore
 			     StringFromPropertySelector:address.mSelector]);
 		return 0;
 	};
@@ -189,7 +189,7 @@ typedef enum {
 		return;
 	default:
 		DLog(@"PlugIn unhandled getPropertyDataWithAddress for %@",
-		     [ObjectStore
+		     [OBSDALObjectStore
 			     StringFromPropertySelector:address.mSelector]);
 		return;
 	};
@@ -202,7 +202,7 @@ typedef enum {
 			      data:(nonnull const void *)data
 {
 	DLog(@"PlugIn unhandled setPropertyDataWithAddress for %@",
-	     [ObjectStore StringFromPropertySelector:address.mSelector]);
+	     [OBSDALObjectStore StringFromPropertySelector:address.mSelector]);
 }
 
 #pragma mark - MachClientDelegate

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALPluginMain.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALPluginMain.mm
@@ -1,8 +1,8 @@
 //
-//  Device.h
+//  PlugInMain.mm
 //  obs-mac-virtualcam
 //
-//  Created by John Boiles  on 4/10/20.
+//  Created by John Boiles  on 4/9/20.
 //
 //  obs-mac-virtualcam is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -17,18 +17,21 @@
 //  You should have received a copy of the GNU General Public License
 //  along with obs-mac-virtualcam. If not, see <http://www.gnu.org/licenses/>.
 
-#import <Foundation/Foundation.h>
+#import <CoreMediaIO/CMIOHardwarePlugin.h>
 
-#import "ObjectStore.h"
+#import "OBSDALPlugInInterface.h"
+#import "Logging.h"
+#import "Defines.h"
 
-NS_ASSUME_NONNULL_BEGIN
+//! PlugInMain is the entrypoint for the plugin
+extern "C" {
+void *PlugInMain(CFAllocatorRef allocator, CFUUIDRef requestedTypeUUID)
+{
+	DLogFunc(@"version=%@", PLUGIN_VERSION);
+	if (!CFEqual(requestedTypeUUID, kCMIOHardwarePlugInTypeID)) {
+		return 0;
+	}
 
-@interface Device : NSObject <CMIOObject>
-
-@property CMIOObjectID objectId;
-@property CMIOObjectID pluginId;
-@property CMIOObjectID streamId;
-
-@end
-
-NS_ASSUME_NONNULL_END
+	return OBSDALPlugInRef();
+}
+}

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.h
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.h
@@ -1,8 +1,8 @@
 //
-//  PlugIn.h
+//  Stream.h
 //  obs-mac-virtualcam
 //
-//  Created by John Boiles  on 4/9/20.
+//  Created by John Boiles  on 4/10/20.
 //
 //  obs-mac-virtualcam is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -18,33 +18,30 @@
 //  along with obs-mac-virtualcam. If not, see <http://www.gnu.org/licenses/>.
 
 #import <Foundation/Foundation.h>
-#import <CoreMediaIO/CMIOHardwarePlugIn.h>
 
-#import "ObjectStore.h"
-#import "MachClient.h"
-#import "Stream.h"
-
-#define kTestCardWidthKey @"obs-mac-virtualcam-test-card-width"
-#define kTestCardHeightKey @"obs-mac-virtualcam-test-card-height"
-#define kTestCardFPSKey @"obs-mac-virtualcam-test-card-fps"
+#import "OBSDALObjectStore.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface PlugIn : NSObject <CMIOObject>
+@interface OBSDALStream : NSObject <CMIOObject>
 
-@property CMIOObjectID objectId;
-@property (readonly) MachClient *machClient;
-@property Stream *stream;
+@property CMIOStreamID objectId;
 
-+ (PlugIn *)SharedPlugIn;
+- (instancetype _Nonnull)init;
 
-- (void)initialize;
+- (CMSimpleQueueRef)copyBufferQueueWithAlteredProc:
+			    (CMIODeviceStreamQueueAlteredProc)alteredProc
+				     alteredRefCon:(void *)alteredRefCon;
 
-- (void)teardown;
+- (void)startServingDefaultFrames;
 
-- (void)startStream;
+- (void)stopServingDefaultFrames;
 
-- (void)stopStream;
+- (void)queueFrameWithSize:(NSSize)size
+		 timestamp:(uint64_t)timestamp
+	      fpsNumerator:(uint32_t)fpsNumerator
+	    fpsDenominator:(uint32_t)fpsDenominator
+		 frameData:(NSData *)frameData;
 
 @end
 

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
@@ -17,7 +17,7 @@
 //  You should have received a copy of the GNU General Public License
 //  along with obs-mac-virtualcam. If not, see <http://www.gnu.org/licenses/>.
 
-#import "Stream.h"
+#import "OBSDALStream.h"
 
 #import <AppKit/AppKit.h>
 #import <mach/mach_time.h>
@@ -25,9 +25,9 @@
 
 #import "Logging.h"
 #import "CMSampleBufferUtils.h"
-#import "PlugIn.h"
+#import "OBSDALPlugin.h"
 
-@interface Stream () {
+@interface OBSDALStream () {
 	CMSimpleQueueRef _queue;
 	CFTypeRef _clock;
 	NSImage *_testCardImage;
@@ -47,7 +47,7 @@
 
 @end
 
-@implementation Stream
+@implementation OBSDALStream
 
 #define DEFAULT_FPS 30.0
 #define DEFAULT_WIDTH 1280
@@ -165,8 +165,8 @@
 - (NSImage *)testCardImage
 {
 	if (_testCardImage == nil) {
-		NSString *bundlePath =
-			[[NSBundle bundleForClass:[Stream class]] bundlePath];
+		NSString *bundlePath = [[NSBundle
+			bundleForClass:[OBSDALStream class]] bundlePath];
 		NSString *placeHolderPath = [bundlePath
 			stringByAppendingString:
 				@"/Contents/Resources/placeholder.png"];
@@ -434,7 +434,7 @@
 		return sizeof(CFTypeRef);
 	default:
 		DLog(@"Stream unhandled getPropertyDataSizeWithAddress for %@",
-		     [ObjectStore
+		     [OBSDALObjectStore
 			     StringFromPropertySelector:address.mSelector]);
 		return 0;
 	};
@@ -510,7 +510,7 @@
 		break;
 	default:
 		DLog(@"Stream unhandled getPropertyDataWithAddress for %@",
-		     [ObjectStore
+		     [OBSDALObjectStore
 			     StringFromPropertySelector:address.mSelector]);
 		*dataUsed = 0;
 	};
@@ -539,12 +539,12 @@
 	case kCMIOStreamPropertyInitialPresentationTimeStampForLinkedAndSyncedAudio:
 	case kCMIOStreamPropertyOutputBuffersNeededForThrottledPlayback:
 		DLog(@"TODO: %@",
-		     [ObjectStore
+		     [OBSDALObjectStore
 			     StringFromPropertySelector:address.mSelector]);
 		return false;
 	default:
 		DLog(@"Stream unhandled hasPropertyWithAddress for %@",
-		     [ObjectStore
+		     [OBSDALObjectStore
 			     StringFromPropertySelector:address.mSelector]);
 		return false;
 	};
@@ -553,7 +553,7 @@
 - (BOOL)isPropertySettableWithAddress:(CMIOObjectPropertyAddress)address
 {
 	DLog(@"Stream unhandled isPropertySettableWithAddress for %@",
-	     [ObjectStore StringFromPropertySelector:address.mSelector]);
+	     [OBSDALObjectStore StringFromPropertySelector:address.mSelector]);
 	return false;
 }
 
@@ -564,7 +564,7 @@
 			      data:(nonnull const void *)data
 {
 	DLog(@"Stream unhandled setPropertyDataWithAddress for %@",
-	     [ObjectStore StringFromPropertySelector:address.mSelector]);
+	     [OBSDALObjectStore StringFromPropertySelector:address.mSelector]);
 }
 
 @end


### PR DESCRIPTION
### Description
Fixes global namespaces issues in the DAL plugin that will arise when another DAL plugin based on the same example code is installed on the system.

### Motivation and Context
ObjectiveC does symbol lookups at runtime, which means that two plugins can be loaded with identical symbol names. This leads to undefined behaviour as it is not defined which class/method will be used.

The issue was mentioned in https://github.com/johnboiles/obs-mac-virtualcam/issues/215 before and has been shown to interfere with the EOS Webcam Utility for macOS (which also didn't namespace its functions uniquely) https://github.com/johnboiles/obs-mac-virtualcam/issues/232#issuecomment-732318227.

### How Has This Been Tested?
Virtualcam tested locally with the plugin-version installed to check if there are still ambiguous symbols.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
