### PR TITLE
rtmp-services: Use official Twitch endpoint to fetch ingests

### DIFF
--- a/plugins/rtmp-services/twitch.c
+++ b/plugins/rtmp-services/twitch.c
@@ -169,7 +169,7 @@ void twitch_ingests_refresh(int seconds)
 
 		twitch_update_info = update_info_create_single(
 			"[twitch ingest update] ", get_module_name(),
-			"https://ingest.twitch.tv/api/v2/ingests",
+			"https://ingest.twitch.tv/ingests",
 			twitch_ingest_update, NULL);
 	}
 


### PR DESCRIPTION
### Description

Updates the Twitch inject endpoint for the "Auto" server option to use the officially documented API.

### Motivation and Context

Fixes #3943

### How Has This Been Tested?

Verified the code path was hit and returned the correct result, and that the stored list was updated.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
