### PR TITLE
UI: Add new QPalette overrides for Qt 5.12+

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -890,48 +890,51 @@ void OBSApp::AddExtraThemeColor(QPalette &pal, int group, const char *name,
 		};                                            \
 	} while (false)
 
-	if (astrcmpi(name, "alternateBase") == 0) {
-		DEF_PALETTE_ASSIGN(AlternateBase);
-	} else if (astrcmpi(name, "base") == 0) {
-		DEF_PALETTE_ASSIGN(Base);
-	} else if (astrcmpi(name, "brightText") == 0) {
-		DEF_PALETTE_ASSIGN(BrightText);
+	if ((astrcmpi(name, "windowText") == 0) ||
+	    (astrcmpi(name, "windowForeground") == 0)) {
+		DEF_PALETTE_ASSIGN(WindowText);
 	} else if (astrcmpi(name, "button") == 0) {
 		DEF_PALETTE_ASSIGN(Button);
-	} else if (astrcmpi(name, "buttonText") == 0) {
-		DEF_PALETTE_ASSIGN(ButtonText);
-	} else if (astrcmpi(name, "brightText") == 0) {
-		DEF_PALETTE_ASSIGN(BrightText);
+	} else if (astrcmpi(name, "light") == 0) {
+		DEF_PALETTE_ASSIGN(Light);
+	} else if (astrcmpi(name, "midlight") == 0) {
+		DEF_PALETTE_ASSIGN(Midlight);
 	} else if (astrcmpi(name, "dark") == 0) {
 		DEF_PALETTE_ASSIGN(Dark);
+	} else if (astrcmpi(name, "mid") == 0) {
+		DEF_PALETTE_ASSIGN(Mid);
+	} else if ((astrcmpi(name, "text") == 0) ||
+		   (astrcmpi(name, "foreground") == 0)) {
+		DEF_PALETTE_ASSIGN(Text);
+	} else if (astrcmpi(name, "brightText") == 0) {
+		DEF_PALETTE_ASSIGN(BrightText);
+	} else if (astrcmpi(name, "buttonText") == 0) {
+		DEF_PALETTE_ASSIGN(ButtonText);
+	} else if (astrcmpi(name, "base") == 0) {
+		DEF_PALETTE_ASSIGN(Base);
+	} else if ((astrcmpi(name, "window") == 0) ||
+		   (astrcmpi(name, "background") == 0)) {
+		DEF_PALETTE_ASSIGN(Window);
+	} else if (astrcmpi(name, "shadow") == 0) {
+		DEF_PALETTE_ASSIGN(Shadow);
 	} else if (astrcmpi(name, "highlight") == 0) {
 		DEF_PALETTE_ASSIGN(Highlight);
 	} else if (astrcmpi(name, "highlightedText") == 0) {
 		DEF_PALETTE_ASSIGN(HighlightedText);
-	} else if (astrcmpi(name, "light") == 0) {
-		DEF_PALETTE_ASSIGN(Light);
 	} else if (astrcmpi(name, "link") == 0) {
 		DEF_PALETTE_ASSIGN(Link);
 	} else if (astrcmpi(name, "linkVisited") == 0) {
 		DEF_PALETTE_ASSIGN(LinkVisited);
-	} else if (astrcmpi(name, "mid") == 0) {
-		DEF_PALETTE_ASSIGN(Mid);
-	} else if (astrcmpi(name, "midlight") == 0) {
-		DEF_PALETTE_ASSIGN(Midlight);
-	} else if (astrcmpi(name, "shadow") == 0) {
-		DEF_PALETTE_ASSIGN(Shadow);
-	} else if (astrcmpi(name, "text") == 0 ||
-		   astrcmpi(name, "foreground") == 0) {
-		DEF_PALETTE_ASSIGN(Text);
+	} else if (astrcmpi(name, "alternateBase") == 0) {
+		DEF_PALETTE_ASSIGN(AlternateBase);
 	} else if (astrcmpi(name, "toolTipBase") == 0) {
 		DEF_PALETTE_ASSIGN(ToolTipBase);
 	} else if (astrcmpi(name, "toolTipText") == 0) {
 		DEF_PALETTE_ASSIGN(ToolTipText);
-	} else if (astrcmpi(name, "windowText") == 0) {
-		DEF_PALETTE_ASSIGN(WindowText);
-	} else if (astrcmpi(name, "window") == 0 ||
-		   astrcmpi(name, "background") == 0) {
-		DEF_PALETTE_ASSIGN(Window);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
+	} else if (astrcmpi(name, "placeholderText") == 0) {
+		DEF_PALETTE_ASSIGN(PlaceholderText);
+#endif
 	} else {
 		return;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Adds the new QPalette definitions to OBSTheme parsing available from Qt 5.12 and later. Additionally re-orders the tests to the in the same order as the definition of QPalette::ColorRole.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
- The QPalette entry for PlaceholderText was not being modified correctly.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested? Themes:
- System: Still works as expected.
- Rachni: Still works as expected.
- Acri: Still works as expected.
- Dark: Still works as expected.
- Ocean Blue: Still works as expected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
    This seems to be completely undocumented.
