### PR TITLE
UI: Scale Interact cursor position based on display DPI

### DIFF
--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -218,6 +218,14 @@ static int TranslateQtMouseEventModifiers(QMouseEvent *event)
 bool OBSBasicInteraction::GetSourceRelativeXY(int mouseX, int mouseY, int &relX,
 					      int &relY)
 {
+#ifdef SUPPORTS_FRACTIONAL_SCALING
+	float pixelRatio = devicePixelRatioF();
+#else
+	float pixelRatio = devicePixelRatio();
+#endif
+	int mouseXscaled = (int)roundf(mouseX * pixelRatio);
+	int mouseYscaled = (int)roundf(mouseY * pixelRatio);
+
 	QSize size = GetPixelSize(ui->preview);
 
 	uint32_t sourceCX = max(obs_source_get_width(source), 1u);
@@ -230,11 +238,11 @@ bool OBSBasicInteraction::GetSourceRelativeXY(int mouseX, int mouseY, int &relX,
 			     y, scale);
 
 	if (x > 0) {
-		relX = int(float(mouseX - x) / scale);
-		relY = int(float(mouseY / scale));
+		relX = int(float(mouseXscaled - x) / scale);
+		relY = int(float(mouseYscaled / scale));
 	} else {
-		relX = int(float(mouseX / scale));
-		relY = int(float(mouseY - y) / scale);
+		relX = int(float(mouseXscaled / scale));
+		relY = int(float(mouseYscaled - y) / scale);
 	}
 
 	// Confirm mouse is inside the source


### PR DESCRIPTION
### Description

Interact passes the Qt cursor position to sources without scaling it, causing the cursor position to be incorrect.

Fixes https://github.com/obsproject/obs-browser/issues/99

### Motivation and Context

Interact is unusable when the cursor is in the wrong position.

### How Has This Been Tested?

Use a display on Windows or macOS with DPI scaling. Tested with 200% on Windows.

Load http://txt.wzd.li/cursor.html and move your cursor in the Interact window.

Attempt to select text or press buttons in any webpage using Interact.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
