### PR TITLE
cmake: Require Qt if UI is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ if(NOT INSTALLER_RUN)
 			list(APPEND CMAKE_PREFIX_PATH "$ENV{QTDIR}")
 		endif()
 
-		find_package(Qt5Widgets ${FIND_MODE})
+		find_package(Qt5Widgets REQUIRED)
 	endif()
 
 	add_subdirectory(deps)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
In CMakeLists.txt, FIND_MODE is not defined here. This was moved from UI/CMakeLists.txt in commit cb4d2ff7faa8b52cf219ae85fe6caf1d2fc3f906. In UI/CMakeLists.txt, FIND_MODE is REQUIRED if DISABLE_UI is false or undefined and ENABLE_UI is true. Since the same booleans are required for the if-else branch in CMakeLists.txt where we try to find Qt, we can set find_package to REQUIRED here as well.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Currently, CMake will only warn that Qt is missing, and it will continue trying to configure, but ultimately fail in obs-vst or UI.  With this change, CMake will abort early if ENABLE_UI is enabled by requiring Qt Widgets.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I ran CMake before and after these changes to observe the change in the timing of the CMake failure.  I also compiled and ran OBS on Windows 10 64-bit and did a short recording.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
