### PR TITLE
Add support for 16-bit images

### DIFF
--- a/libobs/data/default.effect
+++ b/libobs/data/default.effect
@@ -62,6 +62,13 @@ float4 PSDrawNonlinearAlpha(VertInOut vert_in) : TARGET
 	return rgba;
 }
 
+float4 PSDrawAlphaBlend(VertInOut vert_in) : TARGET
+{
+	float4 rgba = image.Sample(def_sampler, vert_in.uv);
+	rgba.rgb *= rgba.a;
+	return rgba;
+}
+
 technique Draw
 {
 	pass
@@ -86,5 +93,14 @@ technique DrawNonlinearAlpha
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawNonlinearAlpha(vert_in);
+	}
+}
+
+technique DrawAlphaBlend
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawAlphaBlend(vert_in);
 	}
 }

--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -151,12 +151,8 @@ static void image_source_render(void *data, gs_effect_t *effect)
 	if (!context->if2.image.texture)
 		return;
 
-	const char *tech_name = "DrawNonlinearAlpha";
-	enum gs_blend_type blend_src_color = GS_BLEND_ONE;
-	if (context->linear_alpha) {
-		tech_name = "Draw";
-		blend_src_color = GS_BLEND_SRCALPHA;
-	}
+	const char *tech_name = context->linear_alpha ? "DrawAlphaBlend"
+						      : "DrawNonlinearAlpha";
 
 	effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
 	gs_technique_t *tech = gs_effect_get_technique(effect, tech_name);
@@ -165,8 +161,7 @@ static void image_source_render(void *data, gs_effect_t *effect)
 	gs_enable_framebuffer_srgb(true);
 
 	gs_blend_state_push();
-	gs_blend_function_separate(blend_src_color, GS_BLEND_INVSRCALPHA,
-				   GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
 	gs_eparam_t *const param = gs_effect_get_param_by_name(effect, "image");
 	gs_effect_set_texture_srgb(param, context->if2.image.texture);


### PR DESCRIPTION
### Description
Add support for 16-bit images.

### Motivation and Context
Helps preserve alpha precision for 16-bit linear textures.

### How Has This Been Tested?
Banding fixed on Windows. Image loads on Linux.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.