### PR TITLE
UI: Support FTL URLs for custom streaming service

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -16,6 +16,7 @@ volatile bool recording_paused = false;
 volatile bool replaybuf_active = false;
 volatile bool virtualcam_active = false;
 
+#define FTL_PROTOCOL "ftl"
 #define RTMP_PROTOCOL "rtmp"
 
 static void OBSStreamStarting(void *data, calldata_t *params)
@@ -763,7 +764,10 @@ bool SimpleOutput::SetupStreaming(obs_service_t *service)
 		type = "rtmp_output";
 		const char *url = obs_service_get_url(service);
 		if (url != NULL &&
-		    strncmp(url, RTMP_PROTOCOL, strlen(RTMP_PROTOCOL)) != 0) {
+		    strncmp(url, FTL_PROTOCOL, strlen(FTL_PROTOCOL)) == 0) {
+			type = "ftl_output";
+		} else if (url != NULL && strncmp(url, RTMP_PROTOCOL,
+						  strlen(RTMP_PROTOCOL)) != 0) {
 			type = "ffmpeg_mpegts_muxer";
 		}
 	}
@@ -1684,7 +1688,10 @@ bool AdvancedOutput::SetupStreaming(obs_service_t *service)
 		type = "rtmp_output";
 		const char *url = obs_service_get_url(service);
 		if (url != NULL &&
-		    strncmp(url, RTMP_PROTOCOL, strlen(RTMP_PROTOCOL)) != 0) {
+		    strncmp(url, FTL_PROTOCOL, strlen(FTL_PROTOCOL)) == 0) {
+			type = "ftl_output";
+		} else if (url != NULL && strncmp(url, RTMP_PROTOCOL,
+						  strlen(RTMP_PROTOCOL)) != 0) {
 			type = "ffmpeg_mpegts_muxer";
 		}
 	}

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -45,6 +45,8 @@
 #define OPT_MAX_SHUTDOWN_TIME_SEC "max_shutdown_time_sec"
 #define OPT_BIND_IP "bind_ip"
 
+#define FTL_URL_PROTOCOL "ftl://"
+
 typedef struct _nalu_t {
 	int len;
 	int dts_usec;
@@ -1019,7 +1021,7 @@ static int init_connect(struct ftl_stream *stream)
 {
 	obs_service_t *service;
 	obs_data_t *settings;
-	const char *bind_ip, *key;
+	const char *bind_ip, *key, *ingest_url;
 	ftl_status_t status_code;
 
 	info("init_connect");
@@ -1045,7 +1047,14 @@ static int init_connect(struct ftl_stream *stream)
 		obs_output_get_video_encoder(stream->output);
 	obs_data_t *video_settings = obs_encoder_get_settings(video_encoder);
 
-	dstr_copy(&stream->path, obs_service_get_url(service));
+	ingest_url = obs_service_get_url(service);
+	if (strncmp(ingest_url, FTL_URL_PROTOCOL, strlen(FTL_URL_PROTOCOL)) ==
+	    0) {
+		dstr_copy(&stream->path, ingest_url + strlen(FTL_URL_PROTOCOL));
+	} else {
+		dstr_copy(&stream->path, ingest_url);
+	}
+
 	key = obs_service_get_key(service);
 
 	int target_bitrate = (int)obs_data_get_int(video_settings, "bitrate");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change allows users to use the FTL protocol when choosing a custom streaming service. By providing a URL starting with `ftl://` in the custom server field, the `ftl_output` plugin is chosen to handle transmitting stream data instead of `rtmp_output`.

![The Stream settings page in OBS with a custom FTL server specified](https://user-images.githubusercontent.com/5422053/101277244-ed759f80-3767-11eb-8799-108f9800c6ae.png)

Thank you for your time in reviewing this change!

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
In order to stream via the FTL protocol to a host that is not included in the curated list of streaming services, a user must [manually update](https://github.com/Glimesh/janus-ftl-plugin#streaming-from-obs) `services.json` with a service listing that specifies the `ftl_output` output.

Along with some folks at Glimesh.tv, I have been building an [open-source FTL ingest server](https://github.com/Glimesh/janus-ftl-plugin), and this change greatly simplifies the process for streamers to configure their OBS client for FTL streaming to a custom host.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
_MSVC v142, Windows 10 20H2 19042.630_

- Verified under debugger that `ftl://` URLs properly select `ftl_output` for both Advanced and Simple output
- Verified that a custom `ftl://hostname` URL results in a successful connection to an FTL ingest server
- Verified under debugger that non-`ftl://` URLs (ex. `rtmp://`) select their respective outputs (ex. `rtmp_output`)
- Verified under debugger that code path for existing FTL service YouNow is unaffected (`younow_get_ingest` is called)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
