### PR TITLE
UI: Can copy-paste filters to multiple sources

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -281,6 +281,7 @@ Undo.Sources.Multi="Delete %1 Sources"
 Undo.Filters="Filter Changes on '%1'"
 Undo.Filters.Paste.Single="Paste Filter '%1' to '%2'"
 Undo.Filters.Paste.Multiple="Copy Filters from '%1' to '%2'"
+Undo.Filters.Paste.MultipleDestinations="Copy Filters from '%1' to %2 sources"
 Undo.Transform="Transform source(s) In '%1'"
 Undo.Transform.Paste="Paste Transformation in '%1'"
 Undo.Transform.Rotate="Rotation In '%1'"
@@ -355,6 +356,10 @@ ConfirmExit.Text="OBS is currently active. All streams/recordings will be shut d
 ConfirmRemove.Title="Confirm Remove"
 ConfirmRemove.Text="Are you sure you wish to remove '$1'?"
 ConfirmRemove.TextMultiple="Are you sure you wish to remove %1 items?"
+
+# confirm paste filter dialog box
+ConfirmPasteFilters.Title="Confirm Paste Filter"
+ConfirmPasteFilters.TextMultiple="Are you sure you wish to paste filters to %1 sources?"
 
 # output start messages
 Output.StartStreamFailed="Failed to start streaming"

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -41,6 +41,7 @@
 
 #include <obs-frontend-internal.hpp>
 
+#include <set>
 #include <util/platform.h>
 #include <util/threading.h>
 #include <util/util.hpp>
@@ -907,6 +908,10 @@ public:
 					     obs_source_t *source,
 					     obs_data_array_t *undo_array,
 					     obs_data_array_t *redo_array);
+
+	void CreateFilterPasteMultipleUndoRedoAction(
+		const QString &text, obs_source_t *source,
+		std::set<OBSSource> &dstSources);
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fix #4290.
Add support for pasting copied filters to multiple selected sources, instead of only one which was selected first. Instead of calling `GetCurrentSceneItem()` which returns the index of the first selected source from the array returned by `ui->sources->selectionModel()->selectedIndexes()`, call `ui->sources->selectionModel()->selectedIndexes()` directly and iterate over all selected sources.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Adds confirmation prompt if filter is pasted to more than 4 sources:
![image](https://user-images.githubusercontent.com/45960703/111022909-e99c8d80-83e6-11eb-868e-830eab64d401.png)

### Motivation and Context
Reporter of the original bug #4290, @AskMP, works with large numbers of sources. In one comment he mentioned having to copy-paste filters to 48 sources by hand.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
I a bunch of tests, here are a few:
 - Created many sources (images)
 - Added a filter to one source which is very obvious
 - Copied filter from source A, selected one other source B and pasted the filter to it (supported prior to the change)
 - Copied filter from source A and pasted it to the same source A, checked that filter was not duplicated (supported prior to the change)
 - Copied filter from source A, selected multiple other sources B,C,D and pasted the filter to them, checked that each got the filter
 - Copied filter from source A, selected multiple other sources, deselected some of them, pasted the filter, checked that deselected sources did not get the filter

Test env:
OS: Windows 10 Home 20H2
CPU: Intel(R) Core(TM) i7-10875H
GPU: Nvidia GeForce RTX 2060

It does not affect any other functions because I changed only `OBSBasic::on_actionPasteFilters_triggered()` (I considered making a helper function for getting all selected scene items analogous to `GetCurrentSceneItem()`, but did not find any other function that could benefit from this helper.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
