### PR TITLE
ftl-stream: Fix reconnect loop on FTL ingest disconnect

### DIFF
--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -886,6 +886,7 @@ static enum ret_type ftl_event(struct ftl_stream *stream,
 	//tell OBS and it will trigger a reconnection
 	blog(LOG_WARNING, "Reconnecting to Ingest");
 	obs_output_signal_stop(stream->output, OBS_OUTPUT_DISCONNECTED);
+	reset_semaphore(stream);
 	return RET_EXIT;
 }
 


### PR DESCRIPTION
### Description
When connection to FTL ingest is lost, ftl_event() calls
obs_output_signal_stop() to trigger a reconnect. However, during the
reconnect delay, send_thread is still waiting on send_sem semaphore.
After the delay, ftl_stream_start() is called, which in turn resets
the semaphore and creates a new send_thread. Old send_thread now exits
the loop and triggers another reconnect and the whole process repeats
again. The fix resets the semaphore in ftl_event() so the old
send_thread exits immediately.

Please let me know if there is a better way to fix the issue, as my
understanding of the reconnect process might still be lacking.

### Motivation and Context
Reconnecting to YouNow FTL ingest would keep retrying and disconnecting 
every few seconds (as set by retry delay) without ever succeeding.

### How Has This Been Tested?
Tested with YouNow FTL ingest by restarting the ingest server and making
sure OBS successfully reconnects and resumes streaming.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
