### PR TITLE
deps: Update cmake_minimum_required to 2.8.12

### DIFF
--- a/deps/jansson/CMakeLists.txt
+++ b/deps/jansson/CMakeLists.txt
@@ -46,7 +46,7 @@
 
 
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8.12)
 # required for exports? cmake_minimum_required (VERSION 2.8.6)
 project (jansson C)
 

--- a/deps/libcaption/CMakeLists.txt
+++ b/deps/libcaption/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(libcaption)
 add_definitions(-D__STDC_CONSTANT_MACROS)
 if (WIN32)

--- a/deps/libff/CMakeLists.txt
+++ b/deps/libff/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 2.8.12)
 project (libff)
 
 find_package(FFmpeg REQUIRED

--- a/deps/obs-scripting/CMakeLists.txt
+++ b/deps/obs-scripting/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 if(NOT ENABLE_SCRIPTING)
 	message(STATUS "Scripting plugin disabled")

--- a/deps/obs-scripting/obslua/CMakeLists.txt
+++ b/deps/obs-scripting/obslua/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(obslua)
 
 if(POLICY CMP0078)

--- a/deps/obs-scripting/obspython/CMakeLists.txt
+++ b/deps/obs-scripting/obspython/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(obspython)
 
 if(POLICY CMP0078)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Bump CMake minimum version required to 2.8.12 for all subprojects.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
CMake 3.19 has begun emitting a deprecation warning that support for CMake 2.8.12 will be dropped in a future CMake release.

> CMake Deprecation Warning at deps/obs-scripting/obslua/CMakeLists.txt:1 (cmake_minimum_required):
>   Compatibility with CMake < 2.8.12 will be removed from a future version of
>   CMake.
> 
>   Update the VERSION argument <min> value or use a ...<max> suffix to tell
>   CMake that the project does not need compatibility with older versions.

Warnings are bad.

The lowest minimum any subproject supported before this was 2.8, so bumping a patch version number shouldn't cause issues.  Also, the OBS root CMakeLists.txt requires CMake 3.10, and 3.16 on Windows, so having the lower 2.x versions on the subprojects probably doesn't make much sense anyway, but I wanted to make a minimal change.

The only subproject I haven't updated is ftl-sdk because it's a git submodule.  At some point, if we don't address this issue in ftl-sdk, the CMake support for compatibility with older than 2.8.12 will be removed.  It's unclear if that means CMake will refuse to configure such projects, or if they just won't guarantee compatibility.

Currently, only YouNow is using the ftl-sdk as Mixer no longer exists and Restream dropped FTL support when Mixer went down.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I built OBS on Windows 10 64-bit 2004 (Build 19041.630) before and after these changes.  I noted the presence of the warning before and its absence after.  I ran a quick recording session after to ensure that OBS worked as expected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
