### PR TITLE
Decklink: Convert to frame scheduling and use preroll [DRAFT]

### DIFF
--- a/plugins/decklink/decklink-device-mode.cpp
+++ b/plugins/decklink/decklink-device-mode.cpp
@@ -24,6 +24,11 @@ DeckLinkDeviceMode::~DeckLinkDeviceMode(void)
 		mode->Release();
 }
 
+void DeckLinkDeviceMode::GetFrameRate (BMDTimeValue *frameDuration, BMDTimeScale *timeScale)
+{
+	mode->GetFrameRate(frameDuration, timeScale);
+}
+
 BMDDisplayMode DeckLinkDeviceMode::GetDisplayMode(void) const
 {
 	if (mode != nullptr)

--- a/plugins/decklink/decklink-device-mode.hpp
+++ b/plugins/decklink/decklink-device-mode.hpp
@@ -17,6 +17,7 @@ public:
 	DeckLinkDeviceMode(const std::string &name, long long id);
 	virtual ~DeckLinkDeviceMode(void);
 
+	void GetFrameRate(BMDTimeValue *frameDuration, BMDTimeScale *timeScale);
 	BMDDisplayMode GetDisplayMode(void) const;
 	BMDDisplayModeFlags GetDisplayModeFlags(void) const;
 	long long GetId(void) const;

--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -121,49 +121,14 @@ static void decklink_output_raw_video(void *data, struct video_data *frame)
 	decklink->DisplayVideoFrame(frame);
 }
 
-static bool prepare_audio(DeckLinkOutput *decklink,
-			  const struct audio_data *frame,
-			  struct audio_data *output)
-{
-	*output = *frame;
-
-	if (frame->timestamp < decklink->start_timestamp) {
-		uint64_t duration = util_mul_div64(frame->frames, 1000000000ULL,
-						   decklink->audio_samplerate);
-		uint64_t end_ts = frame->timestamp + duration;
-		uint64_t cutoff;
-
-		if (end_ts <= decklink->start_timestamp)
-			return false;
-
-		cutoff = decklink->start_timestamp - frame->timestamp;
-		output->timestamp += cutoff;
-
-		cutoff = util_mul_div64(cutoff, decklink->audio_samplerate,
-					1000000000ULL);
-
-		for (size_t i = 0; i < decklink->audio_planes; i++)
-			output->data[i] +=
-				decklink->audio_size * (uint32_t)cutoff;
-
-		output->frames -= (uint32_t)cutoff;
-	}
-
-	return true;
-}
-
 static void decklink_output_raw_audio(void *data, struct audio_data *frames)
 {
 	auto *decklink = (DeckLinkOutput *)data;
-	struct audio_data in;
 
 	if (!decklink->start_timestamp)
 		return;
 
-	if (!prepare_audio(decklink, frames, &in))
-		return;
-
-	decklink->WriteAudio(&in);
+	decklink->WriteAudio(frames);
 }
 
 static bool decklink_output_device_changed(obs_properties_t *props,


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
**This PR is a draft. I am using it to produce test builds for windows.**

**Changes:**
- Switches decklink output to the Decklink SDK's frame scheduling system instead of synchronous frame writing
- Audio packets are now written to the buffer synchronously, to avoid samples being dropped.
- Implemented av preroll to fill the buffer before starting playout.
- Compared to #1865, this fills the video frame buffer according to an explicit number of frames instead of time.

**Current Issues:**
- After a few minutes, decklink starts reporting frames as `bmdOutputFrameDisplayedLate`, however frames are never actually dropped by decklink.
- After a few hours, OBS appears to start dropping frames. I have not figured out why, but decklink does not report any dropped frames still.

**Fixed Issues:**
- Audio and video now stay perfectly synced with each other. Tested for almost 6 hours yesterday. Neither of the above issues affect synchronization.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The current decklink output implementation synchronously writes data to decklink. The correct method is to schedule frames with timestamps, and let decklink handle writing the scheduled frames. This PR uses reference from #1865, with additional fixes and changes that I've made during my own testing process.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I run an AV sync test on loop on a media source, outputting via a Decklink Duo 2 to a display. Measuring sync with my phone's slow motion recording.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
