### PR TITLE
linux-jack: fix timestamps, deadlock on shutdown, and port type

### DIFF
--- a/plugins/linux-jack/jack-wrapper.c
+++ b/plugins/linux-jack/jack-wrapper.c
@@ -128,7 +128,7 @@ int_fast32_t jack_init(struct jack_data *data)
 
 		data->jack_ports[i] = jack_port_register(
 			data->jack_client, port_name, JACK_DEFAULT_AUDIO_TYPE,
-			JackPortIsInput, 0);
+			JackPortIsInput | JackPortIsTerminal, 0);
 		if (data->jack_ports[i] == NULL) {
 			blog(LOG_ERROR,
 			     "jack_port_register Error:"


### PR DESCRIPTION
Resubmit of #3856 (sigh).

### Description

Bug fixes for linux-jack:

* Mark input ports as terminal type. This means latency compensation does not expect to find other output ports that the data flows out of.
* Fix a deadlock when shutting down the source. See the commit message for a detailed description.
* Fix the timestamp calculation, which was completely broken.

### Motivation and Context

The deadlock bug was found at stack depth three trying to reproduce/fix a different OBS bug.

The port type fix is at the suggestion of the Ardour developers. It doesn't quite fix the latency compensation issues when capturing Ardour sessions with OBS for other reasons, but it's correct.

The timestamp calculation also was found due to its poor interaction with the OBS mixing code prior to #3863.

### How Has This Been Tested?

Tested during a >5h production stream with two JACK sources and a lot of other stuff.

System: Gentoo Linux / amd64 / JACK1 (0.125.0)

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.