### PR TITLE
libobs: Fix dstr leak

### DIFF
--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -73,8 +73,9 @@ void *os_dlopen(const char *path)
 	dstr_replace(&dll_name, "\\", "/");
 	if (!dstr_find(&dll_name, ".dll"))
 		dstr_cat(&dll_name, ".dll");
-
 	os_utf8_to_wcs_ptr(dll_name.array, 0, &wpath);
+
+	dstr_free(&dll_name);
 
 	/* to make module dependency issues easier to deal with, allow
 	 * dynamically loaded libraries on windows to search for dependent
@@ -87,8 +88,8 @@ void *os_dlopen(const char *path)
 	}
 
 	h_library = LoadLibraryW(wpath);
+
 	bfree(wpath);
-	dstr_free(&dll_name);
 
 	if (wpath_slash)
 		SetDllDirectoryW(NULL);
@@ -156,8 +157,9 @@ bool os_is_obs_plugin(const char *path)
 	dstr_replace(&dll_name, "\\", "/");
 	if (!dstr_find(&dll_name, ".dll"))
 		dstr_cat(&dll_name, ".dll");
-
 	os_utf8_to_wcs_ptr(dll_name.array, 0, &wpath);
+
+	dstr_free(&dll_name);
 
 	hFile = CreateFileW(wpath, GENERIC_READ, FILE_SHARE_READ, NULL,
 			    OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);


### PR DESCRIPTION
### Description
Fix recently added leak.

### Motivation and Context
Leaks are bad.

### How Has This Been Tested?
OBS now reports 0 leaks.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.