### PR TITLE
Increase brightness precision for filters

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -400,6 +400,14 @@ void OBSPropertiesView::AddFloat(obs_property_t *prop, QFormLayout *layout,
 	spin->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 	spin->setSuffix(QT_UTF8(suffix));
 
+	if (stepVal < 1.0) {
+		int decimals = (int)(log10(1.0 / stepVal) + 0.99);
+		constexpr int sane_limit = 8;
+		decimals = std::min(decimals, sane_limit);
+		if (decimals > spin->decimals())
+			spin->setDecimals(decimals);
+	}
+
 	WidgetInfo *info = new WidgetInfo(this, prop, spin);
 	children.emplace_back(info);
 

--- a/plugins/obs-filters/chroma-key-filter.c
+++ b/plugins/obs-filters/chroma-key-filter.c
@@ -471,7 +471,7 @@ static obs_properties_t *chroma_key_properties_v2(void *data)
 	obs_properties_add_float_slider(props, SETTING_CONTRAST, TEXT_CONTRAST,
 					-4.0, 4.0, 0.01);
 	obs_properties_add_float_slider(props, SETTING_BRIGHTNESS,
-					TEXT_BRIGHTNESS, -1.0, 1.0, 0.01);
+					TEXT_BRIGHTNESS, -1.0, 1.0, 0.0001);
 	obs_properties_add_float_slider(props, SETTING_GAMMA, TEXT_GAMMA, -1.0,
 					1.0, 0.01);
 

--- a/plugins/obs-filters/color-correction-filter.c
+++ b/plugins/obs-filters/color-correction-filter.c
@@ -652,7 +652,7 @@ static obs_properties_t *color_correction_filter_properties_v2(void *data)
 	obs_properties_add_float_slider(props, SETTING_CONTRAST, TEXT_CONTRAST,
 					-4.0, 4.0, 0.01);
 	obs_properties_add_float_slider(props, SETTING_BRIGHTNESS,
-					TEXT_BRIGHTNESS, -1.0, 1.0, 0.01);
+					TEXT_BRIGHTNESS, -1.0, 1.0, 0.0001);
 	obs_properties_add_float_slider(props, SETTING_SATURATION,
 					TEXT_SATURATION, -1.0, 5.0, 0.01);
 	obs_properties_add_float_slider(props, SETTING_HUESHIFT, TEXT_HUESHIFT,

--- a/plugins/obs-filters/color-key-filter.c
+++ b/plugins/obs-filters/color-key-filter.c
@@ -419,7 +419,7 @@ static obs_properties_t *color_key_properties_v2(void *data)
 	obs_properties_add_float_slider(props, SETTING_CONTRAST, TEXT_CONTRAST,
 					-4.0, 4.0, 0.01);
 	obs_properties_add_float_slider(props, SETTING_BRIGHTNESS,
-					TEXT_BRIGHTNESS, -1.0, 1.0, 0.01);
+					TEXT_BRIGHTNESS, -1.0, 1.0, 0.0001);
 	obs_properties_add_float_slider(props, SETTING_GAMMA, TEXT_GAMMA, -1.0,
 					1.0, 0.01);
 


### PR DESCRIPTION
### Description
Now that color math is done in linear space, we need more precise values to adjust brightness for color channels near zero.

### Motivation and Context
User reported the step size is too large.

### How Has This Been Tested?
Setting still works for modified filters.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.