### PR TITLE
UI: Move studio mode options to transitions dock

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1437,7 +1437,13 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 		programWidget->setLayout(programLayout);
 
-		ui->previewLayout->addWidget(programOptions);
+		programOptions->layout()->setContentsMargins(0, 10, 0, 0);
+		QVBoxLayout *trLayout = qobject_cast<QVBoxLayout *>(
+			ui->transitionsContainer->layout());
+
+		if (trLayout)
+			trLayout->insertWidget(2, programOptions);
+
 		ui->previewLayout->addWidget(programWidget);
 		ui->previewLayout->setAlignment(programOptions,
 						Qt::AlignCenter);


### PR DESCRIPTION
### Description
This moves the options in studio mode to the transitions
dock.

![Screenshot from 2020-12-27 01-06-45](https://user-images.githubusercontent.com/19962531/103165780-78830c00-47e1-11eb-84f4-3d0b8f699937.png)

### Motivation and Context
It has been requested to make the studio mode options a dock, so instead of creating another dock, move the options to the existing transitions dock.

### How Has This Been Tested?
Toggled studio mode on and off to make sure it was shown correctly.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
