### PR TITLE
win-capture: Fix the Mosaic or ScreenTearing that appears with a low probability when uncheck "SLI/Crossfire Capture Mode (Slow)"

### DIFF
--- a/plugins/win-capture/graphics-hook-info.h
+++ b/plugins/win-capture/graphics-hook-info.h
@@ -20,6 +20,7 @@
 
 #define MUTEX_TEXTURE1 L"CaptureHook_TextureMutex1"
 #define MUTEX_TEXTURE2 L"CaptureHook_TextureMutex2"
+#define MUTEX_SHTEX L"CaptureHook_SHTEX_Mutex"
 
 #define SHMEM_HOOK_INFO L"CaptureHook_HookInfo"
 #define SHMEM_TEXTURE L"CaptureHook_Texture"

--- a/plugins/win-capture/graphics-hook/d3d10-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d10-capture.cpp
@@ -330,7 +330,9 @@ static inline void d3d10_copy_texture(ID3D10Resource *dst, ID3D10Resource *src)
 
 static inline void d3d10_shtex_capture(ID3D10Resource *backbuffer)
 {
+	lock_shtex();
 	d3d10_copy_texture(data.texture, backbuffer);
+	unlock_shtex();
 }
 
 static void d3d10_shmem_capture_copy(int i)

--- a/plugins/win-capture/graphics-hook/d3d11-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d11-capture.cpp
@@ -335,7 +335,9 @@ static inline void d3d11_copy_texture(ID3D11Resource *dst, ID3D11Resource *src)
 
 static inline void d3d11_shtex_capture(ID3D11Resource *backbuffer)
 {
+	lock_shtex();
 	d3d11_copy_texture(data.texture, backbuffer);
+	unlock_shtex();
 }
 
 static void d3d11_shmem_capture_copy(int i)

--- a/plugins/win-capture/graphics-hook/d3d12-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d12-capture.cpp
@@ -315,10 +315,12 @@ static inline void d3d12_shtex_capture(IDXGISwapChain *swap,
 
 	ID3D11Resource *backbuffer = data.backbuffer11[cur_idx];
 
+	lock_shtex();
 	data.device11on12->AcquireWrappedResources(&backbuffer, 1);
 	d3d12_copy_texture(data.copy_tex, backbuffer);
 	data.device11on12->ReleaseWrappedResources(&backbuffer, 1);
 	data.context11->Flush();
+	unlock_shtex();
 
 	if (!dxgi_1_4) {
 		if (++data.cur_backbuffer >= data.backbuffer_count)

--- a/plugins/win-capture/graphics-hook/d3d9-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d9-capture.cpp
@@ -507,8 +507,11 @@ static inline void d3d9_shtex_capture(IDirect3DSurface9 *backbuffer)
 {
 	HRESULT hr;
 
+	lock_shtex();
 	hr = data.device->StretchRect(backbuffer, nullptr, data.d3d9_copytex,
 				      nullptr, D3DTEXF_NONE);
+	unlock_shtex();
+
 	if (FAILED(hr))
 		hlog_hr("d3d9_shtex_capture: StretchRect failed", hr);
 }

--- a/plugins/win-capture/graphics-hook/gl-capture.c
+++ b/plugins/win-capture/graphics-hook/gl-capture.c
@@ -602,6 +602,8 @@ static void gl_shtex_capture(void)
 	GLint last_fbo;
 	GLint last_tex;
 
+	lock_shtex();
+
 	jimglDXLockObjectsNV(data.gl_device, 1, &data.gl_dxobj);
 
 	glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &last_fbo);
@@ -622,6 +624,8 @@ static void gl_shtex_capture(void)
 	jimglDXUnlockObjectsNV(data.gl_device, 1, &data.gl_dxobj);
 
 	IDXGISwapChain_Present(data.dxgi_swap, 0, 0);
+
+	unlock_shtex();
 }
 
 static void gl_shmem_capture_copy(int i)

--- a/plugins/win-capture/graphics-hook/graphics-hook.h
+++ b/plugins/win-capture/graphics-hook/graphics-hook.h
@@ -40,6 +40,9 @@ extern void shmem_copy_data(size_t idx, void *volatile data);
 extern bool shmem_texture_data_lock(int idx);
 extern void shmem_texture_data_unlock(int idx);
 
+extern void lock_shtex();
+extern void unlock_shtex();
+
 extern bool hook_ddraw(void);
 extern bool hook_d3d8(void);
 extern bool hook_d3d9(void);

--- a/plugins/win-capture/graphics-hook/vulkan-capture.c
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.c
@@ -967,6 +967,8 @@ static void vk_shtex_capture(struct vk_data *data,
 	VkImageMemoryBarrier *src_mb = &mb[0];
 	VkImageMemoryBarrier *dst_mb = &mb[1];
 
+	lock_shtex();
+
 	/* ------------------------------------------------------ */
 	/* do image copy                                          */
 
@@ -1097,6 +1099,8 @@ static void vk_shtex_capture(struct vk_data *data,
 			    VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
 			    swap->export_image,
 			    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &cpy);
+
+	unlock_shtex();
 
 	/* ------------------------------------------------------ */
 	/* Restore the swap chain image layout to what it was 


### PR DESCRIPTION
win-capture: Fix the Mosaic or ScreenTearing that appears with a low probability when uncheck "SLI/Crossfire Capture Mode (Slow)"