### PR TITLE
Add Undo/Redo source visibility transitions

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -290,6 +290,8 @@ Undo.Volume.Change="Volume Change on '%1'"
 Undo.Audio="Audio Changes"
 Undo.Properties="Property Change on '%1'"
 Undo.Scene.Duplicate="Duplicate Scene '%1'"
+Undo.ShowTransition="Show Transition on '%1'"
+Undo.HideTransition="Hide Transition on '%1'"
 
 
 # transition name dialog

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1152,7 +1152,28 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 
 		QString id = action->property("transition_id").toString();
 		OBSSceneItem sceneItem = main->GetCurrentSceneItem();
+		int64_t sceneItemId = obs_sceneitem_get_id(sceneItem);
+		std::string sceneName =
+			obs_source_get_name(obs_scene_get_source(
+				obs_sceneitem_get_scene(sceneItem)));
 
+		auto undo_redo = [sceneName, sceneItemId,
+				  visible](const std::string &data) {
+			obs_source_t *source =
+				obs_get_source_by_name(sceneName.c_str());
+			obs_scene_t *scene = obs_scene_from_source(source);
+			obs_sceneitem_t *i = obs_scene_find_sceneitem_by_id(
+				scene, sceneItemId);
+			if (i) {
+				obs_data_t *dat =
+					obs_data_create_from_json(data.c_str());
+				obs_sceneitem_transition_load(i, dat, visible);
+				obs_data_release(dat);
+			}
+			obs_source_release(source);
+		};
+		obs_data_t *oldTransitionData =
+			obs_sceneitem_transition_save(sceneItem, visible);
 		if (id.isNull() || id.isEmpty()) {
 			if (visible)
 				obs_sceneitem_set_show_transition(sceneItem,
@@ -1204,6 +1225,21 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 			if (obs_source_configurable(tr))
 				CreatePropertiesWindow(tr);
 		}
+		obs_data_t *newTransitionData =
+			obs_sceneitem_transition_save(sceneItem, visible);
+		std::string undo_data(obs_data_get_json(oldTransitionData));
+		std::string redo_data(obs_data_get_json(newTransitionData));
+		if (undo_data.compare(redo_data) != 0)
+			main->undo_s.add_action(
+				QTStr(visible ? "Undo.ShowTransition"
+					      : "Undo.HideTransition")
+					.arg(obs_source_get_name(
+						obs_sceneitem_get_source(
+							sceneItem))),
+				undo_redo, undo_redo, undo_data, redo_data,
+				NULL);
+		obs_data_release(newTransitionData);
+		obs_data_release(oldTransitionData);
 	};
 	if (visible) {
 		auto setDuration = [this](int duration) {

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1780,6 +1780,10 @@ EXPORT obs_source_t *obs_sceneitem_get_hide_transition(obs_sceneitem_t *item);
 EXPORT uint32_t
 obs_sceneitem_get_hide_transition_duration(obs_sceneitem_t *item);
 EXPORT void obs_sceneitem_do_transition(obs_sceneitem_t *item, bool visible);
+EXPORT void obs_sceneitem_transition_load(struct obs_scene_item *item,
+					  obs_data_t *data, bool show);
+EXPORT obs_data_t *obs_sceneitem_transition_save(struct obs_scene_item *item,
+						 bool show);
 
 /* ------------------------------------------------------------------------- */
 /* Outputs */


### PR DESCRIPTION
### Description
Undo/Redo source visibility transitions
### Motivation and Context
allow undo changing source visibility transition

### How Has This Been Tested?
On windows 64

### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [] I have included updates to all appropriate documentation.