### PR TITLE
UI: Copy Filters context menu is active only when needed

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5075,7 +5075,8 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		popup.addAction(QTStr("Properties"), this,
 				SLOT(on_actionSourceProperties_triggered()));
 
-		ui->actionCopyFilters->setEnabled(true);
+		ui->actionCopyFilters->setEnabled(
+			obs_source_filter_count(source) > 0);
 		ui->actionCopySource->setEnabled(true);
 	}
 	ui->actionPasteFilters->setEnabled(copyFiltersString && idx != -1);

--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -1013,6 +1013,12 @@ General Source Functions
 
 ---------------------
 
+.. function:: size_t obs_source_filter_count(const obs_source_t *source)
+
+   Returns the number of filters the source has.
+
+---------------------
+
 .. function:: bool obs_source_enabled(const obs_source_t *source)
               void obs_source_set_enabled(obs_source_t *source, bool enabled)
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -4309,6 +4309,13 @@ obs_source_t *obs_source_get_filter_by_name(obs_source_t *source,
 	return filter;
 }
 
+size_t obs_source_filter_count(const obs_source_t *source)
+{
+	return obs_source_valid(source, "obs_source_filter_count")
+		       ? source->filters.num
+		       : 0;
+}
+
 bool obs_source_enabled(const obs_source_t *source)
 {
 	return obs_source_valid(source, "obs_source_enabled") ? source->enabled

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1101,6 +1101,9 @@ EXPORT void obs_source_enum_filters(obs_source_t *source,
 EXPORT obs_source_t *obs_source_get_filter_by_name(obs_source_t *source,
 						   const char *name);
 
+/** Gets the number of filters the source has. */
+EXPORT size_t obs_source_filter_count(const obs_source_t *source);
+
 EXPORT void obs_source_copy_filters(obs_source_t *dst, obs_source_t *src);
 EXPORT void obs_source_copy_single_filter(obs_source_t *dst,
 					  obs_source_t *filter);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Make "Copy Filters" context menu item active only when there is at least one filter that can be copied.
![image](https://user-images.githubusercontent.com/45960703/111232343-fba34980-85fb-11eb-98bc-9ba0329c0d1e.png)

This adds a helper function for inferring number of filters a source has, documents this helper and uses it to create context menu.

Note: I broke up the PR into two commits, one for helper with its docs and one for actual change. If needed, I can squash them.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
This change upholds OBS consistency of making context menus active only when they can be used.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
1. Create a scene with at least three sources, add one filter to at least one source, add multiple sources to another
2. Check that source with no filters has "Copy Filters" inactive
2. Check that source with one filter has "Copy Filters" active
3. Check that source with multiple filters has "Copy Filters" active
4. Copy filters to the source which did not have any. Check that it has "Copy Filters" active now.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
 - Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
