### PR TITLE
linux-capture: Ignore PipeWire if deps not found

### DIFF
--- a/plugins/linux-capture/CMakeLists.txt
+++ b/plugins/linux-capture/CMakeLists.txt
@@ -45,10 +45,18 @@ set(linux-capture_LIBRARIES
 )
 
 option(ENABLE_PIPEWIRE "Enable PipeWire support" ON)
-if(ENABLE_PIPEWIRE)
-	find_package(PipeWire REQUIRED)
-	find_package(Gio REQUIRED)
 
+if(ENABLE_PIPEWIRE)
+	find_package(PipeWire QUIET)
+	find_package(Gio QUIET)
+
+	if(NOT PIPEWIRE_FOUND OR NOT GIO_FOUND)
+		message(STATUS "PipeWire library not found, PipeWire capture plugin disabled")
+		set(ENABLE_PIPEWIRE OFF CACHE BOOL "Enable PipeWire support" FORCE)
+	endif()
+endif()
+
+if(ENABLE_PIPEWIRE)
 	add_definitions(-DENABLE_PIPEWIRE)
 
 	set(linux-capture_INCLUDES


### PR DESCRIPTION
### Description
On Ubuntu 20.04, or older, PipeWire 0.2 is only available. Version
0.3 is needed for the plugin, so if the version is older, disable
the plugin.

### Motivation and Context
Currently when building OBS on 20.04, the -DENABLE_PIPEWIRE=OFF cmake variable has to be used.

### How Has This Been Tested?
Compiled on 20.04 to make sure everything still worked.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
