### PR TITLE
Use ffmpeg 4.4 in Flatpak

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -129,8 +129,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://www.ffmpeg.org/releases/ffmpeg-4.3.2.tar.xz",
-          "sha256": "46e4e64f1dd0233cbc0934b9f1c0da676008cad34725113fb7f802cfa84ccddb"
+          "url": "https://www.ffmpeg.org/releases/ffmpeg-4.4.tar.xz",
+          "sha256": "06b10a183ce5371f915c6bb15b7b1fffbe046e8275099c96affc29e17645d909"
         }
       ]
     },


### PR DESCRIPTION
### Description

A new release packed with interesting new features [1]. Let's use it.

[1] http://ffmpeg.org/index.html#pr4.4

### Motivation and Context

This update landed in Flathub, this PR is just synchronizing the manifests.

### How Has This Been Tested?

Run OBS Studio from the Flatpak CI and notice nothing is broken. The new ffmpeg should be 100% backwards compatible.

### Types of changes


 - New feature (non-breaking change which adds functionality)

### Checklist:


- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
