### PR TITLE
rtmp-services: Include format version in update URL

### DIFF
--- a/plugins/rtmp-services/rtmp-services-main.c
+++ b/plugins/rtmp-services/rtmp-services-main.c
@@ -84,12 +84,14 @@ bool obs_module_load(void)
 #if !defined(_WIN32) || CHECK_FOR_SERVICE_UPDATES
 	char *local_dir = obs_module_file("");
 	char *cache_dir = obs_module_config_path("");
+	char update_url[128];
+	snprintf(update_url, sizeof(update_url), "%s/v%d", RTMP_SERVICES_URL,
+		 RTMP_SERVICES_FORMAT_VERSION);
 
 	if (cache_dir) {
 		update_info = update_info_create(RTMP_SERVICES_LOG_STR,
-						 module_name.array,
-						 RTMP_SERVICES_URL, local_dir,
-						 cache_dir,
+						 module_name.array, update_url,
+						 local_dir, cache_dir,
 						 confirm_service_file, NULL);
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Include the current format version in the path of the RTMP services URL.

### Motivation and Context
The format has been updated in a backwards-incompatible way, resulting in older OBS versions not being able to receive the latest services updates. Solving this problem requires server-side parsing of the User-Agent to deliver the correct format. In the future, this can be avoided by having OBS insert the required format version in the URI.

### How Has This Been Tested?
Compiled, verified that the correct URL is being downloaded (`https://obsproject.com/obs2_update/rtmp-services/v3/package.json`).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
