### PR TITLE
x264 minor alignment with FFmpeg

### DIFF
--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -460,6 +460,8 @@ static void update_params(struct obs_x264 *obsx264, obs_data_t *settings,
 	obsx264->params.i_height = height;
 	obsx264->params.i_fps_num = voi->fps_num;
 	obsx264->params.i_fps_den = voi->fps_den;
+	obsx264->params.i_timebase_num = voi->fps_den;
+	obsx264->params.i_timebase_den = voi->fps_num;
 	obsx264->params.pf_log = log_x264;
 	obsx264->params.p_log_private = obsx264;
 	obsx264->params.i_log_level = X264_LOG_WARNING;

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -518,9 +518,8 @@ static void update_params(struct obs_x264 *obsx264, obs_data_t *settings,
 		}
 	} else {
 		obsx264->params.rc.i_rc_method = X264_RC_CRF;
+		obsx264->params.rc.f_rf_constant = (float)crf;
 	}
-
-	obsx264->params.rc.f_rf_constant = (float)crf;
 
 	if (info.format == VIDEO_FORMAT_NV12)
 		obsx264->params.i_csp = X264_CSP_NV12;

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -494,6 +494,8 @@ static void update_params(struct obs_x264 *obsx264, obs_data_t *settings,
 		break;
 	}
 
+	obsx264->params.vui.i_sar_height = 1;
+	obsx264->params.vui.i_sar_width = 1;
 	obsx264->params.vui.b_fullrange = info.range == VIDEO_RANGE_FULL;
 	obsx264->params.vui.i_colorprim =
 		get_x264_cs_val(colorprim, x264_colorprim_names);


### PR DESCRIPTION
### Description
Adjusted some x264 settings to make it behave more like FFmpeg. Didn't touch b_filler and b_vfr_input because those seem scary, and didn't want to cause regressions.

### Motivation and Context
More confidence that FFmpeg tests match OBS behavior.

### How Has This Been Tested?
VLC playback was fine. Inspected video recording frame-by-frame in Avidemux.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.