### PR TITLE
UI: Fix Undo/Redo for pasting multiple filters

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -8522,7 +8522,8 @@ void OBSBasic::on_actionPasteFilters_triggered()
 	QString text =
 		QTStr("Undo.Filters.Paste.Multiple").arg(srcName, dstName);
 
-	CreateFilterPasteUndoRedoAction(text, source, undo_array, redo_array);
+	CreateFilterPasteUndoRedoAction(text, dstSource, undo_array,
+					redo_array);
 
 	obs_data_array_release(undo_array);
 	obs_data_array_release(redo_array);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Fixes bug introduced in commit d7e4945eab31983fbe33e7a6b40f4866018c3227

Previously `CreateFilterPasteUndoRedoAction` would get the source which was copied from (source), not the source that was receiving filters (destination). So Undo-Redo would restore the destination's filter state on the source.

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Related to #4562, #4616.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

1. Create empty scene
2. Crate image sources 1 and 2
3. Add "Color correction" filter to 1 and "Scroll" to 2.
4. Right-click source 1 and click "Copy filters"
5. Right-click source 2 and click "Paste filters" (source 2 has color correction and scroll now)
6. Press CTRL+Z and make sure source 2 has only color correction
7. Press CTRL+Y and make sure source 2 has both color correction and scroll

Previously step 6 would be messed up (source 1 would be modified).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
