### PR TITLE
mac-virtualcam: DAL PlugIn check for custom png file

### DIFF
--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
@@ -170,6 +170,15 @@
 		NSString *placeHolderPath = [bundlePath
 			stringByAppendingString:
 				@"/Contents/Resources/placeholder.png"];
+		NSFileManager *fileManager = [NSFileManager defaultManager];
+		NSURL *homeUrl = [fileManager homeDirectoryForCurrentUser];
+		NSURL *customUrl = [homeUrl
+			URLByAppendingPathComponent:
+				@"Library/Application Support/obs-studio/plugin_config/mac-virtualcam/placeholder.png"];
+		NSString *customPlaceHolder = customUrl.path;
+		if ([fileManager isReadableFileAtPath:customPlaceHolder])
+			placeHolderPath = customPlaceHolder;
+		DLog(@"PlaceHolder:%@", placeHolderPath);
 		NSImage *placeholderImage = [[NSImage alloc]
 			initWithContentsOfFile:placeHolderPath];
 


### PR DESCRIPTION
Previous pull request closed accidenally ... sorry ...

mac-virtualcam: DAL PlugIn check $HOME/Documents/obs-studio for a placeholder.png
file and use if instead fo the default placeholder.png file. This will
prevent the user's custom file from being replaced every time OBS is updated.

### Description
The only modification is to OBSDALStream.mm in the source for the dal-plugin module for mac-virtualcam. This change get's the user's home directory, then looks for Documents/obs-studio/placeholder.png relative to the user's home directory. If this custom file is found, the DAL plugin will us it instead of the default placeholder.png file.

### Motivation and Context
The virtual camera a is a very useful addition to OBS, but it is frustrating to have to replace the default placeholder.png file every time OBS Studio is upgraded. It would be quite useful to be able to create a custom placeholder.png file ONCE and not have to track down the default file over and over and over.

### How Has This Been Tested?
I've tested on a MacBook and 2015 MBP both running BigSur. I've tested with Skype and Zoom:

Installed this update over OBS 26.1.2
Used virtual cam, no problems
Stopped virtual cam, verified default image shows in Skype or Zoom
Created custom placeholder.png in /Users/dan/Documents/obs-studio
Verified custom image shows in Skype or Zoom
Start virtual cam, verified OBS output appears in Skype or Zoom
Stop virtual cam, verified custom image shows in Skype fo Zoom
Remove custom placeholder.png
Verified default image shows in Skype or Zoom

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
