### PR TITLE
Make audio mixing robust against lagging sources

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -25,6 +25,7 @@ struct ts_info {
 };
 
 #define DEBUG_AUDIO 0
+#define DEBUG_LAGGED_AUDIO 0
 #define MAX_BUFFERING_TICKS 45
 
 static void push_audio_tree(obs_source_t *parent, obs_source_t *source, void *p)
@@ -80,20 +81,74 @@ static inline void mix_audio(struct audio_output_data *mixes,
 	}
 }
 
-static void ignore_audio(obs_source_t *source, size_t channels,
-			 size_t sample_rate)
+static bool ignore_audio(obs_source_t *source, size_t channels,
+			 size_t sample_rate, uint64_t start_ts)
 {
 	size_t num_floats = source->audio_input_buf[0].size / sizeof(float);
+	const char *name = obs_source_get_name(source);
 
-	if (num_floats) {
+	if (!source->audio_ts && num_floats) {
+#if DEBUG_LAGGED_AUDIO == 1
+		blog(LOG_DEBUG, "[src: %s] no timestamp, but audio available?",
+		     name);
+#endif
 		for (size_t ch = 0; ch < channels; ch++)
 			circlebuf_pop_front(&source->audio_input_buf[ch], NULL,
-					    source->audio_input_buf[ch].size);
+					    source->audio_input_buf[0].size);
+		source->last_audio_input_buf_size = 0;
+		return false;
+	}
+
+	if (num_floats) {
+		/* round up the number of samples to drop */
+		size_t drop = util_mul_div64(start_ts - source->audio_ts - 1,
+					     sample_rate, 1000000000ULL) +
+			      1;
+		if (drop > num_floats)
+			drop = num_floats;
+
+#if DEBUG_LAGGED_AUDIO == 1
+		blog(LOG_DEBUG,
+		     "[src: %s] ignored %" PRIu64 "/%" PRIu64 " samples", name,
+		     (uint64_t)drop, (uint64_t)num_floats);
+#endif
+		for (size_t ch = 0; ch < channels; ch++)
+			circlebuf_pop_front(&source->audio_input_buf[ch], NULL,
+					    drop * sizeof(float));
 
 		source->last_audio_input_buf_size = 0;
 		source->audio_ts +=
-			util_mul_div64(num_floats, 1000000000ULL, sample_rate);
+			util_mul_div64(drop, 1000000000ULL, sample_rate);
+		blog(LOG_DEBUG, "[src: %s] ts lag after ignoring: %" PRIu64,
+		     name, start_ts - source->audio_ts);
+
+		/* rounding error, adjust */
+		if (source->audio_ts == (start_ts - 1))
+			source->audio_ts = start_ts;
+
+		/* source is back in sync */
+		if (source->audio_ts >= start_ts)
+			return true;
+	} else {
+#if DEBUG_LAGGED_AUDIO == 1
+		blog(LOG_DEBUG, "[src: %s] no samples to ignore! ts = %" PRIu64,
+		     name, source->audio_ts);
+#endif
 	}
+
+	if (!source->audio_pending || num_floats) {
+		blog(LOG_WARNING,
+		     "Source %s audio is lagging (over by %.02f ms) "
+		     "at max audio buffering. Restarting source audio.",
+		     name, (start_ts - source->audio_ts) / 1000000.);
+	}
+
+	source->audio_pending = true;
+	source->audio_ts = 0;
+	/* tell the timestamp adjustment code in source_output_audio_data to
+	 * reset everything, and hopefully fix the timestamps */
+	source->timing_set = false;
+	return false;
 }
 
 static bool discard_if_stopped(obs_source_t *source, size_t channels)
@@ -145,6 +200,8 @@ static inline void discard_audio(struct obs_core_audio *audio,
 {
 	size_t total_floats = AUDIO_OUTPUT_FRAMES;
 	size_t size;
+	/* debug assert only */
+	UNUSED_PARAMETER(audio);
 
 #if DEBUG_AUDIO == 1
 	bool is_audio_source = source->info.output_flags & OBS_SOURCE_AUDIO;
@@ -180,9 +237,13 @@ static inline void discard_audio(struct obs_core_audio *audio,
 			     "start timestamp (%" PRIu64 ")",
 			     source->audio_ts, ts->start);
 		}
+
+		/* ignore_audio should have already run and marked this source
+		 * pending, unless we *just* added buffering */
+		assert(audio->total_buffering_ticks < MAX_BUFFERING_TICKS ||
+		       source->audio_pending || !source->audio_ts ||
+		       audio->buffering_wait_ticks);
 #endif
-		if (audio->total_buffering_ticks == MAX_BUFFERING_TICKS)
-			ignore_audio(source, channels, sample_rate);
 		return;
 	}
 
@@ -436,6 +497,38 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in,
 		obs_source_t *source = audio->render_order.array[i];
 		obs_source_audio_render(source, mixers, channels, sample_rate,
 					audio_size);
+
+		/* if a source has gone backward in time and we can no
+		 * longer buffer, drop some or all of its audio */
+		if (audio->total_buffering_ticks == MAX_BUFFERING_TICKS &&
+		    source->audio_ts < ts.start) {
+			if (source->info.audio_render) {
+				blog(LOG_DEBUG,
+				     "render audio source %s timestamp has "
+				     "gone backwards",
+				     obs_source_get_name(source));
+
+				/* just avoid further damage */
+				source->audio_pending = true;
+#if DEBUG_AUDIO == 1
+				/* this should really be fixed */
+				assert(false);
+#endif
+			} else {
+				pthread_mutex_lock(&source->audio_buf_mutex);
+				bool rerender = ignore_audio(source, channels,
+							     sample_rate,
+							     ts.start);
+				pthread_mutex_unlock(&source->audio_buf_mutex);
+
+				/* if we (potentially) recovered, re-render */
+				if (rerender)
+					obs_source_audio_render(source, mixers,
+								channels,
+								sample_rate,
+								audio_size);
+			}
+		}
 	}
 
 	/* ------------------------------------------------ */

--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -889,7 +889,7 @@ static void process_audio(obs_source_t *transition, obs_source_t *child,
 			  uint32_t mixers, size_t channels, size_t sample_rate,
 			  obs_transition_audio_mix_callback_t mix)
 {
-	bool valid = child && !child->audio_pending;
+	bool valid = child && !child->audio_pending && child->audio_ts;
 	struct obs_source_audio_mix child_audio;
 	uint64_t ts;
 	size_t pos;
@@ -927,7 +927,8 @@ static inline uint64_t calc_min_ts(obs_source_t *sources[2])
 	uint64_t min_ts = 0;
 
 	for (size_t i = 0; i < 2; i++) {
-		if (sources[i] && !sources[i]->audio_pending) {
+		if (sources[i] && !sources[i]->audio_pending &&
+		    sources[i]->audio_ts) {
 			if (!min_ts || sources[i]->audio_ts < min_ts)
 				min_ts = sources[i]->audio_ts;
 		}


### PR DESCRIPTION
### Description

This change makes the OBS mixing tree robust against sources with lagging audio. When a source lags beyond the ability to be synced by the audio buffering, only that source will be affected, not the entire mix. df4eb82 fixed a pathological bug that made this happen persistently for a given source and caused OBS audio output to completely fall over; this change addresses the underlying issue that a single misbehaving source breaks global audio output, transiently or not.

### Motivation and Context

Historically, `warning: Max audio buffering reached!` has been treated as some kind of inherent deeply-seated problem; once you get that message all bets are off and restarting OBS is the only solution. This is despite the fact that there are many situations where getting that message does *not* result in persistent problems in practice.

This is not a deep design problem. It's just a bug.

OBS has the ability to buffer audio in order to time-align sources with slightly different audio timestamps. This buffer can grow, up to a maximum of approximately one second, which introduces latency to the stream output. If sources slip in time beyond this maximum, they cannot be reconciled, and a dropout must occur. However, this situation need not and should not result in any catastrophic failure, nor should it affect audio output globally. It should only affect the misbehaving source.

The problem is as follows: when a source has a timestamp that is in the past (before the current audio tick), this triggers OBS to elide mixing, grow its buffer, and try again later. However, this can no longer happen once the buffer is maxed out. At that point, mixing proceeds and audio is processed with the timestamp in the past. Unfortunately, OBS's mixing tree stages cannot cope with out of range timestamps. Scene and transition mixing nodes will pick the lowest input timestamp and treat that as the base for the current audio tick, thus mixing audio for the wrong span of time. Then, `mix_audio` in obs-audio.c will notice the out-of-range incoming timestamp, prior to the current audio tick -which at this point is coming from a top-level transition source- and refuse to mix the audio entirely. This generates a global audio drop-out. At this point, latter code will usually notice the misbehaving source and kick it in some way, but it is too late, as we've already generated a drop-out. And if this sticks for some reason - as it did prior to df4eb82 - then audio breaks forever.

The solution is to catch these lagging sources immediately after their audio is rendered, in the case where the global audio buffering time has reached the limit. At this point we drop their audio partially or fully, and mark the source as pending if necessary, so that latter stages in the mixing tree never see out-of-range timestamps in an active audio input. We also log an error so the user knows that something was up. This creates a drop-out for that source (which can also happen via other codepaths when a source is lagging anyway), but it most importantly avoids any damage to anything *else* that is feeding audio to the mixing tree.

### How Has This Been Tested?

Set up two RTMP media sources, and feed them from two instances of ffmpeg via some RTMP reflector (e.g. nginx-rtmp), such as:

```ffmpeg -stream_loop 100 -re -y -i BigBuckBunny.mp4 -c copy -f flv rtmp://<stream url>```

Set up the audio faders such that the first instance is mixed into the stream, but the second instance is muted. Start streaming (or recording) and view the stream output (or recording).

Use ^Z to pause the second instance, wait a few seconds, and resume it (`fg`). This should trigger the OBS audio buffering to instantly max out. Now repeat the process a few times. Without this patch, each pause will often create a drop-out in stream output, affecting the audio from the first (untouched) instance. With this patch, the audio output will be completely clean, with no drop-outs, as the second source is muted. Unmuting source 2 and continuing the test shows that it drops out as expected while the first source continues on cleanly.

System: Gentoo Linux / amd64

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
