### PR TITLE
obs-ffmpeg: Fix broken muxing on es_ES

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -22,6 +22,10 @@
 #include <util/darray.h>
 #include <util/platform.h>
 
+#if __linux__
+#include <locale.h>
+#endif
+
 #include "obs-ffmpeg-output.h"
 #include "obs-ffmpeg-formats.h"
 #include "obs-ffmpeg-compat.h"
@@ -430,7 +434,15 @@ static inline bool open_output_file(struct ffmpeg_data *data)
 		}
 	}
 
+#if __linux__
+	/* some muxers have locale specific bugs (hls/m3u8) which will fail
+	 * when users are in Euro locales. */
+	setlocale(LC_NUMERIC, "C");
+#endif
 	ret = avformat_write_header(data->output, &dict);
+#if __linux__
+	setlocale(LC_NUMERIC, "");
+#endif
 	if (ret < 0) {
 		ffmpeg_log_error(LOG_WARNING, data, "Error opening '%s': %s",
 				 data->config.url, av_err2str(ret));


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Switch locale over to C before we call into ffmpeg to avoid it failing
to start the encoder.

Fixes #3770

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Weird ffmpeg bug thats reasonably easily worked around. Setting locales is always a bit shaky since its global but hopefully this doesnt have any adverse impact since its only needed for the initial header write.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Setting locale to es_ES causes the issue to appear and this appears to fix it.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
