### PR TITLE
UI: Add obs_frontend_get_current_profile_path() to frontend-api

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -238,6 +238,16 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		return bstrdup(name);
 	}
 
+	char *obs_frontend_get_current_profile_path(void) override
+	{
+		char profilePath[512];
+		int ret = GetProfilePath(profilePath, sizeof(profilePath), "");
+		if (ret <= 0)
+			return nullptr;
+
+		return bstrdup(profilePath);
+	}
+
 	void obs_frontend_set_current_profile(const char *profile) override
 	{
 		QList<QAction *> menuActions = main->ui->profileMenu->actions();

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -204,6 +204,12 @@ char *obs_frontend_get_current_profile(void)
 				   : nullptr;
 }
 
+char *obs_frontend_get_current_profile_path(void)
+{
+	return !!callbacks_valid() ? c->obs_frontend_get_current_profile_path()
+				   : nullptr;
+}
+
 void obs_frontend_set_current_profile(const char *profile)
 {
 	if (callbacks_valid())

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -117,6 +117,7 @@ EXPORT bool obs_frontend_add_scene_collection(const char *name);
 
 EXPORT char **obs_frontend_get_profiles(void);
 EXPORT char *obs_frontend_get_current_profile(void);
+EXPORT char *obs_frontend_get_current_profile_path(void);
 EXPORT void obs_frontend_set_current_profile(const char *profile);
 
 typedef void (*obs_frontend_cb)(void *private_data);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -37,6 +37,7 @@ struct obs_frontend_callbacks {
 	virtual void
 	obs_frontend_get_profiles(std::vector<std::string> &strings) = 0;
 	virtual char *obs_frontend_get_current_profile(void) = 0;
+	virtual char *obs_frontend_get_current_profile_path(void) = 0;
 	virtual void obs_frontend_set_current_profile(const char *profile) = 0;
 
 	virtual void obs_frontend_streaming_start(void) = 0;

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -314,6 +314,13 @@ Functions
 
 ---------------------------------------
 
+.. function:: char *obs_frontend_get_current_profile_path(void)
+
+   :return: A new pointer to the current profile's path on the filesystem. Free
+            with :c:func:`bfree()`.
+
+---------------------------------------
+
 .. function:: void obs_frontend_set_current_profile(const char *profile)
 
    :param profile: Name of the profile to activate.


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Returns the path of the current profile's location on the filesystem.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Plugins may need access to the location of the current profile's directory, and currently there is no way to do so without reimplementing lots of code. Some example usages:

- The plugin needs to store/access data files within the current profile's directory (Palakis/obs-websocket#355)
- The plugin needs to have access to files within the profile directory which cannot be accessed via existing methods. Eg. `streamEncoder.json` (Palakis/obs-websocket#676)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- OS: Ubuntu Desktop 20.04

```cpp
char *profilePath = obs_frontend_get_current_profile_path();
if (!profilePath) {
        blog(LOG_INFO, "Profile path not found!");
} else {
        blog(LOG_INFO, "Profile path is %s", profilePath);
}
bfree(profilePath);
```
Operation returned profile path `/home/tt2468/.config/obs-studio/basic/profiles/Untitled` as expected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
