### PR TITLE
text-freetype2: Render in nonlinear space

### DIFF
--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -248,7 +248,7 @@ static void ft2_source_render(void *data, gs_effect_t *effect)
 	if (srcdata->text == NULL || *srcdata->text == 0)
 		return;
 
-	const bool previous = gs_set_linear_srgb(true);
+	const bool previous = gs_set_linear_srgb(false);
 
 	gs_reset_blend_state();
 	if (srcdata->outline_text)


### PR DESCRIPTION
### Description
Colors not working properly. Don't want to alter gradients (yet).

### Motivation and Context
Colors should work. Also don't want linear vs. nonlinear gradient discussion.

### How Has This Been Tested?
Colors work now.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.