### PR TITLE
UI: Add deferred function to update context bar

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -227,8 +227,7 @@ void SourceTreeItem::ReconnectSignals()
 			(obs_sceneitem_t *)calldata_ptr(cd, "item");
 
 		if (curItem == this_->sceneitem)
-			QMetaObject::invokeMethod(this_, "Select",
-						  Qt::QueuedConnection);
+			QMetaObject::invokeMethod(this_, "Select");
 	};
 
 	auto itemDeselect = [](void *data, calldata_t *cd) {
@@ -238,8 +237,7 @@ void SourceTreeItem::ReconnectSignals()
 			(obs_sceneitem_t *)calldata_ptr(cd, "item");
 
 		if (curItem == this_->sceneitem)
-			QMetaObject::invokeMethod(this_, "Deselect",
-						  Qt::QueuedConnection);
+			QMetaObject::invokeMethod(this_, "Deselect");
 	};
 
 	auto reorderGroup = [](void *data, calldata_t *) {
@@ -538,13 +536,13 @@ void SourceTreeItem::ExpandClicked(bool checked)
 void SourceTreeItem::Select()
 {
 	tree->SelectItem(sceneitem, true);
-	OBSBasic::Get()->UpdateContextBar();
+	OBSBasic::Get()->UpdateContextBarDeferred();
 }
 
 void SourceTreeItem::Deselect()
 {
 	tree->SelectItem(sceneitem, false);
-	OBSBasic::Get()->UpdateContextBar();
+	OBSBasic::Get()->UpdateContextBarDeferred();
 }
 
 /* ========================================================================= */

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2948,6 +2948,12 @@ static bool is_network_media_source(obs_source_t *source, const char *id)
 	return !is_local_file;
 }
 
+void OBSBasic::UpdateContextBarDeferred(bool force)
+{
+	QMetaObject::invokeMethod(this, "UpdateContextBar",
+				  Qt::QueuedConnection, Q_ARG(bool, force));
+}
+
 void OBSBasic::UpdateContextBar(bool force)
 {
 	if (!ui->contextContainer->isVisible() && !force)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1024,6 +1024,7 @@ public slots:
 
 	void ClearContextBar();
 	void UpdateContextBar(bool force = false);
+	void UpdateContextBarDeferred(bool force = false);
 
 public:
 	explicit OBSBasic(QWidget *parent = 0);


### PR DESCRIPTION
### Description
As a result of d68484e7, the "Deselect" signal is never fired for sources that are being deleted, as by the time the queued invokeMethod comes around, the object has already been deleted. This already has visible side effects, as the context bar is not updated when deleting a scene item.

While we could fix this by putting context bar updates directly in the "Remove" signal handler, this is a bit of a hacky workaround as we risk running into the same issue that made d68484e7 necessary in the first place, and we may as well remove the queued connection from the deselect signal to get the same behavior.

Fixing the underlying issue that prevents synchronous calls to the context bar and other things seems very difficult due to the mutex locking order issues. So this PR is a compromise, adding a deferred update for the context bar while still allowing the signal handlers to be synchronous.

### Motivation and Context
Fixes missing signals resulting in context bar not updating when deleting a source.

### How Has This Been Tested?
Deleted and selected / unselected sources and verified context bar updated correctly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
