### PR TITLE
CI: Add decklink-captions to dylibbundler fixups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,6 +191,7 @@ jobs:
             -s ./rundir/RelWithDebInfo/bin \
             -x ./OBS.app/Contents/PlugIns/coreaudio-encoder.so \
             -x ./OBS.app/Contents/PlugIns/decklink-ouput-ui.so \
+            -x ./OBS.app/Contents/PlugIns/decklink-captions.so \
             -x ./OBS.app/Contents/PlugIns/frontend-tools.so \
             -x ./OBS.app/Contents/PlugIns/image-source.so \
             -x ./OBS.app/Contents/PlugIns/linux-jack.so \

--- a/CI/full-build-macos.sh
+++ b/CI/full-build-macos.sh
@@ -309,6 +309,7 @@ bundle_dylibs() {
         -s ./rundir/${BUILD_CONFIG}/bin/ \
         -x ./OBS.app/Contents/PlugIns/coreaudio-encoder.so \
         -x ./OBS.app/Contents/PlugIns/decklink-ouput-ui.so \
+        -x ./OBS.app/Contents/PlugIns/decklink-captions.so \
         -x ./OBS.app/Contents/PlugIns/frontend-tools.so \
         -x ./OBS.app/Contents/PlugIns/image-source.so \
         -x ./OBS.app/Contents/PlugIns/linux-jack.so \


### PR DESCRIPTION
### Description
Adds `decklink-captions` to the fixups done by dylibbbundler.

### Motivation and Context
Without the fixup decklink captions will still be linked against the dynamic libraries in `/tmp/obsdeps` in the build environment, which will crash the app in normal circumstances.

### How Has This Been Tested?
* OBS built and tested locally, then compared against version without the fix

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
