### PR TITLE
UI: Set default source toolbar visibility to true & simplify its setting initialisation

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -446,6 +446,8 @@ bool OBSApp::InitGlobalConfigDefaults()
 				true);
 	config_set_default_bool(globalConfig, "BasicWindow", "ShowSourceIcons",
 				true);
+	config_set_default_bool(globalConfig, "BasicWindow",
+				"ShowContextToolbars", true);
 	config_set_default_bool(globalConfig, "BasicWindow", "StudioModeLabels",
 				true);
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1770,19 +1770,12 @@ void OBSBasic::OBSInit()
 		GetGlobalConfig(), "BasicWindow", "ShowSourceIcons");
 	ui->toggleSourceIcons->setChecked(sourceIconsVisible);
 
-	if (config_has_user_value(App()->GlobalConfig(), "BasicWindow",
-				  "ShowContextToolbars")) {
-		bool visible = config_get_bool(App()->GlobalConfig(),
-					       "BasicWindow",
-					       "ShowContextToolbars");
-		ui->toggleContextBar->setChecked(visible);
-		ui->contextContainer->setVisible(visible);
-		if (visible)
-			UpdateContextBar(true);
-	} else {
-		ui->toggleContextBar->setChecked(true);
-		ui->contextContainer->setVisible(true);
-	}
+	bool contextVisible = config_get_bool(
+		App()->GlobalConfig(), "BasicWindow", "ShowContextToolbars");
+	ui->toggleContextBar->setChecked(contextVisible);
+	ui->contextContainer->setVisible(contextVisible);
+	if (contextVisible)
+		UpdateContextBar(true);
 
 	{
 		ProfileScope("OBSBasic::Load");


### PR DESCRIPTION
### Description

This significantly simplifies the configuration setting's initial load.

This also fixes as issue where the source toolbar would initialise as "TextLabel" with enabled buttons if the user had not yet toggled the setting.

Fixes #3722

### Motivation and Context

UX improvement.

The old `else` clause was not triggering an `UpdateContextBar()` if the user had never toggled the context bar's display. The new code makes it much clearer what will happen, and is more consistent with other settings.

### How Has This Been Tested?

On Windows 10.

* Delete the `ShowContextToolbars` entry in global.ini (or load a fresh OBS)
* Launch OBS

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
