### PR TITLE
libobs/graphics, libobs-opengl, libobs-d3d11, docs/sphinx: Introduce effect results

### DIFF
--- a/docs/sphinx/reference-libobs-graphics-effects.rst
+++ b/docs/sphinx/reference-libobs-graphics-effects.rst
@@ -21,6 +21,9 @@ HLSL format.
 
    Effect parameter object.
 
+.. type:: typedef struct gs_effect_result    gs_eresult_t
+
+   Effect result object.
 
 ---------------------
 
@@ -133,6 +136,15 @@ HLSL format.
 
 ---------------------
 
+.. function:: size_t gs_effect_get_num_results(const gs_effect_t *effect)
+
+   Gets the number of results associated with the effect.
+
+   :param effect: Effect object
+   :return:       Number of results the effect has
+
+---------------------
+
 .. function:: gs_eparam_t *gs_effect_get_param_by_idx(const gs_effect_t *effect, size_t param)
 
    Gets a parameter of an effect by its index.
@@ -144,6 +156,17 @@ HLSL format.
 
 ---------------------
 
+.. function:: gs_eresult_t *gs_effect_get_result_by_idx(const gs_effect_t *effect, size_t result)
+
+   Gets a result of an effect by its index.
+
+   :param effect: Effect object
+   :param result: Result index
+   :return:       The effect result object, or *NULL* if index
+                  invalid
+
+---------------------
+
 .. function:: gs_eparam_t *gs_effect_get_param_by_name(const gs_effect_t *effect, const char *name)
 
    Gets parameter of an effect by its name.
@@ -151,6 +174,16 @@ HLSL format.
    :param effect: Effect object
    :param name:   Name of the parameter
    :return:       The effect parameter object, or *NULL* if not found
+
+---------------------
+
+.. function:: gs_eresult_t *gs_effect_get_result_by_name(const gs_effect_t *effect, const char *name)
+
+   Gets result of an effect by its name.
+
+   :param effect: Effect object
+   :param name:   Name of the result
+   :return:       The effect result object, or *NULL* if not found
 
 ---------------------
 
@@ -246,6 +279,7 @@ HLSL format.
            GS_SHADER_PARAM_INT4,
            GS_SHADER_PARAM_MATRIX4X4,
            GS_SHADER_PARAM_TEXTURE,
+           GS_SHADER_PARAM_ATOMIC_UINT
    };
 
    struct gs_effect_param_info {
@@ -346,6 +380,15 @@ HLSL format.
 
 ---------------------
 
+.. function:: void gs_effect_set_atomic_uint(gs_eparam_t *param, unsigned int val)
+
+   Sets an atomic unsigned integer parameter.
+
+   :param param: Effect parameter
+   :param val:   Unsigned integer value
+
+---------------------
+
 .. function:: void gs_effect_set_val(gs_eparam_t *param, const void *val, size_t size)
 
    Sets a parameter with data manually.
@@ -407,3 +450,12 @@ HLSL format.
 
    :param param:   Effect parameter
    :return:        The size in bytes of the param's default value.
+
+---------------------
+
+.. function:: unsigned int gs_effect_get_atomic_uint_result(gs_eresult_t *result)
+
+   Returns the value of an atomic unsigned integer result.
+
+   :param result: Effect result
+   :return:       Unsigned integer value of the result.

--- a/docs/sphinx/reference-libobs-graphics-graphics.rst
+++ b/docs/sphinx/reference-libobs-graphics-graphics.rst
@@ -881,7 +881,7 @@ Texture Functions
    :param data:         Pointer to array of texture data pointers
    :param flags:        Can be 0 or a bitwise-OR combination of one or
                         more of the following value:
-                        
+
                         - GS_BUILD_MIPMAPS - Automatically builds
                           mipmaps (Note: not fully tested)
                         - GS_DYNAMIC - Dynamic
@@ -1049,7 +1049,7 @@ Cube Texture Functions
    :param data:         Pointer to array of texture data pointers
    :param flags:        Can be 0 or a bitwise-OR combination of one or
                         more of the following value:
-                        
+
                         - GS_BUILD_MIPMAPS - Automatically builds
                           mipmaps (Note: not fully tested)
                         - GS_DYNAMIC - Dynamic
@@ -1461,5 +1461,6 @@ Graphics Types
 .. type:: typedef struct gs_texture_render   gs_texrender_t
 .. type:: typedef struct gs_shader           gs_shader_t
 .. type:: typedef struct gs_shader_param     gs_sparam_t
+.. type:: typedef struct gs_shader_result    gs_sresult_t
 .. type:: typedef struct gs_device           gs_device_t
 .. type:: typedef struct graphics_subsystem  graphics_t

--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -231,6 +231,20 @@ void gs_vertex_shader::Rebuild(ID3D11Device *dev)
 		if (FAILED(hr))
 			throw HRError("Failed to create constant buffer", hr);
 	}
+	if (uavSize) {
+		hr = dev->CreateBuffer(&uavBd, NULL, uavBuffer.Assign());
+		if (FAILED(hr))
+			throw HRError("Failed to create UAV buffer", hr);
+		hr = device->device->CreateUnorderedAccessView(
+			uavBuffer, &uavViewDesc, uavView.Assign());
+		if (FAILED(hr))
+			throw HRError("Failed to create UAV view", hr);
+		hr = device->device->CreateBuffer(&uavTxfrBd, NULL,
+						  uavTxfrBuffer.Assign());
+		if (FAILED(hr))
+			throw HRError("Failed to create UAV transfer buffer",
+				      hr);
+	}
 
 	for (gs_shader_param &param : params) {
 		param.nextSampler = nullptr;
@@ -251,6 +265,20 @@ void gs_pixel_shader::Rebuild(ID3D11Device *dev)
 		hr = dev->CreateBuffer(&bd, NULL, &constants);
 		if (FAILED(hr))
 			throw HRError("Failed to create constant buffer", hr);
+	}
+	if (uavSize) {
+		hr = dev->CreateBuffer(&uavBd, NULL, uavBuffer.Assign());
+		if (FAILED(hr))
+			throw HRError("Failed to create UAV buffer", hr);
+		hr = device->device->CreateUnorderedAccessView(
+			uavBuffer, &uavViewDesc, uavView.Assign());
+		if (FAILED(hr))
+			throw HRError("Failed to create UAV view", hr);
+		hr = device->device->CreateBuffer(&uavTxfrBd, NULL,
+						  uavTxfrBuffer.Assign());
+		if (FAILED(hr))
+			throw HRError("Failed to create UAV transfer buffer",
+				      hr);
 	}
 
 	for (gs_shader_param &param : params) {

--- a/libobs-d3d11/d3d11-shaderprocessor.cpp
+++ b/libobs-d3d11/d3d11-shaderprocessor.cpp
@@ -156,6 +156,8 @@ gs_shader_param::gs_shader_param(shader_var &var, uint32_t &texCounter)
 	: name(var.name),
 	  type(get_shader_param_type(var.type)),
 	  textureID(texCounter),
+	  atomicCounterIndex(var.atomic_counter_index),
+	  isResult(var.is_result),
 	  arrayCount(var.array_count),
 	  changed(false)
 {
@@ -168,6 +170,11 @@ gs_shader_param::gs_shader_param(shader_var &var, uint32_t &texCounter)
 		textureID = 0;
 }
 
+gs_shader_result::gs_shader_result(shader_var &var)
+	: name(var.name), param(nullptr)
+{
+}
+
 static inline void AddParam(shader_var &var, vector<gs_shader_param> &params,
 			    uint32_t &texCounter)
 {
@@ -178,12 +185,23 @@ static inline void AddParam(shader_var &var, vector<gs_shader_param> &params,
 	params.push_back(gs_shader_param(var, texCounter));
 }
 
-void ShaderProcessor::BuildParams(vector<gs_shader_param> &params)
+static inline void AddResult(shader_var var, vector<gs_shader_result> &results)
+{
+	results.push_back(gs_shader_result(var));
+}
+
+void ShaderProcessor::BuildParams(vector<gs_shader_param> &params,
+				  vector<gs_shader_result> &results)
 {
 	uint32_t texCounter = 0;
 
-	for (size_t i = 0; i < parser.params.num; i++)
-		AddParam(parser.params.array[i], params, texCounter);
+	for (size_t i = 0; i < parser.params.num; i++) {
+		shader_var &var = parser.params.array[i];
+		AddParam(var, params, texCounter);
+		if (var.is_result) {
+			AddResult(var, results);
+		}
+	}
 }
 
 static inline void AddSampler(gs_device_t *device, shader_sampler &sampler,
@@ -202,35 +220,104 @@ void ShaderProcessor::BuildSamplers(vector<unique_ptr<ShaderSampler>> &samplers)
 
 void ShaderProcessor::BuildString(string &outputString)
 {
-	stringstream output;
-	output << "static const bool obs_glsl_compile = false;\n\n";
+	stringstream tempOutput, finalOutput;
 
 	cf_token *token = cf_preprocessor_get_tokens(&parser.cfp.pp);
 	while (token->type != CFTOKEN_NONE) {
 		/* cheaply just replace specific tokens */
 		if (strref_cmp(&token->str, "POSITION") == 0)
-			output << "SV_Position";
+			tempOutput << "SV_Position";
 		else if (strref_cmp(&token->str, "TARGET") == 0)
-			output << "SV_Target";
+			tempOutput << "SV_Target";
 		else if (strref_cmp(&token->str, "texture2d") == 0)
-			output << "Texture2D";
+			tempOutput << "Texture2D";
 		else if (strref_cmp(&token->str, "texture3d") == 0)
-			output << "Texture3D";
+			tempOutput << "Texture3D";
 		else if (strref_cmp(&token->str, "texture_cube") == 0)
-			output << "TextureCube";
+			tempOutput << "TextureCube";
 		else if (strref_cmp(&token->str, "texture_rect") == 0)
 			throw "texture_rect is not supported in D3D";
 		else if (strref_cmp(&token->str, "sampler_state") == 0)
-			output << "SamplerState";
+			tempOutput << "SamplerState";
 		else if (strref_cmp(&token->str, "VERTEXID") == 0)
-			output << "SV_VertexID";
-		else
-			output.write(token->str.array, token->str.len);
-
+			tempOutput << "SV_VertexID";
+		else if (strref_cmp(&token->str, "atomicCounterIncrement") == 0)
+			ReplaceAtomicIncrement(token, tempOutput);
+		else if (!PeekAndSkipAtomicUint(token))
+			tempOutput.write(token->str.array, token->str.len);
 		token++;
 	}
 
-	outputString = move(output.str());
+	finalOutput << "static const bool obs_glsl_compile = false;\n\n";
+	if (parser.atomic_counter_next_index > 0)
+		finalOutput
+			<< "RWStructuredBuffer<uint> __uavBuffer : register(u1);\n\n";
+	finalOutput << tempOutput.str();
+
+	outputString = finalOutput.str();
+}
+
+static bool SeekUntil(cf_token *&token, const char *str)
+{
+	while (token->type != CFTOKEN_NONE) {
+		if (strref_cmp(&token->str, str) == 0)
+			return true;
+		token++;
+	}
+	return false;
+}
+
+static bool SeekWhile(cf_token *&token, const char *str)
+{
+	while (token->type != CFTOKEN_NONE) {
+		if (strref_cmp(&token->str, str) != 0)
+			return true;
+		token++;
+	}
+	return false;
+}
+
+void ShaderProcessor::ReplaceAtomicIncrement(cf_token *&token,
+					     stringstream &out)
+{
+	SeekUntil(token, "(");
+	token++;
+	SeekWhile(token, " ");
+
+	std::string name;
+	name.resize(token->str.len);
+	memcpy(name.data(), token->str.array, token->str.len);
+
+	int atomicCounterIndex = -1;
+	for (size_t i = 0; i < parser.params.num; i++) {
+		const shader_var &var = parser.params.array[i];
+		if (name == var.name && !strcmp(var.type, "atomic_uint")) {
+			atomicCounterIndex = var.atomic_counter_index;
+			break;
+		}
+	}
+	if (atomicCounterIndex == -1) {
+		blog(LOG_WARNING, "There is no atomic counter var called %s",
+		     name.data());
+		return;
+	}
+
+	out << "InterlockedAdd(__uavBuffer[" << atomicCounterIndex << "], 1";
+}
+
+bool ShaderProcessor::PeekAndSkipAtomicUint(cf_token *&token)
+{
+	if (strref_cmp(&token->str, "uniform") != 0)
+		return false;
+
+	cf_token *next = token + 1;
+	SeekWhile(next, " ");
+	if (strref_cmp(&next->str, "atomic_uint") == 0) {
+		SeekUntil(next, ";");
+		token = next;
+		return true;
+	}
+	return false;
 }
 
 void ShaderProcessor::Process(const char *shader_string, const char *file)

--- a/libobs-d3d11/d3d11-shaderprocessor.hpp
+++ b/libobs-d3d11/d3d11-shaderprocessor.hpp
@@ -25,14 +25,20 @@ struct ShaderParser : shader_parser {
 };
 
 struct ShaderProcessor {
+public:
 	gs_device_t *device;
 	ShaderParser parser;
 
 	void BuildInputLayout(vector<D3D11_INPUT_ELEMENT_DESC> &inputs);
-	void BuildParams(vector<gs_shader_param> &params);
+	void BuildParams(vector<gs_shader_param> &params,
+			 vector<gs_shader_result> &results);
 	void BuildSamplers(vector<unique_ptr<ShaderSampler>> &samplers);
 	void BuildString(string &outputString);
 	void Process(const char *shader_string, const char *file);
 
 	inline ShaderProcessor(gs_device_t *device) : device(device) {}
+
+protected:
+	void ReplaceAtomicIncrement(cf_token *&token, std::stringstream &out);
+	bool PeekAndSkipAtomicUint(cf_token *&token);
 };

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -1874,6 +1874,16 @@ void device_draw(gs_device_t *device, enum gs_draw_mode draw_mode,
 			num_verts = (uint32_t)device->curVertexBuffer->numVerts;
 		device->context->Draw(num_verts, start_vert);
 	}
+
+	try {
+		device->curVertexShader->DownloadResults();
+		device->curPixelShader->DownloadResults();
+	} catch (const HRError &error) {
+		blog(LOG_ERROR, "device_draw (D3D11): %s (%08lX)", error.str,
+		     error.hr);
+		LogD3D11ErrorDetails(error, device);
+		return;
+	}
 }
 
 void device_end_scene(gs_device_t *device)

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -655,6 +655,9 @@ struct gs_shader_param {
 	uint32_t textureID;
 	struct gs_sampler_state *nextSampler = nullptr;
 
+	int atomicCounterIndex;
+	bool isResult;
+
 	int arrayCount;
 
 	size_t pos;
@@ -664,6 +667,14 @@ struct gs_shader_param {
 	bool changed;
 
 	gs_shader_param(shader_var &var, uint32_t &texCounter);
+};
+
+struct gs_shader_result {
+	string name;
+	struct gs_shader_param *param;
+	vector<uint8_t> curValue;
+
+	gs_shader_result(shader_var &var);
 };
 
 struct ShaderError {
@@ -679,23 +690,39 @@ struct ShaderError {
 struct gs_shader : gs_obj {
 	gs_shader_type type;
 	vector<gs_shader_param> params;
+	vector<gs_shader_result> results;
 	ComPtr<ID3D11Buffer> constants;
+	ComPtr<ID3D11Buffer> uavBuffer;
+	ComPtr<ID3D11Buffer> uavTxfrBuffer;
+	ComPtr<ID3D11UnorderedAccessView> uavView;
 	size_t constantSize;
+	size_t uavSize;
 
 	D3D11_BUFFER_DESC bd = {};
+	D3D11_BUFFER_DESC uavBd = {};
+	D3D11_BUFFER_DESC uavTxfrBd = {};
+	D3D11_UNORDERED_ACCESS_VIEW_DESC uavViewDesc = {};
+
 	vector<uint8_t> data;
 
 	inline void UpdateParam(vector<uint8_t> &constData,
-				gs_shader_param &param, bool &upload);
+				vector<uint8_t> &uavData,
+				gs_shader_param &param, bool &uploadConst,
+				bool &uploadUav);
 	void UploadParams();
+	void DownloadResults();
 
 	void BuildConstantBuffer();
+	void BuildUavBuffer();
 	void Compile(const char *shaderStr, const char *file,
 		     const char *target, ID3D10Blob **shader);
 
 	inline gs_shader(gs_device_t *device, gs_type obj_type,
 			 gs_shader_type type)
-		: gs_obj(device, obj_type), type(type), constantSize(0)
+		: gs_obj(device, obj_type),
+		  type(type),
+		  constantSize(0),
+		  uavSize(0)
 	{
 	}
 
@@ -779,6 +806,8 @@ struct gs_pixel_shader : gs_shader {
 	{
 		shader.Release();
 		constants.Release();
+		uavBuffer.Release();
+		uavTxfrBuffer.Release();
 	}
 
 	inline void GetSamplerStates(ID3D11SamplerState **states)

--- a/libobs-opengl/gl-shader.c
+++ b/libobs-opengl/gl-shader.c
@@ -28,6 +28,7 @@
 static inline void shader_param_init(struct gs_shader_param *param)
 {
 	memset(param, 0, sizeof(struct gs_shader_param));
+	param->buffer_id = GL_INVALID_VALUE;
 }
 
 static inline void shader_param_free(struct gs_shader_param *param)
@@ -35,6 +36,18 @@ static inline void shader_param_free(struct gs_shader_param *param)
 	bfree(param->name);
 	da_free(param->cur_value);
 	da_free(param->def_value);
+}
+
+static inline void shader_result_init(struct gs_shader_result *result)
+{
+	memset(result, 0, sizeof(struct gs_shader_result));
+	da_init(result->cur_value);
+}
+
+static inline void shader_result_free(struct gs_shader_result *result)
+{
+	bfree(result->name);
+	da_free(result->cur_value);
 }
 
 static inline void shader_attrib_free(struct shader_attrib *attrib)
@@ -65,15 +78,32 @@ static void gl_get_shader_info(GLuint shader, const char *file,
 		bfree(errors);
 }
 
+static bool gl_add_result(struct gs_shader *shader,
+			  struct gs_shader_param *param)
+{
+	struct gs_shader_result result;
+	shader_result_init(&result);
+	result.name = bstrdup(param->name);
+	da_push_back(shader->results, &result);
+	return true;
+}
+
 static bool gl_add_param(struct gs_shader *shader, struct shader_var *var,
 			 GLint *texture_id)
 {
-	struct gs_shader_param param = {0};
+	struct gs_shader_param param;
+	shader_param_init(&param);
 
 	param.array_count = var->array_count;
 	param.name = bstrdup(var->name);
 	param.shader = shader;
 	param.type = get_shader_param_type(var->type);
+
+	param.is_result = var->is_result;
+	if (param.type == GS_SHADER_PARAM_ATOMIC_UINT) {
+		param.layout_binding = var->atomic_counter_index;
+		param.layout_offset = 0;
+	}
 
 	if (param.type == GS_SHADER_PARAM_TEXTURE) {
 		param.sampler_id = var->gl_sampler_id;
@@ -86,6 +116,10 @@ static bool gl_add_param(struct gs_shader *shader, struct shader_var *var,
 	da_copy(param.cur_value, param.def_value);
 
 	da_push_back(shader->params, &param);
+
+	if (param.is_result)
+		gl_add_result(shader, &param);
+
 	return true;
 }
 
@@ -340,6 +374,8 @@ void gs_shader_destroy(gs_shader_t *shader)
 
 	for (i = 0; i < shader->params.num; i++)
 		shader_param_free(shader->params.array + i);
+	for (i = 0; i < shader->results.num; i++)
+		shader_result_free(shader->results.array + i);
 
 	if (shader->obj) {
 		glDeleteShader(shader->obj);
@@ -361,6 +397,20 @@ gs_sparam_t *gs_shader_get_param_by_idx(gs_shader_t *shader, uint32_t param)
 {
 	assert(param < shader->params.num);
 	return shader->params.array + param;
+}
+
+gs_sresult_t *gs_shader_get_result_by_name(gs_shader_t *shader,
+					   const char *name)
+{
+	size_t i;
+	for (i = 0; i < shader->results.num; i++) {
+		struct gs_shader_result *result = shader->results.array + i;
+
+		if (strcmp(result->name, name) == 0)
+			return result;
+	}
+
+	return NULL;
 }
 
 gs_sparam_t *gs_shader_get_param_by_name(gs_shader_t *shader, const char *name)
@@ -442,6 +492,11 @@ void gs_shader_set_texture(gs_sparam_t *param, gs_texture_t *val)
 	param->texture = val;
 }
 
+void gs_shader_set_atomic_uint(gs_sparam_t *param, unsigned int val)
+{
+	da_copy_array(param->cur_value, &val, sizeof(val));
+}
+
 static inline bool validate_param(struct program_param *pp,
 				  size_t expected_size)
 {
@@ -455,6 +510,34 @@ static inline bool validate_param(struct program_param *pp,
 	}
 
 	return true;
+}
+
+static bool init_atomic_buffer(unsigned int *buffer_id, size_t sz,
+			       unsigned int binding, unsigned int offset)
+{
+	glGenBuffers(1, buffer_id);
+	if (!gl_success("glGenBuffers") || *buffer_id == GL_INVALID_VALUE)
+		return false;
+
+	glBindBuffer(GL_ATOMIC_COUNTER_BUFFER, *buffer_id);
+	if (!gl_success("glBindBuffer"))
+		return false;
+
+	glBufferData(GL_ATOMIC_COUNTER_BUFFER, (GLsizeiptr)sz, NULL,
+		     GL_DYNAMIC_COPY);
+	if (!gl_success("glBufferData"))
+		return false;
+
+	glBindBuffer(GL_ATOMIC_COUNTER_BUFFER, 0);
+	if (!gl_success("glBindBuffer"))
+		return false;
+
+	glBindBufferBase(GL_ATOMIC_COUNTER_BUFFER, binding, *buffer_id);
+	if (!gl_success("glBindBufferBase"))
+		return false;
+
+	return true;
+	UNUSED_PARAMETER(offset);
 }
 
 static void program_set_param_data(struct gs_program *program,
@@ -532,6 +615,34 @@ static void program_set_param_data(struct gs_program *program,
 		else
 			device_load_texture(program->device, pp->param->texture,
 					    pp->param->texture_id);
+	} else if (pp->param->type == GS_SHADER_PARAM_ATOMIC_UINT) {
+		if (validate_param(pp, sizeof(unsigned int))) {
+			if (pp->param->buffer_id == GL_INVALID_VALUE)
+				if (!init_atomic_buffer(
+					    &pp->param->buffer_id,
+					    sizeof(GLuint),
+					    pp->param->layout_binding,
+					    pp->param->layout_offset))
+					return;
+
+			glBindBuffer(GL_ATOMIC_COUNTER_BUFFER,
+				     pp->param->buffer_id);
+			if (!gl_success("glBindBuffer"))
+				goto unbind;
+
+			glBindBufferBase(GL_ATOMIC_COUNTER_BUFFER,
+					 pp->param->layout_binding,
+					 pp->param->buffer_id);
+			if (!gl_success("glBindBufferBase"))
+				goto unbind;
+
+			glBufferSubData(GL_ATOMIC_COUNTER_BUFFER, 0,
+					sizeof(GLuint), array);
+			gl_success("glBufferSubData");
+
+		unbind:
+			glBindBuffer(GL_ATOMIC_COUNTER_BUFFER, 0);
+		}
 	}
 }
 
@@ -540,6 +651,57 @@ void program_update_params(struct gs_program *program)
 	for (size_t i = 0; i < program->params.num; i++) {
 		struct program_param *pp = program->params.array + i;
 		program_set_param_data(program, pp);
+	}
+}
+
+static void program_get_result_data(struct gs_program *program,
+				    struct gs_shader_result *result)
+{
+	struct gs_shader_param *param = result->param;
+	void *array;
+	unsigned int test = 0;
+
+	if (param->type == GS_SHADER_PARAM_ATOMIC_UINT) {
+		if (param->cur_value.num != sizeof(GLuint))
+			da_resize(param->cur_value, sizeof(GLuint));
+
+		if (param->buffer_id == GL_INVALID_VALUE)
+			if (!init_atomic_buffer(&param->buffer_id,
+						sizeof(GLuint),
+						param->layout_binding,
+						param->layout_offset))
+				return;
+		if (result->cur_value.num != sizeof(GLuint))
+			da_resize(result->cur_value, sizeof(GLuint));
+		array = result->cur_value.array;
+
+		glBindBuffer(GL_ATOMIC_COUNTER_BUFFER, param->buffer_id);
+		if (!gl_success("glBindBuffer"))
+			goto unbind;
+
+		glBindBufferBase(GL_ATOMIC_COUNTER_BUFFER,
+				 param->layout_binding, param->buffer_id);
+		if (!gl_success("glBindBufferBase"))
+			goto unbind;
+
+		glGetBufferSubData(GL_ATOMIC_COUNTER_BUFFER, 0, sizeof(GLuint),
+				   array);
+		if (!gl_success("glGetBufferSubData"))
+			goto unbind;
+
+	unbind:
+		glBindBuffer(GL_ATOMIC_COUNTER_BUFFER, 0);
+	}
+
+	UNUSED_PARAMETER(program);
+	UNUSED_PARAMETER(test);
+}
+
+void program_get_results(struct gs_program *program)
+{
+	for (size_t i = 0; i < program->results.num; i++) {
+		struct program_result *pr = program->results.array + i;
+		program_get_result_data(program, pr->result);
 	}
 }
 
@@ -599,12 +761,16 @@ static bool assign_program_param(struct gs_program *program,
 {
 	struct program_param info;
 
-	info.obj = glGetUniformLocation(program->obj, param->name);
-	if (!gl_success("glGetUniformLocation"))
-		return false;
+	if (param->type == GS_SHADER_PARAM_ATOMIC_UINT) {
+		// uses buffer API instead
+	} else {
+		info.obj = glGetUniformLocation(program->obj, param->name);
+		if (!gl_success("glGetUniformLocation"))
+			return false;
 
-	if (info.obj == -1) {
-		return true;
+		if (info.obj == -1) {
+			return true;
+		}
 	}
 
 	info.param = param;
@@ -634,9 +800,42 @@ static inline bool assign_program_params(struct gs_program *program)
 	return true;
 }
 
+static bool assign_program_shader_results(struct gs_program *program,
+					  struct gs_shader *shader)
+{
+	struct gs_shader_result *result;
+	struct gs_shader_param *param;
+	struct program_result info;
+
+	size_t i;
+	for (i = 0; i < shader->results.num; i++) {
+		result = shader->results.array + i;
+
+		param = gs_shader_get_param_by_name(shader, result->name);
+		result->param = param;
+
+		info.result = result;
+
+		da_push_back(program->results, &info);
+	}
+
+	return true;
+}
+
+static inline bool assign_program_results(struct gs_program *program)
+{
+	if (!assign_program_shader_results(program, program->vertex_shader))
+		return false;
+	if (!assign_program_shader_results(program, program->pixel_shader))
+		return false;
+
+	return true;
+}
+
 struct gs_program *gs_program_create(struct gs_device *device)
 {
 	struct gs_program *program = bzalloc(sizeof(*program));
+
 	int linked = false;
 
 	program->device = device;
@@ -671,6 +870,8 @@ struct gs_program *gs_program_create(struct gs_device *device)
 	if (!assign_program_attribs(program))
 		goto error;
 	if (!assign_program_params(program))
+		goto error;
+	if (!assign_program_results(program))
 		goto error;
 
 	glDetachShader(program->obj, program->vertex_shader->obj);
@@ -713,6 +914,7 @@ void gs_program_destroy(struct gs_program *program)
 
 	da_free(program->attribs);
 	da_free(program->params);
+	da_free(program->results);
 
 	if (program->next)
 		program->next->prev_next = program->prev_next;
@@ -738,6 +940,7 @@ void gs_shader_set_val(gs_sparam_t *param, const void *val, size_t size)
 		break;
 	case GS_SHADER_PARAM_BOOL:
 	case GS_SHADER_PARAM_INT:
+	case GS_SHADER_PARAM_ATOMIC_UINT:
 		expected_size = sizeof(int);
 		break;
 	case GS_SHADER_PARAM_INT2:
@@ -786,6 +989,19 @@ void gs_shader_set_val(gs_sparam_t *param, const void *val, size_t size)
 	} else {
 		da_copy_array(param->cur_value, val, size);
 	}
+}
+
+void gs_shader_get_result(gs_sresult_t *result, struct darray *dst)
+{
+	size_t expected_size = 0;
+	if (result->param->type == GS_SHADER_PARAM_ATOMIC_UINT) {
+		expected_size = 1;
+	} else {
+		blog(LOG_ERROR, "gs_shader_get_result (GL): "
+				"unsupported result type");
+		return;
+	}
+	darray_copy(expected_size, dst, &result->cur_value.da);
 }
 
 void gs_shader_set_default(gs_sparam_t *param)

--- a/libobs-opengl/gl-shaderparser.c
+++ b/libobs-opengl/gl-shaderparser.c
@@ -17,6 +17,7 @@
 
 #include "gl-subsystem.h"
 #include "gl-shaderparser.h"
+#include <stdio.h> // for snprintf
 
 static void gl_write_function_contents(struct gl_shader_parser *glsp,
 				       struct cf_token **p_token,
@@ -106,6 +107,16 @@ static inline bool gl_write_type_token(struct gl_shader_parser *glsp,
 
 static void gl_write_var(struct gl_shader_parser *glsp, struct shader_var *var)
 {
+	char *layout_str;
+
+	if (strcmp(var->type, "atomic_uint") == 0) {
+		layout_str = bmalloc(64);
+		snprintf(layout_str, 64, "layout (binding = %u, offset = %u) ",
+			 var->atomic_counter_index, 0);
+		dstr_cat(&glsp->gl_string, layout_str);
+		bfree(layout_str);
+	}
+
 	if (var->var_type == SHADER_VAR_UNIFORM)
 		dstr_cat(&glsp->gl_string, "uniform ");
 	else if (var->var_type == SHADER_VAR_CONST)
@@ -741,7 +752,7 @@ static bool gl_shader_buildstring(struct gl_shader_parser *glsp)
 		return false;
 	}
 
-	dstr_copy(&glsp->gl_string, "#version 330\n\n");
+	dstr_copy(&glsp->gl_string, "#version 460\n\n");
 	dstr_cat(&glsp->gl_string, "const bool obs_glsl_compile = true;\n\n");
 	dstr_cat(&glsp->gl_string,
 		 "vec4 obs_load_2d(sampler2D s, ivec3 p_lod)\n");

--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -1105,6 +1105,8 @@ void device_draw(gs_device_t *device, enum gs_draw_mode draw_mode,
 			goto fail;
 	}
 
+	program_get_results(program);
+
 	return;
 
 fail:

--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -426,6 +426,11 @@ struct gs_shader_param {
 	gs_samplerstate_t *next_sampler;
 	GLint texture_id;
 	size_t sampler_id;
+	GLuint buffer_id;
+	unsigned int layout_binding;
+	unsigned int layout_offset;
+	bool is_result;
+
 	int array_count;
 
 	struct gs_texture *texture;
@@ -434,6 +439,12 @@ struct gs_shader_param {
 	DARRAY(uint8_t) cur_value;
 	DARRAY(uint8_t) def_value;
 	bool changed;
+};
+
+struct gs_shader_result {
+	char *name;
+	struct gs_shader_param *param;
+	DARRAY(uint8_t) cur_value;
 };
 
 enum attrib_type {
@@ -461,12 +472,17 @@ struct gs_shader {
 
 	DARRAY(struct shader_attrib) attribs;
 	DARRAY(struct gs_shader_param) params;
+	DARRAY(struct gs_shader_result) results;
 	DARRAY(gs_samplerstate_t *) samplers;
 };
 
 struct program_param {
 	GLint obj;
 	struct gs_shader_param *param;
+};
+
+struct program_result {
+	struct gs_shader_result *result;
 };
 
 struct gs_program {
@@ -476,6 +492,7 @@ struct gs_program {
 	struct gs_shader *pixel_shader;
 
 	DARRAY(struct program_param) params;
+	DARRAY(struct program_result) results;
 	DARRAY(GLint) attribs;
 
 	struct gs_program **prev_next;
@@ -485,6 +502,7 @@ struct gs_program {
 extern struct gs_program *gs_program_create(struct gs_device *device);
 extern void gs_program_destroy(struct gs_program *program);
 extern void program_update_params(struct gs_program *shader);
+extern void program_get_results(struct gs_program *shader);
 
 struct gs_vertex_buffer {
 	GLuint vao;

--- a/libobs/graphics/effect-parser.h
+++ b/libobs/graphics/effect-parser.h
@@ -71,7 +71,7 @@ struct ep_param {
 	DARRAY(uint8_t) default_val;
 	DARRAY(char *) properties;
 	struct gs_effect_param *param;
-	bool is_const, is_property, is_uniform, is_texture, written;
+	bool is_const, is_property, is_uniform, is_texture, is_result, written;
 	int writeorder, array_count;
 	DARRAY(struct ep_param) annotations;
 };
@@ -80,13 +80,14 @@ extern void ep_param_writevar(struct dstr *dst, struct darray *use_params);
 
 static inline void ep_param_init(struct ep_param *epp, char *type, char *name,
 				 bool is_property, bool is_const,
-				 bool is_uniform)
+				 bool is_uniform, bool is_result)
 {
 	epp->type = type;
 	epp->name = name;
 	epp->is_property = is_property;
 	epp->is_const = is_const;
 	epp->is_uniform = is_uniform;
+	epp->is_result = is_result;
 	epp->is_texture = (astrcmp_n(epp->type, "texture", 7) == 0);
 	epp->written = false;
 	epp->writeorder = false;

--- a/libobs/graphics/effect.h
+++ b/libobs/graphics/effect.h
@@ -90,9 +90,35 @@ EXPORT void effect_param_parse_property(gs_eparam_t *param,
 
 /* ------------------------------------------------------------------------- */
 
+struct gs_effect_result {
+	char *name;
+	enum gs_shader_param_type type;
+	DARRAY(uint8_t) cur_val;
+	gs_effect_t *effect;
+};
+
+static inline void effect_result_init(struct gs_effect_result *result)
+{
+	memset(result, 0, sizeof(struct gs_effect_result));
+	da_init(result->cur_val);
+}
+
+static inline void effect_result_free(struct gs_effect_result *result)
+{
+	bfree(result->name);
+	da_free(result->cur_val);
+}
+
+/* ------------------------------------------------------------------------- */
+
 struct pass_shaderparam {
 	struct gs_effect_param *eparam;
 	gs_sparam_t *sparam;
+};
+
+struct pass_shaderresult {
+	struct gs_effect_result *eresult;
+	gs_sresult_t *sresult;
 };
 
 struct gs_effect_pass {
@@ -103,6 +129,7 @@ struct gs_effect_pass {
 	gs_shader_t *pixelshader;
 	DARRAY(struct pass_shaderparam) vertshader_params;
 	DARRAY(struct pass_shaderparam) pixelshader_params;
+	DARRAY(struct pass_shaderresult) program_results;
 };
 
 static inline void effect_pass_init(struct gs_effect_pass *pass)
@@ -115,6 +142,7 @@ static inline void effect_pass_free(struct gs_effect_pass *pass)
 	bfree(pass->name);
 	da_free(pass->vertshader_params);
 	da_free(pass->pixelshader_params);
+	da_free(pass->program_results);
 
 	gs_shader_destroy(pass->vertshader);
 	gs_shader_destroy(pass->pixelshader);
@@ -153,6 +181,7 @@ struct gs_effect {
 	char *effect_path, *effect_dir;
 
 	DARRAY(struct gs_effect_param) params;
+	DARRAY(struct gs_effect_result) results;
 	DARRAY(struct gs_effect_technique) techniques;
 
 	struct gs_effect_technique *cur_technique;
@@ -177,6 +206,8 @@ static inline void effect_free(gs_effect_t *effect)
 	size_t i;
 	for (i = 0; i < effect->params.num; i++)
 		effect_param_free(effect->params.array + i);
+	for (i = 0; i < effect->results.num; i++)
+		effect_result_free(effect->results.array + i);
 	for (i = 0; i < effect->techniques.num; i++)
 		effect_technique_free(effect->techniques.array + i);
 

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -172,6 +172,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT(gs_shader_get_num_params);
 	GRAPHICS_IMPORT(gs_shader_get_param_by_idx);
 	GRAPHICS_IMPORT(gs_shader_get_param_by_name);
+	GRAPHICS_IMPORT(gs_shader_get_result_by_name);
 	GRAPHICS_IMPORT(gs_shader_get_viewproj_matrix);
 	GRAPHICS_IMPORT(gs_shader_get_world_matrix);
 	GRAPHICS_IMPORT(gs_shader_get_param_info);
@@ -184,9 +185,11 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT(gs_shader_set_vec3);
 	GRAPHICS_IMPORT(gs_shader_set_vec4);
 	GRAPHICS_IMPORT(gs_shader_set_texture);
+	GRAPHICS_IMPORT(gs_shader_set_atomic_uint);
 	GRAPHICS_IMPORT(gs_shader_set_val);
 	GRAPHICS_IMPORT(gs_shader_set_default);
 	GRAPHICS_IMPORT(gs_shader_set_next_sampler);
+	GRAPHICS_IMPORT(gs_shader_get_result);
 
 	GRAPHICS_IMPORT_OPTIONAL(device_nv12_available);
 

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -246,6 +246,8 @@ struct gs_exports {
 	gs_sparam_t *(*gs_shader_get_world_matrix)(const gs_shader_t *shader);
 	void (*gs_shader_get_param_info)(const gs_sparam_t *param,
 					 struct gs_shader_param_info *info);
+	gs_sresult_t *(*gs_shader_get_result_by_name)(gs_shader_t *program,
+						      const char *name);
 	void (*gs_shader_set_bool)(gs_sparam_t *param, bool val);
 	void (*gs_shader_set_float)(gs_sparam_t *param, float val);
 	void (*gs_shader_set_int)(gs_sparam_t *param, int val);
@@ -257,11 +259,13 @@ struct gs_exports {
 	void (*gs_shader_set_vec3)(gs_sparam_t *param, const struct vec3 *val);
 	void (*gs_shader_set_vec4)(gs_sparam_t *param, const struct vec4 *val);
 	void (*gs_shader_set_texture)(gs_sparam_t *param, gs_texture_t *val);
+	void (*gs_shader_set_atomic_uint)(gs_sparam_t *param, unsigned int val);
 	void (*gs_shader_set_val)(gs_sparam_t *param, const void *val,
 				  size_t size);
 	void (*gs_shader_set_default)(gs_sparam_t *param);
 	void (*gs_shader_set_next_sampler)(gs_sparam_t *param,
 					   gs_samplerstate_t *sampler);
+	void (*gs_shader_get_result)(gs_sresult_t *result, struct darray *dst);
 
 	bool (*device_nv12_available)(gs_device_t *device);
 

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -2154,6 +2154,17 @@ gs_sparam_t *gs_shader_get_param_by_name(gs_shader_t *shader, const char *name)
 	return graphics->exports.gs_shader_get_param_by_name(shader, name);
 }
 
+gs_sresult_t *gs_shader_get_result_by_name(gs_shader_t *shader,
+					   const char *name)
+{
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid_p2("gs_shader_get_result_by_name", shader, name))
+		return NULL;
+
+	return graphics->exports.gs_shader_get_result_by_name(shader, name);
+}
+
 gs_sparam_t *gs_shader_get_viewproj_matrix(const gs_shader_t *shader)
 {
 	graphics_t *graphics = thread_graphics;
@@ -2275,6 +2286,16 @@ void gs_shader_set_texture(gs_sparam_t *param, gs_texture_t *val)
 	graphics->exports.gs_shader_set_texture(param, val);
 }
 
+void gs_shader_set_atomic_uint(gs_sparam_t *param, unsigned int val)
+{
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid_p("gs_shader_set_atomic_uint", param))
+		return;
+
+	graphics->exports.gs_shader_set_atomic_uint(param, val);
+}
+
 void gs_shader_set_val(gs_sparam_t *param, const void *val, size_t size)
 {
 	graphics_t *graphics = thread_graphics;
@@ -2283,6 +2304,16 @@ void gs_shader_set_val(gs_sparam_t *param, const void *val, size_t size)
 		return;
 
 	graphics->exports.gs_shader_set_val(param, val, size);
+}
+
+void gs_shader_get_result(gs_sresult_t *result, struct darray *dst)
+{
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid_p("gs_shader_get_result", dst))
+		return;
+
+	graphics->exports.gs_shader_get_result(result, dst);
 }
 
 void gs_shader_set_default(gs_sparam_t *param)

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -259,6 +259,7 @@ struct gs_swap_chain;
 struct gs_timer;
 struct gs_texrender;
 struct gs_shader_param;
+struct gs_shader_result;
 struct gs_effect;
 struct gs_effect_technique;
 struct gs_effect_pass;
@@ -278,10 +279,12 @@ typedef struct gs_timer_range gs_timer_range_t;
 typedef struct gs_texture_render gs_texrender_t;
 typedef struct gs_shader gs_shader_t;
 typedef struct gs_shader_param gs_sparam_t;
+typedef struct gs_shader_result gs_sresult_t;
 typedef struct gs_effect gs_effect_t;
 typedef struct gs_effect_technique gs_technique_t;
 typedef struct gs_effect_pass gs_epass_t;
 typedef struct gs_effect_param gs_eparam_t;
+typedef struct gs_effect_result gs_eresult_t;
 typedef struct gs_device gs_device_t;
 typedef struct graphics_subsystem graphics_t;
 
@@ -303,6 +306,7 @@ enum gs_shader_param_type {
 	GS_SHADER_PARAM_INT4,
 	GS_SHADER_PARAM_MATRIX4X4,
 	GS_SHADER_PARAM_TEXTURE,
+	GS_SHADER_PARAM_ATOMIC_UINT,
 };
 
 struct gs_shader_texture {
@@ -334,6 +338,10 @@ EXPORT gs_sparam_t *gs_shader_get_world_matrix(const gs_shader_t *shader);
 
 EXPORT void gs_shader_get_param_info(const gs_sparam_t *param,
 				     struct gs_shader_param_info *info);
+
+EXPORT gs_sresult_t *gs_shader_get_result_by_name(gs_shader_t *shader,
+						  const char *name);
+
 EXPORT void gs_shader_set_bool(gs_sparam_t *param, bool val);
 EXPORT void gs_shader_set_float(gs_sparam_t *param, float val);
 EXPORT void gs_shader_set_int(gs_sparam_t *param, int val);
@@ -345,10 +353,12 @@ EXPORT void gs_shader_set_vec2(gs_sparam_t *param, const struct vec2 *val);
 EXPORT void gs_shader_set_vec3(gs_sparam_t *param, const struct vec3 *val);
 EXPORT void gs_shader_set_vec4(gs_sparam_t *param, const struct vec4 *val);
 EXPORT void gs_shader_set_texture(gs_sparam_t *param, gs_texture_t *val);
-EXPORT void gs_shader_set_val(gs_sparam_t *param, const void *val, size_t size);
+EXPORT void gs_shader_set_atomic_uint(gs_sparam_t *param, unsigned int val);
 EXPORT void gs_shader_set_default(gs_sparam_t *param);
 EXPORT void gs_shader_set_next_sampler(gs_sparam_t *param,
 				       gs_samplerstate_t *sampler);
+EXPORT void gs_shader_set_val(gs_sparam_t *param, const void *val, size_t size);
+EXPORT void gs_shader_get_result(gs_sresult_t *result, struct darray *dst);
 #endif
 
 /* ---------------------------------------------------
@@ -396,10 +406,15 @@ gs_technique_get_pass_by_name(const gs_technique_t *technique,
 			      const char *name);
 
 EXPORT size_t gs_effect_get_num_params(const gs_effect_t *effect);
+EXPORT size_t gs_effect_get_num_results(const gs_effect_t *effect);
 EXPORT gs_eparam_t *gs_effect_get_param_by_idx(const gs_effect_t *effect,
 					       size_t param);
 EXPORT gs_eparam_t *gs_effect_get_param_by_name(const gs_effect_t *effect,
 						const char *name);
+EXPORT gs_eresult_t *gs_effect_get_result_by_idx(const gs_effect_t *effect,
+						 size_t result);
+EXPORT gs_eresult_t *gs_effect_get_result_by_name(const gs_effect_t *effect,
+						  const char *name);
 EXPORT size_t gs_param_get_num_annotations(const gs_eparam_t *param);
 EXPORT gs_eparam_t *gs_param_get_annotation_by_idx(const gs_eparam_t *param,
 						   size_t annotation);
@@ -431,6 +446,7 @@ EXPORT void gs_effect_set_vec2(gs_eparam_t *param, const struct vec2 *val);
 EXPORT void gs_effect_set_vec3(gs_eparam_t *param, const struct vec3 *val);
 EXPORT void gs_effect_set_vec4(gs_eparam_t *param, const struct vec4 *val);
 EXPORT void gs_effect_set_texture(gs_eparam_t *param, gs_texture_t *val);
+EXPORT void gs_effect_set_atomic_uint(gs_eparam_t *param, unsigned int val);
 EXPORT void gs_effect_set_texture_srgb(gs_eparam_t *param, gs_texture_t *val);
 EXPORT void gs_effect_set_val(gs_eparam_t *param, const void *val, size_t size);
 EXPORT void gs_effect_set_default(gs_eparam_t *param);
@@ -438,6 +454,9 @@ EXPORT size_t gs_effect_get_val_size(gs_eparam_t *param);
 EXPORT void *gs_effect_get_val(gs_eparam_t *param);
 EXPORT size_t gs_effect_get_default_val_size(gs_eparam_t *param);
 EXPORT void *gs_effect_get_default_val(gs_eparam_t *param);
+
+EXPORT unsigned int gs_effect_get_atomic_uint_result(gs_eresult_t *result);
+
 EXPORT void gs_effect_set_next_sampler(gs_eparam_t *param,
 				       gs_samplerstate_t *sampler);
 


### PR DESCRIPTION
### Description

- Introduce results into OBS effect system; they are tied to respective params of the same name
- Result variables are passed in like other params **before** draw, but they are also fetched back as results **after** draw
- Only one type of result is introduced, which is `atomic_uint`. This type will be used with `atomicCounterIncrement(...)` effect statements to allow atomic increments of a counter, which enabled us to build the [Pixel Match Switcher](https://github.com/HoneyHazard/PixelMatchSwitcher) plugin.
- D3D11: change from `ps_4_0` to `ps_5_0` shader model to support UAV variables
- OpenGL: change `#version 330` to `#version 460` to support atomic counters

### In-depth Look at the Changes

<details>
<summary>Click to Expand</summary>

#### Outline of the changes
1. [Introducing the atomic counter results](#Introducing-the-atomic-counter-results)
2. [Effects](#Effects)
    - [Effect data structures](#Effect-data-structures)
    - [Parsing the effect code](#Parsing-the-effect-code)
    - [Writing intermediate shaders](#Writing-intermediate-shaders)
    - [Interacting with the effects](#Interacting-with-the-effects)
3. [Parsing the intermediate shaders](#Parsing-the-intermediate-shaders)
4. [Graphics API](#Graphics-API)
5. [libobs-opengl](#libobs-opengl)
    - [gl-subsystem](#gl-subsystem)
    - [gl-shaderparser](#gl-shaderparser)
    - [gl-shader](#gl-shader)
6. [libobs-d3d11](#libobs-d3d11)
    - [d3d11-subsystem](#d3d11-subsystem)
    - [d3d11-shaderprocessor](#d3d11-shaderprocessor)
    - [d3d11-shader](#d3d11-shader)

#### Introducing the atomic counter results

- Atomic counters are special variables that allow safe increments (or decrements) of a counter in the parallel shader environment. The [Pixel Match Switcher ](https://github.com/HoneyHazard/PixelMatchSwitcher) plugin for OBS uses this feature of the graphics systems to count matching pixel as video data passes though the plugin's filter. Because the counting is done in the shader, the atomic counters work with great performance on any reasonably modern video card (must support `ps_4_0` for D3D11 or `version 460` for OpenGL)
- Atomic counters require [special treatment by D3D11](https://docs.microsoft.com/en-us/windows/win32/direct3d12/uav-counters) and [special treatment by OpenGL](https://www.khronos.org/opengl/wiki/Atomic_Counter). They need to reside in specially configured blocks of graphics memory and require highly specialized API to be initialized and used.
- We have selected `atomic_uint` keyword to represent atomic counters being introduced into the OBS effect system. This keyword is also how the counters are represented in GLSL. Like other global variables of the effect, it must be preceded by `uniform`.
- We have selected `atomicCounterIncrement(...)` function, also borrowed from GLSL, to perform an atomic increment on a counter.

#### Effects

**Effects** provide a cross platform wrappers for GLSL and HLSL shader use by OBS. In the [OBS effect system](https://obsproject.com/docs/graphics.html#creating-effects) you specify both vertex and pixel shader behavior in the same effect file.

Roughly speaking, the effect initialization is as follows:
1. Effect file is [parsed](#Parsing-the-effect-code) by the `effect-parser` module, generating data structures for all building blocks of the shaders it needs to generate.
2. These building blocks are then used to [write strings](#Writing-intermediate-shaders) that represent intermediate versions of the vertex and pixel shaders for the effect.
3. The intermediate versions of shaders are then parsed by [`shader-parser`](#Parsing-the-intermediate-shaders) module to generate data structures representing the shader functionality.
4. Finally, the data structures generated by the [`shader-parser`](#Parsing-the-intermediate-shaders) are passed to down to either [`gl-shaderparser`](#gl-shaderparser) or [`d3d11-shaderprocessor`](#d3d11-shaderprocessor) modules to write actual shaders that will do the effect's work.

##### Additions to the effect language

We introduce two new syntax elements to support use of the [atomic counters](#Introducing-the-atomic-counter-results) in the OBS effect language. The two are borrowed from GLSL, which, arguably, has a more user-friendly syntax for implementing atomic counters than HLSL.
- `atomic_uint` is the variable type that will be used for the atomic counters. Like other global variables of the effect, it must be preceded by `uniform` keyword.
    - Example: `uniform atomic_uint myCounter;`
- `atomicCounterIncrement(...)` statement increments an atomic counter.
    - Example: `atomicCounterIncrement(myCounter);`
- Note: unlike actual GLSL, will not require and will not support the [`layout(...)`](https://www.khronos.org/opengl/wiki/Layout_Qualifier_(GLSL)#Atomic_counter_storage) qualifier in the effect code, but the [OpenGL graphics subsystem](#gl-subsystem) will have to [generate the qualifier](#gl_write_var-modified-function) in the event it is used.

##### Effect data structures

The data structures built for each effect are used to dynamically generate intermediate shader code, and provide mapping of high-level abstractions for effect variables to lower-level abstractions of shader variables. While modifying the effect data structures, we mirror existing abstractions for effect **parameters** and their pathways to the [Graphics API](#Graphics-API), as we introduce new abstractions and new pathways for interfacing with program and shader **results**.

###### gs_effect [new members]
This struct provides a high level interface for interfacing an effect parameter.
It has an array of parameter data structures called `params` of type `gs_effect_param`. So we also add a new member `results`, which is an array of  [`gs_effect_result`](#gs_effect_result-new-struct).

###### gs_effect_result [new struct]
High level interface for working with a result. Members are:
- `name` result name
- `type` variable type; currently only `GS_SHADER_PARAM_ATOMIC_UINT` is supported
- `cur_val` value that was last retrieved from result.

Analogous to `gs_effect_param`.

###### pass_shaderresult [new struct]
Serves as mapping of higher level **effect result** interface [`gs_effect_result`](#gs_effect_result-new-struct) to a lower-level **shader result** interface handle [`gs_sresult_t`](#gs_sresult_t-new-typedef).

Analogous to `pass_shaderparam`.

###### gs_effect_pass [added members]
Has handle pointers for vertex and pixel shaders, and an array for mapping **effect params** to **shader params**. These are used later to make passing in of parameter values possible.

So we add `program_results`, which is an array of [`pass_shaderresult`](#pass_shaderresult-new-struct), to also do the mapping of **effect results** to **shader results**, and make fetching of the results possible.

##### Parsing the effect code

`effect-parser` module converts the [effect](#Effects) code into data structures and uses them to generate intermediate shader code. Input effect string is tokenized by whitespace, and is then processed, token by token, to build data structures representing individual behavior units of the effect. These are then used to generate intermediate versions of vertex and pixel shaders, so they can be passed down to [`shader-parser`](#Parsing-the-intermediate-shaders).

Here the goal was to introduce support for results and `atomic_uint` type.

###### ep_param [new members]
This data structure maintains information about individual **effect parser parameters** as they are being parsed from the effect code. Since some **parameters** are now also **results**, we add a new field to be used with those results:
- `is_result` gets set to `true` for any **parameter** that is also **result**. This will later lead to [`gs_effect_result`](#gs_effect_result-new-struct) being instantiated for every **param** marked with this flag.

###### ep_param_init(...) [modified function]
Assigns fields to [`ep_param`](#ep_param-new-members). Modified to receive and assign the new field `is_result`.

###### ep_parse_param(...) [modified function]
Calls [`ep_param_init(...)`](#ep_param_init-modified-function) with values received from [`ep_parse_other(...)`](#ep_parse_other-modified-function) and makes sure no erroneous symbols follow the **param** declaration.

Our modifications here are limited to propagating `is_result` value to `ep_param_init(...)`.

###### ep_parse_other(...) [modified function]
This function is for parsing anything in the effect code that is **not** whitespace, `struct`, `technique`, or `sampler_state`. The function has variables for reacting to `property`, `const`, and `type` keywords, and activates functions for parsing `functions`s and `param`s. Our modifications are for special handling of the [`atomic_uint`](#Additions-to-the-effect-language) results.
- `is_result` variable is added, and is set to `true` whenever `atomic_uint` type token is encountered.
- call to [`ep_parse_param(...)`](#ep_parse_param-modified-function) also passes `is_result` variable to the function

##### Writing intermediate shaders
After the effect code is parsed into data structures, these data structures are used to generate the **intermediate shader code** (so it can be processed later by the [`shader-parser`](#Parsing-the-intermediate-shaders)). During this building of the intermediate shader code for a vertex/pixel shader, a mapping is constructed so that higher level **effect params** can be linked with corresponding lower-level **shader params**.

The additions here are for constructing analogous mapping between **effect results** and **shader results**.

###### ep_write_param(...) [modified function]
This function receives a pointer to [`ep_param`](#ep_param-new-members) as input and writes the **param's** declarations in the intermediate shader code. It also appends a name of every used **param** to the array `used_params`.

We teach the function to also append a **param** name, that is also a **result**, to the list of **results**. It will now receive a pointer `used_results`, which is an array of strings representing names of the **results** used in the effect. If the [`ep_param`](#ep_param-new-members), passed into the function, is marked with the `is_result` flag, it is appended to `used_results`.

###### ep_write_func_param_deps(...), ep_write_func_func_deps(...), ep_write_func(...), ep_makeshaderstring(...) [modified functions]
These functions call each other and other lower level functions as the intermediate shader is being built from the data structures representing it. They maintain `used_params` - an array of strings representing **params** that were encountered, to be eventually passed down to [`ep_write_param(...)`](#ep_write_param-modified-function), where a name is appended to the array for every used **param**.

They are all modified so that `used_results`, an array of strings representing names of the **results** used in the effect, can also make its way to [`ep_write_param(...)`](#ep_write_param-modified-function) function, where it can be updated for every used **result**.

###### ep_compile_result(...) [new function]
- Takes as input a name for a **result** and a pointer to an allocated [`gs_effect_result`](#gs_effect_result-new-struct) so its fields can be initialized.
- Finds a corresponding `gs_effect_param` of the same name in the effect's array of **params**, and retains the pointer in `gs_effect_result` being initialized. Because this is all called (and **has** to be called) **after** the **params** are "compiled", the array of **params** is stable and a pointer into that array is safe.
- A string of param/result name is also duplicated into `gs_effect_result`.

###### ep_compilepass_shaderresults(...) [new function]
This function is responsible for building mapping between higher level handles of **effect results** and lower level handles of **shader results**, and also invokes mapping between **effect params** and **effect results**.

For every **result name** in the input array of strings `used_results`:
- Fetches a pointer to [`gs_effect_result`](#gs_effect_result-new-struct) from the `effect_parser` that corresponds to the **result name**.
- Calls [`ep_compile_result(...)`](#ep_compile_result-new-function) so [`gs_effect_result`](#gs_effect_result-new-struct) receives a pointer to corresponding `gs_effect_param`.
- Finds a pointer/handle of type [`gs_sresult_t`](#gs_sresult_t-new-typedef) from `gs_shader_t` that correspots to the **result name**.
- The mapped pair of result handles, represented by [`pass_shaderresult`](#pass_shaderresult-new-struct), is appended to the `pass_results` array, which is passed in by pointer.

Analogous to `ep_compile_pass_shaderparams(...)`.

###### ep_compile_pass_shader [modified function]
This function invokes generation of shader strings for either vertex or pixel shader. While doing so, it also generates mapping of **effect parameters** to **shader parameters**, which is used later to make setting of **params** possible.

We need to provide a mapping of **effect results** to **shader results**, very similar to how it is done for **params**, so the **result** retrieval works. Mapping between **effect results** and corresponding **effect params** will also be indirectly invoked.

- Add variable `used_results`, which is an array of strings representing names of results used in the shader. `used_results` is updated during the calls to [`ep_makeshaderstring(...)`](#ep_write_func_param_deps-ep_write_func_func_deps-ep_write_func-ep_makeshaderstring-modified-functions).
    - This is analogous to how `used_params` is worked with.
- Obtain a pointer variable `pass_results` of type [`pass_shaderresult`](#pass_shaderresult-new-struct). It is pointing to the data member `program_results` of `ep_pass` pointer, and will be modified in-place to retain the **results** mapping in `ep_pass` data structure
    - Similar to `vertshader_params` and `pixelshader_params` members of `ep_pass`.
- Add a call to [`ep_compilepass_shaderresults(...)`](#ep_compilepass_shaderresults-new-function). `used_results` and `pass_results` variables are passed in. `pass_results` will be updated.
    - Analogous to how `ep_compile_pass_shaderparams(...)` is called.
    - Also will result in **effect results** receiping pointers to corresponding **effect params**.

#### Interacting with the effects
In a typical scenario the effect user obtains handles to an effect's **parameters**, and uses those handles to pass the parameters to the effect, so the values can be passed down to the lower level layers and eventually end up in the actual graphics system and shader machinery.

We have to expand the usage to include the **results**. Similarly to **params**, the user will be able to lookup **result** handles by name. The user will then be able to retrieve result values from the result handles.

The **result** variables are also connected to **param** variables of the same name. `atomic_uint` will require a new type of **param** that is **not** `int`, and also requires some special care by either graphics system when using it as a parameter.

###### gs_effect_get_result_by_name(...) [new function]
Obtains a `gs_eresult_t` pointer by name. This handle can then be used by [`gs_effect_get_atomic_uint_result(...)`](#gs_effect_get_atomic_uint_result-new-function) to obtain an effect result.

Analogous to [`gs_effect_get_param_by_name(...)`](https://obsproject.com/docs/reference-libobs-graphics-effects.html#c.gs_effect_get_param_by_name).

###### gs_effect_set_atomic_uint(...) [new function]
This allows you pass a value to an unsigned integer atomic counter in the shader like you would set any other **param**. Nothing new here, except the new parameter type that will be used with the `atomic_uint` variable in the effect code. All lower-level details are in other functions.

Analogous to [`gs_effect_set_int(...)`](https://obsproject.com/docs/reference-libobs-graphics-effects.html#c.gs_effect_set_int).

###### gs_effect_get_atomic_uint_result(...) [new function]
Given a `gs_eresult_t` pointer/handle, retrieves the value of the `atomic_uint` result after drawing with the effect has finished.

Again, no super low-level stuff here; just some memory copies. Very similar to `gs_effect_set_xyz(...)` functions (where *xyz* is a data type) except we **get** instead of **set** since the results are coming back after the draw, instead of being passed in before the draw.

###### effect_setval_inline(...) [modified function]
This is a wrapper for updating effect **parameters** with new values. In addition to some error-checking, the functions prevents updating `uniform` data in the shaders when the values given are no different from the previously assigned value. (so, no update should be necessary)

We customize the behavior to **always** force updates anytime the parameter type is `GS_SHADER_PARAM_ATOMIC_UINT`. Our atomic counters are both a **param** and a **result**, and are treated a little different from other `uniform`s by the graphics systems. So, we must ensure the value is always passed in to the shaders before every draw, even if we keep sending the same value.

###### effect_pass_free(...) [modified function]
This is a cleanup function for [`gs_effect_pass`](#gs_effect_pass-added-members). We modify it to also cleanup the newly introduced `program_results` array.

###### effect_free(...) [modified function]
This is a cleanup function for [`gs_effect`](#gs_effect-new-members). We modify it to also cleanup the newly introduced `results` array.

#### Parsing the intermediate shaders
`shader-parser` processes the intermediate vertex and pixel shader code generated by the [`effect-parser`](#Parsing-the-effect-code). Data structures are generated to represent the shader behavior. This allows reformatting the intermediate shader into GLSL or HLSL code, depending on which graphics subsystem is used.

Our changes here are for supporting **results**, and for assigning a unique index for each [atomic counter](#Introducing-the-atomic-counter-results) variable, so either graphics system will be ready to allocate resources for its specialized handling of the counters.

###### shader_parser [new members]
This structure holds an instance of a `cf_parser` which is a c-style parser, and has arrays of data structures for **params**, **structs**, **samplers**, and **funcs**.

We need an incrementing counter to assign unique, increasing index for each atomic counter we encounter in the intermediate shader code. This struct seems to be a fine place to keep the next index to be assigned, so we add `atomic_counter_next_index` integer field.

###### shader_var [new members]
This struct represents a variable in a shader code. We want results to be special kind of variables, so we add `is_result` flag to the fields. We also add `atomic_counter_index` so that each `atomic_uint` variable can be uniquely identified in preparation to be handled by either graphics system. Increasing values will be assigned to indices of counters in the order of the counter's declaration in the intermediate shader.

###### shader_parser_init(...) [modified function]
This initializes members of [`shader_var`](#shader_var-new-members). We modify it to also initialize `atomic_counter_next_index` to `0`, so the counter enumeration index will begin with `0`.

###### shader_var_init_param(...) [modified function]
This function initializes a [`shader_var`](#shader_var-new-members) that was previous allocated, assigning its fields based on function parameters.

New function parameters are added to support **results** and **atomic counters**; specifically:
- `is_result` set to `true` when the variable is also a **result**
- `atomic_counter_next_index` is an integer that is passed by pointer. Whenever the variable is of type `atomic_uint` this integer is copied to the field `atomic_counter_index` in [`shader_var`](#shader_var-new-members), and then the next index to be assigned is incremented.

###### sp_parse_param(...) [modified function]
Very similarly to [`ep_parse_param(...)`](#ep_parse_param-modified-function), this calls [`shader_var_init_param(...)`](#shader_var_init_param-modified-function) to initialize a [`shader_var`](#shader_var-new-members) and do some error-checking.

We modify the call to [`shader_var_init_param(...)`](#shader_var_init_param-modified-function) so the flag `is_result` is passed down to it, and also pass the pointer to `atomic_counter_next_index` of [`gs_shader`](#gs_shader-new-members-in-libobs-opengl-implementation) as the other new argument.

###### sp_parse_other(...) [modified function]
Very similar to [`ep_parse_other(...)`](#ep_parse_other-modified-function) and is responsible for parsing anything in the intermediate shader code that is not whitespace, `struct` or `sampler_state`. We add special handling for variables of type `atomic_uint`.
- Local boolean `is_result` is added, and is set to `true` when a variable of `atomic_uint` type is encountered.
- `is_result` is also passed down to [`sp_parse_param(...)`](#sp_parse_param-modified-function).

#### Graphics API
[`graphics`](https://obsproject.com/docs/reference-libobs-graphics.html) is "an API-independent graphics subsystem wrapper". Many data types are defined. Among other things, it has function pointers that need be assigned to functions specific to OpenGL vs Direct3D11 operation.

Here we integrate some new functionality needed to make **results** work.

##### New data types

###### gs_shader_result [new struct]
This is actually defined by either D3D11 or OpenGL subsystems. It will contain data that either system will need to interact with an actual shader variable associated with the result.
However, the `graphics` code will pass this data around using the [`gs_eresult_t`](#gs_eresult_t-new typedef) typedef wrapper.

See [OpenGL](#gs_shader_result-libobs-opengl-implementation) and [D3D11](#gs_shader_result-libobs-d3d11-implementation) implementations of `gs_shader_result`.

###### gs_eresult_t [new typedef]
This is a typedef for [`gs_effect_result`](#gs_effect_result-new-struct) so a pointer handle to an **effect result** can be used by modules that don't need knowledge of the graphics internals.

Analogous to `gs_eparam_t`.

###### gs_sresult_t [new typedef]
This is a typedef for [`gs_shader_result`](#gs_shader_result-new-struct) so a pointer handle to a **shader result** can be used by modules that don't need knowledge of the shader internals.

Analogous to `gs_sparam_t`.

###### gs_shader_param_type [extended enum]
This enum for shader **param** data types is extended to include `GS_SHADER_PARAM_ATOMIC_UINT`.

##### New function signatures
The following new function signatures will be declared so they can be defined by either OpenGL or D3D11 subsystems. This will allow platform-agnostic effect abstractions to interact with the actual shader machinery of either subsystem.

###### gs_shader_get_result_by_name(...) [new function signature]
```C++
gs_sresult_t *(*gs_shader_get_result_by_name)(gs_shader_t *program, const char *name);
```
Fetches a pointer/handle [`gs_sresult_t`](#gs_sresult_t-new-typedef) by name from a shader program.

See [OpenGL](#gs_shader_get_result_by_name-libobs-opengl-implementation) and [D3D11](#gs_shader_get_result_by_name-libobs-d3d11-implementation) implementations.

Analogous to `gs_shader_get_param_by_name(...)`.

###### gs_shader_set_atomic_uint(...) [new function signature]
```C++
void (*gs_shader_set_atomic_uint)(gs_sparam_t *param, unsigned int val);
```
Passes an unsigned integer value to the atomic counter variable in the shader represented by the [`gs_sresult_t`](#gs_sresult_t-new-typedef) pointer/handle.

Expands on the existing `gs_shader_set_xyz(...)` function declarations, where *xyz* is a data type.

See [OpenGL](#gs_shader_set_atomic_uint-libobs-opengl-implementation) and [D3D11](#gs_shader_set_atomic_uint-libobs-d3d11-implementation) implementations.

###### gs_shader_get_result(...) [new function signature]
```C++
void (*gs_shader_get_result)(gs_sresult_t *result, struct darray *dst);
```
Copies new result data from the shader into the `dst`, provided a [`gs_sresult_t`](#gs_sresult_t-new-typedef) pointer/handle.

See [OpenGL](#gs_shader_get_result_by_name-libobs-opengl-implementation) and [D3D11](#gs_shader_get_result_by_name-libobs-d3d11-implementation) implementations.

Naming is analogous to `gs_shader_set_val(...)` declaration.

##### New and changed functions

###### download_results(...) [new function]
This uses the array of mapping pairs [`pass_shaderresult`](#pass_shaderresult-new-struct)
to transfer data from shader result handles [`gs_sresult_t`](#gs_sresult_t-new-typedef) (where new data is available after a technique draw is finished) into the associated [`gs_effect_result`](#gs_effect_result-new-struct), which makes the data available to effect users. It calls [`gs_shader_get_result(...)`](#gs_shader_get_result-new-function-signature).

Naming is analogous to `upload_parameters(...)`.

###### gs_technique_end_pass(...) [modified function]
This function is doing some cleanup after a technique draw has finished, and it was a convenient place for us to insert a call to [`download_results(...)`](#download_results-new-function).

#### libobs-opengl
This module provides implementation of the [Graphics API](#Graphics-API) for the OpenGL graphics system.

Roughly speaking, most of the changes fall into the categories of writing low-level code to implement the [atomic counters](#Introducing-the-atomic-counter-results)
with features [available in OpenGL](https://www.khronos.org/opengl/wiki/Atomic_Counter), and adding the structure and logic necessary to make the **results** work.

##### gl-subsystem
`gl-subsystem.h/.cpp` does many GL-specific implementations of the [Graphics API](#Graphics-API), including GL-specific implementations of the data structure for shader and program **params**.

We will modify and add new data structures here to add support for **results**, with some additions being specific to support `atomic_uint` variables.

###### gs_shader_param [new members in libobs-opengl implementation]
This is the GL-specific implementation for the **shader_param**, that has some low-level details for interacting with the params. In platform-agnostic sections of the code the pointers to `gs_shader_param` are passed around using `gs_sparam_t` pointer handles.

Our concept of a **result** implies being linked with a **param** of the same name, and using `atomic_uint` variable as a **shader param** requires some special handling too. So, we choose this struct to contain low-level data necessary for interacting with the atomic counter **params AND results**, as well as flags that were similarly added to other structures to support **results**.

New members are:
- `is_result` when `true` indicates this **param** also has an associated **result**
- `buffer_id` is the ID of the [OpenGL Buffer Object](https://www.khronos.org/opengl/wiki/Buffer_Object) that will be used to interact with the atomic counter. This will be received by calling [`init_atomic_buffer(...)`](#init_atomic_buffer-new-function)
- `layout_binding` in the GL subsystem this represents the index into the indexed target `GL_ATOMIC_COUNTER_BUFFER​` that represents graphics data for our counters.
- `layout_offset` in the GL subsystem we can have multiple atomic counters share the same **layout binding** but have different offsets.

###### gs_shader_result [libobs-opengl implementation]
This will be our implementation of the [shader result](#gs_shader_result-new-struct) for the GL subsystem.

Members are:
- `name`: name of the result
- `param`: pointer to [`gs_shader_param`](#gs_shader_param-new-members-in-libobs-opengl-implementation), which has fields with low-level details for interacting with atomic counter params/results.
- `cur_value` data array where retrieved result data will be stored

###### gs_shader [new members in libobs-opengl implementation]
This is the GL-specific definition for representing an active shader. One of the members is `params`, which is an array of [`gs_shader_param`](#gs_shader_param-new-members-in-libobs-opengl-implementation).

We add `results`, which is an array of [`gs_shader_result`](#gs_shader_result-libobs-opengl-implementation).

###### program_result [new struct]
This just has a pointer [`gs_shader_result`](#gs_shader_result-libobs-opengl-implementation), so a **program result** can be associated with a **shader result**.

Analogous to `program_param`.

###### gs_program [new members]
This represents an OpenGL shader program. It has [`gs_shader`](#gs_shader-new-members-in-libobs-opengl-implementation) pointers to a **vertex** and **pixel shader**, as well as an array of `program_param`s.

We add `results`, which is an array of [`program_result`](#program_result-new-struct)s.

##### gl-shaderparser
After `shader-parser` has [parsed the intermediate shader code](#Parsing-the-intermediate-shaders) into data structures, `gl-shaderparser` code will generate the final GLSL shader code from these data structures.

Our changes here are for generating code that utilizes the atomic counters feature of OpenGL/GLSL. `atomic_uint` type is native to GLSL, but we need to generate the  [`layout(...)`](https://www.khronos.org/opengl/wiki/Layout_Qualifier_(GLSL)#Atomic_counter_storage) qualifier block that is required for `atomic_uint` variable declarations, which we have omitted from the effect language.

Notably, `atomicCounterIncrement(...)` (or decrement) effect statements, that we aim to support, are borrowed from GLSL, and require no special translation when regenerated from intermediate shader code into GLSL.

###### gl_write_var [modified function]
This function writes variable declarations into GLSL, taking into account various qualifiers.

To support `atomic_uint`s in GLSL, the declaration must be preceded by a [`layout(...)`](https://www.khronos.org/opengl/wiki/Layout_Qualifier_(GLSL)#Atomic_counter_storage) qualifier block. So, our declarations for atomic counters will need to look like this:

`(layout binding = 1, offset = 0) uniform atomic_uint myCounter;`

We modify the function to insert the **layout qualifiers** for variable declarations that are of type `atomic_uint`. We will use `atomic_counter_index` of [`shader_var`](#shader_var-new-members) as the source for the **binding** index.

###### gl_shader_buildstring [modified function]
Dispatches lower-level functions for putting together the final GLSL code.

We change `#version 330` preprocessor declaration to `#version 460` to support atomic counters.

##### gl-shader
Defines many functions for activating and interacting with a GLSL shader and an OpenGL shader program.

Our changes are for integrating the flow of data for **results**, and introducing the low-level code for activation and interaction specific to [atomic counters](#Introducing-the-atomic-counter-results) (`atomic_uint`).

###### gl_add_result(...) [new function]
Instantiates and stores a new result in the `results` array of [`gs_shader`](#gs_shader-new-members-in-libobs-opengl-implementation). New instance of [`gs_shader_result`](#gs_shader_result-libobs-opengl-implementation) gets a copy of the param/result **name**, so the corresponding **param** and the **result** can be linked once the intermediate shader parsing has finished and the array of **params** is stable.

###### gl_add_param(...) [modified function]
Initializes a [`gs_shader_param`](#gs_shader_param-new-members-in-libobs-opengl-implementation) given a [`shader_var`](#shader_var-new-members) as input. Textures get some special treatment here. Once initialized, new instance of `gs_shader_param` is pushed back to the `params` array of [`gs_shader`](#gs_shader-new-members-in-libobs-opengl-implementation).
We modify the function as follows:
- When **param** is of type `GS_SHADER_PARAM_ATOMIC_UINT` its `layout_binding` gets set to the value of `atomic_counter_index` of [`shader_var`](#shader_var-new-members), and its `layout_offset` is `0`.
- `is_result` field of `shader_var` propagates to the new `gs_shader_param`.
- in the event `is_result` is true, [`gl_add_result(...)`](#gl_add_result-new-function) is called to instantiate and store a [`gs_shader_result`](#gs_shader_result-libobs-opengl-implementation) corresponding to the **param**'s name.

###### init_atomic_buffer(...) [new function]
Generates a new [OpenGL Buffer Object](https://www.khronos.org/opengl/wiki/Buffer_Object) of type `GL_ATOMIC_COUNTER_BUFFER`, which will be used for writing to and reading from an atomic counter variable. **Buffer ID** is retained to be stored in [`gs_shader_param`](#gs_shader_param-new-members-in-libobs-opengl-implementation).

We use `glGenBuffers(...)`, `glBindBuffer(...)`, `glBufferData(...)`, `glBindBuffer(...)`, and `glBindBufferBase(...)` to get an atomic counter buffer initialized.

###### gs_shader_set_atomic_uint(...) [libobs-opengl implementation]
Implements [`gs_shader_set_atomic_uint(...)`](#gs_shader_set_atomic_uint-new-function-signature) function signature for the OpenGL subsystem.

Very similar to most of the other `gs_shader_set_xyz(...)` implementations (where *xyz* is a data type) that just copy data into `cur_value` data array of [`gs_shader_param`](#gs_shader_param-new-members-in-libobs-opengl-implementation).

###### gs_shader_get_result_by_name(...) [libobs-opengl implementation]
Implements [`gl_shader_get_result_by_name(...)`](#gs_shader_get_result_by_name-new-function-signature) function signature for the OpenGL subsystem.

Analogous to `gs_shader_get_param_by_name(...)` and just searches for the right **result** with `name` field that matches.

###### gs_shader_get_result(...) [libobs-opengl implementation]
Implements [`gs_shader_get_result(...)`](#gs_shader_get_result-new-function-signature) function signature for the OpenGL subsystem.

Just copies data into destination pointer from the `cur_value` data array of [`gs_shader_result`](#gs_shader_result-libobs-opengl-implementation).

###### gs_shader_destroy(...) [modified function]
This is a cleanup function for [`gs_shader`](#gs_shader-new-members-in-libobs-opengl-implementation) and we modify it to also cleanup the `results` array of [`gs_shader_result`](#gs_shader_result-libobs-opengl-implementation).

###### program_set_param_data(...) [modified function]
This function works on getting **param** values/data into `uniform` variables of an active GLSL shader. For most supported data types this means calling `glUniformXyz(...)` function, with some specialized work needed for textures.

The [atomic counter](#Introducing-the-atomic-counter-results) variables are also special and we cannot use `glUniformXyz(...)` style functions to set values before draw. When **param** type is `GS_SHADER_PARAM_ATOMIC_UINT` we add another specialization to call `glBindBuffer(...)`, `glBindBufferBase(...)` and `glBufferSubData(...)` functions so the value can make its way to `atomic_uint` variable of interest in the shader, before the draw.

###### assign_program_param(...) [modified function]
This function finds the uniform locations of a given [`gs_shader_param`](#gs_shader_param-new-members-in-libobs-opengl-implementation) by calling `glGetUniformLocation(...)` with the **param**'s name, and then pushes the given **shader param** to the `params` array of [`gs_program`](#gs_program-new-members).

Because the mechanisms used for initializing and using the atomic counters are different from regular `uniform`s, we modify the function to skip finding and assigning a uniform location any time a **param** is of type is `GS_SHADER_PARAM_ATOMIC_UINT`.

###### assign_program_shader_results(...) [new function]
This function works on connecting each constructed [`gs_shader_result`](#gs_shader_result-libobs-opengl-implementation) with the respective [`gs_shader_param`](#gs_shader_param-new-members-in-libobs-opengl-implementation) of the same name. It also constructs a new [`program_result`](#program_result-new-struct) linked with the **shader result**, and pushes it to `results` array of [`gs_program`](#gs_program-new-members).

Naming is analogous to `assign_program_shader_params(...)`.

###### assign_program_results(...) [new function]
This function calls [`assign_program_shader_results(...)`](#assign_program_shader_results-new-function) for both **vertex** and **pixel** shaders of [`gs_program`](#gs_program-new-members).

Analogous to `assign_program_params(...)`.

###### gs_program_create(...) [modified function]
After GLSL shaders were compiled this function creates a new shader program, attaches the shaders to the program, and links it. After linking it calls `assign_program_params(...)` and `assign_program_attribs(...)`, so we also add a call to [`assign_program_results(...)`](#assign_program_results-new-function).

###### gs_program_destroy(...) [modified function]
This is a cleanup function for [`gs_program`](#gs_program-new-members) and we modify it to also destroy the `results` array containing [`program_result`](#program_result-new-struct)s.

#### libobs-d3d11

This module provides implementation of the [Graphics API](#Graphics-API) for the Direct3D11 graphics system.

Roughly speaking, most of the changes fall into the categories of implementing [atomic counters](#Introducing-the-atomic-counter-results) using Direct3D's [UAV variables](https://docs.microsoft.com/en-us/windows/win32/direct3d12/uav-counters) system, and adding the structure and logic necessary to make the **results** work.

##### d3d11-subsystem
`d3d11-subsystem.h/.cpp` does many D3D11-specific implementations implementations of the [Graphics API](#Graphics-API), including D3D11-specific implementations of the data structure for shader and program **params**.

We will modify and add new data structures here to add support for **results**, with some additions being specific to implement `atomic_uint` variables using the [UAV system](https://docs.microsoft.com/en-us/windows/win32/direct3d12/uav-counters).

###### gs_shader_param [new members in libobs-d3d11 implementation]
This is the D3D11-specific implementation for the **shader_param**, that has some low-level details for interacting with the params. In platform-agnostic sections of the code the pointers to `gs_shader_param` are passed around using `gs_sparam_t` handle.

Our concept of a **result** implies being linked with a **param** of the same name, and using a UAV variable as a **shader param** requires some special handling too. So, we choose this struct to contain low-level data necessary for interacting with the atomic counter **params AND results**, as well as flags that were similarly added to other structures to support **results**.

New members are:
- `is_result` when `true` indicates this **param** also has an associated **result**
- `atomicCounterIndex` in the D3D11 subsystem will represent index into the buffer of UAV memory of unsigned integers where variable resides. The value will be copied from `atomic_counter_index` of  [`shader_var`](#shader_var-new-members).

Situational repurposing of an existing member:
- The `pos` member is being used to store the byte address of the variable in the memory chunk used to set const/uniform variables. For UAV counter variables we will reuse the same variable as the byte address into the UAV memory chunks that we send and receive from the shader. Since each counter variable will be 4 bytes, anything that is a counter will have its `pos` assigned to `atomicCounterIndex * 4`.

###### gs_shader_result [libobs-d3d11 implementation]
This will be our implementation of the [shader result](#gs_shader_result-new-struct) for the D3D11 subsystem.

Members are:
- `name`: name of the result
- `param`: pointer to [`gs_shader_param`](#gs_shader_param-new-members-in-libobs-d3d11-implementation), which has fields with low-level details for interacting with UAV counter params/results.
- `curValue` data array where retrieved result data will be stored

###### gs_shader [new members in libobs-d3d11 implementation]
This is the D3D11-specific definition for representing an active shader. Among other things, it has  `params` member, which is a vector of [`gs_shader_param`](#gs_shader_param-new-members-in-d3d11-implementation), which partakes in passing the **param** values to the shader before the draw. So, we add `results`, which is a vector of [`gs_shader_result`](#gs_shader_result-libobs-d3d11-implementation), and will partake in fetching the **results** after the draw.

The class also holds const data size and descriptor used for initializing the const/uniform buffer. So, we introduce UAV data size and several descriptor variables used to initialize the UAV buffer and its use. The descriptors are initialized in the [`gs_shader::BuildUavBuffer(...)`](#gs_shaderBuildUavBuffer-new-function) (called from the vertex and pixel shader constructors) and are reused in [`gs_vertex/pixel_shader::Rebuild(...)`](#gs_vertexpixel_shaderRebuild-modified-functions).
- `uavBd` is a `D3D11_BUFFER_DESC` structure for describing the UAV buffer. Gets passed down to [`ID3D11Device::CreateBuffer(...)]`](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11device-createbuffer) to create the UAV buffer in graphics memory.
- `uavTxfrBd` is a `D3D11_BUFFER_DESC` structure for describing the UAV transfer buffer. Gets passed down to [`ID3D11Device::CreateBuffer(...)]`](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11device-createbuffer) to create a transfer buffer for transferring data back and forth between the system memory and the UAV graphics memory.
    - analogous to `bd` which is a `D3D11_BUFFER_DESC` used in initializing the constants buffer that transfers uniforms' data to the graphics memory.
- `uavViewDesc` is a `D3D11_UNORDERED_ACCESS_VIEW_DESC` structure for describing the UAV view. Gets passed down to [`ID3D11Device::CreateUnorderedAccessView(...)`](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11device-createunorderedaccessview) to create the UAV view for sending the counter data into the shader.

Finally, the class holds pointer to a D3D11 interface for the buffer used in setting const/uniform data. So, we add pointers to the two buffers and a UAV view used in setting and receiving UAV data. These are created in the [`gs_shader::BuildUavBuffer(...)`](#gs_shader-BuildUavBuffer-new-function) (called from the vertex and pixel shader constructors) and have to be reinitialized in the event of [`gs_vertex/pixel_shader::Rebuild(...)`](#gs_vertexpixel_shaderRebuild-modified-functions).
- `uavBuffer` is a pointer to `ID3D11Buffer` representing the UAV buffer in graphics memory. Obtained by calling [`D3D11Device::CreateBuffer(...)]`](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11device-createbuffer) with `uavBd` as one of parameters.
- `uavTxfrBuffer` is a pointer to `ID3D11Buffer` for **sending and receiving** the UAV data. Obtained by calling [`D3D11Device::CreateBuffer(...)]`](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11device-createbuffer) with `uavTxfrBd` as one of parameters.
    - analogous to `constants` buffer pointer for setting uniforms
- `uavView` is a pointer to `ID3D11UnorderedAccessView` and is used to sending data to the UAV region in graphics memory. Obtained by calling [`ID3D11Device::CreateUnorderedAccessView(...)`](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11device-createunorderedaccessview) with `uavBuffer` and `uavViewDesc` as arguments.

###### device_draw(...) [modified function in libobs-d3d11 implementation]

This function encapsulates much of a typical draw activity, including loading vertex buffer, updating blend, raster, Z-stencil states, view+proj matrix, invoking `UploadParams(...)` on **shader parameters** to **vertex** and **pixel** shaders, and finally drawing primitives. It is called from `gs_draw(...)`.

As we are introducing the concept of **results** that become available after the draw, we add a call to [`gs_shader::DownloadResults(...)`](#gs_shaderDownloadResults-new-function) on the **vertex** and **pixel** shaders, after the primitive draw has finished.

##### d3d11-shaderprocessor
After `shader-parser` has [parsed the intermediate shader code](#Parsing-the-intermediate-shaders) into data structures, `d3d11-shaderprocessor` code will generate the final HLSL shader code from these data structures.

Our changes here are for generating code that parses the added effect syntax for atomic counters, and utilizes the UAV variables of D3D to implement atomic counters. Unfortunately, in HLSL there is no direct analogue to `atomic_uint` type and no `atomicCounterIncrement(...)` function, so we translate our intermediate shader code to become other things in HLSL that needs to be generated:
- `RWStructuredBuffer<uint> __uavBuffer : register(u1);` is used to declare a UAV memory chunk in the shader that we will use for storing the atomic counter variables. Such a buffer will be added when UAV counters were encountered in the effect code, and the `uavBuffer` handle of [`gs_shader`](gs_shader-new-members-in-libobs-d3d11-implementation) will be connected to this buffer when [`gs_shader::BuildUavBuffer(...)](gs_shaderBuildUavBuffer-new-function) or `gs_vertex/pixel_shader::Rebuild(...)` is called.
- We cannot assign and access variables inside our `__uavBuffer` by name, but we can index into it like an array of unsigned 32-bit integers. We will use the `atomicCounterIndex` member of [`gs_shader_param`](#gs_shader_param-new-members-in-libobs-d3d11-implementation) as an index into the buffer (which was inherited from `atomic_counter_index` of  [`shader_var`](#shader_var-new-members)).
- [`InterlockedAdd(...)`](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/interlockedadd) will be used to replace [`atomicCounterIncrement(...)`](#Additions-to-the-effect-language) added to the effect language.
- So, an effect statement `atomicCounterIncrement(varName)` will need to be translated into `InterlockedAdd(__uavBuffer[0], 1)`, where `0` happened to be the **atomic counter index** for `varName`, and `1` is because "increment" is equivalent to "add 1 and assign";

###### ShaderProcessor::SeekUntil(...) [new function]
This protected utility function is added for iterating through `cf_token`s of `ShaderParser` until a token matching a string is found. Used by [`ShaderProcessor::PeekAndSkipAtomicUint(...)`](#PeekAndSkipAtomicUint-new-function) and [`ShaderProcessor::ReplaceAtomicIncrement(...)`](#ShaderProcessorReplaceAtomicIncrement-new-function) functions.

###### ShaderProcessor::SeekWhile(...) [new function]
This protected utility function is added for iterating through `cf_token`s of `ShaderParser` for as long as tokens match a string. Used by [`ShaderProcessor::PeekAndSkipAtomicUint(...)`](#ShaderProcessorPeekAndSkipAtomicUint-new-function) and [`ShaderProcessor::ReplaceAtomicIncrement(...)`](#ShaderProcessorReplaceAtomicIncrement-new-function) functions.

###### ShaderProcessor::PeekAndSkipAtomicUint(...) [new function]
This function as added to eat up all tokens that are part of `uniform atomic_uint myVar;` declarations. As [mentioned before](#d3d11-shaderprocessor), we will be using numeric index into the `__uavBuffer` of the shader code instead of counter variable names, so all tokens that are part of declarations for `atomic_uint`s will be completely ignored - no output will be produced. Returns `true` when one such declaration was encountered and swallowed up.

###### ShaderProcessor::ReplaceAtomicIncrement(...) [new function]
This works on translating the [`atomicCounterIncrement(...)`](#Additions-to-the-effect-language) statement added to the effect language into [`InterlockedAdd(...)`](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/interlockedadd) statements of HLSL. In order to translate variable name of intermediate shader code into a numeric index that can be used with `__uavBuffer` - the `params` array of [`shader_parser`](#shader_parser-new-members) is scanned for [`shader_var`](#shader_var-new-members) with the matching name and the `atomic_counter_index` of that **shader variable** is used.

###### ShaderProcessor::BuildString(...) [modified function]
This one obtains tokens from the parser of the intermediate shader code, and replaces keywords of the [effect](#Effects) language into things that actually exist in HLSL, so the final HLSL string is constructed. Our additions of the atomic counter syntax are no exception to these needs, and even require some additional handling. Changes are:
 -[`ShaderProcessor::ReplaceAtomicIncrement(...)`](#ShaderProcessorReplaceAtomicIncrement-new-function) is called whenever `atomicCounterIncrement` keyword is encountered, and will navigate tokens to replace the entire increment statement.
- We also add a call to [`ShaderProcessor::PeekAndSkipAtomicUint(...)`](#ShaderProcessorPeekAndSkipAtomicUint-new-function), which is called after all other keywords are checked for a need of conversion. If the function returns `true` - this means `atomic_uint` declaration was encountered, and all tokens of the declaration statement will be be skipped in the HLSL.
- As [mentioned before](#d3d11-shaderprocessor), we need to add `RWStructuredBuffer<uint> __uavBuffer : register(u1);` into output to declare the UAV memory block for the counters, but only for the shaders that have atomic counter variables. So, instead of `stringstream output` function variable there are now string streams `tempOutput` and `finalOutput`. `tempOutput` is being written to as tokens are being processed, just like `output` was before. During processing of the tokens, we will learn if the UAV block will be needed or not. And if it is needed, in the `finalOutput` we will insert `RWStructuredBuffer<uint> __uavBuffer : register(u1);` statement **after** `static const bool obs_glsl_compile = false` but **before** the rest of the code, which has been constructed in `tempOutput`. Now `finalOutput` stream has the final HLSL code to be copied into `outputString`, which is the function argument that is passed by reference. Phew.

##### d3d11-shader

Defines much of the functionality for initializing and interacting with an active HLSL shader.

Changes here will be for adding the needed structure and logic for **results**, initializing all the D3D11 device and context handles needed for interacting with the UAV buffer containing atomic counter variables, and using them.

###### gs_shader_get_result_by_name(...) [libobs-d3d11 implementation]
Implements [`gl_shader_get_result_by_name(...)`](#gs_shader_get_result_by_name-new-function-signature) function signature for the GL subsystem.

Analogous to `gs_shader_get_param_by_name(...)` and just searches for the right **result** with `name` field that matches.

###### gs_shader_set_atomic_uint(...) [libobs-d3d11 implementation]
Implements [`gs_shader_set_atomic_uint(...)`](#gs_shader_set_atomic_uint-new-function-signature) function signature for the D3D11 subsystem.

Copies data from a `const void* data` pointer into `curValue` vector of [`gs_shader_param`](#gs_shader_param-new-members-in-libobs-d3d11-implementation), resizing the vector when necessary.

###### gs_shader_get_result(...) [libobs-d3d11 implementation]
Implements [`gs_shader_get_result(...)`](#gs_shader_get_result-new-function-signature) function signature for the D3D11 subsystem.

Just copies data into destination pointer from the `curValue` data array of [`gs_shader_result`](#gs_shader_result-libobs-d3d11-implementation).

###### gs_shader::BuildUavBuffer(...) [new function]
Iterates through the vector of [`gs_shader_param`](#gs_shader_param-new-members-in-libobs-d3d11-implementation). For each **param** that is also a **result**, uses `pos` member to determine the largest value of the mapping index, so the required size of the UAV block is known. Once this size, `uavSize`, is known, and is not zero, initializes the `uavBd`, `uavTxfrBd`, and `uavViewDesc` descriptors, and uses them to create the `uavBuffer` and `uavTxfrBuffer`, and `uavView` of the [`gs_shader`](#gs_shader-new-members-in-libobs-d3d11-implementation), which are used for sending data to and from the UAV graphics memory.

Analogous to the behavior of `gs_shader::BuildConstantBuffer(...)`, except there is some additional complexity due to UAV use and support for bi-directional data flow.

###### gs_vertex/pixel_shader::Rebuild(...) [modified functions]
These functions reconstruct a vertex or pixel shader, maintaining the descriptors for const/uniform buffer but reinstantiating the const buffer and making sure all params work in the new instance of the shader.

Similarly to how const data is handled, we maintain the `uavBd`, `uavTxfrBd`, and `uavViewDesc` descriptors, but we create new instances of the `uavBuffer` and `uavTxfrBuffer`, and `uavView` of [`gs_shader`](#gs_shader-new-members-in-libobs-d3d11-implementation), which are required for sending data to and from the UAV graphics memory.

###### gs_shader::UpdateParam(...) [modified function]
This function adjusts `constData` data array, passed by reference, in response to an input `gs_shader_param`. The `pos` member of each **param** dictates where in the **const data** (uniform) memory chunk the param's data will go. When new or modified **param** data is due to be inserted into the chunk of const data, a pass-by-reference boolean `uploadConst` is set to `true`, to flag that the const data will need to be uploaded to refresh the uniform variable(s).

We mirror this arrangement as we add support for sending UAV memory chunks to the shaders, triggered by the **counter params+results** that need it:
- We add `uavData` data array that is passed into the function by reference. It will be adjusted in response to the input **param** when it is of type `GS_SHADER_PARAM_ATOMIC_UINT`. Once again, `pos` member of each **param** is used as a mapping index, except this time it's indexing into the UAV data instead of the const/uniform data.
- We add `uploadUav`, a boolean passed by reference, that will need to be set to `true` whenever an input [`gs_shader_param`](#gs_shader_param-new-members-in-libobs-d3d11-implementation) is of type `GS_SHADER_PARAM_ATOMIC_UINT`. We always force UAV data refresh anytime a UAV variable is encountered - even if the UAV memory chunk appears unchanged. We want UAV counters to be set to predictable values as we begin drawing with the effect.

###### gs_shader::UploadParams(...) [modified function]
This function initializes a local variable `constData`, which is data vector, and then calls [`gs_shader::UpdateParam(...)`](#gs_shaderUpdateParam-modified-function) on every **param** of [`gs_shader`](#gs_shader-new-members-in-libobs-d3d11-implementation) until `constData` contains all the values to be assigned to the uniforms. If new or modified param data was encountered during the updates - the `uploadConst` flag gets set, and the function uses [`ID3D11DeviceContext::Map(...)`](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11devicecontext-map) to map the `constants` buffer, so the constructed data block in `constData` is copied and ends up in this const/uniform buffer.

We mirror this structure as we introduce UAV counter results. We add `uavData` data array and `uploadUav` boolean, and we also process these by [`gs_shader::UpdateParam(...)`](#gs_shaderUpdateParam-modified-function). If any of the params were atomic counter results, the `uploadUav` flag is set and:
- We call [`ID3D11DeviceContext::OMSetRenderTargetsAndUnorderedAccessViews`](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11devicecontext-omsetrendertargetsandunorderedaccessviews) to activate our **UAV view**
- Call [`ID3D11DeviceContext::Map(...)`](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11devicecontext-map) on the `uavTxfrBuffer` to load the transfer buffer.
- Call [ID3D11DeviceContext::CopyResource(...)](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11devicecontext-copyresource) to deliver the data from `uavTxfrBuffer` to the `uavBuffer` in graphics memory.

##### gs_shader::DownloadResults(...) [new function]
**After the draw** we need to download the UAV data back:
- Add a local veriable, data vector `resultsData` to receive the UAV memory chunk.
- As we work in the opposite direction, we call [ID3D11DeviceContext::CopyResource(...)](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11devicecontext-copyresource) first to copy data from `uavBuffer` in the graphics memory to the `uavTxfrBuffer` in the system memory.
- Then use [`ID3D11DeviceContext::Map(...)`](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11devicecontext-map) to copy data from `uavTxfrBuffer` to the `resultsData` vector.
- Finally, copy data from the `resultsData` vector to individual [`gs_shader_result`](#gs_shader_result-libobs-d3d11-implementation), using the `pos` member of each **result** as a mapping index.

###### gs_pixel_shader::gs_pixel_shader(...) [modified constructor]
This a constructor for a class that represents an active **pixel shader**, and is derived from [`gs_shader`](#gs_shader-new-members-in-libobs-d3d11-implementation) base class. It instantiates and makes calls to [d3d11-shaderprocessor](#d3d11-shaderprocessor), so the previously generated [intermediate shader code](#Parsing-the-intermediate-shaders) can be parsed again into useful data structures for interacting with the shader. The final HLSL code is assembled and [`ID3D11Device::CreatePixelShader(...)`](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11device-createpixelshader) is called to create the shader and keep and handle to it inside `gs_pixel_shader`.

Here, the only modification was changing shader model from `ps_4_0` to `ps_5_0` in order to support UAV buffer.

</details>

### Motivation and Context

[Pixel Match Switcher](https://github.com/HoneyHazard/PixelMatchSwitcher) is being developed to provide users with ability to switch scenes (or toggle sources and filters) when a template image is being matched in a video source. In order for this to be fast we needed to introduce **results** into OBS effect system.

### How Has This Been Tested?

Tested on Windows 10 and Debian 10.

Verified that existing functionality of OBS is not broken, and that results work when using the [Pixel Match Switcher](https://github.com/HoneyHazard/PixelMatchSwitcher) plugin.

### Types of changes
- New feature (non-breaking change which adds functionality)
- Documentation (a change to documentation pages)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
