### PR TITLE
libobs, UI: Add support for button properties as links

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -526,6 +526,9 @@ Basic.PropertiesWindow.EditEditableListEntry="Edit entry from '%1'"
 Basic.PropertiesView.FPS.Simple="Simple FPS Values"
 Basic.PropertiesView.FPS.Rational="Rational FPS Values"
 Basic.PropertiesView.FPS.ValidFPSRanges="Valid FPS Ranges:"
+Basic.PropertiesView.UrlButton.Text="Open this link in your default web browser?"
+Basic.PropertiesView.UrlButton.Text.Url="URL: %1"
+Basic.PropertiesView.UrlButton.OpenUrl="Open URL"
 
 # interaction window
 Basic.InteractionWindow="Interacting with '%1'"

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -17,10 +17,12 @@
 #include <QPlainTextEdit>
 #include <QDialogButtonBox>
 #include <QMenu>
+#include <QMessageBox>
 #include <QStackedWidget>
 #include <QDir>
 #include <QGroupBox>
 #include <QObject>
+#include <QDesktopServices>
 #include "double-slider.hpp"
 #include "slider-ignorewheel.hpp"
 #include "spinbox-ignorewheel.hpp"
@@ -1881,6 +1883,30 @@ void WidgetInfo::EditableListChanged()
 
 void WidgetInfo::ButtonClicked()
 {
+	obs_button_type type = obs_property_button_type(property);
+	const char *savedUrl = obs_property_button_url(property);
+
+	if (type == OBS_BUTTON_URL && strcmp(savedUrl, "") != 0) {
+		QUrl url(savedUrl, QUrl::StrictMode);
+		if (url.isValid() && (url.scheme().compare("http") == 0 ||
+				      url.scheme().compare("https") == 0)) {
+			QString msg(
+				QTStr("Basic.PropertiesView.UrlButton.Text"));
+			msg += "\n\n";
+			msg += QString(QTStr("Basic.PropertiesView.UrlButton.Text.Url"))
+				       .arg(savedUrl);
+
+			QMessageBox::StandardButton button = OBSMessageBox::question(
+				view->window(),
+				QTStr("Basic.PropertiesView.UrlButton.OpenUrl"),
+				msg, QMessageBox::Yes | QMessageBox::No,
+				QMessageBox::No);
+
+			if (button == QMessageBox::Yes)
+				QDesktopServices::openUrl(url);
+		}
+		return;
+	}
 	if (obs_property_button_clicked(property, view->obj)) {
 		QMetaObject::invokeMethod(view, "RefreshProperties",
 					  Qt::QueuedConnection);

--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -240,6 +240,11 @@ Property Object Functions
    :param    description: Localized name shown to user
    :return:               The property
 
+   Important Related Functions:
+
+      - :c:func:`obs_property_button_set_type`
+      - :c:func:`obs_property_button_set_url`
+
    Relevant data types used with this function:
 
 .. code:: cpp
@@ -512,6 +517,19 @@ Property Enumeration Functions
 
 ---------------------
 
+.. function:: enum obs_button_type obs_property_button_type(obs_property_t *p)
+
+   :return: One of the following values:
+
+             - OBS_BUTTON_DEFAULT
+             - OBS_BUTTON_URL
+
+---------------------
+
+.. function:: const char *obs_property_button_url(obs_property_t *p)
+
+---------------------
+
 .. function:: enum obs_group_type obs_property_group_type(obs_property_t *p)
 
   :return: One of the following values:
@@ -658,3 +676,17 @@ Property Modification Functions
 ---------------------
 
 .. function:: void obs_property_frame_rate_fps_range_insert(obs_property_t *p, size_t idx, struct media_frames_per_second min, struct media_frames_per_second max)
+
+---------------------
+
+.. function:: void obs_property_button_set_type(obs_property_t *p, enum obs_button_type type)
+
+   :param   type: Can be one of the following values:
+
+                  - **OBS_BUTTON_DEFAULT** - Standard button
+                  - **OBS_BUTTON_URL** - Button that opens a URL
+   :return:       The property
+
+---------------------
+
+.. function:: void obs_property_button_set_url(obs_property_t *p, char *url)

--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -72,6 +72,8 @@ struct editable_list_data {
 
 struct button_data {
 	obs_property_clicked_t callback;
+	enum obs_button_type type;
+	char *url;
 };
 
 struct frame_rate_option {
@@ -1102,6 +1104,24 @@ void obs_property_text_set_monospace(obs_property_t *p, bool monospace)
 	data->monospace = monospace;
 }
 
+void obs_property_button_set_type(obs_property_t *p, enum obs_button_type type)
+{
+	struct button_data *data = get_type_data(p, OBS_PROPERTY_BUTTON);
+	if (!data)
+		return;
+
+	data->type = type;
+}
+
+void obs_property_button_set_url(obs_property_t *p, char *url)
+{
+	struct button_data *data = get_type_data(p, OBS_PROPERTY_BUTTON);
+	if (!data)
+		return;
+
+	data->url = url;
+}
+
 void obs_property_list_clear(obs_property_t *p)
 {
 	struct list_data *data = get_list_data(p);
@@ -1434,4 +1454,16 @@ obs_properties_t *obs_property_group_content(obs_property_t *p)
 {
 	struct group_data *data = get_type_data(p, OBS_PROPERTY_GROUP);
 	return data ? data->content : NULL;
+}
+
+enum obs_button_type obs_property_button_type(obs_property_t *p)
+{
+	struct button_data *data = get_type_data(p, OBS_PROPERTY_BUTTON);
+	return data ? data->type : OBS_BUTTON_DEFAULT;
+}
+
+const char *obs_property_button_url(obs_property_t *p)
+{
+	struct button_data *data = get_type_data(p, OBS_PROPERTY_BUTTON);
+	return data ? data->url : "";
 }

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -101,6 +101,11 @@ enum obs_group_type {
 	OBS_GROUP_CHECKABLE,
 };
 
+enum obs_button_type {
+	OBS_BUTTON_DEFAULT,
+	OBS_BUTTON_URL,
+};
+
 #define OBS_FONT_BOLD (1 << 0)
 #define OBS_FONT_ITALIC (1 << 1)
 #define OBS_FONT_UNDERLINE (1 << 2)
@@ -334,6 +339,10 @@ EXPORT void obs_property_float_set_suffix(obs_property_t *p,
 					  const char *suffix);
 EXPORT void obs_property_text_set_monospace(obs_property_t *p, bool monospace);
 
+EXPORT void obs_property_button_set_type(obs_property_t *p,
+					 enum obs_button_type type);
+EXPORT void obs_property_button_set_url(obs_property_t *p, char *url);
+
 EXPORT void obs_property_list_clear(obs_property_t *p);
 
 EXPORT size_t obs_property_list_add_string(obs_property_t *p, const char *name,
@@ -400,6 +409,9 @@ obs_property_frame_rate_fps_range_max(obs_property_t *p, size_t idx);
 
 EXPORT enum obs_group_type obs_property_group_type(obs_property_t *p);
 EXPORT obs_properties_t *obs_property_group_content(obs_property_t *p);
+
+EXPORT enum obs_button_type obs_property_button_type(obs_property_t *p);
+EXPORT const char *obs_property_button_url(obs_property_t *p);
 
 #ifndef SWIG
 OBS_DEPRECATED


### PR DESCRIPTION
### Description

Buttons are very useful. They're even more useful if they can take you somewhere, such as to download a dependency or to open a troubleshooting/FAQ page.

This introduces two button attributes, a `type` & a `url`. If a type is not defined, the button behaves as before.

![image](https://user-images.githubusercontent.com/941350/110912907-997ee600-8368-11eb-9709-cd9cf3c8de4f.png)

### Motivation and Context

When @pkviet started working on #3603 it gave me the idea to provide a way for plugins to link to external webpages.

### How Has This Been Tested?

Append this to `duplicator_capture_properties`:
```c
	obs_property_t *btn = obs_properties_add_button(
		props, "help", "Troubleshooting", NULL);
	obs_property_button_set_type(btn, OBS_BUTTON_URL);
	obs_property_button_set_url(
		btn,
		"https://obsproject.com/help");
```

Click the button.

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
