### PR TITLE
obs-filters: Increase luma key precision

### DIFF
--- a/plugins/obs-filters/luma-key-filter.c
+++ b/plugins/obs-filters/luma-key-filter.c
@@ -154,13 +154,13 @@ static obs_properties_t *luma_key_properties(void *data)
 	obs_properties_t *props = obs_properties_create();
 
 	obs_properties_add_float_slider(props, SETTING_LUMA_MAX, TEXT_LUMA_MAX,
-					0, 1, 0.01);
+					0, 1, 0.0001);
 	obs_properties_add_float_slider(props, SETTING_LUMA_MAX_SMOOTH,
-					TEXT_LUMA_MAX_SMOOTH, 0, 1, 0.01);
+					TEXT_LUMA_MAX_SMOOTH, 0, 1, 0.0001);
 	obs_properties_add_float_slider(props, SETTING_LUMA_MIN, TEXT_LUMA_MIN,
-					0, 1, 0.01);
+					0, 1, 0.0001);
 	obs_properties_add_float_slider(props, SETTING_LUMA_MIN_SMOOTH,
-					TEXT_LUMA_MIN_SMOOTH, 0, 1, 0.01);
+					TEXT_LUMA_MIN_SMOOTH, 0, 1, 0.0001);
 
 	UNUSED_PARAMETER(data);
 	return props;


### PR DESCRIPTION
### Description
Increase precision of luma key settings.

### Motivation and Context
Previous step size was reported ineffective, even moreso now with linear color math for luma near zero.

### How Has This Been Tested?
All settings still work as intended.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.