### PR TITLE
libobs: Pulseaudio audio-monitoring list sinks

### DIFF
--- a/libobs/audio-monitoring/pulse/pulseaudio-enum-devices.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-enum-devices.c
@@ -25,7 +25,7 @@ void obs_enum_audio_monitoring_devices(obs_enum_audio_device_cb cb, void *data)
 
 	pulseaudio_init();
 	pa_source_info_cb_t pa_cb = pulseaudio_output_info;
-	pulseaudio_get_source_info_list(pa_cb, (void *)ecb);
+	pulseaudio_get_sink_info_list(pa_cb, (void *)ecb);
 	pulseaudio_unref();
 
 	bfree(ecb);

--- a/libobs/audio-monitoring/pulse/pulseaudio-output.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-output.c
@@ -386,10 +386,21 @@ static bool audio_monitor_init(struct audio_monitor *monitor,
 
 	pulseaudio_init();
 
+	//This id still needed if old config was loaded
+	size_t dev_len = strlen(id) - 8;
+	char *device = bzalloc(dev_len + 1);
+	memcpy(device, id, dev_len);
+
+	if (strcmp(id + dev_len, "monitor")) {
+		id = device;
+	}
+
 	if (strcmp(id, "default") == 0)
 		get_default_id(&monitor->device);
 	else
 		monitor->device = bstrdup(id);
+
+	bfree(device);
 
 	if (!monitor->device)
 		return false;
@@ -400,8 +411,8 @@ static bool audio_monitor_init(struct audio_monitor *monitor,
 		return false;
 	}
 
-	if (pulseaudio_get_source_info(pulseaudio_source_info, monitor->device,
-				       (void *)monitor) < 0) {
+	if (pulseaudio_get_sink_info(pulseaudio_source_info, monitor->device,
+				     (void *)monitor) < 0) {
 		blog(LOG_ERROR, "Unable to get source info !");
 		return false;
 	}

--- a/libobs/audio-monitoring/pulse/pulseaudio-wrapper.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-wrapper.c
@@ -54,7 +54,6 @@ void get_default_id(char **id)
 	} else {
 		*id = bzalloc(strlen(pdo->default_sink_name) + 9);
 		strcat(*id, pdo->default_sink_name);
-		strcat(*id, ".monitor");
 		bfree(pdo->default_sink_name);
 	}
 
@@ -221,16 +220,15 @@ void pulseaudio_accept()
 	pa_threaded_mainloop_accept(pulseaudio_mainloop);
 }
 
-int_fast32_t pulseaudio_get_source_info_list(pa_source_info_cb_t cb,
-					     void *userdata)
+int_fast32_t pulseaudio_get_sink_info_list(pa_sink_info_cb_t cb, void *userdata)
 {
 	if (pulseaudio_context_ready() < 0)
 		return -1;
 
 	pulseaudio_lock();
 
-	pa_operation *op = pa_context_get_source_info_list(pulseaudio_context,
-							   cb, userdata);
+	pa_operation *op =
+		pa_context_get_sink_info_list(pulseaudio_context, cb, userdata);
 	if (!op) {
 		pulseaudio_unlock();
 		return -1;
@@ -244,16 +242,16 @@ int_fast32_t pulseaudio_get_source_info_list(pa_source_info_cb_t cb,
 	return 0;
 }
 
-int_fast32_t pulseaudio_get_source_info(pa_source_info_cb_t cb,
-					const char *name, void *userdata)
+int_fast32_t pulseaudio_get_sink_info(pa_sink_info_cb_t cb, const char *name,
+				      void *userdata)
 {
 	if (pulseaudio_context_ready() < 0)
 		return -1;
 
 	pulseaudio_lock();
 
-	pa_operation *op = pa_context_get_source_info_by_name(
-		pulseaudio_context, name, cb, userdata);
+	pa_operation *op = pa_context_get_sink_info_by_name(pulseaudio_context,
+							    name, cb, userdata);
 	if (!op) {
 		pulseaudio_unlock();
 		return -1;
@@ -312,16 +310,11 @@ int_fast32_t pulseaudio_connect_playback(pa_stream *s, const char *name,
 	if (pulseaudio_context_ready() < 0)
 		return -1;
 
-	size_t dev_len = strlen(name) - 8;
-	char *device = bzalloc(dev_len + 1);
-	memcpy(device, name, dev_len);
-
 	pulseaudio_lock();
 	int_fast32_t ret =
-		pa_stream_connect_playback(s, device, attr, flags, NULL, NULL);
+		pa_stream_connect_playback(s, name, attr, flags, NULL, NULL);
 	pulseaudio_unlock();
 
-	bfree(device);
 	return ret;
 }
 

--- a/libobs/audio-monitoring/pulse/pulseaudio-wrapper.h
+++ b/libobs/audio-monitoring/pulse/pulseaudio-wrapper.h
@@ -95,7 +95,7 @@ void pulseaudio_signal(int wait_for_accept);
 void pulseaudio_accept();
 
 /**
- * Request source information
+ * Request sink information
  *
  * The function will block until the operation was executed and the mainloop
  * called the provided callback function.
@@ -106,17 +106,17 @@ void pulseaudio_accept();
  *
  * @warning call without active locks
  */
-int_fast32_t pulseaudio_get_source_info_list(pa_source_info_cb_t cb,
-					     void *userdata);
+int_fast32_t pulseaudio_get_sink_info_list(pa_sink_info_cb_t cb,
+					   void *userdata);
 
 /**
- * Request source information from a specific source
+ * Request sink information from a specific sink
  *
  * The function will block until the operation was executed and the mainloop
  * called the provided callback function.
  *
  * @param cb pointer to the callback function
- * @param name the source name to get information for
+ * @param name the sink name to get information for
  * @param userdata pointer to userdata the callback will be called with
  *
  * @return negative on error
@@ -125,8 +125,8 @@ int_fast32_t pulseaudio_get_source_info_list(pa_source_info_cb_t cb,
  *
  * @warning call without active locks
  */
-int_fast32_t pulseaudio_get_source_info(pa_source_info_cb_t cb,
-					const char *name, void *userdata);
+int_fast32_t pulseaudio_get_sink_info(pa_sink_info_cb_t cb, const char *name,
+				      void *userdata);
 
 /**
  * Request server information


### PR DESCRIPTION
List Pulse Sinks not Sink monitors in Settings DropDown

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
It is Listig sinks instead of sink monitors.
Now
![After](https://user-images.githubusercontent.com/7487291/107836039-f7d19c80-6d9b-11eb-9208-52ea6d8d9f47.png)

Before
![Before](https://user-images.githubusercontent.com/7487291/107836209-834b2d80-6d9c-11eb-8272-cbb5b70c1f5f.png)


### Motivation and Context
In the drop Down in the Audio Monitor Settings the Monitors of sinks where display instead of the sinks.
With string manipulation the monior was changed to the actual sink to connect audio.
So it was working but not easy to understand.
For me as a user.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
I checked it on my ArchLinux Pulseaudio Jack setup.
I am able to Monitor audio form Media.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
No breaking changes.
Bug fix
I am not sure if there is more Documentation i need to chage?
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [?] I have included updates to all appropriate documentation.
