### PR TITLE
UI: Fix missing files dialog crash loading source icon

### DIFF
--- a/UI/window-missing-files.cpp
+++ b/UI/window-missing-files.cpp
@@ -268,9 +268,11 @@ QVariant MissingFilesModel::data(const QModelIndex &index, int role) const
 		obs_source_t *source = obs_get_source_by_name(
 			files[index.row()].source.toStdString().c_str());
 
-		result = main->GetSourceIcon(obs_source_get_id(source));
+		if (source) {
+			result = main->GetSourceIcon(obs_source_get_id(source));
 
-		obs_source_release(source);
+			obs_source_release(source);
+		}
 	} else if (role == Qt::FontRole &&
 		   index.column() == MissingFilesColumn::State) {
 		QFont font = QFont();


### PR DESCRIPTION
### Description
Fix missing files dialog crash loading source icon

### Motivation and Context
Other solution as #4528 to same crash

obs.dll!get_source_info+0x33
obs.dll!obs_source_get_icon_type+0x9
obs64.exe!OBSBasic::GetSourceIcon+0x18
obs64.exe!MissingFilesModel::data+0x41a

### How Has This Been Tested?
On windows 64 bit loading a corrupt scene collection.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
