### PR TITLE
libobs: replace strcat_s with snprintf to avoid crash #2560

### DIFF
--- a/deps/ipc-util/ipc-util/pipe-windows.c
+++ b/deps/ipc-util/ipc-util/pipe-windows.c
@@ -15,6 +15,7 @@
  */
 
 #include "pipe.h"
+#include<stdio.h>
 
 #define IPC_PIPE_BUF_SIZE 1024
 

--- a/deps/ipc-util/ipc-util/pipe-windows.c
+++ b/deps/ipc-util/ipc-util/pipe-windows.c
@@ -171,8 +171,7 @@ static inline bool ipc_pipe_internal_open_pipe(ipc_pipe_client_t *pipe,
 	DWORD mode = PIPE_READMODE_MESSAGE;
 	char new_name[512];
 
-	strcpy_s(new_name, sizeof(new_name), "\\\\.\\pipe\\");
-	strcat_s(new_name, sizeof(new_name), name);
+	snprintf(new_name, sizeof(new_name), "\\\\.\\pipe\\%s", name);
 
 	pipe->handle = CreateFileA(new_name, GENERIC_READ | GENERIC_WRITE, 0,
 				   NULL, OPEN_EXISTING, 0, NULL);

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -384,16 +384,14 @@ static int os_get_path_internal(char *dst, size_t size, const char *name,
 
 	SHGetFolderPathW(NULL, folder, NULL, SHGFP_TYPE_CURRENT, path_utf16);
 
-	if (os_wcs_to_utf8(path_utf16, 0, dst, size) != 0) {
+	char path_utf8[MAX_PATH];
+	if (os_wcs_to_utf8(path_utf16, 0, path_utf8, sizeof(path_utf8)) != 0) {
 		if (!name || !*name) {
-			return (int)strlen(dst);
+			snprintf(dst, size, "%s", path_utf8);
+		} else {
+			snprintf(dst, size, "%s\\%s", path_utf8, name);
 		}
-
-		if (strcat_s(dst, size, "\\") == 0) {
-			if (strcat_s(dst, size, name) == 0) {
-				return (int)strlen(dst);
-			}
-		}
+		return (int)strlen(dst);
 	}
 
 	return -1;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
For #2560. strcat_s cann't avoid memory error when buffer is overflow.
maybe it's better to use snprintf.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Avoid memory exception by overflow. Fixes #2560.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
win10 works fine

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
