### PR TITLE
UI: Cleanup on_scenes_currentItemChanged function

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4694,21 +4694,10 @@ void OBSBasic::AdvAudioPropsDestroyed()
 void OBSBasic::on_scenes_currentItemChanged(QListWidgetItem *current,
 					    QListWidgetItem *prev)
 {
-	obs_source_t *source = NULL;
-
 	if (current) {
-		obs_scene_t *scene;
-
-		scene = GetOBSRef<OBSScene>(current);
-		source = obs_scene_get_source(scene);
+		OBSScene scene = GetOBSRef<OBSScene>(current);
+		SetCurrentScene(scene);
 	}
-
-	SetCurrentScene(source);
-
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
-
-	UpdateContextBar();
 
 	UNUSED_PARAMETER(prev);
 }


### PR DESCRIPTION
### Description
Removed unnecessary lines from the function. Also if the source happened to be
null, the SetCurrentScene function would be called anyway. Finally, the
UpdateContextBar and api lines were removed, as they are also being called with
SetCurrentScene.

### Motivation and Context
Cleaning up messy code.

### How Has This Been Tested?
Switched scenes to make sure nothing changed.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
