### PR TITLE
Build cache for the Flatpak workflow

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -35,8 +35,9 @@ jobs:
         submodules: 'recursive'
 
     - name: Build Flatpak Manifest
-      uses: bilelmoussaoui/flatpak-github-actions@v2
+      uses: bilelmoussaoui/flatpak-github-actions@master
       if: success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1')
       with:
         bundle: obs-studio-${{ github.sha }}.flatpak
         manifest-path: CI/flatpak/com.obsproject.Studio.json
+        cache-key: flatpak-builder-${{ github.sha }}

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -235,8 +235,8 @@
       ],
       "sources": [
         {
-          "type": "git",
-          "url": "https://github.com/obsproject/obs-studio.git"
+          "type": "dir",
+          "path": "../../"
         }
       ]
     }


### PR DESCRIPTION
### Description

Make the Flatpak workflow cache the build objects between runs, and use this cache to speed up the workflow execution time.

### Motivation and Context

Build cache reduces CI load.

### How Has This Been Tested?

One can observe the last CI run of the `master` branch of my repository for an example of the build cache being used: https://github.com/GeorgesStavracas/obs-studio/runs/2248155034

The build hit the cache of all dependencies, and most of OBS Studio's code also hit ccache, speeding up the build time quite substantially.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes

 - Performance enhancement (non-breaking change which improves efficiency... of CI)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
