### PR TITLE
Switch transition interpolation back to nonlinear SRGB

### DIFF
--- a/plugins/obs-transitions/data/fade_to_color_transition.effect
+++ b/plugins/obs-transitions/data/fade_to_color_transition.effect
@@ -24,7 +24,8 @@ VertData VSDefault(VertData v_in)
 
 float4 PSFadeToColor(VertData v_in) : TARGET
 {
-	return lerp(tex.Sample(textureSampler, v_in.uv), color, swp);
+	float4 premultiplied = float4(color.rgb * color.a, color.a);
+	return lerp(tex.Sample(textureSampler, v_in.uv), premultiplied, swp);
 }
 
 technique FadeToColor

--- a/plugins/obs-transitions/transition-fade-to-color.c
+++ b/plugins/obs-transitions/transition-fade-to-color.c
@@ -52,7 +52,7 @@ static void fade_to_color_update(void *data, obs_data_t *settings)
 
 	color |= 0xFF000000;
 
-	vec4_from_rgba_srgb_premultiply(&fade_to_color->color, color);
+	vec4_from_rgba(&fade_to_color->color, color);
 
 	fade_to_color->switch_point = (float)swp / 100.0f;
 }
@@ -105,19 +105,13 @@ static void fade_to_color_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 
 	float swp = t < fade_to_color->switch_point ? sa : 1.0f - sb;
 
-	gs_texture_t *const tex = (t < fade_to_color->switch_point) ? a : b;
-
-	const bool previous = gs_framebuffer_srgb_enabled();
-	gs_enable_framebuffer_srgb(true);
-
-	gs_effect_set_texture_srgb(fade_to_color->ep_tex, tex);
-	gs_effect_set_vec4(fade_to_color->ep_color, &fade_to_color->color);
+	gs_effect_set_texture(fade_to_color->ep_tex,
+			      t < fade_to_color->switch_point ? a : b);
 	gs_effect_set_float(fade_to_color->ep_swp, swp);
+	gs_effect_set_vec4(fade_to_color->ep_color, &fade_to_color->color);
 
 	while (gs_effect_loop(fade_to_color->effect, "FadeToColor"))
 		gs_draw_sprite(NULL, 0, cx, cy);
-
-	gs_enable_framebuffer_srgb(previous);
 }
 
 static void fade_to_color_video_render(void *data, gs_effect_t *effect)

--- a/plugins/obs-transitions/transition-fade.c
+++ b/plugins/obs-transitions/transition-fade.c
@@ -53,17 +53,12 @@ static void fade_callback(void *data, gs_texture_t *a, gs_texture_t *b, float t,
 {
 	struct fade_info *fade = data;
 
-	const bool previous = gs_framebuffer_srgb_enabled();
-	gs_enable_framebuffer_srgb(true);
-
-	gs_effect_set_texture_srgb(fade->a_param, a);
-	gs_effect_set_texture_srgb(fade->b_param, b);
+	gs_effect_set_texture(fade->a_param, a);
+	gs_effect_set_texture(fade->b_param, b);
 	gs_effect_set_float(fade->fade_param, t);
 
 	while (gs_effect_loop(fade->effect, "Fade"))
 		gs_draw_sprite(NULL, 0, cx, cy);
-
-	gs_enable_framebuffer_srgb(previous);
 }
 
 static void fade_video_render(void *data, gs_effect_t *effect)

--- a/plugins/obs-transitions/transition-luma-wipe.c
+++ b/plugins/obs-transitions/transition-luma-wipe.c
@@ -165,11 +165,8 @@ static void luma_wipe_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 {
 	struct luma_wipe_info *lwipe = data;
 
-	const bool previous = gs_framebuffer_srgb_enabled();
-	gs_enable_framebuffer_srgb(true);
-
-	gs_effect_set_texture_srgb(lwipe->ep_a_tex, a);
-	gs_effect_set_texture_srgb(lwipe->ep_b_tex, b);
+	gs_effect_set_texture(lwipe->ep_a_tex, a);
+	gs_effect_set_texture(lwipe->ep_b_tex, b);
 	gs_effect_set_texture(lwipe->ep_l_tex, lwipe->luma_image.texture);
 	gs_effect_set_float(lwipe->ep_progress, t);
 
@@ -178,8 +175,6 @@ static void luma_wipe_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 
 	while (gs_effect_loop(lwipe->effect, "LumaWipe"))
 		gs_draw_sprite(NULL, 0, cx, cy);
-
-	gs_enable_framebuffer_srgb(previous);
 }
 
 void luma_wipe_video_render(void *data, gs_effect_t *effect)

--- a/plugins/obs-transitions/transition-slide.c
+++ b/plugins/obs-transitions/transition-slide.c
@@ -93,26 +93,14 @@ static void slide_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 	vec2_mulf(&tex_a_dir, &tex_a_dir, t);
 	vec2_mulf(&tex_b_dir, &tex_b_dir, 1.0f - t);
 
-	const bool linear_srgb = gs_get_linear_srgb();
-
-	const bool previous = gs_framebuffer_srgb_enabled();
-	gs_enable_framebuffer_srgb(linear_srgb);
-
-	if (linear_srgb) {
-		gs_effect_set_texture_srgb(slide->a_param, a);
-		gs_effect_set_texture_srgb(slide->b_param, b);
-	} else {
-		gs_effect_set_texture(slide->a_param, a);
-		gs_effect_set_texture(slide->b_param, b);
-	}
+	gs_effect_set_texture(slide->a_param, a);
+	gs_effect_set_texture(slide->b_param, b);
 
 	gs_effect_set_vec2(slide->tex_a_dir_param, &tex_a_dir);
 	gs_effect_set_vec2(slide->tex_b_dir_param, &tex_b_dir);
 
 	while (gs_effect_loop(slide->effect, "Slide"))
 		gs_draw_sprite(NULL, 0, cx, cy);
-
-	gs_enable_framebuffer_srgb(previous);
 }
 
 void slide_video_render(void *data, gs_effect_t *effect)

--- a/plugins/obs-transitions/transition-swipe.c
+++ b/plugins/obs-transitions/transition-swipe.c
@@ -88,26 +88,12 @@ static void swipe_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 
 	vec2_mulf(&swipe_val, &swipe_val, swipe->swipe_in ? 1.0f - t : t);
 
-	const bool linear_srgb = gs_get_linear_srgb();
-
-	const bool previous = gs_framebuffer_srgb_enabled();
-	gs_enable_framebuffer_srgb(linear_srgb);
-
-	gs_texture_t *t0 = swipe->swipe_in ? b : a;
-	gs_texture_t *t1 = swipe->swipe_in ? a : b;
-	if (linear_srgb) {
-		gs_effect_set_texture_srgb(swipe->a_param, t0);
-		gs_effect_set_texture_srgb(swipe->b_param, t1);
-	} else {
-		gs_effect_set_texture(swipe->a_param, t0);
-		gs_effect_set_texture(swipe->b_param, t1);
-	}
+	gs_effect_set_texture(swipe->a_param, swipe->swipe_in ? b : a);
+	gs_effect_set_texture(swipe->b_param, swipe->swipe_in ? a : b);
 	gs_effect_set_vec2(swipe->swipe_param, &swipe_val);
 
 	while (gs_effect_loop(swipe->effect, "Swipe"))
 		gs_draw_sprite(NULL, 0, cx, cy);
-
-	gs_enable_framebuffer_srgb(previous);
 }
 
 static void swipe_video_render(void *data, gs_effect_t *effect)


### PR DESCRIPTION
### Description
Transitions were updated to be color linear, but that's not always what we want.

### Motivation and Context
Nonlinear and linear both have issues, but people are used to nonlinear, so switch back. Maybe we'll switch to CIELUV if we stop caring about performance on bad GPUs.

### How Has This Been Tested?
Checked that the transitions still work.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.