### PR TITLE
vlc-video: Free media struct

### DIFF
--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -332,6 +332,8 @@ static void vlcs_get_metadata(void *data, calldata_t *cd)
 	VLC_META(media, cd, data_id, "album_artist", libvlc_meta_AlbumArtist)
 	VLC_META(media, cd, data_id, "disc_number", libvlc_meta_DiscNumber)
 	VLC_META(media, cd, data_id, "disc_total", libvlc_meta_DiscTotal)
+
+	libvlc_media_release_(media);
 #undef VLC_META
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Should fix #3695, which resulted in OBS crashing on exit if metadata was retrieved on a stopped VLC source. Why it only happened on stopped sources, I don't really know.

### Motivation and Context
Not leaking memory and preventing crashes I guess.

### How Has This Been Tested?
It's been a bit tricky, because the crash didn't happen for me when I ran obs in Visual Studio, but after building the patched vlc-video source and adding it to a release build of obs the crashes stopped.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
