### PR TITLE
mac-capture: Add another virtual audio device to the list

### DIFF
--- a/plugins/mac-capture/audio-device-enum.c
+++ b/plugins/mac-capture/audio-device-enum.c
@@ -14,7 +14,8 @@ static inline bool device_is_input(char *device)
 	       astrstri(device, "soundsiphon") == NULL &&
 	       astrstri(device, "ishowu") == NULL &&
 	       astrstri(device, "blackhole") == NULL &&
-	       astrstri(device, "loopback") == NULL;
+	       astrstri(device, "loopback") == NULL &&
+	       astrstri(device, "groundcontrol") == NULL;
 }
 
 static inline bool enum_success(OSStatus stat, const char *msg)


### PR DESCRIPTION
### Operating System Info

macOS 11.2

### Other OS

No response

### OBS Studio Version

27.0.0-rc1

### OBS Studio Version (Other)

Both RC1 as well as newest nightly

### OBS Studio Log URL

https://obsproject.com/logs/o3_DktbhzZo_B8yL

### OBS Studio Crash Log URL

No response

### Expected Behavior

Add another virtual audio device to mac OS desktop.

### Current Behavior

The following virtual audio devices are missing on Mac OS desktop setting: "GroundControl 2ch", "GroundControl 16ch", "GroundControl 64ch".

### Steps to Reproduce

1. Open OBS preferences->audio->global audio devices->desktop audio
2. Check the drop down menu.
3. See that the following virtual audio devices are missing even though they are installed on my machine:  "GroundControl 2ch", "GroundControl 16ch", "GroundControl 64ch".

### Anything else we should know?

Repository
obsproject/obs-studio