### PR TITLE
mac-virtualcam: Fix codesign error after updating OBS

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -77,8 +77,8 @@ static bool check_dal_plugin()
 		if ([fileManager fileExistsAtPath:dalPluginSourcePath]) {
 			NSString *copyCmd = [NSString
 				stringWithFormat:
-					@"do shell script \"cp -R '%@' '%@'\" with administrator privileges",
-					dalPluginSourcePath,
+					@"do shell script \"rm -rf '%@' && cp -R '%@' '%@'\" with administrator privileges",
+					dalPluginFileName, dalPluginSourcePath,
 					dalPluginDestinationPath];
 
 			NSDictionary *errorDict;


### PR DESCRIPTION
### Description
Potentially fixes crash issues with updated OBS virtualcam versions on macOS by removing an old version of the DAL plugin before copying over the new version.

### Motivation and Context
After updating the DAL plugin (e.g. by updating OBS itself), OBS will work fine at first, but crash on consecutive launches. Fixes #4079.

This is mainly due to macOS considering the DAL plugin to be "tainted" after the update:

```
21:58:15.404192 com.apple.cmio CMIO_DAL_System.cpp:349:CheckOutInstance The System is starting 
21:58:15.404220  Loading Preferences From User CFPrefsD 
21:58:15.411899 com.apple.cmio CMIO_DAL_PlugInManagement.cpp:829:LoadPlugInNow Load plugin now (true) <private> 
21:58:15.421729  CODE SIGNING: process 57860[obs]: rejecting invalid page at address 0x333ef000 from offset 0x4000 in file "/Library/CoreMediaIO/Plug-Ins/DAL/obs-mac-virtualcam.plugin/Contents/MacOS/obs-mac-virtualcam" (cs_mtime:1610150854.0 != mtime:1613852340.154866473) (signed:1 validated:1 tainted:1 nx:0 wpmapped:0 dirty:0 depth:0) 
```

For some reason deleting the original plugin, then copying over the new one (at the same location) circumvents this issue as macOS will recognise the new plugin and check the code signature accordingly. 

*Note:* This could potentially also fix the issue on M1 Macs, I don't have one available to me to confirm this right now.

### How Has This Been Tested?
* Ran official OBS release, installed virtualcam
* Ran local build of OBS (more recent build version), updated virtualcam
* Observed OBS crashing on consecutive launch
* Ran fixed local build of OBS, updated virtualcam
* No crashes on consecutive launches experienced

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
