### PR TITLE
UI: Cleanup Qt for Qt6

### DIFF
--- a/UI/hotkey-edit.cpp
+++ b/UI/hotkey-edit.cpp
@@ -419,7 +419,11 @@ static inline void updateStyle(QWidget *widget)
 	widget->update();
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+void OBSHotkeyWidget::enterEvent(QEnterEvent *event)
+#else
 void OBSHotkeyWidget::enterEvent(QEvent *event)
+#endif
 {
 	if (!label)
 		return;
@@ -448,7 +452,11 @@ void OBSHotkeyLabel::highlightPair(bool highlight)
 	updateStyle(this);
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+void OBSHotkeyLabel::enterEvent(QEnterEvent *event)
+#else
 void OBSHotkeyLabel::enterEvent(QEvent *event)
+#endif
 {
 	if (!pairPartner)
 		return;

--- a/UI/hotkey-edit.hpp
+++ b/UI/hotkey-edit.hpp
@@ -36,7 +36,11 @@ public:
 	QPointer<OBSHotkeyLabel> pairPartner;
 	QPointer<OBSHotkeyWidget> widget;
 	void highlightPair(bool highlight);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	void enterEvent(QEnterEvent *event) override;
+#else
 	void enterEvent(QEvent *event) override;
+#endif
 	void leaveEvent(QEvent *event) override;
 	void setToolTip(const QString &toolTip);
 };
@@ -131,7 +135,11 @@ public:
 	void Save();
 	void Save(std::vector<obs_key_combination_t> &combinations);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	void enterEvent(QEnterEvent *event) override;
+#else
 	void enterEvent(QEvent *event) override;
+#endif
 	void leaveEvent(QEvent *event) override;
 
 private:

--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -101,7 +101,11 @@ void OBSLogViewer::InitLog()
 
 	if (file.open(QIODevice::ReadOnly)) {
 		QTextStream in(&file);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		in.setEncoding(QStringConverter::Utf8);
+#else
 		in.setCodec("UTF-8");
+#endif
 
 		while (!in.atEnd()) {
 			QString line = in.readLine();

--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -31,7 +31,6 @@
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 #include <obs-nix-platform.h>
-#include <QX11Info>
 #endif
 
 #ifdef ENABLE_WAYLAND

--- a/UI/qt-wrappers.hpp
+++ b/UI/qt-wrappers.hpp
@@ -28,7 +28,12 @@
 #include <memory>
 #include <vector>
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#define QT_UTF8(str) QString::fromUtf8(str, -1)
+#else
 #define QT_UTF8(str) QString::fromUtf8(str)
+#endif
+
 #define QT_TO_UTF8(str) str.toUtf8().constData()
 
 class QDataStream;

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -147,7 +147,7 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_)
 void SourceTreeItem::paintEvent(QPaintEvent *event)
 {
 	QStyleOption opt;
-	opt.init(this);
+	opt.initFrom(this);
 	QPainter p(this);
 	style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
 
@@ -305,7 +305,11 @@ void SourceTreeItem::mouseDoubleClickEvent(QMouseEvent *event)
 	}
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+void SourceTreeItem::enterEvent(QEnterEvent *event)
+#else
 void SourceTreeItem::enterEvent(QEvent *event)
+#endif
 {
 	QWidget::enterEvent(event);
 

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -32,7 +32,11 @@ class SourceTreeItem : public QWidget {
 	friend class SourceTreeModel;
 
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	void enterEvent(QEnterEvent *event) override;
+#else
 	void enterEvent(QEvent *event) override;
+#endif
 	void leaveEvent(QEvent *event) override;
 
 	virtual bool eventFilter(QObject *object, QEvent *event) override;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -24,7 +24,6 @@
 #include <QShowEvent>
 #include <QDesktopServices>
 #include <QFileDialog>
-#include <QDesktopWidget>
 #include <QScreen>
 #include <QColorDialog>
 #include <QSizePolicy>
@@ -74,7 +73,6 @@
 #include <fstream>
 #include <sstream>
 
-#include <QScreen>
 #include <QWindow>
 
 #include <json11.hpp>
@@ -208,8 +206,10 @@ extern void RegisterRestreamAuth();
 OBSBasic::OBSBasic(QWidget *parent)
 	: OBSMainWindow(parent), ui(new Ui::OBSBasic)
 {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	qRegisterMetaTypeStreamOperators<SignalContainer<OBSScene>>(
 		"SignalContainer<OBSScene>");
+#endif
 
 	setAttribute(Qt::WA_NativeWindow);
 
@@ -264,10 +264,12 @@ OBSBasic::OBSBasic(QWidget *parent)
 	qRegisterMetaType<obs_hotkey_id>("obs_hotkey_id");
 	qRegisterMetaType<SavedProjectorInfo *>("SavedProjectorInfo *");
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	qRegisterMetaTypeStreamOperators<std::vector<std::shared_ptr<OBSSignal>>>(
 		"std::vector<std::shared_ptr<OBSSignal>>");
 	qRegisterMetaTypeStreamOperators<OBSScene>("OBSScene");
 	qRegisterMetaTypeStreamOperators<OBSSceneItem>("OBSSceneItem");
+#endif
 
 	ui->scenes->setAttribute(Qt::WA_MacShowFocusRect, false);
 	ui->sources->setAttribute(Qt::WA_MacShowFocusRect, false);
@@ -385,7 +387,8 @@ OBSBasic::OBSBasic(QWidget *parent)
 
 		QRect windowGeometry = normalGeometry();
 		if (!WindowPositionValid(windowGeometry)) {
-			QRect rect = App()->desktop()->geometry();
+			QRect rect =
+				QGuiApplication::primaryScreen()->geometry();
 			setGeometry(QStyle::alignedRect(Qt::LeftToRight,
 							Qt::AlignCenter, size(),
 							rect));
@@ -7314,7 +7317,8 @@ void OBSBasic::OpenSavedProjector(SavedProjectorInfo *info)
 			projector->restoreGeometry(byteArray);
 
 			if (!WindowPositionValid(projector->normalGeometry())) {
-				QRect rect = App()->desktop()->geometry();
+				QRect rect = QGuiApplication::primaryScreen()
+						     ->geometry();
 				projector->setGeometry(QStyle::alignedRect(
 					Qt::LeftToRight, Qt::AlignCenter,
 					size(), rect));

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -904,8 +904,8 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	channelIndex = ui->channelSetup->currentIndex();
 	sampleRateIndex = ui->sampleRate->currentIndex();
 
-	QRegExp rx("\\d{1,5}x\\d{1,5}");
-	QValidator *validator = new QRegExpValidator(rx, this);
+	QRegularExpression rx("\\d{1,5}x\\d{1,5}");
+	QValidator *validator = new QRegularExpressionValidator(rx, this);
 	ui->baseResolution->lineEdit()->setValidator(validator);
 	ui->outputResolution->lineEdit()->setValidator(validator);
 }

--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -6,12 +6,12 @@
 #include "obs-app.hpp"
 #include "qt-wrappers.hpp"
 
-#include <QDesktopWidget>
 #include <QPushButton>
 #include <QScrollArea>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QGridLayout>
+#include <QScreen>
 
 #include <string>
 
@@ -204,7 +204,8 @@ OBSBasicStats::OBSBasicStats(QWidget *parent, bool closeable)
 
 		QRect windowGeometry = normalGeometry();
 		if (!WindowPositionValid(windowGeometry)) {
-			QRect rect = App()->desktop()->geometry();
+			QRect rect =
+				QGuiApplication::primaryScreen()->geometry();
 			setGeometry(QStyle::alignedRect(Qt::LeftToRight,
 							Qt::AlignCenter, size(),
 							rect));

--- a/UI/window-missing-files.cpp
+++ b/UI/window-missing-files.cpp
@@ -68,7 +68,7 @@ QWidget *MissingFilesPathItemDelegate::createEditor(
 	};
 
 	QHBoxLayout *layout = new QHBoxLayout();
-	layout->setMargin(0);
+	layout->setContentsMargins(0, 0, 0, 0);
 	layout->setSpacing(0);
 
 	QLineEdit *text = new QLineEdit();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This changes cleans up some deprecated functions that were removed in
Qt6. Some are placed behind version ifdefs and others are replaced for
their non-deprecated Qt5 version.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
There wont be any more Qt5 releases, and the differences to make things compile arnt too different. QtX11Extras and QtMacExtras were removed which complicates making this actually work, but with some creative definitions it compiles enough to test this PR.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiles against Qt6 and Qt5.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
