### PR TITLE
Socks4 proxy

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -1102,6 +1102,38 @@
                </layout>
               </widget>
              </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="socksProxyLabel">
+               <property name="text">
+                <string>socks4 proxy(optional)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QWidget" name="socksProxyWidget" native="true">
+               <layout class="QHBoxLayout" name="horizontalLayout_30">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QLineEdit" name="socksProxy">
+                  <property name="text">
+                   <string notr="true"/>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
              <item row="3" column="0">
               <spacer name="horizontalSpacer_18">
                <property name="orientation">
@@ -5518,6 +5550,7 @@
   <tabstop>useStreamKey</tabstop>
   <tabstop>server</tabstop>
   <tabstop>customServer</tabstop>
+  <tabstop>socksProxy</tabstop>
   <tabstop>key</tabstop>
   <tabstop>show</tabstop>
   <tabstop>getStreamKeyButton</tabstop>

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -104,6 +104,7 @@ void OBSBasicSettings::LoadStream1Settings()
 	const char *service = obs_data_get_string(settings, "service");
 	const char *server = obs_data_get_string(settings, "server");
 	const char *key = obs_data_get_string(settings, "key");
+	const char *socksProxy = obs_data_get_string(settings, "socks_proxy");
 
 	if (strcmp(type, "rtmp_custom") == 0) {
 		ui->service->setCurrentIndex(0);
@@ -146,6 +147,7 @@ void OBSBasicSettings::LoadStream1Settings()
 	}
 
 	ui->key->setText(key);
+	ui->socksProxy->setText(socksProxy);
 
 	lastService.clear();
 	on_service_currentIndexChanged(0);
@@ -220,6 +222,8 @@ void OBSBasicSettings::SaveStream1Settings()
 	}
 
 	obs_data_set_string(settings, "key", QT_TO_UTF8(ui->key->text()));
+	obs_data_set_string(settings, "socks_proxy",
+			    QT_TO_UTF8(ui->socksProxy->text()));
 
 	OBSService newService = obs_service_create(
 		service_id, "default_service", settings, hotkeyData);
@@ -505,6 +509,8 @@ OBSService OBSBasicSettings::SpawnTempService()
 				    QT_TO_UTF8(ui->customServer->text()));
 	}
 	obs_data_set_string(settings, "key", QT_TO_UTF8(ui->key->text()));
+	obs_data_set_string(settings, "socks_proxy",
+			    QT_TO_UTF8(ui->socksProxy->text()));
 
 	OBSService newService = obs_service_create(service_id, "temp_service",
 						   settings, nullptr);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -420,6 +420,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->server,               COMBO_CHANGED,  STREAM1_CHANGED);
 	HookWidget(ui->customServer,         EDIT_CHANGED,   STREAM1_CHANGED);
 	HookWidget(ui->key,                  EDIT_CHANGED,   STREAM1_CHANGED);
+	HookWidget(ui->socksProxy,           EDIT_CHANGED,   STREAM1_CHANGED);
 	HookWidget(ui->bandwidthTestEnable,  CHECK_CHANGED,  STREAM1_CHANGED);
 	HookWidget(ui->twitchAddonDropdown,  COMBO_CHANGED,  STREAM1_CHANGED);
 	HookWidget(ui->useAuth,              CHECK_CHANGED,  STREAM1_CHANGED);

--- a/deps/file-updater/file-updater/file-updater.h
+++ b/deps/file-updater/file-updater/file-updater.h
@@ -24,4 +24,9 @@ update_info_t *update_info_create(const char *log_prefix,
 update_info_t *update_info_create_single(
 	const char *log_prefix, const char *user_agent, const char *file_url,
 	confirm_file_callback_t confirm_callback, void *param);
+update_info_t *
+update_info_create_single_proxy(const char *log_prefix, const char *user_agent,
+				const char *file_url, const char *socks_proxy,
+				confirm_file_callback_t confirm_callback,
+				void *param);
 void update_info_destroy(update_info_t *info);

--- a/libobs/obs-service.c
+++ b/libobs/obs-service.c
@@ -217,6 +217,16 @@ const char *obs_service_get_url(const obs_service_t *service)
 	return service->info.get_url(service->context.data);
 }
 
+const char *obs_service_get_socks_proxy(const obs_service_t *service)
+{
+	if (!obs_service_valid(service, "obs_service_get_socks_proxy"))
+		return NULL;
+
+	if (!service->info.get_socks_proxy)
+		return NULL;
+	return service->info.get_socks_proxy(service->context.data);
+}
+
 const char *obs_service_get_key(const obs_service_t *service)
 {
 	if (!obs_service_valid(service, "obs_service_get_key"))

--- a/libobs/obs-service.h
+++ b/libobs/obs-service.h
@@ -64,6 +64,7 @@ struct obs_service_info {
 
 	const char *(*get_url)(void *data);
 	const char *(*get_key)(void *data);
+	const char *(*get_socks_proxy)(void *data);
 
 	const char *(*get_username)(void *data);
 	const char *(*get_password)(void *data);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2300,6 +2300,9 @@ EXPORT obs_data_t *obs_service_get_settings(const obs_service_t *service);
 /** Returns the URL for this service context */
 EXPORT const char *obs_service_get_url(const obs_service_t *service);
 
+/** Returns the socks_proxy (if any) for this service context */
+EXPORT const char *obs_service_get_socks_proxy(const obs_service_t *service);
+
 /** Returns the stream key (if any) for this service context */
 EXPORT const char *obs_service_get_key(const obs_service_t *service);
 

--- a/plugins/obs-outputs/rtmp-stream.h
+++ b/plugins/obs-outputs/rtmp-stream.h
@@ -79,6 +79,7 @@ struct rtmp_stream {
 	uint64_t shutdown_timeout_ts;
 
 	struct dstr path, key;
+	struct dstr socks_proxy;
 	struct dstr username, password;
 	struct dstr encoder_name;
 	struct dstr bind_ip;

--- a/plugins/rtmp-services/rtmp-custom.c
+++ b/plugins/rtmp-services/rtmp-custom.c
@@ -3,6 +3,7 @@
 
 struct rtmp_custom {
 	char *server, *key;
+	char *socks_proxy;
 	bool use_auth;
 	char *username, *password;
 };
@@ -19,11 +20,14 @@ static void rtmp_custom_update(void *data, obs_data_t *settings)
 
 	bfree(service->server);
 	bfree(service->key);
+	bfree(service->socks_proxy);
 	bfree(service->username);
 	bfree(service->password);
 
 	service->server = bstrdup(obs_data_get_string(settings, "server"));
 	service->key = bstrdup(obs_data_get_string(settings, "key"));
+	service->socks_proxy =
+		bstrdup(obs_data_get_string(settings, "socks_proxy"));
 	service->use_auth = obs_data_get_bool(settings, "use_auth");
 	service->username = bstrdup(obs_data_get_string(settings, "username"));
 	service->password = bstrdup(obs_data_get_string(settings, "password"));
@@ -35,6 +39,7 @@ static void rtmp_custom_destroy(void *data)
 
 	bfree(service->server);
 	bfree(service->key);
+	bfree(service->socks_proxy);
 	bfree(service->username);
 	bfree(service->password);
 	bfree(service);
@@ -72,6 +77,9 @@ static obs_properties_t *rtmp_custom_properties(void *unused)
 	obs_properties_add_text(ppts, "key", obs_module_text("StreamKey"),
 				OBS_TEXT_PASSWORD);
 
+	obs_properties_add_text(ppts, "socks_proxy", "SocksProxy",
+				OBS_TEXT_DEFAULT);
+
 	p = obs_properties_add_bool(ppts, "use_auth",
 				    obs_module_text("UseAuth"));
 	obs_properties_add_text(ppts, "username", obs_module_text("Username"),
@@ -80,6 +88,12 @@ static obs_properties_t *rtmp_custom_properties(void *unused)
 				OBS_TEXT_PASSWORD);
 	obs_property_set_modified_callback(p, use_auth_modified);
 	return ppts;
+}
+
+static const char *rtmp_custom_socks_proxy(void *data)
+{
+	struct rtmp_custom *service = data;
+	return service->socks_proxy;
 }
 
 static const char *rtmp_custom_url(void *data)
@@ -134,6 +148,7 @@ struct obs_service_info rtmp_custom_service = {
 	.get_properties = rtmp_custom_properties,
 	.get_url = rtmp_custom_url,
 	.get_key = rtmp_custom_key,
+	.get_socks_proxy = rtmp_custom_socks_proxy,
 	.get_username = rtmp_custom_username,
 	.get_password = rtmp_custom_password,
 	.apply_encoder_settings = rtmp_custom_apply_settings,

--- a/plugins/rtmp-services/service-specific/dacast.h
+++ b/plugins/rtmp-services/service-specific/dacast.h
@@ -11,4 +11,6 @@ extern void init_dacast_data(void);
 extern void unload_dacast_data(void);
 
 extern void dacast_ingests_load_data(const char *server, const char *key);
+extern void dacast_ingests_load_data_proxy(const char *server, const char *key,
+					   const char *socks_proxy);
 extern struct dacast_ingest *dacast_ingest(const char *key);

--- a/plugins/rtmp-services/service-specific/nimotv.c
+++ b/plugins/rtmp-services/service-specific/nimotv.c
@@ -57,7 +57,7 @@ static char *load_ingest(const char *json)
 	return ingest;
 }
 
-const char *nimotv_get_ingest(const char *key)
+const char *nimotv_get_ingest_proxy(const char *key, const char *socks_proxy)
 {
 	if (current_ingest != NULL) {
 		time_t now = time(NULL);
@@ -92,6 +92,8 @@ const char *nimotv_get_ingest(const char *key)
 	curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT, 3L);
 	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, nimotv_write_cb);
 	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
+	if (socks_proxy != NULL && strlen(socks_proxy))
+		curl_easy_setopt(curl_handle, CURLOPT_PROXY, socks_proxy);
 	curl_obs_set_revoke_setting(curl_handle);
 
 #if LIBCURL_VERSION_NUM >= 0x072400
@@ -142,4 +144,9 @@ const char *nimotv_get_ingest(const char *key)
 	     current_ingest);
 
 	return current_ingest;
+}
+
+const char *nimotv_get_ingest(const char *key)
+{
+	return nimotv_get_ingest_proxy(key, "");
 }

--- a/plugins/rtmp-services/service-specific/nimotv.h
+++ b/plugins/rtmp-services/service-specific/nimotv.h
@@ -1,3 +1,5 @@
 #pragma once
 
 extern const char *nimotv_get_ingest(const char *key);
+extern const char *nimotv_get_ingest_proxy(const char *key,
+					   const char *socks_proxy);

--- a/plugins/rtmp-services/service-specific/showroom.c
+++ b/plugins/rtmp-services/service-specific/showroom.c
@@ -90,8 +90,9 @@ static struct showroom_ingest_info *get_ingest_from_json(char *str,
 	return info;
 }
 
-struct showroom_ingest *showroom_get_ingest(const char *server,
-					    const char *access_key)
+struct showroom_ingest *showroom_get_ingest_proxy(const char *server,
+						  const char *access_key,
+						  const char *socks_proxy)
 {
 	struct showroom_ingest_info *info = find_ingest(access_key);
 	CURL *curl_handle;
@@ -123,6 +124,8 @@ struct showroom_ingest *showroom_get_ingest(const char *server,
 	curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT, 30L);
 	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, showroom_write_cb);
 	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&json);
+	if (socks_proxy != NULL && strlen(socks_proxy))
+		curl_easy_setopt(curl_handle, CURLOPT_PROXY, socks_proxy);
 	curl_obs_set_revoke_setting(curl_handle);
 
 #if LIBCURL_VERSION_NUM >= 0x072400
@@ -160,4 +163,10 @@ cleanup:
 	curl_easy_cleanup(curl_handle);
 	dstr_free(&json);
 	return info ? &info->ingest : &invalid_ingest;
+}
+
+struct showroom_ingest *showroom_get_ingest(const char *server,
+					    const char *access_key)
+{
+	return showroom_get_ingest_proxy(server, access_key, "");
 }

--- a/plugins/rtmp-services/service-specific/showroom.h
+++ b/plugins/rtmp-services/service-specific/showroom.h
@@ -7,5 +7,8 @@ struct showroom_ingest {
 
 extern struct showroom_ingest *showroom_get_ingest(const char *server,
 						   const char *access_key);
+extern struct showroom_ingest *
+showroom_get_ingest_proxy(const char *server, const char *access_key,
+			  const char *socks_proxy);
 
 extern void free_showroom_data();

--- a/plugins/rtmp-services/service-specific/younow.c
+++ b/plugins/rtmp-services/service-specific/younow.c
@@ -32,7 +32,8 @@ static size_t younow_write_cb(void *contents, size_t size, size_t nmemb,
 	return realsize;
 }
 
-const char *younow_get_ingest(const char *server, const char *key)
+const char *younow_get_ingest_proxy(const char *server, const char *key,
+				    const char *socks_proxy)
 {
 	CURL *curl_handle;
 	CURLcode res;
@@ -63,6 +64,8 @@ const char *younow_get_ingest(const char *server, const char *key)
 	curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT, 3L);
 	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, younow_write_cb);
 	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
+	if (socks_proxy != NULL && strlen(socks_proxy))
+		curl_easy_setopt(curl_handle, CURLOPT_PROXY, socks_proxy);
 	curl_obs_set_revoke_setting(curl_handle);
 
 #if LIBCURL_VERSION_NUM >= 0x072400
@@ -111,4 +114,9 @@ const char *younow_get_ingest(const char *server, const char *key)
 	blog(LOG_INFO, "younow_get_ingest: returning ingest: %s",
 	     current_ingest);
 	return current_ingest;
+}
+
+const char *younow_get_ingest(const char *server, const char *key)
+{
+	return younow_get_ingest_proxy(server, key, "");
 }

--- a/plugins/rtmp-services/service-specific/younow.h
+++ b/plugins/rtmp-services/service-specific/younow.h
@@ -1,3 +1,5 @@
 #pragma once
 
 extern const char *younow_get_ingest(const char *server, const char *key);
+extern const char *younow_get_ingest_proxy(const char *server, const char *key,
+					   const char *socks_proxy);


### PR DESCRIPTION
### Description
Added support for SOCKS4 proxy.
![image](https://user-images.githubusercontent.com/83752193/117323841-d3c8b780-aec1-11eb-938b-c00d5234aec4.png)
Fixed `twitch_ingests_refresh` timeout according to previous comments.

### Motivation and Context
SOCKS4 proxy: Allow users to stream using a SOCKS4 proxy, in order to protect privacy and/or pass through firewalls.
Fix timeout: Changed `twitch_ingests_refresh` timeout from `3s` to `5s` according to comments in `plugins/rtmp-services/service-specific/twitch.c`.

### How Has This Been Tested?
Built on windows x64, and successfully connected to some streaming services through a SOCKS4 proxy server.

### Types of changes
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
