### PR TITLE
libobs-winrt: Disable WGC border on insider SDK

### DIFF
--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -336,11 +336,15 @@ try {
 		activation_factory.as<IGraphicsCaptureItemInterop>();
 	winrt::Windows::Graphics::Capture::GraphicsCaptureItem item = {nullptr};
 	try {
-		interop_factory->CreateForWindow(
+		hr = interop_factory->CreateForWindow(
 			window,
 			winrt::guid_of<ABI::Windows::Graphics::Capture::
 					       IGraphicsCaptureItem>(),
 			reinterpret_cast<void **>(winrt::put_abi(item)));
+		if (FAILED(hr)) {
+			blog(LOG_ERROR, "CreateForWindow (0x%08X)", hr);
+			return nullptr;
+		}
 	} catch (winrt::hresult_error &err) {
 		blog(LOG_ERROR, "CreateForWindow (0x%08X): %ls", err.to_abi(),
 		     err.message().c_str());

--- a/libobs-winrt/winrt-dispatch.cpp
+++ b/libobs-winrt/winrt-dispatch.cpp
@@ -1,6 +1,6 @@
 extern "C" EXPORT void winrt_initialize()
 {
-	winrt::init_apartment(winrt::apartment_type::single_threaded);
+	winrt::init_apartment(winrt::apartment_type::multi_threaded);
 }
 
 extern "C" EXPORT void winrt_uninitialize()


### PR DESCRIPTION
### Description
Functionality is coming in a future Windows update to disable the yellow
border when using WGC. Add code now to opt in. Will require SDK upgrade
later for OBS build.

winrt::apartment_type::multi_threaded is necessary to dodge assert for
calling get() on RequestAccessAsync result. Don't think I will ever
fully understand COM apartments.

Also fix a race crash discovered during testing.

### Motivation and Context
Everyone hates the yellow border.

### How Has This Been Tested?
Tried capturing an application that used to show a yellow border, and it doesn't anymore.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.