### PR TITLE
libobs: Fix deadlock removing scene item

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1970,13 +1970,13 @@ void obs_sceneitem_remove(obs_sceneitem_t *item)
 
 	set_visibility(item, false);
 
-	obs_sceneitem_set_show_transition(item, NULL);
-	obs_sceneitem_set_hide_transition(item, NULL);
-
 	signal_item_remove(item);
 	detach_sceneitem(item);
 
 	full_unlock(scene);
+
+	obs_sceneitem_set_show_transition(item, NULL);
+	obs_sceneitem_set_hide_transition(item, NULL);
 
 	obs_sceneitem_release(item);
 }


### PR DESCRIPTION
### Description
Fix deadlock removing scene item
moved the clearing of the show and hide transition outside the full scene lock

### Motivation and Context
Techjar on discord #beta-testing:
> the UI thread acquires the lock on scene->video_mutex in obs_sceneitem_remove
> at the same time the graphics thread acquires the lock on scene->sources_mutex in tick_sources
> the graphics thread then tries to acquire scene->video_mutex in scene_video_tick, but blocks because the UI thread has it locked already
> finally the UI thread goes to actually remove the show/hide transition from the scene, but first tries to acquire the lock on context->mutex (there's a few functions where this occurs), which in this case is actually the same pointer as scene->sources_mutex, which is already locked by the graphics thread, so it blocks
> we are now deadlocked, two threads waiting on eachother to release locks
> OBS is no longer rendering to the output and the UI is completely unresponsive, although the encoder is (maybe) still running and audio is (maybe) still piping through

### How Has This Been Tested?
Tested if everything kept working as normal on windows 64 bit

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
