### PR TITLE
rtmp-services: Add Brime Live service

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -644,6 +644,8 @@ void AutoConfigStreamPage::UpdateKeyLink()
 	} else if (serviceName.startsWith("OPENREC.tv")) {
 		streamKeyLink =
 			"https://www.openrec.tv/login?keep_login=true&url=https://www.openrec.tv/dashboard/live?from=obs";
+	} else if (serviceName == "Brime Live") {
+		streamKeyLink = "https://brimelive.com/obs-stream-key-link";
 	}
 
 	if (QString(streamKeyLink).isNull()) {

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -296,6 +296,8 @@ void OBSBasicSettings::UpdateKeyLink()
 	} else if (serviceName.startsWith("OPENREC.tv")) {
 		streamKeyLink =
 			"https://www.openrec.tv/login?keep_login=true&url=https://www.openrec.tv/dashboard/live?from=obs";
+	} else if (serviceName == "Brime Live") {
+		streamKeyLink = "https://brimelive.com/obs-stream-key-link";
 	}
 
 	if (QString(streamKeyLink).isNull()) {

--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 175,
+	"version": 176,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 175
+			"version": 176
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2135,6 +2135,64 @@
                 "max video bitrate": 7000,
                 "max audio bitrate": 128
             }
+        },
+        {
+            "name": "Brime Live",
+            "servers": [
+                {
+                    "name": "North America - Ashburn, VA",
+                    "url": "rtmp://ingest-us-ashburn.brimelive.com/live"
+                },
+                {
+                    "name": "North America - San Jose, CA",
+                    "url": "rtmp://ingest-us-sanjose.brimelive.com/live"
+                },
+                {
+                    "name": "North America - Atlanta, GA",
+                    "url": "rtmp://ingest-us-atlanta.brimelive.com/live"
+                },
+                {
+                    "name": "North America - Dallas, TX",
+                    "url": "rtmp://ingest-us-dallas.brimelive.com/live"
+                },
+                {
+                    "name": "North America - Chicago, IL",
+                    "url": "rtmp://ingest-us-chicago.brimelive.com/live"
+                },
+                {
+                    "name": "Canada Southeast - Montreal",
+                    "url": "rtmp://ingest-ca-montreal.brimelive.com/live"
+                },
+                {
+                    "name": "Latin America - Brazil East (Sao Paulo)",
+                    "url": "rtmp://ingest-la-saopaulo.brimelive.com/live"
+                },
+                {
+                    "name": "Europe / EMEA - Germany (Frankfurt)",
+                    "url": "rtmp://ingest-eu-frankfurt.brimelive.com/live"
+                },
+                {
+                    "name": "Europe / EMEA - UK South (London)",
+                    "url": "rtmp://ingest-eu-london.brimelive.com/live"
+                },
+                {
+                    "name": "Europe / EMEA - Russia (Moscow)",
+                    "url": "rtmp://ingest-eu-moscow.brimelive.com/live"
+                },
+                {
+                    "name": "APAC - Japan East (Tokyo)",
+                    "url": "rtmp://ingest-apac-tokyo.brimelive.com/live"
+                },
+                {
+                    "name": "APAC - Australia East (Sydney)",
+                    "url": "rtmp://ingest-apac-sydney.brimelive.com/live"
+                }
+            ],
+            "recommended": {
+                "max video bitrate": 20000,
+                "max audio bitrate": 320,
+                "x264opts": "scenecut=0"
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
Add Brime to RTMP stream services, using its RTMP ingestion endpoints. 

### Motivation and Context
Brime Live is a new live streaming platform. We've solidified all of our ingest server regions and have confirmed they all have connectivity. This services addition should serve us through our public launch later this summer.

- Support for 120fps (experimental, but tests have shown really solid results)
- Support for (3840 x 2160)
- Support for 20k bitrate

### How Has This Been Tested?
Tested changes on Windows 10 x64.

### Types of changes
New feature (non-breaking change which adds functionality)
### Checklist:

- [x] My code has been run through clang-format.
- [x]  I have read the contributing document.
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.