### PR TITLE
libobs: Add texture sharing support for macOS/OpenGL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
         if: steps.cef-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          curl -L -O https://obs-nightly.s3-us-west-2.amazonaws.com/cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64.tar.bz2
+          curl -L -O https://cdn-fastly.obsproject.com/downloads/cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64.tar.bz2
           tar -xf ./cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64.tar.bz2 -C ${{ github.workspace }}/cmbuild/
           cd ${{ github.workspace }}/cmbuild/cef_binary_${{ env.CEF_BUILD_VERSION }}_macosx64
           sed -i '.orig' '/add_subdirectory(tests\/ceftests)/d' ./CMakeLists.txt

--- a/CI/full-build-macos.sh
+++ b/CI/full-build-macos.sh
@@ -212,13 +212,13 @@ install_cef() {
     hr "Building dependency CEF v${1}"
     ensure_dir ${DEPS_BUILD_DIR}
     step "Download..."
-    ${CURLCMD} --progress-bar -L -C - -O https://obs-nightly.s3-us-west-2.amazonaws.com/cef_binary_${1}_macosx64.tar.bz2
+    ${CURLCMD} --progress-bar -L -C - -O https://cdn-fastly.obsproject.com/downloads/cef_binary_${1}_macosx64.tar.bz2
     step "Unpack..."
     tar -xf ./cef_binary_${1}_macosx64.tar.bz2
     cd ./cef_binary_${1}_macosx64
     step "Fix tests..."
     sed -i '.orig' '/add_subdirectory(tests\/ceftests)/d' ./CMakeLists.txt
-    sed -i '.orig' s/\"10.9\"/\"${MIN_MACOS_VERSION:-${CI_MIN_MACOS_VERSION}}\"/ ./cmake/cef_variables.cmake
+    sed -i '.orig' 's/"'$(test "${CEF_BUILD_VERSION:-${CI_CEF_VERSION}}" -le 3770 && echo "10.9" || echo "10.10")'"/"'${MIN_MACOS_VERSION:-${CI_MIN_MACOS_VERSION}}'"/' ./cmake/cef_variables.cmake
     ensure_dir ./build
     step "Run CMAKE..."
     cmake \

--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -339,7 +339,7 @@ gs_texture_t *device_texture_create_from_iosurface(gs_device_t *device,
 	tex->base.gl_format = convert_gs_format(color_format);
 	tex->base.gl_internal_format = convert_gs_internal_format(color_format);
 	tex->base.gl_type = GL_UNSIGNED_INT_8_8_8_8_REV;
-	tex->base.gl_target = GL_TEXTURE_RECTANGLE;
+	tex->base.gl_target = GL_TEXTURE_RECTANGLE_ARB;
 	tex->base.is_dynamic = false;
 	tex->base.is_render_target = false;
 	tex->base.gen_mipmaps = false;
@@ -379,6 +379,20 @@ fail:
 	gs_texture_destroy((gs_texture_t *)tex);
 	blog(LOG_ERROR, "device_texture_create_from_iosurface (GL) failed");
 	return NULL;
+}
+
+gs_texture_t *device_texture_open_shared(gs_device_t *device, uint32_t handle)
+{
+	gs_texture_t *texture = NULL;
+	IOSurfaceRef ref = IOSurfaceLookupFromMachPort((mach_port_t)handle);
+	texture = device_texture_create_from_iosurface(device, ref);
+	CFRelease(ref);
+	return texture;
+}
+
+bool device_shared_texture_available(void)
+{
+	return true;
 }
 
 bool gs_texture_rebind_iosurface(gs_texture_t *texture, void *iosurf)

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -193,6 +193,8 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 
 	/* OSX/Cocoa specific functions */
 #ifdef __APPLE__
+	GRAPHICS_IMPORT(device_shared_texture_available);
+	GRAPHICS_IMPORT_OPTIONAL(device_texture_open_shared);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_create_from_iosurface);
 	GRAPHICS_IMPORT_OPTIONAL(gs_texture_rebind_iosurface);
 

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -271,8 +271,11 @@ struct gs_exports {
 	/* OSX/Cocoa specific functions */
 	gs_texture_t *(*device_texture_create_from_iosurface)(gs_device_t *dev,
 							      void *iosurf);
+	gs_texture_t *(*device_texture_open_shared)(gs_device_t *dev,
+						    uint32_t *handle);
 	bool (*gs_texture_rebind_iosurface)(gs_texture_t *texture,
 					    void *iosurf);
+	bool (*device_shared_texture_available)(void);
 
 #elif _WIN32
 	bool (*device_gdi_texture_available)(void);

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -2756,6 +2756,26 @@ bool gs_texture_rebind_iosurface(gs_texture_t *texture, void *iosurf)
 	return graphics->exports.gs_texture_rebind_iosurface(texture, iosurf);
 }
 
+bool gs_shared_texture_available(void)
+{
+	if (!gs_valid("gs_shared_texture_available"))
+		return false;
+
+	return thread_graphics->exports.device_shared_texture_available();
+}
+
+gs_texture_t *gs_texture_open_shared(uint32_t handle)
+{
+	graphics_t *graphics = thread_graphics;
+	if (!gs_valid("gs_texture_open_shared"))
+		return NULL;
+
+	if (graphics->exports.device_texture_open_shared)
+		return graphics->exports.device_texture_open_shared(
+			graphics->device, handle);
+	return NULL;
+}
+
 #elif _WIN32
 
 bool gs_gdi_texture_available(void)

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -831,6 +831,8 @@ EXPORT void gs_debug_marker_end(void);
  * from shared surface resources */
 EXPORT gs_texture_t *gs_texture_create_from_iosurface(void *iosurf);
 EXPORT bool gs_texture_rebind_iosurface(gs_texture_t *texture, void *iosurf);
+EXPORT gs_texture_t *gs_texture_open_shared(uint32_t handle);
+EXPORT bool gs_shared_texture_available(void);
 
 #elif _WIN32
 


### PR DESCRIPTION
### Description
Adds the necessary changes to make texture sharing available for `obs-browser` with compatible CEF versions (4183+).

### Motivation and Context
Reduces CPU load for browser sources by using shared off-screen rendered texture from CEF.

Do note that with the new renderer and new patch the texture handle will change with every `AcceleratedPaint` call, which will regress performance on Windows a bit. macOS never had this feature before, so it's not an issue there.

Also note that for the time being `SendBeginFrame` crashes the GPU process on macOS, so CEF will render at its own frame rate with the plugin defaulting to the canvas frame rate on browser source initialisation. 

**Notes:**
* This PR is necessary to build OBS once https://github.com/obsproject/obs-browser/pull/252 is merged and the submodule updated to include it.
* This PR does *not* activate hardware acceleration, a separate PR activating the setting in the UI is required for that.
* `GL_TEXTURE_RECTANGLE_ARB` and `GL_TEXTURE_RECTANGLE` are the same `GLEnum` on macOS as Apple ported OpenGL extensions into their "core". But the `ARB` variant is more "correct" according to Apple's docs.

### How Has This Been Tested?
CEF 4183 with texture sharing has been tested locally and by @pkviet.

### Types of changes
- New feature (non-breaking change which adds functionality)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
