### PR TITLE
CI: use a KDE image for Flatpak

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -13,7 +13,7 @@ jobs:
     name: Bundle
     runs-on: [ubuntu-latest]
     container:
-      image: docker.io/bilelmoussaoui/flatpak-github-actions
+      image: bilelmoussaoui/flatpak-github-actions:kde-5.15
       options: --privileged
     steps:
     - name: 'Check for Github Labels'


### PR DESCRIPTION
### Description
Use the KDE image for Flatpak CI

### Motivation and Context
The KDE images comes with the SDK needed pre-installed and should avoid re-downloading/installing it everytime. This should hopefully reduce the build time by a few minutes 

Details at https://github.com/bilelmoussaoui/flatpak-github-actions#docker-image

### How Has This Been Tested?

It needs the Seeking Testers label to be tested, since the Flatpak workflow skips pull requests without it

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
