### PR TITLE
rtmp-services: Add Loola.tv service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 161,
+	"version": 162,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 161
+			"version": 162
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -259,6 +259,40 @@
                 "max audio bitrate": 160
             }
         },
+		{
+            "name": "Loola.tv",
+            "common": false,
+            "servers": [             
+                {
+                    "name": "US East: Virginia",
+                    "url": "rtmp://rtmp.loola.tv/push"
+                },
+		{
+                    "name": "EU Central: Germany",
+                    "url": "rtmp://rtmp-eu.loola.tv/push"
+                },
+		{
+                    "name": "South America: Brazil",
+                    "url": "rtmp://rtmp-sa.loola.tv/push"
+                },
+		{
+                    "name": "Asia/Pacific: Singapore",
+                    "url": "rtmp://rtmp-sg.loola.tv/push"
+                },               
+                {
+                    "name": "Middle East: Bahrain",
+                    "url": "rtmp://rtmp-me.loola.tv/push"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "profile": "high",
+                "max video bitrate": 2500,
+                "max audio bitrate": 160,
+                "bframes": 2,
+                "x264opts": "scenecut=0"
+            }
+        },
         {
             "name": "VIMM",
             "servers": [


### PR DESCRIPTION
### Description
Added Loola.tv servers and encoder defaults to rtmp-services.

### Motivation and Context
Adding support to the Loola.tv streaming platform.

### How Has This Been Tested?
The new preset has been tested with OBS 26 by modifying the local copy of /plugins/rtmp-services/data/services.json
All Loola servers/regions were tested, as well as encoders parameters both with x264 and NVENC-H.264 encoders.

### Types of changes
New feature (non-breaking change which adds functionality)
Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
