### PR TITLE
UI: Fix invalid check for Remove Multiple Sources dialog result

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5524,7 +5524,7 @@ void OBSBasic::on_actionRemoveSource_triggered()
 		remove_items.setWindowTitle(QTStr("ConfirmRemove.Title"));
 		remove_items.exec();
 
-		confirmed = remove_items.clickedButton();
+		confirmed = Yes == remove_items.clickedButton();
 	} else {
 		OBSSceneItem &item = items[0];
 		obs_source_t *source = obs_sceneitem_get_source(item);


### PR DESCRIPTION
### Description

When Undo/Redo was added, this comparison was accidentally removed. The resulting conditional would always return true, causing sources to be deleted unintentionally.


### Motivation and Context

Fixes #4546

### How Has This Been Tested?
Click "No" when deleting multiple sources

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
