### PR TITLE
UI: Don't let CEF dictate browser dock destruction

### DIFF
--- a/UI/window-dock-browser.cpp
+++ b/UI/window-dock-browser.cpp
@@ -17,4 +17,6 @@ void BrowserDock::closeEvent(QCloseEvent *event)
 	if (panel_version >= 2 && !!cefWidget) {
 		cefWidget->closeBrowser();
 	}
+	setVisible(false);
+	event->ignore();
 }


### PR DESCRIPTION
# Description

This fixes an issue in preparation for Browser Panels for macOS. Closing a browser dock in a detatched state and then re-opening it would lock it to the minimum size, making them quite unusable until an OBS restart.

This shouldn't visually or functionally change behaviour on Windows, but by submitting this change without a compile-time platform check, any potential bugs should be caught earlier. In my testing, behaviour did not change.

For more information on other attempted (unsuccessful) workarounds, read https://github.com/obsproject/obs-browser/pull/197#issuecomment-728533099

For more information on the resulting fix, read https://github.com/obsproject/obs-browser/pull/197#issuecomment-734916328

### Motivation and Context

We'd really like to roll out browser docks to macOS, but this was a problematic blocker.

### How Has This Been Tested?

For macOS testing methodology, check the second link above. Apply the above PR + this change, undock a browser widget, close it using the dock's close button, then reopen it using View -> Docks.

On Windows, do the same, but keep an eye on Task Manager to ensure no `obs-browser-page.exe` processes (other than the 2 base level tasks) stick around. In my case, I went from 2 -> 6 (open) -> 2 (close) -> 6 (open).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
