### PR TITLE
win-dshow: Check for custom placeholder.png file

### DIFF
--- a/plugins/win-dshow/virtualcam-module/placeholder.cpp
+++ b/plugins/win-dshow/virtualcam-module/placeholder.cpp
@@ -81,7 +81,7 @@ static void convert_placeholder(const uint8_t *rgb_in, int width, int height)
 	}
 }
 
-static bool load_placeholder_internal()
+static bool load_placeholder_internal(wchar_t *png)
 {
 	Status s;
 
@@ -97,7 +97,7 @@ static bool load_placeholder_internal()
 
 	slash[1] = 0;
 
-	StringCbCat(file, sizeof(file), L"placeholder.png");
+	StringCbCat(file, sizeof(file), png);
 
 	Bitmap bmp(file);
 	if (bmp.GetLastStatus() != Status::Ok) {
@@ -127,7 +127,9 @@ bool initialize_placeholder()
 	ULONG_PTR token;
 	GdiplusStartup(&token, &si, nullptr);
 
-	initialized = load_placeholder_internal();
+	initialized = load_placeholder_internal(L"custom_placeholder.png");
+	if (!initialized)
+		initialized = load_placeholder_internal(L"placeholder.png");
 
 	GdiplusShutdown(token);
 	return initialized;


### PR DESCRIPTION
### Description

win-dshow: Check for custom placeholder.png file. This will enabled the user have a custom placeholder.png file that will not get replaced every time OBS is updated.

This is the Windows version of [PR #4232](https://github.com/obsproject/obs-studio/pull/4232)

The only modification is to placeholder.cpp in the source for the virtual cam-module for the win-dshow plugin. This change looks for custom_placeholder.png in the same directory where the default placeholder.png file is installed (so it will work wiht standard and portable OBS installs). ... If this custom file is found, the virtualcam-module will use it instead of the default placeholder.png file.

### Motivation and Context

The virtual camera is a very useful addition to OBS, but it is frustrating to have to replace the default placeholder.png file every time OBS Studio is upgraded. It would be quite useful to be able to create a custom placeholder.png file ONCE and not have to track down the default file over and over and over.

### How Has This Been Tested?

I've tested on a 2015 MacBookPro running Windows 10 using BOOTCAMP. I've tested with Skype and Zoom:

Installed this update over OBS 26.1.1
Used virtual cam, no problems
Stopped virtual cam, verified default image shows in Skype or Zoom
Created custom placeholder.png in C:\Program Files\obs-studio\data\obs-plugins\win-dshow\custom_placeholder.png
Verified custom image shows in Skype or Zoom
Start virtual cam, verified OBS output appears in Skype or Zoom
Stop virtual cam, verified custom image shows in Skype fo Zoom
Remove custom placeholder.png
Verified default image shows in Skype or Zoom

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
