### PR TITLE
libobs, linux-v4l2: Set thread names

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -1373,6 +1373,8 @@ void *obs_hotkey_thread(void *arg)
 {
 	UNUSED_PARAMETER(arg);
 
+	os_set_thread_name("libobs: hotkey thread");
+
 	const char *hotkey_thread_name =
 		profile_store_name(obs_get_profiler_name_store(),
 				   "obs_hotkey_thread(%g" NBSP "ms)", 25.);

--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -169,6 +169,7 @@ static void *v4l2_thread(void *vptr)
 	uint64_t timeout_usec;
 
 	blog(LOG_DEBUG, "%s: new capture thread", data->device_id);
+	os_set_thread_name("v4l2: capture");
 
 	/* Get framerate and calculate appropriate select timeout value. */
 	v4l2_unpack_tuple(&fps_num, &fps_denom, data->framerate);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Sets the thread name for the hotkey thread. Name chosen to match the graphics thread naming.
Sets thread name for the v4l2 capture thread.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Currently these threads are either unnamed or inherits the main libobs name which can be marginally confusing.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
It compiles and gdb shows the right thread names.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
