### PR TITLE
obs-scripting: add transition duration functions

### DIFF
--- a/deps/obs-scripting/obs-scripting-lua-frontend.c
+++ b/deps/obs-scripting/obs-scripting-lua-frontend.c
@@ -113,6 +113,22 @@ static int set_current_transition(lua_State *script)
 	return 0;
 }
 
+static int get_transition_duration(lua_State *script)
+{
+	int duration = obs_frontend_get_transition_duration();
+	lua_pushinteger(script, duration);
+	return 1;
+}
+
+static int set_transition_duration(lua_State *script)
+{
+	if (lua_isnumber(script, 1)) {
+		const int *duration = lua_tointeger(script, 1);
+		obs_frontend_set_transition_duration(duration);
+	}
+	return 0;
+}
+
 static int get_scene_collections(lua_State *script)
 {
 	char **names = obs_frontend_get_scene_collections();
@@ -299,6 +315,8 @@ void add_lua_frontend_funcs(lua_State *script)
 	add_func(get_transitions);
 	add_func(get_current_transition);
 	add_func(set_current_transition);
+	add_func(get_transition_duration);
+	add_func(set_transition_duration);
 	add_func(get_scene_collections);
 	add_func(get_current_scene_collection);
 	add_func(set_current_scene_collection);

--- a/deps/obs-scripting/obs-scripting-python-frontend.c
+++ b/deps/obs-scripting/obs-scripting-python-frontend.c
@@ -161,6 +161,27 @@ static PyObject *set_current_transition(PyObject *self, PyObject *args)
 	return python_none();
 }
 
+static PyObject *get_transition_duration(PyObject *self, PyObject *args)
+{
+
+	int duration = obs_frontend_get_transition_duration();
+	PyObject *ret = PyLong_FromVoidPtr(duration);
+	UNUSED_PARAMETER(self);
+	UNUSED_PARAMETER(args);
+	return ret;
+}
+
+static PyObject *set_transition_duration(PyObject *self, PyObject *args)
+{
+	const int *duration;
+	if (!parse_args(args, "i", &duration))
+		return python_none();
+
+	obs_frontend_set_transition_duration(duration);
+	UNUSED_PARAMETER(self);
+	return python_none();
+}
+
 static PyObject *get_scene_collections(PyObject *self, PyObject *args)
 {
 	char **names = obs_frontend_get_scene_collections();
@@ -415,6 +436,8 @@ void add_python_frontend_funcs(PyObject *module)
 		DEF_FUNC(get_transitions),
 		DEF_FUNC(get_current_transition),
 		DEF_FUNC(set_current_transition),
+		DEF_FUNC(set_transition_duration),
+		DEF_FUNC(get_transition_duration),
 		DEF_FUNC(get_scene_collections),
 		DEF_FUNC(get_current_scene_collection),
 		DEF_FUNC(set_current_scene_collection),


### PR DESCRIPTION
### Description
The PR adds the `get_transition_duration` and `set_transition_duration` functions that were missing from the obs scripting code.

### Motivation and Context
This maintains feature parity to the scripting functionality.
This was also recently discussed on the scripting discussion room, therefore I believe users are in need of it.

### How Has This Been Tested?

I tested this with two scripts, one for each language.
Both of these operated successfully, printing expected test results
<details><summary>Python</summary>

```py
import obspython as obs

def script_properties():
	properties = obs.obs_properties_create()
	obs.obs_properties_add_button(properties, "test", "Test It", testbtn)
	return properties

def testbtn(properties, property):
	print(obs.obs_frontend_get_transition_duration())
	obs.obs_frontend_set_transition_duration(500)
	print(obs.obs_frontend_get_transition_duration())
	obs.obs_frontend_set_transition_duration(300)
```
</details>
<details><summary>Lua</summary>

```lua
obs = obslua

function script_properties()
	local props = obs.obs_properties_create()
	obs.obs_properties_add_button(props, "test", "Test It", testbtn)
	return props
end

function testbtn(properties, property)
	print(obs.obs_frontend_get_transition_duration())
	obs.obs_frontend_set_transition_duration(500)
	print(obs.obs_frontend_get_transition_duration())
	obs.obs_frontend_set_transition_duration(300)
end
```
</details>

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
