### PR TITLE
libobs: fix the pending stop trick

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -116,7 +116,7 @@ static bool discard_if_stopped(obs_source_t *source, size_t channels)
 			blog(LOG_DEBUG, "doing pending stop trick: '%s'",
 			     source->context.name);
 #endif
-			return true;
+			return false;
 		}
 
 		for (size_t ch = 0; ch < channels; ch++)


### PR DESCRIPTION
### Description

Regression introduced by dc4e20500: while the stop detection is pending,
it should still return false so the rest of the discard code can run.
Otherwise, the source audio will remain in the buffer, lagging the
source and triggering audio buffering increases until max audio
buffering is reached.

### Motivation and Context

This is at least one of the possible root causes of the catastrophic audio death that multiple streamers have experienced since at least 2018. It was reproduced by repeatedly toggling monitor mode for multiple sources.

### How Has This Been Tested?

[This script](https://gist.github.com/marcan/ac89490843389ee0919f2a56c9f5ff3a) using obs-websocket will repeatedly toggle monitor mode for certain sources (adjust `source_patterns` to taste). Running it with a couple RTMP media sources active will reproduce the original problem - you can see the audio buffering increasing, every time after the pending stop trick. Filtered log:

```
debug: ts 515383806129912-515383827463246
debug: ts 515383827463246-515383848796579
debug: ts 515383848796579-515383870129912
debug: can't discard, data still pending
debug: ts 515383870129912-515383891463246
debug: ts 515383891463246-515383912796579
debug: can't discard, data still pending
debug: ts 515383912796579-515383934129912
debug: doing pending stop trick: 'RTMP test1'
debug: ts 515383934129912-515383955463246
info: adding 21 milliseconds of audio buffering, total audio buffering is now 64 milliseconds (source: RTMP test1)
debug: ts 515383934129912-515383955463246
debug: ts 515383955463246-515383976796579
debug: can't discard, data still pending
debug: ts 515383976796579-515383998129912
debug: doing pending stop trick: 'RTMP test1'
debug: ts 515383998129912-515384019463246
info: adding 21 milliseconds of audio buffering, total audio buffering is now 85 milliseconds (source: RTMP test1)
debug: ts 515383998129912-515384019463246
debug: ts 515384019463246-515384040796579
debug: ts 515384040796579-515384062129912
```

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
