### PR TITLE
rtmp-services: Added recommendation settings for Aparat

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 170,
+	"version": 171,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 170
+			"version": 171
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1276,7 +1276,13 @@
                     "name": "Default",
                     "url": "rtmp://rtmp.cdn.asset.aparat.com:443/event"
                 }
-            ]
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 6000,
+                "max audio bitrate": 320,
+                "x264opts": "scenecut=0"
+            }
         },
         {
             "name": "GameTips.TV",


### PR DESCRIPTION
### Description
Adding recommendation settings for aparat including 

- keyframe
- Max video bitrate 
- Max audio bitrate 
- Options for x264

### Motivation and Context
This change makes sure the streamers who are using Aparat Live Platform Season3 experience no problem with the latest changes.

### How Has This Been Tested?
Tested on macOS Big Sur 11.2.1 against the Aparat RTMPS service.
Verified the stream quality is good and there is no lag for the viewers.

### Types of changes
New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
