### PR TITLE
UI: Force Wayland usage under Wayland session

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2009,6 +2009,18 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 	InstallNSApplicationSubclass();
 #endif
 
+#if !defined(_WIN32) && !defined(__APPLE__) && defined(USE_XDG) && \
+	defined(ENABLE_WAYLAND)
+	/* NOTE: Qt doesn't use the Wayland platform on GNOME, so we have to
+	 * force it using the QT_QPA_PLATFORM env var. It's still possible to
+	 * use other QPA platforms using this env var, or the -platform command
+	 * line option. */
+
+	const char *session_type = getenv("XDG_SESSION_TYPE");
+	if (session_type && strcmp(session_type, "wayland") == 0)
+		setenv("QT_QPA_PLATFORM", "wayland", false);
+#endif
+
 	OBSApp program(argc, argv, profilerNameStore.get());
 	try {
 		QAccessible::installFactory(accessibleFactory);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
Since Qt doesn't use Wayland by default only under session with `XDG_CURRENT_DESKTOP=GNOME` like Gnome Shell or Phosh.

**We now force Qt with OBS to use Wayland under Wayland sessions directly in the code, the user still can choose an other platform if he needs to.**

~~- I made the original entry invisible in a session with `XDG_CURRENT_DESKTOP=GNOME` and also change his action name from "New Window" to "New Instance". (I can undo the name change, if  needed)
Why "Instance" ? Because it makes more sense since OBS asked if you really want to run an another instance of OBS when already launched~~

~~- I added a new entry which only show under GNOME with a second action to launch it with `-platform wayland`~~

~~**Once this Qt issue is resolved and any Qt LTS with this behavior is unsupported, removing the custom entry and the setting "NotShowIn" in the original will be needed**~~

<!--- If this change includes UI elements, please include screenshots. -->
<!--![OBS-dotdesktop](https://user-images.githubusercontent.com/17492366/114296816-da1f6b80-9a9c-11eb-9abe-673470cb90a1.png)-->
~~If the action link to "new-window" is not created, a placeholder would be put between the two options.~~

~~Note: #4484 only modified the original one with a new action, I was thinking that the Qt behavior was on any Wayland DE, it seems only GNOME is affected~~

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I made this PR, to make users with session having `XDG_CURRENT_DESKTOP=GNOME` able to use OBS with Wayland without using a terminal.

<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
~~I put the new entries to \~/.local/share/applications/ and check my activity tab since I'm under Gnome.~~
~~And try to launch both action under Wayland.~~
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Launch OBS under GNOME Wayland
- Launch with xcb as platform on GNOME Wayland with a terminal
- Launch with `XDG_SESSION_TYPE` unset

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
