### PR TITLE
obs-frontend-api: Add frontend api functions for the virtual camera

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -23,6 +23,7 @@ extern volatile bool streaming_active;
 extern volatile bool recording_active;
 extern volatile bool recording_paused;
 extern volatile bool replaybuf_active;
+extern volatile bool virtualcam_active;
 
 /* ------------------------------------------------------------------------- */
 
@@ -546,6 +547,28 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	{
 		QMetaObject::invokeMethod(main, "Screenshot",
 					  Q_ARG(OBSSource, OBSSource(source)));
+	}
+
+	obs_output_t *obs_frontend_get_virtualcam_output(void) override
+	{
+		OBSOutput output = main->outputHandler->virtualCam;
+		obs_output_addref(output);
+		return output;
+	}
+
+	void obs_frontend_start_virtualcam(void) override
+	{
+		QMetaObject::invokeMethod(main, "StartVirtualCam");
+	}
+
+	void obs_frontend_stop_virtualcam(void) override
+	{
+		QMetaObject::invokeMethod(main, "StopVirtualCam");
+	}
+
+	bool obs_frontend_virtualcam_active(void) override
+	{
+		return os_atomic_load_bool(&virtualcam_active);
 	}
 
 	void on_load(obs_data_t *settings) override

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -475,3 +475,27 @@ void obs_frontend_take_source_screenshot(obs_source_t *source)
 	if (callbacks_valid())
 		c->obs_frontend_take_source_screenshot(source);
 }
+
+obs_output_t *obs_frontend_get_virtualcam_output(void)
+{
+	return !!callbacks_valid() ? c->obs_frontend_get_virtualcam_output()
+				   : nullptr;
+}
+
+void obs_frontend_start_virtualcam(void)
+{
+	if (callbacks_valid())
+		c->obs_frontend_start_virtualcam();
+}
+
+void obs_frontend_stop_virtualcam(void)
+{
+	if (callbacks_valid())
+		c->obs_frontend_stop_virtualcam();
+}
+
+bool obs_frontend_virtualcam_active(void)
+{
+	return !!callbacks_valid() ? c->obs_frontend_virtualcam_active()
+				   : false;
+}

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -50,6 +50,9 @@ enum obs_frontend_event {
 
 	OBS_FRONTEND_EVENT_TRANSITION_DURATION_CHANGED,
 	OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED,
+
+	OBS_FRONTEND_EVENT_VIRTUALCAM_STARTED,
+	OBS_FRONTEND_EVENT_VIRTUALCAM_STOPPED,
 };
 
 /* ------------------------------------------------------------------------- */
@@ -197,6 +200,11 @@ EXPORT void obs_frontend_set_current_preview_scene(obs_source_t *scene);
 
 EXPORT void obs_frontend_take_screenshot(void);
 EXPORT void obs_frontend_take_source_screenshot(obs_source_t *source);
+
+EXPORT obs_output_t *obs_frontend_get_virtualcam_output(void);
+EXPORT void obs_frontend_start_virtualcam(void);
+EXPORT void obs_frontend_stop_virtualcam(void);
+EXPORT bool obs_frontend_virtualcam_active(void);
 
 /* ------------------------------------------------------------------------- */
 

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -122,6 +122,11 @@ struct obs_frontend_callbacks {
 	virtual void obs_frontend_take_screenshot() = 0;
 	virtual void
 	obs_frontend_take_source_screenshot(obs_source_t *source) = 0;
+
+	virtual obs_output_t *obs_frontend_get_virtualcam_output(void) = 0;
+	virtual void obs_frontend_start_virtualcam(void) = 0;
+	virtual void obs_frontend_stop_virtualcam(void) = 0;
+	virtual bool obs_frontend_virtualcam_active(void) = 0;
 };
 
 EXPORT void

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6286,6 +6286,9 @@ void OBSBasic::OnVirtualCamStart()
 	vcamButton->setText(QTStr("Basic.Main.StopVirtualCam"));
 	vcamButton->setChecked(true);
 
+	if (api)
+		api->on_event(OBS_FRONTEND_EVENT_VIRTUALCAM_STARTED);
+
 	OnActivate();
 
 	blog(LOG_INFO, VIRTUAL_CAM_START);
@@ -6298,6 +6301,9 @@ void OBSBasic::OnVirtualCamStop(int)
 
 	vcamButton->setText(QTStr("Basic.Main.StartVirtualCam"));
 	vcamButton->setChecked(false);
+
+	if (api)
+		api->on_event(OBS_FRONTEND_EVENT_VIRTUALCAM_STOPPED);
 
 	blog(LOG_INFO, VIRTUAL_CAM_STOP);
 

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -140,6 +140,15 @@ Structures/Enumerations
 
      Triggered when the recording has been unpaused.
 
+   - **OBS_FRONTEND_EVENT_VIRTUALCAM_STARTED**
+
+     Triggered when the virtual camera is started.
+
+   - **OBS_FRONTEND_EVENT_VIRTUALCAM_STOPPED**
+
+     Triggered when the virtual camera is stopped.
+
+
 .. type:: struct obs_frontend_source_list
 
    - DARRAY(obs_source_t*) **sources**
@@ -547,3 +556,27 @@ Functions
    Takes a screenshot of the specified source.
 
    :param source: The source to take screenshot of.
+
+---------------------------------------
+
+.. function:: obs_output_t *obs_frontend_get_virtualcam_output(void)
+
+   :return: A new reference to the current virtual camera output.
+
+---------------------------------------
+
+.. function:: void obs_frontend_start_virtualcam(void)
+
+   Starts the virtual camera.
+
+---------------------------------------
+
+.. function:: void obs_frontend_stop_virtualcam(void)
+
+   Stops the virtual camera.
+
+---------------------------------------
+
+.. function:: bool obs_frontend_virtualcam_active(void)
+
+   :return: *true* if virtual camera is active, *false* otherwise.


### PR DESCRIPTION
### Description
This adds functions to the frontend api to start/stop the virtual
camera, to check if it is active and adds function to get the output
reference. It also adds api events for when the virtual camera is
started or stopped.

### Motivation and Context
The other outputs have frontend api functions, so the virtual camera should as well.

### How Has This Been Tested?
Tested by creating a script to call the functions and using the api events.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
