### PR TITLE
UI: Fix qt display bug with preview widgets

### DIFF
--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -85,7 +85,6 @@ OBSQTDisplay::OBSQTDisplay(QWidget *parent, Qt::WindowFlags flags)
 	setAttribute(Qt::WA_StaticContents);
 	setAttribute(Qt::WA_NoSystemBackground);
 	setAttribute(Qt::WA_OpaquePaintEvent);
-	setAttribute(Qt::WA_DontCreateNativeAncestors);
 	setAttribute(Qt::WA_NativeWindow);
 
 	auto windowVisible = [this](bool visible) {


### PR DESCRIPTION
### Description
When entering studio mode or source properties, the preview widget
wouldn't render properly on Linux.

### Motivation and Context
Bug introduced with https://github.com/obsproject/obs-studio/pull/3782

### How Has This Been Tested?
Only tested on Linux with X11. Needs to be tested on other OSs and with Wayland.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
