### PR TITLE
libobs: Return target vec not current when within EPSILON

### DIFF
--- a/libobs/graphics/math-extra.c
+++ b/libobs/graphics/math-extra.c
@@ -101,7 +101,7 @@ void calc_torque(struct vec3 *dst, const struct vec3 *v1, const struct vec3 *v2,
 	float orig_dist, torque_dist, adjust_dist;
 
 	if (vec3_close(v1, v2, EPSILON)) {
-		vec3_copy(dst, v1);
+		vec3_copy(dst, v2);
 		return;
 	}
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
If v1 vector is within EPSILON, it would previously return v1, when logically v2 (the target) should be returned instead.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noted by @jpark37 in #2930. No parts of OBS use this util, however it follows the same issue as was fixed in #2930, so it deserves to be fixed too.

To summarize how the current behavior can be an issue, if there is a transition which uses torque for gradual translation to a target (v2), and the current position(v1) is within the EPSILON, v2 will never be reached, which would make a check like
```c
struct vec3 dst;
calc_torque(&dst, current, target, ...);
if (dst == target) {
    transitionCompleted();
}
```
have undefined behavior.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
**This fix could not be tested, as no examples of this util function's usage could be found.**

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
