### PR TITLE
linux-v4l2: added range check for try_connect()

### DIFF
--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -93,7 +93,9 @@ static bool try_connect(void *data, int device)
 	vcam->frame_size = width * height * 2;
 
 	char new_device[16];
-	sprintf(new_device, "/dev/video%d", device);
+	if (device < 0 || device >= MAX_DEVICES)
+		return false;
+	snprintf(new_device, 16, "/dev/video%d", device);
 
 	vcam->device = open(new_device, O_RDWR);
 


### PR DESCRIPTION
### Description, Motivation and Context

While the current code only ever calls try_connect() with the input
argument 'device' in the range of 0 and MAX_DEVICES, this adds a check
to ensure that future code does not break the following sprintf.

In addition, use snprintf instead of sprintf to ensure that if anything
breaks, the sprintf does not lead to memory corruption. Again, the new
check should already make sure of that, but the additional effort of
using snprintf instead of sprintf is so low that it is worth to have a
little more security in the future.

### How Has This Been Tested?
Device detection still worked with this change.

This used current-git-master on a Debian 10 system,
even with a self-compiled v4l2loopback module outside
of the main kernel tree.

### Types of changes
- Code cleanup (non-breaking change which makes code more secure)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
