### PR TITLE
UI: Fix issues with audio filters and undo/redo

### DIFF
--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -59,6 +59,7 @@ public:
 	{
 		if (update_timer) {
 			update_timer->stop();
+			QMetaObject::invokeMethod(update_timer, "timeout");
 			update_timer->deleteLater();
 			obs_data_release(old_settings_cache);
 		}

--- a/UI/undo-stack-obs.cpp
+++ b/UI/undo-stack-obs.cpp
@@ -116,7 +116,8 @@ void undo_stack::enable_undo_redo()
 	last_is_repeatable = false;
 
 	ui->actionMainUndo->setDisabled(false);
-	ui->actionMainRedo->setDisabled(false);
+	if (redo_items.size() > 0)
+		ui->actionMainRedo->setDisabled(false);
 }
 
 void undo_stack::disable_undo_redo()

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -71,6 +71,8 @@ private:
 
 	void FilterNameEdited(QWidget *editor, QListWidget *list);
 
+	void delete_filter(OBSSource filter);
+
 	bool isAsync;
 
 	int noPreviewMargin;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This PR includes 3 commits that fix 3 distinct issues coming from the audio filters. First, if audio filters were changed (and probably filters in general, but I did not check), it would enable the redo option, even though there was no redo action available. Secondly, audio filters were not being added to the undo stack once they were deleted. Third, the changes to audio filters (at least dropdown selections) were not being added to the undo stack.

### Motivation and Context
Fixes audio filters issues.

### How Has This Been Tested?
Tested this on my machine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
