### PR TITLE
UI: Don't attempt to resize parent group when changing cursor

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -395,7 +395,7 @@ static vec2 GetItemSize(obs_sceneitem_t *item)
 	return size;
 }
 
-void OBSBasicPreview::GetStretchHandleData(const vec2 &pos)
+void OBSBasicPreview::GetStretchHandleData(const vec2 &pos, bool ignoreGroup)
 {
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 
@@ -450,7 +450,7 @@ void OBSBasicPreview::GetStretchHandleData(const vec2 &pos)
 				   startCrop.top - startCrop.bottom);
 
 		stretchGroup = obs_sceneitem_get_group(scene, stretchItem);
-		if (stretchGroup) {
+		if (stretchGroup && !ignoreGroup) {
 			obs_sceneitem_get_draw_transform(stretchGroup,
 							 &invGroupTransform);
 			matrix4_inv(&invGroupTransform, &invGroupTransform);
@@ -571,7 +571,7 @@ void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 	}
 
 	vec2_set(&startPos, x, y);
-	GetStretchHandleData(startPos);
+	GetStretchHandleData(startPos, false);
 
 	vec2_divf(&startPos, &startPos, main->previewScale / pixelRatio);
 	startPos.x = std::round(startPos.x);
@@ -1521,7 +1521,7 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 	}
 
 	if (updateCursor) {
-		GetStretchHandleData(startPos);
+		GetStretchHandleData(startPos, true);
 		uint32_t stretchFlags = (uint32_t)stretchHandle;
 		UpdateCursor(stretchFlags);
 	}

--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -90,7 +90,7 @@ private:
 
 	static vec3 GetSnapOffset(const vec3 &tl, const vec3 &br);
 
-	void GetStretchHandleData(const vec2 &pos);
+	void GetStretchHandleData(const vec2 &pos, bool ignoreGroup);
 
 	void UpdateCursor(uint32_t &flags);
 


### PR DESCRIPTION
### Description

If a group only contains one source, and the source is resized, the group often doesn't resize/move to reflect the new size of the source. This bug was introduced by the cursor code which meant GetStretchHandleData() is run twice, on move & click.

Bug originally found by @Warchamp7 

There might be a cleaner way to do this, but I can't think of a good way to get the handle data in move & click without rewriting the event handling altogether.

### Motivation and Context

Bugs are bad, especially for groups.

### How Has This Been Tested?

Place an image source in a group on its own. Resize the source using the mouse.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
