### PR TITLE
docs/sphinx: Add missing obs_frontend_open_projector

### DIFF
--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -454,6 +454,15 @@ Functions
 
 ---------------------------------------
 
+.. function:: void obs_frontend_open_projector(const char *type, int monitor, const char *geometry, const char *name)
+
+   :param type:     "Preview", "Source", "Scene", "StudioProgram", or "Multiview" (case insensitive).
+   :param monitor:  Monitor to open the projector on. If -1, opens a window.
+   :param geometry: If *monitor* is -1, size and position of the projector window. Encoded in Base64 using Qt's geometry encoding.
+   :param name:     If *type* is "Source" or "Scene", name of the source or scene to be displayed.
+
+---------------------------------------
+
 .. function:: void obs_frontend_save(void)
 
    Saves the current scene collection.


### PR DESCRIPTION

### Description
I found that there where no docs added for #1910 and with some digging found the doc strings from the obs-websocket in https://github.com/Palakis/obs-websocket/pull/338 This simply puts the docs together so that others don't have to scry for them.

### Motivation and Context
The docs where not added with the original commit, I've pulled together what appears to be documentation @Rosuav used in obs-websocket

### How Has This Been Tested?
On 26.1.0 Linux, I've confirmed that API treats the arguments as expected via a lua script. The only exception is `geometry` (other than it does fine with an empty string) as I cant find examples of the data to encode to pass it)

### Types of changes
Documentation

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
