### PR TITLE
obs-app: Add startup flag to disable missing files window

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -90,6 +90,7 @@ bool opt_allow_opengl = false;
 bool opt_always_on_top = false;
 bool opt_disable_high_dpi_scaling = false;
 bool opt_disable_updater = false;
+bool opt_disable_missing_files_check = false;
 string opt_starting_collection;
 string opt_starting_profile;
 string opt_starting_scene;
@@ -1497,6 +1498,11 @@ bool OBSApp::IsUpdaterDisabled()
 	return opt_disable_updater;
 }
 
+bool OBSApp::IsMissingFilesCheckDisabled()
+{
+	return opt_disable_missing_files_check;
+}
+
 #ifdef __APPLE__
 #define INPUT_AUDIO_SOURCE "coreaudio_input_capture"
 #define OUTPUT_AUDIO_SOURCE "coreaudio_output_capture"
@@ -2697,6 +2703,10 @@ int main(int argc, char *argv[])
 		} else if (arg_is(argv[i], "--disable-updater", nullptr)) {
 			opt_disable_updater = true;
 
+		} else if (arg_is(argv[i], "--disable-missing-files-check",
+				  nullptr)) {
+			opt_disable_missing_files_check = true;
+
 		} else if (arg_is(argv[i], "--disable-high-dpi-scaling",
 				  nullptr)) {
 			opt_disable_high_dpi_scaling = true;
@@ -2720,6 +2730,7 @@ int main(int argc, char *argv[])
 				"--always-on-top: Start in 'always on top' mode.\n\n"
 				"--unfiltered_log: Make log unfiltered.\n\n"
 				"--disable-updater: Disable built-in updater (Windows/Mac only)\n\n"
+				"--disable-missing-files-check: Disable the missing files dialog which can appear on startup.\n\n"
 				"--disable-high-dpi-scaling: Disable automatic high-DPI scaling\n\n";
 
 #ifdef _WIN32
@@ -2751,6 +2762,14 @@ int main(int argc, char *argv[])
 		opt_disable_updater =
 			os_file_exists(BASE_PATH "/disable_updater") ||
 			os_file_exists(BASE_PATH "/disable_updater.txt");
+	}
+
+	if (!opt_disable_missing_files_check) {
+		opt_disable_missing_files_check =
+			os_file_exists(BASE_PATH
+				       "/disable_missing_files_check") ||
+			os_file_exists(BASE_PATH
+				       "/disable_missing_files_check.txt");
 	}
 #endif
 

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -150,6 +150,7 @@ public:
 	std::string GetVersionString() const;
 	bool IsPortableMode();
 	bool IsUpdaterDisabled();
+	bool IsMissingFilesCheckDisabled();
 
 	const char *InputAudioSource() const;
 	const char *OutputAudioSource() const;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1161,7 +1161,8 @@ retryScene:
 
 	LogScenes();
 
-	if (obs_missing_files_count(files) > 0) {
+	if (obs_missing_files_count(files) > 0 &&
+	    !App()->IsMissingFilesCheckDisabled()) {
 		/* the window hasn't fully initialized by this point on macOS,
 		 * so put this at the end of the current task queue. Fixes a
 		 * bug where the window be behind OBS on startup */


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds `--disable-missing-files-check` as a startup flag. Prevents the missing files popup from being spawned if missing files are found.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Just like there is a flag for `--disable-updater`, users may be using OBS in an environment where they do not want any popups when OBS launches. This would be helpful for both power users and anyone who uses OBS in an automated fashion.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Using `--disable-missing-files-check` when launching OBS via the command line successfully prevents the popup from appearing.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
