### PR TITLE
UI: Fix rounding truncation

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -393,13 +393,6 @@ void OBSPropertiesView::AddFloat(obs_property_t *prop, QFormLayout *layout,
 	double stepVal = obs_property_float_step(prop);
 	const char *suffix = obs_property_float_suffix(prop);
 
-	spin->setMinimum(minVal);
-	spin->setMaximum(maxVal);
-	spin->setSingleStep(stepVal);
-	spin->setValue(val);
-	spin->setToolTip(QT_UTF8(obs_property_long_description(prop)));
-	spin->setSuffix(QT_UTF8(suffix));
-
 	if (stepVal < 1.0) {
 		int decimals = (int)(log10(1.0 / stepVal) + 0.99);
 		constexpr int sane_limit = 8;
@@ -407,6 +400,13 @@ void OBSPropertiesView::AddFloat(obs_property_t *prop, QFormLayout *layout,
 		if (decimals > spin->decimals())
 			spin->setDecimals(decimals);
 	}
+
+	spin->setMinimum(minVal);
+	spin->setMaximum(maxVal);
+	spin->setSingleStep(stepVal);
+	spin->setValue(val);
+	spin->setToolTip(QT_UTF8(obs_property_long_description(prop)));
+	spin->setSuffix(QT_UTF8(suffix));
 
 	WidgetInfo *info = new WidgetInfo(this, prop, spin);
 	children.emplace_back(info);


### PR DESCRIPTION
### Description
Set decimal places before value on QDoubleSpinBox to preserve precision.

### Motivation and Context
Large precision filter values (Brightness/Opacity) were being truncated.

### How Has This Been Tested?
Values are no longer truncated after filter switches and OBS restarts.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.