### PR TITLE
UI: Replace deprecated QLayout->setMargin with setContentsMargin

### DIFF
--- a/UI/hotkey-edit.hpp
+++ b/UI/hotkey-edit.hpp
@@ -102,7 +102,7 @@ public:
 	{
 		auto layout = new QVBoxLayout;
 		layout->setSpacing(0);
-		layout->setMargin(0);
+		layout->setContentsMargins(0, 0, 0, 0);
 		setLayout(layout);
 
 		SetKeyCombinations(combos);

--- a/UI/window-importer.cpp
+++ b/UI/window-importer.cpp
@@ -81,7 +81,7 @@ QWidget *ImporterEntryPathItemDelegate::createEditor(
 	};
 
 	QHBoxLayout *layout = new QHBoxLayout();
-	layout->setMargin(0);
+	layout->setContentsMargins(0, 0, 0, 0);
 	layout->setSpacing(0);
 
 	QLineEdit *text = new QLineEdit();

--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -100,7 +100,7 @@ QWidget *RemuxEntryPathItemDelegate::createEditor(
 		};
 
 		QHBoxLayout *layout = new QHBoxLayout();
-		layout->setMargin(0);
+		layout->setContentsMargins(0, 0, 0, 0);
 		layout->setSpacing(0);
 
 		QLineEdit *text = new QLineEdit();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
UI: Replace deprecated QLayout->setMargin with setContentsMargin

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
QLayout->setMargin has been deprecated since Qt 5.13 (though marked obsolete since at least Qt 4.8) and removed in Qt6. It was replaced by QLayout->setContentsMargins, which is available in all versions of Qt5. Building against Qt 5.13+ can produce compiler warnings when using QLayout->setMargin, and warnings are bad.

https://doc.qt.io/archives/qt-4.8/qlayout-obsolete.html
https://doc.qt.io/qt-5/qlayout-obsolete.html
https://github.com/qt/qtbase/commit/d6d33f0b80dd85043c71f71a3ed5485d6014e6c4
https://github.com/qt/qtbase/blame/5.15.2/src/widgets/kernel/qlayout.h

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I compiled and ran OBS using Qt 5.15.2 on Windows 10 Home 64-bit 2004 (Build 19041.630) with and without these changes and compared UI elements that had used the old function.  Everything looked fine to me.  Furthermore, you can see from the Qt commit above that `setMargin(int margin)` is just an alias for `setContentsMargins(margin, margin, margin, margin)`.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
