### PR TITLE
vlc-video: Emit media ended signal regardless of loop setting

### DIFF
--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -737,8 +737,9 @@ static void vlcs_stopped(const struct libvlc_event_t *event, void *data)
 	struct vlc_source *c = data;
 	if (!c->loop) {
 		obs_source_output_video(c->source, NULL);
-		obs_source_media_ended(c->source);
 	}
+
+	obs_source_media_ended(c->source);
 
 	UNUSED_PARAMETER(event);
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Emits `obs_source_media_ended` regardless of whether the playlist is in loop mode. Makes the signal's behavior on-par with `obs_source_media_started`.

An affected use case would be:
A VLC source plays a video stream 24/7. Sometimes the stream playback ends unexpectedly and requires manual intervention.
A script listens for the `obs_source_media_ended` signal and resets the source automatically, allowing continued playback. Currently, this script would not receive the event unless `loop` is disabled.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
`obs_source_media_started` is emitted every time an entry in the playlist is played, and so therefore `obs_source_media_ended` should be emitted every time playback of a playlist entry ends.

Currently, the signal is only emitted when the loop setting is disabled, however the parent handler function is called every time a playlist entry finishes playing, and so it doesn't matter whether loop mode is enabled.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Made a playlist with a bunch of files. Every time playback ended on a file, the signal was emitted.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
