### PR TITLE
Enable browser source for real in Flatpak

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -259,8 +259,7 @@
         "-DUSE_XDG=ON",
         "-DDISABLE_ALSA=ON",
         "-DENABLE_PULSEAUDIO=ON",
-        "-DWITH_RTMPS=ON",
-        "-DBUILD_BROWSER=OFF"
+        "-DWITH_RTMPS=ON"
       ],
       "sources": [
         {

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -140,7 +140,8 @@
       "no-autogen": true,
       "cleanup": [
         "/bin",
-        "/include"
+        "/include",
+        "*.a"
       ],
       "sources": [
         {
@@ -236,6 +237,7 @@
         "cp -R ./libcef_dll_wrapper/libcef_dll_wrapper.a /app/cef/libcef_dll_wrapper"
       ],
       "cleanup": [
+        "*.a",
         "./*"
       ],
       "sources": [


### PR DESCRIPTION
### Description

Actually really enable the browser source in the Flatpak manifest.

### Motivation and Context

Due to an unfortunate series of events, we ended up with both `-DBUILD_BROWSER=ON` **and** `-DBUILD_BROWSER=OFF` in the Flatpak manifest, which was effectively disabling the browser source even after https://github.com/obsproject/obs-studio/pull/4431 landed.

### How Has This Been Tested?

 - Download the Flatpak bundle generated by the "Flatpak (experimental)" workflow
 - Try and add the browser source - it must be at least available

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)
 - Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
