### PR TITLE
Fix filter regressions from SRGB changes

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -1334,9 +1334,29 @@ Functions used by filters
 
 ---------------------
 
+.. function:: void obs_source_process_filter_end_srgb(obs_source_t *filter, gs_effect_t *effect, uint32_t width, uint32_t height)
+
+   Draws the filter using the effect's "Draw" technique, and use automatic SRGB conversion.
+  
+   Before calling this function, first call obs_source_process_filter_begin and
+   then set the effect parameters, and then call this function to finalize the
+   filter.
+
+---------------------
+
 .. function:: void obs_source_process_filter_tech_end(obs_source_t *filter, gs_effect_t *effect, uint32_t width, uint32_t height, const char *tech_name)
 
    Draws the filter with a specific technique in the effect.
+  
+   Before calling this function, first call obs_source_process_filter_begin and
+   then set the effect parameters, and then call this function to finalize the
+   filter.
+
+---------------------
+
+.. function:: void obs_source_process_filter_tech_end_srgb(obs_source_t *filter, gs_effect_t *effect, uint32_t width, uint32_t height, const char *tech_name)
+
+   Draws the filter with a specific technique in the effect, and use automatic SRGB conversion.
   
    Before calling this function, first call obs_source_process_filter_begin and
    then set the effect parameters, and then call this function to finalize the

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1316,6 +1316,9 @@ obs_source_process_filter_begin(obs_source_t *filter,
 EXPORT void obs_source_process_filter_end(obs_source_t *filter,
 					  gs_effect_t *effect, uint32_t width,
 					  uint32_t height);
+EXPORT void obs_source_process_filter_end_srgb(obs_source_t *filter,
+					       gs_effect_t *effect,
+					       uint32_t width, uint32_t height);
 
 /**
  * Draws the filter with a specific technique.
@@ -1328,6 +1331,11 @@ EXPORT void obs_source_process_filter_tech_end(obs_source_t *filter,
 					       gs_effect_t *effect,
 					       uint32_t width, uint32_t height,
 					       const char *tech_name);
+EXPORT void obs_source_process_filter_tech_end_srgb(obs_source_t *filter,
+						    gs_effect_t *effect,
+						    uint32_t width,
+						    uint32_t height,
+						    const char *tech_name);
 
 /** Skips the filter if the filter is invalid and cannot be rendered */
 EXPORT void obs_source_skip_video_filter(obs_source_t *filter);

--- a/plugins/obs-filters/chroma-key-filter.c
+++ b/plugins/obs-filters/chroma-key-filter.c
@@ -191,7 +191,7 @@ chroma_settings_update_v2(struct chroma_key_filter_data_v2 *filter,
 	else if (strcmp(key_type, "magenta") == 0)
 		key_color = 0xFF00FF;
 
-	vec4_from_rgba_srgb(&key_rgb, key_color | 0xFF000000);
+	vec4_from_rgba(&key_rgb, key_color | 0xFF000000);
 
 	memcpy(&cb_v4, cb_vec, sizeof(cb_v4));
 	memcpy(&cr_v4, cr_vec, sizeof(cr_v4));

--- a/plugins/obs-filters/chroma-key-filter.c
+++ b/plugins/obs-filters/chroma-key-filter.c
@@ -388,9 +388,8 @@ static void chroma_key_render_v2(void *data, gs_effect_t *effect)
 	gs_effect_set_float(filter->smoothness_param, filter->smoothness);
 	gs_effect_set_float(filter->spill_param, filter->spill);
 
-	const bool previous = gs_set_linear_srgb(true);
-	obs_source_process_filter_end(filter->context, filter->effect, 0, 0);
-	gs_set_linear_srgb(previous);
+	obs_source_process_filter_end_srgb(filter->context, filter->effect, 0,
+					   0);
 
 	UNUSED_PARAMETER(effect);
 }

--- a/plugins/obs-filters/color-correction-filter.c
+++ b/plugins/obs-filters/color-correction-filter.c
@@ -571,9 +571,8 @@ static void color_correction_filter_render_v2(void *data, gs_effect_t *effect)
 	gs_effect_set_matrix4(filter->final_matrix_param,
 			      &filter->final_matrix);
 
-	const bool previous = gs_set_linear_srgb(true);
-	obs_source_process_filter_end(filter->context, filter->effect, 0, 0);
-	gs_set_linear_srgb(previous);
+	obs_source_process_filter_end_srgb(filter->context, filter->effect, 0,
+					   0);
 
 	UNUSED_PARAMETER(effect);
 }

--- a/plugins/obs-filters/color-grade-filter.c
+++ b/plugins/obs-filters/color-grade-filter.c
@@ -452,10 +452,8 @@ static void color_grade_filter_render(void *data, gs_effect_t *effect)
 	param = gs_effect_get_param_by_name(filter->effect, "cube_width_i");
 	gs_effect_set_float(param, 1.0f / filter->cube_width);
 
-	const bool previous = gs_set_linear_srgb(true);
-	obs_source_process_filter_tech_end(filter->context, filter->effect, 0,
-					   0, tech_name);
-	gs_set_linear_srgb(previous);
+	obs_source_process_filter_tech_end_srgb(filter->context, filter->effect,
+						0, 0, tech_name);
 
 	UNUSED_PARAMETER(effect);
 }

--- a/plugins/obs-filters/color-key-filter.c
+++ b/plugins/obs-filters/color-key-filter.c
@@ -336,9 +336,8 @@ static void color_key_render_v2(void *data, gs_effect_t *effect)
 	gs_effect_set_float(filter->similarity_param, filter->similarity);
 	gs_effect_set_float(filter->smoothness_param, filter->smoothness);
 
-	const bool previous = gs_set_linear_srgb(true);
-	obs_source_process_filter_end(filter->context, filter->effect, 0, 0);
-	gs_set_linear_srgb(previous);
+	obs_source_process_filter_end_srgb(filter->context, filter->effect, 0,
+					   0);
 
 	UNUSED_PARAMETER(effect);
 }

--- a/plugins/obs-filters/data/chroma_key_filter_v2.effect
+++ b/plugins/obs-filters/data/chroma_key_filter_v2.effect
@@ -46,9 +46,20 @@ float GetChromaDist(float3 rgb)
 	return distance(chroma_key, float2(cr, cb));
 }
 
-float4 SampleTexture(float2 uv)
+float GetNonlinearChannel(float u)
 {
-	return image.Sample(textureSampler, uv);
+	return (u <= 0.0031308) ? (12.92 * u) : ((1.055 * pow(u, 1.0 / 2.4)) - 0.055);
+}
+
+float3 GetNonlinearColor(float3 rgb)
+{
+	return float3(GetNonlinearChannel(rgb.r), GetNonlinearChannel(rgb.g), GetNonlinearChannel(rgb.b));
+}
+
+float3 SampleTexture(float2 uv)
+{
+	float3 rgb = image.Sample(textureSampler, uv).rgb;
+	return GetNonlinearColor(rgb);
 }
 
 float GetBoxFilteredChromaDist(float3 rgb, float2 texCoord)
@@ -56,12 +67,12 @@ float GetBoxFilteredChromaDist(float3 rgb, float2 texCoord)
 	float2 h_pixel_size = pixel_size / 2.0;
 	float2 point_0 = float2(pixel_size.x, h_pixel_size.y);
 	float2 point_1 = float2(h_pixel_size.x, -pixel_size.y);
-	float distVal = GetChromaDist(SampleTexture(texCoord-point_0).rgb);
-	distVal += GetChromaDist(SampleTexture(texCoord+point_0).rgb);
-	distVal += GetChromaDist(SampleTexture(texCoord-point_1).rgb);
-	distVal += GetChromaDist(SampleTexture(texCoord+point_1).rgb);
+	float distVal = GetChromaDist(SampleTexture(texCoord-point_0));
+	distVal += GetChromaDist(SampleTexture(texCoord+point_0));
+	distVal += GetChromaDist(SampleTexture(texCoord-point_1));
+	distVal += GetChromaDist(SampleTexture(texCoord+point_1));
 	distVal *= 2.0;
-	distVal += GetChromaDist(rgb);
+	distVal += GetChromaDist(GetNonlinearColor(rgb));
 	return distVal / 9.0;
 }
 

--- a/plugins/obs-filters/scale-filter.c
+++ b/plugins/obs-filters/scale-filter.c
@@ -297,11 +297,9 @@ static void scale_filter_render(void *data, gs_effect_t *effect)
 		gs_effect_set_next_sampler(filter->image_param,
 					   filter->point_sampler);
 
-	const bool previous = gs_set_linear_srgb(true);
-	obs_source_process_filter_tech_end(filter->context, filter->effect,
-					   filter->cx_out, filter->cy_out,
-					   technique);
-	gs_set_linear_srgb(previous);
+	obs_source_process_filter_tech_end_srgb(filter->context, filter->effect,
+						filter->cx_out, filter->cy_out,
+						technique);
 
 	UNUSED_PARAMETER(effect);
 }


### PR DESCRIPTION
### Description
Need to expand filter API to ensure existing filters don't render incorrectly.

Also restore chroma key matching algorithm to nonlinear space because I don't want to deal with regressions by trying to improve the algorithm.

### Motivation and Context
Fix regressions.

### How Has This Been Tested?
Legacy filter no longer renders incorrectly, and chroma key behavior is restored on user-provided sample image.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Documentation (a change to documentation pages)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.