### PR TITLE
linux-v4l2: Fix bashism in v4l2loopback detection

### DIFF
--- a/plugins/linux-v4l2/linux-v4l2.c
+++ b/plugins/linux-v4l2/linux-v4l2.c
@@ -31,7 +31,7 @@ static bool v4l2loopback_installed()
 {
 	bool loaded = false;
 
-	int ret = system("modinfo v4l2loopback &>/dev/null");
+	int ret = system("modinfo v4l2loopback >/dev/null 2>&1");
 
 	if (ret == 0)
 		loaded = true;


### PR DESCRIPTION
### Description
The output functionality in the linux-v4l2 plugin assumes that /bin/sh is bash when checking whether the v4l2loopback module is installed, giving incorrect results and undesired console output when this assumption is violated. This patch fixes that.

### Motivation and Context
When /bin/sh isn't bash, the existing system() call used to check for installation of the v4l2loopback module always returns success, whether or not it really is installed. This causes the "Start Virtual Camera" button to appear even when it can't work. The modinfo console output that also appears either way is a distraction from more important information in OBS's output.

### How Has This Been Tested?
I'm running Debian testing with dash as /bin/sh and have v4l2loopback-dkms installed. When I rename v4l2loopback.ko to something else to simulate it not being installed, this patch properly causes the "Start Virtual Camera" button to not appear when OBS is started, and it suppresses the console output from modinfo in either case.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
