### PR TITLE
obs-scripting: Fix removing signal handlers in lua

### DIFF
--- a/deps/obs-scripting/obs-scripting-lua.c
+++ b/deps/obs-scripting/obs-scripting-lua.c
@@ -456,7 +456,7 @@ static int obs_lua_signal_handler_disconnect(lua_State *script)
 		const char *cb_signal =
 			calldata_string(&cb->base.extra, "signal");
 
-		if (cb_signal && strcmp(signal, cb_signal) != 0 &&
+		if (cb_signal && strcmp(signal, cb_signal) == 0 &&
 		    handler == cb_handler)
 			break;
 


### PR DESCRIPTION
### Description
This was implemented in python in #3286, but was not implemented into the lua scripting. Currently lua scripters can not disconnect from handlers

### Motivation and Context
This will close #3841 

### How Has This Been Tested?
This direct solution has not been tested, but with how this is the same fix from python scripting, I do not believe there will be any discrepancies between implementations as the previous fix had been tested and implemented into a existing version of OBS

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [x] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
