### PR TITLE
UI: Add ability for stingers to use filters

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -657,6 +657,7 @@ void OBSBasic::on_transitionProps_clicked()
 		return;
 
 	auto properties = [&]() { CreatePropertiesWindow(source); };
+	auto filters = [&]() { CreateFiltersWindow(source); };
 
 	QMenu menu(this);
 
@@ -673,6 +674,13 @@ void OBSBasic::on_transitionProps_clicked()
 	action = new QAction(QTStr("Properties"), &menu);
 	connect(action, &QAction::triggered, properties);
 	menu.addAction(action);
+
+	if (strcmp(obs_source_get_unversioned_id(source),
+		   "obs_stinger_transition") == 0) {
+		action = new QAction(QTStr("Filters"), &menu);
+		connect(action, &QAction::triggered, filters);
+		menu.addAction(action);
+	}
 
 	menu.exec(QCursor::pos());
 }


### PR DESCRIPTION
### Description
This adds a menu item in the transitions config menu to access
filters for stinger transitions.

#### TODO
- [ ] Use actual media source instead of transition source
- [ ] Filters don't save when exiting

### Motivation and Context
Users have requested filters for stingers.

### How Has This Been Tested?
Applied filters to stinger transitions to made sure it worked.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
