### PR TITLE
CI: Run Flatpak Build on GitHub labeled event

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths-ignore: ['**.md']
     branches: [master]
+    types: [labeled, opened, reopened, synchronize]
 
 jobs:
   flatpak_builder:
@@ -16,8 +17,8 @@ jobs:
       image: bilelmoussaoui/flatpak-github-actions:kde-5.15
       options: --privileged
     steps:
-    - name: 'Check for Github Labels'
-      if: github.event_name == 'pull_request'
+    - name: 'PR: Check for Github Labels'
+      if: github.event_name == 'pull_request' && github.event.action != 'labeled'
       shell: bash
       run: |
         LABELS_URL="$(echo ${{ github.event.pull_request.url }} | sed s'/pulls/issues/')"
@@ -27,6 +28,12 @@ jobs:
         else
           echo "SEEKING_TESTERS=0" >> $GITHUB_ENV
         fi
+
+    - name: 'PR: Check if specific label got applied'
+      if: env.SEEKING_TESTERS == '0' && github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'Seeking Testers'
+      shell: bash
+      run: |
+        echo "SEEKING_TESTERS=1" >> $GITHUB_ENV
 
     - name: Checkout
       uses: actions/checkout@v2.3.3


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Makes the "Flatpack (Experimental)" build automatically rerun when the
label "Seeking Testers" is added to a pull request.

The task will be skipped on other labels. The default pull_request types
are kept.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
To run the Flatpack Build after adding the "Seeking Testers" label, the workflow had to be rerun, which is an additional two clicks and not very convenient.
Now, when adding the label, the workflow should automatically rerun. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Committed to my own master branch and started a PR to it, as usual the workflow was mostly skipped.
After adding the label, it was automatically restarted and started building.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
^ I think I'd put it there, not sure to be honest

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
