### PR TITLE
libobs/util: OS-independent custom placeholder.png

### DIFF
--- a/docs/sphinx/reference-libobs-util-platform.rst
+++ b/docs/sphinx/reference-libobs-util-platform.rst
@@ -209,6 +209,12 @@ Sleep/Time Functions
 Other Path/File Functions
 -------------------------
 
+.. function:: char *os_get_placeholder_ptr()
+
+   Gets the user-specific path for a custom placeoholder.png file..
+
+---------------------
+
 .. function:: int os_get_config_path(char *dst, size_t size, const char *name)
               char *os_get_config_path_ptr(const char *name)
 

--- a/libobs/util/platform-cocoa.m
+++ b/libobs/util/platform-cocoa.m
@@ -89,6 +89,18 @@ static char *os_get_path_ptr_internal(const char *name,
 	return path.array;
 }
 
+char *os_get_placeholder_ptr()
+{
+	char *phpath = os_get_path_ptr_internal(
+		"obs-studio/plugin_config/mac-virtualcam", NSUserDomainMask);
+	if (!os_file_exists(phpath))
+		os_mkdirs(phpath);
+	bfree(phpath);
+	return os_get_path_ptr_internal(
+		"obs-studio/plugin_config/mac-virtualcam/placeholder.png",
+		NSUserDomainMask);
+}
+
 int os_get_config_path(char *dst, size_t size, const char *name)
 {
 	return os_get_path_internal(dst, size, name, NSUserDomainMask);

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -507,6 +507,18 @@ char *os_get_abs_path_ptr(const char *path)
 	return ptr;
 }
 
+char *os_get_placeholder_ptr()
+{
+	char *phpath = os_get_path_ptr_internal(
+		"obs-studio\\plugin_config\\win-dshow", CSIDL_APPDATA);
+	if (!os_file_exists(phpath))
+		os_mkdirs(phpath);
+	bfree(phpath);
+	return os_get_path_ptr_internal(
+		"obs-studio\\plugin_config\\win-dshow\\placeholder.png",
+		CSIDL_APPDATA);
+}
+
 struct os_dir {
 	HANDLE handle;
 	WIN32_FIND_DATA wfd;

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -122,6 +122,8 @@ EXPORT char *os_get_abs_path_ptr(const char *path);
 
 EXPORT const char *os_get_path_extension(const char *path);
 
+EXPORT char *os_get_placeholder_ptr();
+
 struct os_dir;
 typedef struct os_dir os_dir_t;
 


### PR DESCRIPTION
### Description

Defines OS-independent function os_get_placeholder_ptr() which returns a (char *) pointer containing the path of the custom placeholder.png file on MacOS and Windows.

This is a companion PR to PR #4232 and PR #4389, though this code change does not depend on either of those PRs. 

The modification is to platform.h, platform-cocoa.m, and platform-windows.c in libobs/util. This change creates the function:

char *os_get_placeholder.ptr()

This function returns a pointer to a string containing the path to the custom placeholder.png file. The specific string returned depends on whether it is running on Windows or MacOS. The string returned matches that used in PR #4232 or PR #4389, depending on the OS. The function will also create the directory structure it if does not already exist.

### Motivation and Context

The virtual camera a is a very useful addition to OBS, but it is frustrating to have to replace the default placeholder.png file every time OBS Studio is upgraded. It would be quite useful to be able to create a custom placeholder.png file ONCE and not have to track down the default file over and over and over. Adding a UI setting for the custom placeholder.png file requires a platform-indendent function to retrieve the path to the file.

### How Has This Been Tested?

I've tested on a 2015 MacBookPro running Windows 10 using BOOTCAMP, and BigSur on the same hardware. I've tested with Skype and Zoom:

Installed this update over OBS 26.1.1 (Windows) and OBS 26.1.2 (MacOS)
Used virtual cam, no problems
Stopped virtual cam, verified default image shows in Skype or Zoom
Created custom placeholder.png in the OS-appropriate directory
Verified custom image shows in Skype or Zoom
Start virtual cam, verified OBS output appears in Skype or Zoom
Stop virtual cam, verified custom image shows in Skype fo Zoom
Remove custom placeholder.png
Verified default image shows in Skype or Zoom

Testing this new function required UI modifications which will be submitted in a future PR. UI modifications included logging for verification and debugging.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
