### PR TITLE
rtmp-services: Add Glimesh service

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -629,6 +629,8 @@ void AutoConfigStreamPage::UpdateKeyLink()
 		streamKeyLink = "https://www.app.youstreamer.com/stream/";
 	} else if (serviceName == "Trovo") {
 		streamKeyLink = "https://studio.trovo.live/mychannel/stream";
+	} else if (serviceName == "Glimesh") {
+		streamKeyLink = "https://glimesh.tv/users/settings/stream";
 	}
 
 	if (QString(streamKeyLink).isNull()) {

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -288,6 +288,8 @@ void OBSBasicSettings::UpdateKeyLink()
 		streamKeyLink = "https://app.youstreamer.com/stream/";
 	} else if (serviceName == "Trovo") {
 		streamKeyLink = "https://studio.trovo.live/mychannel/stream";
+	} else if (serviceName == "Glimesh") {
+		streamKeyLink = "https://glimesh.tv/users/settings/stream";
 	}
 
 	if (QString(streamKeyLink).isNull()) {

--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 164,
+	"version": 165,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 164
+			"version": 165
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1878,6 +1878,55 @@
                 "max audio bitrate": 192,
                 "x264opts": "tune=zerolatency scenecut=0"
             }
+        },
+        {
+            "name": "Glimesh",
+            "servers": [
+                {
+                    "name": "North America - Chicago, United States",
+                    "url": "ingest.kord.live.glimesh.tv"
+                },
+                {
+                    "name": "North America - New York, United States",
+                    "url": "ingest.kjfk.live.glimesh.tv"
+                },
+                {
+                    "name": "North America - San Francisco, United States",
+                    "url": "ingest.ksfo.live.glimesh.tv"
+                },
+                {
+                    "name": "North America - Toronto, Canada",
+                    "url": "ingest.cyyz.live.glimesh.tv"
+                },
+                {
+                    "name": "Europe - Amsterdam, Netherlands",
+                    "url": "ingest.eham.live.glimesh.tv"
+                },
+                {
+                    "name": "Europe - Frankfurt, Germany",
+                    "url": "ingest.eddf.live.glimesh.tv"
+                },
+                {
+                    "name": "Europe - London, United Kingdom",
+                    "url": "ingest.egll.live.glimesh.tv"
+                },
+                {
+                    "name": "Asia - Bangalore, India",
+                    "url": "ingest.vobl.live.glimesh.tv"
+                },
+                {
+                    "name": "Asia - Singapore",
+                    "url": "ingest.wsss.live.glimesh.tv"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "output": "ftl_output",
+                "max audio bitrate": 160,
+                "max video bitrate": 6000,
+                "bframes": 0,
+                "x264opts": "scenecut=0"
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
Add Glimesh to the list of supported stream services, using its FTL ingestion endpoints. Also includes the Get Stream Key button shown to users when the Glimesh service is selected.

### Motivation and Context
Glimesh is a new live streaming platform launching soon, due to the ongoing deprecation of the FTL protocol from OBS we want to ensure we can get Glimesh support landed without hassle. We've solidified all of our ingest server regions and have confirmed they all have connectivity. This services addition should serve us through our launch.

### How Has This Been Tested?
Tested changes on Mac OSX and Windows.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

I also noticed some service updates include a change to the `plugins/rtmp-services/data/package.json` and some do not, if that is required for this pull request please let me know and I'll be happy to update.
