### PR TITLE
CI: Update macOS to Qt 5.15.2 and deps 2020-12-11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: [macos-latest]
     env:
       MIN_MACOS_VERSION: '10.13'
-      MACOS_DEPS_VERSION: '2020-08-30'
+      MACOS_DEPS_VERSION: '2020-12-11'
       VLC_VERSION: '3.0.8'
       SPARKLE_VERSION: '1.23.0'
-      QT_VERSION: '5.14.1'
+      QT_VERSION: '5.15.2'
       SIGN_IDENTITY: ''
     steps:
       - name: 'Checkout'


### PR DESCRIPTION
### Description

Updates CI build configuration for macOS to use Qt 5.15.2 and obs-deps 2020-12-11.

### Motivation and Context
Update dependencies for OBS 26.1 release. Fixes several Qt-related issues in the app and ensures HLS streaming compatibility.

### How Has This Been Tested?
Qt 5.15.2 and the deps were tested with multiple local builds.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
