### PR TITLE
CI: Fix macOS 10.13 crashes and dependency incompatibilities

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: [macos-latest]
     env:
       MIN_MACOS_VERSION: '10.13'
-      MACOS_DEPS_VERSION: '2020-12-11'
+      MACOS_DEPS_VERSION: '2020-12-19'
       VLC_VERSION: '3.0.8'
       SPARKLE_VERSION: '1.23.0'
       QT_VERSION: '5.15.2'

--- a/cmake/Modules/FindLibcurl.cmake
+++ b/cmake/Modules/FindLibcurl.cmake
@@ -36,29 +36,45 @@ find_path(CURL_INCLUDE_DIR
 	PATH_SUFFIXES
 		include)
 
-find_library(CURL_LIB
-	NAMES ${_CURL_LIBRARIES} curl libcurl
-	HINTS
-		ENV curlPath${_lib_suffix}
-		ENV curlPath
-		ENV DepsPath${_lib_suffix}
-		ENV DepsPath
-		${curlPath${_lib_suffix}}
-		${curlPath}
-		${DepsPath${_lib_suffix}}
-		${DepsPath}
-		${_CURL_LIBRARY_DIRS}
-	PATHS
-		/usr/lib /usr/local/lib /opt/local/lib /sw/lib
-	PATH_SUFFIXES
-		lib${_lib_suffix} lib
-		libs${_lib_suffix} libs
-		bin${_lib_suffix} bin
-		../lib${_lib_suffix} ../lib
-		../libs${_lib_suffix} ../libs
-		../bin${_lib_suffix} ../bin
-		"build/Win${_lib_suffix}/VC12/DLL Release - DLL Windows SSPI"
-		"../build/Win${_lib_suffix}/VC12/DLL Release - DLL Windows SSPI")
+if(APPLE)
+	find_library(CURL_LIB
+		NAMES ${_CURL_LIBRARIES} curl libcurl
+		HINTS
+			ENV curlPath${_lib_suffix}
+			ENV curlPath
+			ENV DepsPath${_lib_suffix}
+			ENV DepsPath
+			${curlPath${_lib_suffix}}
+			${curlPath}
+			${DepsPath${_lib_suffix}}
+			${DepsPath}
+			${_CURL_LIBRARY_DIRS}
+		)
+else()
+	find_library(CURL_LIB
+		NAMES ${_CURL_LIBRARIES} curl libcurl
+		HINTS
+			ENV curlPath${_lib_suffix}
+			ENV curlPath
+			ENV DepsPath${_lib_suffix}
+			ENV DepsPath
+			${curlPath${_lib_suffix}}
+			${curlPath}
+			${DepsPath${_lib_suffix}}
+			${DepsPath}
+			${_CURL_LIBRARY_DIRS}
+		PATHS
+			/usr/lib /usr/local/lib /opt/local/lib /sw/lib
+		PATH_SUFFIXES
+			lib${_lib_suffix} lib
+			libs${_lib_suffix} libs
+			bin${_lib_suffix} bin
+			../lib${_lib_suffix} ../lib
+			../libs${_lib_suffix} ../libs
+			../bin${_lib_suffix} ../bin
+			"build/Win${_lib_suffix}/VC12/DLL Release - DLL Windows SSPI"
+			"../build/Win${_lib_suffix}/VC12/DLL Release - DLL Windows SSPI")
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Libcurl DEFAULT_MSG CURL_LIB CURL_INCLUDE_DIR)


### PR DESCRIPTION
### Description
Coerces `cmake` to not find and use Homebrew `curl`.

Fixes https://github.com/obsproject/obs-studio/issues/3887.

### Motivation and Context
Github Action runners seem to have Homebrew `curl` installed by default which is picked up by OBS' `cmake` run. This will link OBS against that `curl` installation which has a lot more further dependencies (among them OpenSSL) since Homebrew merged their `curl` and `curl-openssl` packages.

Even though `cmake` is supposed to prefer the library stubs provided by the platform SDKs, without this change it still prefers the version installed by Homebrew.

### How Has This Been Tested?
Needs to be tested via CI runs.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
