### PR TITLE
linux-jack: fix timestamps, deadlock on shutdown, and port type

### DIFF
--- a/plugins/linux-jack/jack-wrapper.c
+++ b/plugins/linux-jack/jack-wrapper.c
@@ -61,6 +61,12 @@ static enum speaker_layout jack_channels_to_obs_speakers(uint_fast32_t channels)
 int jack_process_callback(jack_nframes_t nframes, void *arg)
 {
 	struct jack_data *data = (struct jack_data *)arg;
+	jack_nframes_t current_frames;
+	jack_time_t current_usecs, next_usecs;
+	float period_usecs;
+
+	uint64_t now = os_gettime_ns();
+
 	if (data == 0)
 		return 0;
 
@@ -78,8 +84,15 @@ int jack_process_callback(jack_nframes_t nframes, void *arg)
 	}
 
 	out.frames = nframes;
-	out.timestamp = os_gettime_ns() -
-			jack_frames_to_time(data->jack_client, nframes);
+	if (!jack_get_cycle_times(data->jack_client, &current_frames,
+				  &current_usecs, &next_usecs, &period_usecs)) {
+		out.timestamp = now - (int64_t)(period_usecs * 1000);
+	} else {
+		out.timestamp = now - util_mul_div64(nframes, 1000000000ULL,
+						     data->samples_per_sec);
+		blog(LOG_WARNING,
+		     "jack_get_cycle_times error: guessing timestamp");
+	}
 
 	/* FIXME: this function is not realtime-safe, we should do something
 	 * about this */

--- a/plugins/linux-jack/jack-wrapper.c
+++ b/plugins/linux-jack/jack-wrapper.c
@@ -64,8 +64,6 @@ int jack_process_callback(jack_nframes_t nframes, void *arg)
 	if (data == 0)
 		return 0;
 
-	pthread_mutex_lock(&data->jack_mutex);
-
 	struct obs_source_audio out;
 	out.speakers = jack_channels_to_obs_speakers(data->channels);
 	out.samples_per_sec = jack_get_sample_rate(data->jack_client);
@@ -83,8 +81,9 @@ int jack_process_callback(jack_nframes_t nframes, void *arg)
 	out.timestamp = os_gettime_ns() -
 			jack_frames_to_time(data->jack_client, nframes);
 
+	/* FIXME: this function is not realtime-safe, we should do something
+	 * about this */
 	obs_source_output_audio(data->source, &out);
-	pthread_mutex_unlock(&data->jack_mutex);
 	return 0;
 }
 
@@ -151,17 +150,11 @@ void deactivate_jack(struct jack_data *data)
 	pthread_mutex_lock(&data->jack_mutex);
 
 	if (data->jack_client) {
+		jack_client_close(data->jack_client);
 		if (data->jack_ports != NULL) {
-			for (int i = 0; i < data->channels; ++i) {
-				if (data->jack_ports[i] != NULL)
-					jack_port_unregister(
-						data->jack_client,
-						data->jack_ports[i]);
-			}
 			bfree(data->jack_ports);
 			data->jack_ports = NULL;
 		}
-		jack_client_close(data->jack_client);
 		data->jack_client = NULL;
 	}
 	pthread_mutex_unlock(&data->jack_mutex);

--- a/plugins/linux-jack/jack-wrapper.c
+++ b/plugins/linux-jack/jack-wrapper.c
@@ -115,7 +115,7 @@ int_fast32_t jack_init(struct jack_data *data)
 
 		data->jack_ports[i] = jack_port_register(
 			data->jack_client, port_name, JACK_DEFAULT_AUDIO_TYPE,
-			JackPortIsInput, 0);
+			JackPortIsInput | JackPortIsTerminal, 0);
 		if (data->jack_ports[i] == NULL) {
 			blog(LOG_ERROR,
 			     "jack_port_register Error:"


### PR DESCRIPTION
### Description

Bug fixes for linux-jack:

* Mark input ports as terminal type. This means latency compensation does not expect to find other output ports that the data flows out of.
* Fix a deadlock when shutting down the source. See the commit message for a detailed description.
* Fix the timestamp calculation, which was completely broken.

### Motivation and Context

The deadlock bug was found at stack depth three trying to reproduce/fix a different OBS bug.

The port type fix is at the suggestion of the Ardour developers. It doesn't quite fix the latency compensation issues when capturing Ardour sessions with OBS for other reasons, but it's correct.

The timestamp calculation also was found due to its poor interaction with the OBS mixing code prior to #3863.

### How Has This Been Tested?

Switching scene collections from one with a couple JACK clients used to deadlock a good fraction of the time, and no longer does.

System: Gentoo Linux / amd64 / JACK1 (0.125.0)

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.