### PR TITLE
UI: Add Copy/Paste for source visibility transitions

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -225,6 +225,7 @@ private:
 	obs_transform_info copiedTransformInfo;
 	obs_sceneitem_crop copiedCropInfo;
 	bool hasCopiedTransform = false;
+	OBSWeakSourceAutoRelease copySourceTransition;
 
 	bool closing = false;
 	QScopedPointer<QThread> devicePropertiesThread;
@@ -460,6 +461,8 @@ private:
 	void EnableTransitionWidgets(bool enable);
 	void CreateDefaultQuickTransitions();
 
+	void PasteShowHideTransition(obs_sceneitem_t *item, bool show,
+				     obs_source_t *tr);
 	QMenu *CreatePerSceneTransitionMenu();
 	QMenu *CreateVisibilityTransitionMenu(bool visible);
 

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -3768,6 +3768,8 @@ void obs_sceneitem_transition_load(struct obs_scene_item *item,
 		obs_sceneitem_set_transition(item, show, t);
 		obs_source_release(t);
 		obs_data_release(s);
+	} else {
+		obs_sceneitem_set_transition(item, show, NULL);
 	}
 	obs_sceneitem_set_transition_duration(
 		item, show, (uint32_t)obs_data_get_int(data, "duration"));


### PR DESCRIPTION
### Description
Add Copy  and Paste options to the source visibility menu.
![image](https://user-images.githubusercontent.com/5457024/114315217-39619800-9afe-11eb-8b95-2296f41ebfc6.png)

### Motivation and Context
Allows you to set the same transition on multiple sources without configuring each one.

### How Has This Been Tested?
On windows 64bit by copy and pasting source visibility transitions.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
