### PR TITLE
CI: Remove jack, speex and fdk-aac from default builds for macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: [macos-latest]
     env:
       MIN_MACOS_VERSION: '10.13'
-      MACOS_DEPS_VERSION: '2020-12-19'
+      MACOS_DEPS_VERSION: '2020-12-22'
       VLC_VERSION: '3.0.8'
       SPARKLE_VERSION: '1.23.0'
       QT_VERSION: '5.15.2'
@@ -54,13 +54,17 @@ jobs:
         shell: bash
         run: |
           if [ -d /usr/local/opt/openssl@1.0.2t ]; then
-              brew uninstall openssl@1.0.2t
-              brew untap local/openssl
+            brew uninstall openssl@1.0.2t
+            brew untap local/openssl
           fi
 
           if [ -d /usr/local/opt/python@2.7.17 ]; then
-              brew uninstall python@2.7.17
-              brew untap local/python2
+            brew uninstall python@2.7.17
+            brew untap local/python2
+          fi
+
+          if [ -d /usr/local/opt/speexdsp ]; then
+            brew unlink speexdsp
           fi
           brew bundle --file ./CI/scripts/macos/Brewfile
       - name: 'Restore Chromium Embedded Framework from cache'
@@ -199,7 +203,6 @@ jobs:
             ./OBS.app/Contents/PlugIns/decklink-captions.so
             ./OBS.app/Contents/PlugIns/frontend-tools.so
             ./OBS.app/Contents/PlugIns/image-source.so
-            ./OBS.app/Contents/PlugIns/linux-jack.so
             ./OBS.app/Contents/PlugIns/mac-avcapture.so
             ./OBS.app/Contents/PlugIns/mac-capture.so
             ./OBS.app/Contents/PlugIns/mac-decklink.so
@@ -216,7 +219,6 @@ jobs:
             ./OBS.app/Contents/MacOS/obslua.so
             ./OBS.app/Contents/PlugIns/obs-x264.so
             ./OBS.app/Contents/PlugIns/text-freetype2.so
-            ./OBS.app/Contents/PlugIns/obs-libfdk.so
             ./OBS.app/Contents/PlugIns/obs-outputs.so
           )
 

--- a/CI/full-build-macos.sh
+++ b/CI/full-build-macos.sh
@@ -311,7 +311,6 @@ bundle_dylibs() {
         ./OBS.app/Contents/PlugIns/decklink-captions.so
         ./OBS.app/Contents/PlugIns/frontend-tools.so
         ./OBS.app/Contents/PlugIns/image-source.so
-        ./OBS.app/Contents/PlugIns/linux-jack.so
         ./OBS.app/Contents/PlugIns/mac-avcapture.so
         ./OBS.app/Contents/PlugIns/mac-capture.so
         ./OBS.app/Contents/PlugIns/mac-decklink.so
@@ -328,7 +327,6 @@ bundle_dylibs() {
         ./OBS.app/Contents/MacOS/obslua.so
         ./OBS.app/Contents/PlugIns/obs-x264.so
         ./OBS.app/Contents/PlugIns/text-freetype2.so
-        ./OBS.app/Contents/PlugIns/obs-libfdk.so
         ./OBS.app/Contents/PlugIns/obs-outputs.so
         )
     if ! [ "${CEF_BUILD_VERSION:-${CI_CEF_VERSION}}" -le 3770 ]; then

--- a/CI/scripts/macos/Brewfile
+++ b/CI/scripts/macos/Brewfile
@@ -1,8 +1,5 @@
 tap "akeru-inc/tap"
-brew "jack"
-brew "speexdsp"
 brew "cmake"
 brew "freetype"
-brew "fdk-aac"
 brew "cmocka"
 brew "akeru-inc/tap/xcnotary"


### PR DESCRIPTION
### Description
Removes `libjack` and `fdk-aac` from default macOS builds to ensure compatibility with macOS 10.13.

### Motivation and Context
With Homebrew deprecating macOS 10.13 but OBS still supporting it we need to build external dependencies ourselves. SpeexDSP is added to macOS-deps via https://github.com/obsproject/obs-deps/pull/44, `libjack` is removed (because it has too many dependencies we'd need to manually fix up) as well as `fdk-aac` as macOS' CoreAudio encoder has better quality.

### How Has This Been Tested?
OBS built created locally and tested, some more tests are pending with users of 10.13.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
