### PR TITLE
obs-filters: RTX denoiser initialization fix and code cleanup

### DIFF
--- a/plugins/obs-filters/noise-suppress-filter.c
+++ b/plugins/obs-filters/noise-suppress-filter.c
@@ -336,18 +336,17 @@ static void noise_suppress_update(void *data, obs_data_t *s)
 
 	/* Ignore if already allocated */
 #if defined(LIBSPEEXDSP_ENABLED)
-	if (ng->spx_states[0])
-		return;
-#endif
-#ifdef LIBRNNOISE_ENABLED
-	if (ng->rnn_states[0])
+	if (!ng->use_rnnoise && !ng->use_nvafx && ng->spx_states[0])
 		return;
 #endif
 #ifdef LIBNVAFX_ENABLED
-	if (ng->handle[0])
+	if (ng->use_nvafx && ng->handle[0])
 		return;
 #endif
-
+#ifdef LIBRNNOISE_ENABLED
+	if (ng->use_rnnoise && ng->rnn_states[0])
+		return;
+#endif
 	/* One speex/rnnoise state for each channel (limit 2) */
 	ng->copy_buffers[0] = bmalloc(frames * channels * sizeof(float));
 #ifdef LIBSPEEXDSP_ENABLED


### PR DESCRIPTION
### Description
This fixes #4441 (first commit).
The second commit is a minor code cleanup:
- sets defaults intensity of RTX denoiser to max.
- adds an initialization check of nvafx.
- splits nvafx initialization from channel allocation for better
readability of the code.
- moves the intensity update from the filter_audio process function
to the plugin update function.
- logs the error code in case nvafx returns an error when running.
(useful for devs; I haven't translated the error codes which are
available in the sdk).

### Motivation and Context
- Fixes an issue.
- Code cleanup will make maintainance easier.

### How Has This Been Tested?
Tested that the issue is fixed and that the plugin works fien after the code cleanup.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
- Code cleanup (non-breaking change which makes code smaller or more readable) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
