### PR TITLE
vlc-video: Ignore URLs when checking for missing files

### DIFF
--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -1131,7 +1131,8 @@ static obs_missing_files_t *vlcs_missingfiles(void *data)
 		const char *path = obs_data_get_string(item, "value");
 
 		if (strcmp(path, "") != 0) {
-			if (!os_file_exists(path)) {
+			if (!os_file_exists(path) &&
+			    strstr(path, "://") == NULL) {
 				obs_missing_file_t *file =
 					obs_missing_file_create(
 						path, missing_file_callback,


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Excludes URL entries from being marked as "missing" by the missing file dialog

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
URLs should not be considered missing files, and generally should not be checked for validity anyway. Previously, if an entry in the playlist was a URL, it would be marked as a missing file and pop up on load.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Made a playlist full of url and file entries, urls did not show up in missing files dialog, but missing files did.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
