### PR TITLE
frontend-tools: Don't give every loaded filter focus

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -225,7 +225,7 @@ void OBSBasicFilters::UpdateProperties(void *data, calldata_t *)
 				  "ReloadProperties");
 }
 
-void OBSBasicFilters::AddFilter(OBSSource filter)
+void OBSBasicFilters::AddFilter(OBSSource filter, bool focus)
 {
 	uint32_t flags = obs_source_get_output_flags(filter);
 	bool async = (flags & OBS_SOURCE_ASYNC) != 0;
@@ -238,7 +238,8 @@ void OBSBasicFilters::AddFilter(OBSSource filter)
 	item->setData(Qt::UserRole, QVariant::fromValue(filter));
 
 	list->addItem(item);
-	list->setCurrentItem(item);
+	if (focus)
+		list->setCurrentItem(item);
 	SetupVisibilityItem(list, item, filter);
 }
 
@@ -352,9 +353,15 @@ void OBSBasicFilters::UpdateFilters()
 			OBSBasicFilters *window =
 				reinterpret_cast<OBSBasicFilters *>(p);
 
-			window->AddFilter(filter);
+			window->AddFilter(filter, false);
 		},
 		this);
+
+	if (ui->asyncFilters->count() > 0) {
+		ui->asyncFilters->setCurrentItem(ui->asyncFilters->item(0));
+	} else if (ui->effectFilters->count() > 0) {
+		ui->effectFilters->setCurrentItem(ui->effectFilters->item(0));
+	}
 
 	main->SaveProject();
 }

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -78,7 +78,7 @@ private:
 	bool editActive = false;
 
 private slots:
-	void AddFilter(OBSSource filter);
+	void AddFilter(OBSSource filter, bool focus = true);
 	void RemoveFilter(OBSSource filter);
 	void ReorderFilters();
 	void RenameAsyncFilter();


### PR DESCRIPTION
### Description
Instead of giving each filter that is loaded in the OBSBasicFilters window focus, only focus a single row on loading and still focus a new row on adding a filter.

### Motivation and Context
Speeds up loading of the filter window with large number of filters
Prevents deadlock by not getting the properties of filters during OBSBasicFilters::UpdateFilters() which uses the source->filter_mutex

### How Has This Been Tested?
On Windows 64 bit by having a source with multiple filters with properties that load other scenes, scene items, sources and filters.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
