### PR TITLE
UI: Fix spamming of log when setting current scene

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -731,11 +731,10 @@ void OBSBasic::SetCurrentScene(OBSSource scene, bool force)
 				obs_source_inc_showing(scene);
 			if (actualLastScene)
 				obs_source_dec_showing(actualLastScene);
-			lastScene = OBSGetWeakRef(scene);
 		}
 	}
 
-	if (obs_scene_get_source(GetCurrentScene()) != scene) {
+	if (OBSGetStrongRef(lastScene) != scene) {
 		for (int i = 0; i < ui->scenes->count(); i++) {
 			QListWidgetItem *item = ui->scenes->item(i);
 			OBSScene itemScene = GetOBSRef<OBSScene>(item);
@@ -751,16 +750,16 @@ void OBSBasic::SetCurrentScene(OBSSource scene, bool force)
 				break;
 			}
 		}
-	}
 
-	UpdateContextBar(true);
+		lastScene = OBSGetWeakRef(scene);
 
-	if (scene) {
 		bool userSwitched = (!force && !disableSaving);
 		blog(LOG_INFO, "%s to scene '%s'",
 		     userSwitched ? "User switched" : "Switched",
 		     obs_source_get_name(scene));
 	}
+
+	UpdateContextBar(true);
 }
 
 void OBSBasic::CreateProgramDisplay()
@@ -1645,7 +1644,6 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 			OBSSource actualLastScene = OBSGetStrongRef(lastScene);
 			if (actualLastScene)
 				obs_source_dec_showing(actualLastScene);
-			lastScene = nullptr;
 		}
 
 		programScene = nullptr;


### PR DESCRIPTION
### Description
When setting the current scene and if it was the same as the previous,
the log would be spammed with switching scene messages.

This issue particularly happened when using undo/redo, as their
functions were setting the current scene.

### Motivation and Context
Users reported the log was being spammed when using undo and redo.

### How Has This Been Tested?
Used undo/redo and switch scenes to make sure everything worked as expected.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
