### PR TITLE
UI: Use Qt::MiddleButton instead of deprecated Qt::MidButton

### DIFF
--- a/UI/hotkey-edit.cpp
+++ b/UI/hotkey-edit.cpp
@@ -101,7 +101,7 @@ void OBSHotkeyEdit::mousePressEvent(QMouseEvent *event)
 	case Qt::MouseButtonMask:
 		return;
 
-	case Qt::MidButton:
+	case Qt::MiddleButton:
 		new_key.key = OBS_KEY_MOUSE3;
 		break;
 

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -116,7 +116,7 @@ QObject *CreateShortcutFilter()
 			case Qt::MouseButtonMask:
 				return false;
 
-			case Qt::MidButton:
+			case Qt::MiddleButton:
 				hotkey.key = OBS_KEY_MOUSE3;
 				break;
 

--- a/UI/slider-absoluteset-style.cpp
+++ b/UI/slider-absoluteset-style.cpp
@@ -15,6 +15,6 @@ int SliderAbsoluteSetStyle::styleHint(QStyle::StyleHint hint,
 				      QStyleHintReturn *returnData = 0) const
 {
 	if (hint == QStyle::SH_Slider_AbsoluteSetButtons)
-		return (Qt::LeftButton | Qt::MidButton);
+		return (Qt::LeftButton | Qt::MiddleButton);
 	return QProxyStyle::styleHint(hint, option, widget, returnData);
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
UI: Use Qt::MiddleButton instead of deprecated Qt::MidButton

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Qt::MidButton has been deprecated since Qt4 and removed in Qt6.  It was replaced by Qt::MiddleButton, which is available in all versions of Qt5.  Building against Qt 5.15+ will produce compiler warnings when using Qt::MidButton, and warnings are bad.

https://github.com/qt/qtbase/commit/880cbf602701b0116ca1143d6d07ee8e7eb3f03f
https://github.com/qt/qtbase/commit/16e546e32fec393bc3b126f280114bcbfa7151ff

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I compiled and ran OBS on Windows 10 Home 64-bit 2004 (Build 19041.630).  I bound "Start Recording" to my mouse's middle button, and tested the hotkey, and it worked fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
