### PR TITLE
win-dshow: Add autorotation toggle

### DIFF
--- a/plugins/win-dshow/data/locale/en-US.ini
+++ b/plugins/win-dshow/data/locale/en-US.ini
@@ -33,6 +33,7 @@ Buffering.Disable="Disable"
 Activate="Activate"
 Deactivate="Deactivate"
 FlipVertically="Flip Vertically"
+Autorotation="Apply rotation data from camera (if any)"
 DeactivateWhenNotShowing="Deactivate when not showing"
 
 # encoder text

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -46,6 +46,7 @@ using namespace DShow;
 #define COLOR_SPACE       "color_space"
 #define COLOR_RANGE       "color_range"
 #define DEACTIVATE_WNS    "deactivate_when_not_showing"
+#define AUTOROTATION      "autorotation"
 
 #define TEXT_INPUT_NAME     obs_module_text("VideoCaptureDevice")
 #define TEXT_DEVICE         obs_module_text("Device")
@@ -64,6 +65,7 @@ using namespace DShow;
 #define TEXT_BUFFERING_ON   obs_module_text("Buffering.Enable")
 #define TEXT_BUFFERING_OFF  obs_module_text("Buffering.Disable")
 #define TEXT_FLIP_IMAGE     obs_module_text("FlipVertically")
+#define TEXT_AUTOROTATION   obs_module_text("Autorotation")
 #define TEXT_AUDIO_MODE     obs_module_text("AudioOutputMode")
 #define TEXT_MODE_CAPTURE   obs_module_text("AudioOutputMode.Capture")
 #define TEXT_MODE_DSOUND    obs_module_text("AudioOutputMode.DirectSound")
@@ -181,6 +183,7 @@ struct DShowInput {
 	bool deviceHasSeparateAudioFilter = false;
 	bool flip = false;
 	bool active = false;
+	bool autorotation = true;
 
 	Decoder audio_decoder;
 	Decoder video_decoder;
@@ -522,7 +525,7 @@ void DShowInput::OnVideoData(const VideoConfig &config, unsigned char *data,
 			     size_t size, long long startTime,
 			     long long endTime, long rotation)
 {
-	if (rotation != lastRotation) {
+	if (autorotation && rotation != lastRotation) {
 		lastRotation = rotation;
 		obs_source_set_async_rotation(source, rotation);
 	}
@@ -868,6 +871,7 @@ bool DShowInput::UpdateVideoConfig(obs_data_t *settings)
 	string video_device_id = obs_data_get_string(settings, VIDEO_DEVICE_ID);
 	deactivateWhenNotShowing = obs_data_get_bool(settings, DEACTIVATE_WNS);
 	flip = obs_data_get_bool(settings, FLIP_IMAGE);
+	autorotation = obs_data_get_bool(settings, AUTOROTATION);
 
 	DeviceId id;
 	if (!DecodeDeviceId(id, video_device_id.c_str())) {
@@ -1191,6 +1195,7 @@ static void GetDShowDefaults(obs_data_t *settings)
 	obs_data_set_default_string(settings, COLOR_RANGE, "default");
 	obs_data_set_default_int(settings, AUDIO_OUTPUT_MODE,
 				 (int)AudioMode::Capture);
+	obs_data_set_default_bool(settings, AUTOROTATION, true);
 }
 
 struct Resolution {
@@ -1939,6 +1944,8 @@ static obs_properties_t *GetDShowProperties(void *obj)
 					  obs_module_text("Buffering.ToolTip"));
 
 	obs_properties_add_bool(ppts, FLIP_IMAGE, TEXT_FLIP_IMAGE);
+
+	obs_properties_add_bool(ppts, AUTOROTATION, TEXT_AUTOROTATION);
 
 	/* ------------------------------------- */
 	/* audio settings */


### PR DESCRIPTION
### Description

A new toggle has been added to DirectShow's plugin video capture settings to allow enabling/disabling autorotation of the video source.

### Motivation and Context

I'm trying to use a Logitech StreamCam to record my desk. This camera sends rotation information that is then used by OBS's DirectShow plugin to rotate the video (think it's currently [the only camera that does this](https://github.com/obsproject/libdshowcapture/blob/afca513c7ad555e273a55eaa9ab9bc9447218d49/source/device.cpp#L264) 😅).

Because of the camera position (top view of my desk, with the lens in parallel to it), the rotation sensor goes crazy, being triggered by the lightest touch to the desk (or even on its own). You can check the issue on [this video](http://www.youtube.com/watch?v=042OG-OEot0).

[![Autorotation Hell](http://img.youtube.com/vi/042OG-OEot0/0.jpg)](http://www.youtube.com/watch?v=042OG-OEot0 "Autorotation Hell")

The DirectShow plugin [gets and forwards camera rotation status](https://github.com/obsproject/libdshowcapture/blob/afca513c7ad555e273a55eaa9ab9bc9447218d49/source/device.cpp#L115-L122) to OBS which then applies it immediatly. This behaviour is undesirable in situations like this one, but it couldn't be disabled either at system level, using Logitech's software ([apparently they acknowledge that](https://www.reddit.com/r/logitech/comments/kpwtca/streamcam_auto_rotate/glqf9hk)) or from OBS, so I've added a new toggle to DirectShow's plugin video capture settings to allow enabling/disabling this behaviour ("Apply rotation data from camera").

![image](https://user-images.githubusercontent.com/1395606/107151484-19c5bc00-6963-11eb-9831-67a82f08637d.png)

### How Has This Been Tested?

This plugin affects the Windows version (Linux doesn't apply the rotation data from the camera and Mac seems to ignore it too unless Logitech's app is installed). I've compiled OBS on Windows 10 x64 and tested the toggle behaviour using a Logitech StreamCam.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
