### PR TITLE
UI, linux-v4l2: Assorted fixes

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6316,7 +6316,8 @@ void OBSBasic::OnVirtualCamStart()
 		return;
 
 	vcamButton->setText(QTStr("Basic.Main.StopVirtualCam"));
-	sysTrayVirtualCam->setText(QTStr("Basic.Main.StopVirtualCam"));
+	if (sysTrayVirtualCam)
+		sysTrayVirtualCam->setText(QTStr("Basic.Main.StopVirtualCam"));
 	vcamButton->setChecked(true);
 
 	if (api)
@@ -6333,7 +6334,8 @@ void OBSBasic::OnVirtualCamStop(int)
 		return;
 
 	vcamButton->setText(QTStr("Basic.Main.StartVirtualCam"));
-	sysTrayVirtualCam->setText(QTStr("Basic.Main.StartVirtualCam"));
+	if (sysTrayVirtualCam)
+		sysTrayVirtualCam->setText(QTStr("Basic.Main.StartVirtualCam"));
 	vcamButton->setChecked(false);
 
 	if (api)

--- a/plugins/linux-v4l2/linux-v4l2.c
+++ b/plugins/linux-v4l2/linux-v4l2.c
@@ -26,18 +26,7 @@ MODULE_EXPORT const char *obs_module_description(void)
 
 extern struct obs_source_info v4l2_input;
 extern struct obs_output_info virtualcam_info;
-
-static bool v4l2loopback_installed()
-{
-	bool loaded = false;
-
-	int ret = system("modinfo v4l2loopback >/dev/null 2>&1");
-
-	if (ret == 0)
-		loaded = true;
-
-	return loaded;
-}
+extern bool loopback_module_available();
 
 bool obs_module_load(void)
 {
@@ -45,7 +34,7 @@ bool obs_module_load(void)
 
 	obs_data_t *obs_settings = obs_data_create();
 
-	if (v4l2loopback_installed()) {
+	if (loopback_module_available()) {
 		obs_register_output(&virtualcam_info);
 		obs_data_set_bool(obs_settings, "vcamEnabled", true);
 	} else {

--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -50,10 +50,24 @@ static bool loopback_module_loaded()
 	return loaded;
 }
 
+bool loopback_module_available()
+{
+	if (loopback_module_loaded()) {
+		return true;
+	}
+
+	if (system("PATH=\"$PATH:/sbin\" modinfo v4l2loopback >/dev/null 2>&1") ==
+	    0) {
+		return true;
+	}
+
+	return false;
+}
+
 static int loopback_module_load()
 {
 	return system(
-		"pkexec modprobe v4l2loopback exclusive_caps=1 card_label='OBS Virtual Camera' && sleep 0.5");
+		"PATH=\"$PATH:/sbin\" pkexec modprobe v4l2loopback exclusive_caps=1 card_label='OBS Virtual Camera' && sleep 0.5");
 }
 
 static void *virtualcam_create(obs_data_t *settings, obs_output_t *output)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Expand PATH for Debian-like systems.
Moves v4l2 module checks together.
Improve detection when the module is already loaded.
Fix crash when systray is not enabled

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Improve life for everyone.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on dkms systems with and without modprobe on path. Systray check looks other similar checks for systray elements.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
