### PR TITLE
Make VirtualCam work with Flatpak

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -14,6 +14,7 @@
     "--filesystem=xdg-run/pipewire-0",
     "--filesystem=host",
     "--talk-name=org.kde.StatusNotifierWatcher",
+    "--talk-name=org.freedesktop.Flatpak",
     "--talk-name=org.freedesktop.ScreenSaver",
     "--talk-name=org.freedesktop.PowerManagement.Inhibit",
     "--talk-name=org.freedesktop.Notifications",


### PR DESCRIPTION

### Description

It is not possible to run host system executables like modinfo, pkexec, and modprobe inside a Flatpak sandbox. However, Flatpak provides a way to run command on the host system: the flatpak-spawn executable.

flatpak-spawn is a tiny helper that, when executed with the '--host' parameter, talks to the org.freedesktop.Flatpak D-Bus interface to run and retrieve the return value of the executable. This provides OBS Studio a way to escape this sandbox limitation without opening large holes in the sandbox.

Make v4l2's implementation of VirtualCam run system commands using flatpak-spawn when inside a Flatpak sandbox. The detection of the sandbox is done by checking the existence of the /.flatpak-info file, which is created by Flatpak itself, and only exists inside the sandbox. If OBS Studio is not running inside a Flatpak sandbox, run the exact same command it used to run before this commit.

Add the permission to talk to the org.freedesktop.Flatpak D-Bus interface to the Flatpak manifest, so we can run flatpak-spawn with the '--host' parameter.

Notice that the same constraints apply with and without Flatpak: the host system needs to have the v4l2loopback kernel module available for the v4l2 implementation of VirtualCam to work.

### Motivation and Context

VirtualCam is an important feature, and making it work properly with Flatpak will impact many (dozens of thousands, according to Flatpak) users. It also gets us closer to complete feature-parity between Flatpak and host system OBS Studio.

### How Has This Been Tested?

 - Have `v4l2loopback` installed on your host system
 -  Run this PR of OBS Studio using Flatpak (the Flatpak CI workflow artifact is enough)
 - Try to create and feed a VirtualCam

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
