### PR TITLE
Fix color overlay in correction filter, add color picker with alpha

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -635,14 +635,16 @@ QWidget *OBSPropertiesView::AddButton(obs_property_t *prop)
 	return NewWidget(prop, button, SIGNAL(clicked()));
 }
 
-void OBSPropertiesView::AddColor(obs_property_t *prop, QFormLayout *layout,
-				 QLabel *&label)
+void OBSPropertiesView::AddColorInternal(obs_property_t *prop,
+					 QFormLayout *layout, QLabel *&label,
+					 bool supportAlpha)
 {
 	QPushButton *button = new QPushButton;
 	QLabel *colorLabel = new QLabel;
 	const char *name = obs_property_name(prop);
 	long long val = obs_data_get_int(settings, name);
 	QColor color = color_from_int(val);
+	QColor::NameFormat format;
 
 	if (!obs_property_enabled(prop)) {
 		button->setEnabled(false);
@@ -653,19 +655,21 @@ void OBSPropertiesView::AddColor(obs_property_t *prop, QFormLayout *layout,
 	button->setText(QTStr("Basic.PropertiesWindow.SelectColor"));
 	button->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 
-	color.setAlpha(255);
+	if (supportAlpha) {
+		format = QColor::HexArgb;
+	} else {
+		format = QColor::HexRgb;
+		color.setAlpha(255);
+	}
 
 	QPalette palette = QPalette(color);
 	colorLabel->setFrameStyle(QFrame::Sunken | QFrame::Panel);
-	// The picker doesn't have an alpha option, show only RGB
-	colorLabel->setText(color.name(QColor::HexRgb));
+	colorLabel->setText(color.name(format));
 	colorLabel->setPalette(palette);
 	colorLabel->setStyleSheet(
 		QString("background-color :%1; color: %2;")
-			.arg(palette.color(QPalette::Window)
-				     .name(QColor::HexRgb))
-			.arg(palette.color(QPalette::WindowText)
-				     .name(QColor::HexRgb)));
+			.arg(palette.color(QPalette::Window).name(format))
+			.arg(palette.color(QPalette::WindowText).name(format)));
 	colorLabel->setAutoFillBackground(true);
 	colorLabel->setAlignment(Qt::AlignCenter);
 	colorLabel->setToolTip(QT_UTF8(obs_property_long_description(prop)));
@@ -682,6 +686,18 @@ void OBSPropertiesView::AddColor(obs_property_t *prop, QFormLayout *layout,
 
 	label = new QLabel(QT_UTF8(obs_property_description(prop)));
 	layout->addRow(label, subLayout);
+}
+
+void OBSPropertiesView::AddColor(obs_property_t *prop, QFormLayout *layout,
+				 QLabel *&label)
+{
+	AddColorInternal(prop, layout, label, false);
+}
+
+void OBSPropertiesView::AddColorAlpha(obs_property_t *prop, QFormLayout *layout,
+				      QLabel *&label)
+{
+	AddColorInternal(prop, layout, label, true);
 }
 
 void MakeQFont(obs_data_t *font_obj, QFont &font, bool limit = false)
@@ -1419,6 +1435,9 @@ void OBSPropertiesView::AddProperty(obs_property_t *property,
 		break;
 	case OBS_PROPERTY_GROUP:
 		AddGroup(property, layout);
+		break;
+	case OBS_PROPERTY_COLOR_ALPHA:
+		AddColorAlpha(property, layout, label);
 	}
 
 	if (widget && !obs_property_enabled(property))
@@ -1698,13 +1717,18 @@ void WidgetInfo::ListChanged(const char *setting)
 	}
 }
 
-bool WidgetInfo::ColorChanged(const char *setting)
+bool WidgetInfo::ColorChangedInternal(const char *setting, bool supportAlpha)
 {
 	const char *desc = obs_property_description(property);
 	long long val = obs_data_get_int(view->settings, setting);
 	QColor color = color_from_int(val);
+	QColor::NameFormat format;
 
 	QColorDialog::ColorDialogOptions options;
+
+	if (supportAlpha) {
+		options |= QColorDialog::ShowAlphaChannel;
+	}
 
 	/* The native dialog on OSX has all kinds of problems, like closing
 	 * other open QDialogs on exit, and
@@ -1715,24 +1739,38 @@ bool WidgetInfo::ColorChanged(const char *setting)
 #endif
 
 	color = QColorDialog::getColor(color, view, QT_UTF8(desc), options);
-	color.setAlpha(255);
-
 	if (!color.isValid())
 		return false;
 
+	if (supportAlpha) {
+		format = QColor::HexArgb;
+	} else {
+		color.setAlpha(255);
+		format = QColor::HexRgb;
+	}
+
 	QLabel *label = static_cast<QLabel *>(widget);
-	label->setText(color.name(QColor::HexRgb));
+	label->setText(color.name(format));
 	QPalette palette = QPalette(color);
 	label->setPalette(palette);
-	label->setStyleSheet(QString("background-color :%1; color: %2;")
-				     .arg(palette.color(QPalette::Window)
-						  .name(QColor::HexRgb))
-				     .arg(palette.color(QPalette::WindowText)
-						  .name(QColor::HexRgb)));
+	label->setStyleSheet(
+		QString("background-color :%1; color: %2;")
+			.arg(palette.color(QPalette::Window).name(format))
+			.arg(palette.color(QPalette::WindowText).name(format)));
 
 	obs_data_set_int(view->settings, setting, color_to_int(color));
 
 	return true;
+}
+
+bool WidgetInfo::ColorChanged(const char *setting)
+{
+	return ColorChangedInternal(setting, false);
+}
+
+bool WidgetInfo::ColorAlphaChanged(const char *setting)
+{
+	return ColorChangedInternal(setting, true);
 }
 
 bool WidgetInfo::FontChanged(const char *setting)
@@ -1888,6 +1926,10 @@ void WidgetInfo::ControlChanged()
 		break;
 	case OBS_PROPERTY_GROUP:
 		GroupChanged(setting);
+		break;
+	case OBS_PROPERTY_COLOR_ALPHA:
+		if (!ColorAlphaChanged(setting))
+			return;
 		break;
 	}
 

--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -30,7 +30,9 @@ private:
 	void TextChanged(const char *setting);
 	bool PathChanged(const char *setting);
 	void ListChanged(const char *setting);
+	bool ColorChangedInternal(const char *setting, bool supportAlpha);
 	bool ColorChanged(const char *setting);
+	bool ColorAlphaChanged(const char *setting);
 	bool FontChanged(const char *setting);
 	void GroupChanged(const char *setting);
 	void EditableListChanged();
@@ -101,8 +103,12 @@ private:
 	void AddEditableList(obs_property_t *prop, QFormLayout *layout,
 			     QLabel *&label);
 	QWidget *AddButton(obs_property_t *prop);
+	void AddColorInternal(obs_property_t *prop, QFormLayout *layout,
+			      QLabel *&label, bool supportAlpha);
 	void AddColor(obs_property_t *prop, QFormLayout *layout,
 		      QLabel *&label);
+	void AddColorAlpha(obs_property_t *prop, QFormLayout *layout,
+			   QLabel *&label);
 	void AddFont(obs_property_t *prop, QFormLayout *layout, QLabel *&label);
 	void AddFrameRate(obs_property_t *prop, bool &warning,
 			  QFormLayout *layout, QLabel *&label);

--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -212,7 +212,17 @@ Property Object Functions
 
 .. function:: obs_property_t *obs_properties_add_color(obs_properties_t *props, const char *name, const char *description)
 
-   Adds a color property.
+   Adds a color property without alpha.
+
+   :param    name:        Setting identifier string
+   :param    description: Localized name shown to user
+   :return:               The property
+
+---------------------
+
+.. function:: obs_property_t *obs_properties_add_color_alpha(obs_properties_t *props, const char *name, const char *description)
+
+   Adds a color property with alpha.
 
    :param    name:        Setting identifier string
    :param    description: Localized name shown to user

--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -438,6 +438,8 @@ static inline size_t get_property_size(enum obs_property_type type)
 		return sizeof(struct frame_rate_data);
 	case OBS_PROPERTY_GROUP:
 		return sizeof(struct group_data);
+	case OBS_PROPERTY_COLOR_ALPHA:
+		return 0;
 	}
 
 	return 0;
@@ -650,6 +652,15 @@ obs_property_t *obs_properties_add_color(obs_properties_t *props,
 	if (!props || has_prop(props, name))
 		return NULL;
 	return new_prop(props, name, desc, OBS_PROPERTY_COLOR);
+}
+
+obs_property_t *obs_properties_add_color_alpha(obs_properties_t *props,
+					       const char *name,
+					       const char *desc)
+{
+	if (!props || has_prop(props, name))
+		return NULL;
+	return new_prop(props, name, desc, OBS_PROPERTY_COLOR_ALPHA);
 }
 
 obs_property_t *obs_properties_add_button(obs_properties_t *props,

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -56,6 +56,7 @@ enum obs_property_type {
 	OBS_PROPERTY_EDITABLE_LIST,
 	OBS_PROPERTY_FRAME_RATE,
 	OBS_PROPERTY_GROUP,
+	OBS_PROPERTY_COLOR_ALPHA,
 };
 
 enum obs_combo_format {
@@ -223,6 +224,10 @@ EXPORT obs_property_t *obs_properties_add_list(obs_properties_t *props,
 EXPORT obs_property_t *obs_properties_add_color(obs_properties_t *props,
 						const char *name,
 						const char *description);
+
+EXPORT obs_property_t *obs_properties_add_color_alpha(obs_properties_t *props,
+						      const char *name,
+						      const char *description);
 
 EXPORT obs_property_t *
 obs_properties_add_button(obs_properties_t *props, const char *name,

--- a/plugins/obs-filters/color-correction-filter.c
+++ b/plugins/obs-filters/color-correction-filter.c
@@ -380,7 +380,7 @@ static obs_properties_t *color_correction_filter_properties(void *data)
 	obs_properties_add_int_slider(props, SETTING_OPACITY, TEXT_OPACITY, 0,
 				      100, 1);
 
-	obs_properties_add_color(props, SETTING_COLOR, TEXT_COLOR);
+	obs_properties_add_color_alpha(props, SETTING_COLOR, TEXT_COLOR);
 
 	UNUSED_PARAMETER(data);
 	return props;
@@ -401,7 +401,7 @@ static void color_correction_filter_defaults(obs_data_t *settings)
 	obs_data_set_default_double(settings, SETTING_SATURATION, 0.0);
 	obs_data_set_default_double(settings, SETTING_HUESHIFT, 0.0);
 	obs_data_set_default_double(settings, SETTING_OPACITY, 100.0);
-	obs_data_set_default_int(settings, SETTING_COLOR, 0xFFFFFF);
+	obs_data_set_default_int(settings, SETTING_COLOR, 0x00FFFFFF);
 }
 
 /*


### PR DESCRIPTION
### Description
Restore alpha support to color picker as a separate property type. This is one of several fixes for the color overlay feature in the color correction filter, which had some questionable math in it.

This is technically a breaking change since I'm tweaking the math, but I don't think many noticed the total regression in the first place, so I doubt this feature is widely used.

### Motivation and Context
Doing a pass to redo the filters in linear space, and noticed this feature must have regressed when alpha was removed from the main color picker.

### How Has This Been Tested?
Color overlay works again. Verified chroma key did not regress.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.