### PR TITLE
libobs-winrt: Make Close() failures non-fatal

### DIFF
--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -233,8 +233,27 @@ static void winrt_capture_device_loss_release(void *data)
 	capture->active = FALSE;
 
 	capture->frame_arrived.revoke();
-	capture->frame_pool.Close();
-	capture->session.Close();
+
+	try {
+		capture->frame_pool.Close();
+	} catch (winrt::hresult_error &err) {
+		blog(LOG_ERROR,
+		     "Direct3D11CaptureFramePool::Close (0x%08X): %ls",
+		     err.to_abi(), err.message().c_str());
+	} catch (...) {
+		blog(LOG_ERROR, "Direct3D11CaptureFramePool::Close (0x%08X)",
+		     winrt::to_hresult());
+	}
+
+	try {
+		capture->session.Close();
+	} catch (winrt::hresult_error &err) {
+		blog(LOG_ERROR, "GraphicsCaptureSession::Close (0x%08X): %ls",
+		     err.to_abi(), err.message().c_str());
+	} catch (...) {
+		blog(LOG_ERROR, "GraphicsCaptureSession::Close (0x%08X)",
+		     winrt::to_hresult());
+	}
 
 	capture->session = nullptr;
 	capture->frame_pool = nullptr;
@@ -516,8 +535,30 @@ extern "C" EXPORT void winrt_capture_free(struct winrt_capture *capture)
 
 		capture->frame_arrived.revoke();
 		capture->closed.revoke();
-		capture->frame_pool.Close();
-		capture->session.Close();
+
+		try {
+			capture->frame_pool.Close();
+		} catch (winrt::hresult_error &err) {
+			blog(LOG_ERROR,
+			     "Direct3D11CaptureFramePool::Close (0x%08X): %ls",
+			     err.to_abi(), err.message().c_str());
+		} catch (...) {
+			blog(LOG_ERROR,
+			     "Direct3D11CaptureFramePool::Close (0x%08X)",
+			     winrt::to_hresult());
+		}
+
+		try {
+			capture->session.Close();
+		} catch (winrt::hresult_error &err) {
+			blog(LOG_ERROR,
+			     "GraphicsCaptureSession::Close (0x%08X): %ls",
+			     err.to_abi(), err.message().c_str());
+		} catch (...) {
+			blog(LOG_ERROR,
+			     "GraphicsCaptureSession::Close (0x%08X)",
+			     winrt::to_hresult());
+		}
 
 		delete capture;
 	}


### PR DESCRIPTION
### Description
Catch WinRT exceptions instead of letting OBS die.

### Motivation and Context
Attempt to fix #4230. If nothing else, we'll have more log info.

### How Has This Been Tested?
WGC still works. I haven't reproduced the Close() exception myself.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.