### PR TITLE
libobs: fix property group check

### DIFF
--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -752,7 +752,7 @@ static bool check_property_group_recursion(obs_properties_t *parent,
 				 * lets verify anyway. */
 				return true;
 			}
-			if (check_property_group_recursion(cprops, group))
+			if (check_property_group_recursion(parent, cprops))
 				return true;
 		}
 


### PR DESCRIPTION
### Description
Fix property group check

### Motivation and Context
Fix bug introduced by #4360

### How Has This Been Tested?
With the move transition plugin adding a move source filter the "General" group.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
