### PR TITLE
Warnings 2021-05-04

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2224,7 +2224,7 @@ static inline void obs_source_main_render(obs_source_t *source)
 	bool srgb_aware = (flags & OBS_SOURCE_SRGB) != 0;
 	bool default_effect = !source->filter_parent &&
 			      source->filters.num == 0 && !custom_draw;
-	bool previous_srgb;
+	bool previous_srgb = false;
 
 	if (!srgb_aware) {
 		previous_srgb = gs_get_linear_srgb();

--- a/libobs/util/platform.c
+++ b/libobs/util/platform.c
@@ -339,12 +339,14 @@ int64_t os_get_file_size(const char *path)
 
 size_t os_mbs_to_wcs(const char *str, size_t len, wchar_t *dst, size_t dst_size)
 {
+	UNUSED_PARAMETER(len);
+
 	size_t out_len;
 
 	if (!str)
 		return 0;
 
-	out_len = dst ? (dst_size - 1) : mbstowcs(NULL, str, len);
+	out_len = dst ? (dst_size - 1) : mbstowcs(NULL, str, 0);
 
 	if (dst) {
 		if (!dst_size)
@@ -387,6 +389,8 @@ size_t os_utf8_to_wcs(const char *str, size_t len, wchar_t *dst,
 
 size_t os_wcs_to_mbs(const wchar_t *str, size_t len, char *dst, size_t dst_size)
 {
+	UNUSED_PARAMETER(len);
+
 	size_t out_len;
 
 	if (!str)

--- a/plugins/obs-filters/noise-suppress-filter.c
+++ b/plugins/obs-filters/noise-suppress-filter.c
@@ -953,7 +953,11 @@ static void noise_suppress_defaults_v2(obs_data_t *s)
 static obs_properties_t *noise_suppress_properties(void *data)
 {
 	obs_properties_t *ppts = obs_properties_create();
+#ifdef LIBNVAFX_ENABLED
 	struct noise_suppress_data *ng = (struct noise_suppress_data *)data;
+#else
+	UNUSED_PARAMETER(data);
+#endif
 
 #if defined(LIBRNNOISE_ENABLED) && defined(LIBSPEEXDSP_ENABLED)
 	obs_property_t *method = obs_properties_add_list(
@@ -977,7 +981,6 @@ static obs_properties_t *noise_suppress_properties(void *data)
 	obs_property_int_set_suffix(speex_slider, " dB");
 #endif
 
-	UNUSED_PARAMETER(data);
 #ifdef LIBNVAFX_ENABLED
 	obs_property_t *nvafx_slider = obs_properties_add_float_slider(
 		ppts, S_NVAFX_INTENSITY, TEXT_NVAFX_INTENSITY, 0.0f, 1.0f,


### PR DESCRIPTION
### Description
Fix a couple warnings seen in GCC.

### Motivation and Context
Don't like warnings.

### How Has This Been Tested?
Warnings are gone.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.