### PR TITLE
obs-filters: Fix shader for LUT on OpenGL

### DIFF
--- a/plugins/obs-filters/data/color_grade_filter.effect
+++ b/plugins/obs-filters/data/color_grade_filter.effect
@@ -86,7 +86,7 @@ float4 LUT1D(VertDataOut v_in) : TARGET
 float4 LUT3D(VertDataOut v_in) : TARGET
 {
 	float4 textureColor = image.Sample(textureSampler, v_in.uv);
-	textureColor.rgb = max(0.0, textureColor.rgb / textureColor.a);
+	textureColor.rgb = max(float3(0.0, 0.0, 0.0), textureColor.rgb / textureColor.a);
 	textureColor.rgb = srgb_linear_to_nonlinear(textureColor.rgb);
 	float r = textureColor.r;
 	float g = textureColor.g;


### PR DESCRIPTION
### Description
Shader regressed for Apply LUT on OpenGL. Trivial fix.

### Motivation and Context
Apply LUT should work on OpenGL.

### How Has This Been Tested?
Apply LUT works on OpenGL.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.