### PR TITLE
UI: Remove ifdefs for Qt 5.9 and older

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4514,7 +4514,7 @@ void OBSBasic::AddProjectorMenuMonitors(QMenu *parent, QObject *target,
 		fullname << ")";
 #elif defined(__APPLE__)
 		name = screen->name();
-#elif QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
+#else
 		name = screen->model().simplified();
 
 		if (name.length() > 1 && name.endsWith("-"))
@@ -7399,7 +7399,6 @@ void OBSBasic::on_resetUI_triggered()
 
 	restoreState(startingDockLayout);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
 	int cx = width();
 	int cy = height();
 
@@ -7426,7 +7425,6 @@ void OBSBasic::on_resetUI_triggered()
 
 	resizeDocks(docks, {cy, cy, cy, cy, cy}, Qt::Vertical);
 	resizeDocks(docks, sizes, Qt::Horizontal);
-#endif
 
 	activateWindow();
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Remove ifdefs checking for Qt Version >= 5.6 or 5.9.  This does not include removals in #4394 or obsproject/obs-browser#273.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Among the systems we officially support, the oldest Qt version is Qt 5.9 on Ubuntu 18.04, so Qt 5.9 is the oldest Qt we officially support, even though Qt 5.9 is EOL. We should be able to safely remove these ifdefs.  Less ifdefs, cleaner code.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled and ran OBS and obs-browser on Windows 10 64-bit with these changes. I verified that display names in projector menus and "Reset UI" behave the same in OBS Studio 26.1.1 and after this patch.

Additional testing on other operating systems appreciated.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
