### PR TITLE
UI: Remove renderer/adapter code

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -151,8 +151,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>803</width>
-              <height>1026</height>
+              <width>806</width>
+              <height>1320</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -1295,8 +1295,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>820</width>
-              <height>677</height>
+              <width>813</width>
+              <height>739</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -3804,8 +3804,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>555</width>
-              <height>469</height>
+              <width>767</width>
+              <height>582</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_50">
@@ -4660,8 +4660,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>602</width>
-              <height>781</height>
+              <width>806</width>
+              <height>908</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -4740,46 +4740,6 @@
                     <number>2</number>
                    </property>
                    <item row="0" column="0">
-                    <widget class="QLabel" name="rendererLabel">
-                     <property name="text">
-                      <string>Basic.Settings.Video.Renderer</string>
-                     </property>
-                     <property name="buddy">
-                      <cstring>renderer</cstring>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="0" column="1">
-                    <widget class="QComboBox" name="renderer">
-                     <property name="currentText">
-                      <string notr="true"/>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="adapterLabel">
-                     <property name="text">
-                      <string>Basic.Settings.Video.Adapter</string>
-                     </property>
-                     <property name="alignment">
-                      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                     </property>
-                     <property name="buddy">
-                      <cstring>adapter</cstring>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QComboBox" name="adapter">
-                     <property name="enabled">
-                      <bool>false</bool>
-                     </property>
-                     <property name="currentText">
-                      <string notr="true"/>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="0">
                     <widget class="QLabel" name="label_30">
                      <property name="minimumSize">
                       <size>
@@ -4798,7 +4758,7 @@
                      </property>
                     </widget>
                    </item>
-                   <item row="2" column="1">
+                   <item row="0" column="1">
                     <widget class="QComboBox" name="colorFormat">
                      <item>
                       <property name="text">
@@ -4822,37 +4782,17 @@
                      </item>
                     </widget>
                    </item>
-                   <item row="4" column="1">
-                    <layout class="QHBoxLayout" name="horizontalLayout_18">
-                     <property name="leftMargin">
-                      <number>0</number>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="label_33">
+                     <property name="text">
+                      <string>Basic.Settings.Advanced.Video.ColorSpace</string>
                      </property>
-                     <property name="topMargin">
-                      <number>0</number>
+                     <property name="buddy">
+                      <cstring>colorSpace</cstring>
                      </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                     <item>
-                      <widget class="QCheckBox" name="disableOSXVSync">
-                       <property name="text">
-                        <string>DisableOSXVSync</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QCheckBox" name="resetOSXVSync">
-                       <property name="text">
-                        <string>ResetOSXVSyncOnExit</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
+                    </widget>
                    </item>
-                   <item row="3" column="1">
+                   <item row="1" column="1">
                     <layout class="QHBoxLayout" name="horizontalLayout_20">
                      <property name="leftMargin">
                       <number>0</number>
@@ -4906,17 +4846,7 @@
                      </item>
                     </layout>
                    </item>
-                   <item row="3" column="0">
-                    <widget class="QLabel" name="label_33">
-                     <property name="text">
-                      <string>Basic.Settings.Advanced.Video.ColorSpace</string>
-                     </property>
-                     <property name="buddy">
-                      <cstring>colorSpace</cstring>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="4" column="0">
+                   <item row="2" column="0">
                     <spacer name="horizontalSpacer_12">
                      <property name="orientation">
                       <enum>Qt::Horizontal</enum>
@@ -4928,6 +4858,36 @@
                       </size>
                      </property>
                     </spacer>
+                   </item>
+                   <item row="2" column="1">
+                    <layout class="QHBoxLayout" name="horizontalLayout_18">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QCheckBox" name="disableOSXVSync">
+                       <property name="text">
+                        <string>DisableOSXVSync</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QCheckBox" name="resetOSXVSync">
+                       <property name="text">
+                        <string>ResetOSXVSyncOnExit</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
                    </item>
                   </layout>
                  </widget>
@@ -5639,8 +5599,6 @@
   <tabstop>fpsDenominator</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>processPriority</tabstop>
-  <tabstop>renderer</tabstop>
-  <tabstop>adapter</tabstop>
   <tabstop>colorFormat</tabstop>
   <tabstop>colorSpace</tabstop>
   <tabstop>colorRange</tabstop>

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -405,13 +405,6 @@ bool OBSApp::InitGlobalConfigDefaults()
 	config_set_default_bool(globalConfig, "General", "EnableAutoUpdates",
 				true);
 
-#if _WIN32
-	config_set_default_string(globalConfig, "Video", "Renderer",
-				  "Direct3D 11");
-#else
-	config_set_default_string(globalConfig, "Video", "Renderer", "OpenGL");
-#endif
-
 	config_set_default_bool(globalConfig, "BasicWindow", "PreviewEnabled",
 				true);
 	config_set_default_bool(globalConfig, "BasicWindow",
@@ -1308,10 +1301,14 @@ void OBSApp::AppInit()
 
 const char *OBSApp::GetRenderModule() const
 {
-	const char *renderer =
-		config_get_string(globalConfig, "Video", "Renderer");
+#ifdef _WIN32
+	if (opt_allow_opengl)
+		return DL_OPENGL;
 
-	return (astrcmpi(renderer, "Direct3D 11") == 0) ? DL_D3D11 : DL_OPENGL;
+	return DL_D3D11;
+#else
+	return DL_OPENGL;
+#endif
 }
 
 static bool StartupOBS(const char *locale, profiler_name_store_t *store)
@@ -2663,7 +2660,7 @@ int main(int argc, char *argv[])
 		} else if (arg_is(argv[i], "--studio-mode", nullptr)) {
 			opt_studio_mode = true;
 
-		} else if (arg_is(argv[i], "--allow-opengl", nullptr)) {
+		} else if (arg_is(argv[i], "--enable-opengl", nullptr)) {
 			opt_allow_opengl = true;
 
 		} else if (arg_is(argv[i], "--disable-updater", nullptr)) {

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4000,17 +4000,6 @@ int OBSBasic::ResetVideo()
 					  "already active");
 			return ret;
 		}
-
-		/* Try OpenGL if DirectX fails on windows */
-		if (astrcmpi(ovi.graphics_module, DL_OPENGL) != 0) {
-			blog(LOG_WARNING,
-			     "Failed to initialize obs video (%d) "
-			     "with graphics_module='%s', retrying "
-			     "with graphics_module='%s'",
-			     ret, ovi.graphics_module, DL_OPENGL);
-			ovi.graphics_module = DL_OPENGL;
-			ret = AttemptToResetVideo(&ovi);
-		}
 	} else if (ret == OBS_VIDEO_SUCCESS) {
 		ResizePreview(ovi.base_width, ovi.base_height);
 		if (program)

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -526,8 +526,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->fpsInteger,           SCROLL_CHANGED, VIDEO_CHANGED);
 	HookWidget(ui->fpsNumerator,         SCROLL_CHANGED, VIDEO_CHANGED);
 	HookWidget(ui->fpsDenominator,       SCROLL_CHANGED, VIDEO_CHANGED);
-	HookWidget(ui->renderer,             COMBO_CHANGED,  ADV_RESTART);
-	HookWidget(ui->adapter,              COMBO_CHANGED,  ADV_RESTART);
 	HookWidget(ui->colorFormat,          COMBO_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->colorSpace,           COMBO_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->colorRange,           COMBO_CHANGED,  ADV_CHANGED);
@@ -620,10 +618,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 		ui->processPriority->addItem(QTStr(pri.name), pri.val);
 
 #else
-	delete ui->rendererLabel;
-	delete ui->renderer;
-	delete ui->adapterLabel;
-	delete ui->adapter;
 	delete ui->processPriorityLabel;
 	delete ui->processPriority;
 	delete ui->advancedGeneralGroupBox;
@@ -636,10 +630,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 #if defined(__APPLE__) || HAVE_PULSEAUDIO
 	delete ui->disableAudioDucking;
 #endif
-	ui->rendererLabel = nullptr;
-	ui->renderer = nullptr;
-	ui->adapterLabel = nullptr;
-	ui->adapter = nullptr;
 	ui->processPriorityLabel = nullptr;
 	ui->processPriority = nullptr;
 	ui->advancedGeneralGroupBox = nullptr;
@@ -1363,32 +1353,6 @@ void OBSBasicSettings::LoadGeneralSettings()
 		ui->language->setEnabled(false);
 
 	loading = false;
-}
-
-void OBSBasicSettings::LoadRendererList()
-{
-#ifdef _WIN32
-	const char *renderer =
-		config_get_string(GetGlobalConfig(), "Video", "Renderer");
-
-	ui->renderer->addItem(QT_UTF8("Direct3D 11"));
-	if (opt_allow_opengl || strcmp(renderer, "OpenGL") == 0)
-		ui->renderer->addItem(QT_UTF8("OpenGL"));
-
-	int idx = ui->renderer->findText(QT_UTF8(renderer));
-	if (idx == -1)
-		idx = 0;
-
-	// the video adapter selection is not currently implemented, hide for now
-	// to avoid user confusion. was previously protected by
-	// if (strcmp(renderer, "OpenGL") == 0)
-	delete ui->adapter;
-	delete ui->adapterLabel;
-	ui->adapter = nullptr;
-	ui->adapterLabel = nullptr;
-
-	ui->renderer->setCurrentIndex(idx);
-#endif
 }
 
 static string ResString(uint32_t cx, uint32_t cy)
@@ -2494,8 +2458,6 @@ void OBSBasicSettings::LoadAdvancedSettings()
 
 	loading = true;
 
-	LoadRendererList();
-
 #if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
 	if (!SetComboByValue(ui->monitoringDevice, monDevId))
 		SetInvalidValue(ui->monitoringDevice, monDevName, monDevId);
@@ -3169,10 +3131,6 @@ void OBSBasicSettings::SaveAdvancedSettings()
 		main->Config(), "Audio", "MonitoringDeviceId");
 
 #ifdef _WIN32
-	if (WidgetChanged(ui->renderer))
-		config_set_string(App()->GlobalConfig(), "Video", "Renderer",
-				  QT_TO_UTF8(ui->renderer->currentText()));
-
 	std::string priority =
 		QT_TO_UTF8(ui->processPriority->currentData().toString());
 	config_set_string(App()->GlobalConfig(), "General", "ProcessPriority",

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -285,7 +285,6 @@ private:
 	void LoadAudioSources();
 
 	/* video */
-	void LoadRendererList();
 	void ResetDownscales(uint32_t cx, uint32_t cy,
 			     bool ignoreAllSignals = false);
 	void LoadDownscaleFilters();


### PR DESCRIPTION
### Description
As the renderer option is only used on Windows, and OpenGL barely
works there, remove the widget. This also removes the adapter
widget as that isn't used anywhere.

Also added --enable-opengl command line option to enable OpenGL
on Windows and removed the --allow-opengl option.

### Motivation and Context
Removes unneeded code.

### How Has This Been Tested?
Launched OBS to make sure the correct renderer was used.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
