### PR TITLE
obs-ffmpeg: Hangs when global_stream_key is not configured

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -237,7 +237,9 @@ static void ffmpeg_log_callback(void *param, int level, const char *format,
 
 	vsnprintf(out_buffer, sizeof(out_buffer), format, args);
 	dstr_copy(&out, out_buffer);
-	dstr_replace(&out, global_stream_key, "{stream_key}");
+	if (global_stream_key && *global_stream_key) {
+		dstr_replace(&out, global_stream_key, "{stream_key}");
+	}
 
 	switch (level) {
 	case AV_LOG_INFO:


### PR DESCRIPTION
### Description
When not configuring global_stream_key and starting a recording, obs-ffmpeg-mux.exe will hang. Applied same check as seen in init_params() to prevent this.

I think VS applied the formatting properly.

### Motivation and Context
This issue will be a problem for anyone who initially compiles and debugs OBS.

### How Has This Been Tested?
Started recording in OBS. Should always happen if global_stream_key is empty.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.

