### PR TITLE
obs-ffmpeg: Fix bug with obs_source_media_play_pause

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -665,10 +665,14 @@ static void ffmpeg_source_play_pause(void *data, bool pause)
 
 	mp_media_play_pause(&s->media, pause);
 
-	if (pause)
+	if (pause) {
+
 		set_media_state(s, OBS_MEDIA_STATE_PAUSED);
-	else
+	} else {
+
 		set_media_state(s, OBS_MEDIA_STATE_PLAYING);
+		obs_source_media_started(s->source);
+	}
 }
 
 static void ffmpeg_source_stop(void *data)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
 Add `obs_source_media_started(s->source);` to function `ffmpeg_source_play_pause` in `obs-ffmpeg-source.c`

### Motivation and Context
Fixes #4252 obs_source_media_play_pause does not play a stopped or ended media_source

This does not happen with the vlc_media_source 

### How Has This Been Tested?

Tested play/pause functionality 
- Windows 10 X64
### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
