### PR TITLE
UI: Fix Qt6 build issues

### DIFF
--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -101,9 +101,7 @@ void OBSLogViewer::InitLog()
 
 	if (file.open(QIODevice::ReadOnly)) {
 		QTextStream in(&file);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-		in.setEncoding(QStringConverter::Utf8);
-#else
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 		in.setCodec("UTF-8");
 #endif
 

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -31,6 +31,7 @@
 #include <obs-config.h>
 #include <obs.hpp>
 
+#include <QFile>
 #include <QGuiApplication>
 #include <QProxyStyle>
 #include <QScreen>

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1390,7 +1390,9 @@ bool OBSApp::OBSInit()
 {
 	ProfileScope("OBSApp::OBSInit");
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
 	setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
 
 	qRegisterMetaType<VoidFunc>();

--- a/UI/qt-wrappers.hpp
+++ b/UI/qt-wrappers.hpp
@@ -28,12 +28,7 @@
 #include <memory>
 #include <vector>
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #define QT_UTF8(str) QString::fromUtf8(str, -1)
-#else
-#define QT_UTF8(str) QString::fromUtf8(str)
-#endif
-
 #define QT_TO_UTF8(str) str.toUtf8().constData()
 
 class QDataStream;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1746,10 +1746,14 @@ void OBSBasic::OBSInit()
 	InitOBSCallbacks();
 	InitHotkeys();
 
-	/* hack to prevent elgato from loading its own Qt5Network that it tries
+	/* hack to prevent elgato from loading its own QtNetwork that it tries
 	 * to ship with */
 #if defined(_WIN32) && !defined(_DEBUG)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	LoadLibraryW(L"Qt5Network");
+#else
+	LoadLibraryW(L"Qt6Network");
+#endif
 #endif
 
 	AddExtraModulePaths();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix some issues with Qt6 compatibility.  Strictly speaking, only the first and fourth commits are necessary.  I consider the others to be cleanups as they either simplify `#if` checks or prevent warnings.  Descriptions are included in the individual commits, but they are also provided here for convenience.


1. UI: Force plugins to use version appropriate Qt Network
Make building against either Qt5 or Qt6 easier by checking the Qt version used and loading the appropriate Qt Network DLL.


2. UI: Set default string size arg for QT_UTF8 / QString::fromUtf8
Our QT_UTF8(str) macro uses QString::fromUtf8(str) with no size argument. In Qt5, QString::fromUtf8 uses a default value of -1 for the size arg. If size is -1, it is taken to be strlen(str). In Qt6, QString::fromUtf8 doesn't use a default value for the size arg, but has the same behavior if you manually specify -1 for the size. Let's manually specify -1 to maintain the same behavior between Qt5 and Qt6.
https://doc.qt.io/qt-5/qstring.html#fromUtf8
https://doc.qt.io/qt-6/qstring.html#fromUtf8


3. UI: Don't use QTextStream::setCodec in Qt6
In Qt6, QTextStream::setCodec has been replaced by QTextStream::setEncoding. However, all text is assumed to be UTF-8, so we don't need to specify UTF-8 in Qt6.
https://doc.qt.io/qt-5/qtextstream.html#setCodec-1
https://doc.qt.io/qt-6/qtextstream.html#setEncoding


4. UI: Explicitly include QFile
Explicitly include QFile to prevent a build failure with VS2019 and Qt6.


5. UI: Set Qt::AA_UseHighDpiPixmaps only on Qt5
Qt6 enables Qt::AA_UseHighDpiPixmaps by default and will emit a warning if you try to enable it. To prevent the warning, only set this on Qt5.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Being able to build on Qt6 now will make things easier whenever we move to Qt6.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I've compiled and run OBS with Qt6 on Windows 10 64-bit.  I've also verified that compiling against Qt5 still works on Windows 10 64-bit.

Please note that compiling with Qt6 requires additional CMake changes.  Those changes will be in a separate PR because they're disruptive and not compatible with Qt5, and perhaps they're better suited for a separate branch.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
