### PR TITLE
Reenable browser source in Flatpak

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -221,12 +221,39 @@
       ]
     },
     {
+      "name": "cef",
+      "buildsystem": "cmake-ninja",
+      "no-make-install": true,
+      "make-args": [
+        "libcef_dll_wrapper"
+      ],
+      "build-commands": [
+        "mkdir -p /app/cef/libcef_dll_wrapper",
+        "cp -R ./include /app/cef",
+        "cp -R ./Release /app/cef",
+        "cp -R ./Resources /app/cef",
+        "cp -R ./libcef_dll_wrapper/libcef_dll_wrapper.a /app/cef/libcef_dll_wrapper"
+      ],
+      "cleanup": [
+        "./*"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://cdn-fastly.obsproject.com/downloads/cef_binary_4280_linux64.tar.bz2",
+          "sha256": "d91c78349ecbfbfdfc18d5f882dc28b939028f1a631191c603b5d0d938ada972"
+        }
+      ]
+    },
+    {
       "name": "obs",
       "buildsystem": "cmake-ninja",
       "builddir": true,
       "config-opts": [
         "-DCMAKE_BUILD_TYPE=Release",
         "-DENABLE_WAYLAND=ON",
+        "-DBUILD_BROWSER=ON",
+        "-DCEF_ROOT_DIR=/app/cef",
         "-DUNIX_STRUCTURE=ON",
         "-DUSE_XDG=ON",
         "-DDISABLE_ALSA=ON",


### PR DESCRIPTION
### Description

It seems that the browser source works inside a Flatpak sandbox and/or Wayland with CEF 4280, so let's try and reenable it.

This reverts commit e64c61710fb064ca87341f091ac55cb5861fc202.

### Motivation and Context

The browser source is pretty important! :slightly_smiling_face: 

In addition to that, this is another step towards feature parity of the Flatpak build and regular builds.

### How Has This Been Tested?

 - Install the Flatpak bundle generated by the "Flatpak (experimental)" workflow
 - Run this version OBS Studio
 - Add a browser source

### Types of changes

I'm actually not sure? It could either be

 - Bug fix (non-breaking change which fixes an issue)

or

 - New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
