### PR TITLE
image-source: Add webp to file filter

### DIFF
--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -218,6 +218,7 @@ static const char *image_filter =
 	"JPEG Files (*.jpeg *.jpg);;"
 	"GIF Files (*.gif);;"
 	"PSD Files (*.psd);;"
+	"WebP Files (*.webp);;"
 	"All Files (*.*)";
 
 static obs_properties_t *image_source_properties(void *data)

--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -211,7 +211,7 @@ static void image_source_tick(void *data, float seconds)
 }
 
 static const char *image_filter =
-	"All formats (*.bmp *.tga *.png *.jpeg *.jpg *.gif *.psd);;"
+	"All formats (*.bmp *.tga *.png *.jpeg *.jpg *.gif *.psd *.webp);;"
 	"BMP Files (*.bmp);;"
 	"Targa Files (*.tga);;"
 	"PNG Files (*.png);;"

--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -848,7 +848,7 @@ static void ss_defaults(obs_data_t *settings)
 }
 
 static const char *file_filter =
-	"Image files (*.bmp *.tga *.png *.jpeg *.jpg *.gif)";
+	"Image files (*.bmp *.tga *.png *.jpeg *.jpg *.gif *.webp)";
 
 static const char *aspects[] = {"16:9", "16:10", "4:3", "1:1"};
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Simply adds .webp files to the file browser's file filter.

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context

OBS already supports WebP images, but they do not display in the file browser due to the filter excluding them.

Presently, users have to explicitly set the filter to `All Files (*.*)` or manually write in the path of their .webp image. There is also advice on the internet to use Browser Source to load .webp files, which is a subpar experience.


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?

Used macOS Catalina (10.15.7) to build and run. Tested image slideshow and Image sources, loading a .webp image, using both the specific WebP file filter and the "All formats" filter.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
