### PR TITLE
Cleanup native widgets

### DIFF
--- a/UI/forms/AutoConfigStreamPage.ui
+++ b/UI/forms/AutoConfigStreamPage.ui
@@ -30,7 +30,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
        <horstretch>0</horstretch>
@@ -74,7 +74,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QWidget" name="serviceWidget" native="true">
+       <widget class="QWidget" name="serviceWidget">
         <layout class="QHBoxLayout" name="serviceWidgetLayout">
          <property name="leftMargin">
           <number>0</number>
@@ -286,7 +286,7 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QWidget" name="streamKeyWidget" native="true">
+        <widget class="QWidget" name="streamKeyWidget">
          <layout class="QHBoxLayout" name="horizontalLayout_4">
           <property name="leftMargin">
            <number>0</number>

--- a/UI/forms/OBSAbout.ui
+++ b/UI/forms/OBSAbout.ui
@@ -149,7 +149,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget">
      <property name="minimumSize">
       <size>
        <width>0</width>

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -61,7 +61,7 @@
          <number>2</number>
         </property>
         <item>
-         <widget class="QWidget" name="previewDisabledWidget" native="true">
+         <widget class="QWidget" name="previewDisabledWidget">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
             <horstretch>0</horstretch>
@@ -167,7 +167,7 @@
            </widget>
           </item>
           <item>
-           <widget class="OBSBasicPreview" name="preview" native="true">
+           <widget class="OBSBasicPreview" name="preview">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
               <horstretch>0</horstretch>
@@ -196,7 +196,7 @@
      </layout>
     </item>
     <item>
-     <widget class="QWidget" name="contextContainer" native="true">
+     <widget class="QWidget" name="contextContainer">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
         <horstretch>0</horstretch>
@@ -235,7 +235,7 @@
         <number>4</number>
        </property>
        <item>
-        <widget class="QWidget" name="contextSubContainer" native="true">
+        <widget class="QWidget" name="contextSubContainer">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -377,7 +377,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="emptySpace" native="true">
+        <widget class="QWidget" name="emptySpace">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -1083,7 +1083,7 @@
       <number>4</number>
      </property>
      <item>
-      <widget class="QWidget" name="transitionsContainer" native="true">
+      <widget class="QWidget" name="transitionsContainer">
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="spacing">
          <number>2</number>

--- a/UI/forms/OBSBasicFilters.ui
+++ b/UI/forms/OBSBasicFilters.ui
@@ -22,7 +22,7 @@
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QWidget" name="asyncWidget" native="true">
+        <widget class="QWidget" name="asyncWidget">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
            <horstretch>0</horstretch>
@@ -63,7 +63,7 @@
            </widget>
           </item>
           <item alignment="Qt::AlignLeft">
-           <widget class="QWidget" name="widget" native="true">
+           <widget class="QWidget" name="widget">
             <layout class="QHBoxLayout" name="horizontalLayout_4">
              <property name="spacing">
               <number>4</number>
@@ -210,7 +210,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="effectWidget" native="true">
+        <widget class="QWidget" name="effectWidget">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
            <horstretch>0</horstretch>
@@ -251,7 +251,7 @@
            </widget>
           </item>
           <item alignment="Qt::AlignLeft">
-           <widget class="QWidget" name="widget_2" native="true">
+           <widget class="QWidget" name="widget_2">
             <layout class="QHBoxLayout" name="horizontalLayout_6">
              <property name="spacing">
               <number>4</number>
@@ -397,7 +397,7 @@
        <item>
         <layout class="QVBoxLayout" name="rightLayout">
          <item>
-          <widget class="OBSQTDisplay" name="preview" native="true">
+          <widget class="OBSQTDisplay" name="preview">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>

--- a/UI/forms/OBSBasicInteraction.ui
+++ b/UI/forms/OBSBasicInteraction.ui
@@ -18,7 +18,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="OBSQTDisplay" name="preview" native="true">
+    <widget class="OBSQTDisplay" name="preview">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -169,7 +169,7 @@
               <number>9</number>
              </property>
              <item alignment="Qt::AlignTop">
-              <widget class="QWidget" name="widget_2" native="true">
+              <widget class="QWidget" name="widget_2">
                <layout class="QVBoxLayout" name="verticalLayout_20">
                 <item>
                  <widget class="QGroupBox" name="groupBox_15">
@@ -799,7 +799,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QWidget" name="widget_5" native="true">
+          <widget class="QWidget" name="widget_5">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
              <horstretch>0</horstretch>
@@ -824,7 +824,7 @@
              </widget>
             </item>
             <item row="3" column="1">
-             <widget class="QWidget" name="serviceWidget" native="true">
+             <widget class="QWidget" name="serviceWidget">
               <layout class="QHBoxLayout" name="serviceWidgetLayout" stretch="0,0">
                <property name="leftMargin">
                 <number>0</number>
@@ -1052,7 +1052,7 @@
               </widget>
              </item>
              <item row="1" column="1">
-              <widget class="QWidget" name="streamKeyWidget" native="true">
+              <widget class="QWidget" name="streamKeyWidget">
                <layout class="QHBoxLayout" name="horizontalLayout_11">
                 <property name="leftMargin">
                  <number>0</number>
@@ -1201,7 +1201,7 @@
               </widget>
              </item>
              <item row="9" column="1">
-              <widget class="QWidget" name="authPwWidget" native="true">
+              <widget class="QWidget" name="authPwWidget">
                <layout class="QHBoxLayout" name="horizontalLayout_25">
                 <property name="leftMargin">
                  <number>0</number>
@@ -1313,7 +1313,7 @@
               <number>9</number>
              </property>
              <item alignment="Qt::AlignTop">
-              <widget class="QWidget" name="widget" native="true">
+              <widget class="QWidget" name="widget">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                  <horstretch>0</horstretch>
@@ -1830,7 +1830,7 @@
                   </spacer>
                  </item>
                  <item alignment="Qt::AlignTop">
-                  <widget class="QWidget" name="simpleOutputContainer" native="true">
+                  <widget class="QWidget" name="simpleOutputContainer">
                    <layout class="QVBoxLayout" name="verticalLayout_4">
                     <property name="leftMargin">
                      <number>0</number>
@@ -1889,7 +1889,7 @@
                       <number>9</number>
                      </property>
                      <item alignment="Qt::AlignTop">
-                      <widget class="QWidget" name="widget_4" native="true">
+                      <widget class="QWidget" name="widget_4">
                        <layout class="QVBoxLayout" name="verticalLayout_14">
                         <property name="spacing">
                          <number>0</number>
@@ -1907,7 +1907,7 @@
                          <number>0</number>
                         </property>
                         <item>
-                         <widget class="QWidget" name="advOutTopContainer" native="true">
+                         <widget class="QWidget" name="advOutTopContainer">
                           <property name="sizePolicy">
                            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
                             <horstretch>0</horstretch>
@@ -1938,7 +1938,7 @@
                             </widget>
                            </item>
                            <item row="1" column="1">
-                            <widget class="QWidget" name="widget_8" native="true">
+                            <widget class="QWidget" name="widget_8">
                              <property name="sizePolicy">
                               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                                <horstretch>0</horstretch>
@@ -2071,7 +2071,7 @@
                       <number>9</number>
                      </property>
                      <item>
-                      <widget class="QWidget" name="advOutRecTypeContainer" native="true">
+                      <widget class="QWidget" name="advOutRecTypeContainer">
                        <layout class="QFormLayout" name="formLayout_9">
                         <property name="fieldGrowthPolicy">
                          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -2141,7 +2141,7 @@
                           <number>0</number>
                          </property>
                          <item>
-                          <widget class="QWidget" name="advOutRecTopContainer" native="true">
+                          <widget class="QWidget" name="advOutRecTopContainer">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
                              <horstretch>0</horstretch>
@@ -2295,7 +2295,7 @@
                              </widget>
                             </item>
                             <item row="5" column="1">
-                             <widget class="QWidget" name="advOutRecRescaleContainer" native="true">
+                             <widget class="QWidget" name="advOutRecRescaleContainer">
                               <layout class="QHBoxLayout" name="horizontalLayout_4">
                                <property name="leftMargin">
                                 <number>0</number>
@@ -2466,7 +2466,7 @@
                           </widget>
                          </item>
                          <item alignment="Qt::AlignTop">
-                          <widget class="QWidget" name="widget_7" native="true">
+                          <widget class="QWidget" name="widget_7">
                            <layout class="QVBoxLayout" name="verticalLayout_15">
                             <property name="leftMargin">
                              <number>0</number>
@@ -2820,7 +2820,7 @@
                           </widget>
                          </item>
                          <item row="13" column="1">
-                          <widget class="QWidget" name="widget_10" native="true">
+                          <widget class="QWidget" name="widget_10">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                              <horstretch>0</horstretch>
@@ -2958,7 +2958,7 @@
                       <number>0</number>
                      </property>
                      <item alignment="Qt::AlignTop">
-                      <widget class="QWidget" name="widget_3" native="true">
+                      <widget class="QWidget" name="widget_3">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                          <horstretch>0</horstretch>
@@ -3822,7 +3822,7 @@
               <number>9</number>
              </property>
              <item alignment="Qt::AlignTop">
-              <widget class="QWidget" name="widget_50" native="true">
+              <widget class="QWidget" name="widget_50">
                <layout class="QVBoxLayout" name="verticalLayout_51">
                 <item>
                  <widget class="QGroupBox" name="audioGeneralGroupBox">
@@ -4678,7 +4678,7 @@
               <number>9</number>
              </property>
              <item>
-              <widget class="QWidget" name="widget_11" native="true">
+              <widget class="QWidget" name="widget_11">
                <layout class="QVBoxLayout" name="verticalLayout_24">
                 <item>
                  <widget class="QGroupBox" name="advancedGeneralGroupBox">
@@ -5071,7 +5071,7 @@
                     </widget>
                    </item>
                    <item row="1" column="1">
-                    <widget class="QWidget" name="widget_12" native="true">
+                    <widget class="QWidget" name="widget_12">
                      <property name="enabled">
                       <bool>true</bool>
                      </property>

--- a/UI/forms/OBSBasicTransform.ui
+++ b/UI/forms/OBSBasicTransform.ui
@@ -48,7 +48,7 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QWidget" name="widget" native="true">
+      <widget class="QWidget" name="widget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -149,7 +149,7 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QWidget" name="widget_2" native="true">
+      <widget class="QWidget" name="widget_2">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -404,7 +404,7 @@
       </widget>
      </item>
      <item row="7" column="1">
-      <widget class="QWidget" name="widget_3" native="true">
+      <widget class="QWidget" name="widget_3">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
          <horstretch>0</horstretch>

--- a/UI/forms/source-toolbar/game-capture-toolbar.ui
+++ b/UI/forms/source-toolbar/game-capture-toolbar.ui
@@ -148,7 +148,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="empty" native="true">
+    <widget class="QWidget" name="empty">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>

--- a/UI/forms/source-toolbar/media-controls.ui
+++ b/UI/forms/source-toolbar/media-controls.ui
@@ -391,7 +391,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="emptySpaceAgain" native="true">
+    <widget class="QWidget" name="emptySpaceAgain">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>

--- a/UI/forms/source-toolbar/text-source-toolbar.ui
+++ b/UI/forms/source-toolbar/text-source-toolbar.ui
@@ -83,7 +83,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="emptySpace" native="true">
+    <widget class="QWidget" name="emptySpace">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1377,6 +1377,7 @@ bool OBSApp::OBSInit()
 	ProfileScope("OBSApp::OBSInit");
 
 	setAttribute(Qt::AA_UseHighDpiPixmaps);
+	setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
 
 	qRegisterMetaType<VoidFunc>();
 

--- a/UI/window-dock-browser.hpp
+++ b/UI/window-dock-browser.hpp
@@ -9,7 +9,7 @@ extern QCefCookieManager *panel_cookies;
 
 class BrowserDock : public OBSDock {
 public:
-	inline BrowserDock() : OBSDock() {}
+	inline BrowserDock() : OBSDock() { setAttribute(Qt::WA_NativeWindow); }
 
 	QScopedPointer<QCefWidget> cefWidget;
 


### PR DESCRIPTION
### Description

When marking a widget as native, Qt makes part of the widget hierarchy native as well. This is for historical reasons, at least on Linux, mostly to match how X deals with frame and input windows.

However, this doesn't play well with QtWayland. As a preparation for Wayland, let's disable this behavior.

All credits go to @davidedmundson.

### Motivation and Context

This way of creating native widgets makes OBS Studio behave poorly on Wayland.

### How Has This Been Tested?

Run OBS Studio and make sure everything looks correct, specially with the previews.

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)
 - Code cleanup (non-breaking change which makes code smaller or more readable) 

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
