### PR TITLE
UI: Handle (de)select scene items queued

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -220,7 +220,8 @@ void SourceTreeItem::ReconnectSignals()
 			(obs_sceneitem_t *)calldata_ptr(cd, "item");
 
 		if (curItem == this_->sceneitem)
-			QMetaObject::invokeMethod(this_, "Select");
+			QMetaObject::invokeMethod(this_, "Select",
+						  Qt::QueuedConnection);
 	};
 
 	auto itemDeselect = [](void *data, calldata_t *cd) {
@@ -230,7 +231,8 @@ void SourceTreeItem::ReconnectSignals()
 			(obs_sceneitem_t *)calldata_ptr(cd, "item");
 
 		if (curItem == this_->sceneitem)
-			QMetaObject::invokeMethod(this_, "Deselect");
+			QMetaObject::invokeMethod(this_, "Deselect",
+						  Qt::QueuedConnection);
 	};
 
 	auto reorderGroup = [](void *data, calldata_t *) {


### PR DESCRIPTION
### Description
The (de)select signal can come from a obs_scene_enum_items which locks the scene. The Qt::QueuedConnection makes sure the (de)select is handled outside of that lock.

### Motivation and Context
Fixes #3673

### How Has This Been Tested?
On windows 64 bit by replicating the bug in #3673

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
