### PR TITLE
Initial Flatpak CI support

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,42 @@
+name: Flatpak (Experimental)
+
+on:
+  push:
+    paths-ignore: ['**.md']
+    branches: [master]
+  pull_request:
+    paths-ignore: ['**.md']
+    branches: [master]
+
+jobs:
+  flatpak_builder:
+    name: Bundle
+    runs-on: [ubuntu-latest]
+    container:
+      image: docker.io/bilelmoussaoui/flatpak-github-actions
+      options: --privileged
+    steps:
+    - name: 'Check for Github Labels'
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        LABELS_URL="$(echo ${{ github.event.pull_request.url }} | sed s'/pulls/issues/')"
+        LABEL_FOUND="$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "${LABELS_URL}/labels" | sed -n 's/.*"name": "\(.*\)",/\1/p' | grep 'Seeking Testers' || true)"
+        if [ "${LABEL_FOUND}" = "Seeking Testers" ]; then
+          echo "SEEKING_TESTERS=1" >> $GITHUB_ENV
+        else
+          echo "SEEKING_TESTERS=0" >> $GITHUB_ENV
+        fi
+
+    - name: Checkout
+      uses: actions/checkout@v2.3.3
+      if: success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1')
+      with:
+        submodules: 'recursive'
+
+    - name: Build Flatpak Manifest
+      uses: bilelmoussaoui/flatpak-github-actions@v2
+      if: success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1')
+      with:
+        bundle: obs-studio-${{ github.sha }}.flatpak
+        manifest-path: CI/flatpak/com.obsproject.Studio.json

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -1,0 +1,269 @@
+{
+  "app-id": "com.obsproject.Studio",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "5.15",
+  "sdk": "org.kde.Sdk",
+  "command": "obs",
+  "finish-args": [
+    "--socket=x11",
+    "--socket=pulseaudio",
+    "--device=all",
+    "--share=network",
+    "--share=ipc",
+    "--filesystem=xdg-run/obs-xdg-portal:create",
+    "--filesystem=host",
+    "--talk-name=org.kde.StatusNotifierWatcher",
+    "--talk-name=org.freedesktop.ScreenSaver",
+    "--talk-name=org.freedesktop.PowerManagement.Inhibit",
+    "--talk-name=org.freedesktop.Notifications",
+    "--talk-name=org.mate.SessionManager",
+    "--talk-name=org.gnome.SessionManager",
+    "--own-name=org.kde.StatusNotifierItem-2-2",
+    "--system-talk-name=org.freedesktop.Avahi"
+  ],
+  "cleanup": [
+    "/lib/pkgconfig",
+    "/share/man",
+    "*.la"
+  ],
+  "modules": [
+    {
+      "name": "x264",
+      "config-opts": [
+        "--disable-cli",
+        "--enable-shared"
+      ],
+      "cleanup": [
+        "/include"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://code.videolan.org/videolan/x264.git",
+          "commit": "cde9a93319bea766a92e306d69059c76de970190"
+        }
+      ]
+    },
+    {
+      "name": "v4l-utils",
+      "config-opts": [
+        "--disable-static",
+        "--disable-doxygen-doc",
+        "--disable-libdvbv5",
+        "--disable-v4l-utils",
+        "--disable-qv4l2",
+        "--with-udevdir=/app/lib/udev/"
+      ],
+      "cleanup": [
+        "/include"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.20.0.tar.bz2",
+          "sha256": "956118713f7ccb405c55c7088a6a2490c32d54300dd9a30d8d5008c28d3726f7"
+        }
+      ]
+    },
+    {
+      "name": "nv-codec-headers",
+      "no-autogen": true,
+      "make-install-args": [
+        "PREFIX=/app"
+      ],
+      "cleanup": [
+        "*"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://git.videolan.org/git/ffmpeg/nv-codec-headers.git",
+          "commit": "a99740a84b49fd609e04b03279e66c5a8b767440",
+          "tag": "n10.0.26.1"
+        }
+      ]
+    },
+    {
+      "name": "srt",
+      "buildsystem": "cmake-ninja",
+      "config-opts": [
+        "-DENABLE_STATIC=OFF",
+        "-DENABLE_APPS=OFF",
+        "-DENABLE_LOGGING=OFF"
+      ],
+      "cleanup": [
+        "/include",
+        "/bin"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/Haivision/srt.git",
+          "tag": "v1.4.2",
+          "commit": "50b7af06f3a0a456c172b4cb3aceafa8a5cc0036"
+        }
+      ]
+    },
+    {
+      "name": "ffmpeg",
+      "config-opts": [
+        "--enable-gpl",
+        "--enable-shared",
+        "--disable-static",
+        "--enable-gnutls",
+        "--disable-doc",
+        "--disable-programs",
+        "--disable-devices",
+        "--enable-libopus",
+        "--enable-libvpx",
+        "--enable-libvorbis",
+        "--enable-libx264",
+        "--enable-nvenc",
+        "--enable-libsrt"
+      ],
+      "cleanup": [
+        "/share/ffmpeg",
+        "/include"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://www.ffmpeg.org/releases/ffmpeg-4.3.1.tar.xz",
+          "sha256": "ad009240d46e307b4e03a213a0f49c11b650e445b1f8be0dda2a9212b34d2ffb"
+        },
+        {
+          "type": "patch",
+          "path": "ffmpeg-libsrt.patch"
+        }
+      ]
+    },
+    {
+      "name": "luajit",
+      "no-autogen": true,
+      "cleanup": [
+        "/bin",
+        "/include"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz",
+          "sha256": "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
+        },
+        {
+          "type": "shell",
+          "commands": [
+            "sed -i 's|/usr/local|/app|' ./Makefile"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "swig",
+      "config-opts": [
+        "--without-boost",
+        "--without-pcre",
+        "--without-alllang",
+        "--with-lua=/app/bin/luajit-2.1.0-beta2",
+        "--with-luaincl=/app/include/luajit-2.1",
+        "--with-python3"
+      ],
+      "cleanup": [
+        "*"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://prdownloads.sourceforge.net/swig/swig-4.0.2.tar.gz",
+          "sha256": "d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
+        }
+      ]
+    },
+    {
+      "name": "mbedtls",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+        "-DUSE_SHARED_MBEDTLS_LIBRARY=ON",
+        "-DUSE_STATIC_MBEDTLS_LIBRARY=OFF",
+        "-DENABLE_TESTING=OFF",
+        "-DENABLE_PROGRAMS=OFF"
+      ],
+      "cleanup": [
+        "/include"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/ARMmbed/mbedtls.git",
+          "commit": "848a4e06b375e067552f1a21d4bc69322c673217",
+          "tag": "mbedtls-2.16.8"
+        }
+      ]
+    },
+    {
+      "name": "jack2",
+      "buildsystem": "simple",
+      "build-commands": [
+        "./waf configure --prefix=$FLATPAK_DEST",
+        "./waf build -j $FLATPAK_BUILDER_N_JOBS",
+        "./waf install"
+      ],
+      "cleanup": [
+        "*"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/jackaudio/jack2/releases/download/v1.9.14/v1.9.14.tar.gz",
+          "sha256": "a20a32366780c0061fd58fbb5f09e514ea9b7ce6e53b080a44b11a558a83217c"
+        }
+      ]
+    },
+    {
+      "name": "cef",
+      "buildsystem": "cmake-ninja",
+      "no-make-install": true,
+      "make-args": [
+        "libcef_dll_wrapper"
+      ],
+      "build-commands": [
+        "mkdir -p /app/cef/libcef_dll_wrapper",
+        "cp -R ./include /app/cef",
+        "cp -R ./Release /app/cef",
+        "cp -R ./Resources /app/cef",
+        "cp -R ./libcef_dll_wrapper/libcef_dll_wrapper.a /app/cef/libcef_dll_wrapper"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://cef-builds.spotifycdn.com/cef_binary_76.1.13+gf19c584+chromium-76.0.3809.132_linux64_minimal.tar.bz2",
+          "sha256": "6b0dfa8ddafcec822fcd20018cf081959ffa6d0565be3793da1f596ac0733c38"
+        }
+      ]
+    },
+    {
+      "name": "obs",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_BROWSER=ON",
+        "-DCEF_ROOT_DIR=/app/cef",
+        "-DUNIX_STRUCTURE=ON",
+        "-DUSE_XDG=ON",
+        "-DDISABLE_ALSA=ON",
+        "-DENABLE_PULSEAUDIO=ON",
+        "-DWITH_RTMPS=ON"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/obsproject/obs-studio.git"
+        }
+      ]
+    }
+  ]
+}

--- a/CI/flatpak/ffmpeg-libsrt.patch
+++ b/CI/flatpak/ffmpeg-libsrt.patch
@@ -1,0 +1,50 @@
+From 7c59e1b0f285cd7c7b35fcd71f49c5fd52cf9315 Mon Sep 17 00:00:00 2001
+From: Jun Zhao <barryjzhao@tencent.com>
+Date: Sun, 12 Jul 2020 13:48:48 +0800
+Subject: [PATCH 1/1] lavf/srt: fix build fail when used the libsrt 1.4.1
+
+libsrt changed the:
+SRTO_SMOOTHER   -> SRTO_CONGESTION
+SRTO_STRICTENC  -> SRTO_ENFORCEDENCRYPTION
+and removed the front of deprecated options (SRTO_SMOOTHER/SRTO_STRICTENC)
+in the header, it's lead to build fail
+
+fix #8760
+
+Signed-off-by: Jun Zhao <barryjzhao@tencent.com>
+---
+ libavformat/libsrt.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/libavformat/libsrt.c b/libavformat/libsrt.c
+index 4de575b..4719ce0 100644
+--- a/libavformat/libsrt.c
++++ b/libavformat/libsrt.c
+@@ -313,8 +313,12 @@ static int libsrt_set_options_pre(URLContext *h, int fd)
+         (s->pbkeylen >= 0 && libsrt_setsockopt(h, fd, SRTO_PBKEYLEN, "SRTO_PBKEYLEN", &s->pbkeylen, sizeof(s->pbkeylen)) < 0) ||
+         (s->passphrase && libsrt_setsockopt(h, fd, SRTO_PASSPHRASE, "SRTO_PASSPHRASE", s->passphrase, strlen(s->passphrase)) < 0) ||
+ #if SRT_VERSION_VALUE >= 0x010302
++#if SRT_VERSION_VALUE >= 0x010401
++        (s->enforced_encryption >= 0 && libsrt_setsockopt(h, fd, SRTO_ENFORCEDENCRYPTION, "SRTO_ENFORCEDENCRYPTION", &s->enforced_encryption, sizeof(s->enforced_encryption)) < 0) ||
++#else
+         /* SRTO_STRICTENC == SRTO_ENFORCEDENCRYPTION (53), but for compatibility, we used SRTO_STRICTENC */
+         (s->enforced_encryption >= 0 && libsrt_setsockopt(h, fd, SRTO_STRICTENC, "SRTO_STRICTENC", &s->enforced_encryption, sizeof(s->enforced_encryption)) < 0) ||
++#endif
+         (s->kmrefreshrate >= 0 && libsrt_setsockopt(h, fd, SRTO_KMREFRESHRATE, "SRTO_KMREFRESHRATE", &s->kmrefreshrate, sizeof(s->kmrefreshrate)) < 0) ||
+         (s->kmpreannounce >= 0 && libsrt_setsockopt(h, fd, SRTO_KMPREANNOUNCE, "SRTO_KMPREANNOUNCE", &s->kmpreannounce, sizeof(s->kmpreannounce)) < 0) ||
+ #endif
+@@ -333,7 +337,11 @@ static int libsrt_set_options_pre(URLContext *h, int fd)
+         (s->lossmaxttl >= 0 && libsrt_setsockopt(h, fd, SRTO_LOSSMAXTTL, "SRTO_LOSSMAXTTL", &s->lossmaxttl, sizeof(s->lossmaxttl)) < 0) ||
+         (s->minversion >= 0 && libsrt_setsockopt(h, fd, SRTO_MINVERSION, "SRTO_MINVERSION", &s->minversion, sizeof(s->minversion)) < 0) ||
+         (s->streamid && libsrt_setsockopt(h, fd, SRTO_STREAMID, "SRTO_STREAMID", s->streamid, strlen(s->streamid)) < 0) ||
++#if SRT_VERSION_VALUE >= 0x010401
++        (s->smoother && libsrt_setsockopt(h, fd, SRTO_CONGESTION, "SRTO_CONGESTION", s->smoother, strlen(s->smoother)) < 0) ||
++#else
+         (s->smoother && libsrt_setsockopt(h, fd, SRTO_SMOOTHER, "SRTO_SMOOTHER", s->smoother, strlen(s->smoother)) < 0) ||
++#endif
+         (s->messageapi >= 0 && libsrt_setsockopt(h, fd, SRTO_MESSAGEAPI, "SRTO_MESSAGEAPI", &s->messageapi, sizeof(s->messageapi)) < 0) ||
+         (s->payload_size >= 0 && libsrt_setsockopt(h, fd, SRTO_PAYLOADSIZE, "SRTO_PAYLOADSIZE", &s->payload_size, sizeof(s->payload_size)) < 0) ||
+         ((h->flags & AVIO_FLAG_WRITE) && libsrt_setsockopt(h, fd, SRTO_SENDER, "SRTO_SENDER", &yes, sizeof(yes)) < 0)) {
+--
+2.7.4
+


### PR DESCRIPTION
### Description

This pull requests adds a new workflow to generate a Flatpak manifest. The workflow is limited to the master branch, and pull requests with the "Seeking Testers" label. Only in-tree plugins are included.

This is only the very minimal setup that's able to produce such bundles. The workflow is explicitly named "experimental" for now, because ALSA is disabled in the Flatpak bundle, and JACK depends on PipeWire 0.3.

(Side note: I made this while preparing to investigate various CEF-on-Linux problems. The bundle contain CEF and the Browser plugin is enabled.)

### Motivation and Context

The Flatpak bundle improves testing compared to the current setup that generates a Debian package, mostly because it is not limited to Debian-based systems.

### How Has This Been Tested?

The new CI workflow generates a Flatpak bundle file that can be downloaded via GitHub:

![Captura de tela de 2020-11-30 13-23-09](https://user-images.githubusercontent.com/3518204/100636458-83e13580-3310-11eb-8ec4-277b660e4ecd.png)

After downloading, Linux users can double-click the file to install it:

![Captura de tela de 2020-11-30 13-29-15](https://user-images.githubusercontent.com/3518204/100636529-922f5180-3310-11eb-8e6b-efed68c02fe2.png)

Alternatively, it is possible to install the bundle through the command line:

![Captura de tela de 2020-11-30 13-31-08](https://user-images.githubusercontent.com/3518204/100636576-9f4c4080-3310-11eb-9483-a702102ecdc8.png)

### Types of changes

 - New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
