### PR TITLE
CI: Build on Ubuntu 18.04, use newer clang-format

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -13,18 +13,7 @@ jobs:
 
       - name: Install clang format
         run: |
-          # gets us newer clang
-          sudo bash -c "cat >> /etc/apt/sources.list" << LLVMAPT
-          # 3.8
-          deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main
-          deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main
-          LLVMAPT
-
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-
-          sudo apt-get -qq update
-
-          sudo apt-get install -y clang-format-8
+          sudo apt-get install -y clang-format-10
 
       - name: Check the Formatting
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -352,7 +352,7 @@ jobs:
           path: ./release/*.dmg
   ubuntu64:
     name: 'Linux/Ubuntu 64-bit'
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-18.04]
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2.3.3

--- a/formatcode.sh
+++ b/formatcode.sh
@@ -19,7 +19,9 @@ if [[ $OS = "Linux" || $OS = "Darwin" ]] ; then
 fi
 
 # Discover clang-format
-if type clang-format-8 2> /dev/null ; then
+if type clang-format-10 2> /dev/null ; then
+    CLANG_FORMAT=clang-format-10
+elif type clang-format-8 2> /dev/null ; then
     CLANG_FORMAT=clang-format-8
 else
     CLANG_FORMAT=clang-format


### PR DESCRIPTION
### Description

1. Rather than using clang-format-8 from a secondary repo, use clang-format-10 directly. Compatible with both 18.04 and 20.04 CI.

2. Lock Ubuntu CI builds to building on Ubuntu 18.04 LTS for now. v4l2loopback-dkms fails to install/build on the GH CI on Ubuntu 20.04 as iti's a stripped down kernel for Azure which is missing the videodev headers. Attempting to manually install required extras does not work. Attempted with both 0.12.3 and 0.12.5 v4l2loopback versions. I didn't feel comfortable removing virtual camera for CI builds, so I went with downgrading for now.

```
Building v4l2-loopback driver...
make -C /lib/modules/5.4.0-1039-azure/build M=/var/lib/dkms/v4l2loopback/0.12.5/build modules
make[1]: Entering directory '/usr/src/linux-headers-5.4.0-1039-azure'
  CC [M]  /var/lib/dkms/v4l2loopback/0.12.5/build/v4l2loopback.o
  Building modules, stage 2.
  MODPOST 1 modules
ERROR: "video_ioctl2" [/var/lib/dkms/v4l2loopback/0.12.5/build/v4l2loopback.ko] undefined!
ERROR: "__video_register_device" [/var/lib/dkms/v4l2loopback/0.12.5/build/v4l2loopback.ko] undefined!
ERROR: "v4l2_ctrl_new_custom" [/var/lib/dkms/v4l2loopback/0.12.5/build/v4l2loopback.ko] undefined!
ERROR: "v4l2_ctrl_handler_init_class" [/var/lib/dkms/v4l2loopback/0.12.5/build/v4l2loopback.ko] undefined!
ERROR: "video_device_release" [/var/lib/dkms/v4l2loopback/0.12.5/build/v4l2loopback.ko] undefined!
ERROR: "video_device_alloc" [/var/lib/dkms/v4l2loopback/0.12.5/build/v4l2loopback.ko] undefined!
ERROR: "v4l2_device_register" [/var/lib/dkms/v4l2loopback/0.12.5/build/v4l2loopback.ko] undefined!
ERROR: "v4l2_ctrl_handler_free" [/var/lib/dkms/v4l2loopback/0.12.5/build/v4l2loopback.ko] undefined!
ERROR: "v4l2_device_unregister" [/var/lib/dkms/v4l2loopback/0.12.5/build/v4l2loopback.ko] undefined!
ERROR: "video_unregister_device" [/var/lib/dkms/v4l2loopback/0.12.5/build/v4l2loopback.ko] undefined!
ERROR: "video_devdata" [/var/lib/dkms/v4l2loopback/0.12.5/build/v4l2loopback.ko] undefined!
make[2]: *** [scripts/Makefile.modpost:94: __modpost] Error 1
make[1]: *** [Makefile:1670: modules] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-5.4.0-1039-azure'
make: *** [Makefile:43: v4l2loopback.ko] Error 2
```

### Motivation and Context

There are too many issues with 20.04 to successfully build with VirtualCam - the azure kernel is missing videodev headers. For now, use 18.04 LTS directly for main CI builds. This allows us to actually have functional CI.

Both 18.04 and 20.04 include clang-format-10 without issue.

### How Has This Been Tested?

* Wait for CI to finish successfully.

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
