### PR TITLE
UI: Fix can't paste removed item's filter issue

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4553,7 +4553,13 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 	if (item) {
 		QAction *pasteFilters =
 			new QAction(QTStr("Paste.Filters"), this);
-		pasteFilters->setEnabled(copyFiltersString);
+		OBSSource filterSource = NULL;
+		if (copyFiltersString) {
+			filterSource =
+				obs_get_source_by_name(copyFiltersString);
+			obs_source_release(filterSource);
+		}
+		pasteFilters->setEnabled(filterSource != NULL);
 		connect(pasteFilters, SIGNAL(triggered()), this,
 			SLOT(ScenePasteFilters()));
 
@@ -5078,7 +5084,12 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		ui->actionCopyFilters->setEnabled(true);
 		ui->actionCopySource->setEnabled(true);
 	}
-	ui->actionPasteFilters->setEnabled(copyFiltersString && idx != -1);
+	OBSSource filterSource = NULL;
+	if (copyFiltersString) {
+		filterSource = obs_get_source_by_name(copyFiltersString);
+		obs_source_release(filterSource);
+	}
+	ui->actionPasteFilters->setEnabled(filterSource != NULL && idx != -1);
 
 	popup.exec(QCursor::pos());
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Previously: Paste filters is clickable after removing source after copy, but doesn't do anything.
Now changed to disable paste filter action if the item is removed

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Refer to issue #4075.
It is due to missing out checking the source item is still existed when setting up the context menu

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

1. Add any source.
2. Add any filters to that source.
3. Add another source (that can have these filters, e.g. both sources can have video filters)
4. Copy filters from the first source.
5. Remove the first source.
6. Right click -> Paste Filters on the second source.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
