### PR TITLE
UI: Force current scene when using undo/redo

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -62,7 +62,7 @@ void SourceToolbar::SetUndoProperties(obs_source_t *source)
 
 		obs_source_t *scene_source =
 			obs_get_source_by_name(scene_name.c_str());
-		main->SetCurrentScene(scene_source);
+		main->SetCurrentScene(scene_source, true);
 		obs_source_release(scene_source);
 
 		obs_data_release(settings);

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -413,7 +413,7 @@ void SourceTreeItem::ExitEditMode(bool save)
 
 		obs_source_t *scene_source =
 			obs_get_source_by_name(scene_name.c_str());
-		main->SetCurrentScene(scene_source);
+		main->SetCurrentScene(scene_source, true);
 		obs_source_release(scene_source);
 	};
 
@@ -424,7 +424,7 @@ void SourceTreeItem::ExitEditMode(bool save)
 
 		obs_source_t *scene_source =
 			obs_get_source_by_name(scene_name.c_str());
-		main->SetCurrentScene(scene_source);
+		main->SetCurrentScene(scene_source, true);
 		obs_source_release(scene_source);
 	};
 

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -575,7 +575,7 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 			obs_source_t *ssource =
 				obs_get_source_by_name(scene_name.c_str());
 			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->SetCurrentScene(ssource);
+				->SetCurrentScene(ssource, true);
 			obs_source_release(ssource);
 
 			obs_data_t *dat =
@@ -599,7 +599,7 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 			obs_source_t *ssource =
 				obs_get_source_by_name(scene_name.c_str());
 			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->SetCurrentScene(ssource);
+				->SetCurrentScene(ssource, true);
 			obs_source_release(ssource);
 
 			obs_data_t *dat =
@@ -829,7 +829,7 @@ void OBSBasicFilters::on_removeEffectFilter_clicked()
 					scene_name.c_str());
 				reinterpret_cast<OBSBasic *>(
 					App()->GetMainWindow())
-					->SetCurrentScene(ssource);
+					->SetCurrentScene(ssource, true);
 				obs_source_release(ssource);
 
 				obs_data_t *dat =
@@ -854,7 +854,7 @@ void OBSBasicFilters::on_removeEffectFilter_clicked()
 					scene_name.c_str());
 				reinterpret_cast<OBSBasic *>(
 					App()->GetMainWindow())
-					->SetCurrentScene(ssource);
+					->SetCurrentScene(ssource, true);
 				obs_source_release(ssource);
 
 				obs_data_t *dat =
@@ -1134,7 +1134,7 @@ void OBSBasicFilters::FilterNameEdited(QWidget *editor, QListWidget *list)
 			obs_source_t *ssource =
 				obs_get_source_by_name(scene_name.c_str());
 			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->SetCurrentScene(ssource);
+				->SetCurrentScene(ssource, true);
 			obs_source_release(ssource);
 
 			obs_source_t *source =
@@ -1151,7 +1151,7 @@ void OBSBasicFilters::FilterNameEdited(QWidget *editor, QListWidget *list)
 			obs_source_t *ssource =
 				obs_get_source_by_name(scene_name.c_str());
 			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->SetCurrentScene(ssource);
+				->SetCurrentScene(ssource, true);
 			obs_source_release(ssource);
 
 			obs_source_t *source =

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3739,7 +3739,7 @@ void OBSBasic::RemoveSelectedScene()
 
 		obs_source_t *scene_source = sources.back();
 		OBSScene scene = obs_scene_from_source(scene_source);
-		SetCurrentScene(scene);
+		SetCurrentScene(scene, true);
 
 		/* set original index in list box */
 		ui->scenes->blockSignals(true);
@@ -4927,7 +4927,7 @@ void OBSBasic::on_actionAddScene_triggered()
 		auto redo_fn = [this](const std::string &data) {
 			obs_scene_t *scene = obs_scene_create(data.c_str());
 			obs_source_t *source = obs_scene_get_source(scene);
-			SetCurrentScene(source);
+			SetCurrentScene(source, true);
 			obs_scene_release(scene);
 		};
 		undo_s.add_action(QTStr("Undo.Add").arg(QString(name.c_str())),
@@ -7155,7 +7155,7 @@ void undo_redo(const std::string &data)
 	obs_source_t *source =
 		obs_get_source_by_name(obs_data_get_string(dat, "scene_name"));
 	reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-		->SetCurrentScene(source);
+		->SetCurrentScene(source, true);
 	obs_source_release(source);
 	obs_data_release(dat);
 

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -730,7 +730,7 @@ void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 		obs_source_t *source = obs_get_source_by_name(
 			obs_data_get_string(dat, "scene_name"));
 		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(source);
+			->SetCurrentScene(source, true);
 		obs_source_release(source);
 		obs_data_release(dat);
 

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -375,7 +375,7 @@ void OBSBasicProperties::on_buttonBox_clicked(QAbstractButton *button)
 			obs_source_t *scene_source =
 				obs_get_source_by_name(scene_name.c_str());
 
-			OBSBasic::Get()->SetCurrentScene(source);
+			OBSBasic::Get()->SetCurrentScene(source, true);
 
 			obs_source_release(scene_source);
 

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -252,7 +252,7 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 
 			obs_source_t *scene_source =
 				obs_get_source_by_name(scene_name.c_str());
-			main->SetCurrentScene(scene_source);
+			main->SetCurrentScene(scene_source, true);
 			obs_source_release(scene_source);
 
 			main->RefreshSources(main->GetCurrentScene());
@@ -282,7 +282,7 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 
 			obs_source_t *scene_source =
 				obs_get_source_by_name(scene_name.c_str());
-			main->SetCurrentScene(scene_source);
+			main->SetCurrentScene(scene_source, true);
 			obs_source_release(scene_source);
 
 			main->RefreshSources(main->GetCurrentScene());

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -92,7 +92,7 @@ OBSBasicTransform::~OBSBasicTransform()
 		obs_source_t *source = obs_get_source_by_name(
 			obs_data_get_string(dat, "scene_name"));
 		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(source);
+			->SetCurrentScene(source, true);
 		obs_source_release(source);
 		obs_data_release(dat);
 		obs_scene_load_transform_states(data.c_str());


### PR DESCRIPTION
### Description
The undo/redo functions are setting the current scene. Every time
it would do this, it would actually transition to the scene.
This forces the current scene, so it fixes a bug where the
transition would be grayed out when undoing/redoing.

### Motivation and Context
Fixes bug that I found

### How Has This Been Tested?
Used undo/redo and made sure everything worked as expected.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
