### PR TITLE
xdg-data: Add to dotdesktop a desktop action to use obs with wayland

### DIFF
--- a/UI/xdg-data/com.obsproject.Studio.desktop
+++ b/UI/xdg-data/com.obsproject.Studio.desktop
@@ -13,3 +13,12 @@ Type=Application
 Categories=AudioVideo;Recorder;
 StartupNotify=true
 StartupWMClass=obs
+Actions=new-window;new-wayland-window;
+
+[Desktop Action new-window]
+Name=New Instance
+Exec=obs
+
+[Desktop Action new-wayland-window]
+Name=New Wayland Instance
+Exec=env QT_QPA_PLATFORM=wayland obs


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
It adds desktop actions to the dotdesktop file:
- One which only launch OBS
- One which launch OBS with QT_QPA_PLATFORM=wayland

~The only issue here is translation or the actions name, this is why it's a draft~
Note: The Wayland action will appear even on X11 Gnome session

Some feedback to improve this are welcome.
<!--- If this change includes UI elements, please include screenshots. -->
![OBS-dotdesktop](https://user-images.githubusercontent.com/17492366/114221615-0df37780-995d-11eb-84ac-9f3813625345.png)


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Since Qt5 decide to default to x11, I created a way to launch it with Wayland without the use of a terminal
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I put the new dotdesktop to `~/.local/share/applications/` and check my activity tab since I'm under Gnome.
And try to launch both action under Wayland.
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
