### PR TITLE
UI: fix the maximum search length of Hotkeys Filter

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2583,8 +2583,9 @@ LayoutHotkey(obs_hotkey_id id, obs_hotkey_t *key, Func &&fun,
 	auto *label = new OBSHotkeyLabel;
 	QString text = QT_UTF8(obs_hotkey_get_description(key));
 
+	label->setProperty("fullName", text);
+
 	if (text.length() > TRUNCATE_TEXT_LENGTH) {
-		label->setProperty("fullName", text);
 		text = text.left(TRUNCATE_TEXT_LENGTH);
 		text += "...'";
 	}
@@ -2722,7 +2723,10 @@ void OBSBasicSettings::LoadHotkeySettings(obs_hotkey_id ignoreKey)
 					qobject_cast<OBSHotkeyLabel *>(
 						label->widget());
 				if (item) {
-					if (item->text().toLower().contains(
+					QString fullname =
+						item->property("fullName")
+							.value<QString>();
+					if (fullname.toLower().contains(
 						    text.toLower()))
 						setRowVisible(i, true, label);
 					else


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
The "fullName" property was filled only in case of exceeding TRUNCATE_TEXT_LENGTH. The length now is 80 chars. Also search function had worked only with item->text() what was the reason of maximum search length in Hotkeys Filter(Setting->Hotkeys).

The following changes allow to search in filter without the length limit of string along with the current functionality.

<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
The issue is well described here https://github.com/obsproject/obs-studio/issues/3902
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
The bug has been reproduced and changes have been tested on 5.4.0-58-generic #64~18.04.1-Ubuntu  

![Screenshot from 2021-01-20 19-17-23](https://user-images.githubusercontent.com/32442477/105207137-35a22300-5b58-11eb-9a3b-1e9120953b65.png)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
