### PR TITLE
coreaudio-encoder: Set compiler flag for mingw before adding resource file

### DIFF
--- a/plugins/coreaudio-encoder/CMakeLists.txt
+++ b/plugins/coreaudio-encoder/CMakeLists.txt
@@ -4,17 +4,18 @@ set(coreaudio-encoder_SOURCES
 	encoder.cpp)
 
 if (WIN32)
+	# Set compiler flag before adding resource file
+	if (MINGW)
+		set_source_files_properties(${coreaudio-encoder_SOURCES}
+			PROPERTIES COMPILE_FLAGS "-Wno-multichar")
+	endif()
+
 	set(MODULE_DESCRIPTION "OBS Core Audio encoder")
 	configure_file(${CMAKE_SOURCE_DIR}/cmake/winrc/obs-module.rc.in coreaudio-encoder.rc)
 	list(APPEND coreaudio-encoder_SOURCES
 		coreaudio-encoder.rc)
 	set(coreaudio-encoder_HEADERS windows-imports.h)
 	set(coreaudio-encoder_LIBS )
-
-	if (MINGW)
-		set_source_files_properties(${coreaudio-encoder_SOURCES}
-			PROPERTIES COMPILE_FLAGS "-Wno-multichar")
-	endif()
 else()
 	find_library(COREFOUNDATION CoreFoundation)
 	find_library(COREAUDIO CoreAudio)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
coreaudio-encoder: Set compiler flag for mingw before adding resource file. 

### Motivation and Context
Before this change, the resource file is added to source list and compiler flag is added after it. While compiling with mingw toolchain `windres` resource compiler catches up the `-Wno-multichar' as an option which is unknow to it. This change fixes it. This flag was added in commit aa0e64b7c9c331f69a73f56c9b7fcc4d27bd72df

### How Has This Been Tested?
I have used msys2/mingw-w64 toolchain to test it.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
