### PR TITLE
UI: Fix crash in Source Toolbar

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -179,6 +179,10 @@ void AudioCaptureToolbar::Init()
 
 	obs_module_t *mod =
 		get_os_module("win-wasapi", "mac-capture", "linux-pulseaudio");
+	if (!mod) {
+		return;
+	}
+
 	const char *device_str =
 		get_os_text(mod, "Device", "CoreAudio.Device", "Device");
 	ui->deviceLabel->setText(device_str);


### PR DESCRIPTION
I guess I might as well push this out here, at least as a draft, for a bit of review and suggestions for improvement.

### Description

This adds a check for 'null' in 'mod' and simply 'return' if it's there, to prevent a segmentation fault.

### Motivation and Context

This prevents a segmentation fault when, for example, an ALSA source is selected, and adds ALSA devices to the Source Toolbar (this could most likely be done better).

This also fixes the following issue: https://github.com/obsproject/obs-studio/issues/3485

### How Has This Been Tested?

Tested building and running OBS Studio with all sound backends disabled, as well as with both, or only one of ALSA and PulseAudio enabled on Gentoo Linux.

I don't actually ever use PulseAudio, so more testing with that would be nice.  I can only say that I saw more sources available with it installed.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
