### PR TITLE
Remove X11Extras

### DIFF
--- a/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
@@ -9,8 +9,6 @@ if(UNIX AND NOT APPLE)
 	find_package(X11 REQUIRED)
 	link_libraries(${X11_LIBRARIES})
 	include_directories(${X11_INCLUDE_DIR})
-
-	find_package(Qt5X11Extras REQUIRED)
 endif()
 
 set(decklink-ouput-ui_HEADERS
@@ -68,11 +66,6 @@ target_link_libraries(decklink-ouput-ui
 	obs-frontend-api
 	Qt5::Widgets
 	libobs)
-
-if(UNIX AND NOT APPLE)
-	target_link_libraries(decklink-ouput-ui
-		Qt5::X11Extras)
-endif()
 
 set_target_properties(decklink-ouput-ui PROPERTIES FOLDER "frontend")
 

--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -9,8 +9,6 @@ if(UNIX AND NOT APPLE)
 	find_package(X11 REQUIRED)
 	link_libraries(${X11_LIBRARIES})
 	include_directories(${X11_INCLUDE_DIR})
-
-	find_package(Qt5X11Extras REQUIRED)
 endif()
 
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/deps/obs-scripting")
@@ -124,11 +122,6 @@ target_link_libraries(frontend-tools
 	obs-frontend-api
 	Qt5::Widgets
 	libobs)
-
-if(UNIX AND NOT APPLE)
-	target_link_libraries(frontend-tools
-		Qt5::X11Extras)
-endif()
 
 set_target_properties(frontend-tools PROPERTIES FOLDER "frontend")
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Qt5X11Extras (QX11Info) was added in 762983b5d853ba8444c4efee450ea872b294060e, but it doesn't seem to actually be used. Qt6 doesn't yet ship X11Extras, so let's remove it.

#3177 added Qt5X11Extras as a dependency, though doesn't actually seem to use classes or functions from it.  This was to work around obsproject/obs-browser#219, but that appears to have been resolved by updating to CEF 4280+.  Native dialogs were reinstated in https://github.com/obsproject/obs-studio/commit/58497e59d9054b538f4cd65b93d11b210ac26618 (#4155), but we still have Qt5X11Extras as a dependency.  Since X11Extras is not currently part of Qt6, and it has no expected ship date, and we aren't using it, let's remove it.

Pinging @cg2121 and @GeorgesStavracas since they authored the PRs linked above.

https://doc.qt.io/qt-5/qtx11extras-module.html
https://doc.qt.io/qt-5/qx11info.html

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Less dependencies.  Makes a future transition to Qt6 easier.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiles on a Ubuntu 20.04 VM against Qt 5.12.8.  Would appreciate more testing or review from people who use Linux regularly.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
