### PR TITLE
CI: Use flatpak-builder subaction

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -35,7 +35,7 @@ jobs:
         submodules: 'recursive'
 
     - name: Build Flatpak Manifest
-      uses: bilelmoussaoui/flatpak-github-actions@master
+      uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@master
       if: success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1')
       with:
         bundle: obs-studio-${{ github.sha }}.flatpak


### PR DESCRIPTION
### Description

Use the right subaction (flatpak-builder) for the Flatpak workflow.

### Motivation and Context

The Flatpak action now contains two subactions:

- flatpak-builder: for building and uploading a bundle
- flat-manager: for deploying the bundle to a remote repository

We're only interested in the `flatpak-builder` subaction for now. In the future, we can use `flat-manager` to automatically send OBS Studio releases to e.g. Flathub.

This won't affect existing pull requests, except the ones that have the "Seeking Testers" label applied - in which case, they may simply need to rebase against the master branch.

### How Has This Been Tested?

 - Run the "Flatpak (experimental)" workflow, both with and without the "Seeking Testers" label

### Types of changes

 - New feature (non-breaking change which adds functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
