### PR TITLE
UI: Add mute checkbox to Advanced Audio Properties

### DIFF
--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -25,6 +25,7 @@ private:
 	OBSSource source;
 
 	QPointer<QWidget> activeContainer;
+	QPointer<QWidget> muteContainer;
 	QPointer<QWidget> forceMonoContainer;
 	QPointer<QWidget> mixerContainer;
 	QPointer<QWidget> balanceContainer;
@@ -32,6 +33,7 @@ private:
 	QPointer<QLabel> iconLabel;
 	QPointer<QLabel> nameLabel;
 	QPointer<QLabel> active;
+	QPointer<QCheckBox> mute;
 	QPointer<QStackedWidget> stackedWidget;
 	QPointer<QSpinBox> percent;
 	QPointer<QDoubleSpinBox> volume;
@@ -54,9 +56,11 @@ private:
 	OBSSignal mixersSignal;
 	OBSSignal activateSignal;
 	OBSSignal deactivateSignal;
+	OBSSignal muteChangedSignal;
 
 	static void OBSSourceActivated(void *param, calldata_t *calldata);
 	static void OBSSourceDeactivated(void *param, calldata_t *calldata);
+	static void OBSSourceMuteChanged(void *param, calldata_t *calldata);
 	static void OBSSourceFlagsChanged(void *param, calldata_t *calldata);
 	static void OBSSourceVolumeChanged(void *param, calldata_t *calldata);
 	static void OBSSourceSyncChanged(void *param, calldata_t *calldata);
@@ -74,11 +78,13 @@ public:
 
 public slots:
 	void SourceActiveChanged(bool active);
+	void SourceMuteChanged(bool muted);
 	void SourceFlagsChanged(uint32_t flags);
 	void SourceVolumeChanged(float volume);
 	void SourceSyncChanged(int64_t offset);
 	void SourceMixersChanged(uint32_t mixers);
 
+	void muteChanged(bool mute);
 	void volumeChanged(double db);
 	void percentChanged(int percent);
 	void downmixMonoChanged(bool checked);

--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -59,6 +59,9 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 	label = new QLabel(QTStr("Basic.Stats.Status"));
 	label->setStyleSheet("font-weight: bold;");
 	mainLayout->addWidget(label, 0, idx++);
+	label = new QLabel(QTStr("Mute"));
+	label->setStyleSheet("font-weight: bold;");
+	mainLayout->addWidget(label, 0, idx++);
 	mainLayout->addLayout(volLayout, 0, idx++);
 	label = new QLabel(QTStr("Basic.AdvAudio.Mono"));
 	label->setStyleSheet("font-weight: bold;");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
In my context I want to know if a specific source is muted even if it isn't showing in the final mix. This because I have scenes where media file start automatically and I want to know if the source is muted or not before making it visible.
With Studio mode enabled I can't get what I want.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows 10 Pro. Downloaded artifact form Actions on my fork.
Muting / unmuting either from Audio Mixer or Advanced Audio Properties works well.

I don't know if this should be documented, please let me now.

Attached screenshot below
![Cattura](https://user-images.githubusercontent.com/25064808/110759350-cdb1b400-824d-11eb-9018-22ceff7998ea.PNG)


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
