### PR TITLE
libobs: Add dsk scene type

### DIFF
--- a/libobs/obs-scene.h
+++ b/libobs/obs-scene.h
@@ -97,4 +97,6 @@ struct obs_scene {
 	pthread_mutex_t video_mutex;
 	pthread_mutex_t audio_mutex;
 	struct obs_scene_item *first_item;
+
+	bool is_dsk;
 };

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -542,6 +542,8 @@ obs_source_t *obs_source_duplicate(obs_source_t *source, const char *new_name,
 		if (!scene)
 			scene = obs_group_from_source(source);
 		if (!scene)
+			scene = obs_dsk_from_source(source);
+		if (!scene)
 			return NULL;
 
 		obs_scene_t *new_scene = obs_scene_duplicate(

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -828,6 +828,7 @@ static inline void obs_free_hotkeys(void)
 
 extern const struct obs_source_info scene_info;
 extern const struct obs_source_info group_info;
+extern const struct obs_source_info dsk_info;
 
 static const char *submix_name(void *unused)
 {
@@ -875,6 +876,7 @@ static bool obs_init(const char *locale, const char *module_config_path,
 	obs->locale = bstrdup(locale);
 	obs_register_source(&scene_info);
 	obs_register_source(&group_info);
+	obs_register_source(&dsk_info);
 	obs_register_source(&audio_line_info);
 	add_default_module_paths();
 	return true;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1499,6 +1499,8 @@ EXPORT void obs_transition_swap_end(obs_source_t *tr_dest,
  */
 EXPORT obs_scene_t *obs_scene_create(const char *name);
 
+EXPORT obs_scene_t *obs_dsk_create(const char *name);
+
 EXPORT obs_scene_t *obs_scene_create_private(const char *name);
 
 enum obs_scene_duplicate_type {
@@ -1701,6 +1703,12 @@ EXPORT obs_scene_t *obs_group_from_source(const obs_source_t *source);
 
 EXPORT void obs_sceneitem_defer_group_resize_begin(obs_sceneitem_t *item);
 EXPORT void obs_sceneitem_defer_group_resize_end(obs_sceneitem_t *item);
+
+/** Gets the dsk from its source, or NULL if not a dsk */
+EXPORT obs_scene_t *obs_dsk_from_source(const obs_source_t *source);
+
+EXPORT bool obs_source_is_dsk(const obs_source_t *source);
+EXPORT bool obs_scene_is_dsk(const obs_scene_t *scene);
 
 /* ------------------------------------------------------------------------- */
 /* Outputs */


### PR DESCRIPTION
### Description
This adds a downstream keyer scene type. This is part 1 of
implementing a dsk.

### Motivation and Context
Splits #2846 into more manageable separate PRs.

### How Has This Been Tested?
Tested with #2846

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
