### PR TITLE
mac-virtualcam: Mark parameters as unused

### DIFF
--- a/plugins/mac-virtualcam/src/dal-plugin/CMSampleBufferUtils.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/CMSampleBufferUtils.mm
@@ -83,6 +83,9 @@ OSStatus CMSampleBufferCreateFromData(NSSize size,
 
 static void releaseNSData(void *o, void *block, size_t size)
 {
+	UNUSED_PARAMETER(block);
+	UNUSED_PARAMETER(size);
+
 	NSData *data = (__bridge_transfer NSData *)o;
 	data = nil; // Assuming ARC is enabled
 }

--- a/plugins/mac-virtualcam/src/dal-plugin/Logging.h
+++ b/plugins/mac-virtualcam/src/dal-plugin/Logging.h
@@ -29,4 +29,6 @@
 #define VLogFunc(fmt, ...)
 #define ELog(fmt, ...) DLog(fmt, ##__VA_ARGS__)
 
+#define UNUSED_PARAMETER(param) (void)param
+
 #endif /* Logging_h */

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugInInterface.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugInInterface.mm
@@ -34,6 +34,8 @@ static UInt32 sRefCount = 0;
 
 ULONG HardwarePlugIn_AddRef(CMIOHardwarePlugInRef self)
 {
+	UNUSED_PARAMETER(self);
+
 	sRefCount += 1;
 	DLogFunc(@"sRefCount now = %d", sRefCount);
 	return sRefCount;
@@ -41,6 +43,8 @@ ULONG HardwarePlugIn_AddRef(CMIOHardwarePlugInRef self)
 
 ULONG HardwarePlugIn_Release(CMIOHardwarePlugInRef self)
 {
+	UNUSED_PARAMETER(self);
+
 	sRefCount -= 1;
 	DLogFunc(@"sRefCount now = %d", sRefCount);
 	return sRefCount;
@@ -49,6 +53,7 @@ ULONG HardwarePlugIn_Release(CMIOHardwarePlugInRef self)
 HRESULT HardwarePlugIn_QueryInterface(CMIOHardwarePlugInRef self, REFIID uuid,
 				      LPVOID *interface)
 {
+	UNUSED_PARAMETER(self);
 	DLogFunc(@"");
 
 	if (!interface) {
@@ -161,6 +166,7 @@ OSStatus HardwarePlugIn_Teardown(CMIOHardwarePlugInRef self)
 void HardwarePlugIn_ObjectShow(CMIOHardwarePlugInRef self,
 			       CMIOObjectID objectID)
 {
+	UNUSED_PARAMETER(objectID);
 	DLogFunc(@"self=%p", self);
 }
 
@@ -169,6 +175,7 @@ HardwarePlugIn_ObjectHasProperty(CMIOHardwarePlugInRef self,
 				 CMIOObjectID objectID,
 				 const CMIOObjectPropertyAddress *address)
 {
+	UNUSED_PARAMETER(self);
 
 	NSObject<CMIOObject> *object =
 		[OBSDALObjectStore GetObjectWithId:objectID];
@@ -215,6 +222,7 @@ OSStatus HardwarePlugIn_ObjectGetPropertyDataSize(
 	const CMIOObjectPropertyAddress *address, UInt32 qualifierDataSize,
 	const void *qualifierData, UInt32 *dataSize)
 {
+	UNUSED_PARAMETER(self);
 
 	NSObject<CMIOObject> *object =
 		[OBSDALObjectStore GetObjectWithId:objectID];
@@ -240,6 +248,7 @@ OSStatus HardwarePlugIn_ObjectGetPropertyData(
 	const void *qualifierData, UInt32 dataSize, UInt32 *dataUsed,
 	void *data)
 {
+	UNUSED_PARAMETER(self);
 
 	NSObject<CMIOObject> *object =
 		[OBSDALObjectStore GetObjectWithId:objectID];
@@ -345,6 +354,8 @@ OSStatus HardwarePlugIn_DeviceStartStream(CMIOHardwarePlugInRef self,
 OSStatus HardwarePlugIn_DeviceSuspend(CMIOHardwarePlugInRef self,
 				      CMIODeviceID deviceID)
 {
+	UNUSED_PARAMETER(deviceID);
+
 	DLogFunc(@"self=%p", self);
 	return kCMIOHardwareNoError;
 }
@@ -352,6 +363,8 @@ OSStatus HardwarePlugIn_DeviceSuspend(CMIOHardwarePlugInRef self,
 OSStatus HardwarePlugIn_DeviceResume(CMIOHardwarePlugInRef self,
 				     CMIODeviceID deviceID)
 {
+	UNUSED_PARAMETER(deviceID);
+
 	DLogFunc(@"self=%p", self);
 	return kCMIOHardwareNoError;
 }
@@ -380,6 +393,9 @@ HardwarePlugIn_DeviceProcessAVCCommand(CMIOHardwarePlugInRef self,
 				       CMIODeviceID deviceID,
 				       CMIODeviceAVCCommand *ioAVCCommand)
 {
+	UNUSED_PARAMETER(deviceID);
+	UNUSED_PARAMETER(ioAVCCommand);
+
 	DLogFunc(@"self=%p", self);
 	return kCMIOHardwareNoError;
 }
@@ -389,6 +405,9 @@ HardwarePlugIn_DeviceProcessRS422Command(CMIOHardwarePlugInRef self,
 					 CMIODeviceID deviceID,
 					 CMIODeviceRS422Command *ioRS422Command)
 {
+	UNUSED_PARAMETER(deviceID);
+	UNUSED_PARAMETER(ioRS422Command);
+
 	DLogFunc(@"self=%p", self);
 	return kCMIOHardwareNoError;
 }
@@ -396,6 +415,8 @@ HardwarePlugIn_DeviceProcessRS422Command(CMIOHardwarePlugInRef self,
 OSStatus HardwarePlugIn_StreamDeckPlay(CMIOHardwarePlugInRef self,
 				       CMIOStreamID streamID)
 {
+	UNUSED_PARAMETER(streamID);
+
 	DLogFunc(@"self=%p", self);
 	return kCMIOHardwareIllegalOperationError;
 }
@@ -403,6 +424,8 @@ OSStatus HardwarePlugIn_StreamDeckPlay(CMIOHardwarePlugInRef self,
 OSStatus HardwarePlugIn_StreamDeckStop(CMIOHardwarePlugInRef self,
 				       CMIOStreamID streamID)
 {
+	UNUSED_PARAMETER(streamID);
+
 	DLogFunc(@"self=%p", self);
 	return kCMIOHardwareIllegalOperationError;
 }
@@ -410,6 +433,9 @@ OSStatus HardwarePlugIn_StreamDeckStop(CMIOHardwarePlugInRef self,
 OSStatus HardwarePlugIn_StreamDeckJog(CMIOHardwarePlugInRef self,
 				      CMIOStreamID streamID, SInt32 speed)
 {
+	UNUSED_PARAMETER(streamID);
+	UNUSED_PARAMETER(speed);
+
 	DLogFunc(@"self=%p", self);
 	return kCMIOHardwareIllegalOperationError;
 }
@@ -419,6 +445,10 @@ OSStatus HardwarePlugIn_StreamDeckCueTo(CMIOHardwarePlugInRef self,
 					Float64 requestedTimecode,
 					Boolean playOnCue)
 {
+	UNUSED_PARAMETER(streamID);
+	UNUSED_PARAMETER(requestedTimecode);
+	UNUSED_PARAMETER(playOnCue);
+
 	DLogFunc(@"self=%p", self);
 	return kCMIOHardwareIllegalOperationError;
 }

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALPluginMain.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALPluginMain.mm
@@ -27,6 +27,8 @@
 extern "C" {
 void *PlugInMain(CFAllocatorRef allocator, CFUUIDRef requestedTypeUUID)
 {
+	UNUSED_PARAMETER(allocator);
+
 	DLogFunc(@"version=%@", PLUGIN_VERSION);
 	if (!CFEqual(requestedTypeUUID, kCMIOHardwarePlugInTypeID)) {
 		return 0;

--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -117,6 +117,8 @@ static void *data = &data;
 static void *virtualcam_output_create(obs_data_t *settings,
 				      obs_output_t *output)
 {
+	UNUSED_PARAMETER(settings);
+
 	outputRef = output;
 
 	blog(LOG_DEBUG, "output_create");
@@ -126,12 +128,15 @@ static void *virtualcam_output_create(obs_data_t *settings,
 
 static void virtualcam_output_destroy(void *data)
 {
+	UNUSED_PARAMETER(data);
 	blog(LOG_DEBUG, "output_destroy");
 	sMachServer = nil;
 }
 
 static bool virtualcam_output_start(void *data)
 {
+	UNUSED_PARAMETER(data);
+
 	bool hasDalPlugin = check_dal_plugin();
 
 	if (!hasDalPlugin) {
@@ -158,6 +163,9 @@ static bool virtualcam_output_start(void *data)
 
 static void virtualcam_output_stop(void *data, uint64_t ts)
 {
+	UNUSED_PARAMETER(data);
+	UNUSED_PARAMETER(ts);
+
 	blog(LOG_DEBUG, "output_stop");
 	obs_output_end_data_capture(outputRef);
 	[sMachServer stop];
@@ -165,6 +173,8 @@ static void virtualcam_output_stop(void *data, uint64_t ts)
 
 static void virtualcam_output_raw_video(void *data, struct video_data *frame)
 {
+	UNUSED_PARAMETER(data);
+
 	uint8_t *outData = frame->data[0];
 	if (frame->linesize[0] != (videoInfo.output_width * 2)) {
 		blog(LOG_ERROR,


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Marks function parameters as unused, removing compiler warnings

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
These warnings bothered me in Xcode as they made real problems less clear.
Also less warnings = better, I suppose.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Successfully compiled (Xcode 12.2, macOS 11.1), warnings are gone.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
