### PR TITLE
obs-transitions: Track Matte fixes for Source Visibility transitions

### DIFF
--- a/plugins/obs-transitions/transition-stinger.c
+++ b/plugins/obs-transitions/transition-stinger.c
@@ -221,12 +221,8 @@ static void stinger_matte_render(void *data, gs_texture_t *a, gs_texture_t *b,
 	// Track matte media render
 	gs_texrender_reset(s->matte_tex);
 	if (matte_cx > 0 && matte_cy > 0) {
-		float scale_x = (float)cx / matte_cx;
-		float scale_y = (float)cy / matte_cy;
-
 		if (gs_texrender_begin(s->matte_tex, cx, cy)) {
 			gs_matrix_push();
-			gs_matrix_scale3f(scale_x, scale_y, 1.0f);
 			gs_matrix_translate3f(width_offset, height_offset,
 					      0.0f);
 			gs_clear(GS_CLEAR_COLOR, &background, 0.0f, 0);

--- a/plugins/obs-transitions/transition-stinger.c
+++ b/plugins/obs-transitions/transition-stinger.c
@@ -40,7 +40,8 @@ struct stinger_info {
 	gs_eparam_t *ep_matte_tex;
 	gs_eparam_t *ep_invert_matte;
 
-	gs_texrender_t *matte_tex;
+	gs_texrender_t *matte_texrender;
+	gs_texrender_t *stinger_texrender;
 
 	float (*mix_a)(void *data, float t);
 	float (*mix_b)(void *data, float t);
@@ -169,7 +170,8 @@ static void *stinger_create(obs_data_t *settings, obs_source_t *source)
 	s->ep_invert_matte =
 		gs_effect_get_param_by_name(s->matte_effect, "invert_matte");
 
-	s->matte_tex = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+	s->matte_texrender = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+	s->stinger_texrender = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
 
 	obs_transition_enable_fixed(s->source, true, 0);
 	obs_source_update(source, settings);
@@ -182,7 +184,8 @@ static void stinger_destroy(void *data)
 	obs_source_release(s->media_source);
 	obs_source_release(s->matte_source);
 
-	gs_texrender_destroy(s->matte_tex);
+	gs_texrender_destroy(s->stinger_texrender);
+	gs_texrender_destroy(s->matte_texrender);
 
 	gs_effect_destroy(s->matte_effect);
 
@@ -219,9 +222,9 @@ static void stinger_matte_render(void *data, gs_texture_t *a, gs_texture_t *b,
 		(s->matte_layout == MATTE_LAYOUT_VERTICAL ? (-matte_cy) : 0.0f);
 
 	// Track matte media render
-	gs_texrender_reset(s->matte_tex);
+	gs_texrender_reset(s->matte_texrender);
 	if (matte_cx > 0 && matte_cy > 0) {
-		if (gs_texrender_begin(s->matte_tex, cx, cy)) {
+		if (gs_texrender_begin(s->matte_texrender, cx, cy)) {
 			gs_matrix_push();
 			gs_matrix_translate3f(width_offset, height_offset,
 					      0.0f);
@@ -229,14 +232,14 @@ static void stinger_matte_render(void *data, gs_texture_t *a, gs_texture_t *b,
 			obs_source_video_render(matte_source);
 			gs_matrix_pop();
 
-			gs_texrender_end(s->matte_tex);
+			gs_texrender_end(s->matte_texrender);
 		}
 	}
 
 	gs_effect_set_texture(s->ep_a_tex, a);
 	gs_effect_set_texture(s->ep_b_tex, b);
 	gs_effect_set_texture(s->ep_matte_tex,
-			      gs_texrender_get_texture(s->matte_tex));
+			      gs_texrender_get_texture(s->matte_texrender));
 	gs_effect_set_bool(s->ep_invert_matte, s->invert_matte);
 
 	while (gs_effect_loop(s->matte_effect, "StingerMatte"))
@@ -265,8 +268,8 @@ static void stinger_video_render(void *data, gs_effect_t *effect)
 
 	/* --------------------- */
 
-	float source_cx = (float)obs_source_get_width(s->source);
-	float source_cy = (float)obs_source_get_height(s->source);
+	float cx = (float)obs_source_get_width(s->source);
+	float cy = (float)obs_source_get_height(s->source);
 
 	uint32_t media_cx = obs_source_get_width(s->media_source);
 	uint32_t media_cy = obs_source_get_height(s->media_source);
@@ -276,20 +279,36 @@ static void stinger_video_render(void *data, gs_effect_t *effect)
 
 	float scale_x, scale_y;
 	if (s->track_matte_enabled) {
-		scale_x = source_cx / ((float)media_cx / s->matte_width_factor);
-		scale_y =
-			source_cy / ((float)media_cy / s->matte_height_factor);
+		scale_x = cx / ((float)media_cx / s->matte_width_factor);
+		scale_y = cy / ((float)media_cy / s->matte_height_factor);
 	} else {
-		scale_x = source_cx / (float)media_cx;
-		scale_y = source_cy / (float)media_cy;
+		scale_x = cx / (float)media_cx;
+		scale_y = cy / (float)media_cy;
 	}
 
-	gs_matrix_push();
-	gs_matrix_scale3f(scale_x, scale_y, 1.0f);
-	obs_source_video_render(s->media_source);
-	gs_matrix_pop();
+	// rendering the stinger media in an intermediary texture with the same size
+	// as the transition itself ensures that stacked and side-by-side files used with
+	// the Track Matte mode will only show their stinger side, and crop out the matte side
+	// of the texture
+	gs_texrender_reset(s->stinger_texrender);
+	if (gs_texrender_begin(s->stinger_texrender, cx, cy)) {
+		struct vec4 background;
+		vec4_zero(&background);
+		gs_clear(GS_CLEAR_COLOR, &background, 0.0f, 0);
 
-	UNUSED_PARAMETER(effect);
+		obs_source_video_render(s->media_source);
+
+		gs_texrender_end(s->stinger_texrender);
+	}
+
+	gs_texture_t *stinger_tex =
+		gs_texrender_get_texture(s->stinger_texrender);
+	if (stinger_tex) {
+		effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+		while (gs_effect_loop(effect, "Draw")) {
+			obs_source_draw(stinger_tex, 0, 0, 0, 0, false);
+		}
+	}
 }
 
 static inline float calc_fade(float t, float mul)


### PR DESCRIPTION
### Description

- When resolutions on the source and stinger don't match, the Matte texture is rescaled before being provided to the Matte shader. This results in a Matte smaller than the textures it is supposed to cover
- When using a Track Matte Stinger as a visibility transition, side-by-side and stacked file modes will render the full texture (both the stinger side and the matte side) instead of cropping it to only show the stinger side.

### Motivation and Context

Fixes this: https://obsproject.com/forum/threads/obs-studio-27-release-candidate.141857/page-2#post-522508

### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on Windows 10 20H2, with a 1920x1080 Track Matte Stinger running as the visibility transition of a 1024x768 source (either an image or a video).

### Types of changes

- Bug fix (non-breaking change which fixes an issue) -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
