### PR TITLE
Disable browser docks on Wayland

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1928,7 +1928,7 @@ void OBSBasic::OBSInit()
 	/* add custom browser docks      */
 
 #ifdef BROWSER_AVAILABLE
-	if (cef) {
+	if (cef && !isWayland) {
 		QAction *action = new QAction(QTStr("Basic.MainMenu."
 						    "View.Docks."
 						    "CustomBrowserDocks"),

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -9,6 +9,11 @@
 #include "url-push-button.hpp"
 
 #ifdef BROWSER_AVAILABLE
+
+#ifdef ENABLE_WAYLAND
+#include <obs-nix-platform.h>
+#endif
+
 #include <browser-panel.hpp>
 #include "auth-oauth.hpp"
 #endif
@@ -375,7 +380,14 @@ void OBSBasicSettings::on_service_currentIndexChanged(int)
 	ui->twitchAddonLabel->setVisible(false);
 
 #ifdef BROWSER_AVAILABLE
-	if (cef) {
+
+#ifdef ENABLE_WAYLAND
+	bool isWayland = obs_get_nix_platform() == OBS_NIX_PLATFORM_WAYLAND;
+#else
+	bool isWayland = false;
+#endif
+
+	if (cef && !isWayland) {
 		if (lastService != service.c_str()) {
 			QString key = ui->key->text();
 			bool can_auth = is_auth_service(service);


### PR DESCRIPTION
### Description

Disable browser docks on Wayland.

### Motivation and Context

When running on Wayland, the browser docks look broken and sometimes they crash OBS Studio. Interestingly, browser sources seem to work just fine. Ideally we'd be able to dig into the issue and find the root cause, but time is short for the 27 release and disabling the docks until this is figured out seems to be the best alternative for now.

Of course this is a temporary workaround, and eventually this commit will be reverted, and browser docks will work just fine, flowers and rainbows and happy unicorns.

Related: https://github.com/obsproject/obs-browser/issues/279

### How Has This Been Tested?

 - Compile OBS Studio with browser and Wayland support
 - Run OBS Studio on Wayland with browser enabled
 - The browser source must still be accessible; browser docks, however, must not

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
