### PR TITLE
Apply alpha in nonlinear space for images and async video

### DIFF
--- a/libobs/data/default.effect
+++ b/libobs/data/default.effect
@@ -33,6 +33,35 @@ float4 PSDrawAlphaDivide(VertInOut vert_in) : TARGET
 	return float4(rgba.rgb * multiplier, alpha);
 }
 
+float srgb_linear_to_nonlinear_channel(float u)
+{
+	return (u <= 0.0031308) ? (12.92 * u) : ((1.055 * pow(u, 1.0 / 2.4)) - 0.055);
+}
+
+float3 srgb_linear_to_nonlinear(float3 v)
+{
+	return float3(srgb_linear_to_nonlinear_channel(v.r), srgb_linear_to_nonlinear_channel(v.g), srgb_linear_to_nonlinear_channel(v.b));
+}
+
+float srgb_nonlinear_to_linear_channel(float u)
+{
+	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
+}
+
+float3 srgb_nonlinear_to_linear(float3 v)
+{
+	return float3(srgb_nonlinear_to_linear_channel(v.r), srgb_nonlinear_to_linear_channel(v.g), srgb_nonlinear_to_linear_channel(v.b));
+}
+
+float4 PSDrawNonlinearAlpha(VertInOut vert_in) : TARGET
+{
+	float4 rgba = image.Sample(def_sampler, vert_in.uv);
+	rgba.rgb = srgb_linear_to_nonlinear(rgba.rgb);
+	rgba.rgb *= rgba.a;
+	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
+	return rgba;
+}
+
 technique Draw
 {
 	pass
@@ -48,5 +77,14 @@ technique DrawAlphaDivide
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawAlphaDivide(vert_in);
+	}
+}
+
+technique DrawNonlinearAlpha
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawNonlinearAlpha(vert_in);
 	}
 }

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3701,10 +3701,11 @@ bool obs_source_process_filter_begin(obs_source_t *filter,
 		filter->filter_texrender =
 			gs_texrender_create(format, GS_ZS_NONE);
 
-	gs_blend_state_push();
-	gs_blend_function(GS_BLEND_ONE, GS_BLEND_ZERO);
-
 	if (gs_texrender_begin(filter->filter_texrender, cx, cy)) {
+		gs_blend_state_push();
+		gs_blend_function_separate(GS_BLEND_SRCALPHA, GS_BLEND_ZERO,
+					   GS_BLEND_ONE, GS_BLEND_ZERO);
+
 		bool custom_draw = (parent_flags & OBS_SOURCE_CUSTOM_DRAW) != 0;
 		bool async = (parent_flags & OBS_SOURCE_ASYNC) != 0;
 		struct vec4 clear_color;
@@ -3718,10 +3719,10 @@ bool obs_source_process_filter_begin(obs_source_t *filter,
 		else
 			obs_source_video_render(target);
 
+		gs_blend_state_pop();
+
 		gs_texrender_end(filter->filter_texrender);
 	}
-
-	gs_blend_state_pop();
 	return true;
 }
 
@@ -3748,6 +3749,9 @@ static void obs_source_process_filter_tech_end_internal(
 
 	const char *tech = tech_name ? tech_name : "Draw";
 
+	gs_blend_state_push();
+	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+
 	if (can_bypass(target, parent, parent_flags, filter->allow_direct)) {
 		render_filter_bypass(target, effect, tech);
 	} else {
@@ -3756,6 +3760,8 @@ static void obs_source_process_filter_tech_end_internal(
 			render_filter_tex(texture, effect, width, height, tech);
 		}
 	}
+
+	gs_blend_state_pop();
 
 	gs_set_linear_srgb(previous);
 }


### PR DESCRIPTION
### Description
Apply alpha in nonlinear space for compatibility with bad applications.

The image source now needs to be a custom draw, which prevents the direct filter rendering optimization.

We may want to provide a toggle in the future, but just try to match previous behavior for now. v27 has enough new features for support to deal with.

### Motivation and Context
Alpha should be applied in linear space, but most applications do not, including Chromium and Visual Studio.

### How Has This Been Tested?
Used 255/255/255/64 texture in various scenarios.

The shader involved in more complicated, but the performance hit seems manageable:
NVIDIA RTX 2080 Ti: 34 us -> 41 us for 1080p image
Intel UHD Graphics 750: 448 us -> 576 us for 1080p image

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.