### PR TITLE
libobs: Add function to get module lib

### DIFF
--- a/docs/sphinx/reference-modules.rst
+++ b/docs/sphinx/reference-modules.rst
@@ -308,3 +308,12 @@ plugin modules.
    :param  module: The module associated with the path
    :param  file:   The file to get a path to
    :return:        Path string, or NULL if not found.  Use bfree to free string
+
+---------------------
+
+.. function:: void *obs_get_module_lib(obs_module_t *module)
+
+   Returns library file of specified module.
+
+   :param  module: The module where to find library file.
+   :return:        Pointer to module library.

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -223,6 +223,11 @@ obs_module_t *obs_get_module(const char *name)
 	return NULL;
 }
 
+void *obs_get_module_lib(obs_module_t *module)
+{
+	return module ? module->module : NULL;
+}
+
 char *obs_find_module_file(obs_module_t *module, const char *file)
 {
 	struct dstr output = {0};

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -429,6 +429,9 @@ EXPORT bool obs_init_module(obs_module_t *module);
 /** Returns a module based upon its name, or NULL if not found */
 EXPORT obs_module_t *obs_get_module(const char *name);
 
+/** Gets library of module */
+EXPORT void *obs_get_module_lib(obs_module_t *module);
+
 /** Returns locale text from a specific module */
 EXPORT bool obs_module_get_locale_string(const obs_module_t *mod,
 					 const char *lookup_string,


### PR DESCRIPTION
### Description
This adds a function to find module library.

Co-authored-by: @Palakis

### Motivation and Context
In order to easily find the library file needed to load the browser panels on Linux, these functions were added. This should work on Mac and Windows as well.

Used code made by @Palakis, as they were trying to make Linux browser panels work as well.

### How Has This Been Tested?
Tested with https://github.com/obsproject/obs-browser/pull/254

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
