### PR TITLE
decklink-ui: fix double free of settings

### DIFF
--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
@@ -68,7 +68,6 @@ void output_start()
 					   settings, NULL);
 
 		bool started = obs_output_start(output);
-		obs_data_release(settings);
 
 		main_output_running = started;
 


### PR DESCRIPTION
### Description

This leads to a crash when the output is stopped, either by clicking the
stop button or when exiting OBS studio.

Example with clear trace: https://obsproject.com/logs/UokqjcvadJ9pEesu

This crash is:
- rare in release builds
- reliable for me (100% so far) in debug builds

It is held by an `OBSData`, which, if not null, will automatically
call `obs_data_release()` on scope exit.

### Motivation and Context

Fixes a crash.

### How Has This Been Tested?

1. Tools -> Decklink Output
2. Enable autostart of main output
3. restart obs
4. Tools -> Decklink Output
5. click 'stop' by main output

#### With this patch

output reliably stops without a crash

#### Without this patch

- release builds: intermittent crash (say 10% of the time)
- debug builds: reliable crash (appears to be 100% of the time)

Windows 10 Pro x64 10.0.19042
DeckLink Mini Monitor 4k
Visual Studio 2019 16.8.4
Qt 5.15.2

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
