### PR TITLE
mac-virtualcam: Fix remaining global namespaces

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/CMakeLists.txt
+++ b/plugins/mac-virtualcam/src/obs-plugin/CMakeLists.txt
@@ -25,12 +25,12 @@ include_directories(${AVFOUNDATION}
 
 set(mac-virtualcam_HEADERS
 	Defines.h
-	MachServer.h
+	OBSDALMachServer.h
 	../common/MachProtocol.h)
 
 set(mac-virtualcam_SOURCES
 	plugin-main.mm
-	MachServer.mm)
+	OBSDALMachServer.mm)
 
 add_library(mac-virtualcam MODULE
 	${mac-virtualcam_SOURCES}

--- a/plugins/mac-virtualcam/src/obs-plugin/OBSDALMachServer.h
+++ b/plugins/mac-virtualcam/src/obs-plugin/OBSDALMachServer.h
@@ -9,7 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MachServer : NSObject
+@interface OBSDALMachServer : NSObject
 
 - (void)run;
 

--- a/plugins/mac-virtualcam/src/obs-plugin/OBSDALMachServer.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/OBSDALMachServer.mm
@@ -5,19 +5,19 @@
 //  Created by John Boiles  on 5/5/20.
 //
 
-#import "MachServer.h"
+#import "OBSDALMachServer.h"
 #import <Foundation/Foundation.h>
 #include <obs-module.h>
 #include "MachProtocol.h"
 #include "Defines.h"
 
-@interface MachServer () <NSPortDelegate>
+@interface OBSDALMachServer () <NSPortDelegate>
 @property NSPort *port;
 @property NSMutableSet *clientPorts;
 @property NSRunLoop *runLoop;
 @end
 
-@implementation MachServer
+@implementation OBSDALMachServer
 
 - (id)init
 {

--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -7,7 +7,7 @@
 #include <obs.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <AppKit/AppKit.h>
-#include "MachServer.h"
+#include "OBSDALMachServer.h"
 #include "Defines.h"
 
 OBS_DECLARE_MODULE()
@@ -19,7 +19,7 @@ MODULE_EXPORT const char *obs_module_description(void)
 
 obs_output_t *outputRef;
 obs_video_info videoInfo;
-static MachServer *sMachServer;
+static OBSDALMachServer *sMachServer;
 
 static bool check_dal_plugin()
 {
@@ -120,7 +120,7 @@ static void *virtualcam_output_create(obs_data_t *settings,
 	outputRef = output;
 
 	blog(LOG_DEBUG, "output_create");
-	sMachServer = [[MachServer alloc] init];
+	sMachServer = [[OBSDALMachServer alloc] init];
 	return data;
 }
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Gives the MachServer of the mac-virtualcam a unique name which was forgotten in a previous commit (#3758)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
@PatTheMav noticed he forgot to change this in his PR (https://github.com/johnboiles/obs-mac-virtualcam/pull/242#issuecomment-734944476), I hope this is what he meant.
He described all other details in his PR #3758, which is probably a way better explanation than what I could give.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built locally on my machine (macOS 11.0.1, Intel), and tested that the virtual camera still works.
### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
