### PR TITLE
flatpak: Enable Wayland

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -5,6 +5,7 @@
   "sdk": "org.kde.Sdk",
   "command": "obs",
   "finish-args": [
+    "--socket=wayland",
     "--socket=x11",
     "--socket=pulseaudio",
     "--device=all",
@@ -228,6 +229,7 @@
       "builddir": true,
       "config-opts": [
         "-DCMAKE_BUILD_TYPE=Release",
+        "-DENABLE_WAYLAND=ON",
         "-DUNIX_STRUCTURE=ON",
         "-DUSE_XDG=ON",
         "-DDISABLE_ALSA=ON",


### PR DESCRIPTION
### Description

Expose the Wayland socket to the sandbox, and enable Wayland at build time using the new ENABLE_WAYLAND define for CMake.

### Motivation and Context

Enabling the newly introduced Wayland support on the "Flatpak (experimental)" workflow allows easily testing it.

### How Has This Been Tested?

Install the artifact generated by the "Flatpak (experimental)" workflow. In a Linux / Wayland session, run OBS Studio and notice the following lines:

```
info: Initializing OpenGL...
info: Using EGL/Wayland
info: Initialized EGL 1.4
```

### Types of changes

 - New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
