### PR TITLE
UI/libobs: Remove undo/redo for scenes and sources keeping zombies

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5450,6 +5450,9 @@ void OBSBasic::on_actionRemoveSource_triggered()
 		obs_source_t *si_source = obs_sceneitem_get_source(item);
 		std::string scene_name = obs_source_get_name(obs_scene_get_source(obs_sceneitem_get_scene(item)));
 
+		source_save temp = {obs_source_get_name(si_source), scene_name};
+		item_save.push_back(temp);
+
 		if (obs_source_is_group(si_source)) {
 
 			auto saver = [](obs_scene_t *, obs_sceneitem_t *item, void *vp) {
@@ -5492,13 +5495,9 @@ void OBSBasic::on_actionRemoveSource_triggered()
 
 
 		obs_data_t *save_data = obs_save_source(si_source);
-
-		source_save temp = {obs_source_get_name(si_source), scene_name};
-		item_save.push_back(temp);
-
 		obs_data_t *transform = obs_sceneitem_save_transform(item);
 		obs_data_set_obj(save_data, "undo_transform", transform);
-		obs_data_set_string(save_data, "undo_scene", temp.scene_name.c_str());
+		obs_data_set_string(save_data, "undo_scene", scene_name.c_str());
 		obs_data_set_bool(save_data, "is_group", false);
 
 		obs_data_array_push_back(sources, save_data);
@@ -5562,7 +5561,6 @@ void OBSBasic::on_actionRemoveSource_triggered()
 
 			obs_source_release(scene_source);
 			obs_source_release(source);
-			obs_sceneitem_release(si);
 			obs_data_release(transforms);
 		};
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5461,6 +5461,7 @@ void OBSBasic::on_actionRemoveSource_triggered()
 				obs_data_array_push_back(arr, save);
 
 				obs_data_release(save);
+				obs_data_release(transform);
 
 				return true;
 			};
@@ -5481,7 +5482,10 @@ void OBSBasic::on_actionRemoveSource_triggered()
 			obs_data_array_push_back(sources, saved_source);
 
 			obs_data_release(saved_source);
+			obs_data_release(save_group);
+			obs_data_release(group_transform);
 			obs_data_array_release(saved_sources);
+
 
 			continue;
 		}
@@ -5529,12 +5533,22 @@ void OBSBasic::on_actionRemoveSource_triggered()
 					obs_scene_t *group = static_cast<obs_scene_t *>(vp);
 					obs_source_t *source = obs_load_source(data);
 					obs_sceneitem_t *item = obs_scene_add(group, source);
-					obs_data_t *transform = obs_data_get_obj(data, "undo_transform");
-					obs_sceneitem_load_transform(group, item, transform);
-					obs_sceneitem_set_id(item, obs_data_get_int(transform, "id"));
+					obs_data_t *transforms = obs_data_get_obj(data, "undo_transform");
+					obs_sceneitem_load_transform(group, item, transforms);
+					obs_sceneitem_set_id(item, obs_data_get_int(transforms, "id"));
+
+					obs_source_release(source);
+					obs_data_release(transforms);
 				};
 
 				obs_data_array_enum(arr, groups, (void *) obs_group_from_source(group_source));
+
+				obs_data_array_release(arr);
+				obs_data_release(group_data);
+				obs_data_release(group_transform);
+				obs_source_release(group_source);
+
+				obs_source_release(scene_source);
 
 				return;
 			}
@@ -5548,6 +5562,7 @@ void OBSBasic::on_actionRemoveSource_triggered()
 
 			obs_source_release(scene_source);
 			obs_source_release(source);
+			obs_sceneitem_release(si);
 			obs_data_release(transforms);
 		};
 

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -2069,35 +2069,35 @@ struct passthrough {
 
 obs_data_t *obs_sceneitem_save_transform(obs_sceneitem_t *item)
 {
-		obs_data_t *temp = obs_data_create();
+	obs_data_t *temp = obs_data_create();
 
-		struct obs_transform_info info;
-		struct obs_sceneitem_crop crop;
-		obs_sceneitem_get_info(item, &info);
-		obs_sceneitem_get_crop(item, &crop);
+	struct obs_transform_info info;
+	struct obs_sceneitem_crop crop;
+	obs_sceneitem_get_info(item, &info);
+	obs_sceneitem_get_crop(item, &crop);
 
-		struct vec2 pos = info.pos;
-		struct vec2 scale = info.scale;
-		float rot = info.rot;
-		uint32_t alignment = info.alignment;
-		uint32_t bounds_type = info.bounds_type;
-		uint32_t bounds_alignment = info.bounds_alignment;
-		struct vec2 bounds = info.bounds;
+	struct vec2 pos = info.pos;
+	struct vec2 scale = info.scale;
+	float rot = info.rot;
+	uint32_t alignment = info.alignment;
+	uint32_t bounds_type = info.bounds_type;
+	uint32_t bounds_alignment = info.bounds_alignment;
+	struct vec2 bounds = info.bounds;
 
-		obs_data_set_int(temp, "id", obs_sceneitem_get_id(item));
-		obs_data_set_vec2(temp, "pos", &pos);
-		obs_data_set_vec2(temp, "scale", &scale);
-		obs_data_set_double(temp, "rot", rot);
-		obs_data_set_int(temp, "alignment", alignment);
-		obs_data_set_int(temp, "bounds_type", bounds_type);
-		obs_data_set_vec2(temp, "bounds", &bounds);
-		obs_data_set_int(temp, "bounds_alignment", bounds_alignment);
-		obs_data_set_int(temp, "top", crop.top);
-		obs_data_set_int(temp, "bottom", crop.bottom);
-		obs_data_set_int(temp, "left", crop.left);
-		obs_data_set_int(temp, "right", crop.right);
+	obs_data_set_int(temp, "id", obs_sceneitem_get_id(item));
+	obs_data_set_vec2(temp, "pos", &pos);
+	obs_data_set_vec2(temp, "scale", &scale);
+	obs_data_set_double(temp, "rot", rot);
+	obs_data_set_int(temp, "align", alignment);
+	obs_data_set_int(temp, "bounds_type", bounds_type);
+	obs_data_set_vec2(temp, "bounds", &bounds);
+	obs_data_set_int(temp, "bounds_align", bounds_alignment);
+	obs_data_set_int(temp, "crop_top", crop.top);
+	obs_data_set_int(temp, "crop_bottom", crop.bottom);
+	obs_data_set_int(temp, "crop_left", crop.left);
+	obs_data_set_int(temp, "crop_right", crop.right);
 
-		return temp;
+	return temp;
 }
 
 bool save_transform_states(obs_scene_t *scene, obs_sceneitem_t *item,
@@ -2134,23 +2134,24 @@ obs_data_t *obs_scene_save_transform_states(obs_scene_t *scene, bool all_items)
 	return wrapper;
 }
 
-void obs_sceneitem_load_transform(obs_scene_t *scene, obs_sceneitem_t *item, obs_data_t *temp)
+void obs_sceneitem_load_transform(obs_scene_t *scene, obs_sceneitem_t *item,
+				  obs_data_t *temp)
 {
 	struct obs_transform_info info;
 	struct obs_sceneitem_crop crop;
 	obs_data_get_vec2(temp, "pos", &info.pos);
 	obs_data_get_vec2(temp, "scale", &info.scale);
 	info.rot = (float)obs_data_get_double(temp, "rot");
-	info.alignment = (uint32_t)obs_data_get_int(temp, "alignment");
+	info.alignment = (uint32_t)obs_data_get_int(temp, "align");
 	info.bounds_type =
 		(enum obs_bounds_type)obs_data_get_int(temp, "bounds_type");
 	info.bounds_alignment =
-		(uint32_t)obs_data_get_int(temp, "bounds_alignment");
+		(uint32_t)obs_data_get_int(temp, "bounds_align");
 	obs_data_get_vec2(temp, "bounds", &info.bounds);
-	crop.top = (int)obs_data_get_int(temp, "top");
-	crop.bottom = (int)obs_data_get_int(temp, "bottom");
-	crop.left = (int)obs_data_get_int(temp, "left");
-	crop.right = (int)obs_data_get_int(temp, "right");
+	crop.top = (int)obs_data_get_int(temp, "crop_top");
+	crop.bottom = (int)obs_data_get_int(temp, "crop_bottom");
+	crop.left = (int)obs_data_get_int(temp, "crop_left");
+	crop.right = (int)obs_data_get_int(temp, "crop_right");
 
 	obs_sceneitem_defer_update_begin(item);
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1564,7 +1564,9 @@ EXPORT obs_sceneitem_t *obs_scene_find_sceneitem_by_id(obs_scene_t *scene,
 						       int64_t id);
 
 EXPORT obs_data_t *obs_sceneitem_save_transform(obs_sceneitem_t *scene_item);
-EXPORT void obs_sceneitem_load_transform(obs_scene_t *scene, obs_sceneitem_t *scene_item, obs_data_t *data);
+EXPORT void obs_sceneitem_load_transform(obs_scene_t *scene,
+					 obs_sceneitem_t *scene_item,
+					 obs_data_t *data);
 
 /** Enumerates sources within a scene */
 EXPORT void obs_scene_enum_items(obs_scene_t *scene,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1563,6 +1563,9 @@ EXPORT obs_sceneitem_t *obs_scene_find_source_recursive(obs_scene_t *scene,
 EXPORT obs_sceneitem_t *obs_scene_find_sceneitem_by_id(obs_scene_t *scene,
 						       int64_t id);
 
+EXPORT obs_data_t *obs_sceneitem_save_transform(obs_sceneitem_t *scene_item);
+EXPORT void obs_sceneitem_load_transform(obs_scene_t *scene, obs_sceneitem_t *scene_item, obs_data_t *data);
+
 /** Enumerates sources within a scene */
 EXPORT void obs_scene_enum_items(obs_scene_t *scene,
 				 bool (*callback)(obs_scene_t *,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
The previous implementation for undo/redo deletion of scenes and sources left the sources in a zombified state. This is dangerous and can cause hard to find bugs.

### Motivation and Context
Saving your sanity.

### How Has This Been Tested?
Testing on my linux machine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
