### PR TITLE
graphics-hook: Fix build without COMPILE_D3D12_HOOK

### DIFF
--- a/plugins/win-capture/graphics-hook/dxgi-capture.cpp
+++ b/plugins/win-capture/graphics-hook/dxgi-capture.cpp
@@ -24,7 +24,7 @@ static struct func_hook present;
 static struct func_hook present1;
 
 thread_local bool dxgi_presenting = false;
-ID3D12CommandQueue *dxgi_possible_swap_queue = nullptr;
+struct ID3D12CommandQueue *dxgi_possible_swap_queue = nullptr;
 bool dxgi_present_attempted = false;
 
 struct dxgi_swap_data {


### PR DESCRIPTION
### Description
Just need to forward declare D3D12 type.

### Motivation and Context
Keep toggle working.

### How Has This Been Tested?
Build works fine now.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.