### PR TITLE
Re-enable native filepicker

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1940,10 +1940,6 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 #endif
 
-#if !defined(_WIN32) && !defined(__APPLE__) && BROWSER_AVAILABLE
-	setenv("QT_NO_GLIB", "1", true);
-#endif
-
 	QCoreApplication::addLibraryPath(".");
 
 #if __APPLE__

--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -351,16 +351,9 @@ void setThemeID(QWidget *widget, const QString &themeID)
 
 QString SelectDirectory(QWidget *parent, QString title, QString path)
 {
-#if defined(BROWSER_AVAILABLE) && defined(__linux__)
-	QString dir = QFileDialog::getExistingDirectory(
-		parent, title, path,
-		QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks |
-			QFileDialog::DontUseNativeDialog);
-#else
 	QString dir = QFileDialog::getExistingDirectory(
 		parent, title, path,
 		QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
-#endif
 
 	return dir;
 }
@@ -368,14 +361,8 @@ QString SelectDirectory(QWidget *parent, QString title, QString path)
 QString SaveFile(QWidget *parent, QString title, QString path,
 		 QString extensions)
 {
-#if defined(BROWSER_AVAILABLE) && defined(__linux__)
-	QString file = QFileDialog::getSaveFileName(
-		parent, title, path, extensions, nullptr,
-		QFileDialog::DontUseNativeDialog);
-#else
 	QString file =
 		QFileDialog::getSaveFileName(parent, title, path, extensions);
-#endif
 
 	return file;
 }
@@ -383,14 +370,8 @@ QString SaveFile(QWidget *parent, QString title, QString path,
 QString OpenFile(QWidget *parent, QString title, QString path,
 		 QString extensions)
 {
-#if defined(BROWSER_AVAILABLE) && defined(__linux__)
-	QString file = QFileDialog::getOpenFileName(
-		parent, title, path, extensions, nullptr,
-		QFileDialog::DontUseNativeDialog);
-#else
 	QString file =
 		QFileDialog::getOpenFileName(parent, title, path, extensions);
-#endif
 
 	return file;
 }
@@ -398,14 +379,8 @@ QString OpenFile(QWidget *parent, QString title, QString path,
 QStringList OpenFiles(QWidget *parent, QString title, QString path,
 		      QString extensions)
 {
-#if defined(BROWSER_AVAILABLE) && defined(__linux__)
-	QStringList files = QFileDialog::getOpenFileNames(
-		parent, title, path, extensions, nullptr,
-		QFileDialog::DontUseNativeDialog);
-#else
 	QStringList files =
 		QFileDialog::getOpenFileNames(parent, title, path, extensions);
-#endif
 
 	return files;
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Re-enable native file pickers in Linux when the browser plugin is enabled.

### Motivation and Context

After the recent CEF upgrade, it seems Chromium doesn't conflict with GMainLoop anymore, so the reason to disable platform native file choosers, and the GLib mainloop integration, is gone.

### How Has This Been Tested?

Build with the browser plugin, add a Browser source, and open any file using OBS Studio.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
 - Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
