### PR TITLE
libobs: Fix crash loading source icon

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -5101,6 +5101,8 @@ uint32_t obs_source_get_last_obs_version(const obs_source_t *source)
 
 enum obs_icon_type obs_source_get_icon_type(const char *id)
 {
+	if (!id)
+		return OBS_ICON_TYPE_UNKNOWN;
 	const struct obs_source_info *info = get_source_info(id);
 	return (info) ? info->icon_type : OBS_ICON_TYPE_UNKNOWN;
 }


### PR DESCRIPTION
### Description
Fix crash loading source icon

### Motivation and Context
Fix crash during startup loading the new missing files dialog.

obs.dll!get_source_info+0x33
obs.dll!obs_source_get_icon_type+0x9
obs64.exe!OBSBasic::GetSourceIcon+0x18
obs64.exe!MissingFilesModel::data+0x41a

### How Has This Been Tested?
On windows 64 bit loading a corrupt scene collection.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
