### PR TITLE
UI: Add css on Drag and Drop

### DIFF
--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -72,6 +72,20 @@ void OBSBasic::AddDropURL(const char *url, QString &name, obs_data_t *settings,
 		cx = query.queryItemValue("layer-width").toInt();
 	if (query.hasQueryItem("layer-height"))
 		cy = query.queryItemValue("layer-height").toInt();
+	if (query.hasQueryItem("layer-css")) {
+		// QUrl::FullyDecoded does NOT properly decode a
+		// application/x-www-form-urlencoded space represented as '+'
+		// Thus, this is manually filtered out before QUrl's
+		// decoding kicks in again. This is to allow JavaScript's
+		// default searchParams.append function to simply append css
+		// to the query parameters, which is the intended usecase for this.
+		QString fullyEncoded =
+			query.queryItemValue("layer-css", QUrl::FullyEncoded);
+		fullyEncoded = fullyEncoded.replace("+", "%20");
+		QString decoded = QUrl::fromPercentEncoding(
+			QByteArray::fromStdString(QT_TO_UTF8(fullyEncoded)));
+		obs_data_set_string(settings, "css", QT_TO_UTF8(decoded));
+	}
 
 	obs_data_set_int(settings, "width", cx);
 	obs_data_set_int(settings, "height", cy);
@@ -83,6 +97,7 @@ void OBSBasic::AddDropURL(const char *url, QString &name, obs_data_t *settings,
 	query.removeQueryItem("layer-width");
 	query.removeQueryItem("layer-height");
 	query.removeQueryItem("layer-name");
+	query.removeQueryItem("layer-css");
 	path.setQuery(query);
 
 	obs_data_set_string(settings, "url", QT_TO_UTF8(path.url()));


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds parsing for the "layer-css" query param of URLs dragged into the main window, similarly to the other layer-* parameters already used.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
OBS allows developers to effectively design overlays through browser sources and implement a lot of logic in javascript and style it through CSS, even dynmically changing it within the overlay itself. This all happens client-side, without the need to save further configuration data on a backend.

However, aside from the name, url and sizing of the Browser Source Element, no further data can currently be set/defined for such dragged elements. End Users are often not as knowledgable in CSS styling, thus requiring further tools to customize the looks of their overlays and widgets externally and then being required to copy such styling information into the custon css field. By allowing this information to be imported throgh the drag&drop element, only that needs to be dropped into OBS and no additional copypasting of styling needs to be done, effectively simplifying the end user experience by one step.

I thought of allowing arbitrary data to be drag&drop'ed onto OBS, but OS and JavaScript limitations of what data is/can be provided through this channel is limited and unless we utilize parsing of plain text as base64 or json (or similar) in the dragged element, having arbitrary data in the payload of the dragged element does not seem reasonable, even if it would potentially be more extensible in the future - thus i chose to append to the already-used query parameters of the url, which are stripped of the created browser source for brevity.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
* Windows 10 (20H2/19042.804) using Chrome (Beta) 89 as the drag source
* I used [my current project](https://marenthyu.de/twitch/jump/config) for testing this change, as it was what inspired me to think of this in the first place.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality) 
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.

Information about this new parameter should be added to [the drag and drop demo page](https://obsproject.com/tools/browser-drag-and-drop), but i am unaware if i have access to the website's source. I'll gladly add an explanation to the mentioned page if i am pointed as to where to put it.
