### PR TITLE
obs-filters: Fix pow arguments

### DIFF
--- a/plugins/obs-filters/data/chroma_key_filter_v2.effect
+++ b/plugins/obs-filters/data/chroma_key_filter_v2.effect
@@ -36,7 +36,7 @@ VertData VSDefault(VertData v_in)
 
 float4 CalcColor(float4 rgba)
 {
-	return float4(pow(rgba.rgb, gamma) * contrast + brightness, rgba.a);
+	return float4(pow(rgba.rgb, float3(gamma, gamma, gamma)) * contrast + brightness, rgba.a);
 }
 
 float GetChromaDist(float3 rgb)

--- a/plugins/obs-filters/data/color_correction_filter.effect
+++ b/plugins/obs-filters/data/color_correction_filter.effect
@@ -49,7 +49,7 @@ float4 PSColorFilterRGBA(VertData vert_in) : TARGET
 	float4 currentPixel = image.Sample(textureSampler, vert_in.uv);
 
 	/* Always address the gamma first. */
-	currentPixel.rgb = pow(currentPixel.rgb, gamma);
+	currentPixel.rgb = pow(currentPixel.rgb, float3(gamma, gamma, gamma));
 
 	/* Much easier to manipulate pixels for these types of operations
 	 * when in a matrix such as the below. See

--- a/plugins/obs-filters/data/color_key_filter_v2.effect
+++ b/plugins/obs-filters/data/color_key_filter_v2.effect
@@ -31,7 +31,7 @@ VertData VSDefault(VertData v_in)
 
 float4 CalcColor(float4 rgba)
 {
-	return float4(pow(rgba.rgb, gamma) * contrast + brightness, rgba.a);
+	return float4(pow(rgba.rgb, float3(gamma, gamma, gamma)) * contrast + brightness, rgba.a);
 }
 
 float GetColorDist(float3 rgb)


### PR DESCRIPTION
### Description
GLSL does not auto-promote float to vector where HLSL does.

### Motivation and Context
Filters broken on Linux.

### How Has This Been Tested?
Filters not broken anymore on Linux.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.