### PR TITLE
UI: Use QScopedPointers for dialogs

### DIFF
--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -16,7 +16,6 @@ OBSLogViewer::OBSLogViewer(QWidget *parent) : QDialog(parent)
 {
 	setWindowFlags(windowFlags() & Qt::WindowMaximizeButtonHint &
 		       ~Qt::WindowContextHelpButtonHint);
-	setAttribute(Qt::WA_DeleteOnClose);
 
 	QVBoxLayout *layout = new QVBoxLayout();
 	layout->setContentsMargins(0, 0, 0, 0);

--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -126,7 +126,6 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 	setSizeGripEnabled(true);
 	setWindowModality(Qt::NonModal);
-	setAttribute(Qt::WA_DeleteOnClose, true);
 
 	setContextMenuPolicy(Qt::CustomContextMenu);
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -233,15 +233,15 @@ private:
 	QScopedPointer<QThread> introCheckThread;
 	QScopedPointer<QThread> logUploadThread;
 
-	QPointer<OBSBasicInteraction> interaction;
-	QPointer<OBSBasicProperties> properties;
-	QPointer<OBSBasicTransform> transformWindow;
-	QPointer<OBSBasicAdvAudio> advAudioWindow;
-	QPointer<OBSBasicFilters> filters;
+	QScopedPointer<OBSBasicInteraction> interaction;
+	QScopedPointer<OBSBasicProperties> properties;
+	QScopedPointer<OBSBasicTransform> transformWindow;
+	QScopedPointer<OBSBasicAdvAudio> advAudioWindow;
+	QScopedPointer<OBSBasicFilters> filters;
 	QPointer<QDockWidget> statsDock;
-	QPointer<OBSAbout> about;
-	QPointer<OBSMissingFiles> missDialog;
-	QPointer<OBSLogViewer> logView;
+	QScopedPointer<OBSAbout> about;
+	QScopedPointer<OBSMissingFiles> missDialog;
+	QScopedPointer<OBSLogViewer> logView;
 
 	QPointer<QTimer> cpuUsageTimer;
 	QPointer<QTimer> diskFullTimer;


### PR DESCRIPTION
### Description
With QScopedPointers, the dialogs are automatically deleted
when going out of scope.

### Motivation and Context
Automating deletion is nice.

### How Has This Been Tested
Open and closed all of the dialogs and closed OBS to make sure nothing broke.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
