### PR TITLE
rtmp-services: Make YouTube - RTMPS service the default

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 170,
+	"version": 171,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 170
+			"version": 171
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -219,30 +219,13 @@
             }
         },
         {
-            "name": "YouTube - RTMP",
+            "name": "YouTube - RTMPS",
             "common": true,
             "alt_names": [
-                "YouTube / YouTube Gaming"
+                "YouTube / YouTube Gaming",
+                "YouTube - RTMP",
+                "YouTube - RTMPS (Beta)"
             ],
-            "servers": [
-                {
-                    "name": "Primary YouTube ingest server",
-                    "url": "rtmp://a.rtmp.youtube.com/live2"
-                },
-                {
-                    "name": "Backup YouTube ingest server",
-                    "url": "rtmp://b.rtmp.youtube.com/live2?backup=1"
-                }
-            ],
-            "recommended": {
-                "keyint": 2,
-                "max video bitrate": 51000,
-                "max audio bitrate": 160
-            }
-        },
-        {
-            "name": "YouTube - RTMPS (Beta)",
-            "common": true,
             "servers": [
                 {
                     "name": "Primary YouTube ingest server",
@@ -250,7 +233,15 @@
                 },
                 {
                     "name": "Backup YouTube ingest server",
-                    "url": "rtmps://b.rtmps.youtube.com:443/live2"
+                    "url": "rtmps://b.rtmps.youtube.com:443/live2?backup=1"
+                },
+                {
+                    "name": "Primary YouTube ingest server (legacy RTMP)",
+                    "url": "rtmp://a.rtmp.youtube.com/live2"
+                },
+                {
+                    "name": "Backup YouTube ingest server (legacy RTMP)",
+                    "url": "rtmp://b.rtmp.youtube.com/live2?backup=1"
                 }
             ],
             "recommended": {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Remove beta label for YouTube - RTMPS service and make it the default. Remove
YouTube - RTMP service and move the legacy RTMP URLs to the Server
dropdown list.

### Motivation and Context
We have verified YouTube - RTMPS as a beta option. Ready to make it as default.

### How Has This Been Tested?
- Tested on macOS Big Sur 11.2.1 against the YouTube RTMPS service.
- Verified that the stream health is good.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
