### PR TITLE
UI: Log viewer fixes

### DIFF
--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -16,6 +16,7 @@ OBSLogViewer::OBSLogViewer(QWidget *parent) : QDialog(parent)
 {
 	setWindowFlags(windowFlags() & Qt::WindowMaximizeButtonHint &
 		       ~Qt::WindowContextHelpButtonHint);
+	setAttribute(Qt::WA_DeleteOnClose);
 
 	QVBoxLayout *layout = new QVBoxLayout();
 	layout->setContentsMargins(0, 0, 0, 0);
@@ -35,7 +36,7 @@ OBSLogViewer::OBSLogViewer(QWidget *parent) : QDialog(parent)
 	connect(openButton, &QPushButton::clicked, this,
 		&OBSLogViewer::OpenFile);
 	QPushButton *closeButton = new QPushButton(QTStr("Close"));
-	connect(closeButton, &QPushButton::clicked, this, &QDialog::hide);
+	connect(closeButton, &QPushButton::clicked, this, &QDialog::close);
 
 	bool showLogViewerOnStartup = config_get_bool(
 		App()->GlobalConfig(), "LogViewer", "ShowLogStartup");

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2068,11 +2068,8 @@ void OBSBasic::OnFirstLoad()
 	bool showLogViewerOnStartup = config_get_bool(
 		App()->GlobalConfig(), "LogViewer", "ShowLogStartup");
 
-	if (showLogViewerOnStartup) {
-		if (!logView)
-			logView = new OBSLogViewer();
-		logView->show();
-	}
+	if (showLogViewerOnStartup)
+		on_actionViewCurrentLog_triggered();
 }
 
 void OBSBasic::DeferredSysTrayLoad(int requeueCount)

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2554,7 +2554,6 @@ OBSBasic::~OBSBasic()
 		updateCheckThread->wait();
 
 	delete screenshotData;
-	delete logView;
 	delete multiviewProjectorMenu;
 	delete previewProjector;
 	delete studioProgramProjector;
@@ -5725,15 +5724,12 @@ void OBSBasic::on_actionViewCurrentLog_triggered()
 	if (!logView)
 		logView = new OBSLogViewer();
 
-	if (!logView->isVisible()) {
-		logView->setVisible(true);
-	} else {
-		logView->setWindowState(
-			(logView->windowState() & ~Qt::WindowMinimized) |
-			Qt::WindowActive);
-		logView->activateWindow();
-		logView->raise();
-	}
+	logView->show();
+	logView->setWindowState(
+		(logView->windowState() & ~Qt::WindowMinimized) |
+		Qt::WindowActive);
+	logView->activateWindow();
+	logView->raise();
 }
 
 void OBSBasic::on_actionShowCrashLogs_triggered()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -218,8 +218,7 @@ private:
 	QPointer<QDockWidget> statsDock;
 	QPointer<OBSAbout> about;
 	QPointer<OBSMissingFiles> missDialog;
-
-	OBSLogViewer *logView = nullptr;
+	QPointer<OBSLogViewer> logView;
 
 	QPointer<QTimer> cpuUsageTimer;
 	QPointer<QTimer> diskFullTimer;


### PR DESCRIPTION
### Description
Commit 1 - Removes redundant code when using log viewer on startup.
Commit 2 - Deletes the log viewer when closing it, instead of hiding it.

### Motivation and Context
Cleanup of code.

### How Has This Been Tested?
Open and closed log viewer to make sure everything was deleted properly.

### Types of changes
- Bug fix
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
