### PR TITLE
Improve scene collection importer

### DIFF
--- a/UI/window-importer.cpp
+++ b/UI/window-importer.cpp
@@ -600,8 +600,15 @@ void OBSImporter::importCollections()
 
 			std::string out_str = json11::Json(out).dump();
 
-			os_quick_write_utf8_file(save.c_str(), out_str.c_str(),
-						 out_str.size(), false);
+			bool success = os_quick_write_utf8_file(save.c_str(),
+								out_str.c_str(),
+								out_str.size(),
+								false);
+
+			blog(LOG_INFO, "Import Scene Collection: %s (%s) - %s",
+			     name.toStdString().c_str(),
+			     file.toStdString().c_str(),
+			     success ? "SUCCESS" : "FAILURE");
 		}
 	}
 

--- a/UI/window-importer.cpp
+++ b/UI/window-importer.cpp
@@ -577,11 +577,12 @@ void OBSImporter::importCollections()
 			json11::Json::object out = res.object_items();
 			QString file = res["name"].string_value().c_str();
 
+			file.replace(" ", "_");
 			bool safe = !CheckConfigExists(dst, file);
 			int x = 1;
 			while (!safe) {
 				file = name;
-				file += " (";
+				file += "_(";
 				file += QString::number(x);
 				file += ")";
 
@@ -593,7 +594,7 @@ void OBSImporter::importCollections()
 
 			std::string save = dst;
 			save += "/";
-			save += file.replace(" ", "_").toStdString();
+			save += file.toStdString();
 			save += ".json";
 
 			std::string out_str = json11::Json(out).dump();

--- a/UI/window-importer.cpp
+++ b/UI/window-importer.cpp
@@ -578,6 +578,7 @@ void OBSImporter::importCollections()
 			QString file = res["name"].string_value().c_str();
 
 			file.replace(" ", "_");
+			file.replace("/", "_");
 			bool safe = !CheckConfigExists(dst, file);
 			int x = 1;
 			while (!safe) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix a few issues with importing scene collections
* Prevent name collision during scene collection import
* Prevent import failure for collections with slash in name
* Log success/failure for scene collection importer

The Scene Collection Importer for importing scene collections from other applications would attempt to set the new filename using the name of the scene collection. However, it would determine an unused filename, and then replace spaces with underscores, which could cause a name collision. This changes the importer to replace spaces with underscores first for the base filename, and then determine an unused filename.

Ultimately, I think that refactoring to use something like `GetUnusedSceneCollectionFile` from `UI\window-basic-main-scene-collections.cpp` for the filename generation code in the importer would be better, but for now, this is an improvement.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We should prevent issues importing scene collections.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I compiled and tested on Windows 10 2004 (Build 19041.630) with a scene collection file that used a forward slash in its "name" property.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
