### PR TITLE
Convert input and transition sources to use SRGB views properly

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -589,11 +589,13 @@ void OBSBasicFilters::DrawPreview(void *data, uint32_t cx, uint32_t cy)
 
 	gs_viewport_push();
 	gs_projection_push();
+	const bool previous = gs_set_linear_srgb(true);
+
 	gs_ortho(0.0f, float(sourceCX), 0.0f, float(sourceCY), -100.0f, 100.0f);
 	gs_set_viewport(x, y, newCX, newCY);
-
 	obs_source_video_render(window->source);
 
+	gs_set_linear_srgb(previous);
 	gs_projection_pop();
 	gs_viewport_pop();
 }

--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -148,10 +148,13 @@ void OBSBasicInteraction::DrawPreview(void *data, uint32_t cx, uint32_t cy)
 
 	gs_viewport_push();
 	gs_projection_push();
+	const bool previous = gs_set_linear_srgb(true);
+
 	gs_ortho(0.0f, float(sourceCX), 0.0f, float(sourceCY), -100.0f, 100.0f);
 	gs_set_viewport(x, y, newCX, newCY);
 	obs_source_video_render(window->source);
 
+	gs_set_linear_srgb(previous);
 	gs_projection_pop();
 	gs_viewport_pop();
 }

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -392,11 +392,13 @@ void OBSBasicProperties::DrawPreview(void *data, uint32_t cx, uint32_t cy)
 
 	gs_viewport_push();
 	gs_projection_push();
+	const bool previous = gs_set_linear_srgb(true);
+
 	gs_ortho(0.0f, float(sourceCX), 0.0f, float(sourceCY), -100.0f, 100.0f);
 	gs_set_viewport(x, y, newCX, newCY);
-
 	obs_source_video_render(window->source);
 
+	gs_set_linear_srgb(previous);
 	gs_projection_pop();
 	gs_viewport_pop();
 }

--- a/docs/sphinx/graphics.rst
+++ b/docs/sphinx/graphics.rst
@@ -77,6 +77,7 @@ Then the uniforms are set through the following functions:
 - :c:func:`gs_effect_set_vec3()`
 - :c:func:`gs_effect_set_vec4()`
 - :c:func:`gs_effect_set_texture()`
+- :c:func:`gs_effect_set_texture_srgb()`
 
 There are two "universal" effect parameters that may be expected of
 effects:  **ViewProj**, and **image**.  The **ViewProj** parameter

--- a/docs/sphinx/reference-libobs-graphics-effects.rst
+++ b/docs/sphinx/reference-libobs-graphics-effects.rst
@@ -337,6 +337,15 @@ HLSL format.
 
 ---------------------
 
+.. function:: void gs_effect_set_texture_srgb(gs_eparam_t *param, gs_texture_t *val)
+
+   Sets a texture parameter using SRGB view if available.
+
+   :param param: Effect parameter
+   :param val:   Texture
+
+---------------------
+
 .. function:: void gs_effect_set_val(gs_eparam_t *param, const void *val, size_t size)
 
    Sets a parameter with data manually.

--- a/docs/sphinx/reference-libobs-graphics-graphics.rst
+++ b/docs/sphinx/reference-libobs-graphics-graphics.rst
@@ -42,6 +42,9 @@ Graphics Enumerations
    - GS_DXT1        - Compressed DXT1
    - GS_DXT3        - Compressed DXT3
    - GS_DXT5        - Compressed DXT5
+   - GS_RGBA_UNORM  - RGBA, 8 bits per channel, no SRGB aliasing
+   - GS_BGRX_UNORM  - BGRX, 8 bits per channel, no SRGB aliasing
+   - GS_BGRA_UNORM  - BGRA, 8 bits per channel, no SRGB aliasing
 
 .. type:: enum gs_zstencil_format
 

--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -33,24 +33,37 @@ void gs_index_buffer::Rebuild(ID3D11Device *dev)
 
 void gs_texture_2d::RebuildSharedTextureFallback()
 {
+	static const gs_color_format format = GS_BGRA;
+	static const DXGI_FORMAT dxgi_format_resource =
+		ConvertGSTextureFormatResource(format);
+	static const DXGI_FORMAT dxgi_format_view =
+		ConvertGSTextureFormatView(format);
+	static const DXGI_FORMAT dxgi_format_view_linear =
+		ConvertGSTextureFormatViewLinear(format);
+
 	td = {};
 	td.Width = 2;
 	td.Height = 2;
 	td.MipLevels = 1;
-	td.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	td.Format = dxgi_format_resource;
 	td.ArraySize = 1;
 	td.SampleDesc.Count = 1;
 	td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
 
 	width = td.Width;
 	height = td.Height;
-	dxgiFormat = td.Format;
+	dxgiFormatResource = dxgi_format_resource;
+	dxgiFormatView = dxgi_format_view;
+	dxgiFormatViewLinear = dxgi_format_view_linear;
 	levels = 1;
 
-	resourceDesc = {};
-	resourceDesc.Format = td.Format;
-	resourceDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-	resourceDesc.Texture2D.MipLevels = 1;
+	viewDesc = {};
+	viewDesc.Format = dxgi_format_view;
+	viewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+	viewDesc.Texture2D.MipLevels = 1;
+
+	viewDescLinear = viewDesc;
+	viewDescLinear.Format = dxgi_format_view_linear;
 
 	isShared = false;
 }
@@ -77,9 +90,18 @@ void gs_texture_2d::Rebuild(ID3D11Device *dev)
 			throw HRError("Failed to create 2D texture", hr);
 	}
 
-	hr = dev->CreateShaderResourceView(texture, &resourceDesc, &shaderRes);
+	hr = dev->CreateShaderResourceView(texture, &viewDesc, &shaderRes);
 	if (FAILED(hr))
-		throw HRError("Failed to create resource view", hr);
+		throw HRError("Failed to create SRV", hr);
+
+	if (viewDesc.Format == viewDescLinear.Format) {
+		shaderResLinear = shaderRes;
+	} else {
+		hr = dev->CreateShaderResourceView(texture, &viewDescLinear,
+						   &shaderResLinear);
+		if (FAILED(hr))
+			throw HRError("Failed to create linear SRV", hr);
+	}
 
 	if (isRenderTarget)
 		InitRenderTargets();
@@ -110,9 +132,18 @@ void gs_texture_2d::RebuildNV12_Y(ID3D11Device *dev)
 	if (FAILED(hr))
 		throw HRError("Failed to create 2D texture", hr);
 
-	hr = dev->CreateShaderResourceView(texture, &resourceDesc, &shaderRes);
+	hr = dev->CreateShaderResourceView(texture, &viewDesc, &shaderRes);
 	if (FAILED(hr))
-		throw HRError("Failed to create resource view", hr);
+		throw HRError("Failed to create Y SRV", hr);
+
+	if (viewDesc.Format == viewDescLinear.Format) {
+		shaderResLinear = shaderRes;
+	} else {
+		hr = dev->CreateShaderResourceView(texture, &viewDescLinear,
+						   &shaderResLinear);
+		if (FAILED(hr))
+			throw HRError("Failed to create linear Y SRV", hr);
+	}
 
 	if (isRenderTarget)
 		InitRenderTargets();
@@ -136,9 +167,18 @@ void gs_texture_2d::RebuildNV12_UV(ID3D11Device *dev)
 
 	texture = tex_y->texture;
 
-	hr = dev->CreateShaderResourceView(texture, &resourceDesc, &shaderRes);
+	hr = dev->CreateShaderResourceView(texture, &viewDesc, &shaderRes);
 	if (FAILED(hr))
-		throw HRError("Failed to create resource view", hr);
+		throw HRError("Failed to create UV SRV", hr);
+
+	if (viewDesc.Format == viewDescLinear.Format) {
+		shaderResLinear = shaderRes;
+	} else {
+		hr = dev->CreateShaderResourceView(texture, &viewDescLinear,
+						   &shaderResLinear);
+		if (FAILED(hr))
+			throw HRError("Failed to create linear UV SRV", hr);
+	}
 
 	if (isRenderTarget)
 		InitRenderTargets();
@@ -253,25 +293,38 @@ void gs_timer_range::Rebuild(ID3D11Device *dev)
 
 void gs_texture_3d::RebuildSharedTextureFallback()
 {
+	static const gs_color_format format = GS_BGRA;
+	static const DXGI_FORMAT dxgi_format_resource =
+		ConvertGSTextureFormatResource(format);
+	static const DXGI_FORMAT dxgi_format_view =
+		ConvertGSTextureFormatView(format);
+	static const DXGI_FORMAT dxgi_format_view_linear =
+		ConvertGSTextureFormatViewLinear(format);
+
 	td = {};
 	td.Width = 2;
 	td.Height = 2;
 	td.Depth = 2;
 	td.MipLevels = 1;
-	td.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	td.Format = dxgi_format_resource;
 	td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
 
 	width = td.Width;
 	height = td.Height;
 	depth = td.Depth;
-	dxgiFormat = td.Format;
+	dxgiFormatResource = dxgi_format_resource;
+	dxgiFormatView = dxgi_format_view;
+	dxgiFormatViewLinear = dxgi_format_view_linear;
 	levels = 1;
 
-	resourceDesc = {};
-	resourceDesc.Format = td.Format;
-	resourceDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE3D;
-	resourceDesc.Texture3D.MostDetailedMip = 0;
-	resourceDesc.Texture3D.MipLevels = 1;
+	viewDesc = {};
+	viewDesc.Format = dxgi_format_view;
+	viewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE3D;
+	viewDesc.Texture3D.MostDetailedMip = 0;
+	viewDesc.Texture3D.MipLevels = 1;
+
+	viewDescLinear = viewDesc;
+	viewDescLinear.Format = dxgi_format_view_linear;
 
 	isShared = false;
 }
@@ -298,9 +351,18 @@ void gs_texture_3d::Rebuild(ID3D11Device *dev)
 			throw HRError("Failed to create 3D texture", hr);
 	}
 
-	hr = dev->CreateShaderResourceView(texture, &resourceDesc, &shaderRes);
+	hr = dev->CreateShaderResourceView(texture, &viewDesc, &shaderRes);
 	if (FAILED(hr))
-		throw HRError("Failed to create resource view", hr);
+		throw HRError("Failed to create 3D SRV", hr);
+
+	if (viewDesc.Format == viewDescLinear.Format) {
+		shaderResLinear = shaderRes;
+	} else {
+		hr = dev->CreateShaderResourceView(texture, &viewDescLinear,
+						   &shaderResLinear);
+		if (FAILED(hr))
+			throw HRError("Failed to create linear 3D SRV", hr);
+	}
 
 	acquired = false;
 

--- a/libobs-d3d11/d3d11-shader.cpp
+++ b/libobs-d3d11/d3d11-shader.cpp
@@ -262,10 +262,15 @@ inline void gs_shader::UpdateParam(vector<uint8_t> &constData,
 			param.changed = false;
 		}
 
-	} else if (param.curValue.size() == sizeof(gs_texture_t *)) {
-		gs_texture_t *tex;
-		memcpy(&tex, param.curValue.data(), sizeof(gs_texture_t *));
-		device_load_texture(device, tex, param.textureID);
+	} else if (param.curValue.size() == sizeof(struct gs_shader_texture)) {
+		struct gs_shader_texture shader_tex;
+		memcpy(&shader_tex, param.curValue.data(), sizeof(shader_tex));
+		if (shader_tex.srgb)
+			device_load_texture_srgb(device, shader_tex.tex,
+						 param.textureID);
+		else
+			device_load_texture(device, shader_tex.tex,
+					    param.textureID);
 
 		if (param.nextSampler) {
 			ID3D11SamplerState *state = param.nextSampler->state;

--- a/libobs-d3d11/d3d11-stagesurf.cpp
+++ b/libobs-d3d11/d3d11-stagesurf.cpp
@@ -23,7 +23,7 @@ gs_stage_surface::gs_stage_surface(gs_device_t *device, uint32_t width,
 	  width(width),
 	  height(height),
 	  format(colorFormat),
-	  dxgiFormat(ConvertGSTextureFormat(colorFormat))
+	  dxgiFormat(ConvertGSTextureFormatView(colorFormat))
 {
 	HRESULT hr;
 

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -78,7 +78,7 @@ static inline void make_swap_desc(DXGI_SWAP_CHAIN_DESC &desc,
 {
 	memset(&desc, 0, sizeof(desc));
 	desc.BufferCount = data->num_backbuffers;
-	desc.BufferDesc.Format = ConvertGSTextureFormat(data->format);
+	desc.BufferDesc.Format = ConvertGSTextureFormatView(data->format);
 	desc.BufferDesc.Width = data->cx;
 	desc.BufferDesc.Height = data->cy;
 	desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
@@ -99,10 +99,24 @@ void gs_swap_chain::InitTarget(uint32_t cx, uint32_t cy)
 	if (FAILED(hr))
 		throw HRError("Failed to get swap buffer texture", hr);
 
+	D3D11_RENDER_TARGET_VIEW_DESC rtv;
+	rtv.Format = target.dxgiFormatView;
+	rtv.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+	rtv.Texture2D.MipSlice = 0;
 	hr = device->device->CreateRenderTargetView(
-		target.texture, NULL, target.renderTarget[0].Assign());
+		target.texture, &rtv, target.renderTarget[0].Assign());
 	if (FAILED(hr))
-		throw HRError("Failed to create swap render target view", hr);
+		throw HRError("Failed to create swap RTV", hr);
+	if (target.dxgiFormatView == target.dxgiFormatViewLinear) {
+		target.renderTargetLinear[0] = target.renderTarget[0];
+	} else {
+		rtv.Format = target.dxgiFormatViewLinear;
+		hr = device->device->CreateRenderTargetView(
+			target.texture, &rtv,
+			target.renderTargetLinear[0].Assign());
+		if (FAILED(hr))
+			throw HRError("Failed to create linear swap RTV", hr);
+	}
 }
 
 void gs_swap_chain::InitZStencilBuffer(uint32_t cx, uint32_t cy)
@@ -125,6 +139,7 @@ void gs_swap_chain::Resize(uint32_t cx, uint32_t cy)
 
 	target.texture.Clear();
 	target.renderTarget[0].Clear();
+	target.renderTargetLinear[0].Clear();
 	zs.texture.Clear();
 	zs.view.Clear();
 
@@ -139,7 +154,7 @@ void gs_swap_chain::Resize(uint32_t cx, uint32_t cy)
 			cy = clientRect.bottom;
 	}
 
-	hr = swap->ResizeBuffers(numBuffers, cx, cy, target.dxgiFormat, 0);
+	hr = swap->ResizeBuffers(numBuffers, cx, cy, DXGI_FORMAT_UNKNOWN, 0);
 	if (FAILED(hr))
 		throw HRError("Failed to resize swap buffers", hr);
 
@@ -152,7 +167,11 @@ void gs_swap_chain::Init()
 	target.device = device;
 	target.isRenderTarget = true;
 	target.format = initData.format;
-	target.dxgiFormat = ConvertGSTextureFormat(initData.format);
+	target.dxgiFormatResource =
+		ConvertGSTextureFormatResource(initData.format);
+	target.dxgiFormatView = ConvertGSTextureFormatView(initData.format);
+	target.dxgiFormatViewLinear =
+		ConvertGSTextureFormatViewLinear(initData.format);
 	InitTarget(initData.cx, initData.cy);
 
 	zs.device = device;
@@ -310,6 +329,7 @@ try {
 	UpdateBlendState();
 	UpdateRasterState();
 	UpdateZStencilState();
+	FlushOutputViews();
 	context->Draw(4, 0);
 
 	device_set_viewport(this, 0, 0, NV12_CX / 2, NV12_CY / 2);
@@ -318,6 +338,7 @@ try {
 	UpdateBlendState();
 	UpdateRasterState();
 	UpdateZStencilState();
+	FlushOutputViews();
 	context->Draw(4, 0);
 
 	device_load_pixelshader(this, nullptr);
@@ -727,6 +748,30 @@ void gs_device::UpdateViewProjMatrix()
 				      &curViewProjMatrix);
 }
 
+void gs_device::FlushOutputViews()
+{
+	if (curFramebufferInvalidate) {
+		ID3D11RenderTargetView *rtv = nullptr;
+		if (curRenderTarget) {
+			const int i = curRenderSide;
+			rtv = curFramebufferSrgb
+				      ? curRenderTarget->renderTargetLinear[i]
+						.Get()
+				      : curRenderTarget->renderTarget[i].Get();
+			if (!rtv) {
+				blog(LOG_ERROR,
+				     "device_draw (D3D11): texture is not a render target");
+				return;
+			}
+		}
+		ID3D11DepthStencilView *dsv = nullptr;
+		if (curZStencilBuffer)
+			dsv = curZStencilBuffer->view;
+		context->OMSetRenderTargets(1, &rtv, dsv);
+		curFramebufferInvalidate = false;
+	}
+}
+
 gs_device::gs_device(uint32_t adapterIdx)
 	: curToplogy(D3D11_PRIMITIVE_TOPOLOGY_UNDEFINED)
 {
@@ -1045,18 +1090,9 @@ void device_resize(gs_device_t *device, uint32_t cx, uint32_t cy)
 
 	try {
 		ID3D11RenderTargetView *renderView = NULL;
-		ID3D11DepthStencilView *depthView = NULL;
-		int i = device->curRenderSide;
-
-		device->context->OMSetRenderTargets(1, &renderView, depthView);
+		device->context->OMSetRenderTargets(1, &renderView, NULL);
 		device->curSwapChain->Resize(cx, cy);
-
-		if (device->curRenderTarget)
-			renderView = device->curRenderTarget->renderTarget[i];
-		if (device->curZStencilBuffer)
-			depthView = device->curZStencilBuffer->view;
-		device->context->OMSetRenderTargets(1, &renderView, depthView);
-
+		device->curFramebufferInvalidate = true;
 	} catch (const HRError &error) {
 		blog(LOG_ERROR, "device_resize (D3D11): %s (%08lX)", error.str,
 		     error.hr);
@@ -1419,18 +1455,27 @@ void device_load_indexbuffer(gs_device_t *device, gs_indexbuffer_t *indexbuffer)
 	device->context->IASetIndexBuffer(buffer, format, 0);
 }
 
-void device_load_texture(gs_device_t *device, gs_texture_t *tex, int unit)
+static void device_load_texture_internal(gs_device_t *device, gs_texture_t *tex,
+					 int unit,
+					 ID3D11ShaderResourceView *view)
 {
-	ID3D11ShaderResourceView *view = NULL;
-
 	if (device->curTextures[unit] == tex)
 		return;
 
-	if (tex)
-		view = tex->shaderRes;
-
 	device->curTextures[unit] = tex;
 	device->context->PSSetShaderResources(unit, 1, &view);
+}
+
+void device_load_texture(gs_device_t *device, gs_texture_t *tex, int unit)
+{
+	ID3D11ShaderResourceView *view = tex ? tex->shaderRes : NULL;
+	return device_load_texture_internal(device, tex, unit, view);
+}
+
+void device_load_texture_srgb(gs_device_t *device, gs_texture_t *tex, int unit)
+{
+	ID3D11ShaderResourceView *view = tex ? tex->shaderResLinear : NULL;
+	return device_load_texture_internal(device, tex, unit, view);
 }
 
 void device_load_samplerstate(gs_device_t *device,
@@ -1574,26 +1619,19 @@ void device_set_render_target(gs_device_t *device, gs_texture_t *tex,
 		return;
 
 	if (tex && tex->type != GS_TEXTURE_2D) {
-		blog(LOG_ERROR, "device_set_render_target (D3D11): "
-				"texture is not a 2D texture");
+		blog(LOG_ERROR,
+		     "device_set_render_target (D3D11): texture is not a 2D texture");
 		return;
 	}
 
-	gs_texture_2d *tex2d = static_cast<gs_texture_2d *>(tex);
-	if (tex2d && !tex2d->renderTarget[0]) {
-		blog(LOG_ERROR, "device_set_render_target (D3D11): "
-				"texture is not a render target");
-		return;
+	gs_texture_2d *const tex2d = static_cast<gs_texture_2d *>(tex);
+	if (device->curRenderTarget != tex2d || device->curRenderSide != 0 ||
+	    device->curZStencilBuffer != zstencil) {
+		device->curRenderTarget = tex2d;
+		device->curRenderSide = 0;
+		device->curZStencilBuffer = zstencil;
+		device->curFramebufferInvalidate = true;
 	}
-
-	ID3D11RenderTargetView *rt = tex2d ? tex2d->renderTarget[0].Get()
-					   : nullptr;
-
-	device->curRenderTarget = tex2d;
-	device->curRenderSide = 0;
-	device->curZStencilBuffer = zstencil;
-	device->context->OMSetRenderTargets(
-		1, &rt, zstencil ? zstencil->view : nullptr);
 }
 
 void device_set_cube_render_target(gs_device_t *device, gs_texture_t *tex,
@@ -1619,19 +1657,27 @@ void device_set_cube_render_target(gs_device_t *device, gs_texture_t *tex,
 		return;
 	}
 
-	gs_texture_2d *tex2d = static_cast<gs_texture_2d *>(tex);
-	if (!tex2d->renderTarget[side]) {
-		blog(LOG_ERROR, "device_set_cube_render_target (D3D11): "
-				"texture is not a render target");
-		return;
+	gs_texture_2d *const tex2d = static_cast<gs_texture_2d *>(tex);
+	if (device->curRenderTarget != tex2d || device->curRenderSide != side ||
+	    device->curZStencilBuffer != zstencil) {
+		device->curRenderTarget = tex2d;
+		device->curRenderSide = side;
+		device->curZStencilBuffer = zstencil;
+		device->curFramebufferInvalidate = true;
 	}
+}
 
-	ID3D11RenderTargetView *rt = tex2d->renderTarget[0];
+void device_enable_framebuffer_srgb(gs_device_t *device, bool enable)
+{
+	if (device->curFramebufferSrgb != enable) {
+		device->curFramebufferSrgb = enable;
+		device->curFramebufferInvalidate = true;
+	}
+}
 
-	device->curRenderTarget = tex2d;
-	device->curRenderSide = side;
-	device->curZStencilBuffer = zstencil;
-	device->context->OMSetRenderTargets(1, &rt, zstencil->view);
+bool device_framebuffer_srgb_enabled(gs_device_t *device)
+{
+	return device->curFramebufferSrgb;
 }
 
 inline void gs_device::CopyTex(ID3D11Texture2D *dst, uint32_t dst_x,
@@ -1779,6 +1825,8 @@ void device_draw(gs_device_t *device, enum gs_draw_mode draw_mode,
 
 		if (!device->curSwapChain && !device->curRenderTarget)
 			throw "No render target or swap chain to render to";
+
+		device->FlushOutputViews();
 
 		gs_effect_t *effect = gs_get_effect();
 		if (effect)
@@ -2589,9 +2637,10 @@ device_texture_create_gdi(gs_device_t *device, uint32_t width, uint32_t height)
 {
 	gs_texture *texture = nullptr;
 	try {
-		texture = new gs_texture_2d(device, width, height, GS_BGRA, 1,
-					    nullptr, GS_RENDER_TARGET,
-					    GS_TEXTURE_2D, true);
+		texture = new gs_texture_2d(device, width, height,
+					    GS_BGRA_UNORM, 1, nullptr,
+					    GS_RENDER_TARGET, GS_TEXTURE_2D,
+					    true);
 	} catch (const HRError &error) {
 		blog(LOG_ERROR, "device_texture_create_gdi (D3D11): %s (%08lX)",
 		     error.str, error.hr);

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -59,7 +59,7 @@ static inline uint32_t GetWinVer()
 	return (ver.major << 8) | ver.minor;
 }
 
-static inline DXGI_FORMAT ConvertGSTextureFormat(gs_color_format format)
+static inline DXGI_FORMAT ConvertGSTextureFormatResource(gs_color_format format)
 {
 	switch (format) {
 	case GS_UNKNOWN:
@@ -69,11 +69,11 @@ static inline DXGI_FORMAT ConvertGSTextureFormat(gs_color_format format)
 	case GS_R8:
 		return DXGI_FORMAT_R8_UNORM;
 	case GS_RGBA:
-		return DXGI_FORMAT_R8G8B8A8_UNORM;
+		return DXGI_FORMAT_R8G8B8A8_TYPELESS;
 	case GS_BGRX:
-		return DXGI_FORMAT_B8G8R8X8_UNORM;
+		return DXGI_FORMAT_B8G8R8X8_TYPELESS;
 	case GS_BGRA:
-		return DXGI_FORMAT_B8G8R8A8_UNORM;
+		return DXGI_FORMAT_B8G8R8A8_TYPELESS;
 	case GS_R10G10B10A2:
 		return DXGI_FORMAT_R10G10B10A2_UNORM;
 	case GS_RGBA16:
@@ -100,9 +100,44 @@ static inline DXGI_FORMAT ConvertGSTextureFormat(gs_color_format format)
 		return DXGI_FORMAT_BC3_UNORM;
 	case GS_R8G8:
 		return DXGI_FORMAT_R8G8_UNORM;
+	case GS_RGBA_UNORM:
+		return DXGI_FORMAT_R8G8B8A8_UNORM;
+	case GS_BGRX_UNORM:
+		return DXGI_FORMAT_B8G8R8X8_UNORM;
+	case GS_BGRA_UNORM:
+		return DXGI_FORMAT_B8G8R8A8_UNORM;
 	}
 
 	return DXGI_FORMAT_UNKNOWN;
+}
+
+static inline DXGI_FORMAT ConvertGSTextureFormatView(gs_color_format format)
+{
+	switch (format) {
+	case GS_RGBA:
+		return DXGI_FORMAT_R8G8B8A8_UNORM;
+	case GS_BGRX:
+		return DXGI_FORMAT_B8G8R8X8_UNORM;
+	case GS_BGRA:
+		return DXGI_FORMAT_B8G8R8A8_UNORM;
+	default:
+		return ConvertGSTextureFormatResource(format);
+	}
+}
+
+static inline DXGI_FORMAT
+ConvertGSTextureFormatViewLinear(gs_color_format format)
+{
+	switch (format) {
+	case GS_RGBA:
+		return DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+	case GS_BGRX:
+		return DXGI_FORMAT_B8G8R8X8_UNORM_SRGB;
+	case GS_BGRA:
+		return DXGI_FORMAT_B8G8R8A8_UNORM_SRGB;
+	default:
+		return ConvertGSTextureFormatResource(format);
+	}
 }
 
 static inline gs_color_format ConvertDXGITextureFormat(DXGI_FORMAT format)
@@ -115,12 +150,9 @@ static inline gs_color_format ConvertDXGITextureFormat(DXGI_FORMAT format)
 	case DXGI_FORMAT_R8G8_UNORM:
 		return GS_R8G8;
 	case DXGI_FORMAT_R8G8B8A8_TYPELESS:
-	case DXGI_FORMAT_R8G8B8A8_UNORM:
 		return GS_RGBA;
-	case DXGI_FORMAT_B8G8R8X8_UNORM:
 	case DXGI_FORMAT_B8G8R8X8_TYPELESS:
 		return GS_BGRX;
-	case DXGI_FORMAT_B8G8R8A8_UNORM:
 	case DXGI_FORMAT_B8G8R8A8_TYPELESS:
 		return GS_BGRA;
 	case DXGI_FORMAT_R10G10B10A2_UNORM:
@@ -147,6 +179,12 @@ static inline gs_color_format ConvertDXGITextureFormat(DXGI_FORMAT format)
 		return GS_DXT3;
 	case DXGI_FORMAT_BC3_UNORM:
 		return GS_DXT5;
+	case DXGI_FORMAT_R8G8B8A8_UNORM:
+		return GS_RGBA_UNORM;
+	case DXGI_FORMAT_B8G8R8X8_UNORM:
+		return GS_BGRX_UNORM;
+	case DXGI_FORMAT_B8G8R8A8_UNORM:
+		return GS_BGRA_UNORM;
 	}
 
 	return GS_UNKNOWN;
@@ -410,7 +448,9 @@ struct gs_texture : gs_obj {
 	gs_color_format format;
 
 	ComPtr<ID3D11ShaderResourceView> shaderRes;
-	D3D11_SHADER_RESOURCE_VIEW_DESC resourceDesc = {};
+	ComPtr<ID3D11ShaderResourceView> shaderResLinear;
+	D3D11_SHADER_RESOURCE_VIEW_DESC viewDesc{};
+	D3D11_SHADER_RESOURCE_VIEW_DESC viewDescLinear{};
 
 	void Rebuild(ID3D11Device *dev);
 
@@ -440,11 +480,14 @@ struct gs_texture : gs_obj {
 struct gs_texture_2d : gs_texture {
 	ComPtr<ID3D11Texture2D> texture;
 	ComPtr<ID3D11RenderTargetView> renderTarget[6];
+	ComPtr<ID3D11RenderTargetView> renderTargetLinear[6];
 	ComPtr<IDXGISurface1> gdiSurface;
 
 	uint32_t width = 0, height = 0;
 	uint32_t flags = 0;
-	DXGI_FORMAT dxgiFormat = DXGI_FORMAT_UNKNOWN;
+	DXGI_FORMAT dxgiFormatResource = DXGI_FORMAT_UNKNOWN;
+	DXGI_FORMAT dxgiFormatView = DXGI_FORMAT_UNKNOWN;
+	DXGI_FORMAT dxgiFormatViewLinear = DXGI_FORMAT_UNKNOWN;
 	bool isRenderTarget = false;
 	bool isGDICompatible = false;
 	bool isDynamic = false;
@@ -476,10 +519,13 @@ struct gs_texture_2d : gs_texture {
 	inline void Release()
 	{
 		texture.Release();
-		for (auto &rt : renderTarget)
+		for (ComPtr<ID3D11RenderTargetView> &rt : renderTarget)
+			rt.Release();
+		for (ComPtr<ID3D11RenderTargetView> &rt : renderTargetLinear)
 			rt.Release();
 		gdiSurface.Release();
 		shaderRes.Release();
+		shaderResLinear.Release();
 	}
 
 	inline gs_texture_2d() : gs_texture(GS_TEXTURE_2D, 0, GS_UNKNOWN) {}
@@ -501,7 +547,9 @@ struct gs_texture_3d : gs_texture {
 
 	uint32_t width = 0, height = 0, depth = 0;
 	uint32_t flags = 0;
-	DXGI_FORMAT dxgiFormat = DXGI_FORMAT_UNKNOWN;
+	DXGI_FORMAT dxgiFormatResource = DXGI_FORMAT_UNKNOWN;
+	DXGI_FORMAT dxgiFormatView = DXGI_FORMAT_UNKNOWN;
+	DXGI_FORMAT dxgiFormatViewLinear = DXGI_FORMAT_UNKNOWN;
 	bool isDynamic = false;
 	bool isShared = false;
 	bool genMipmaps = false;
@@ -912,6 +960,8 @@ struct gs_device {
 	gs_texture_2d *curRenderTarget = nullptr;
 	gs_zstencil_buffer *curZStencilBuffer = nullptr;
 	int curRenderSide = 0;
+	bool curFramebufferSrgb = false;
+	bool curFramebufferInvalidate = false;
 	gs_texture *curTextures[GS_MAX_TEXTURES];
 	gs_sampler_state *curSamplers[GS_MAX_TEXTURES];
 	gs_vertex_buffer *curVertexBuffer = nullptr;
@@ -971,6 +1021,8 @@ struct gs_device {
 			    uint32_t src_y, uint32_t src_w, uint32_t src_h);
 
 	void UpdateViewProjMatrix();
+
+	void FlushOutputViews();
 
 	void RebuildDevice();
 

--- a/libobs-d3d11/d3d11-texture2d.cpp
+++ b/libobs-d3d11/d3d11-texture2d.cpp
@@ -98,7 +98,7 @@ void gs_texture_2d::InitTexture(const uint8_t *const *data)
 	td.Height = height;
 	td.MipLevels = genMipmaps ? 0 : levels;
 	td.ArraySize = type == GS_TEXTURE_CUBE ? 6 : 1;
-	td.Format = nv12 ? DXGI_FORMAT_NV12 : dxgiFormat;
+	td.Format = nv12 ? DXGI_FORMAT_NV12 : dxgiFormatResource;
 	td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
 	td.SampleDesc.Count = 1;
 	td.CPUAccessFlags = isDynamic ? D3D11_CPU_ACCESS_WRITE : 0;
@@ -172,23 +172,35 @@ void gs_texture_2d::InitResourceView()
 {
 	HRESULT hr;
 
-	memset(&resourceDesc, 0, sizeof(resourceDesc));
-	resourceDesc.Format = dxgiFormat;
+	memset(&viewDesc, 0, sizeof(viewDesc));
+	viewDesc.Format = dxgiFormatView;
 
 	if (type == GS_TEXTURE_CUBE) {
-		resourceDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBE;
-		resourceDesc.TextureCube.MipLevels =
-			genMipmaps || !levels ? -1 : levels;
+		viewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBE;
+		viewDesc.TextureCube.MipLevels = genMipmaps || !levels ? -1
+								       : levels;
 	} else {
-		resourceDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-		resourceDesc.Texture2D.MipLevels =
-			genMipmaps || !levels ? -1 : levels;
+		viewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+		viewDesc.Texture2D.MipLevels = genMipmaps || !levels ? -1
+								     : levels;
 	}
 
-	hr = device->device->CreateShaderResourceView(texture, &resourceDesc,
+	hr = device->device->CreateShaderResourceView(texture, &viewDesc,
 						      shaderRes.Assign());
 	if (FAILED(hr))
-		throw HRError("Failed to create resource view", hr);
+		throw HRError("Failed to create SRV", hr);
+
+	viewDescLinear = viewDesc;
+	viewDescLinear.Format = dxgiFormatViewLinear;
+
+	if (dxgiFormatView == dxgiFormatViewLinear) {
+		shaderResLinear = shaderRes;
+	} else {
+		hr = device->device->CreateShaderResourceView(
+			texture, &viewDescLinear, shaderResLinear.Assign());
+		if (FAILED(hr))
+			throw HRError("Failed to create linear SRV", hr);
+	}
 }
 
 void gs_texture_2d::InitRenderTargets()
@@ -196,18 +208,27 @@ void gs_texture_2d::InitRenderTargets()
 	HRESULT hr;
 	if (type == GS_TEXTURE_2D) {
 		D3D11_RENDER_TARGET_VIEW_DESC rtv;
-		rtv.Format = dxgiFormat;
+		rtv.Format = dxgiFormatView;
 		rtv.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
 		rtv.Texture2D.MipSlice = 0;
 
 		hr = device->device->CreateRenderTargetView(
 			texture, &rtv, renderTarget[0].Assign());
 		if (FAILED(hr))
-			throw HRError("Failed to create render target view",
-				      hr);
+			throw HRError("Failed to create RTV", hr);
+		if (dxgiFormatView == dxgiFormatViewLinear) {
+			renderTargetLinear[0] = renderTarget[0];
+		} else {
+			rtv.Format = dxgiFormatViewLinear;
+			hr = device->device->CreateRenderTargetView(
+				texture, &rtv, renderTargetLinear[0].Assign());
+			if (FAILED(hr))
+				throw HRError("Failed to create linear RTV",
+					      hr);
+		}
 	} else {
 		D3D11_RENDER_TARGET_VIEW_DESC rtv;
-		rtv.Format = dxgiFormat;
+		rtv.Format = dxgiFormatView;
 		rtv.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
 		rtv.Texture2DArray.MipSlice = 0;
 		rtv.Texture2DArray.ArraySize = 1;
@@ -217,9 +238,19 @@ void gs_texture_2d::InitRenderTargets()
 			hr = device->device->CreateRenderTargetView(
 				texture, &rtv, renderTarget[i].Assign());
 			if (FAILED(hr))
-				throw HRError("Failed to create cube render "
-					      "target view",
-					      hr);
+				throw HRError("Failed to create cube RTV", hr);
+			if (dxgiFormatView == dxgiFormatViewLinear) {
+				renderTargetLinear[i] = renderTarget[i];
+			} else {
+				rtv.Format = dxgiFormatViewLinear;
+				hr = device->device->CreateRenderTargetView(
+					texture, &rtv,
+					renderTargetLinear[i].Assign());
+				if (FAILED(hr))
+					throw HRError(
+						"Failed to create linear cube RTV",
+						hr);
+			}
 		}
 	}
 }
@@ -235,7 +266,9 @@ gs_texture_2d::gs_texture_2d(gs_device_t *device, uint32_t width,
 	  width(width),
 	  height(height),
 	  flags(flags_),
-	  dxgiFormat(ConvertGSTextureFormat(format)),
+	  dxgiFormatResource(ConvertGSTextureFormatResource(format)),
+	  dxgiFormatView(ConvertGSTextureFormatView(format)),
+	  dxgiFormatViewLinear(ConvertGSTextureFormatViewLinear(format)),
 	  isRenderTarget((flags_ & GS_RENDER_TARGET) != 0),
 	  isGDICompatible(gdiCompatible),
 	  isDynamic((flags_ & GS_DYNAMIC) != 0),
@@ -271,7 +304,9 @@ gs_texture_2d::gs_texture_2d(gs_device_t *device, ID3D11Texture2D *nv12tex,
 	this->chroma = true;
 	this->width = td.Width / 2;
 	this->height = td.Height / 2;
-	this->dxgiFormat = DXGI_FORMAT_R8G8_UNORM;
+	this->dxgiFormatResource = DXGI_FORMAT_R8G8_UNORM;
+	this->dxgiFormatView = DXGI_FORMAT_R8G8_UNORM;
+	this->dxgiFormatViewLinear = DXGI_FORMAT_R8G8_UNORM;
 
 	InitResourceView();
 	if (isRenderTarget)
@@ -292,24 +327,20 @@ gs_texture_2d::gs_texture_2d(gs_device_t *device, uint32_t handle)
 
 	texture->GetDesc(&td);
 
+	const gs_color_format format = ConvertDXGITextureFormat(td.Format);
+
 	this->type = GS_TEXTURE_2D;
-	this->format = ConvertDXGITextureFormat(td.Format);
+	this->format = format;
 	this->levels = 1;
 	this->device = device;
 
 	this->width = td.Width;
 	this->height = td.Height;
-	this->dxgiFormat = td.Format;
+	this->dxgiFormatResource = ConvertGSTextureFormatResource(format);
+	this->dxgiFormatView = ConvertGSTextureFormatView(format);
+	this->dxgiFormatViewLinear = ConvertGSTextureFormatViewLinear(format);
 
-	memset(&resourceDesc, 0, sizeof(resourceDesc));
-	resourceDesc.Format = ConvertGSTextureFormat(this->format);
-	resourceDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-	resourceDesc.Texture2D.MipLevels = 1;
-
-	hr = device->device->CreateShaderResourceView(texture, &resourceDesc,
-						      shaderRes.Assign());
-	if (FAILED(hr))
-		throw HRError("Failed to create shader resource view", hr);
+	InitResourceView();
 }
 
 gs_texture_2d::gs_texture_2d(gs_device_t *device, ID3D11Texture2D *obj)
@@ -319,22 +350,18 @@ gs_texture_2d::gs_texture_2d(gs_device_t *device, ID3D11Texture2D *obj)
 
 	texture->GetDesc(&td);
 
+	const gs_color_format format = ConvertDXGITextureFormat(td.Format);
+
 	this->type = GS_TEXTURE_2D;
-	this->format = ConvertDXGITextureFormat(td.Format);
+	this->format = format;
 	this->levels = 1;
 	this->device = device;
 
 	this->width = td.Width;
 	this->height = td.Height;
-	this->dxgiFormat = td.Format;
+	this->dxgiFormatResource = ConvertGSTextureFormatResource(format);
+	this->dxgiFormatView = ConvertGSTextureFormatView(format);
+	this->dxgiFormatViewLinear = ConvertGSTextureFormatViewLinear(format);
 
-	memset(&resourceDesc, 0, sizeof(resourceDesc));
-	resourceDesc.Format = ConvertGSTextureFormat(this->format);
-	resourceDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-	resourceDesc.Texture2D.MipLevels = 1;
-
-	HRESULT hr = device->device->CreateShaderResourceView(
-		texture, &resourceDesc, shaderRes.Assign());
-	if (FAILED(hr))
-		throw HRError("Failed to create shader resource view", hr);
+	InitResourceView();
 }

--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -71,6 +71,12 @@ static inline GLenum convert_gs_format(enum gs_color_format format)
 		return GL_RGBA;
 	case GS_DXT5:
 		return GL_RGBA;
+	case GS_RGBA_UNORM:
+		return GL_RGBA;
+	case GS_BGRX_UNORM:
+		return GL_BGRA;
+	case GS_BGRA_UNORM:
+		return GL_BGRA;
 	case GS_UNKNOWN:
 		return 0;
 	}
@@ -86,11 +92,11 @@ static inline GLenum convert_gs_internal_format(enum gs_color_format format)
 	case GS_R8:
 		return GL_R8;
 	case GS_RGBA:
-		return GL_RGBA;
+		return GL_SRGB8_ALPHA8;
 	case GS_BGRX:
-		return GL_RGB;
+		return GL_SRGB8;
 	case GS_BGRA:
-		return GL_RGBA;
+		return GL_SRGB8_ALPHA8;
 	case GS_R10G10B10A2:
 		return GL_RGB10_A2;
 	case GS_RGBA16:
@@ -117,6 +123,12 @@ static inline GLenum convert_gs_internal_format(enum gs_color_format format)
 		return GL_COMPRESSED_RGBA_S3TC_DXT3_EXT;
 	case GS_DXT5:
 		return GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
+	case GS_RGBA_UNORM:
+		return GL_RGBA;
+	case GS_BGRX_UNORM:
+		return GL_RGB;
+	case GS_BGRA_UNORM:
+		return GL_RGBA;
 	case GS_UNKNOWN:
 		return 0;
 	}
@@ -162,6 +174,12 @@ static inline GLenum get_gl_format_type(enum gs_color_format format)
 	case GS_DXT3:
 		return GL_UNSIGNED_BYTE;
 	case GS_DXT5:
+		return GL_UNSIGNED_BYTE;
+	case GS_RGBA_UNORM:
+		return GL_UNSIGNED_BYTE;
+	case GS_BGRX_UNORM:
+		return GL_UNSIGNED_BYTE;
+	case GS_BGRA_UNORM:
 		return GL_UNSIGNED_BYTE;
 	case GS_UNKNOWN:
 		return 0;
@@ -411,6 +429,7 @@ struct gs_shader_param {
 	int array_count;
 
 	struct gs_texture *texture;
+	bool srgb;
 
 	DARRAY(uint8_t) cur_value;
 	DARRAY(uint8_t) def_value;

--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -596,6 +596,7 @@ struct gs_device {
 	enum copy_type copy_type;
 
 	GLuint empty_vao;
+	gs_samplerstate_t *raw_load_sampler;
 
 	gs_texture_t *cur_render_target;
 	gs_zstencil_t *cur_zstencil_buffer;

--- a/libobs/graphics/device-exports.h
+++ b/libobs/graphics/device-exports.h
@@ -88,6 +88,8 @@ EXPORT void device_load_indexbuffer(gs_device_t *device,
 				    gs_indexbuffer_t *indexbuffer);
 EXPORT void device_load_texture(gs_device_t *device, gs_texture_t *tex,
 				int unit);
+EXPORT void device_load_texture_srgb(gs_device_t *device, gs_texture_t *tex,
+				     int unit);
 EXPORT void device_load_samplerstate(gs_device_t *device,
 				     gs_samplerstate_t *samplerstate, int unit);
 EXPORT void device_load_vertexshader(gs_device_t *device,
@@ -105,6 +107,8 @@ EXPORT void device_set_render_target(gs_device_t *device, gs_texture_t *tex,
 EXPORT void device_set_cube_render_target(gs_device_t *device,
 					  gs_texture_t *cubetex, int side,
 					  gs_zstencil_t *zstencil);
+EXPORT void device_enable_framebuffer_srgb(gs_device_t *device, bool enable);
+EXPORT bool device_framebuffer_srgb_enabled(gs_device_t *device);
 EXPORT void device_copy_texture(gs_device_t *device, gs_texture_t *dst,
 				gs_texture_t *src);
 EXPORT void device_copy_texture_region(gs_device_t *device, gs_texture_t *dst,

--- a/libobs/graphics/effect.c
+++ b/libobs/graphics/effect.c
@@ -486,7 +486,18 @@ void gs_effect_set_color(gs_eparam_t *param, uint32_t argb)
 
 void gs_effect_set_texture(gs_eparam_t *param, gs_texture_t *val)
 {
-	effect_setval_inline(param, &val, sizeof(gs_texture_t *));
+	struct gs_shader_texture shader_tex;
+	shader_tex.tex = val;
+	shader_tex.srgb = false;
+	effect_setval_inline(param, &shader_tex, sizeof(shader_tex));
+}
+
+void gs_effect_set_texture_srgb(gs_eparam_t *param, gs_texture_t *val)
+{
+	struct gs_shader_texture shader_tex;
+	shader_tex.tex = val;
+	shader_tex.srgb = true;
+	effect_setval_inline(param, &shader_tex, sizeof(shader_tex));
 }
 
 void gs_effect_set_val(gs_eparam_t *param, const void *val, size_t size)

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -82,6 +82,8 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT(device_get_zstencil_target);
 	GRAPHICS_IMPORT(device_set_render_target);
 	GRAPHICS_IMPORT(device_set_cube_render_target);
+	GRAPHICS_IMPORT(device_enable_framebuffer_srgb);
+	GRAPHICS_IMPORT(device_framebuffer_srgb_enabled);
 	GRAPHICS_IMPORT(device_copy_texture_region);
 	GRAPHICS_IMPORT(device_copy_texture);
 	GRAPHICS_IMPORT(device_stage_texture);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -106,6 +106,9 @@ struct gs_exports {
 	void (*device_set_cube_render_target)(gs_device_t *device,
 					      gs_texture_t *cubetex, int side,
 					      gs_zstencil_t *zstencil);
+	void (*device_enable_framebuffer_srgb)(gs_device_t *device,
+					       bool enable);
+	bool (*device_framebuffer_srgb_enabled)(gs_device_t *device);
 	void (*device_copy_texture)(gs_device_t *device, gs_texture_t *dst,
 				    gs_texture_t *src);
 	void (*device_copy_texture_region)(gs_device_t *device,
@@ -362,4 +365,6 @@ struct graphics_subsystem {
 
 	struct blend_state cur_blend_state;
 	DARRAY(struct blend_state) blend_state_stack;
+
+	bool linear_srgb;
 };

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -1708,6 +1708,50 @@ void gs_set_cube_render_target(gs_texture_t *cubetex, int side,
 		graphics->device, cubetex, side, zstencil);
 }
 
+void gs_enable_framebuffer_srgb(bool enable)
+{
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_enable_framebuffer_srgb"))
+		return;
+
+	graphics->exports.device_enable_framebuffer_srgb(graphics->device,
+							 enable);
+}
+
+bool gs_framebuffer_srgb_enabled(void)
+{
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_framebuffer_srgb_enabled"))
+		return false;
+
+	return graphics->exports.device_framebuffer_srgb_enabled(
+		graphics->device);
+}
+
+bool gs_get_linear_srgb(void)
+{
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_get_linear_srgb"))
+		return false;
+
+	return graphics->linear_srgb;
+}
+
+bool gs_set_linear_srgb(bool linear_srgb)
+{
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_set_linear_srgb"))
+		return false;
+
+	const bool previous = graphics->linear_srgb;
+	graphics->linear_srgb = linear_srgb;
+	return previous;
+}
+
 void gs_copy_texture(gs_texture_t *dst, gs_texture_t *src)
 {
 	graphics_t *graphics = thread_graphics;

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -73,6 +73,9 @@ enum gs_color_format {
 	GS_DXT3,
 	GS_DXT5,
 	GS_R8G8,
+	GS_RGBA_UNORM,
+	GS_BGRX_UNORM,
+	GS_BGRA_UNORM,
 };
 
 enum gs_zstencil_format {
@@ -302,6 +305,11 @@ enum gs_shader_param_type {
 	GS_SHADER_PARAM_TEXTURE,
 };
 
+struct gs_shader_texture {
+	gs_texture_t *tex;
+	bool srgb;
+};
+
 #ifndef SWIG
 struct gs_shader_param_info {
 	enum gs_shader_param_type type;
@@ -423,6 +431,7 @@ EXPORT void gs_effect_set_vec2(gs_eparam_t *param, const struct vec2 *val);
 EXPORT void gs_effect_set_vec3(gs_eparam_t *param, const struct vec3 *val);
 EXPORT void gs_effect_set_vec4(gs_eparam_t *param, const struct vec4 *val);
 EXPORT void gs_effect_set_texture(gs_eparam_t *param, gs_texture_t *val);
+EXPORT void gs_effect_set_texture_srgb(gs_eparam_t *param, gs_texture_t *val);
 EXPORT void gs_effect_set_val(gs_eparam_t *param, const void *val, size_t size);
 EXPORT void gs_effect_set_default(gs_eparam_t *param);
 EXPORT size_t gs_effect_get_val_size(gs_eparam_t *param);
@@ -666,6 +675,12 @@ EXPORT gs_zstencil_t *gs_get_zstencil_target(void);
 EXPORT void gs_set_render_target(gs_texture_t *tex, gs_zstencil_t *zstencil);
 EXPORT void gs_set_cube_render_target(gs_texture_t *cubetex, int side,
 				      gs_zstencil_t *zstencil);
+
+EXPORT void gs_enable_framebuffer_srgb(bool enable);
+EXPORT bool gs_framebuffer_srgb_enabled(void);
+
+EXPORT bool gs_get_linear_srgb(void);
+EXPORT bool gs_set_linear_srgb(bool linear_srgb);
 
 EXPORT void gs_copy_texture(gs_texture_t *dst, gs_texture_t *src);
 EXPORT void gs_copy_texture_region(gs_texture_t *dst, uint32_t dst_x,
@@ -939,6 +954,12 @@ static inline uint32_t gs_get_format_bpp(enum gs_color_format format)
 		return 8;
 	case GS_R8G8:
 		return 16;
+	case GS_RGBA_UNORM:
+		return 32;
+	case GS_BGRX_UNORM:
+		return 32;
+	case GS_BGRA_UNORM:
+		return 32;
 	case GS_UNKNOWN:
 		return 0;
 	}
@@ -949,6 +970,18 @@ static inline uint32_t gs_get_format_bpp(enum gs_color_format format)
 static inline bool gs_is_compressed_format(enum gs_color_format format)
 {
 	return (format == GS_DXT1 || format == GS_DXT3 || format == GS_DXT5);
+}
+
+static inline bool gs_is_srgb_format(enum gs_color_format format)
+{
+	switch (format) {
+	case GS_RGBA:
+	case GS_BGRX:
+	case GS_BGRA:
+		return true;
+	default:
+		return false;
+	}
 }
 
 static inline uint32_t gs_get_total_levels(uint32_t width, uint32_t height,

--- a/libobs/graphics/vec4.h
+++ b/libobs/graphics/vec4.h
@@ -199,43 +199,126 @@ static inline void vec4_ceil(struct vec4 *dst, const struct vec4 *v)
 static inline uint32_t vec4_to_rgba(const struct vec4 *src)
 {
 	uint32_t val;
-	val = (uint32_t)((double)src->x * 255.0);
-	val |= (uint32_t)((double)src->y * 255.0) << 8;
-	val |= (uint32_t)((double)src->z * 255.0) << 16;
-	val |= (uint32_t)((double)src->w * 255.0) << 24;
+	val = (uint32_t)((src->x * 255.0f) + 0.5f);
+	val |= (uint32_t)((src->y * 255.0f) + 0.5f) << 8;
+	val |= (uint32_t)((src->z * 255.0f) + 0.5f) << 16;
+	val |= (uint32_t)((src->w * 255.0f) + 0.5f) << 24;
 	return val;
 }
 
 static inline uint32_t vec4_to_bgra(const struct vec4 *src)
 {
 	uint32_t val;
-	val = (uint32_t)((double)src->z * 255.0);
-	val |= (uint32_t)((double)src->y * 255.0) << 8;
-	val |= (uint32_t)((double)src->x * 255.0) << 16;
-	val |= (uint32_t)((double)src->w * 255.0) << 24;
+	val = (uint32_t)((src->z * 255.0f) + 0.5f);
+	val |= (uint32_t)((src->y * 255.0f) + 0.5f) << 8;
+	val |= (uint32_t)((src->x * 255.0f) + 0.5f) << 16;
+	val |= (uint32_t)((src->w * 255.0f) + 0.5f) << 24;
 	return val;
 }
 
 static inline void vec4_from_rgba(struct vec4 *dst, uint32_t rgba)
 {
-	dst->x = (float)((double)(rgba & 0xFF) * (1.0 / 255.0));
+	dst->x = (float)(rgba & 0xFF) / 255.0f;
 	rgba >>= 8;
-	dst->y = (float)((double)(rgba & 0xFF) * (1.0 / 255.0));
+	dst->y = (float)(rgba & 0xFF) / 255.0f;
 	rgba >>= 8;
-	dst->z = (float)((double)(rgba & 0xFF) * (1.0 / 255.0));
+	dst->z = (float)(rgba & 0xFF) / 255.0f;
 	rgba >>= 8;
-	dst->w = (float)((double)(rgba & 0xFF) * (1.0 / 255.0));
+	dst->w = (float)rgba / 255.0f;
 }
 
 static inline void vec4_from_bgra(struct vec4 *dst, uint32_t bgra)
 {
-	dst->z = (float)((double)(bgra & 0xFF) * (1.0 / 255.0));
+	dst->z = (float)(bgra & 0xFF) / 255.0f;
 	bgra >>= 8;
-	dst->y = (float)((double)(bgra & 0xFF) * (1.0 / 255.0));
+	dst->y = (float)(bgra & 0xFF) / 255.0f;
 	bgra >>= 8;
-	dst->x = (float)((double)(bgra & 0xFF) * (1.0 / 255.0));
+	dst->x = (float)(bgra & 0xFF) / 255.0f;
 	bgra >>= 8;
-	dst->w = (float)((double)(bgra & 0xFF) * (1.0 / 255.0));
+	dst->w = (float)bgra / 255.0f;
+}
+
+static inline float srgb_nonlinear_to_linear(float u)
+{
+	return (u <= 0.04045f) ? (u / 12.92f)
+			       : powf((u + 0.055f) / 1.055f, 2.4f);
+}
+
+static inline void vec4_from_rgba_srgb(struct vec4 *dst, uint32_t rgba)
+{
+	dst->x = srgb_nonlinear_to_linear((float)(rgba & 0xFF) / 255.0f);
+	rgba >>= 8;
+	dst->y = srgb_nonlinear_to_linear((float)(rgba & 0xFF) / 255.0f);
+	rgba >>= 8;
+	dst->z = srgb_nonlinear_to_linear((float)(rgba & 0xFF) / 255.0f);
+	rgba >>= 8;
+	dst->w = (float)rgba / 255.0f;
+}
+
+static inline void vec4_from_bgra_srgb(struct vec4 *dst, uint32_t bgra)
+{
+	dst->z = srgb_nonlinear_to_linear((float)(bgra & 0xFF) / 255.0f);
+	bgra >>= 8;
+	dst->y = srgb_nonlinear_to_linear((float)(bgra & 0xFF) / 255.0f);
+	bgra >>= 8;
+	dst->x = srgb_nonlinear_to_linear((float)(bgra & 0xFF) / 255.0f);
+	bgra >>= 8;
+	dst->w = (float)bgra / 255.0f;
+}
+
+static inline void vec4_from_rgba_srgb_premultiply(struct vec4 *dst,
+						   uint32_t rgba)
+{
+	vec4_from_rgba_srgb(dst, rgba);
+	dst->x *= dst->w;
+	dst->y *= dst->w;
+	dst->z *= dst->w;
+}
+
+static inline void vec4_from_bgra_srgb_premultiply(struct vec4 *dst,
+						   uint32_t bgra)
+{
+	vec4_from_bgra_srgb(dst, bgra);
+	dst->x *= dst->w;
+	dst->y *= dst->w;
+	dst->z *= dst->w;
+}
+
+static inline float srgb_linear_to_nonlinear(float u)
+{
+	return (u <= 0.0031308f) ? (12.92f * u)
+				 : ((1.055f * powf(u, 1.0f / 2.4f)) - 0.055f);
+}
+
+static inline uint32_t vec4_to_rgba_srgb(const struct vec4 *src)
+{
+	uint32_t val;
+	val = (uint32_t)((srgb_linear_to_nonlinear(src->x) * 255.0f) + 0.5f);
+	val |= (uint32_t)((srgb_linear_to_nonlinear(src->y) * 255.0f) + 0.5f)
+	       << 8;
+	val |= (uint32_t)((srgb_linear_to_nonlinear(src->z) * 255.0f) + 0.5f)
+	       << 16;
+	val |= (uint32_t)((src->w * 255.0f) + 0.5f) << 24;
+	return val;
+}
+
+static inline uint32_t vec4_to_bgra_srgb(const struct vec4 *src)
+{
+	uint32_t val;
+	val = (uint32_t)((srgb_linear_to_nonlinear(src->z) * 255.0f) + 0.5f);
+	val |= (uint32_t)((srgb_linear_to_nonlinear(src->y) * 255.0f) + 0.5f)
+	       << 8;
+	val |= (uint32_t)((srgb_linear_to_nonlinear(src->x) * 255.0f) + 0.5f)
+	       << 16;
+	val |= (uint32_t)((src->w * 255.0f) + 0.5f) << 24;
+	return val;
+}
+
+static inline void vec4_srgb_linear_to_nonlinear(struct vec4 *dst)
+{
+	dst->x = srgb_linear_to_nonlinear(dst->x);
+	dst->y = srgb_linear_to_nonlinear(dst->y);
+	dst->y = srgb_linear_to_nonlinear(dst->y);
 }
 
 EXPORT void vec4_transform(struct vec4 *dst, const struct vec4 *v,

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -570,6 +570,7 @@ static inline void render_item(struct obs_scene_item *item)
 		}
 	}
 
+	const bool previous = gs_set_linear_srgb(true);
 	gs_matrix_push();
 	gs_matrix_mul(&item->draw_transform);
 	if (item->item_render) {
@@ -578,6 +579,7 @@ static inline void render_item(struct obs_scene_item *item)
 		obs_source_video_render(item->source);
 	}
 	gs_matrix_pop();
+	gs_set_linear_srgb(previous);
 
 cleanup:
 	GS_DEBUG_MARKER_END();

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -256,8 +256,9 @@ static inline gs_texture_t *render_output_texture(struct obs_core_video *video)
 		gs_effect_set_vec2(bres_i, &base_i);
 	}
 
-	gs_effect_set_texture(image, texture);
+	gs_effect_set_texture_srgb(image, texture);
 
+	gs_enable_framebuffer_srgb(true);
 	gs_enable_blending(false);
 	passes = gs_technique_begin(tech);
 	for (i = 0; i < passes; i++) {
@@ -267,6 +268,7 @@ static inline gs_texture_t *render_output_texture(struct obs_core_video *video)
 	}
 	gs_technique_end(tech);
 	gs_enable_blending(true);
+	gs_enable_framebuffer_srgb(false);
 
 	profile_end(render_output_texture_name);
 

--- a/plugins/image-source/color-source.c
+++ b/plugins/image-source/color-source.c
@@ -1,7 +1,8 @@
 #include <obs-module.h>
 
 struct color_source {
-	uint32_t color;
+	struct vec4 color;
+	struct vec4 color_srgb;
 
 	uint32_t width;
 	uint32_t height;
@@ -22,7 +23,8 @@ static void color_source_update(void *data, obs_data_t *settings)
 	uint32_t width = (uint32_t)obs_data_get_int(settings, "width");
 	uint32_t height = (uint32_t)obs_data_get_int(settings, "height");
 
-	context->color = color;
+	vec4_from_rgba(&context->color, color);
+	vec4_from_rgba_srgb(&context->color_srgb, color);
 	context->width = width;
 	context->height = height;
 }
@@ -50,8 +52,8 @@ static obs_properties_t *color_source_properties(void *unused)
 
 	obs_properties_t *props = obs_properties_create();
 
-	obs_properties_add_color(props, "color",
-				 obs_module_text("ColorSource.Color"));
+	obs_properties_add_color_alpha(props, "color",
+				       obs_module_text("ColorSource.Color"));
 
 	obs_properties_add_int(props, "width",
 			       obs_module_text("ColorSource.Width"), 0, 4096,
@@ -64,19 +66,14 @@ static obs_properties_t *color_source_properties(void *unused)
 	return props;
 }
 
-static void color_source_render(void *data, gs_effect_t *effect)
+static void color_source_render_helper(struct color_source *context,
+				       struct vec4 *colorVal)
 {
-	UNUSED_PARAMETER(effect);
-
-	struct color_source *context = data;
-
 	gs_effect_t *solid = obs_get_base_effect(OBS_EFFECT_SOLID);
 	gs_eparam_t *color = gs_effect_get_param_by_name(solid, "color");
 	gs_technique_t *tech = gs_effect_get_technique(solid, "Solid");
 
-	struct vec4 colorVal;
-	vec4_from_rgba(&colorVal, context->color);
-	gs_effect_set_vec4(color, &colorVal);
+	gs_effect_set_vec4(color, colorVal);
 
 	gs_technique_begin(tech);
 	gs_technique_begin_pass(tech, 0);
@@ -85,6 +82,27 @@ static void color_source_render(void *data, gs_effect_t *effect)
 
 	gs_technique_end_pass(tech);
 	gs_technique_end(tech);
+}
+
+static void color_source_render(void *data, gs_effect_t *effect)
+{
+	UNUSED_PARAMETER(effect);
+
+	struct color_source *context = data;
+
+	/* need linear path for correct alpha blending */
+	const bool linear_srgb = gs_get_linear_srgb() ||
+				 (context->color.w < 1.0f);
+
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(linear_srgb);
+
+	if (linear_srgb)
+		color_source_render_helper(context, &context->color_srgb);
+	else
+		color_source_render_helper(context, &context->color);
+
+	gs_enable_framebuffer_srgb(previous);
 }
 
 static uint32_t color_source_getwidth(void *data)

--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -147,10 +147,21 @@ static void image_source_render(void *data, gs_effect_t *effect)
 	if (!context->if2.image.texture)
 		return;
 
-	gs_effect_set_texture(gs_effect_get_param_by_name(effect, "image"),
-			      context->if2.image.texture);
+	const bool linear_srgb = gs_get_linear_srgb();
+
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(linear_srgb);
+
+	gs_eparam_t *const param = gs_effect_get_param_by_name(effect, "image");
+	if (linear_srgb)
+		gs_effect_set_texture_srgb(param, context->if2.image.texture);
+	else
+		gs_effect_set_texture(param, context->if2.image.texture);
+
 	gs_draw_sprite(context->if2.image.texture, 0, context->if2.image.cx,
 		       context->if2.image.cy);
+
+	gs_enable_framebuffer_srgb(previous);
 }
 
 static void image_source_tick(void *data, float seconds)

--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -313,11 +313,11 @@ static gs_color_format gs_format_from_tex()
 	// GS_RGBX format
 	switch (iformat) {
 	case GL_RGB:
-		return GS_BGRX;
+		return GS_BGRX_UNORM;
 	case GL_RGBA:
-		return GS_RGBA;
+		return GS_RGBA_UNORM;
 	default:
-		return GS_RGBA;
+		return GS_RGBA_UNORM;
 	}
 }
 
@@ -513,7 +513,7 @@ void XCompcapMain::updateSettings(obs_data_t *settings)
 	XFree(configs);
 
 	// Build an OBS texture to bind the pixmap to.
-	p->gltex = gs_texture_create(p->width, p->height, GS_RGBA, 1, 0,
+	p->gltex = gs_texture_create(p->width, p->height, GS_RGBA_UNORM, 1, 0,
 				     GS_GL_DUMMYTEX);
 	GLuint gltex = *(GLuint *)gs_texture_get_obj(p->gltex);
 	glBindTexture(GL_TEXTURE_2D, gltex);

--- a/plugins/linux-capture/xcursor-xcb.c
+++ b/plugins/linux-capture/xcursor-xcb.c
@@ -93,9 +93,17 @@ void xcb_xcursor_render(xcb_xcursor_t *data)
 	if (!data->tex)
 		return;
 
+	const bool linear_srgb = gs_get_linear_srgb();
+
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(linear_srgb);
+
 	gs_effect_t *effect = gs_get_effect();
 	gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
-	gs_effect_set_texture(image, data->tex);
+	if (linear_srgb)
+		gs_effect_set_texture_srgb(image, data->tex);
+	else
+		gs_effect_set_texture(image, data->tex);
 
 	gs_blend_state_push();
 	gs_blend_function(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA);
@@ -108,6 +116,8 @@ void xcb_xcursor_render(xcb_xcursor_t *data)
 
 	gs_enable_color(true, true, true, true);
 	gs_blend_state_pop();
+
+	gs_enable_framebuffer_srgb(previous);
 }
 
 void xcb_xcursor_offset(xcb_xcursor_t *data, const int x_org, const int y_org)

--- a/plugins/linux-capture/xcursor.c
+++ b/plugins/linux-capture/xcursor.c
@@ -108,9 +108,17 @@ void xcursor_render(xcursor_t *data, int x_offset, int y_offset)
 	if (!data->tex)
 		return;
 
+	const bool linear_srgb = gs_get_linear_srgb();
+
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(linear_srgb);
+
 	gs_effect_t *effect = gs_get_effect();
 	gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
-	gs_effect_set_texture(image, data->tex);
+	if (linear_srgb)
+		gs_effect_set_texture_srgb(image, data->tex);
+	else
+		gs_effect_set_texture(image, data->tex);
 
 	gs_blend_state_push();
 	gs_blend_function(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA);
@@ -124,6 +132,8 @@ void xcursor_render(xcursor_t *data, int x_offset, int y_offset)
 
 	gs_enable_color(true, true, true, true);
 	gs_blend_state_pop();
+
+	gs_enable_framebuffer_srgb(previous);
 }
 
 void xcursor_offset(xcursor_t *data, int_fast32_t x_org, int_fast32_t y_org)

--- a/plugins/linux-capture/xshm-input.c
+++ b/plugins/linux-capture/xshm-input.c
@@ -523,12 +523,22 @@ static void xshm_video_render(void *vptr, gs_effect_t *effect)
 	if (!data->texture)
 		return;
 
+	const bool linear_srgb = gs_get_linear_srgb();
+
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(linear_srgb);
+
 	gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
-	gs_effect_set_texture(image, data->texture);
+	if (linear_srgb)
+		gs_effect_set_texture_srgb(image, data->texture);
+	else
+		gs_effect_set_texture(image, data->texture);
 
 	while (gs_effect_loop(effect, "Draw")) {
 		gs_draw_sprite(data->texture, 0, 0, 0);
 	}
+
+	gs_enable_framebuffer_srgb(previous);
 
 	if (data->show_cursor) {
 		effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);

--- a/plugins/mac-capture/mac-display-capture.m
+++ b/plugins/mac-capture/mac-display-capture.m
@@ -399,13 +399,21 @@ static void display_capture_video_render(void *data, gs_effect_t *effect)
 	if (!dc->tex || (requires_window(dc->crop) && !dc->on_screen))
 		return;
 
+	const bool linear_srgb = gs_get_linear_srgb();
+
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(linear_srgb);
+
 	gs_vertexbuffer_flush(dc->vertbuf);
 	gs_load_vertexbuffer(dc->vertbuf);
 	gs_load_indexbuffer(NULL);
 	gs_load_samplerstate(dc->sampler, 0);
 	gs_technique_t *tech = gs_effect_get_technique(dc->effect, "Draw");
-	gs_effect_set_texture(gs_effect_get_param_by_name(dc->effect, "image"),
-			      dc->tex);
+	gs_eparam_t *param = gs_effect_get_param_by_name(dc->effect, "image");
+	if (linear_srgb)
+		gs_effect_set_texture_srgb(param, dc->tex);
+	else
+		gs_effect_set_texture(param, dc->tex);
 	gs_technique_begin(tech);
 	gs_technique_begin_pass(tech, 0);
 
@@ -413,6 +421,8 @@ static void display_capture_video_render(void *data, gs_effect_t *effect)
 
 	gs_technique_end_pass(tech);
 	gs_technique_end(tech);
+
+	gs_enable_framebuffer_srgb(previous);
 }
 
 static const char *display_capture_getname(void *unused)

--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -871,15 +871,20 @@ inline void TextSource::Render()
 	gs_effect_t *effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
 	gs_technique_t *tech = gs_effect_get_technique(effect, "Draw");
 
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(true);
+
 	gs_technique_begin(tech);
 	gs_technique_begin_pass(tech, 0);
 
-	gs_effect_set_texture(gs_effect_get_param_by_name(effect, "image"),
-			      tex);
+	gs_effect_set_texture_srgb(gs_effect_get_param_by_name(effect, "image"),
+				   tex);
 	gs_draw_sprite(tex, 0, cx, cy);
 
 	gs_technique_end_pass(tech);
 	gs_technique_end(tech);
+
+	gs_enable_framebuffer_srgb(previous);
 }
 
 /* ------------------------------------------------------------------------- */

--- a/plugins/obs-transitions/data/fade_to_color_transition.effect
+++ b/plugins/obs-transitions/data/fade_to_color_transition.effect
@@ -24,8 +24,7 @@ VertData VSDefault(VertData v_in)
 
 float4 PSFadeToColor(VertData v_in) : TARGET
 {
-	float4 premultiplied = float4(color.rgb * color.a, color.a);
-	return lerp(tex.Sample(textureSampler, v_in.uv), premultiplied, swp);
+	return lerp(tex.Sample(textureSampler, v_in.uv), color, swp);
 }
 
 technique FadeToColor

--- a/plugins/obs-transitions/transition-fade.c
+++ b/plugins/obs-transitions/transition-fade.c
@@ -53,12 +53,17 @@ static void fade_callback(void *data, gs_texture_t *a, gs_texture_t *b, float t,
 {
 	struct fade_info *fade = data;
 
-	gs_effect_set_texture(fade->a_param, a);
-	gs_effect_set_texture(fade->b_param, b);
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(true);
+
+	gs_effect_set_texture_srgb(fade->a_param, a);
+	gs_effect_set_texture_srgb(fade->b_param, b);
 	gs_effect_set_float(fade->fade_param, t);
 
 	while (gs_effect_loop(fade->effect, "Fade"))
 		gs_draw_sprite(NULL, 0, cx, cy);
+
+	gs_enable_framebuffer_srgb(previous);
 }
 
 static void fade_video_render(void *data, gs_effect_t *effect)

--- a/plugins/obs-transitions/transition-luma-wipe.c
+++ b/plugins/obs-transitions/transition-luma-wipe.c
@@ -165,8 +165,11 @@ static void luma_wipe_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 {
 	struct luma_wipe_info *lwipe = data;
 
-	gs_effect_set_texture(lwipe->ep_a_tex, a);
-	gs_effect_set_texture(lwipe->ep_b_tex, b);
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(true);
+
+	gs_effect_set_texture_srgb(lwipe->ep_a_tex, a);
+	gs_effect_set_texture_srgb(lwipe->ep_b_tex, b);
 	gs_effect_set_texture(lwipe->ep_l_tex, lwipe->luma_image.texture);
 	gs_effect_set_float(lwipe->ep_progress, t);
 
@@ -175,6 +178,8 @@ static void luma_wipe_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 
 	while (gs_effect_loop(lwipe->effect, "LumaWipe"))
 		gs_draw_sprite(NULL, 0, cx, cy);
+
+	gs_enable_framebuffer_srgb(previous);
 }
 
 void luma_wipe_video_render(void *data, gs_effect_t *effect)

--- a/plugins/obs-transitions/transition-slide.c
+++ b/plugins/obs-transitions/transition-slide.c
@@ -93,14 +93,26 @@ static void slide_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 	vec2_mulf(&tex_a_dir, &tex_a_dir, t);
 	vec2_mulf(&tex_b_dir, &tex_b_dir, 1.0f - t);
 
-	gs_effect_set_texture(slide->a_param, a);
-	gs_effect_set_texture(slide->b_param, b);
+	const bool linear_srgb = gs_get_linear_srgb();
+
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(linear_srgb);
+
+	if (linear_srgb) {
+		gs_effect_set_texture_srgb(slide->a_param, a);
+		gs_effect_set_texture_srgb(slide->b_param, b);
+	} else {
+		gs_effect_set_texture(slide->a_param, a);
+		gs_effect_set_texture(slide->b_param, b);
+	}
 
 	gs_effect_set_vec2(slide->tex_a_dir_param, &tex_a_dir);
 	gs_effect_set_vec2(slide->tex_b_dir_param, &tex_b_dir);
 
 	while (gs_effect_loop(slide->effect, "Slide"))
 		gs_draw_sprite(NULL, 0, cx, cy);
+
+	gs_enable_framebuffer_srgb(previous);
 }
 
 void slide_video_render(void *data, gs_effect_t *effect)

--- a/plugins/obs-transitions/transition-swipe.c
+++ b/plugins/obs-transitions/transition-swipe.c
@@ -88,12 +88,26 @@ static void swipe_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 
 	vec2_mulf(&swipe_val, &swipe_val, swipe->swipe_in ? 1.0f - t : t);
 
-	gs_effect_set_texture(swipe->a_param, swipe->swipe_in ? b : a);
-	gs_effect_set_texture(swipe->b_param, swipe->swipe_in ? a : b);
+	const bool linear_srgb = gs_get_linear_srgb();
+
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(linear_srgb);
+
+	gs_texture_t *t0 = swipe->swipe_in ? b : a;
+	gs_texture_t *t1 = swipe->swipe_in ? a : b;
+	if (linear_srgb) {
+		gs_effect_set_texture_srgb(swipe->a_param, t0);
+		gs_effect_set_texture_srgb(swipe->b_param, t1);
+	} else {
+		gs_effect_set_texture(swipe->a_param, t0);
+		gs_effect_set_texture(swipe->b_param, t1);
+	}
 	gs_effect_set_vec2(swipe->swipe_param, &swipe_val);
 
 	while (gs_effect_loop(swipe->effect, "Swipe"))
 		gs_draw_sprite(NULL, 0, cx, cy);
+
+	gs_enable_framebuffer_srgb(previous);
 }
 
 static void swipe_video_render(void *data, gs_effect_t *effect)

--- a/plugins/text-freetype2/obs-convenience.c
+++ b/plugins/text-freetype2/obs-convenience.c
@@ -67,6 +67,11 @@ void draw_uv_vbuffer(gs_vertbuffer_t *vbuf, gs_texture_t *tex,
 	if (vbuf == NULL || tex == NULL)
 		return;
 
+	const bool linear_srgb = gs_get_linear_srgb();
+
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(linear_srgb);
+
 	gs_vertexbuffer_flush(vbuf);
 	gs_load_vertexbuffer(vbuf);
 	gs_load_indexbuffer(NULL);
@@ -75,7 +80,10 @@ void draw_uv_vbuffer(gs_vertbuffer_t *vbuf, gs_texture_t *tex,
 
 	for (size_t i = 0; i < passes; i++) {
 		if (gs_technique_begin_pass(tech, i)) {
-			gs_effect_set_texture(image, texture);
+			if (linear_srgb)
+				gs_effect_set_texture_srgb(image, texture);
+			else
+				gs_effect_set_texture(image, texture);
 
 			gs_draw(GS_TRIS, 0, num_verts);
 
@@ -84,4 +92,6 @@ void draw_uv_vbuffer(gs_vertbuffer_t *vbuf, gs_texture_t *tex,
 	}
 
 	gs_technique_end(tech);
+
+	gs_enable_framebuffer_srgb(previous);
 }

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -247,6 +247,8 @@ static void ft2_source_render(void *data, gs_effect_t *effect)
 	if (srcdata->text == NULL || *srcdata->text == 0)
 		return;
 
+	const bool previous = gs_set_linear_srgb(true);
+
 	gs_reset_blend_state();
 	if (srcdata->outline_text)
 		draw_outlines(srcdata);
@@ -255,6 +257,8 @@ static void ft2_source_render(void *data, gs_effect_t *effect)
 
 	draw_uv_vbuffer(srcdata->vbuf, srcdata->tex, srcdata->draw_effect,
 			(uint32_t)wcslen(srcdata->text) * 6);
+
+	gs_set_linear_srgb(previous);
 
 	UNUSED_PARAMETER(effect);
 }

--- a/plugins/win-capture/dc-capture.c
+++ b/plugins/win-capture/dc-capture.c
@@ -172,7 +172,15 @@ static void draw_texture(struct dc_capture *capture, gs_effect_t *effect)
 	gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
 	size_t passes;
 
-	gs_effect_set_texture(image, texture);
+	const bool linear_srgb = gs_get_linear_srgb() && capture->compatibility;
+
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(linear_srgb);
+
+	if (linear_srgb)
+		gs_effect_set_texture_srgb(image, texture);
+	else
+		gs_effect_set_texture(image, texture);
 
 	passes = gs_technique_begin(tech);
 	for (size_t i = 0; i < passes; i++) {
@@ -186,6 +194,8 @@ static void draw_texture(struct dc_capture *capture, gs_effect_t *effect)
 		}
 	}
 	gs_technique_end(tech);
+
+	gs_enable_framebuffer_srgb(previous);
 }
 
 void dc_capture_render(struct dc_capture *capture, gs_effect_t *effect)

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -236,6 +236,8 @@ static void duplicator_capture_render(void *data, gs_effect_t *effect)
 
 	rot = capture->rot;
 
+	const bool previous = gs_set_linear_srgb(false);
+
 	while (gs_effect_loop(effect, "Draw")) {
 		if (rot != 0) {
 			float x = 0.0f;
@@ -264,6 +266,8 @@ static void duplicator_capture_render(void *data, gs_effect_t *effect)
 		if (rot != 0)
 			gs_matrix_pop();
 	}
+
+	gs_set_linear_srgb(previous);
 
 	if (capture->capture_cursor) {
 		effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);


### PR DESCRIPTION
### Description
Input sources should check if linear SRGB is expected and act accordingly. The key functions are usually gs_effect_set_texture_srgb and gs_enable_framebuffer_srgb.

TODO: Rebase after #2067 is merged.

### Motivation and Context
#2067 is pointless unless the sources and filters are updated.

### How Has This Been Tested?
- [x] decklink\decklink-source.cpp (async)
- [x] image-source\color-source.c
- [x] image-source\image-source.c
- [x] image-source\obs-slideshow.c
- [x] Screen Capture (XSHM)
- [x] Window Capture (Xcomposite)
- [x] linux-v4l2\v4l2-input.c (async)
- [x] mac-avcapture\av-capture.mm (async)
- [x] mac-capture\mac-display-capture.m
- [x] mac-capture\mac-window-capture.m (async)
- [x] obs-ffmpeg\obs-ffmpeg-source.c (async)
- [x] obs-text\gdiplus\obs-text.cpp
- [x] text-freetype2\text-freetype2.c
- [x] vlc-video\vlc-video-source.c (async)
- [x] win-capture\duplicator-monitor-capture.c
- [x] win-capture\game-capture.c
- [x] win-capture\monitor-capture.c
- [x] win-capture\window-capture.c
- [x] win-dshow\win-dshow.cpp (async)
- [x] obs-transitions\transition-fade.c
- [x] obs-transitions\transition-fade-to-color.c
- [x] obs-transitions\transition-luma-wipe.c
- [x] obs-transitions\transition-slide.c
- [x] obs-transitions\transition-swipe.c

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.