### PR TITLE
decklink: Don't show incompatible formats in Decklink output window

### DIFF
--- a/plugins/decklink/decklink-device-mode.cpp
+++ b/plugins/decklink/decklink-device-mode.cpp
@@ -66,6 +66,24 @@ const std::string &DeckLinkDeviceMode::GetName(void) const
 	return name;
 }
 
+bool DeckLinkDeviceMode::IsEqualFrameRate(int64_t num, int64_t den)
+{
+	if (!mode)
+		return false;
+
+	BMDTimeValue timeValue;
+	BMDTimeScale timeScale;
+	if (mode->GetFrameRate(&timeValue, &timeScale) != S_OK)
+		return false;
+
+	// Calculate greatest common divisor of both values to properly compare framerates
+	int decklinkGcd = std::gcd(timeScale, timeValue);
+	int inputGcd = std::gcd(num, den);
+
+	return ((timeScale / decklinkGcd) == (num / inputGcd) &&
+		(timeValue / decklinkGcd) == (den / inputGcd));
+}
+
 void DeckLinkDeviceMode::SetMode(IDeckLinkDisplayMode *mode_)
 {
 	IDeckLinkDisplayMode *old = mode;

--- a/plugins/decklink/decklink-device-mode.hpp
+++ b/plugins/decklink/decklink-device-mode.hpp
@@ -3,6 +3,7 @@
 #include "platform.hpp"
 
 #include <string>
+#include <numeric>
 
 #define MODE_ID_AUTO -1
 
@@ -21,6 +22,7 @@ public:
 	BMDDisplayModeFlags GetDisplayModeFlags(void) const;
 	long long GetId(void) const;
 	const std::string &GetName(void) const;
+	bool IsEqualFrameRate(int64_t num, int64_t den);
 
 	void SetMode(IDeckLinkDisplayMode *mode);
 

--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -66,6 +66,18 @@ static bool decklink_output_start(void *data)
 
 	DeckLinkDeviceMode *mode = device->FindOutputMode(decklink->modeID);
 
+	struct obs_video_info ovi;
+	if (!obs_get_video_info(&ovi)) {
+		LOG(LOG_ERROR,
+		    "Start failed: could not retrieve obs_video_info!");
+		return false;
+	}
+
+	if (!mode->IsEqualFrameRate(ovi.fps_num, ovi.fps_den)) {
+		LOG(LOG_ERROR, "Start failed: FPS mismatch!");
+		return false;
+	}
+
 	decklink->SetSize(mode->GetWidth(), mode->GetHeight());
 
 	struct video_scale_info to = {};
@@ -208,10 +220,17 @@ static bool decklink_output_device_changed(obs_properties_t *props,
 		const std::vector<DeckLinkDeviceMode *> &modes =
 			device->GetOutputModes();
 
-		for (DeckLinkDeviceMode *mode : modes) {
-			obs_property_list_add_int(modeList,
-						  mode->GetName().c_str(),
-						  mode->GetId());
+		struct obs_video_info ovi;
+		if (obs_get_video_info(&ovi)) {
+			for (DeckLinkDeviceMode *mode : modes) {
+				if (mode->IsEqualFrameRate(ovi.fps_num,
+							   ovi.fps_den)) {
+					obs_property_list_add_int(
+						modeList,
+						mode->GetName().c_str(),
+						mode->GetId());
+				}
+			}
 		}
 
 		obs_property_list_add_int(keyerList, "Disabled", 0);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
- Changes the formats dropdown for Decklink output to only show formats using the same framerate as OBS does.
- Prevents the output from starting if the configured Decklink output FPS differs from the current OBS FPS.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
OBS cannot perform framerate conversions, meaning that if OBS's framerate is set to 45fps, and decklink output is set to 60fps, the output will either lag heavily or simply not function.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Changed OBS's framerate, opened the Decklink output dialog. It only shows compatible rates.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
