### PR TITLE
Improve laptop check for Desktop Capture method auto-selection

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -2866,3 +2866,29 @@ extern "C" EXPORT void device_unregister_loss_callbacks(gs_device_t *device,
 		}
 	}
 }
+
+uint32_t gs_get_adapter_count(void)
+{
+	uint32_t count = 0;
+
+	const IID factoryIID = (GetWinVer() >= 0x602) ? dxgiFactory2
+						      : __uuidof(IDXGIFactory1);
+	ComPtr<IDXGIFactory1> factory;
+	HRESULT hr = CreateDXGIFactory1(factoryIID, (void **)factory.Assign());
+	if (SUCCEEDED(hr)) {
+		ComPtr<IDXGIAdapter1> adapter;
+		for (UINT i = 0;
+		     factory->EnumAdapters1(i, adapter.Assign()) == S_OK; ++i) {
+			DXGI_ADAPTER_DESC desc;
+			if (SUCCEEDED(adapter->GetDesc(&desc))) {
+				/* ignore Microsoft's 'basic' renderer' */
+				if (desc.VendorId != 0x1414 &&
+				    desc.DeviceId != 0x8c) {
+					++count;
+				}
+			}
+		}
+	}
+
+	return count;
+}

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -210,6 +210,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT_OPTIONAL(gs_duplicator_destroy);
 	GRAPHICS_IMPORT_OPTIONAL(gs_duplicator_update_frame);
 	GRAPHICS_IMPORT_OPTIONAL(gs_duplicator_get_texture);
+	GRAPHICS_IMPORT_OPTIONAL(gs_get_adapter_count);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_create_gdi);
 	GRAPHICS_IMPORT_OPTIONAL(gs_texture_get_dc);
 	GRAPHICS_IMPORT_OPTIONAL(gs_texture_release_dc);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -297,6 +297,8 @@ struct gs_exports {
 	bool (*gs_duplicator_update_frame)(gs_duplicator_t *duplicator);
 	gs_texture_t *(*gs_duplicator_get_texture)(gs_duplicator_t *duplicator);
 
+	uint32_t (*gs_get_adapter_count)(void);
+
 	gs_texture_t *(*device_texture_create_gdi)(gs_device_t *device,
 						   uint32_t width,
 						   uint32_t height);

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -2913,6 +2913,16 @@ bool gs_duplicator_update_frame(gs_duplicator_t *duplicator)
 	return thread_graphics->exports.gs_duplicator_update_frame(duplicator);
 }
 
+uint32_t gs_get_adapter_count(void)
+{
+	if (!gs_valid("gs_get_adapter_count"))
+		return 0;
+	if (!thread_graphics->exports.gs_get_adapter_count)
+		return 0;
+
+	return thread_graphics->exports.gs_get_adapter_count();
+}
+
 gs_texture_t *gs_duplicator_get_texture(gs_duplicator_t *duplicator)
 {
 	if (!gs_valid_p("gs_duplicator_get_texture", duplicator))

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -874,6 +874,8 @@ EXPORT void gs_duplicator_destroy(gs_duplicator_t *duplicator);
 EXPORT bool gs_duplicator_update_frame(gs_duplicator_t *duplicator);
 EXPORT gs_texture_t *gs_duplicator_get_texture(gs_duplicator_t *duplicator);
 
+EXPORT uint32_t gs_get_adapter_count(void);
+
 /** creates a windows GDI-lockable texture */
 EXPORT gs_texture_t *gs_texture_create_gdi(uint32_t width, uint32_t height);
 

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -159,8 +159,22 @@ choose_method(enum display_capture_method method, bool wgc_supported,
 		obs_leave_graphics();
 	}
 
-	if (method == METHOD_AUTO)
-		method = (*dxgi_index == -1) ? METHOD_WGC : METHOD_DXGI;
+	if (method == METHOD_AUTO) {
+		method = METHOD_DXGI;
+		if (*dxgi_index == -1) {
+			method = METHOD_WGC;
+		} else {
+			SYSTEM_POWER_STATUS status;
+			if (GetSystemPowerStatus(&status) &&
+			    status.BatteryFlag < 128) {
+				obs_enter_graphics();
+				const uint32_t count = gs_get_adapter_count();
+				obs_leave_graphics();
+				if (count >= 2)
+					method = METHOD_WGC;
+			}
+		}
+	}
 
 	return method;
 }


### PR DESCRIPTION
### Description
We want WGC for laptops and DXGI for everything else (except desktops with multiple GPUs where the monitor is attached to the opposite GPU). Assume laptop if multiple GPUs and battery exists.

Builds on PR #4140.

### Motivation and Context
Current test still selects DXGI for laptops.

### How Has This Been Tested?
Verified DXGI is selected on desktop, and that one adapter is returned on PC with one GPU.

Ryto says this works on laptop..

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.