### PR TITLE
Update of E2k support

### DIFF
--- a/deps/libcaption/caption/caption.h
+++ b/deps/libcaption/caption/caption.h
@@ -99,7 +99,7 @@ static inline int caption_frame_painton(caption_frame_t* frame) { return (frame-
 /*! \brief
     \param
 */
-const static int _caption_frame_rollup[] = { 0, 2, 3, 4 };
+static const int _caption_frame_rollup[] = { 0, 2, 3, 4 };
 static inline int caption_frame_rollup(caption_frame_t* frame) { return _caption_frame_rollup[frame->state.rup]; }
 /*! \brief
     \param

--- a/deps/libcaption/caption/cea708.h
+++ b/deps/libcaption/caption/cea708.h
@@ -87,8 +87,8 @@ typedef struct {
     double timestamp;
 } cea708_t;
 
-const static uint32_t GA94 = (('G' << 24) | ('A' << 16) | ('9' << 8) | '4');
-const static uint32_t DTG1 = (('D' << 24) | ('T' << 16) | ('G' << 8) | '1');
+static const uint32_t GA94 = (('G' << 24) | ('A' << 16) | ('9' << 8) | '4');
+static const uint32_t DTG1 = (('D' << 24) | ('T' << 16) | ('G' << 8) | '1');
 
 /*! \brief
     \param


### PR DESCRIPTION
### Description
As of support for Elbrus has been introduced in PR #3288, this pull request improves support for building obs-studio on Elbrus hardware platform (which is based on Russian [Elbrus](https://en.wikipedia.org/wiki/Elbrus-8S) CPU family) with its native lcc (eLbrus Compiler Collection) compiler.

### Motivation and Context
It allows current master of OBS be built on Elbrus out-of-the-box (and use SIMD functionality with altered version of SIMDE as of [this PR](https://github.com/simd-everywhere/simde/pull/700)).

### How Has This Been Tested?
Build and testing plan:

* Build on Elbrus workstation (e2k-linux-gnu) and run there.
* Build on x86_64 workstation (x86_64-linux-gnu) and run there (to be sure that nothing is broken on x86_64).

Details of Elbrus workstation:

* CPU: Elbrus-8C (formerly Elbrus-8S) running on 1300 MHz
* Motherboard: E8C-EATX
* OS: OS Elbrus 6.0.0
* GPU: Advanced Micro Devices, Inc. [AMD/ATI] Ellesmere Radeon RX 580 (rev e7)
* Kernel: 5.4.0-2.3-e8c
* Compiler: lcc:1.25.09:Oct--1-2020:e2k-v4-linux gcc (GCC) 7.3.0 compatible

Details of x86_64 workstation:

* CPU: AMD Ryzen Threadripper 2990WX 32-Core Processor running at 3.0 GHz
* Motherboard: MSI X399 SLI PLUS (MS-7B09)
* GPU: Advanced Micro Devices, Inc. [AMD/ATI] Caicos [Radeon HD 6450/7450/8450 / R5 230 OEM]
* OS: Ubuntu 20.04.1 LTS
* Kernel:  5.4.0-54-generic #60-Ubuntu
* Compiler: gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0

Results:

* Successfully performed `mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=Release .. && make -j16 && sudo make install`, and ran `obs` on both workstations; no suspicious behavior found.

### Types of changes
* New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
