### PR TITLE
UI: Submit naming & Add Source dialogs using Return

### DIFF
--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -283,6 +283,8 @@ OBSBasicSourceSelect::OBSBasicSourceSelect(OBSBasic *parent, const char *id_)
 	ui->sourceName->setText(text);
 	ui->sourceName->setFocus(); //Fixes deselect of text.
 	ui->sourceName->selectAll();
+	connect(ui->sourceName, SIGNAL(returnPressed()), ui->buttonBox,
+		SIGNAL(accepted()));
 
 	installEventFilter(CreateShortcutFilter());
 

--- a/UI/window-namedialog.cpp
+++ b/UI/window-namedialog.cpp
@@ -46,6 +46,8 @@ NameDialog::NameDialog(QWidget *parent) : QDialog(parent)
 		QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 	layout->addWidget(buttonbox);
 	buttonbox->setCenterButtons(true);
+	connect(userText, SIGNAL(returnPressed()), buttonbox,
+		SIGNAL(accepted()));
 	connect(buttonbox, &QDialogButtonBox::accepted, this, &QDialog::accept);
 	connect(buttonbox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 }


### PR DESCRIPTION
### Description

Pressing Enter/Return after typing a name of a Scene, Source, Filter or Transition will now submit the dialog.

### Motivation and Context

While creating new sources, it feels natural to press Enter/Return. This also improves accessibility.

### How Has This Been Tested?

1. Create a new Scene, Source, FIlter or Transition
2. Press Enter/Return.

Wanted to submit as a PR first to make sure I didn't miss anything.

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
