### PR TITLE
UI: Fix change profile with audio properties miss prompt restart message

### DIFF
--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -487,13 +487,13 @@ void OBSBasic::on_actionRemoveProfile_triggered()
 			  newName.c_str());
 	config_set_string(App()->GlobalConfig(), "Basic", "ProfileDir", newDir);
 
-    auto main = reinterpret_cast<OBSMainWindow *>(App()->GetMainWindow());
-    
-    const char *oldSpeakers =
-        config_get_string(main->Config(), "Audio", "ChannelSetup");
-    uint oldSampleRate =
-        config_get_uint(main->Config(), "Audio", "SampleRate");
-    
+	auto main = reinterpret_cast<OBSMainWindow *>(App()->GetMainWindow());
+
+	const char *oldSpeakers =
+		config_get_string(main->Config(), "Audio", "ChannelSetup");
+	uint oldSampleRate =
+		config_get_uint(main->Config(), "Audio", "SampleRate");
+
 	Auth::Save();
 	auth.reset();
 	DeleteCookies();
@@ -519,23 +519,23 @@ void OBSBasic::on_actionRemoveProfile_triggered()
 		api->on_event(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
 		api->on_event(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
 	}
-    
-    const char *newSpeakers =
-        config_get_string(main->Config(), "Audio", "ChannelSetup");
-    uint newSampleRate =
-        config_get_uint(main->Config(), "Audio", "SampleRate");
-    
-    // need restart if audio sample rate or channel is modified
-    if (strcmp(oldSpeakers, newSpeakers) != 0 ||
-        oldSampleRate != newSampleRate) {
-        QMessageBox::StandardButton button = OBSMessageBox::question(
-            this, QTStr("Restart"), QTStr("NeedsRestart"));
 
-        if (button == QMessageBox::Yes) {
-            restart = true;
-            close();
-        }
-    }
+	const char *newSpeakers =
+		config_get_string(main->Config(), "Audio", "ChannelSetup");
+	uint newSampleRate =
+		config_get_uint(main->Config(), "Audio", "SampleRate");
+
+	// need restart if audio sample rate or channel is modified
+	if (strcmp(oldSpeakers, newSpeakers) != 0 ||
+	    oldSampleRate != newSampleRate) {
+		QMessageBox::StandardButton button = OBSMessageBox::question(
+			this, QTStr("Restart"), QTStr("NeedsRestart"));
+
+		if (button == QMessageBox::Yes) {
+			restart = true;
+			close();
+		}
+	}
 }
 
 void OBSBasic::on_actionImportProfile_triggered()
@@ -670,13 +670,13 @@ void OBSBasic::ChangeProfile()
 	config_set_string(App()->GlobalConfig(), "Basic", "Profile", newName);
 	config_set_string(App()->GlobalConfig(), "Basic", "ProfileDir", newDir);
 
-    auto main = reinterpret_cast<OBSMainWindow *>(App()->GetMainWindow());
-    
-    const char *oldSpeakers =
-        config_get_string(main->Config(), "Audio", "ChannelSetup");
-    uint oldSampleRate =
-        config_get_uint(main->Config(), "Audio", "SampleRate");
-    
+	auto main = reinterpret_cast<OBSMainWindow *>(App()->GetMainWindow());
+
+	const char *oldSpeakers =
+		config_get_string(main->Config(), "Audio", "ChannelSetup");
+	uint oldSampleRate =
+		config_get_uint(main->Config(), "Audio", "SampleRate");
+
 	Auth::Save();
 	auth.reset();
 	DestroyPanelCookieManager();
@@ -698,23 +698,23 @@ void OBSBasic::ChangeProfile()
 
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
-    
-    const char *newSpeakers =
-        config_get_string(main->Config(), "Audio", "ChannelSetup");
-    uint newSampleRate =
-        config_get_uint(main->Config(), "Audio", "SampleRate");
-    
-    // need restart if audio sample rate or channel is modified
-    if (strcmp(oldSpeakers, newSpeakers) != 0 ||
-        oldSampleRate != newSampleRate) {
-        QMessageBox::StandardButton button = OBSMessageBox::question(
-            this, QTStr("Restart"), QTStr("NeedsRestart"));
 
-        if (button == QMessageBox::Yes) {
-            restart = true;
-            close();
-        }
-    }
+	const char *newSpeakers =
+		config_get_string(main->Config(), "Audio", "ChannelSetup");
+	uint newSampleRate =
+		config_get_uint(main->Config(), "Audio", "SampleRate");
+
+	// need restart if audio sample rate or channel is modified
+	if (strcmp(oldSpeakers, newSpeakers) != 0 ||
+	    oldSampleRate != newSampleRate) {
+		QMessageBox::StandardButton button = OBSMessageBox::question(
+			this, QTStr("Restart"), QTStr("NeedsRestart"));
+
+		if (button == QMessageBox::Yes) {
+			restart = true;
+			close();
+		}
+	}
 }
 
 void OBSBasic::CheckForSimpleModeX264Fallback()

--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -487,6 +487,13 @@ void OBSBasic::on_actionRemoveProfile_triggered()
 			  newName.c_str());
 	config_set_string(App()->GlobalConfig(), "Basic", "ProfileDir", newDir);
 
+    auto main = reinterpret_cast<OBSMainWindow *>(App()->GetMainWindow());
+    
+    const char *oldSpeakers =
+        config_get_string(main->Config(), "Audio", "ChannelSetup");
+    uint oldSampleRate =
+        config_get_uint(main->Config(), "Audio", "SampleRate");
+    
 	Auth::Save();
 	auth.reset();
 	DeleteCookies();
@@ -512,6 +519,23 @@ void OBSBasic::on_actionRemoveProfile_triggered()
 		api->on_event(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
 		api->on_event(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
 	}
+    
+    const char *newSpeakers =
+        config_get_string(main->Config(), "Audio", "ChannelSetup");
+    uint newSampleRate =
+        config_get_uint(main->Config(), "Audio", "SampleRate");
+    
+    // need restart if audio sample rate or channel is modified
+    if (strcmp(oldSpeakers, newSpeakers) != 0 ||
+        oldSampleRate != newSampleRate) {
+        QMessageBox::StandardButton button = OBSMessageBox::question(
+            this, QTStr("Restart"), QTStr("NeedsRestart"));
+
+        if (button == QMessageBox::Yes) {
+            restart = true;
+            close();
+        }
+    }
 }
 
 void OBSBasic::on_actionImportProfile_triggered()
@@ -646,6 +670,13 @@ void OBSBasic::ChangeProfile()
 	config_set_string(App()->GlobalConfig(), "Basic", "Profile", newName);
 	config_set_string(App()->GlobalConfig(), "Basic", "ProfileDir", newDir);
 
+    auto main = reinterpret_cast<OBSMainWindow *>(App()->GetMainWindow());
+    
+    const char *oldSpeakers =
+        config_get_string(main->Config(), "Audio", "ChannelSetup");
+    uint oldSampleRate =
+        config_get_uint(main->Config(), "Audio", "SampleRate");
+    
 	Auth::Save();
 	auth.reset();
 	DestroyPanelCookieManager();
@@ -667,6 +698,23 @@ void OBSBasic::ChangeProfile()
 
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
+    
+    const char *newSpeakers =
+        config_get_string(main->Config(), "Audio", "ChannelSetup");
+    uint newSampleRate =
+        config_get_uint(main->Config(), "Audio", "SampleRate");
+    
+    // need restart if audio sample rate or channel is modified
+    if (strcmp(oldSpeakers, newSpeakers) != 0 ||
+        oldSampleRate != newSampleRate) {
+        QMessageBox::StandardButton button = OBSMessageBox::question(
+            this, QTStr("Restart"), QTStr("NeedsRestart"));
+
+        if (button == QMessageBox::Yes) {
+            restart = true;
+            close();
+        }
+    }
 }
 
 void OBSBasic::CheckForSimpleModeX264Fallback()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Missing restart action after change profile which contains audio properties

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #3207

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on macOS v10.15.7 multiple times with the steps to reproduce provided by the user(Audio Channel and Sample Rate)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
