### PR TITLE
linux-capture: Add partial window title matching as fallback

### DIFF
--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -245,6 +245,8 @@ static Window getWindowFromString(std::string wstr)
 		}
 	}
 
+	Window nextWin = -1;
+
 	// then try to find a match by name & class
 	for (Window cwin : XCompcap::getTopLevelWindows()) {
 		std::string cwinname = XCompcap::getWindowName(cwin);
@@ -253,7 +255,18 @@ static Window getWindowFromString(std::string wstr)
 		// match by name and class
 		if (wname == cwinname && wcls == ccls) {
 			return cwin;
+		} else if (wcls == ccls &&
+			   (cwinname.find(wname) != std::string::npos)) {
+			// keep track of first window of same class and partial title match
+			if (nextWin == -1) {
+				nextWin = cwin;
+			}
 		}
+	}
+
+	if (nextWin != -1) {
+		// choose first window of same class and partial title match
+		return nextWin;
 	}
 
 	// no match


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a fallback for window capturing. If all the existing window matching criteria are not met, the linux-capture plugin will attempt to choose the next window of the same window class with a partially matching window title.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Previously windows were first captured by id and then by window name as long as the window is of the same window class. This does not account for applications such as Zoom whose window ids and window names change such as when moving between breakout rooms. In these cases, the linux-capture plugin will fail to capture the window. This has been accounted for by falling back to choosing the next window of the same class whose title partially matches if such a window exists.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This has been tested on Kubuntu 20.04 with Zoom specifically whose window ids and window titles change when moving between different breakout rooms in the same meeting. The previous lines of code that handled window matching are unaffected as the code added only acts as a fallback in the case where a window cannot be found by the existing matching methods.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
