### PR TITLE
obs-frontend-api: Send OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP event

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -604,7 +604,8 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 
 	void on_event(enum obs_frontend_event event) override
 	{
-		if (main->disableSaving)
+		if (main->disableSaving &&
+		    event != OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP)
 			return;
 
 		for (size_t i = callbacks.size(); i > 0; i--) {


### PR DESCRIPTION
### Description
Send OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP

### Motivation and Context
OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP was never send.
The only place triggering it is in [ClearSceneData()](https://github.com/obsproject/obs-studio/blob/bab21888f389cf16c2966d9c7a099682dd6f4974/UI/window-basic-main.cpp#L4388)
but disableSaving is always set there by the function itself and by the calling functions so the line in this PR blocks it

other events like OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED still need to be blocked while loading

### How Has This Been Tested?
On windows 64 bit receiving OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP in a plugin. 

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
