### PR TITLE
rtmp-services: Add OPENREC.tv service

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -631,6 +631,9 @@ void AutoConfigStreamPage::UpdateKeyLink()
 		streamKeyLink = "https://studio.trovo.live/mychannel/stream";
 	} else if (serviceName == "Glimesh") {
 		streamKeyLink = "https://glimesh.tv/users/settings/stream";
+	} else if (serviceName.startsWith("OPENREC.tv")) {
+		streamKeyLink =
+			"https://www.openrec.tv/login?keep_login=true&url=https://www.openrec.tv/dashboard/live?from=obs";
 	}
 
 	if (QString(streamKeyLink).isNull()) {

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -290,6 +290,9 @@ void OBSBasicSettings::UpdateKeyLink()
 		streamKeyLink = "https://studio.trovo.live/mychannel/stream";
 	} else if (serviceName == "Glimesh") {
 		streamKeyLink = "https://glimesh.tv/users/settings/stream";
+	} else if (serviceName.startsWith("OPENREC.tv")) {
+		streamKeyLink =
+			"https://www.openrec.tv/login?keep_login=true&url=https://www.openrec.tv/dashboard/live?from=obs";
 	}
 
 	if (QString(streamKeyLink).isNull()) {

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1983,6 +1983,20 @@
                 "bframes": 0,
                 "x264opts": "scenecut=0"
             }
+        },
+        {
+            "name": "OPENREC.tv - Premium member (プレミアム会員)",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://a.station.openrec.tv:1935/live1"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 5000,
+                "max audio bitrate": 160
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
add streaming service "OPENREC.tv" into "plugins/rtmp-services/data/services.json".
add stream key link for "OPENREC.tv"

### Motivation and Context
This change allows users to stream without complicated operations.

### Types of changes
- New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
- JSON is valid
- I confirmed that it works after build. I checked on Mac and Windows.


### Checklist:
- [x] My code has been run through clang-format.
- [x] I have read the contributing document.
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.