### PR TITLE
obs-outputs: fix RTMP reconnect (fixes #2865)

### DIFF
--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -463,6 +463,17 @@ RTMP_Init(RTMP *r)
 {
     memset(r, 0, sizeof(RTMP));
     r->m_sb.sb_socket = -1;
+    RTMP_Reset(r);
+
+#ifdef CRYPTO
+    RTMP_TLS_Init(r);
+#endif
+
+}
+
+void
+RTMP_Reset(RTMP *r)
+{
     r->m_inChunkSize = RTMP_DEFAULT_CHUNKSIZE;
     r->m_outChunkSize = RTMP_DEFAULT_CHUNKSIZE;
     r->m_bSendChunkSizeInfo = 1;
@@ -476,11 +487,6 @@ RTMP_Init(RTMP *r)
     r->Link.nStreams = 0;
     r->Link.timeout = 30;
     r->Link.swfAge = 30;
-
-#ifdef CRYPTO
-    RTMP_TLS_Init(r);
-#endif
-
 }
 
 void

--- a/plugins/obs-outputs/librtmp/rtmp.h
+++ b/plugins/obs-outputs/librtmp/rtmp.h
@@ -506,6 +506,7 @@ extern "C"
     int RTMP_ClientPacket(RTMP *r, RTMPPacket *packet);
 
     void RTMP_Init(RTMP *r);
+    void RTMP_Reset(RTMP *r);
     void RTMP_Close(RTMP *r);
     RTMP *RTMP_Alloc(void);
     void RTMP_TLS_Free(RTMP *r);

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -969,8 +969,9 @@ static int try_connect(struct rtmp_stream *stream)
 
 	info("Connecting to RTMP URL %s...", stream->path.array);
 
-	// this should have been called already by rtmp_stream_create
-	//RTMP_Init(&stream->rtmp);
+	// on reconnect we need to reset the internal variables of librtmp
+	// otherwise the data sent/received will not parse correctly on the other end
+	RTMP_Reset(&stream->rtmp);
 
 	// since we don't call RTMP_Init above, there's no other good place
 	// to reset this as doing it in RTMP_Close breaks the ugly RTMP


### PR DESCRIPTION
### Description
This commit splits RTMP_Init off into a new RTMP_Reset function, which resets the internal connection state variables without re-initing the rest of the library.
The original RTMP_Init calls the new function, perfectly preserving the old behaviour while adding a new reset function to address the issue with.

### Motivation and Context
Fixes #2865 (RTMP reconnects fail).
Bug is caused by the internal connection variables not being reset on reconnect, leading OBS to both be unable to parse valid packets from and send valid packets to the remote end.

### How Has This Been Tested?
Tested using portable mode install against an unpatched media server (specifically: MistServer), by streaming to localhost on a Linux machine. Bug can no longer be reproduced by me with this commit applied. Since the only changes to the RTMP connection are local variables about the current connection state, and these are only overwritten on (re)connect, this should not cause any other code to break. Only RTMP (re)connect has any changes.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
