### PR TITLE
mac-virtualcam: Move DAL plugin to plugin data directory

### DIFF
--- a/plugins/mac-virtualcam/src/dal-plugin/CMakeLists.txt
+++ b/plugins/mac-virtualcam/src/dal-plugin/CMakeLists.txt
@@ -104,6 +104,6 @@ add_custom_command(TARGET mac-dal-plugin
 add_custom_command(TARGET mac-dal-plugin
 	POST_BUILD
 	COMMAND rm -rf "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/data/obs-mac-virtualcam.plugin" || true
-	COMMAND ${CMAKE_COMMAND} -E copy_directory ${TARGET_DIR}/obs-mac-virtualcam.plugin "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/data/obs-mac-virtualcam.plugin"
+	COMMAND ${CMAKE_COMMAND} -E copy_directory ${TARGET_DIR}/obs-mac-virtualcam.plugin "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/data/obs-plugins/mac-virtualcam/obs-mac-virtualcam.plugin"
 	COMMENT "Copy plugin to destination"
 )

--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -58,7 +58,7 @@ static bool check_dal_plugin()
 		if ([app bundleIdentifier] != nil) {
 			NSURL *bundleURL = [app bundleURL];
 			NSString *pluginPath =
-				@"Contents/Resources/data/obs-mac-virtualcam.plugin";
+				@"Contents/Resources/data/obs-plugins/mac-virtualcam/obs-mac-virtualcam.plugin";
 
 			NSURL *pluginUrl = [bundleURL
 				URLByAppendingPathComponent:pluginPath];
@@ -66,7 +66,7 @@ static bool check_dal_plugin()
 		} else {
 			dalPluginSourcePath = [[[[app executableURL]
 				URLByAppendingPathComponent:
-					@"../data/obs-mac-virtualcam.plugin"]
+					@"../data/obs-plugins/mac-virtualcam/obs-mac-virtualcam.plugin"]
 				path]
 				stringByReplacingOccurrencesOfString:@"obs/"
 							  withString:@""];


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Moves the DAL plugin to the data directory of the mac-virtualcam. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Until now, the DAL plugin was just lying in the top-level data directory next to the libobs, obs-plugins,
and obs-studio directory, which was kind of bothering.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 11.2.3, Xcode 12.2
Virtual cam is still installed, both when running OBS within and outside of the app bundle.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
