### PR TITLE
UI: Fix screen resolution calculation for Canvas (Base) Resolution

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1563,7 +1563,15 @@ void OBSBasicSettings::LoadResolutionLists()
 
 	for (QScreen *screen : QGuiApplication::screens()) {
 		QSize as = screen->size();
-		addRes(as.width(), as.height());
+		uint32_t as_width = as.width();
+		uint32_t as_height = as.height();
+
+		// Calculate physical screen resolution based on the virtual screen resolution
+		// They might differ if scaling is enabled, e.g. for HiDPI screens
+		as_width = round(as_width * screen->devicePixelRatio());
+		as_height = round(as_height * screen->devicePixelRatio());
+
+		addRes(as_width, as_height);
 	}
 
 	addRes(1920, 1080);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
In #3988, @RytoEx mentioned that the recent Qt upgrade to 5.15.2 introduced a regression in which Qt begins returning DPI/scaling aware resolutions for each screen. While this was fixed for new profiles, this was not reflected in the choice for the Canvas (Base) Resolution in the Settings screen yet.

This commits fixes this issue, and calculates the correct physical screen size again, respecting per-screen DPI scaling.

NOTE: The previous commits related to HiDPI scaling usually use the following ifdef block:
```cpp
#ifdef SUPPORTS_FRACTIONAL_SCALING
	cx *= devicePixelRatioF();
	cy *= devicePixelRatioF();
#elif
	cx *= devicePixelRatio();
	cy *= devicePixelRatio();
#endif
```
For this commit, I used the `devicePixelRatio()` which is supplied by `QScreen`, which returns a `qreal` value (and thus, would fall under fractional scaling) as the other implementations so far do not respect per-screen scaling correctly. For example, adding the above block instead of `screen->devicePixelRatio()` would work for my main screen at 3000x2000, but my secondary screen would be added as 3840x2160 instead of just 1920x1080.

Given that I have never worked so far on the OBS codebase and I am not sure if this is an potential issue or not, feedback would be appreciated here :).

### Motivation and Context
On the current OBS Studio release (26.1.1), the maximum Base (Canvas) Resolution suggested is only 1500x1000, which is half of my primary screen's real resolution (3000x2000 @ 200% DPI scaling for the main screen). This made adding a Screen or Window Capture awkward, as they always seemed to grab the physical resolution, yet I always had to scale them down manually due to this mistake.

Previously:
![The bug.](https://user-images.githubusercontent.com/26608194/107822561-99e28c00-6d7e-11eb-9198-0f853af5188e.png)

Afterwards:
![With the new commit](https://user-images.githubusercontent.com/26608194/107822588-a5ce4e00-6d7e-11eb-8fa7-abd5bdf04866.png)



### How Has This Been Tested?
Hardware: Microsoft Surface Book 2
Operating System: Windows 10 Pro ver. 2004 (10.0.19042.746)
Screens: 
- 3000x2000 internal screen @ 200% DPI Scaling
- 1920x1080 external screen over HDMI @ 100% DPI Scaling

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] The code has been tested.
- [x] My code is not on the master branch.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
