### PR TITLE
UI: Wipe undo/redo stack when switching scene collections

### DIFF
--- a/UI/undo-stack-obs.cpp
+++ b/UI/undo-stack-obs.cpp
@@ -15,6 +15,20 @@ void undo_stack::release()
 			f.d(false);
 }
 
+void undo_stack::clear()
+{
+	release();
+
+	undo_items.clear();
+	redo_items.clear();
+
+	ui->actionMainUndo->setText(QTStr("Undo.Undo"));
+	ui->actionMainRedo->setText(QTStr("Undo.Redo"));
+
+	ui->actionMainUndo->setDisabled(true);
+	ui->actionMainRedo->setDisabled(true);
+}
+
 void undo_stack::add_action(const QString &name, undo_redo_cb undo,
 			    undo_redo_cb redo, std::string undo_data,
 			    std::string redo_data, func d)

--- a/UI/undo-stack-obs.hpp
+++ b/UI/undo-stack-obs.hpp
@@ -38,6 +38,7 @@ public:
 	void disable_undo_redo();
 
 	void release();
+	void clear();
 	void add_action(const QString &name, undo_redo_cb undo,
 			undo_redo_cb redo, std::string undo_data,
 			std::string redo_data, func d);

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -532,8 +532,6 @@ void OBSBasic::ChangeSceneCollection()
 
 	const char *oldName = config_get_string(App()->GlobalConfig(), "Basic",
 						"SceneCollection");
-	std::string oldFile = std::string(config_get_string(
-		App()->GlobalConfig(), "Basic", "SceneCollectionFile"));
 
 	if (action->text().compare(QT_UTF8(oldName)) == 0) {
 		action->setChecked(true);
@@ -556,28 +554,7 @@ void OBSBasic::ChangeSceneCollection()
 
 	UpdateTitleBar();
 
-	auto undo = [this, fn = std::string(oldFile)](const std::string &) {
-		string fileName = fn;
-		char path[512];
-		int ret = GetConfigPath(path, 512, "obs-studio/basic/scenes/");
-		if (ret <= 0) {
-			blog(LOG_WARNING,
-			     "Failed to get scene collection config path");
-			return;
-		}
-		fileName.insert(0, path);
-		fileName += ".json";
-		Load(fileName.c_str());
-		RefreshSceneCollections();
-	};
-
-	auto redo = [this, fileName](const std::string &) {
-		Load(fileName.c_str());
-		RefreshSceneCollections();
-	};
-
-	undo_s.add_action(QTStr("Undo.SceneCollection.Switch").arg(newName),
-			  undo, redo, "", "", NULL);
+	undo_s.clear();
 
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Wipes the stack on scene collection change

### Motivation and Context
We discussed this in discord.

### How Has This Been Tested?
I tested it on my linux machine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
