### PR TITLE
UI: Add checks for overwrite setting to replay buffer

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <algorithm>
+#include <QFileInfo>
 #include <QMessageBox>
 #include "qt-wrappers.hpp"
 #include "audio-encoders.hpp"
@@ -294,6 +295,7 @@ struct SimpleOutput : BasicOutputHandler {
 	virtual bool StartStreaming(obs_service_t *service) override;
 	virtual bool StartRecording() override;
 	virtual bool StartReplayBuffer() override;
+	virtual void ConfigureReplayBuffer() override;
 	virtual void StopStreaming(bool force) override;
 	virtual void StopRecording(bool force) override;
 	virtual void StopReplayBuffer(bool force) override;
@@ -986,6 +988,13 @@ bool SimpleOutput::ConfigureRecording(bool updateReplayBuffer)
 		strPath = GetOutputFilename(path, ffmpegOutput ? "avi" : format,
 					    noSpace, overwriteIfExists,
 					    f.c_str());
+
+		QFileInfo fileInfo(QString::fromStdString(strPath));
+		QString fileName(fileInfo.completeBaseName());
+
+		if (!fileName.isEmpty())
+			f = fileName.toStdString();
+
 		obs_data_set_string(settings, "directory", path);
 		obs_data_set_string(settings, "format", f.c_str());
 		obs_data_set_string(settings, "extension", format);
@@ -1046,6 +1055,11 @@ bool SimpleOutput::StartReplayBuffer()
 	}
 
 	return true;
+}
+
+void SimpleOutput::ConfigureReplayBuffer()
+{
+	ConfigureRecording(true);
 }
 
 void SimpleOutput::StopStreaming(bool force)
@@ -1122,6 +1136,7 @@ struct AdvancedOutput : BasicOutputHandler {
 	virtual bool StartStreaming(obs_service_t *service) override;
 	virtual bool StartRecording() override;
 	virtual bool StartReplayBuffer() override;
+	virtual void ConfigureReplayBuffer() override;
 	virtual void StopStreaming(bool force) override;
 	virtual void StopRecording(bool force) override;
 	virtual void StopReplayBuffer(bool force) override;
@@ -1879,16 +1894,6 @@ bool AdvancedOutput::StartRecording()
 
 bool AdvancedOutput::StartReplayBuffer()
 {
-	const char *path;
-	const char *recFormat;
-	const char *filenameFormat;
-	bool noSpace = false;
-	bool overwriteIfExists = false;
-	const char *rbPrefix;
-	const char *rbSuffix;
-	int rbTime;
-	int rbSize;
-
 	if (!useStreamEncoder) {
 		if (!ffmpegOutput)
 			UpdateRecordingSettings();
@@ -1901,44 +1906,7 @@ bool AdvancedOutput::StartReplayBuffer()
 	if (!Active())
 		SetupOutputs();
 
-	if (!ffmpegOutput || ffmpegRecording) {
-		path = config_get_string(main->Config(), "AdvOut",
-					 ffmpegRecording ? "FFFilePath"
-							 : "RecFilePath");
-		recFormat = config_get_string(main->Config(), "AdvOut",
-					      ffmpegRecording ? "FFExtension"
-							      : "RecFormat");
-		filenameFormat = config_get_string(main->Config(), "Output",
-						   "FilenameFormatting");
-		overwriteIfExists = config_get_bool(main->Config(), "Output",
-						    "OverwriteIfExists");
-		noSpace = config_get_bool(main->Config(), "AdvOut",
-					  ffmpegRecording
-						  ? "FFFileNameWithoutSpace"
-						  : "RecFileNameWithoutSpace");
-		rbPrefix = config_get_string(main->Config(), "SimpleOutput",
-					     "RecRBPrefix");
-		rbSuffix = config_get_string(main->Config(), "SimpleOutput",
-					     "RecRBSuffix");
-		rbTime = config_get_int(main->Config(), "AdvOut", "RecRBTime");
-		rbSize = config_get_int(main->Config(), "AdvOut", "RecRBSize");
-
-		string f = GetFormatString(filenameFormat, rbPrefix, rbSuffix);
-		string strPath = GetOutputFilename(
-			path, recFormat, noSpace, overwriteIfExists, f.c_str());
-
-		OBSDataAutoRelease settings = obs_data_create();
-
-		obs_data_set_string(settings, "directory", path);
-		obs_data_set_string(settings, "format", f.c_str());
-		obs_data_set_string(settings, "extension", recFormat);
-		obs_data_set_bool(settings, "allow_spaces", !noSpace);
-		obs_data_set_int(settings, "max_time_sec", rbTime);
-		obs_data_set_int(settings, "max_size_mb",
-				 usesBitrate ? 0 : rbSize);
-
-		obs_output_update(replayBuffer, settings);
-	}
+	ConfigureReplayBuffer();
 
 	if (!obs_output_start(replayBuffer)) {
 		QString error_reason;
@@ -1954,6 +1922,53 @@ bool AdvancedOutput::StartReplayBuffer()
 	}
 
 	return true;
+}
+
+void AdvancedOutput::ConfigureReplayBuffer()
+{
+	if (ffmpegOutput && !ffmpegRecording)
+		return;
+
+	const char *path = config_get_string(main->Config(), "AdvOut",
+					     ffmpegRecording ? "FFFilePath"
+							     : "RecFilePath");
+	const char *recFormat = config_get_string(
+		main->Config(), "AdvOut",
+		ffmpegRecording ? "FFExtension" : "RecFormat");
+	const char *filenameFormat = config_get_string(main->Config(), "Output",
+						       "FilenameFormatting");
+	bool overwriteIfExists =
+		config_get_bool(main->Config(), "Output", "OverwriteIfExists");
+	bool noSpace = config_get_bool(main->Config(), "AdvOut",
+				       ffmpegRecording
+					       ? "FFFileNameWithoutSpace"
+					       : "RecFileNameWithoutSpace");
+	const char *rbPrefix = config_get_string(main->Config(), "SimpleOutput",
+						 "RecRBPrefix");
+	const char *rbSuffix = config_get_string(main->Config(), "SimpleOutput",
+						 "RecRBSuffix");
+	int rbTime = config_get_int(main->Config(), "AdvOut", "RecRBTime");
+	int rbSize = config_get_int(main->Config(), "AdvOut", "RecRBSize");
+
+	string f = GetFormatString(filenameFormat, rbPrefix, rbSuffix);
+	string strPath = GetOutputFilename(path, recFormat, noSpace,
+					   overwriteIfExists, f.c_str());
+	QFileInfo fileInfo(QString::fromStdString(strPath));
+	QString fileName(fileInfo.completeBaseName());
+
+	if (!fileName.isEmpty())
+		f = fileName.toStdString();
+
+	OBSDataAutoRelease settings = obs_data_create();
+
+	obs_data_set_string(settings, "directory", path);
+	obs_data_set_string(settings, "format", f.c_str());
+	obs_data_set_string(settings, "extension", recFormat);
+	obs_data_set_bool(settings, "allow_spaces", !noSpace);
+	obs_data_set_int(settings, "max_time_sec", rbTime);
+	obs_data_set_int(settings, "max_size_mb", usesBitrate ? 0 : rbSize);
+
+	obs_output_update(replayBuffer, settings);
 }
 
 void AdvancedOutput::StopStreaming(bool force)

--- a/UI/window-basic-main-outputs.hpp
+++ b/UI/window-basic-main-outputs.hpp
@@ -43,6 +43,7 @@ struct BasicOutputHandler {
 	virtual bool StartStreaming(obs_service_t *service) = 0;
 	virtual bool StartRecording() = 0;
 	virtual bool StartReplayBuffer() { return false; }
+	virtual void ConfigureReplayBuffer() = 0;
 	virtual bool StartVirtualCam();
 	virtual void StopStreaming(bool force = false) = 0;
 	virtual void StopRecording(bool force = false) = 0;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7204,6 +7204,8 @@ void OBSBasic::ReplayBufferSave()
 	if (!outputHandler->ReplayBufferActive())
 		return;
 
+	outputHandler->ConfigureReplayBuffer();
+
 	calldata_t cd = {0};
 	proc_handler_t *ph =
 		obs_output_get_proc_handler(outputHandler->replayBuffer);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
"Overwrite if file exists" setting not respected for replay buffer

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Refer to issue #4227
The reason behind this is there are no file overwritten checkings when saving replay buffer.
Even there is a file name checking when starting replay buffer, the variable is unused actually
> https://github.com/obsproject/obs-studio/blob/2787e63d8ecd0f4578ab47c6ca5cf73c0bce1844/UI/window-basic-main-outputs.cpp#L1946-L1947

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
1. Open OBS
2. Set local recording and replay buffer filename to something static
3. Save replay buffer multiple times
4. Observe that the file is overwritten

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
