### PR TITLE
flatpak: Don't specify luajit commit

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -146,7 +146,6 @@
           "type": "git",
           "url": "https://luajit.org/git/luajit-2.0.git",
           "branch": "v2.1",
-          "commit": "787736990ac3b7d5ceaba2697c7d0f58f77bb782",
           "disable-shallow-clone": true
         },
         {


### PR DESCRIPTION
### Description

luajit developers ask people to use branches instead of tarballs, however, Flatpak interprets having both 'commit' and 'branch' fields as 'use this branch, and this commit should be at the top of the branch', which is not really what we want.

Remove the specified commit from the Flatpak manifest.

### Motivation and Context

The Flatpak workflow is broken because this particular commit simply doesn't exist anymore.

### How Has This Been Tested?

 * Let the Flatpak workflow run

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
