### PR TITLE
Do not use hardcoded paths for module tools

### DIFF
--- a/plugins/linux-v4l2/CMakeLists.txt
+++ b/plugins/linux-v4l2/CMakeLists.txt
@@ -29,6 +29,28 @@ else()
 	endif()
 endif()
 
+find_program(MODPROBE_BINARY NAMES modprobe PATHS /usr/sbin/ /sbin/ /usr/local/sbin)
+find_program(MODINFO_BINARY  NAMES modinfo  PATHS /usr/sbin/ /sbin/ /usr/local/sbin)
+find_program(PKEXEC_BINARY   NAMES pkexec)
+
+if (NOT MODPROBE_BINARY)
+  message(STATUS "Falling back to 'modprobe' without a path")
+  set(MODPROBE_BINARY modprobe)
+endif (NOT MODPROBE_BINARY)
+
+if (NOT MODINFO_BINARY)
+  message(STATUS "Falling back to 'modinfo' without a path")
+  set(MODINFO_BINARY modinfo)
+endif (NOT MODINFO_BINARY)
+
+if (NOT PKEXEC_BINARY)
+  message(STATUS "Falling back to 'pkexec' without a path")
+  set(PKEXEC_BINARY pkexec)
+endif (NOT PKEXEC_BINARY)
+
+# TODO: most of the other cmake files seem to stick to add_definitions instead of add_compile_definitions so lets stick to that
+add_definitions(-DMODPROBE_BINARY="${MODPROBE_BINARY}" -DMODINFO_BINARY="${MODINFO_BINARY}" -DPKEXEC_BINARY="${PKEXEC_BINARY}")
+
 include_directories(
 	SYSTEM "${CMAKE_SOURCE_DIR}/libobs"
 	${LIBV4L2_INCLUDE_DIRS}

--- a/plugins/linux-v4l2/linux-v4l2.c
+++ b/plugins/linux-v4l2/linux-v4l2.c
@@ -31,7 +31,7 @@ static bool v4l2loopback_installed()
 {
 	bool loaded = false;
 
-	int ret = system("modinfo v4l2loopback >/dev/null 2>&1");
+	int ret = system(MODINFO_BINARY " v4l2loopback >/dev/null 2>&1");
 
 	if (ret == 0)
 		loaded = true;

--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -53,7 +53,9 @@ static bool loopback_module_loaded()
 static int loopback_module_load()
 {
 	return system(
-		"pkexec modprobe v4l2loopback exclusive_caps=1 card_label='OBS Virtual Camera' && sleep 0.5");
+		PKEXEC_BINARY
+		" " MODPROBE_BINARY
+		" v4l2loopback exclusive_caps=1 card_label='OBS Virtual Camera' && sleep 0.5");
 }
 
 static void *virtualcam_create(obs_data_t *settings, obs_output_t *output)


### PR DESCRIPTION
### Description
Use cmake to find the binaries used to interact with the v4l2loopback driver.

### Motivation and Context
Not all distributions have /sbin and /usr/sbin in $PATH so it would be better to call the tools with the full path if possible.

### How Has This Been Tested?
package build with and without the tools available to test the fallback path

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
