### PR TITLE
libobs: Fix missing Linux libraries with certain flags

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -20,6 +20,9 @@ if(UNIX)
 		find_package(X11 REQUIRED)
 		find_package(X11_XCB REQUIRED)
 		find_package(XCB OPTIONAL_COMPONENTS XINPUT)
+		find_package(XCB)
+		find_library(M_LIBRARY NAMES m)
+		find_library(DL_LIBRARY NAMES dl)
 		if (XCB_XINPUT_FOUND)
 			set(USE_XINPUT "1")
 		else()
@@ -219,7 +222,10 @@ elseif(UNIX)
 		${X11_XCB_DEFINITIONS})
 	set(libobs_PLATFORM_DEPS
 		${libobs_PLATFORM_DEPS}
+		${DL_LIBRARY}
+		${M_LIBRARY}
 		${X11_X11_LIB}
+		${XCB_LIBRARIES}
 		${X11_XCB_LIBRARIES})
 
 	if(USE_XINPUT)


### PR DESCRIPTION
### Description
not all symbols were satisified in libobs. This was noticable when building with '-DCMAKE_SHARED_LINKER_FLAGS= -Wl,--as-needed -Wl,--no-undefined -Wl,-z,now'

### Motivation and Context
This fixes #3924


### How Has This Been Tested?
Package build got fixed after applying this patch

### Types of changes
- Bug fix (non-breaking change which fixes an issue)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
