### PR TITLE
obs-outputs: Use system-wide FTL-SDK if present

### DIFF
--- a/plugins/obs-outputs/CMakeLists.txt
+++ b/plugins/obs-outputs/CMakeLists.txt
@@ -3,6 +3,8 @@ project(obs-outputs)
 set(WITH_RTMPS AUTO CACHE STRING "Enable RTMPS support with mbedTLS")
 set_property(CACHE WITH_RTMPS PROPERTY STRINGS AUTO ON OFF)
 
+find_package(PkgConfig)
+
 option(STATIC_MBEDTLS "Statically link mbedTLS into binary" OFF)
 
 if (WITH_RTMPS STREQUAL "AUTO")
@@ -23,7 +25,21 @@ else()
 	add_definitions(-DNO_CRYPTO)
 endif()
 
-if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ftl-sdk/CMakeLists.txt")
+set(COMPILE_FTL FALSE)
+
+if (PKG_CONFIG_FOUND)
+	pkg_check_modules(FTL libftl)
+endif()
+
+if (FTL_FOUND)
+	find_package(Libcurl REQUIRED)
+	message(STATUS "Found ftl-sdk (system): ftl outputs enabled")
+
+	set(ftl_SOURCES ftl-stream.c)
+
+	include_directories(${LIBCURL_INCLUDE_DIRS} ${FTL_INCLUDE_DIRS})
+	set(COMPILE_FTL TRUE)
+elseif (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ftl-sdk/CMakeLists.txt")
 	find_package(Libcurl REQUIRED)
 	message(STATUS "Found ftl-sdk: ftl outputs enabled")
 
@@ -74,8 +90,6 @@ if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ftl-sdk/CMakeLists.txt")
 	include_directories(ftl-sdk/libftl)
 
 	set(COMPILE_FTL TRUE)
-else()
-	set(COMPILE_FTL FALSE)
 endif()
 
 configure_file(
@@ -169,6 +183,12 @@ add_library(obs-outputs MODULE
 	${obs-outputs_HEADERS}
 	${obs-outputs_librtmp_SOURCES}
 	${obs-outputs_librtmp_HEADERS})
+
+if(FTL_FOUND)
+	target_link_libraries(obs-outputs ${FTL_LIBRARIES})
+	target_include_directories(obs-outputs PUBLIC ${FTL_INCLUDE_DIRS})
+endif()
+
 target_link_libraries(obs-outputs
 	libobs
 	${MBEDTLS_LIBRARIES}


### PR DESCRIPTION
Related #3834
Fixes #3881 
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
To support FTL, it needed to be present in-tree to be compiled. This PR adds support for system-wide installations of libftl. 

It uses pkg-config to find the system-wide installation. 
If pkg-config can't provide `libftl` we just fall back to using the in-tree submodule. 
If that's also not available it won't be included at all like before.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The OBS Studio package on Arch Linux does not come with FTL support, as both FTL-SDK and OBS Studio lacked the capabilities to use system libraries. (See [[1]] [[2]])
The former was solved by a [fork][3] as development stopped (The company behind it, Mixer, is not operating anymore). This PR should fix the latter problem upstream, instead of having to maintain patchsets in Arch Linux.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I tested this on my Arch Linux machine. I installed [ftl-sdk][4] from the AUR and then built OBS in portable-mode. After starting the binary I tested the output by streaming to my instance of the [Lightspeed streaming server][5].

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.

Not really sure about the first and last checkboxes, as I didn't change anything in code. I guess they are not applicable.


[1]: https://bugs.archlinux.org/task/55441
[2]: https://bugs.archlinux.org/task/63403
[3]: https://github.com/Scrumplex/ftl-sdk
[4]: https://aur.archlinux.org/packages/ftl-sdk/
[5]: https://github.com/GRVYDEV/Project-Lightspeed