### PR TITLE
mac-capture: Fix #3529  - Mac Capture showing last image on window close

### DIFF
--- a/plugins/mac-capture/mac-window-capture.m
+++ b/plugins/mac-capture/mac-window-capture.m
@@ -45,8 +45,8 @@ static inline void capture_frame(struct window_capture *wc)
 	uint64_t ts = os_gettime_ns();
 	CGImageRef img = get_image(wc);
 	if (!img)
-		img = CGImageCreate(NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-				    NULL, NULL, NULL, NULL);
+		obs_source_output_video(wc->source, NULL);
+		return;
 
 	size_t width = CGImageGetWidth(img);
 	size_t height = CGImageGetHeight(img);

--- a/plugins/mac-capture/mac-window-capture.m
+++ b/plugins/mac-capture/mac-window-capture.m
@@ -45,7 +45,8 @@ static inline void capture_frame(struct window_capture *wc)
 	uint64_t ts = os_gettime_ns();
 	CGImageRef img = get_image(wc);
 	if (!img)
-		return;
+		img = CGImageCreate(NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+				    NULL, NULL, NULL, NULL);
 
 	size_t width = CGImageGetWidth(img);
 	size_t height = CGImageGetHeight(img);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This fixes #3529 

instead of maintaining the last known image on the window capture window close, it seems to default to the desktop now. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
issue #3529
### How Has This Been Tested?
yes, macOS. 
### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
