### PR TITLE
UI: Add obs_frontend_reset_video() function

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -571,6 +571,8 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		return os_atomic_load_bool(&virtualcam_active);
 	}
 
+	void obs_frontend_reset_video(void) override { main->ResetVideo(); }
+
 	void on_load(obs_data_t *settings) override
 	{
 		for (size_t i = saveCallbacks.size(); i > 0; i--) {

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -499,3 +499,9 @@ bool obs_frontend_virtualcam_active(void)
 	return !!callbacks_valid() ? c->obs_frontend_virtualcam_active()
 				   : false;
 }
+
+void obs_frontend_reset_video(void)
+{
+	if (callbacks_valid())
+		c->obs_frontend_reset_video();
+}

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -206,6 +206,8 @@ EXPORT void obs_frontend_start_virtualcam(void);
 EXPORT void obs_frontend_stop_virtualcam(void);
 EXPORT bool obs_frontend_virtualcam_active(void);
 
+EXPORT void obs_frontend_reset_video(void);
+
 /* ------------------------------------------------------------------------- */
 
 #ifdef __cplusplus

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -127,6 +127,8 @@ struct obs_frontend_callbacks {
 	virtual void obs_frontend_start_virtualcam(void) = 0;
 	virtual void obs_frontend_stop_virtualcam(void) = 0;
 	virtual bool obs_frontend_virtualcam_active(void) = 0;
+
+	virtual void obs_frontend_reset_video(void) = 0;
 };
 
 EXPORT void

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -589,3 +589,9 @@ Functions
 .. function:: bool obs_frontend_virtualcam_active(void)
 
    :return: *true* if virtual camera is active, *false* otherwise.
+
+---------------------------------------
+
+.. function:: void obs_frontend_reset_video(void)
+
+   Reloads the UI canvas and resets libobs video with latest data from profile.


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a new api function `obs_frontend_reset_video()` which calls the internal `ResetVideo()` UI function to reload the video with any new settings. Useful when changing video settings via plugins.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This is required in order to implement a new request `SetVideoSettings` into obs-websocket. When profile settings are changed, we must be able to reset the video in order to apply them. `obs_reset_video()` only resets the libobs side and as such is not useful.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Been using this in combination with a private obs-websocket branch for almost 6 months now to adjust video settings over websocket. OBS running on Ubuntu 20.04 Desktop

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
