### PR TITLE
Backwards compatibility for sources without SRGB awareness

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -1348,29 +1348,9 @@ Functions used by filters
 
 ---------------------
 
-.. function:: void obs_source_process_filter_end_srgb(obs_source_t *filter, gs_effect_t *effect, uint32_t width, uint32_t height)
-
-   Draws the filter using the effect's "Draw" technique, and use automatic SRGB conversion.
-
-   Before calling this function, first call obs_source_process_filter_begin and
-   then set the effect parameters, and then call this function to finalize the
-   filter.
-
----------------------
-
 .. function:: void obs_source_process_filter_tech_end(obs_source_t *filter, gs_effect_t *effect, uint32_t width, uint32_t height, const char *tech_name)
 
    Draws the filter with a specific technique in the effect.
-
-   Before calling this function, first call obs_source_process_filter_begin and
-   then set the effect parameters, and then call this function to finalize the
-   filter.
-
----------------------
-
-.. function:: void obs_source_process_filter_tech_end_srgb(obs_source_t *filter, gs_effect_t *effect, uint32_t width, uint32_t height, const char *tech_name)
-
-   Draws the filter with a specific technique in the effect, and use automatic SRGB conversion.
 
    Before calling this function, first call obs_source_process_filter_begin and
    then set the effect parameters, and then call this function to finalize the

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1261,7 +1261,8 @@ const struct obs_source_info scene_info = {
 	.id = "scene",
 	.type = OBS_SOURCE_TYPE_SCENE,
 	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-			OBS_SOURCE_COMPOSITE | OBS_SOURCE_DO_NOT_DUPLICATE,
+			OBS_SOURCE_COMPOSITE | OBS_SOURCE_DO_NOT_DUPLICATE |
+			OBS_SOURCE_SRGB,
 	.get_name = scene_getname,
 	.create = scene_create,
 	.destroy = scene_destroy,
@@ -1279,7 +1280,7 @@ const struct obs_source_info group_info = {
 	.id = "group",
 	.type = OBS_SOURCE_TYPE_SCENE,
 	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-			OBS_SOURCE_COMPOSITE,
+			OBS_SOURCE_COMPOSITE | OBS_SOURCE_SRGB,
 	.get_name = group_getname,
 	.create = scene_create,
 	.destroy = scene_destroy,

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -191,6 +191,11 @@ enum obs_media_state {
  */
 #define OBS_SOURCE_CEA_708 (1 << 14)
 
+/**
+ * Source understands SRGB rendering
+ */
+#define OBS_SOURCE_SRGB (1 << 15)
+
 /** @} */
 
 typedef void (*obs_source_enum_proc_t)(obs_source_t *parent,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1330,9 +1330,6 @@ obs_source_process_filter_begin(obs_source_t *filter,
 EXPORT void obs_source_process_filter_end(obs_source_t *filter,
 					  gs_effect_t *effect, uint32_t width,
 					  uint32_t height);
-EXPORT void obs_source_process_filter_end_srgb(obs_source_t *filter,
-					       gs_effect_t *effect,
-					       uint32_t width, uint32_t height);
 
 /**
  * Draws the filter with a specific technique.
@@ -1345,11 +1342,6 @@ EXPORT void obs_source_process_filter_tech_end(obs_source_t *filter,
 					       gs_effect_t *effect,
 					       uint32_t width, uint32_t height,
 					       const char *tech_name);
-EXPORT void obs_source_process_filter_tech_end_srgb(obs_source_t *filter,
-						    gs_effect_t *effect,
-						    uint32_t width,
-						    uint32_t height,
-						    const char *tech_name);
 
 /** Skips the filter if the filter is invalid and cannot be rendered */
 EXPORT void obs_source_skip_video_filter(obs_source_t *filter);

--- a/plugins/image-source/color-source.c
+++ b/plugins/image-source/color-source.c
@@ -177,7 +177,8 @@ struct obs_source_info color_source_info_v3 = {
 	.id = "color_source",
 	.version = 3,
 	.type = OBS_SOURCE_TYPE_INPUT,
-	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
+			OBS_SOURCE_SRGB,
 	.create = color_source_create,
 	.destroy = color_source_destroy,
 	.update = color_source_update,

--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -310,7 +310,8 @@ static obs_missing_files_t *image_source_missingfiles(void *data)
 static struct obs_source_info image_source_info = {
 	.id = "image_source",
 	.type = OBS_SOURCE_TYPE_INPUT,
-	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
+			OBS_SOURCE_SRGB,
 	.get_name = image_source_get_name,
 	.create = image_source_create,
 	.destroy = image_source_destroy,

--- a/plugins/linux-capture/xshm-input.c
+++ b/plugins/linux-capture/xshm-input.c
@@ -346,10 +346,9 @@ static bool xshm_server_changed(obs_properties_t *props, obs_property_t *p,
 	bool randr = randr_is_active(xcb);
 	bool xinerama = xinerama_is_active(xcb);
 	int_fast32_t count =
-		(randr) ? randr_screen_count(xcb)
-			: (xinerama)
-				  ? xinerama_screen_count(xcb)
-				  : xcb_setup_roots_length(xcb_get_setup(xcb));
+		randr ? randr_screen_count(xcb)
+		      : (xinerama ? xinerama_screen_count(xcb)
+				  : xcb_setup_roots_length(xcb_get_setup(xcb)));
 
 	for (int_fast32_t i = 0; i < count; ++i) {
 		char *name;
@@ -571,7 +570,7 @@ struct obs_source_info xshm_input = {
 	.id = "xshm_input",
 	.type = OBS_SOURCE_TYPE_INPUT,
 	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-			OBS_SOURCE_DO_NOT_DUPLICATE,
+			OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB,
 	.get_name = xshm_getname,
 	.create = xshm_create,
 	.destroy = xshm_destroy,

--- a/plugins/mac-capture/mac-display-capture.m
+++ b/plugins/mac-capture/mac-display-capture.m
@@ -658,7 +658,7 @@ struct obs_source_info display_capture_info = {
 	.destroy = display_capture_destroy,
 
 	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-			OBS_SOURCE_DO_NOT_DUPLICATE,
+			OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB,
 	.video_tick = display_capture_video_tick,
 	.video_render = display_capture_video_render,
 

--- a/plugins/obs-filters/chroma-key-filter.c
+++ b/plugins/obs-filters/chroma-key-filter.c
@@ -390,8 +390,7 @@ static void chroma_key_render_v2(void *data, gs_effect_t *effect)
 	gs_blend_state_push();
 	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
-	obs_source_process_filter_end_srgb(filter->context, filter->effect, 0,
-					   0);
+	obs_source_process_filter_end(filter->context, filter->effect, 0, 0);
 
 	gs_blend_state_pop();
 
@@ -526,7 +525,7 @@ struct obs_source_info chroma_key_filter_v2 = {
 	.id = "chroma_key_filter",
 	.version = 2,
 	.type = OBS_SOURCE_TYPE_FILTER,
-	.output_flags = OBS_SOURCE_VIDEO,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
 	.get_name = chroma_key_name,
 	.create = chroma_key_create_v2,
 	.destroy = chroma_key_destroy_v2,

--- a/plugins/obs-filters/color-correction-filter.c
+++ b/plugins/obs-filters/color-correction-filter.c
@@ -613,8 +613,7 @@ static void color_correction_filter_render_v2(void *data, gs_effect_t *effect)
 	gs_blend_state_push();
 	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
-	obs_source_process_filter_end_srgb(filter->context, filter->effect, 0,
-					   0);
+	obs_source_process_filter_end(filter->context, filter->effect, 0, 0);
 
 	gs_blend_state_pop();
 
@@ -734,7 +733,7 @@ struct obs_source_info color_filter_v2 = {
 	.id = "color_filter",
 	.version = 2,
 	.type = OBS_SOURCE_TYPE_FILTER,
-	.output_flags = OBS_SOURCE_VIDEO,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
 	.get_name = color_correction_filter_name,
 	.create = color_correction_filter_create_v2,
 	.destroy = color_correction_filter_destroy_v2,

--- a/plugins/obs-filters/color-grade-filter.c
+++ b/plugins/obs-filters/color-grade-filter.c
@@ -452,8 +452,8 @@ static void color_grade_filter_render(void *data, gs_effect_t *effect)
 	param = gs_effect_get_param_by_name(filter->effect, "cube_width_i");
 	gs_effect_set_float(param, 1.0f / filter->cube_width);
 
-	obs_source_process_filter_tech_end_srgb(filter->context, filter->effect,
-						0, 0, tech_name);
+	obs_source_process_filter_tech_end(filter->context, filter->effect, 0,
+					   0, tech_name);
 
 	UNUSED_PARAMETER(effect);
 }
@@ -461,7 +461,7 @@ static void color_grade_filter_render(void *data, gs_effect_t *effect)
 struct obs_source_info color_grade_filter = {
 	.id = "clut_filter",
 	.type = OBS_SOURCE_TYPE_FILTER,
-	.output_flags = OBS_SOURCE_VIDEO,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
 	.get_name = color_grade_filter_get_name,
 	.create = color_grade_filter_create,
 	.destroy = color_grade_filter_destroy,

--- a/plugins/obs-filters/color-key-filter.c
+++ b/plugins/obs-filters/color-key-filter.c
@@ -338,8 +338,7 @@ static void color_key_render_v2(void *data, gs_effect_t *effect)
 	gs_blend_state_push();
 	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
-	obs_source_process_filter_end_srgb(filter->context, filter->effect, 0,
-					   0);
+	obs_source_process_filter_end(filter->context, filter->effect, 0, 0);
 
 	gs_blend_state_pop();
 
@@ -472,7 +471,7 @@ struct obs_source_info color_key_filter_v2 = {
 	.id = "color_key_filter",
 	.version = 2,
 	.type = OBS_SOURCE_TYPE_FILTER,
-	.output_flags = OBS_SOURCE_VIDEO,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
 	.get_name = color_key_name,
 	.create = color_key_create_v2,
 	.destroy = color_key_destroy_v2,

--- a/plugins/obs-filters/crop-filter.c
+++ b/plugins/obs-filters/crop-filter.c
@@ -196,8 +196,8 @@ static void crop_filter_render(void *data, gs_effect_t *effect)
 	gs_blend_state_push();
 	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
-	obs_source_process_filter_end_srgb(filter->context, filter->effect,
-					   filter->width, filter->height);
+	obs_source_process_filter_end(filter->context, filter->effect,
+				      filter->width, filter->height);
 
 	gs_blend_state_pop();
 
@@ -219,7 +219,7 @@ static uint32_t crop_filter_height(void *data)
 struct obs_source_info crop_filter = {
 	.id = "crop_filter",
 	.type = OBS_SOURCE_TYPE_FILTER,
-	.output_flags = OBS_SOURCE_VIDEO,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
 	.get_name = crop_filter_get_name,
 	.create = crop_filter_create,
 	.destroy = crop_filter_destroy,

--- a/plugins/obs-filters/luma-key-filter.c
+++ b/plugins/obs-filters/luma-key-filter.c
@@ -115,8 +115,10 @@ static void *luma_key_create_v2(obs_data_t *settings, obs_source_t *context)
 					"luma_key_filter_v2.effect");
 }
 
-static void luma_key_render_internal(void *data, bool srgb)
+static void luma_key_render(void *data, gs_effect_t *effect)
 {
+	UNUSED_PARAMETER(effect);
+
 	struct luma_key_filter_data *filter = data;
 
 	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
@@ -130,27 +132,7 @@ static void luma_key_render_internal(void *data, bool srgb)
 	gs_effect_set_float(filter->luma_min_smooth_param,
 			    filter->luma_min_smooth);
 
-	if (srgb) {
-		obs_source_process_filter_end_srgb(filter->context,
-						   filter->effect, 0, 0);
-	} else {
-		obs_source_process_filter_end(filter->context, filter->effect,
-					      0, 0);
-	}
-}
-
-static void luma_key_render_v1(void *data, gs_effect_t *effect)
-{
-	UNUSED_PARAMETER(effect);
-
-	luma_key_render_internal(data, false);
-}
-
-static void luma_key_render_v2(void *data, gs_effect_t *effect)
-{
-	UNUSED_PARAMETER(effect);
-
-	luma_key_render_internal(data, true);
+	obs_source_process_filter_end(filter->context, filter->effect, 0, 0);
 }
 
 static obs_properties_t *luma_key_properties(void *data)
@@ -185,7 +167,7 @@ struct obs_source_info luma_key_filter = {
 	.get_name = luma_key_name,
 	.create = luma_key_create_v1,
 	.destroy = luma_key_destroy,
-	.video_render = luma_key_render_v1,
+	.video_render = luma_key_render,
 	.update = luma_key_update,
 	.get_properties = luma_key_properties,
 	.get_defaults = luma_key_defaults,
@@ -195,11 +177,11 @@ struct obs_source_info luma_key_filter_v2 = {
 	.id = "luma_key_filter",
 	.version = 2,
 	.type = OBS_SOURCE_TYPE_FILTER,
-	.output_flags = OBS_SOURCE_VIDEO,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
 	.get_name = luma_key_name,
 	.create = luma_key_create_v2,
 	.destroy = luma_key_destroy,
-	.video_render = luma_key_render_v2,
+	.video_render = luma_key_render,
 	.update = luma_key_update,
 	.get_properties = luma_key_properties,
 	.get_defaults = luma_key_defaults,

--- a/plugins/obs-filters/mask-filter.c
+++ b/plugins/obs-filters/mask-filter.c
@@ -262,7 +262,7 @@ static void mask_filter_tick(void *data, float seconds)
 	}
 }
 
-static void mask_filter_render_internal(void *data, bool srgb)
+static void mask_filter_render(void *data, gs_effect_t *effect)
 {
 	struct mask_filter_data *filter = data;
 	obs_source_t *target = obs_filter_get_target(filter->context);
@@ -324,27 +324,9 @@ static void mask_filter_render_internal(void *data, bool srgb)
 	gs_blend_state_push();
 	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
-	if (srgb) {
-		obs_source_process_filter_end_srgb(filter->context,
-						   filter->effect, 0, 0);
-	} else {
-		obs_source_process_filter_end(filter->context, filter->effect,
-					      0, 0);
-	}
+	obs_source_process_filter_end(filter->context, filter->effect, 0, 0);
 
 	gs_blend_state_pop();
-}
-
-static void mask_filter_render_v1(void *data, gs_effect_t *effect)
-{
-	mask_filter_render_internal(data, false);
-
-	UNUSED_PARAMETER(effect);
-}
-
-static void mask_filter_render_v2(void *data, gs_effect_t *effect)
-{
-	mask_filter_render_internal(data, true);
 
 	UNUSED_PARAMETER(effect);
 }
@@ -360,14 +342,14 @@ struct obs_source_info mask_filter = {
 	.get_defaults = mask_filter_defaults_v1,
 	.get_properties = mask_filter_properties_v1,
 	.video_tick = mask_filter_tick,
-	.video_render = mask_filter_render_v1,
+	.video_render = mask_filter_render,
 };
 
 struct obs_source_info mask_filter_v2 = {
 	.id = "mask_filter",
 	.version = 2,
 	.type = OBS_SOURCE_TYPE_FILTER,
-	.output_flags = OBS_SOURCE_VIDEO,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
 	.get_name = mask_filter_get_name,
 	.create = mask_filter_create,
 	.destroy = mask_filter_destroy,
@@ -375,5 +357,5 @@ struct obs_source_info mask_filter_v2 = {
 	.get_defaults = mask_filter_defaults_v2,
 	.get_properties = mask_filter_properties_v2,
 	.video_tick = mask_filter_tick,
-	.video_render = mask_filter_render_v2,
+	.video_render = mask_filter_render,
 };

--- a/plugins/obs-filters/scale-filter.c
+++ b/plugins/obs-filters/scale-filter.c
@@ -297,9 +297,9 @@ static void scale_filter_render(void *data, gs_effect_t *effect)
 		gs_effect_set_next_sampler(filter->image_param,
 					   filter->point_sampler);
 
-	obs_source_process_filter_tech_end_srgb(filter->context, filter->effect,
-						filter->cx_out, filter->cy_out,
-						technique);
+	obs_source_process_filter_tech_end(filter->context, filter->effect,
+					   filter->cx_out, filter->cy_out,
+					   technique);
 
 	UNUSED_PARAMETER(effect);
 }
@@ -422,7 +422,7 @@ static uint32_t scale_filter_height(void *data)
 struct obs_source_info scale_filter = {
 	.id = "scale_filter",
 	.type = OBS_SOURCE_TYPE_FILTER,
-	.output_flags = OBS_SOURCE_VIDEO,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
 	.get_name = scale_filter_name,
 	.create = scale_filter_create,
 	.destroy = scale_filter_destroy,

--- a/plugins/obs-filters/scroll-filter.c
+++ b/plugins/obs-filters/scroll-filter.c
@@ -221,8 +221,7 @@ static void scroll_filter_render(void *data, gs_effect_t *effect)
 	gs_blend_state_push();
 	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
-	obs_source_process_filter_end_srgb(filter->context, filter->effect, cx,
-					   cy);
+	obs_source_process_filter_end(filter->context, filter->effect, cx, cy);
 
 	gs_blend_state_pop();
 
@@ -257,7 +256,7 @@ static void scroll_filter_show(void *data)
 struct obs_source_info scroll_filter = {
 	.id = "scroll_filter",
 	.type = OBS_SOURCE_TYPE_FILTER,
-	.output_flags = OBS_SOURCE_VIDEO,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
 	.get_name = scroll_filter_get_name,
 	.create = scroll_filter_create,
 	.destroy = scroll_filter_destroy,

--- a/plugins/obs-filters/sharpness-filter.c
+++ b/plugins/obs-filters/sharpness-filter.c
@@ -73,7 +73,7 @@ static void *sharpness_create(obs_data_t *settings, obs_source_t *context)
 	return filter;
 }
 
-static void sharpness_render_internal(void *data, bool srgb)
+static void sharpness_render(void *data, gs_effect_t *effect)
 {
 	struct sharpness_data *filter = data;
 
@@ -93,22 +93,9 @@ static void sharpness_render_internal(void *data, bool srgb)
 	gs_blend_state_push();
 	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
-	obs_source_process_filter_end_srgb(filter->context, filter->effect, 0,
-					   0);
+	obs_source_process_filter_end(filter->context, filter->effect, 0, 0);
 
 	gs_blend_state_pop();
-}
-
-static void sharpness_render_v1(void *data, gs_effect_t *effect)
-{
-	sharpness_render_internal(data, false);
-
-	UNUSED_PARAMETER(effect);
-}
-
-static void sharpness_render_v2(void *data, gs_effect_t *effect)
-{
-	sharpness_render_internal(data, true);
 
 	UNUSED_PARAMETER(effect);
 }
@@ -138,7 +125,7 @@ struct obs_source_info sharpness_filter = {
 	.create = sharpness_create,
 	.destroy = sharpness_destroy,
 	.update = sharpness_update,
-	.video_render = sharpness_render_v1,
+	.video_render = sharpness_render,
 	.get_properties = sharpness_properties,
 	.get_defaults = sharpness_defaults,
 };
@@ -147,12 +134,12 @@ struct obs_source_info sharpness_filter_v2 = {
 	.id = "sharpness_filter",
 	.version = 2,
 	.type = OBS_SOURCE_TYPE_FILTER,
-	.output_flags = OBS_SOURCE_VIDEO,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
 	.get_name = sharpness_getname,
 	.create = sharpness_create,
 	.destroy = sharpness_destroy,
 	.update = sharpness_update,
-	.video_render = sharpness_render_v2,
+	.video_render = sharpness_render,
 	.get_properties = sharpness_properties,
 	.get_defaults = sharpness_defaults,
 };

--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -1112,7 +1112,7 @@ bool obs_module_load(void)
 	si.id = "text_gdiplus";
 	si.type = OBS_SOURCE_TYPE_INPUT;
 	si.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-			  OBS_SOURCE_CAP_OBSOLETE;
+			  OBS_SOURCE_CAP_OBSOLETE | OBS_SOURCE_SRGB;
 	si.get_properties = get_properties;
 	si.icon_type = OBS_ICON_TYPE_TEXT;
 

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -248,8 +248,6 @@ static void ft2_source_render(void *data, gs_effect_t *effect)
 	if (srcdata->text == NULL || *srcdata->text == 0)
 		return;
 
-	const bool previous = gs_set_linear_srgb(false);
-
 	gs_reset_blend_state();
 	if (srcdata->outline_text)
 		draw_outlines(srcdata);
@@ -258,8 +256,6 @@ static void ft2_source_render(void *data, gs_effect_t *effect)
 
 	draw_uv_vbuffer(srcdata->vbuf, srcdata->tex, srcdata->draw_effect,
 			(uint32_t)wcslen(srcdata->text) * 6);
-
-	gs_set_linear_srgb(previous);
 
 	UNUSED_PARAMETER(effect);
 }

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -533,8 +533,6 @@ static void duplicator_capture_render(void *data, gs_effect_t *effect)
 
 		rot = capture->rot;
 
-		const bool previous = gs_set_linear_srgb(false);
-
 		while (gs_effect_loop(effect, "Draw")) {
 			if (rot != 0) {
 				float x = 0.0f;
@@ -564,8 +562,6 @@ static void duplicator_capture_render(void *data, gs_effect_t *effect)
 			if (rot != 0)
 				gs_matrix_pop();
 		}
-
-		gs_set_linear_srgb(previous);
 
 		if (capture->capture_cursor) {
 			effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -2081,7 +2081,7 @@ struct obs_source_info game_capture_info = {
 	.id = "game_capture",
 	.type = OBS_SOURCE_TYPE_INPUT,
 	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-			OBS_SOURCE_DO_NOT_DUPLICATE,
+			OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB,
 	.get_name = game_capture_name,
 	.create = game_capture_create,
 	.destroy = game_capture_destroy,

--- a/plugins/win-capture/monitor-capture.c
+++ b/plugins/win-capture/monitor-capture.c
@@ -232,7 +232,7 @@ struct obs_source_info monitor_capture_info = {
 	.id = "monitor_capture",
 	.type = OBS_SOURCE_TYPE_INPUT,
 	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-			OBS_SOURCE_DO_NOT_DUPLICATE,
+			OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_SRGB,
 	.get_name = monitor_capture_getname,
 	.create = monitor_capture_create,
 	.destroy = monitor_capture_destroy,

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -586,7 +586,8 @@ static void wc_render(void *data, gs_effect_t *effect)
 struct obs_source_info window_capture_info = {
 	.id = "window_capture",
 	.type = OBS_SOURCE_TYPE_INPUT,
-	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
+			OBS_SOURCE_SRGB,
 	.get_name = wc_getname,
 	.create = wc_create,
 	.destroy = wc_destroy,


### PR DESCRIPTION
### Description
Add new flag OBS_SOURCE_SRGB to indicate SRGB awareness. SRGB usage will be forced off if this flag is not present.

Also requires obsproject/obs-browser#292 to be submitted afterward.

### Motivation and Context
Too many third-party plugins are displaying wrong colors.

### How Has This Been Tested?
- [x] OBS_SOURCE_SRGB
	scene
	group

- [x] obs_source_main_render
	srgb_aware
	!srgb_aware

- [x] filter direct rendering
	OBS_SOURCE_SRGB
	!OBS_SOURCE_SRGB

- [x] obs_source_process_filter_tech_end
	v1 no srgb
	v2 srgb

- [x] sources
	Color
	Image
	text (gdi)
	text (freetype)
	duplicator monitor (DXGI)
	game capture
	window capture (bitblt)
	window capture (wgc)
	monitor capture (win7, hack code)
	browser
	XSHM (Linux)
	Display Capture (Mac)

- [x] filters v1/v2
	apply lut
	chroma key
	color correction
	color key
	crop
	luma key
	mask
	scale
	scroll
	sharpness

- [x] Other
	transitions
	async video
	Off-World-Live/obs-spout2-source-plugin
	OBS.Live

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
