### PR TITLE
UI: Use FileNameWithoutSpace for screenshot output

### DIFF
--- a/UI/window-basic-main-screenshot.cpp
+++ b/UI/window-basic-main-screenshot.cpp
@@ -127,13 +127,15 @@ void ScreenshotObj::Save()
 			? config_get_string(config, "SimpleOutput", "FilePath")
 			: adv_path;
 
+	bool noSpace =
+		config_get_bool(config, "SimpleOutput", "FileNameWithoutSpace");
 	const char *filenameFormat =
 		config_get_string(config, "Output", "FilenameFormatting");
 	bool overwriteIfExists =
 		config_get_bool(config, "Output", "OverwriteIfExists");
 
 	path = GetOutputFilename(
-		rec_path, "png", false, overwriteIfExists,
+		rec_path, "png", noSpace, overwriteIfExists,
 		GetFormatString(filenameFormat, "Screenshot", nullptr).c_str());
 
 	th = std::thread([this] { MuxAndFinish(); });


### PR DESCRIPTION
### Description
This uses the existing config bool SimpleOutput/FileNameWithoutSpace when saving screenshots.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Screenshot filenames contained spaces even when the checkbox for "Generate File Name without Space" was checked. This was surprising.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built and tested by saving a screenshot and checking the filename.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
