### PR TITLE
rtmp-service: Add bitwave.tv

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 171,
+	"version": 172,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 171
+			"version": 172
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1205,6 +1205,23 @@
             }
         },
         {
+            "name": "Bitwave",
+            "servers": [
+                {
+                    "name": "Primary",
+                    "url": "rtmp://stream.bitwave.tv/live"
+                }
+            ],
+            "recommended": {
+                "keyint": 1,
+                "profile": "high",
+                "max video bitrate": 3000,
+                "max audio bitrate": 320,
+                "max fps": 60,
+                "x264opts": "scenecut=0"
+            }
+        },
+        {
             "name": "Trovo",
             "alt_names": ["Madcat"],
             "servers": [


### PR DESCRIPTION
### Description

Adds bitwave.tv to RTMP services.

### Motivation and Context

Provide a simple method within OBS to connect to our service while also pre-configuring some settings that improve compatibility with our livestream ingestion and help reduce delay. 

Location Documenting OBS Profile & Tune for service: https://github.com/bitwave-tv/bitwave/issues/215

(disclosure: I am the developer for bitwave)

### How Has This Been Tested?

Tested on Windows 10 PC (as of 2021.03.18) to Primary ingestion server listed.

### Types of changes

- New feature (non-breaking change which adds functionality)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
