### PR TITLE
win-dshow: Fix memory leak caused by using incorrect API

### DIFF
--- a/plugins/win-dshow/ffmpeg-decode.c
+++ b/plugins/win-dshow/ffmpeg-decode.c
@@ -107,7 +107,7 @@ int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id,
 void ffmpeg_decode_free(struct ffmpeg_decode *decode)
 {
 	if (decode->hw_frame)
-		av_free(decode->hw_frame);
+		av_frame_free(&decode->hw_frame);
 
 	if (decode->decoder) {
 		avcodec_close(decode->decoder);
@@ -115,7 +115,7 @@ void ffmpeg_decode_free(struct ffmpeg_decode *decode)
 	}
 
 	if (decode->frame)
-		av_free(decode->frame);
+		av_frame_free(&decode->frame);
 
 	if (decode->packet_buffer)
 		bfree(decode->packet_buffer);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This fixed #4367. While freeing decode->hw_frame and decode->frame, we should use av_frame_free() instead of av_free(). Otherwise, memory leak happen.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Memory leak will happen while switching video format for camera between MJPG and H264.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on windows 10 works fine

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
