### PR TITLE
Document gs_texture_create_from_dmabuf

### DIFF
--- a/docs/sphinx/reference-libobs-graphics-graphics.rst
+++ b/docs/sphinx/reference-libobs-graphics-graphics.rst
@@ -966,6 +966,34 @@ Texture Functions
 
 ---------------------
 
+.. function:: gs_texture_t *gs_texture_create_from_dmabuf(unsigned int width, unsigned int height, uint32_t drm_format, enum gs_color_format color_format, uint32_t n_planes, const int *fds, const uint32_t *strides, const uint32_t *offsets, const uint64_t *modifiers)
+
+   **Linux only:** Creates a texture from DMA-BUF metadata.
+
+   Exchanging DMA-BUFs is a verbose process because of its multiplanar nature.
+   For example, YUV can have each plane as a color channel, or a monitor buffer
+   can have the cursor stored in a separate plane.
+
+   This function treats the OBS Studio format and the DRM format separately.
+   This allows creating textures from DMA-BUFs with unsupported formats (e.g.
+   YUV) and perform the color format conversion using shaders. However, be
+   careful to always try and match the formats correctly, otherwise textures
+   can fail to be created or rendered.
+
+   :param width:        Width of the texture
+   :param height:       Height of the texture
+   :param drm_format:   DRM format of the DMA-BUF buffer
+   :param color_format: Color format compatible with OBS Studio
+   :param n_planes:     Number of planes of the DMA-BUF
+   :param fds:          Array of size *n_planes* with the file descriptor of each plane
+   :param strides:      Array of size *n_planes* with the stride of each plane
+   :param offsets:      Array of size *n_planes* with the offset of each plane
+   :param modifiers:    Array of size *n_planes* with the modifier of each plane
+   :return:             A texture object on success, or *NULL* on failure
+   :rtype:              gs_texture_t*
+
+---------------------
+
 .. function:: gs_texture_t *gs_texture_create_from_iosurface(void *iosurf)
 
    **Mac only:** Creates a texture from an IOSurface.


### PR DESCRIPTION
### Description

Add some documentation about this new Linux-only function, and its characteristics.

### Motivation and Context

It's good to have this new function documented, since it can be tricky to understand it simply by staring it.

### How Has This Been Tested?

(Nothing needs to be tested)

### Types of changes

 - Documentation (a change to documentation pages)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
