### PR TITLE
UI: Fix crash on *nix caused by OBSQTDisplay destruction after draw surface invalidation

### DIFF
--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -90,9 +90,8 @@ OBSQTDisplay::OBSQTDisplay(QWidget *parent, Qt::WindowFlags flags)
 
 	auto windowVisible = [this](bool visible) {
 		if (!visible) {
-#ifdef ENABLE_WAYLAND
-			if (obs_get_nix_platform() == OBS_NIX_PLATFORM_WAYLAND)
-				display = nullptr;
+#if !defined(_WIN32) && !defined(__APPLE__)
+			display = nullptr;
 #endif
 			return;
 		}


### PR DESCRIPTION
### Description
Deletes the underlying `obs_display_t` object when the window draw surface is destroyed (X11 and Wayland), preventing OBS from attempting to switch to invalid GLX context on draw.

Closes #4185

### Motivation and Context
Currently: This issue is mainly caused by the behavior of Qt's `DeleteLater`. When a window using OBSQTDisplay is closed, there is an indeterminate delay until the Qt object for it is deleted, allowing for a race.

With this: The `OBSQTDisplay` object is deleted before the draw surface is, preventing the race condition. No longer reports *any* X errors, let alone crashes.

### How Has This Been Tested?
This issue can be most easily reproduced by doing:
- Open OBS
- Open the filters dialog of a playing source
- Close the dialog via the x in the top right corner (Not the `Close` button)
Expect X errors to be logged, and if lucky enough, a crash. It varies system to system, but if you have the bug (like me), it's usually very easy to reproduce.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
