### PR TITLE
UI: Ignore scene source which has been removed

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -608,6 +608,11 @@ static bool enumItem(obs_scene_t *, obs_sceneitem_t *item, void *ptr)
 	QVector<OBSSceneItem> &items =
 		*reinterpret_cast<QVector<OBSSceneItem> *>(ptr);
 
+	obs_source_t *src = obs_sceneitem_get_source(item);
+	if (obs_source_removed(src)) {
+		return true;
+	}
+
 	if (obs_sceneitem_is_group(item)) {
 		obs_data_t *data = obs_sceneitem_get_private_settings(item);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR is for #2602. While getting source list, we should ignore scene source which has been removed. If we don't ignore it,  a deleted scene source will be added later. Besides, signals of that scene have been sent before, such as "remove" of scene.  So we can't remove this scene source by "auto removeItem" defined in SourceTreeItem::ReconnectSignals().

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
ignore deleted scene source

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
steps as #2602, the ways to delete scene include hotkey and menu.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
