### PR TITLE
UI: Change position of filters defaults button

### DIFF
--- a/UI/forms/OBSBasicFilters.ui
+++ b/UI/forms/OBSBasicFilters.ui
@@ -423,19 +423,6 @@
           <enum>QLayout::SetMaximumSize</enum>
          </property>
          <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
           <widget class="QDialogButtonBox" name="buttonBox">
            <property name="standardButtons">
             <set>QDialogButtonBox::Reset|QDialogButtonBox::Close</set>


### PR DESCRIPTION
### Description
The button was not on the left side, as other default buttons are in
the UI.

Before:
![Screenshot from 2021-05-10 18-30-42](https://user-images.githubusercontent.com/19962531/117736978-7af96780-b1be-11eb-83aa-35189d611df2.png)

After:
![Screenshot from 2021-05-10 18-33-36](https://user-images.githubusercontent.com/19962531/117737005-82207580-b1be-11eb-8ebd-58b2e875b516.png)

### Motivation and Context
Makes dialog look better.

### How Has This Been Tested?
Opened the filters dialog and made sure the button was at the right position

### Types of changes
- UI tweak

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
