### PR TITLE
UI: Update context bar when using undo/redo

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -753,6 +753,8 @@ void OBSBasic::SetCurrentScene(OBSSource scene, bool force)
 		}
 	}
 
+	UpdateContextBar(true);
+
 	if (scene) {
 		bool userSwitched = (!force && !disableSaving);
 		blog(LOG_INFO, "%s to scene '%s'",


### PR DESCRIPTION
### Description
The context bar wouldn't update when using undo and redo.

### Motivation and Context
Fixing bug that I noticed.

### How Has This Been Tested?
Used undo and redo and made sure the context bar was updating.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
