### PR TITLE
image-source: Fix slideshow transition not working when randomized

### DIFF
--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -699,9 +699,9 @@ static void ss_video_tick(void *data, float seconds)
 	if (!ss->transition || !ss->slide_time)
 		return;
 
-	if (ss->restart_on_activate && !ss->randomize && ss->use_cut) {
+	if (ss->restart_on_activate && ss->use_cut) {
 		ss->elapsed = 0.0f;
-		ss->cur_item = 0;
+		ss->cur_item = ss->randomize ? random_file(ss) : 0;
 		do_transition(ss, false);
 		ss->restart_on_activate = false;
 		ss->use_cut = false;


### PR DESCRIPTION
### Description
This fixes a bug where the transition wouldn't work when playback
is randomized and restart on activate is used.

### Motivation and Context
Fixes #3993

### How Has This Been Tested?
Created slideshow with randomize playback and restart on activation enabled. Switch to another scene and back and made sure the transitions were working as expected.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
