### PR TITLE
Load plugins from path specified by OBS_PLUGINS_PATH

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -136,6 +136,16 @@ template<typename T> static void SetOBSRef(QListWidgetItem *item, T &&val)
 
 static void AddExtraModulePaths()
 {
+	char *plugins_path = getenv("OBS_PLUGINS_PATH");
+	char *plugins_data_path = getenv("OBS_PLUGINS_DATA_PATH");
+	if (plugins_path && plugins_data_path) {
+		string data_path_with_module_suffix;
+		data_path_with_module_suffix += plugins_data_path;
+		data_path_with_module_suffix += "/%module%";
+		obs_add_module_path(plugins_path,
+				    data_path_with_module_suffix.c_str());
+	}
+
 	char base_module_dir[512];
 #if defined(_WIN32) || defined(__APPLE__)
 	int ret = GetProgramDataPath(base_module_dir, sizeof(base_module_dir),


### PR DESCRIPTION
### Description
Allow to load obs plugins from custom directory, specified by
OBS_PLUGINS_PATH and OBS_PLUGINS_DATA_PATH environment variables.

Example usage:

`OBS_PLUGINS_PATH=/opt/lib/obs-plugins OBS_PLUGINS_DATA_PATH=/opt/share/obs/obs-plugins obs`

### Motivation and Context
It's required to make it possible to package obs plugins using guix and nix package managers. Because in those package managers every package has it's own directory with the result of the build, it's not possible to relocate plugin's binaries to obs directory.

It will help to solve: https://github.com/NixOS/nixpkgs/issues/77627

### How Has This Been Tested?
Tested on Guix GNU/Linux, kernel 5.10.3, x1 yoga 4th laptop
- Built a patched obs package for Guix GNU/Linux
- Built wlrobs and specrtralizer plugins
- Set enviroment variables, checked with strace that plugins are loaded and work as expected
Those changes should not affect other obs subsystem, only plugin loading process.
- Unset environment variables, checked that everything still works, but plugins not loaded.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
