### PR TITLE
UI: Use newer Twitch Dashboard docks for integration

### DIFF
--- a/UI/auth-twitch.cpp
+++ b/UI/auth-twitch.cpp
@@ -285,9 +285,9 @@ void TwitchAuth::LoadSecondaryUIPanes()
 
 	/* ----------------------------------- */
 
-	url = "https://www.twitch.tv/popout/";
+	url = "https://dashboard.twitch.tv/popout/u/";
 	url += name;
-	url += "/dashboard/live/stream-info";
+	url += "/stream-manager/edit-stream-info";
 
 	info.reset(new BrowserDock());
 	info->setObjectName("twitchInfo");
@@ -325,9 +325,9 @@ void TwitchAuth::LoadSecondaryUIPanes()
 
 	/* ----------------------------------- */
 
-	url = "https://www.twitch.tv/popout/";
+	url = "https://dashboard.twitch.tv/popout/u/";
 	url += name;
-	url += "/dashboard/live/activity-feed";
+	url += "/stream-manager/activity-feed";
 
 	feed.reset(new BrowserDock());
 	feed->setObjectName("twitchFeed");


### PR DESCRIPTION
### Description

When Twitch introduced the new Dashboard, it included some updated popouts. We decided against replacing the in-app docks until we were confident that nothing would break.

This also fixes an issue where the submit button on the Stream Information dock would be cut off at certain resolutions.

Two notes:

1. I have not updated the Chat URL because FFZ's Settings button does not appear in the Dashboard Chat popout (but BTTV's does)
2. Twitch have yet to make an updated popout for Stats, so it uses the old URL

I also purposefully chose to continue using `/u/<user>/` URLs instead of removing the user part as this ensures that the logged in Twitch session/user cookies match the authenticated user in Settings -> Stream.

### Motivation and Context

Using outdated URLs is never recommended. While Twitch haven't mentioned if/when the old URLs will stop working, it's better to update them sooner rather than later.

### How Has This Been Tested?

Log in using Twitch & Service Integration.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
