### PR TITLE
Fix crashing when using a custom vcam placeholder

### DIFF
--- a/plugins/win-dshow/virtualcam-module/virtualcam-filter.hpp
+++ b/plugins/win-dshow/virtualcam-module/virtualcam-filter.hpp
@@ -12,6 +12,13 @@
 #define DEFAULT_CY 1080
 #define DEFAULT_INTERVAL 333333ULL
 
+typedef struct {
+	int cx;
+	int cy;
+	nv12_scale_t scaler;
+	const uint8_t *data;
+} placeholder_t;
+
 class VCamFilter : public DShow::OutputFilter {
 	std::thread th;
 
@@ -19,7 +26,7 @@ class VCamFilter : public DShow::OutputFilter {
 	int queue_mode = 0;
 	bool in_obs = false;
 	enum queue_state prev_state = SHARED_QUEUE_STATE_INVALID;
-	const uint8_t *placeholder;
+	placeholder_t placeholder;
 	uint32_t cx = DEFAULT_CX;
 	uint32_t cy = DEFAULT_CY;
 	uint64_t interval = DEFAULT_INTERVAL;


### PR DESCRIPTION
### Description
The virtual camera assumed a statically-sized image and would crash if the user modified it. This PR allows a different sized image which will be scaled to fit the resolution of the camera.

### Motivation and Context
Hopefully fixes one of the crash reports we've seen with the virtual camera in #4243.

### How Has This Been Tested?
Tested in multiple apps at multiple resolutions, verified no crashing or corruption appeared. @RytoEX performed additional extensive testing on Discord (thanks!)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
