### PR TITLE
obs-filters: Fix bad math in Color Key v1

### DIFF
--- a/plugins/obs-filters/data/color_key_filter.effect
+++ b/plugins/obs-filters/data/color_key_filter.effect
@@ -49,8 +49,9 @@ float4 ProcessColorKey(float4 rgba, VertData v_in)
 
 float4 PSColorKeyRGBA(VertData v_in) : TARGET
 {
-	float4 rgba = image.Sample(textureSampler, v_in.uv) * color;
+	float4 rgba = image.Sample(textureSampler, v_in.uv);
 	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba *= color;
 	return ProcessColorKey(rgba, v_in);
 }
 


### PR DESCRIPTION
### Description
Do not treat incoming color uniform as premultiplied.

### Motivation and Context
Incorrect color expansion was causing hue shifts.

### How Has This Been Tested?
Hue shift no longer occurs.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.