### PR TITLE
Premultiply image sources on load

### DIFF
--- a/libobs/data/default.effect
+++ b/libobs/data/default.effect
@@ -62,13 +62,6 @@ float4 PSDrawNonlinearAlpha(VertInOut vert_in) : TARGET
 	return rgba;
 }
 
-float4 PSDrawAlphaBlend(VertInOut vert_in) : TARGET
-{
-	float4 rgba = image.Sample(def_sampler, vert_in.uv);
-	rgba.rgb *= rgba.a;
-	return rgba;
-}
-
 technique Draw
 {
 	pass
@@ -93,14 +86,5 @@ technique DrawNonlinearAlpha
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawNonlinearAlpha(vert_in);
-	}
-}
-
-technique DrawAlphaBlend
-{
-	pass
-	{
-		vertex_shader = VSDefault(vert_in);
-		pixel_shader  = PSDrawAlphaBlend(vert_in);
 	}
 }

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -559,10 +559,19 @@ EXPORT gs_shader_t *gs_vertexshader_create_from_file(const char *file,
 EXPORT gs_shader_t *gs_pixelshader_create_from_file(const char *file,
 						    char **error_string);
 
+enum gs_image_alpha_mode {
+	GS_IMAGE_ALPHA_STRAIGHT,
+	GS_IMAGE_ALPHA_PREMULTIPLY_SRGB,
+	GS_IMAGE_ALPHA_PREMULTIPLY,
+};
+
 EXPORT gs_texture_t *gs_texture_create_from_file(const char *file);
 EXPORT uint8_t *gs_create_texture_file_data(const char *file,
 					    enum gs_color_format *format,
 					    uint32_t *cx, uint32_t *cy);
+EXPORT uint8_t *gs_create_texture_file_data2(
+	const char *file, enum gs_image_alpha_mode alpha_mode,
+	enum gs_color_format *format, uint32_t *cx, uint32_t *cy);
 
 #define GS_FLIP_U (1 << 0)
 #define GS_FLIP_V (1 << 1)

--- a/libobs/graphics/image-file.h
+++ b/libobs/graphics/image-file.h
@@ -51,8 +51,14 @@ struct gs_image_file2 {
 	uint64_t mem_usage;
 };
 
+struct gs_image_file3 {
+	struct gs_image_file2 image2;
+	enum gs_image_alpha_mode alpha_mode;
+};
+
 typedef struct gs_image_file gs_image_file_t;
 typedef struct gs_image_file2 gs_image_file2_t;
+typedef struct gs_image_file3 gs_image_file3_t;
 
 EXPORT void gs_image_file_init(gs_image_file_t *image, const char *file);
 EXPORT void gs_image_file_free(gs_image_file_t *image);
@@ -64,26 +70,36 @@ EXPORT void gs_image_file_update_texture(gs_image_file_t *image);
 
 EXPORT void gs_image_file2_init(gs_image_file2_t *if2, const char *file);
 
+EXPORT bool gs_image_file2_tick(gs_image_file2_t *if2,
+				uint64_t elapsed_time_ns);
+EXPORT void gs_image_file2_update_texture(gs_image_file2_t *if2);
+
+EXPORT void gs_image_file3_init(gs_image_file3_t *if3, const char *file,
+				enum gs_image_alpha_mode alpha_mode);
+
+EXPORT bool gs_image_file3_tick(gs_image_file3_t *if3,
+				uint64_t elapsed_time_ns);
+EXPORT void gs_image_file3_update_texture(gs_image_file3_t *if3);
+
 static void gs_image_file2_free(gs_image_file2_t *if2)
 {
 	gs_image_file_free(&if2->image);
 	if2->mem_usage = 0;
 }
 
-static inline void gs_image_file2_init_texture(gs_image_file2_t *if2)
+static void gs_image_file2_init_texture(gs_image_file2_t *if2)
 {
 	gs_image_file_init_texture(&if2->image);
 }
 
-static inline bool gs_image_file2_tick(gs_image_file2_t *if2,
-				       uint64_t elapsed_time_ns)
+static void gs_image_file3_free(gs_image_file3_t *if3)
 {
-	return gs_image_file_tick(&if2->image, elapsed_time_ns);
+	gs_image_file2_free(&if3->image2);
 }
 
-static inline void gs_image_file2_update_texture(gs_image_file2_t *if2)
+static void gs_image_file3_init_texture(gs_image_file3_t *if3)
 {
-	gs_image_file_update_texture(&if2->image);
+	gs_image_file2_init_texture(&if3->image2);
 }
 
 #ifdef __cplusplus

--- a/libobs/graphics/srgb.h
+++ b/libobs/graphics/srgb.h
@@ -1,0 +1,187 @@
+/******************************************************************************
+    Copyright (C) 2021 by Hugh Bailey <obs.jim@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#pragma once
+
+#include <math.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline float gs_srgb_nonlinear_to_linear(float u)
+{
+	return (u <= 0.04045f) ? (u / 12.92f)
+			       : powf((u + 0.055f) / 1.055f, 2.4f);
+}
+
+static inline float gs_srgb_linear_to_nonlinear(float u)
+{
+	return (u <= 0.0031308f) ? (12.92f * u)
+				 : ((1.055f * powf(u, 1.0f / 2.4f)) - 0.055f);
+}
+
+static inline float gs_u8_to_float(uint8_t u)
+{
+	return (float)u / 255.0f;
+}
+
+static inline void gs_u8x4_to_float4(float *f, const uint8_t *u)
+{
+	f[0] = gs_u8_to_float(u[0]);
+	f[1] = gs_u8_to_float(u[1]);
+	f[2] = gs_u8_to_float(u[2]);
+	f[3] = gs_u8_to_float(u[3]);
+}
+
+static inline uint8_t gs_float_to_u8(float f)
+{
+	return (uint8_t)(f * 255.0f + 0.5f);
+}
+
+static inline void gs_premultiply_float4(float *f)
+{
+	f[0] *= f[3];
+	f[1] *= f[3];
+	f[2] *= f[3];
+}
+
+static inline void gs_float3_to_u8x3(uint8_t *u, const float *f)
+{
+	u[0] = gs_float_to_u8(f[0]);
+	u[1] = gs_float_to_u8(f[1]);
+	u[2] = gs_float_to_u8(f[2]);
+}
+
+static inline void gs_float4_to_u8x4(uint8_t *u, const float *f)
+{
+	u[0] = gs_float_to_u8(f[0]);
+	u[1] = gs_float_to_u8(f[1]);
+	u[2] = gs_float_to_u8(f[2]);
+	u[3] = gs_float_to_u8(f[3]);
+}
+
+static inline void gs_float3_srgb_nonlinear_to_linear(float *f)
+{
+	f[0] = gs_srgb_nonlinear_to_linear(f[0]);
+	f[1] = gs_srgb_nonlinear_to_linear(f[1]);
+	f[2] = gs_srgb_nonlinear_to_linear(f[2]);
+}
+
+static inline void gs_float3_srgb_linear_to_nonlinear(float *f)
+{
+	f[0] = gs_srgb_linear_to_nonlinear(f[0]);
+	f[1] = gs_srgb_linear_to_nonlinear(f[1]);
+	f[2] = gs_srgb_linear_to_nonlinear(f[2]);
+}
+
+static inline void gs_premultiply_xyza(uint8_t *data)
+{
+	uint8_t u[4];
+	float f[4];
+	memcpy(&u, data, sizeof(u));
+	gs_u8x4_to_float4(f, u);
+	gs_premultiply_float4(f);
+	gs_float3_to_u8x3(u, f);
+	memcpy(data, &u, sizeof(u));
+}
+
+static inline void gs_premultiply_xyza_srgb(uint8_t *data)
+{
+	uint8_t u[4];
+	float f[4];
+	memcpy(&u, data, sizeof(u));
+	gs_u8x4_to_float4(f, u);
+	gs_float3_srgb_nonlinear_to_linear(f);
+	gs_premultiply_float4(f);
+	gs_float3_srgb_linear_to_nonlinear(f);
+	gs_float3_to_u8x3(u, f);
+	memcpy(data, &u, sizeof(u));
+}
+
+static inline void gs_premultiply_xyza_restrict(uint8_t *__restrict dst,
+						const uint8_t *__restrict src)
+{
+	uint8_t u[4];
+	float f[4];
+	memcpy(&u, src, sizeof(u));
+	gs_u8x4_to_float4(f, u);
+	gs_premultiply_float4(f);
+	gs_float3_to_u8x3(u, f);
+	memcpy(dst, &u, sizeof(u));
+}
+
+static inline void
+gs_premultiply_xyza_srgb_restrict(uint8_t *__restrict dst,
+				  const uint8_t *__restrict src)
+{
+	uint8_t u[4];
+	float f[4];
+	memcpy(&u, src, sizeof(u));
+	gs_u8x4_to_float4(f, u);
+	gs_float3_srgb_nonlinear_to_linear(f);
+	gs_premultiply_float4(f);
+	gs_float3_srgb_linear_to_nonlinear(f);
+	gs_float3_to_u8x3(u, f);
+	memcpy(dst, &u, sizeof(u));
+}
+
+static inline void gs_premultiply_xyza_loop(uint8_t *data, size_t texel_count)
+{
+	for (size_t i = 0; i < texel_count; ++i) {
+		gs_premultiply_xyza(data);
+		data += 4;
+	}
+}
+
+static inline void gs_premultiply_xyza_srgb_loop(uint8_t *data,
+						 size_t texel_count)
+{
+	for (size_t i = 0; i < texel_count; ++i) {
+		gs_premultiply_xyza_srgb(data);
+		data += 4;
+	}
+}
+
+static inline void
+gs_premultiply_xyza_loop_restrict(uint8_t *__restrict dst,
+				  const uint8_t *__restrict src,
+				  size_t texel_count)
+{
+	for (size_t i = 0; i < texel_count; ++i) {
+		gs_premultiply_xyza_restrict(dst, src);
+		dst += 4;
+		src += 4;
+	}
+}
+
+static inline void
+gs_premultiply_xyza_srgb_loop_restrict(uint8_t *__restrict dst,
+				       const uint8_t *__restrict src,
+				       size_t texel_count)
+{
+	for (size_t i = 0; i < texel_count; ++i) {
+		gs_premultiply_xyza_srgb_restrict(dst, src);
+		dst += 4;
+		src += 4;
+	}
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3684,7 +3684,7 @@ static inline bool can_bypass(obs_source_t *target, obs_source_t *parent,
 	       ((parent_flags & OBS_SOURCE_CUSTOM_DRAW) == 0) &&
 	       ((parent_flags & OBS_SOURCE_ASYNC) == 0) &&
 	       (((filter_flags & OBS_SOURCE_SRGB) == 0) ||
-		((parent_flags & OBS_SOURCE_SRGB) == 0));
+		((parent_flags & OBS_SOURCE_SRGB) != 0));
 }
 
 bool obs_source_process_filter_begin(obs_source_t *filter,


### PR DESCRIPTION
### Description
Image sources are now premultiplied on load, allowing properly filtered samples. We can also trivialize the render function and remove the custom draw attribute to restore the direct rendering filter optimization.

### Motivation and Context
Correctly filtered samples are nice. Speed is good.

### How Has This Been Tested?
Exercised all modified code paths, even if it meant temporarily modifying code or copying snippets to a testbed to run them.

Tests included 8-bit and 16-bit images with transparency, animated gifs, verifying the direct rendering optimization is restored, and toggling the linear checkbox for all images.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation. (Well, I followed the pattern of non-documentation.)