### PR TITLE
UI: Fix crash when closing missing files window

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1165,12 +1165,9 @@ retryScene:
 
 	if (obs_missing_files_count(files) > 0) {
 		missDialog = new OBSMissingFiles(files, this);
+		missDialog->setAttribute(Qt::WA_DeleteOnClose, true);
 		missDialog->show();
 		missDialog->raise();
-
-		auto close = [=]() { delete missDialog; };
-
-		connect(missDialog, &OBSMissingFiles::finished, close);
 	} else {
 		obs_missing_files_destroy(files);
 	}

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -217,6 +217,7 @@ private:
 	QPointer<OBSBasicFilters> filters;
 	QPointer<QDockWidget> statsDock;
 	QPointer<OBSAbout> about;
+	QPointer<OBSMissingFiles> missDialog;
 
 	OBSLogViewer *logView = nullptr;
 
@@ -485,8 +486,6 @@ private:
 	QList<QDialog *> visDialogs;
 	QList<QDialog *> modalDialogs;
 	QList<QMessageBox *> visMsgBoxes;
-
-	OBSMissingFiles *missDialog;
 
 	QList<QPoint> visDlgPositions;
 


### PR DESCRIPTION
### Description
A crash would occur when clicking the 'x' button in the missing files
dialog. This seemed to only happen in debug mode and using QT 5.15.0.

Closes #4363
Fixes #4359

### Motivation and Context
Fixes crash that I found.

### How Has This Been Tested?
Closed the dialog and made sure it didn't crash.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
