### PR TITLE
obs-transitions: Remove dead code

### DIFF
--- a/plugins/obs-transitions/transition-stinger.c
+++ b/plugins/obs-transitions/transition-stinger.c
@@ -268,23 +268,14 @@ static void stinger_video_render(void *data, gs_effect_t *effect)
 
 	/* --------------------- */
 
-	float cx = (float)obs_source_get_width(s->source);
-	float cy = (float)obs_source_get_height(s->source);
+	const uint32_t cx = obs_source_get_width(s->source);
+	const uint32_t cy = obs_source_get_height(s->source);
 
-	uint32_t media_cx = obs_source_get_width(s->media_source);
-	uint32_t media_cy = obs_source_get_height(s->media_source);
+	const uint32_t media_cx = obs_source_get_width(s->media_source);
+	const uint32_t media_cy = obs_source_get_height(s->media_source);
 
 	if (!media_cx || !media_cy)
 		return;
-
-	float scale_x, scale_y;
-	if (s->track_matte_enabled) {
-		scale_x = cx / ((float)media_cx / s->matte_width_factor);
-		scale_y = cy / ((float)media_cy / s->matte_height_factor);
-	} else {
-		scale_x = cx / (float)media_cx;
-		scale_y = cy / (float)media_cy;
-	}
 
 	// rendering the stinger media in an intermediary texture with the same size
 	// as the transition itself ensures that stacked and side-by-side files used with


### PR DESCRIPTION
### Description
Remove dead code after #4549.

### Motivation and Context
Was causing warnings when I noticed the variables weren't being used.

### How Has This Been Tested?
Code compiles without warnings.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.