### PR TITLE
Make drag and drop insensitive to file extension case

### DIFF
--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -247,7 +247,7 @@ void OBSBasic::dropEvent(QDropEvent *event)
 #define CHECK_SUFFIX(extensions, type)                         \
 	cmp = extensions;                                      \
 	while (*cmp) {                                         \
-		if (strcmp(*cmp, suffix) == 0) {               \
+		if (astrcmpi(*cmp, suffix) == 0) {             \
 			AddDropSource(QT_TO_UTF8(file), type); \
 			found = true;                          \
 			break;                                 \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fixes #4236.
Makes OBS support drag and drop of files with capitalized file names. This one-liner was suggested by @WizardCM in [this comment](https://github.com/obsproject/obs-studio/issues/4236#issuecomment-778775619).
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
When people drag and drop into OBS files with capitalized extensions in the names, these files do not show up in OBS (and no explanation is provided). People with systems set to hide file extensions might get confused. (Other programs typically can handle capitalized file names.)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I verified existence of the bug prior to this change:
 1. Dropped file called Untitled.png in OBS - it appeared in the scene
 2. Dropped file called Untitled.PNG in OBS - *nothing happened* - bug

Then I created the patch and verified that it works as expected:

 1. Dropped file called Untitled.png in OBS - it appeared in the scene
 2. Dropped file called Untitled.PNG in OBS - it appeared in the scene

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
