### PR TITLE
UI: Remove fractional scaling ifdefs

### DIFF
--- a/UI/display-helpers.hpp
+++ b/UI/display-helpers.hpp
@@ -17,10 +17,6 @@
 
 #pragma once
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-#define SUPPORTS_FRACTIONAL_SCALING
-#endif
-
 static inline void GetScaleAndCenterPos(int baseCX, int baseCY, int windowCX,
 					int windowCY, int &x, int &y,
 					float &scale)
@@ -55,9 +51,5 @@ static inline void GetCenterPosFromFixedScale(int baseCX, int baseCY,
 
 static inline QSize GetPixelSize(QWidget *widget)
 {
-#ifdef SUPPORTS_FRACTIONAL_SCALING
 	return widget->size() * widget->devicePixelRatioF();
-#else
-	return widget->size() * widget->devicePixelRatio();
-#endif
 }

--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -221,11 +221,7 @@ static int TranslateQtMouseEventModifiers(QMouseEvent *event)
 bool OBSBasicInteraction::GetSourceRelativeXY(int mouseX, int mouseY, int &relX,
 					      int &relY)
 {
-#ifdef SUPPORTS_FRACTIONAL_SCALING
 	float pixelRatio = devicePixelRatioF();
-#else
-	float pixelRatio = devicePixelRatio();
-#endif
 	int mouseXscaled = (int)roundf(mouseX * pixelRatio);
 	int mouseYscaled = (int)roundf(mouseY * pixelRatio);
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1279,13 +1279,8 @@ bool OBSBasic::InitBasicConfigDefaults()
 	uint32_t cx = primaryScreen->size().width();
 	uint32_t cy = primaryScreen->size().height();
 
-#ifdef SUPPORTS_FRACTIONAL_SCALING
 	cx *= devicePixelRatioF();
 	cy *= devicePixelRatioF();
-#elif
-	cx *= devicePixelRatio();
-	cy *= devicePixelRatio();
-#endif
 
 	bool oldResolutionDefaults = config_get_bool(
 		App()->GlobalConfig(), "General", "Pre19Defaults");

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -13,9 +13,6 @@
 
 #define HANDLE_RADIUS 4.0f
 #define HANDLE_SEL_RADIUS (HANDLE_RADIUS * 1.5f)
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-#define SUPPORTS_FRACTIONAL_SCALING
-#endif
 
 /* TODO: make C++ math classes and clean up code here later */
 
@@ -44,11 +41,7 @@ OBSBasicPreview::~OBSBasicPreview()
 vec2 OBSBasicPreview::GetMouseEventPos(QMouseEvent *event)
 {
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
-#ifdef SUPPORTS_FRACTIONAL_SCALING
 	float pixelRatio = main->devicePixelRatioF();
-#else
-	float pixelRatio = main->devicePixelRatio();
-#endif
 	float scale = pixelRatio / main->previewScale;
 	vec2 pos;
 	vec2_set(&pos,
@@ -406,11 +399,7 @@ void OBSBasicPreview::GetStretchHandleData(const vec2 &pos, bool ignoreGroup)
 	if (!scene)
 		return;
 
-#ifdef SUPPORTS_FRACTIONAL_SCALING
 	float scale = main->previewScale / main->devicePixelRatioF();
-#else
-	float scale = main->previewScale / main->devicePixelRatio();
-#endif
 	vec2 scaled_pos = pos;
 	vec2_divf(&scaled_pos, &scaled_pos, scale);
 	HandleFindData data(scaled_pos, scale);
@@ -533,11 +522,7 @@ void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 	}
 
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
-#ifdef SUPPORTS_FRACTIONAL_SCALING
 	float pixelRatio = main->devicePixelRatioF();
-#else
-	float pixelRatio = main->devicePixelRatio();
-#endif
 	float x = float(event->x()) - main->previewX / pixelRatio;
 	float y = float(event->y()) - main->previewY / pixelRatio;
 	Qt::KeyboardModifiers modifiers = QGuiApplication::keyboardModifiers();
@@ -1553,11 +1538,7 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 			mousePos = pos;
 			OBSBasic *main = reinterpret_cast<OBSBasic *>(
 				App()->GetMainWindow());
-#ifdef SUPPORTS_FRACTIONAL_SCALING
 			float scale = main->devicePixelRatioF();
-#else
-			float scale = main->devicePixelRatio();
-#endif
 			float x = float(event->x()) - main->previewX / scale;
 			float y = float(event->y()) - main->previewY / scale;
 			vec2_set(&startPos, x, y);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Remove ifdefs for fractional scaling support (Qt 5.6+).

This is a companion PR to obsproject/obs-browser#273.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Among the systems we officially support, the oldest Qt version is Qt 5.9 on Ubuntu 18.04. Fractional scaling is supported in Qt 5.6 and newer. We should be able to safely remove these ifdefs and simplify the code.

@WizardCM Wanted me to check what Qt versions FreeBSD and Arch currently offer, and they both offer Qt 5.15.2. Xenial (Ubuntu 16.04) still has Qt 5.5, but we no longer officially support that platform, and its End of Standard Support is April 2021, so I don't think we need to worry about it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled and ran OBS and obs-browser on Windows 10 64-bit with these changes. I verified that browser interaction and the preview pane behave the same in OBS Studio 26.1.1 and after this patch.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
