### PR TITLE
UI: Do not reset rotation when fitting/stretching item

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6884,11 +6884,14 @@ static bool CenterAlignSelectedItems(obs_scene_t *scene, obs_sceneitem_t *item,
 	obs_video_info ovi;
 	obs_get_video_info(&ovi);
 
+	obs_transform_info oldItemInfo;
+	obs_sceneitem_get_info(item, &oldItemInfo);
+
 	obs_transform_info itemInfo;
 	vec2_set(&itemInfo.pos, 0.0f, 0.0f);
 	vec2_set(&itemInfo.scale, 1.0f, 1.0f);
 	itemInfo.alignment = OBS_ALIGN_LEFT | OBS_ALIGN_TOP;
-	itemInfo.rot = 0.0f;
+	itemInfo.rot = oldItemInfo.rot;
 
 	vec2_set(&itemInfo.bounds, float(ovi.base_width),
 		 float(ovi.base_height));


### PR DESCRIPTION
### Description
When fitting/stretching a scene item in a scene, the rotation
would be reset.

### Motivation and Context
I find it annoying when rotating a image 90 degrees and trying to fit it to screen, it would reset the rotation

### How Has This Been Tested?
Rotated a source, then fitted it to screen and made sure it didn't change the rotation.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
