### PR TITLE
UI: Support fractional scaling for Canvas/Base size

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1218,6 +1218,14 @@ bool OBSBasic::InitBasicConfigDefaults()
 	uint32_t cx = primaryScreen->size().width();
 	uint32_t cy = primaryScreen->size().height();
 
+#ifdef SUPPORTS_FRACTIONAL_SCALING
+	cx *= devicePixelRatioF();
+	cy *= devicePixelRatioF();
+#elif
+	cx *= devicePixelRatio();
+	cy *= devicePixelRatio();
+#endif
+
 	bool oldResolutionDefaults = config_get_bool(
 		App()->GlobalConfig(), "General", "Pre19Defaults");
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
UI: Support fractional scaling for Canvas/Base size

Without this change, new profiles created on systems using a fractional scaling factor (e.g., 125%, 150%, 175%) will get an incorrect (X, Y) pair for the new canvas size. For a display with 125% scaling, OBS would set (1536, 864) instead of (1920, 1080). With this change, it will set (1920, 1080).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I noticed that new profiles created on my system, which has a 125% scaling factor, were being given a canvas size of 1536x864.  This seems to be an uncaught issue with fractional scaling and high DPI, and we should fix those.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I compiled and ran the current OBS git master on Windows 10 64-bit (Build 19041.685).  I verified that new profiles on my system are now created with a base/canvas size of 1920x1080 instead of 1536x864 as before.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
