### PR TITLE
Add exit codes for silent installer

### DIFF
--- a/UI/installer/mp-installer.nsi
+++ b/UI/installer/mp-installer.nsi
@@ -93,12 +93,18 @@ Function PreReqCheck
 !ifdef INSTALL64
 	${if} ${RunningX64}
 	${Else}
+		IfSilent +1 +3
+			SetErrorLevel 3
+			Quit
 		MessageBox MB_OK|MB_ICONSTOP "This version of OBS Studio is not compatible with your system.  Please use the 32bit (x86) installer."
 	${EndIf}
 	; Abort on XP or lower
 !endif
 
 	${If} ${AtMostWinVista}
+		IfSilent +1 +3
+			SetErrorLevel 3
+			Quit
 		MessageBox MB_OK|MB_ICONSTOP "Due to extensive use of DirectX 10 features, ${APPNAME} requires Windows 7 or higher and cannot be installed on this version of Windows."
 		Quit
 	${EndIf}
@@ -112,6 +118,9 @@ Function PreReqCheck
 	Delete "$PLUGINSDIR\check_for_64bit_visual_studio_2019_runtimes.exe"
 	IntCmp $R0 126 vs2019Missing_64 vs2019OK_64
 	vs2019Missing_64:
+		IfSilent +1 +3
+			SetErrorLevel 4
+			Quit
 		MessageBox MB_YESNO|MB_ICONEXCLAMATION "Your system is missing runtime components that ${APPNAME} requires. Would you like to download them?" IDYES vs2019true_64 IDNO vs2019false_64
 		vs2019true_64:
 			ExecShell "open" "https://obsproject.com/visual-studio-2019-runtimes-64-bit"
@@ -127,6 +136,9 @@ Function PreReqCheck
 	GetDLLVersion "msvcp140_1.DLL" $R0 $R1
 	IfErrors vs2019Missing_32 vs2019OK_32
 	vs2019Missing_32:
+		IfSilent +1 +3
+			SetErrorLevel 4
+			Quit
 		MessageBox MB_YESNO|MB_ICONEXCLAMATION "Your system is missing runtime components that ${APPNAME} requires. Would you like to download them?" IDYES vs2019true_32 IDNO vs2019false_32
 		vs2019true_32:
 			ExecShell "open" "https://obsproject.com/visual-studio-2019-runtimes-32-bit"
@@ -189,6 +201,9 @@ Function PreReqCheck
 	GetDLLVersion "D3DCompiler_49.dll" $R0 $R1
 	IfErrors dxMissing49 dxOK
 	dxMissing49:
+	IfSilent +1 +3
+		SetErrorLevel 4
+		Quit
 	MessageBox MB_YESNO|MB_ICONEXCLAMATION "Your system is missing DirectX components that ${APPNAME} requires. Would you like to download them?" IDYES dxtrue IDNO dxfalse
 	dxtrue:
 		ExecShell "open" "https://obsproject.com/go/dxwebsetup"
@@ -201,6 +216,9 @@ Function PreReqCheck
 	check32BitRunning:
 	OBSInstallerUtils::IsProcessRunning "obs32.exe"
 	IntCmp $R0 1 0 notRunning1
+		IfSilent +1 +3
+			SetErrorLevel 5
+			Quit
 		MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "${APPNAME} is already running. Please close it first before installing a new version." /SD IDCANCEL IDRETRY check32BitRunning
 		Quit
 	notRunning1:
@@ -209,6 +227,9 @@ Function PreReqCheck
 		check64BitRunning:
 		OBSInstallerUtils::IsProcessRunning "obs64.exe"
 		IntCmp $R0 1 0 notRunning2
+			IfSilent +1 +3
+				SetErrorLevel 5
+				Quit
 			MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "${APPNAME} is already running. Please close it first before installing a new version." /SD IDCANCEL IDRETRY check64BitRunning
 			Quit
 		notRunning2:
@@ -240,6 +261,9 @@ Function checkFilesInUse
 	retryFileChecks:
 	Call checkDLLs
 	StrCmp $dllFilesInUse "" dllsNotInUse
+	IfSilent +1 +3
+		SetErrorLevel 6
+		Quit
 	MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "OBS files are being used by the following applications:$\r$\n$\r$\n$dllFilesInUse$\r$\nPlease close these applications to continue setup." /SD IDCANCEL IDRETRY retryFileChecks
 	Quit
 


### PR DESCRIPTION
### Description
Adds exit codes to the installer when running in silent mode. The following codes are defined:

Code 3 = Unsupported OS (64bit on 32bit or below Windows 7)
Code 4 = Missing a dependency (VS 2019 or DirectX redistributables)
Code 5 = OBS is already running
Code 6 = OBS files are in use by another app (eg virtual camera)

### Motivation and Context
Third party packaging systems might invoke the OBS installer in silent mode. This gives them useful exit status information so that they can report an appropriate error to the user instead of a generic "Installation failed".

### How Has This Been Tested?
Ran the installer with OBS open, verified proper exit status was set. Ran the installer without OBS open, verified it installed silently.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
