### PR TITLE
UI: Fix canvas resolution in auto-config

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -157,13 +157,20 @@ AutoConfigVideoPage::AutoConfigVideoPage(QWidget *parent)
 	for (int i = 0; i < screens.size(); i++) {
 		QScreen *screen = screens[i];
 		QSize as = screen->size();
+		int as_width = as.width();
+		int as_height = as.height();
 
-		encRes = int(as.width() << 16) | int(as.height());
+		// Calculate physical screen resolution based on the virtual screen resolution
+		// They might differ if scaling is enabled, e.g. for HiDPI screens
+		as_width = round(as_width * screen->devicePixelRatio());
+		as_height = round(as_height * screen->devicePixelRatio());
+
+		encRes = as_width << 16 | as_height;
 
 		QString str = QTStr(RES_USE_DISPLAY)
 				      .arg(QString::number(i + 1),
-					   QString::number(as.width()),
-					   QString::number(as.height()));
+					   QString::number(as_width),
+					   QString::number(as_height));
 
 		ui->canvasRes->addItem(str, encRes);
 	}


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
With the same approach as in #4225, fix the canvas resolution calculation in the auto-config utility. This fixes #4298.

### Motivation and Context
The current release version of OBS has several issues when determining the canvas resolution. This initially occurred due to the Qt update to 5.15.2. While this was fixed for a new profile in a previous commit, I fixed it in the settings screen in #4225. However, now I noticed that thanks to #4298 that I did not adjust this in the auto-config utility. 

This PR adds this.

_Note: In the filed issue, @energizerfellow mentioned that OBS calculates a weird output resolution for screens >4096 pixels in either dimension. Maybe that's worth looking into? I haven't checked this issue and this PR won't change anything to it, but given that this fix will usually cause an increase in the determined canvas resolution, I think it might be worth looking into at some point._

### How Has This Been Tested?
Hardware: Microsoft Surface Book 2
Operating System: Windows 10 Pro ver. 2004 (10.0.19042.746)
Screens:
3000x2000 internal screen @ 200% DPI Scaling

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
