### PR TITLE
libobs: Duplicate source name for private sources

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1252,7 +1252,8 @@ static inline obs_source_t *dup_child(struct darray *array, size_t idx,
 		}
 	}
 
-	return obs_source_duplicate(source, NULL, private);
+	return obs_source_duplicate(
+		source, private ? obs_source_get_name(source) : NULL, private);
 }
 
 static inline obs_source_t *new_ref(obs_source_t *source)


### PR DESCRIPTION
### Description
Duplicate source name for private sources in scene

### Motivation and Context
Allows for identification of sources in studio mode.
Makes it like scenes and filters that keep there name when duplicated

### How Has This Been Tested?
On windows x64 with the move transition plugin

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
