### PR TITLE
mac-virtualcam: Build a universal x86_64+arm64 binary for M1 Macs

### DIFF
--- a/plugins/mac-virtualcam/src/dal-plugin/CMakeLists.txt
+++ b/plugins/mac-virtualcam/src/dal-plugin/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Universal build for Apple Silicon
+set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
+
 project(mac-dal-plugin)
 
 find_library(AVFOUNDATION AVFoundation)


### PR DESCRIPTION
### Description
This patch updates the DAL part of the macOS Virtualcam plugin to be a fat binary that includes both x86_64 and arm64 binaries.

### Motivation and Context
This enables universal apps running on Apple Silicon to use the plugin (even while OBS is running as x86_64 under Rosetta).

This patch can probably be removed once all of OBS supports Apple Silicon (since I assume something like this will be the default for the entire build).

```
> file build/plugins/mac-virtualcam/src/dal-plugin/obs-mac-virtualcam.plugin/Contents/MacOS/obs-mac-virtualcam
build/plugins/mac-virtualcam/src/dal-plugin/obs-mac-virtualcam.plugin/Contents/MacOS/obs-mac-virtualcam: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit bundle x86_64] [arm64:Mach-O 64-bit bundle arm64]
build/plugins/mac-virtualcam/src/dal-plugin/obs-mac-virtualcam.plugin/Contents/MacOS/obs-mac-virtualcam (for architecture x86_64):	Mach-O 64-bit bundle x86_64
build/plugins/mac-virtualcam/src/dal-plugin/obs-mac-virtualcam.plugin/Contents/MacOS/obs-mac-virtualcam (for architecture arm64):	Mach-O 64-bit bundle arm64
```

### How Has This Been Tested?
There's been some testing in my Repo with a similar change. See:

https://github.com/johnboiles/obs-mac-virtualcam/issues/239
https://github.com/johnboiles/obs-mac-virtualcam/pull/240

### Types of changes
* Cmake build change

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
