### PR TITLE
UI: Allow multiple instances for --start args

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2603,15 +2603,19 @@ int main(int argc, char *argv[])
 
 		} else if (arg_is(argv[i], "--startstreaming", nullptr)) {
 			opt_start_streaming = true;
+			multi = true;
 
 		} else if (arg_is(argv[i], "--startrecording", nullptr)) {
 			opt_start_recording = true;
+			multi = true;
 
 		} else if (arg_is(argv[i], "--startreplaybuffer", nullptr)) {
 			opt_start_replaybuffer = true;
+			multi = true;
 
 		} else if (arg_is(argv[i], "--startvirtualcam", nullptr)) {
 			opt_start_virtualcam = true;
+			multi = true;
 
 		} else if (arg_is(argv[i], "--collection", nullptr)) {
 			if (++i < argc)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This PR implies --multi for any of the --start* arguments.

### Motivation and Context
I recently updated to version 26.1.0 which includes the following change that broke my automation scripts without any prior warning.
> On Linux, the program will now detect other instances that are currently running and warn the user about running more than one copies at a time [clockley]

Additionally, one would expect a command line argument such as `--startrecording` to start recording without any user interaction whatsoever, which is not the case at the moment.
Even worse is that one might not realise this is the case until they end up having another instance running for a different use and their script stops functioning when they're not paying attention.

### How Has This Been Tested?
Running `./bin/obs` on one terminal and `./bin/obs --startrecording` on another.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
