### PR TITLE
flatpak: Disable browser for now

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -223,35 +223,11 @@
       ]
     },
     {
-      "name": "cef",
-      "buildsystem": "cmake-ninja",
-      "no-make-install": true,
-      "make-args": [
-        "libcef_dll_wrapper"
-      ],
-      "build-commands": [
-        "mkdir -p /app/cef/libcef_dll_wrapper",
-        "cp -R ./include /app/cef",
-        "cp -R ./Release /app/cef",
-        "cp -R ./Resources /app/cef",
-        "cp -R ./libcef_dll_wrapper/libcef_dll_wrapper.a /app/cef/libcef_dll_wrapper"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://cef-builds.spotifycdn.com/cef_binary_76.1.13+gf19c584+chromium-76.0.3809.132_linux64_minimal.tar.bz2",
-          "sha256": "6b0dfa8ddafcec822fcd20018cf081959ffa6d0565be3793da1f596ac0733c38"
-        }
-      ]
-    },
-    {
       "name": "obs",
       "buildsystem": "cmake-ninja",
       "builddir": true,
       "config-opts": [
         "-DCMAKE_BUILD_TYPE=Release",
-        "-DBUILD_BROWSER=ON",
-        "-DCEF_ROOT_DIR=/app/cef",
         "-DUNIX_STRUCTURE=ON",
         "-DUSE_XDG=ON",
         "-DDISABLE_ALSA=ON",


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Disable the obs-browser plugin from the Flatpak (experimental) workflow.

### Motivation and Context

The Chromium sandbox is conflicting with the Flatpak sandbox in a non-trivial,
non-workaroundable way. Until Chromium / CEF provides a way to unconditionally
disable the entire sandbox, let's not degrade the Flatpak experience.

### How Has This Been Tested?

TBD

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
