### PR TITLE
Bug fixes for Apple Silicon

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -419,7 +419,6 @@ target_link_libraries(obs
 if (APPLE)
 	target_link_libraries(obs
 			Qt5::MacExtras)
-	set_target_properties(obs PROPERTIES LINK_FLAGS "-pagezero_size 10000 -image_base 100000000")
 endif()
 set_target_properties(obs PROPERTIES FOLDER "frontend")
 

--- a/libobs/util/platform-cocoa.m
+++ b/libobs/util/platform-cocoa.m
@@ -38,44 +38,9 @@
 
 #include "apple/cfstring-utils.h"
 
-/* clock function selection taken from libc++ */
-static uint64_t ns_time_simple()
-{
-	return mach_absolute_time();
-}
-
-static double ns_time_compute_factor()
-{
-	mach_timebase_info_data_t info = {1, 1};
-	mach_timebase_info(&info);
-	return ((double)info.numer) / info.denom;
-}
-
-static uint64_t ns_time_full()
-{
-	static double factor = 0.;
-	if (factor == 0.)
-		factor = ns_time_compute_factor();
-	return (uint64_t)(mach_absolute_time() * factor);
-}
-
-typedef uint64_t (*time_func)();
-
-static time_func ns_time_select_func()
-{
-	mach_timebase_info_data_t info = {1, 1};
-	mach_timebase_info(&info);
-	if (info.denom == info.numer)
-		return ns_time_simple;
-	return ns_time_full;
-}
-
 uint64_t os_gettime_ns(void)
 {
-	static time_func f = NULL;
-	if (!f)
-		f = ns_time_select_func();
-	return f();
+	return clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
 }
 
 /* gets the location [domain mask]/Library/Application Support/[name] */

--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -5,6 +5,7 @@
 #include <errno.h>
 
 #include <obs-module.h>
+#include <mach/mach_time.h>
 #include <util/threading.h>
 #include <util/c99defs.h>
 #include <util/apple/cfstring-utils.h>
@@ -348,7 +349,16 @@ static OSStatus input_callback(void *data,
 	audio.speakers = ca->speakers;
 	audio.format = ca->format;
 	audio.samples_per_sec = ca->sample_rate;
-	audio.timestamp = ts_data->mHostTime;
+	static double factor = 0.;
+	static mach_timebase_info_data_t info = {0, 0};
+	if (info.numer == 0 && info.denom == 0) {
+		mach_timebase_info(&info);
+		factor = ((double)info.numer) / info.denom;
+	}
+	if (info.numer != info.denom)
+		audio.timestamp = (uint64_t)(factor * ts_data->mHostTime);
+	else
+		audio.timestamp = ts_data->mHostTime;
 
 	obs_source_output_audio(ca->source, &audio);
 

--- a/plugins/mac-vth264/encoder.c
+++ b/plugins/mac-vth264/encoder.c
@@ -23,9 +23,6 @@
 extern const double NSAppKitVersionNumber;
 #define NSAppKitVersionNumber10_8 1187
 
-#define APPLE_H264_ENC_ID_HW "com.apple.videotoolbox.videoencoder.h264.gva"
-#define APPLE_H264_ENC_ID_SW "com.apple.videotoolbox.videoencoder.h264"
-
 // Get around missing symbol on 10.8 during compilation
 enum { kCMFormatDescriptionBridgeError_InvalidParameter_ = -12712,
 };
@@ -490,15 +487,14 @@ static bool vt_h264_update(void *data, obs_data_t *settings)
 	return true;
 }
 
-static void *vt_h264_create(obs_data_t *settings, obs_encoder_t *encoder,
-			    const char *vt_encoder_id)
+static void *vt_h264_create(obs_data_t *settings, obs_encoder_t *encoder)
 {
 	struct vt_h264_encoder *enc = bzalloc(sizeof(struct vt_h264_encoder));
 
 	OSStatus code;
 
 	enc->encoder = encoder;
-	enc->vt_encoder_id = vt_encoder_id;
+	enc->vt_encoder_id = obs_encoder_get_id(encoder);
 
 	update_params(enc, settings);
 
@@ -514,16 +510,6 @@ static void *vt_h264_create(obs_data_t *settings, obs_encoder_t *encoder,
 fail:
 	vt_h264_destroy(enc);
 	return NULL;
-}
-
-static void *vt_h264_create_hw(obs_data_t *settings, obs_encoder_t *encoder)
-{
-	return vt_h264_create(settings, encoder, APPLE_H264_ENC_ID_HW);
-}
-
-static void *vt_h264_create_sw(obs_data_t *settings, obs_encoder_t *encoder)
-{
-	return vt_h264_create(settings, encoder, APPLE_H264_ENC_ID_SW);
 }
 
 static const uint8_t annexb_startcode[4] = {0, 0, 0, 1};
@@ -845,16 +831,16 @@ static bool vt_h264_extra_data(void *data, uint8_t **extra_data, size_t *size)
 	return true;
 }
 
-static const char *vt_h264_getname_hw(void *unused)
+static const char *vt_h264_getname(void *data)
 {
-	UNUSED_PARAMETER(unused);
-	return obs_module_text("VTH264EncHW");
-}
+	const char *disp_name = vt_encoders.array[(int)data].disp_name;
 
-static const char *vt_h264_getname_sw(void *unused)
-{
-	UNUSED_PARAMETER(unused);
-	return obs_module_text("VTH264EncSW");
+	if (strcmp("Apple H.264 (HW)", disp_name) == 0) {
+		return obs_module_text("VTH264EncHW");
+	} else if (strcmp("Apple H.264 (SW)", disp_name) == 0) {
+		return obs_module_text("VTH264EncSW");
+	}
+	return disp_name;
 }
 
 #define TEXT_VT_ENCODER obs_module_text("VTEncoder")
@@ -994,19 +980,11 @@ void register_encoders()
 	};
 
 	for (size_t i = 0; i < vt_encoders.num; i++) {
-		if (strcmp(vt_encoders.array[i].id, APPLE_H264_ENC_ID_HW) ==
-		    0) {
-			info.id = "vt_h264_hw";
-			info.get_name = vt_h264_getname_hw;
-			info.create = vt_h264_create_hw;
-			obs_register_encoder(&info);
-		} else if (strcmp(vt_encoders.array[i].id,
-				  APPLE_H264_ENC_ID_SW) == 0) {
-			info.id = "vt_h264_sw";
-			info.get_name = vt_h264_getname_sw;
-			info.create = vt_h264_create_sw;
-			obs_register_encoder(&info);
-		}
+		info.id = vt_encoders.array[i].id;
+		info.type_data = (void *)i;
+		info.get_name = vt_h264_getname;
+		info.create = vt_h264_create;
+		obs_register_encoder(&info);
 	}
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Updates for compatibility with Apple Silicon Macs, as documented in "[Addressing Architectural Differences in your macOS Code](https://developer.apple.com/documentation/apple_silicon/addressing_architectural_differences_in_your_macos_code)" 
The largest difference is the behavior of the timebase on Apple Silicon machines when running natively; this does not appear to impact OBS when running under Rosetta. The `mHostTime` returned by CoreAudio's `AudioTimeStamp` also appears to be scaled to the host's time base, so in order to ensure proper synchronization, it must be scaled to nanoseconds for OBS as well. OBS's `os_gettime_ns()` can be greatly simplified by simply using `clock_gettime_nsec_np()` as well -- this seems to have been added in macOS Sierra 10.12, so it shouldn't cause any major backwards compatibility issues, either.

### Motivation and Context
When running OBS Studio natively built for Apple Silicon, the following changes were necessary to have a working build. The `-pagezero_size` and `-image_base` linker options caused the app to be killed immediately on launch when included (and according to the latest "[Embedding LuaJIT](https://luajit.org/install.html)" instructions, these options are not needed for 2.1.
The other changes clean up how to get the nanosecond time in a manner compatible across architecture (it works on Intel and Apple Silicon), and are required to ensure the audio is properly synced and included in the stream.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Manually built dependencies for Apple Silicon (most compile fine by simply setting the "-arch" compiler flag accordingly, but a few had to be manually built independently for each architecture and stitched together with the "lipo" tool). Unfortunately, this is an exercise left to the reader.
Tested on both Apple Silicon hardware (MacBook Pro) running macOS Big Sur 11.2 Public Beta (20D5029f) under both Rosetta and as a native Apple Silicon Binary, as well as on an Intel MacBook Pro 16" running macOS Big Sur 11.1.
Ensured streaming to Twitch and recording to a file encoded properly using AVToolbox codecs, and verified both video and audio were present in stream.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
