### PR TITLE
UI: Add save notifications to status bar

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -535,6 +535,10 @@ Basic.StatusBar.Delay="Delay (%1 sec)"
 Basic.StatusBar.DelayStartingIn="Delay (starting in %1 sec)"
 Basic.StatusBar.DelayStoppingIn="Delay (stopping in %1 sec)"
 Basic.StatusBar.DelayStartingStoppingIn="Delay (stopping in %1 sec, starting in %2 sec)"
+Basic.StatusBar.RecordingSavedTo="Recording saved to '%1'"
+Basic.StatusBar.ReplayBufferSavedTo="Replay buffer saved to '%1'"
+Basic.StatusBar.ScreenshotSavedTo="Screenshot saved to '%1'"
+Basic.StatusBar.AutoRemuxedTo="Recording auto remuxed to '%1'"
 
 # filters window
 Basic.Filters="Filters"

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -2018,12 +2018,11 @@ bool AdvancedOutput::ReplayBufferActive() const
 
 /* ------------------------------------------------------------------------ */
 
-bool BasicOutputHandler::SetupAutoRemux(const char *&ext)
+void BasicOutputHandler::SetupAutoRemux(const char *&ext)
 {
 	bool autoRemux = config_get_bool(main->Config(), "Video", "AutoRemux");
 	if (autoRemux && strcmp(ext, "mp4") == 0)
 		ext = "mkv";
-	return autoRemux;
 }
 
 std::string
@@ -2031,9 +2030,11 @@ BasicOutputHandler::GetRecordingFilename(const char *path, const char *ext,
 					 bool noSpace, bool overwrite,
 					 const char *format, bool ffmpeg)
 {
-	bool remux = !ffmpeg && SetupAutoRemux(ext);
+	if (!ffmpeg)
+		SetupAutoRemux(ext);
+
 	string dst = GetOutputFilename(path, ext, noSpace, overwrite, format);
-	lastRecordingPath = remux ? dst : "";
+	lastRecordingPath = dst;
 	return dst;
 }
 

--- a/UI/window-basic-main-outputs.hpp
+++ b/UI/window-basic-main-outputs.hpp
@@ -63,7 +63,7 @@ struct BasicOutputHandler {
 	}
 
 protected:
-	bool SetupAutoRemux(const char *&ext);
+	void SetupAutoRemux(const char *&ext);
 	std::string GetRecordingFilename(const char *path, const char *ext,
 					 bool noSpace, bool overwrite,
 					 const char *format, bool ffmpeg);

--- a/UI/window-basic-main-screenshot.cpp
+++ b/UI/window-basic-main-screenshot.cpp
@@ -37,8 +37,17 @@ ScreenshotObj::~ScreenshotObj()
 	obs_leave_graphics();
 
 	obs_remove_tick_callback(ScreenshotTick, this);
-	if (th.joinable())
+
+	if (th.joinable()) {
 		th.join();
+
+		if (cx && cy) {
+			OBSBasic *main = OBSBasic::Get();
+			main->ShowStatusBarMessage(
+				QTStr("Basic.StatusBar.ScreenshotSavedTo")
+					.arg(QT_UTF8(path.c_str())));
+		}
+	}
 }
 
 void ScreenshotObj::Screenshot()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -857,6 +857,8 @@ public:
 
 	OBSWeakSource copyFilter = nullptr;
 
+	void ShowStatusBarMessage(const QString &message);
+
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;
 	virtual void changeEvent(QEvent *event) override;

--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -33,6 +33,7 @@
 #include <QTimer>
 
 #include "qt-wrappers.hpp"
+#include "window-basic-main.hpp"
 
 #include <memory>
 #include <cmath>
@@ -927,6 +928,11 @@ void OBSRemux::remuxFinished(bool success)
 
 	if (autoRemux && autoRemuxFile != "") {
 		QTimer::singleShot(3000, this, SLOT(close()));
+
+		OBSBasic *main = OBSBasic::Get();
+		main->ShowStatusBarMessage(
+			QTStr("Basic.StatusBar.AutoRemuxedTo")
+				.arg(autoRemuxFile));
 	}
 
 	remuxNextEntry();


### PR DESCRIPTION
### Description
This shows a message in the status bar with the following events:

- Recording is saved
- Recording is auto remuxed
- Replay buffer is saved
- Screenshot is taken

![Screenshot from 2020-12-20 23-53-48](https://user-images.githubusercontent.com/19962531/102746410-d6b47880-4323-11eb-88c6-fd0ba21db067.png)

![Screenshot from 2020-12-21 00-21-47](https://user-images.githubusercontent.com/19962531/102746422-dddb8680-4323-11eb-84f2-9b713892f277.png)

![Screenshot from 2020-12-20 23-52-14](https://user-images.githubusercontent.com/19962531/102746446-ed5acf80-4323-11eb-8281-02d1dff4288c.png)

![Screenshot from 2020-12-20 23-51-42](https://user-images.githubusercontent.com/19962531/102746457-f3e94700-4323-11eb-80f2-c263bc541417.png)

### Motivation and Context
OBS has no feedback when files are saved.

### How Has This Been Tested?
Saved different types of files to make sure it showed the message correctly.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
