### PR TITLE
CI: Add necessary changes for CEF 4183

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ on:
       - master
 
 env:
-  CEF_BUILD_VERSION: '3770'
-  CEF_VERSION: '75.1.16+g16a67c4+chromium-75.0.3770.100'
+  CEF_BUILD_VERSION: '4183'
+  CEF_VERSION: '85.0.0-HEAD.2272+gd5ec257+chromium-85.0.4183.121'
 
 jobs:
   macos64:
@@ -136,7 +136,7 @@ jobs:
         run: |
           mkdir ./build
           cd ./build
-          cmake -DENABLE_UNIT_TESTS=YES -DENABLE_SPARKLE_UPDATER=ON -DDISABLE_PYTHON=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ env.MIN_MACOS_VERSION }} -DQTDIR="/tmp/obsdeps" -DSWIGDIR="/tmp/obsdeps" -DDepsPath="/tmp/obsdeps" -DVLCPath="${{ github.workspace }}/cmbuild/vlc-${{ env.VLC_VERSION }}" -DENABLE_VLC=ON -DBUILD_BROWSER=ON -DBROWSER_DEPLOY=ON -DWITH_RTMPS=ON -DCEF_ROOT_DIR="${{ github.workspace }}/cmbuild/cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64" ..
+          cmake -DENABLE_UNIT_TESTS=YES -DENABLE_SPARKLE_UPDATER=ON -DDISABLE_PYTHON=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ env.MIN_MACOS_VERSION }} -DQTDIR="/tmp/obsdeps" -DSWIGDIR="/tmp/obsdeps" -DDepsPath="/tmp/obsdeps" -DVLCPath="${{ github.workspace }}/cmbuild/vlc-${{ env.VLC_VERSION }}" -DENABLE_VLC=ON -DBUILD_BROWSER=ON -DWITH_RTMPS=ON -DCEF_ROOT_DIR="${{ github.workspace }}/cmbuild/cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64" ..
       - name: 'Build'
         shell: bash
         working-directory: ${{ github.workspace }}/build
@@ -169,9 +169,14 @@ jobs:
           mkdir -p OBS.app/Contents/MacOS
           mkdir OBS.app/Contents/PlugIns
           mkdir OBS.app/Contents/Resources
+          mkdir OBS.app/Contents/Frameworks
 
           cp rundir/RelWithDebInfo/bin/obs ./OBS.app/Contents/MacOS
           cp rundir/RelWithDebInfo/bin/obs-ffmpeg-mux ./OBS.app/Contents/MacOS
+          cp -R "rundir/RelWithDebInfo/bin/OBS Helper.app" "./OBS.app/Contents/Frameworks/OBS Helper.app"
+          cp -R "rundir/RelWithDebInfo/bin/OBS Helper (GPU).app" "./OBS.app/Contents/Frameworks/OBS Helper (GPU).app"
+          cp -R "rundir/RelWithDebInfo/bin/OBS Helper (Plugin).app" "./OBS.app/Contents/Frameworks/OBS Helper (Plugin).app"
+          cp -R "rundir/RelWithDebInfo/bin/OBS Helper (Renderer).app" "./OBS.app/Contents/Frameworks/OBS Helper (Renderer).app"
           cp rundir/RelWithDebInfo/bin/libobsglad.0.dylib ./OBS.app/Contents/MacOS
           cp -R rundir/RelWithDebInfo/data ./OBS.app/Contents/Resources
           cp ../CI/scripts/macos/app/AppIcon.icns ./OBS.app/Contents/Resources
@@ -202,7 +207,6 @@ jobs:
             -x ./OBS.app/Contents/PlugIns/mac-vth264.so \
             -x ./OBS.app/Contents/PlugIns/mac-virtualcam.so \
             -x ./OBS.app/Contents/PlugIns/obs-browser.so \
-            -x ./OBS.app/Contents/PlugIns/obs-browser-page \
             -x ./OBS.app/Contents/PlugIns/obs-ffmpeg.so \
             -x ./OBS.app/Contents/PlugIns/obs-filters.so \
             -x ./OBS.app/Contents/PlugIns/obs-transitions.so \
@@ -250,11 +254,16 @@ jobs:
           codesign --force --options runtime --sign "${SIGN_IDENTITY:--}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libswiftshader_libEGL.dylib"
           codesign --force --options runtime --sign "${SIGN_IDENTITY:--}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libGLESv2.dylib"
           codesign --force --options runtime --sign "${SIGN_IDENTITY:--}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libswiftshader_libGLESv2.dylib"
+          codesign --force --options runtime --sign "${SIGN_IDENTITY:--}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libvk_swiftshader.dylib"
           codesign --force --options runtime --sign "${SIGN_IDENTITY:--}" --deep "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework"
 
           codesign --force --options runtime --deep --sign "${SIGN_IDENTITY:--}" "./OBS.app/Contents/Resources/data/obs-mac-virtualcam.plugin"
 
           codesign --force --options runtime --entitlements "../CI/scripts/macos/app/entitlements.plist" --sign "${SIGN_IDENTITY:--}" --deep ./OBS.app
+
+          codesign --force --options runtime --entitlements "../CI/scripts/macos/helpers/helper-gpu-entitlements.plist" --sign "${SIGN_IDENTITY:--}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (GPU).app"
+          codesign --force --options runtime --entitlements "../CI/scripts/macos/helpers/helper-plugin-entitlements.plist" --sign "${SIGN_IDENTITY:--}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (Plugin).app"
+          codesign --force --options runtime --entitlements "../CI/scripts/macos/helpers/helper-renderer-entitlements.plist" --sign "${SIGN_IDENTITY:--}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (Renderer).app"
 
           codesign -dvv ./OBS.app
       - name: 'Package'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ on:
       - master
 
 env:
-  CEF_BUILD_VERSION: '4183'
-  CEF_VERSION: '85.0.0-HEAD.2272+gd5ec257+chromium-85.0.4183.121'
+  CEF_BUILD_VERSION: '3770'
+  CEF_VERSION: '75.1.16+g16a67c4+chromium-75.0.3770.100'
 
 jobs:
   macos64:
@@ -136,7 +136,8 @@ jobs:
         run: |
           mkdir ./build
           cd ./build
-          cmake -DENABLE_UNIT_TESTS=YES -DENABLE_SPARKLE_UPDATER=ON -DDISABLE_PYTHON=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ env.MIN_MACOS_VERSION }} -DQTDIR="/tmp/obsdeps" -DSWIGDIR="/tmp/obsdeps" -DDepsPath="/tmp/obsdeps" -DVLCPath="${{ github.workspace }}/cmbuild/vlc-${{ env.VLC_VERSION }}" -DENABLE_VLC=ON -DBUILD_BROWSER=ON -DWITH_RTMPS=ON -DCEF_ROOT_DIR="${{ github.workspace }}/cmbuild/cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64" ..
+          LEGACY_BROWSER="$(test "${{ env.CEF_BUILD_VERSION }}" -le 3770 && echo "ON" || echo "OFF")"
+          cmake -DENABLE_UNIT_TESTS=YES -DENABLE_SPARKLE_UPDATER=ON -DDISABLE_PYTHON=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ env.MIN_MACOS_VERSION }} -DQTDIR="/tmp/obsdeps" -DSWIGDIR="/tmp/obsdeps" -DDepsPath="/tmp/obsdeps" -DVLCPath="${{ github.workspace }}/cmbuild/vlc-${{ env.VLC_VERSION }}" -DENABLE_VLC=ON -DBUILD_BROWSER=ON -DBROWSER_LEGACY=$LEGACY_BROWSER -DWITH_RTMPS=ON -DCEF_ROOT_DIR="${{ github.workspace }}/cmbuild/cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64" ..
       - name: 'Build'
         shell: bash
         working-directory: ${{ github.workspace }}/build
@@ -173,10 +174,12 @@ jobs:
 
           cp rundir/RelWithDebInfo/bin/obs ./OBS.app/Contents/MacOS
           cp rundir/RelWithDebInfo/bin/obs-ffmpeg-mux ./OBS.app/Contents/MacOS
-          cp -R "rundir/RelWithDebInfo/bin/OBS Helper.app" "./OBS.app/Contents/Frameworks/OBS Helper.app"
-          cp -R "rundir/RelWithDebInfo/bin/OBS Helper (GPU).app" "./OBS.app/Contents/Frameworks/OBS Helper (GPU).app"
-          cp -R "rundir/RelWithDebInfo/bin/OBS Helper (Plugin).app" "./OBS.app/Contents/Frameworks/OBS Helper (Plugin).app"
-          cp -R "rundir/RelWithDebInfo/bin/OBS Helper (Renderer).app" "./OBS.app/Contents/Frameworks/OBS Helper (Renderer).app"
+          if ! [ "${{ env.CEF_BUILD_VERSION }}" -le 3770 ]; then
+            cp -R "rundir/RelWithDebInfo/bin/OBS Helper.app" "./OBS.app/Contents/Frameworks/OBS Helper.app"
+            cp -R "rundir/RelWithDebInfo/bin/OBS Helper (GPU).app" "./OBS.app/Contents/Frameworks/OBS Helper (GPU).app"
+            cp -R "rundir/RelWithDebInfo/bin/OBS Helper (Plugin).app" "./OBS.app/Contents/Frameworks/OBS Helper (Plugin).app"
+            cp -R "rundir/RelWithDebInfo/bin/OBS Helper (Renderer).app" "./OBS.app/Contents/Frameworks/OBS Helper (Renderer).app"
+          fi
           cp rundir/RelWithDebInfo/bin/libobsglad.0.dylib ./OBS.app/Contents/MacOS
           cp -R rundir/RelWithDebInfo/data ./OBS.app/Contents/Resources
           cp ../CI/scripts/macos/app/AppIcon.icns ./OBS.app/Contents/Resources
@@ -190,34 +193,47 @@ jobs:
             rm -rf ./OBS.app/Contents/Resources/data/obs-scripting/
           fi
 
+          BUNDLE_PLUGINS=(
+            ./OBS.app/Contents/PlugIns/coreaudio-encoder.so
+            ./OBS.app/Contents/PlugIns/decklink-ouput-ui.so
+            ./OBS.app/Contents/PlugIns/decklink-captions.so
+            ./OBS.app/Contents/PlugIns/frontend-tools.so
+            ./OBS.app/Contents/PlugIns/image-source.so
+            ./OBS.app/Contents/PlugIns/linux-jack.so
+            ./OBS.app/Contents/PlugIns/mac-avcapture.so
+            ./OBS.app/Contents/PlugIns/mac-capture.so
+            ./OBS.app/Contents/PlugIns/mac-decklink.so
+            ./OBS.app/Contents/PlugIns/mac-syphon.so
+            ./OBS.app/Contents/PlugIns/mac-vth264.so
+            ./OBS.app/Contents/PlugIns/mac-virtualcam.so
+            ./OBS.app/Contents/PlugIns/obs-browser.so
+            ./OBS.app/Contents/PlugIns/obs-ffmpeg.so
+            ./OBS.app/Contents/PlugIns/obs-filters.so
+            ./OBS.app/Contents/PlugIns/obs-transitions.so
+            ./OBS.app/Contents/PlugIns/obs-vst.so
+            ./OBS.app/Contents/PlugIns/rtmp-services.so
+            ./OBS.app/Contents/MacOS/obs-ffmpeg-mux
+            ./OBS.app/Contents/MacOS/obslua.so
+            ./OBS.app/Contents/PlugIns/obs-x264.so
+            ./OBS.app/Contents/PlugIns/text-freetype2.so
+            ./OBS.app/Contents/PlugIns/obs-libfdk.so
+            ./OBS.app/Contents/PlugIns/obs-outputs.so
+          )
+
+          if ! [ "${{ env.CEF_BUILD_VERSION }}" -le 3770 ]; then
           ../CI/scripts/macos/app/dylibBundler -cd -of -a ./OBS.app -q -f \
             -s ./OBS.app/Contents/MacOS \
             -s "${{ github.workspace }}/cmbuild/sparkle/Sparkle.framework" \
             -s ./rundir/RelWithDebInfo/bin \
-            -x ./OBS.app/Contents/PlugIns/coreaudio-encoder.so \
-            -x ./OBS.app/Contents/PlugIns/decklink-ouput-ui.so \
-            -x ./OBS.app/Contents/PlugIns/decklink-captions.so \
-            -x ./OBS.app/Contents/PlugIns/frontend-tools.so \
-            -x ./OBS.app/Contents/PlugIns/image-source.so \
-            -x ./OBS.app/Contents/PlugIns/linux-jack.so \
-            -x ./OBS.app/Contents/PlugIns/mac-avcapture.so \
-            -x ./OBS.app/Contents/PlugIns/mac-capture.so \
-            -x ./OBS.app/Contents/PlugIns/mac-decklink.so \
-            -x ./OBS.app/Contents/PlugIns/mac-syphon.so \
-            -x ./OBS.app/Contents/PlugIns/mac-vth264.so \
-            -x ./OBS.app/Contents/PlugIns/mac-virtualcam.so \
-            -x ./OBS.app/Contents/PlugIns/obs-browser.so \
-            -x ./OBS.app/Contents/PlugIns/obs-ffmpeg.so \
-            -x ./OBS.app/Contents/PlugIns/obs-filters.so \
-            -x ./OBS.app/Contents/PlugIns/obs-transitions.so \
-            -x ./OBS.app/Contents/PlugIns/obs-vst.so \
-            -x ./OBS.app/Contents/PlugIns/rtmp-services.so \
-            -x ./OBS.app/Contents/MacOS/obs-ffmpeg-mux \
-            -x ./OBS.app/Contents/MacOS/obslua.so \
-            -x ./OBS.app/Contents/PlugIns/obs-x264.so \
-            -x ./OBS.app/Contents/PlugIns/text-freetype2.so \
-            -x ./OBS.app/Contents/PlugIns/obs-libfdk.so \
-            -x ./OBS.app/Contents/PlugIns/obs-outputs.so
+            $(echo "${BUNDLE_PLUGINS[@]/#/-x }")
+          else
+          ../CI/scripts/macos/app/dylibBundler -cd -of -a ./OBS.app -q -f \
+            -s ./OBS.app/Contents/MacOS \
+            -s "${{ github.workspace }}/cmbuild/sparkle/Sparkle.framework" \
+            -s ./rundir/RelWithDebInfo/bin \
+            $(echo "${BUNDLE_PLUGINS[@]/#/-x }") \
+            -x ./OBS.app/Contents/PlugIns/obs-browser-page
+          fi
 
           mv ./libobs-opengl/libobs-opengl.so ./OBS.app/Contents/Frameworks
 
@@ -254,16 +270,21 @@ jobs:
           codesign --force --options runtime --sign "${SIGN_IDENTITY:--}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libswiftshader_libEGL.dylib"
           codesign --force --options runtime --sign "${SIGN_IDENTITY:--}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libGLESv2.dylib"
           codesign --force --options runtime --sign "${SIGN_IDENTITY:--}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libswiftshader_libGLESv2.dylib"
-          codesign --force --options runtime --sign "${SIGN_IDENTITY:--}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libvk_swiftshader.dylib"
+          if ! [ "${{ env.CEF_BUILD_VERSION }}" -le 3770 ]; then
+            codesign --force --options runtime --sign "${SIGN_IDENTITY:--}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libvk_swiftshader.dylib"
+          fi
           codesign --force --options runtime --sign "${SIGN_IDENTITY:--}" --deep "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework"
 
           codesign --force --options runtime --deep --sign "${SIGN_IDENTITY:--}" "./OBS.app/Contents/Resources/data/obs-mac-virtualcam.plugin"
 
           codesign --force --options runtime --entitlements "../CI/scripts/macos/app/entitlements.plist" --sign "${SIGN_IDENTITY:--}" --deep ./OBS.app
 
-          codesign --force --options runtime --entitlements "../CI/scripts/macos/helpers/helper-gpu-entitlements.plist" --sign "${SIGN_IDENTITY:--}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (GPU).app"
-          codesign --force --options runtime --entitlements "../CI/scripts/macos/helpers/helper-plugin-entitlements.plist" --sign "${SIGN_IDENTITY:--}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (Plugin).app"
-          codesign --force --options runtime --entitlements "../CI/scripts/macos/helpers/helper-renderer-entitlements.plist" --sign "${SIGN_IDENTITY:--}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (Renderer).app"
+          if ! [ "${{ env.CEF_BUILD_VERSION }}" -le 3770 ]; then
+            codesign --force --options runtime --sign "${SIGN_IDENTITY:--}" --deep "./OBS.app/Contents/Frameworks/OBS Helper.app"
+            codesign --force --options runtime --entitlements "../CI/scripts/macos/helpers/helper-gpu-entitlements.plist" --sign "${SIGN_IDENTITY:--}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (GPU).app"
+            codesign --force --options runtime --entitlements "../CI/scripts/macos/helpers/helper-plugin-entitlements.plist" --sign "${SIGN_IDENTITY:--}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (Plugin).app"
+            codesign --force --options runtime --entitlements "../CI/scripts/macos/helpers/helper-renderer-entitlements.plist" --sign "${SIGN_IDENTITY:--}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (Renderer).app"
+          fi
 
           codesign -dvv ./OBS.app
       - name: 'Package'

--- a/CI/full-build-macos.sh
+++ b/CI/full-build-macos.sh
@@ -277,6 +277,7 @@ configure_obs_build() {
         -DDepsPath="/tmp/obsdeps" \
         -DVLCPath="${DEPS_BUILD_DIR}/vlc-${VLC_VERSION:-${CI_VLC_VERSION}}" \
         -DBUILD_BROWSER=ON \
+        -DBROWSER_LEGACY="$(test "${CEF_BUILD_VERSION:-${CI_CEF_VERSION}}" -le 3770 && echo "ON" || echo "OFF")" \
         -DWITH_RTMPS=ON \
         -DCEF_ROOT_DIR="${DEPS_BUILD_DIR}/cef_binary_${CEF_BUILD_VERSION:-${CI_CEF_VERSION}}_macosx64" \
         -DCMAKE_BUILD_TYPE="${BUILD_CONFIG}" \
@@ -302,36 +303,49 @@ bundle_dylibs() {
     hr "Bundle dylibs for macOS application"
 
     step "Run dylibBundler.."
-    ${CI_SCRIPTS}/app/dylibbundler -cd -of -a ./OBS.app -q -f \
-        -s ./OBS.app/Contents/MacOS \
-        -s "${DEPS_BUILD_DIR}/sparkle/Sparkle.framework" \
-        -s ./rundir/${BUILD_CONFIG}/bin/ \
-        -x ./OBS.app/Contents/PlugIns/coreaudio-encoder.so \
-        -x ./OBS.app/Contents/PlugIns/decklink-ouput-ui.so \
-        -x ./OBS.app/Contents/PlugIns/decklink-captions.so \
-        -x ./OBS.app/Contents/PlugIns/frontend-tools.so \
-        -x ./OBS.app/Contents/PlugIns/image-source.so \
-        -x ./OBS.app/Contents/PlugIns/linux-jack.so \
-        -x ./OBS.app/Contents/PlugIns/mac-avcapture.so \
-        -x ./OBS.app/Contents/PlugIns/mac-capture.so \
-        -x ./OBS.app/Contents/PlugIns/mac-decklink.so \
-        -x ./OBS.app/Contents/PlugIns/mac-syphon.so \
-        -x ./OBS.app/Contents/PlugIns/mac-vth264.so \
-        -x ./OBS.app/Contents/PlugIns/mac-virtualcam.so \
-        -x ./OBS.app/Contents/PlugIns/obs-browser.so \
-        -x ./OBS.app/Contents/PlugIns/obs-ffmpeg.so \
-        -x ./OBS.app/Contents/PlugIns/obs-filters.so \
-        -x ./OBS.app/Contents/PlugIns/obs-transitions.so \
-        -x ./OBS.app/Contents/PlugIns/obs-vst.so \
-        -x ./OBS.app/Contents/PlugIns/rtmp-services.so \
-        -x ./OBS.app/Contents/MacOS/obs-ffmpeg-mux \
-        -x ./OBS.app/Contents/MacOS/obslua.so \
-        -x ./OBS.app/Contents/PlugIns/obs-x264.so \
-        -x ./OBS.app/Contents/PlugIns/text-freetype2.so \
-        -x ./OBS.app/Contents/PlugIns/obs-libfdk.so \
-        -x ./OBS.app/Contents/PlugIns/obs-outputs.so
-    step "Move libobs-opengl to final destination"
 
+    BUNDLE_PLUGINS=(
+        ./OBS.app/Contents/PlugIns/coreaudio-encoder.so
+        ./OBS.app/Contents/PlugIns/decklink-ouput-ui.so
+        ./OBS.app/Contents/PlugIns/decklink-captions.so
+        ./OBS.app/Contents/PlugIns/frontend-tools.so
+        ./OBS.app/Contents/PlugIns/image-source.so
+        ./OBS.app/Contents/PlugIns/linux-jack.so
+        ./OBS.app/Contents/PlugIns/mac-avcapture.so
+        ./OBS.app/Contents/PlugIns/mac-capture.so
+        ./OBS.app/Contents/PlugIns/mac-decklink.so
+        ./OBS.app/Contents/PlugIns/mac-syphon.so
+        ./OBS.app/Contents/PlugIns/mac-vth264.so
+        ./OBS.app/Contents/PlugIns/mac-virtualcam.so
+        ./OBS.app/Contents/PlugIns/obs-browser.so
+        ./OBS.app/Contents/PlugIns/obs-ffmpeg.so
+        ./OBS.app/Contents/PlugIns/obs-filters.so
+        ./OBS.app/Contents/PlugIns/obs-transitions.so
+        ./OBS.app/Contents/PlugIns/obs-vst.so
+        ./OBS.app/Contents/PlugIns/rtmp-services.so
+        ./OBS.app/Contents/MacOS/obs-ffmpeg-mux
+        ./OBS.app/Contents/MacOS/obslua.so
+        ./OBS.app/Contents/PlugIns/obs-x264.so
+        ./OBS.app/Contents/PlugIns/text-freetype2.so
+        ./OBS.app/Contents/PlugIns/obs-libfdk.so
+        ./OBS.app/Contents/PlugIns/obs-outputs.so
+        )
+    if ! [ "${CEF_BUILD_VERSION:-${CI_CEF_VERSION}}" -le 3770 ]; then
+        ${CI_SCRIPTS}/app/dylibbundler -cd -of -a ./OBS.app -q -f \
+            -s ./OBS.app/Contents/MacOS \
+            -s "${DEPS_BUILD_DIR}/sparkle/Sparkle.framework" \
+            -s ./rundir/${BUILD_CONFIG}/bin/ \
+            $(echo "${BUNDLE_PLUGINS[@]/#/-x }")
+    else
+        ${CI_SCRIPTS}/app/dylibbundler -cd -of -a ./OBS.app -q -f \
+            -s ./OBS.app/Contents/MacOS \
+            -s "${DEPS_BUILD_DIR}/sparkle/Sparkle.framework" \
+            -s ./rundir/${BUILD_CONFIG}/bin/ \
+            $(echo "${BUNDLE_PLUGINS[@]/#/-x }") \
+            -x ./OBS.app/Contents/PlugIns/obs-browser-page
+    fi
+
+    step "Move libobs-opengl to final destination"
     if [ -f "./libobs-opengl/libobs-opengl.so" ]; then
         cp ./libobs-opengl/libobs-opengl.so ./OBS.app/Contents/Frameworks
     else
@@ -382,10 +396,12 @@ prepare_macos_bundle() {
     cp rundir/${BUILD_CONFIG}/bin/obs ./OBS.app/Contents/MacOS
     cp rundir/${BUILD_CONFIG}/bin/obs-ffmpeg-mux ./OBS.app/Contents/MacOS
     cp rundir/${BUILD_CONFIG}/bin/libobsglad.0.dylib ./OBS.app/Contents/MacOS
-    cp -R "rundir/${BUILD_CONFIG}/bin/OBS Helper.app" "./OBS.app/Contents/Frameworks/OBS Helper.app"
-    cp -R "rundir/${BUILD_CONFIG}/bin/OBS Helper (GPU).app" "./OBS.app/Contents/Frameworks/OBS Helper (GPU).app"
-    cp -R "rundir/${BUILD_CONFIG}/bin/OBS Helper (Plugin).app" "./OBS.app/Contents/Frameworks/OBS Helper (Plugin).app"
-    cp -R "rundir/${BUILD_CONFIG}/bin/OBS Helper (Renderer).app" "./OBS.app/Contents/Frameworks/OBS Helper (Renderer).app"
+    if ! [ "${CEF_BUILD_VERSION:-${CI_CEF_VERSION}}" -le 3770 ]; then
+        cp -R "rundir/${BUILD_CONFIG}/bin/OBS Helper.app" "./OBS.app/Contents/Frameworks/OBS Helper.app"
+        cp -R "rundir/${BUILD_CONFIG}/bin/OBS Helper (GPU).app" "./OBS.app/Contents/Frameworks/OBS Helper (GPU).app"
+        cp -R "rundir/${BUILD_CONFIG}/bin/OBS Helper (Plugin).app" "./OBS.app/Contents/Frameworks/OBS Helper (Plugin).app"
+        cp -R "rundir/${BUILD_CONFIG}/bin/OBS Helper (Renderer).app" "./OBS.app/Contents/Frameworks/OBS Helper (Renderer).app"
+    fi
     cp -R rundir/${BUILD_CONFIG}/data ./OBS.app/Contents/Resources
     cp ${CI_SCRIPTS}/app/AppIcon.icns ./OBS.app/Contents/Resources
     cp -R rundir/${BUILD_CONFIG}/obs-plugins/ ./OBS.app/Contents/PlugIns
@@ -509,8 +525,9 @@ codesign_bundle() {
     codesign --force --options runtime --sign "${CODESIGN_IDENT}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libswiftshader_libEGL.dylib"
     codesign --force --options runtime --sign "${CODESIGN_IDENT}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libGLESv2.dylib"
     codesign --force --options runtime --sign "${CODESIGN_IDENT}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libswiftshader_libGLESv2.dylib"
-    codesign --force --options runtime --sign "${CODESIGN_IDENT}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libvk_swiftshader.dylib"
-    codesign --force --options runtime --sign "${CODESIGN_IDENT}" --deep "./OBS.app/Contents/Frameworks/OBS Helper.app"
+    if ! [ "${CEF_BUILD_VERSION:-${CI_CEF_VERSION}}" -le 3770 ]; then
+        codesign --force --options runtime --sign "${CODESIGN_IDENT}" "./OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework/Libraries/libvk_swiftshader.dylib"
+    fi
 
     echo -n "${COLOR_RESET}"
 
@@ -524,12 +541,15 @@ codesign_bundle() {
     codesign --force --options runtime --entitlements "${CI_SCRIPTS}/app/entitlements.plist" --sign "${CODESIGN_IDENT}" --deep ./OBS.app
     echo -n "${COLOR_RESET}"
 
-    step "Code-sign CEF helper apps..."
-    echo -n "${COLOR_ORANGE}"
-    codesign --force --options runtime --entitlements "${CI_SCRIPTS}/helpers/helper-gpu-entitlements.plist" --sign "${CODESIGN_IDENT}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (GPU).app"
-    codesign --force --options runtime --entitlements "${CI_SCRIPTS}/helpers/helper-plugin-entitlements.plist" --sign "${CODESIGN_IDENT}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (Plugin).app"
-    codesign --force --options runtime --entitlements "${CI_SCRIPTS}/helpers/helper-renderer-entitlements.plist" --sign "${CODESIGN_IDENT}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (Renderer).app"
-    echo -n "${COLOR_RESET}"
+    if ! [ "${CEF_BUILD_VERSION:-${CI_CEF_VERSION}}" -le 3770 ]; then
+        step "Code-sign CEF helper apps..."
+        echo -n "${COLOR_ORANGE}"
+        codesign --force --options runtime --sign "${CODESIGN_IDENT}" --deep "./OBS.app/Contents/Frameworks/OBS Helper.app"
+        codesign --force --options runtime --entitlements "${CI_SCRIPTS}/helpers/helper-gpu-entitlements.plist" --sign "${CODESIGN_IDENT}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (GPU).app"
+        codesign --force --options runtime --entitlements "${CI_SCRIPTS}/helpers/helper-plugin-entitlements.plist" --sign "${CODESIGN_IDENT}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (Plugin).app"
+        codesign --force --options runtime --entitlements "${CI_SCRIPTS}/helpers/helper-renderer-entitlements.plist" --sign "${CODESIGN_IDENT}" --deep "./OBS.app/Contents/Frameworks/OBS Helper (Renderer).app"
+        echo -n "${COLOR_RESET}"
+    fi
 
     step "Check code-sign result..."
     codesign -dvv ./OBS.app

--- a/CI/scripts/macos/helpers/helper-gpu-entitlements.plist
+++ b/CI/scripts/macos/helpers/helper-gpu-entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>

--- a/CI/scripts/macos/helpers/helper-plugin-entitlements.plist
+++ b/CI/scripts/macos/helpers/helper-plugin-entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/CI/scripts/macos/helpers/helper-renderer-entitlements.plist
+++ b/CI/scripts/macos/helpers/helper-renderer-entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
### Description
Adds necessary changes to package OBS with the planned updated CEF version 4183.

### Motivation and Context
Chromium requires a multi-process setup on macOS which adds 4 new app bundles in the main app bundle's framework directory. These app bundles need to be signed with appropriate entitlements for notarisation.

*Note:* This PR will break until our build of CEF 4183 is made available on our CDN (might require another force-push if we move from S3 to our own CDN) and the obs-browser submodule has been updated with the appropriate commit for CEF 4183.

### How Has This Been Tested?
* OBS built, signed and notarised successfully

### Types of changes
- Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
