### PR TITLE
UI: Remove x11info dependency

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -123,13 +123,17 @@ elseif(APPLE)
 	endif()
 
 elseif(UNIX)
-        find_package(Qt5X11Extras REQUIRED)
+	find_package(Qt5Gui REQUIRED)
+
+	include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 
 	set(obs_PLATFORM_SOURCES
 		platform-x11.cpp)
 
-        set(obs_PLATFORM_LIBRARIES
-                Qt5::X11Extras)
+	set(obs_PLATFORM_LIBRARIES
+		${obs_PLATFORM_LIBRARIES}
+		Qt5::Gui
+		Qt5::GuiPrivate)
 
 	if("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
 		list(APPEND obs_PLATFORM_LIBRARIES
@@ -394,16 +398,6 @@ if(WIN32)
 	set_target_properties(obs
 		PROPERTIES
 			OUTPUT_NAME "obs${_output_suffix}")
-endif()
-
-if (ENABLE_WAYLAND)
-	find_package(Qt5Gui REQUIRED)
-	include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
-
-	set(obs_PLATFORM_LIBRARIES
-		${obs_PLATFORM_LIBRARIES}
-		Qt5::Gui
-		Qt5::GuiPrivate)
 endif()
 
 target_link_libraries(obs

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -61,12 +61,7 @@
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 #include <obs-nix-platform.h>
-#include <QX11Info>
-
-#ifdef ENABLE_WAYLAND
 #include <qpa/qplatformnativeinterface.h>
-#endif
-
 #endif
 
 #include <iostream>
@@ -1398,27 +1393,23 @@ bool OBSApp::OBSInit()
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 	obs_set_nix_platform(OBS_NIX_PLATFORM_X11_GLX);
-	if (QApplication::platformName() == "xcb") {
-		if (getenv("OBS_USE_EGL")) {
-			blog(LOG_INFO, "Using EGL/X11");
-			obs_set_nix_platform(OBS_NIX_PLATFORM_X11_EGL);
-		}
-		obs_set_nix_platform_display(QX11Info::display());
+	if (QApplication::platformName() == "xcb" && getenv("OBS_USE_EGL")) {
+		obs_set_nix_platform(OBS_NIX_PLATFORM_X11_EGL);
+		blog(LOG_INFO, "Using EGL/X11");
 	}
 
 #ifdef ENABLE_WAYLAND
 	if (QApplication::platformName().contains("wayland")) {
 		obs_set_nix_platform(OBS_NIX_PLATFORM_WAYLAND);
-		QPlatformNativeInterface *native =
-			QGuiApplication::platformNativeInterface();
-		obs_set_nix_platform_display(
-			native->nativeResourceForIntegration("display"));
-
 		setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
-
 		blog(LOG_INFO, "Platform: Wayland");
 	}
 #endif
+
+	QPlatformNativeInterface *native =
+		QGuiApplication::platformNativeInterface();
+	obs_set_nix_platform_display(
+		native->nativeResourceForIntegration("display"));
 #endif
 
 	if (!StartupOBS(locale.c_str(), GetProfilerNameStore()))


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This moves X11 platform to the qt private functions, as x11info was
removed from Qt6 so this is required for a clean Qt5/6 transition.

This is the implementation of x11info::getdisplay so it should still
work on older platforms. This "API" doesnt really guarantee anything
though.

Also clean up wayland only bits as we use them for all windowing systems
now, and the name of the native pointer we want is the same on both
platforms for now.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
x11info was removed from Qt6 so this is required for a clean Qt5/6 transition.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
X11 still runs with this change on Qt 5.15.2.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
