### PR TITLE
UI: Fix padding on Acri context bar buttons

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -317,8 +317,8 @@ QScrollBar::left-arrow:horizontal, QScrollBar::right-arrow:horizontal, QScrollBa
     max-height: 40px;
 }
 
-#contextContainer QPushButton[themeID2=contextBarButton] {
-    padding: 0px;
+#contextContainer QPushButton {
+    padding: 0px 12px;
 }
 
 QPushButton#sourcePropertiesButton {


### PR DESCRIPTION
### Description
Fixes text getting clipped by the padding applied to all Acri theme buttons by default by removing it from context bar buttons

Before:
![image](https://user-images.githubusercontent.com/1554753/102759278-e3e06000-4341-11eb-960e-3494118ebe5a.png)

After:
![image](https://user-images.githubusercontent.com/1554753/102759169-beebed00-4341-11eb-9863-c0c5b3a0f9a0.png)

### Motivation and Context
Currently the text on context bar buttons gets clipped on Acri due to the vertical padding applied to buttons, and the context bar being a fixed height that does not have room for it

### How Has This Been Tested?
Checked various source types on Acri

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
