### PR TITLE
obs-ffmpeg: Align both NVENC implementations

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -468,10 +468,14 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 	enc->bframes = bf;
 
 	/* lookahead */
+	const bool use_profile_lookahead = config->rcParams.enableLookahead;
 	lookahead = nv_get_cap(enc, NV_ENC_CAPS_SUPPORT_LOOKAHEAD) &&
-		    (lookahead || config->rcParams.enableLookahead);
-	if (lookahead)
-		enc->rc_lookahead = 8;
+		    (lookahead || use_profile_lookahead);
+	if (lookahead) {
+		enc->rc_lookahead = use_profile_lookahead
+					    ? config->rcParams.lookaheadDepth
+					    : 8;
+	}
 
 	int buf_count = max(4, config->frameIntervalP * 2 * 2);
 	if (lookahead) {

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -437,6 +437,11 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 		h264_config->outputAUD = 1;
 	}
 
+	h264_config->sliceMode = 3;
+	h264_config->sliceModeData = 1;
+
+	h264_config->useBFramesAsRef = NV_ENC_BFRAME_REF_MODE_DISABLED;
+
 	vui_params->videoSignalTypePresentFlag = 1;
 	vui_params->videoFullRangeFlag = (voi->range == VIDEO_RANGE_FULL);
 	vui_params->colourDescriptionPresentFlag = 1;
@@ -487,6 +492,8 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 		config->rcParams.enableLookahead = 1;
 		config->rcParams.lookaheadDepth =
 			max(enc->rc_lookahead, lkd_bound);
+		config->rcParams.disableIadapt = 0;
+		config->rcParams.disableBadapt = 0;
 	}
 
 	/* psycho aq */

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -3,6 +3,7 @@
 #include <util/darray.h>
 #include <util/dstr.h>
 #include <obs-avc.h>
+#include <libavutil/rational.h>
 #define INITGUID
 #include <dxgi.h>
 #include <d3d11.h>
@@ -408,14 +409,17 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 	NV_ENC_CONFIG_H264_VUI_PARAMETERS *vui_params =
 		&h264_config->h264VUIParameters;
 
+	int darWidth, darHeight;
+	av_reduce(&darWidth, &darHeight, voi->width, voi->height, 1024 * 1024);
+
 	memset(params, 0, sizeof(*params));
 	params->version = NV_ENC_INITIALIZE_PARAMS_VER;
 	params->encodeGUID = NV_ENC_CODEC_H264_GUID;
 	params->presetGUID = nv_preset;
 	params->encodeWidth = voi->width;
 	params->encodeHeight = voi->height;
-	params->darWidth = voi->width;
-	params->darHeight = voi->height;
+	params->darWidth = darWidth;
+	params->darHeight = darHeight;
 	params->frameRateNum = voi->fps_num;
 	params->frameRateDen = voi->fps_den;
 	params->enableEncodeAsync = 1;

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -425,8 +425,6 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 	params->enableEncodeAsync = 1;
 	params->enablePTD = 1;
 	params->encodeConfig = &enc->config;
-	params->maxEncodeWidth = voi->width;
-	params->maxEncodeHeight = voi->height;
 	config->gopLength = gop_size;
 	config->frameIntervalP = 1 + bf;
 	h264_config->idrPeriod = gop_size;

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -50,7 +50,7 @@ struct nvenc_data {
 	bool encode_started;
 	bool first_packet;
 	bool can_change_bitrate;
-	bool bframes;
+	int32_t bframes;
 
 	DARRAY(struct nv_bitstream) bitstreams;
 	DARRAY(struct nv_texture) textures;
@@ -461,7 +461,7 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 		break;
 	}
 
-	enc->bframes = bf > 0;
+	enc->bframes = bf;
 
 	/* lookahead */
 	if (lookahead && nv_get_cap(enc, NV_ENC_CAPS_SUPPORT_LOOKAHEAD)) {
@@ -908,8 +908,7 @@ static bool nvenc_encode_tex(void *data, uint32_t handle, int64_t pts,
 		circlebuf_pop_front(&enc->dts_list, &dts, sizeof(dts));
 
 		/* subtract bframe delay from dts */
-		if (enc->bframes)
-			dts -= packet->timebase_num;
+		dts -= (int64_t)enc->bframes * packet->timebase_num;
 
 		*received_packet = true;
 		packet->data = enc->packet_data.array;

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -472,6 +472,7 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 	/* psycho aq */
 	if (nv_get_cap(enc, NV_ENC_CAPS_SUPPORT_TEMPORAL_AQ)) {
 		config->rcParams.enableAQ = psycho_aq;
+		config->rcParams.aqStrength = 8;
 		config->rcParams.enableTemporalAQ = psycho_aq;
 	}
 

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -462,11 +462,11 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 	enc->bframes = bf;
 
 	/* lookahead */
-	if (lookahead && nv_get_cap(enc, NV_ENC_CAPS_SUPPORT_LOOKAHEAD)) {
+	lookahead = nv_get_cap(enc, NV_ENC_CAPS_SUPPORT_LOOKAHEAD) &&
+		    (lookahead || config->rcParams.enableLookahead);
+	if (lookahead) {
 		config->rcParams.lookaheadDepth = 8;
 		config->rcParams.enableLookahead = 1;
-	} else {
-		lookahead = false;
 	}
 
 	/* psycho aq */

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -509,6 +509,7 @@ static bool init_encoder(struct nvenc_data *enc, obs_data_t *settings)
 	h264_config->outputPictureTimingSEI = 1;
 	config->rcParams.averageBitRate = bitrate * 1000;
 	config->rcParams.maxBitRate = vbr ? max_bitrate * 1000 : bitrate * 1000;
+	config->rcParams.vbvBufferSize = bitrate * 1000;
 
 	/* -------------------------- */
 	/* profile                    */

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -221,8 +221,9 @@ static bool nvenc_update(void *data, obs_data_t *settings)
 
 	} else if (astrcmpi(rc, "vbr") != 0) { /* CBR by default */
 		av_opt_set_int(enc->context->priv_data, "cbr", true, 0);
-		enc->context->rc_max_rate = bitrate * 1000;
-		enc->context->rc_min_rate = bitrate * 1000;
+		const int64_t rate = (int64_t)bitrate * 1000;
+		enc->context->rc_max_rate = rate;
+		enc->context->rc_min_rate = rate;
 		cqp = 0;
 	}
 
@@ -233,8 +234,9 @@ static bool nvenc_update(void *data, obs_data_t *settings)
 	av_opt_set_int(enc->context->priv_data, "spatial-aq", psycho_aq, 0);
 	av_opt_set_int(enc->context->priv_data, "temporal-aq", psycho_aq, 0);
 
-	enc->context->bit_rate = bitrate * 1000;
-	enc->context->rc_buffer_size = bitrate * 1000;
+	const int rate = bitrate * 1000;
+	enc->context->bit_rate = rate;
+	enc->context->rc_buffer_size = rate;
 	enc->context->width = obs_encoder_get_width(enc->encoder);
 	enc->context->height = obs_encoder_get_height(enc->encoder);
 	enc->context->time_base = (AVRational){voi->fps_den, voi->fps_num};
@@ -295,13 +297,14 @@ static bool nvenc_reconfigure(void *data, obs_data_t *settings)
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 19, 101)
 	struct nvenc_encoder *enc = data;
 
-	int bitrate = (int)obs_data_get_int(settings, "bitrate");
+	const int64_t bitrate = obs_data_get_int(settings, "bitrate");
 	const char *rc = obs_data_get_string(settings, "rate_control");
 	bool cbr = astrcmpi(rc, "CBR") == 0;
 	bool vbr = astrcmpi(rc, "VBR") == 0;
 	if (cbr || vbr) {
-		enc->context->bit_rate = bitrate * 1000;
-		enc->context->rc_max_rate = bitrate * 1000;
+		const int64_t rate = bitrate * 1000;
+		enc->context->bit_rate = rate;
+		enc->context->rc_max_rate = rate;
 	}
 #endif
 	return true;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -173,6 +173,7 @@ static bool nvenc_update(void *data, obs_data_t *settings)
 	int gpu = (int)obs_data_get_int(settings, "gpu");
 	bool cbr_override = obs_data_get_bool(settings, "cbr");
 	int bf = (int)obs_data_get_int(settings, "bf");
+	bool psycho_aq = obs_data_get_bool(settings, "psycho_aq");
 
 	video_t *video = obs_encoder_video(enc->encoder);
 	const struct video_output_info *voi = video_output_get_info(video);
@@ -228,6 +229,9 @@ static bool nvenc_update(void *data, obs_data_t *settings)
 	av_opt_set(enc->context->priv_data, "level", "auto", 0);
 	av_opt_set_int(enc->context->priv_data, "2pass", twopass, 0);
 	av_opt_set_int(enc->context->priv_data, "gpu", gpu, 0);
+
+	av_opt_set_int(enc->context->priv_data, "spatial-aq", psycho_aq, 0);
+	av_opt_set_int(enc->context->priv_data, "temporal-aq", psycho_aq, 0);
 
 	enc->context->bit_rate = bitrate * 1000;
 	enc->context->rc_buffer_size = bitrate * 1000;


### PR DESCRIPTION
### Description
Set aspect ratio after av_reduce, e.g. 1920:1080 becomes 16:9.

Modify dts computation to offset by number of bframes to match FFmpeg.

Hard-code various H264 config values as they appear in FFmpeg.

Don't set maxEncodeWidth/maxEncodeHeight since FFmpeg doesn't, and we
don't support resolution changes.

Force-enable lookahead if nvEncGetEncodePresetConfig says to.

If Psycho Visual Tuning is on, switch aqStrength to from 0 to 8 to match
FFmpeg default.

Set vbvBufferSize to match FFmpeg behavior.

Compute buffer count according to FFmpeg logic.

Fix various static analysis warnings about variable size.

Plumb Psycho Visual Tuning setting into fallback encoder.

### Motivation and Context
Cleaning things up before a future NVENC upgrade.

### How Has This Been Tested?
Various experiments with modified FFmpeg to simulate OBS encodes against lossless Sintel trailer source. PSNR/VMAF are pretty close to identical on my personal set of settings.

Inspected all diffs under debugger to make sure values are applied as expected. Verified NVENC init params match FFmpeg behavior as needed.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.