### PR TITLE
mac-avcapture: Add additional capture presets

### DIFF
--- a/plugins/mac-avcapture/av-capture.mm
+++ b/plugins/mac-avcapture/av-capture.mm
@@ -1,3 +1,4 @@
+#import <AvailabilityMacros.h>
 #import <AVFoundation/AVFoundation.h>
 #import <CoreFoundation/CoreFoundation.h>
 #import <CoreMedia/CoreMedia.h>
@@ -1230,8 +1231,13 @@ static void *av_capture_create(obs_data_t *settings, obs_source_t *source)
 static NSArray *presets(void)
 {
 	return @[
-		//AVCaptureSessionPresetiFrame1280x720,
-		//AVCaptureSessionPresetiFrame960x540,
+	//AVCaptureSessionPresetiFrame1280x720,
+	//AVCaptureSessionPresetiFrame960x540,
+#if defined(MAC_OS_X_VERSION_10_15) && \
+	MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
+		AVCaptureSessionPreset3840x2160,
+		AVCaptureSessionPreset1920x1080,
+#endif
 		AVCaptureSessionPreset1280x720, AVCaptureSessionPreset960x540,
 		AVCaptureSessionPreset640x480, AVCaptureSessionPreset352x288,
 		AVCaptureSessionPreset320x240, AVCaptureSessionPresetHigh,
@@ -1252,6 +1258,11 @@ static NSString *preset_names(NSString *preset)
 		AVCaptureSessionPreset640x480: @"640x480",
 		AVCaptureSessionPreset960x540: @"960x540",
 		AVCaptureSessionPreset1280x720: @"1280x720",
+#if defined(MAC_OS_X_VERSION_10_15) && \
+	MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
+		AVCaptureSessionPreset1920x1080: @"1920x1080",
+		AVCaptureSessionPreset3840x2160: @"3840x2160",
+#endif
 		AVCaptureSessionPresetHigh: @"High",
 	};
 	NSString *name = preset_names[preset];


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This adds additional capture presets, including 3840x2160 and 1920x1080, in addition to the preset "High." There's no reason these can't be supported, they just haven't been added.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Newer capture hardware is capable of supporting these capture modes, so there's no reason that I can see to not include them.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Verified the capture is successful on a MacBook Pro running macOS Big Sur Public Beta (11.2 - 20D5029f) when paired with an Elgato HD60 S+ interface over USB.  This interface could only capture 4K at 30fps, which I verified using a 4K/30Hz source. 1080p@60Hz capture was also verified.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
