### PR TITLE
UI: Close context menu on destroy of VolControl

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -125,7 +125,8 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 	  levelCount(0.0f),
 	  obs_fader(obs_fader_create(OBS_FADER_LOG)),
 	  obs_volmeter(obs_volmeter_create(OBS_FADER_LOG)),
-	  vertical(vertical)
+	  vertical(vertical),
+	  contextMenu(nullptr)
 {
 	nameLabel = new QLabel();
 	volLabel = new QLabel();
@@ -291,6 +292,8 @@ VolControl::~VolControl()
 
 	obs_fader_destroy(obs_fader);
 	obs_volmeter_destroy(obs_volmeter);
+	if (contextMenu)
+		contextMenu->close();
 }
 
 QColor VolumeMeter::getBackgroundNominalColor() const

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -7,6 +7,7 @@
 #include <QTimer>
 #include <QMutex>
 #include <QList>
+#include <QMenu>
 
 class QPushButton;
 class VolumeMeterTimer;
@@ -219,6 +220,7 @@ private:
 	obs_fader_t *obs_fader;
 	obs_volmeter_t *obs_volmeter;
 	bool vertical;
+	QMenu *contextMenu;
 
 	static void OBSVolumeChanged(void *param, float db);
 	static void OBSVolumeLevel(void *data,
@@ -254,4 +256,5 @@ public:
 	void setPeakMeterType(enum obs_peak_meter_type peakMeterType);
 
 	void EnableSlider(bool enable);
+	inline void SetContextMenu(QMenu *cm) { contextMenu = cm; }
 };

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3301,6 +3301,7 @@ void OBSBasic::VolControlContextMenu()
 		pasteFiltersAction.setEnabled(true);
 
 	QMenu popup;
+	vol->SetContextMenu(&popup);
 	popup.addAction(&lockAction);
 	popup.addSeparator();
 	popup.addAction(&unhideAllAction);
@@ -3316,6 +3317,7 @@ void OBSBasic::VolControlContextMenu()
 	popup.addAction(&propertiesAction);
 	popup.addAction(&advPropAction);
 	popup.exec(QCursor::pos());
+	vol->SetContextMenu(nullptr);
 }
 
 void OBSBasic::on_hMixerScrollArea_customContextMenuRequested()


### PR DESCRIPTION
### Description
Close context menu on destroy of VolControl

### Motivation and Context
Fix crash of OBS
Steps to reproduce:
- open context menu of a volume control
- use hotkey to switch to a scene without the source you have the context menu open for
- click properties or filters option in the context menu

### How Has This Been Tested?
On windows 64bit by replicating the steps above.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
