### PR TITLE
libobs: Set lock state when duplicating scene item

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1300,6 +1300,7 @@ static inline void duplicate_item_data(struct obs_scene_item *dst,
 	}
 
 	obs_sceneitem_set_crop(dst, &src->crop);
+	obs_sceneitem_set_locked(dst, src->locked);
 
 	if (defer_texture_update) {
 		os_atomic_set_bool(&dst->update_transform, true);


### PR DESCRIPTION
### Description
Fixes bug where the lock state wouldn't be copied when duplicating
a scene.

### Motivation and Context
Bug mentioned on Discord.

### How Has This Been Tested?
Duplicated a scene to make sure scene items were still locked or unlocked.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation
