### PR TITLE
UI: Add virtual camera to system tray

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6298,6 +6298,7 @@ void OBSBasic::OnVirtualCamStart()
 		return;
 
 	vcamButton->setText(QTStr("Basic.Main.StopVirtualCam"));
+	sysTrayVirtualCam->setText(QTStr("Basic.Main.StopVirtualCam"));
 	vcamButton->setChecked(true);
 
 	if (api)
@@ -6314,6 +6315,7 @@ void OBSBasic::OnVirtualCamStop(int)
 		return;
 
 	vcamButton->setText(QTStr("Basic.Main.StartVirtualCam"));
+	sysTrayVirtualCam->setText(QTStr("Basic.Main.StartVirtualCam"));
 	vcamButton->setChecked(false);
 
 	if (api)
@@ -7605,6 +7607,8 @@ void OBSBasic::SystemTrayInit()
 				    trayIcon.data());
 	sysTrayReplayBuffer = new QAction(QTStr("Basic.Main.StartReplayBuffer"),
 					  trayIcon.data());
+	sysTrayVirtualCam = new QAction(QTStr("Basic.Main.StartVirtualCam"),
+					trayIcon.data());
 	exit = new QAction(QTStr("Exit"), trayIcon.data());
 
 	trayMenu = new QMenu;
@@ -7620,12 +7624,15 @@ void OBSBasic::SystemTrayInit()
 	trayMenu->addAction(sysTrayStream);
 	trayMenu->addAction(sysTrayRecord);
 	trayMenu->addAction(sysTrayReplayBuffer);
+	trayMenu->addAction(sysTrayVirtualCam);
 	trayMenu->addAction(exit);
 	trayIcon->setContextMenu(trayMenu);
 	trayIcon->show();
 
 	if (outputHandler && !outputHandler->replayBuffer)
 		sysTrayReplayBuffer->setEnabled(false);
+
+	sysTrayVirtualCam->setEnabled(vcamEnabled);
 
 	connect(trayIcon.data(),
 		SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this,
@@ -7637,6 +7644,8 @@ void OBSBasic::SystemTrayInit()
 		SLOT(on_recordButton_clicked()));
 	connect(sysTrayReplayBuffer.data(), &QAction::triggered, this,
 		&OBSBasic::ReplayBufferClicked);
+	connect(sysTrayVirtualCam.data(), &QAction::triggered, this,
+		&OBSBasic::VCamButtonClicked);
 	connect(exit, SIGNAL(triggered()), this, SLOT(close()));
 }
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -265,6 +265,7 @@ private:
 	QPointer<QAction> sysTrayStream;
 	QPointer<QAction> sysTrayRecord;
 	QPointer<QAction> sysTrayReplayBuffer;
+	QPointer<QAction> sysTrayVirtualCam;
 	QPointer<QAction> showHide;
 	QPointer<QAction> exit;
 	QPointer<QMenu> trayMenu;


### PR DESCRIPTION
### Description
Adds ability to start and stop the virtual camera from the
system tray.

### Motivation and Context
https://ideas.obsproject.com/posts/1297/add-start-virtual-camera-option-to-tray-menu

### How Has This Been Tested?
Tested by clicking the system tray action to make sure the virtual camera started and stopped properly.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
