### PR TITLE
mac-virtualcam: Hide logging behind debug flag

### DIFF
--- a/plugins/mac-virtualcam/src/dal-plugin/Logging.h
+++ b/plugins/mac-virtualcam/src/dal-plugin/Logging.h
@@ -22,9 +22,15 @@
 
 #include "Defines.h"
 
+#ifdef DEBUG
 #define DLog(fmt, ...) NSLog((PLUGIN_NAME @"(DAL): " fmt), ##__VA_ARGS__)
 #define DLogFunc(fmt, ...) \
 	NSLog((PLUGIN_NAME @"(DAL): %s " fmt), __FUNCTION__, ##__VA_ARGS__)
+#else
+#define DLog(fmt, ...) (void)(fmt, ##__VA_ARGS__)
+#define DLogFunc(fmt, ...) (void)(fmt, __FUNCTION__, ##__VA_ARGS__)
+#endif
+
 #define VLog(fmt, ...)
 #define VLogFunc(fmt, ...)
 #define ELog(fmt, ...) DLog(fmt, ##__VA_ARGS__)


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Hides the DLog and DLogFunc macros behind the -DDEBUG flag, causing the logs to only appear in testing environments.

On production build, calls to these macros will result in nothing happening.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Console logs in this amount:
<img width="1440" alt="Bildschirmfoto 2021-04-12 um 17 35 38" src="https://user-images.githubusercontent.com/59806498/114428252-3cbb5900-9bbc-11eb-9925-7219ee37a1e4.png">
are hilarious.

On production, there will be no more unnecessary debug logs, leaving the console like this:
<img width="1440" alt="Bildschirmfoto 2021-04-12 um 18 14 05" src="https://user-images.githubusercontent.com/59806498/114428427-7724f600-9bbc-11eb-9e56-699809feaddc.png">


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 11.2.3, Intel

Building in Xcode keeps the logs, outside of it with the `-DCMAKE_BUILD_TYPE=RelWithDebInfo` flag, the logs are gone.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
