### PR TITLE
UI: Conform transition duration in Scene Transition dock

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1218,10 +1218,10 @@
              <string> ms</string>
             </property>
             <property name="minimum">
-             <number>2</number>
+             <number>50</number>
             </property>
             <property name="maximum">
-             <number>10000</number>
+             <number>20000</number>
             </property>
             <property name="singleStep">
              <number>50</number>


### PR DESCRIPTION
### Description
The behavior of Duration input in Scene Transitions dock is now conformed to the one of Studio Mode transitions UI.
Prior to this commit, the Studio Mode transitions menu allowed for 50 ms minimum, 50 ms step, and 20000 ms maximum, yet the Scene Transitions dock allowed for 2 ms minimum, 50 step, and 10000 ms maximum. 2 ms duration is basically a cut transition, therefore both minimums and maximums have been conformed to the ones of the Studio Mode menu.

### Motivation and Context
I knew that it was possible to do 20 second fades (as witnessed on LGIO livestreams), yet my OBS only allowed 10 seconds. I investigated the code and found discrepancies in how the UI elements are specified. Since either elements are controlling the same property, I believe both should enforce the same constraints.

### How Has This Been Tested?
Purely cosmetic and single-character changes not affecting overall file size or any other components, no testing is believed to be necessary.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.