### PR TITLE
libobs-opengl: Add support for border color

### DIFF
--- a/libobs-opengl/gl-helpers.h
+++ b/libobs-opengl/gl-helpers.h
@@ -167,10 +167,34 @@ static inline void gl_delete_framebuffers(GLsizei num_arrays, GLuint *arrays)
 	gl_success("glDeleteFramebuffers");
 }
 
+static inline bool gl_tex_param_fv(GLenum target, GLenum param, GLfloat *val)
+{
+	glTexParameterfv(target, param, val);
+	return gl_success("glTexParameterfv");
+}
+
 static inline bool gl_tex_param_f(GLenum target, GLenum param, GLfloat val)
 {
 	glTexParameterf(target, param, val);
 	return gl_success("glTexParameterf");
+}
+
+static inline bool gl_tex_param_Iiv(GLenum target, GLenum param, GLint *val)
+{
+	glTexParameterIiv(target, param, val);
+	return gl_success("glTexParameterIiv");
+}
+
+static inline bool gl_tex_param_Iuiv(GLenum target, GLenum param, GLuint *val)
+{
+	glTexParameterIuiv(target, param, val);
+	return gl_success("glTexParameterIuiv");
+}
+
+static inline bool gl_tex_param_iv(GLenum target, GLenum param, GLint *val)
+{
+	glTexParameteriv(target, param, val);
+	return gl_success("glTexParameteriv");
 }
 
 static inline bool gl_tex_param_i(GLenum target, GLenum param, GLint val)

--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -173,6 +173,14 @@ void convert_sampler_info(struct gs_sampler_state *sampler,
 	sampler->address_w = convert_address_mode(info->address_w);
 	sampler->max_anisotropy = info->max_anisotropy;
 
+	sampler->border[0] = (GLfloat)(((info->border_color) & 0xFF) / 255.);
+	sampler->border[1] =
+		(GLfloat)(((info->border_color >> 8) & 0xFF) / 255.);
+	sampler->border[2] =
+		(GLfloat)(((info->border_color >> 16) & 0xFF) / 255.);
+	sampler->border[3] =
+		(GLfloat)(((info->border_color >> 24) & 0xFF) / 255.);
+
 	max_anisotropy_max = 1;
 	if (GLAD_GL_EXT_texture_filter_anisotropic) {
 		glGetIntegerv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT,
@@ -458,6 +466,10 @@ static bool load_texture_sampler(gs_texture_t *tex, gs_samplerstate_t *ss)
 				    ss->max_anisotropy))
 			success = false;
 	}
+
+	if (!gl_tex_param_fv(tex->gl_target, GL_TEXTURE_BORDER_COLOR,
+			     ss->border))
+		success = false;
 
 	apply_swizzle(tex);
 

--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -383,6 +383,8 @@ struct gs_sampler_state {
 	GLint address_v;
 	GLint address_w;
 	GLint max_anisotropy;
+
+	GLfloat border[4];
 };
 
 static inline void samplerstate_addref(gs_samplerstate_t *ss)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Adds support for the border color sampler setting to the OpenGL renderer, fixing a feature disparity between platforms. This resulted in Linux and MacOS getting a worse experience out of the box, instead of the same experience as Windows.

Fixes #3794 and [StreamFX#245](https://github.com/Xaymar/obs-StreamFX/issues/245)

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
StreamFX's SDF Effects rely on border color to work.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
SDF Effects were no longer broken as described [here](https://github.com/Xaymar/obs-StreamFX/issues/245).
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
