### PR TITLE
CI: Fix CEF version for both Linux & macOS

### DIFF
--- a/CI/before-script-linux.sh
+++ b/CI/before-script-linux.sh
@@ -3,4 +3,4 @@
 set -ex
 ccache -s || echo "CCache is not available."
 mkdir build && cd build
-cmake -DBUILD_BROWSER=ON -DCEF_ROOT_DIR="../cef_binary_${CEF_BUILD_VERSION}_linux64" ..
+cmake -DBUILD_BROWSER=ON -DCEF_ROOT_DIR="../cef_binary_${LINUX_CEF_BUILD_VERSION}_linux64" ..

--- a/CI/install-dependencies-linux.sh
+++ b/CI/install-dependencies-linux.sh
@@ -48,5 +48,5 @@ sudo apt-get install -y \
         v4l2loopback-dkms
 
 # build cef
-wget --quiet --retry-connrefused --waitretry=1 https://cdn-fastly.obsproject.com/downloads/cef_binary_${CEF_BUILD_VERSION}_linux64.tar.bz2
-tar -xjf ./cef_binary_${CEF_BUILD_VERSION}_linux64.tar.bz2
+wget --quiet --retry-connrefused --waitretry=1 https://cdn-fastly.obsproject.com/downloads/cef_binary_${LINUX_CEF_BUILD_VERSION}_linux64.tar.bz2
+tar -xjf ./cef_binary_${LINUX_CEF_BUILD_VERSION}_linux64.tar.bz2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,8 @@
 
 variables:
   CMAKE_PREFIX_PATH: /usr/local/opt/qt5/lib/cmake
-  CEF_BUILD_VERSION: 3770
+  MACOS_CEF_BUILD_VERSION: 4183
+  LINUX_CEF_BUILD_VERSION: 3770
   CEF_VERSION: 75.1.16+g16a67c4+chromium-75.0.3770.100
   TWITCH-CLIENTID: $(twitch_clientid)
   TWITCH-HASH: $(twitch_hash)


### PR DESCRIPTION
### Description

I've manually gone through and fixed stray mentions of `CEF_BUILD_VERSION` and replaced them with `LINUX_CEF_BUILD_VERSION` and `MACOS_CEF_BUILD_VERSION` respectively. This should, theoretically, fix a number of build conditionals.

### Motivation and Context

Seems @DDRBoxman missed a few.

Parent commits: 30569777378c713e153845ae80bd8022c4d02666 and 410c60e799f76aa413305e3cce10347d8f0a00f5

### How Has This Been Tested?

I'm marking this as "Seeking Testers" to check that the CI build succeeds, and then will ask @dori4n to test.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
