### PR TITLE
Only set AA_DontCreateNativeWidgetSiblings on Wayland

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1393,7 +1393,6 @@ bool OBSApp::OBSInit()
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
-	setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
 
 	qRegisterMetaType<VoidFunc>();
 
@@ -1414,6 +1413,8 @@ bool OBSApp::OBSInit()
 			QGuiApplication::platformNativeInterface();
 		obs_set_nix_platform_display(
 			native->nativeResourceForIntegration("display"));
+
+		setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
 
 		blog(LOG_INFO, "Platform: Wayland");
 	}


### PR DESCRIPTION
### Description

It seems this flag introduced various regressions on X11 (and, potentially, on other platforms too, but needs confirmation). Let's preserve the old ways on current platforms, and only use this flag on the new Wayland platform.

### Motivation and Context

This is a potential fix for the broken previews on X11 issue that @cg2121 reported.

### How Has This Been Tested?

 - Open OBS Studio on Linux / X11
 - Switch to Studio Mode
 - Observe no issues

Alternatively:

 - Add a screen capture on X11
 - Go to the properties dialog
 - Observe no issues

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
