### PR TITLE
obs-filters: Fix color key distance

### DIFF
--- a/plugins/obs-filters/data/color_key_filter_v2.effect
+++ b/plugins/obs-filters/data/color_key_filter_v2.effect
@@ -34,9 +34,19 @@ float4 CalcColor(float4 rgba)
 	return float4(pow(rgba.rgb, float3(gamma, gamma, gamma)) * contrast + brightness, rgba.a);
 }
 
+float GetNonlinearChannel(float u)
+{
+	return (u <= 0.0031308) ? (12.92 * u) : ((1.055 * pow(u, 1.0 / 2.4)) - 0.055);
+}
+
+float3 GetNonlinearColor(float3 rgb)
+{
+	return float3(GetNonlinearChannel(rgb.r), GetNonlinearChannel(rgb.g), GetNonlinearChannel(rgb.b));
+}
+
 float GetColorDist(float3 rgb)
 {
-	return distance(key_color.rgb, rgb);
+	return distance(key_color.rgb, GetNonlinearColor(rgb));
 }
 
 float4 ProcessColorKey(float4 rgba, VertData v_in)


### PR DESCRIPTION
### Description
Was incorrectly computing distance between linear color and nonlinear
key. Make color nonlinear to match previous behavior.

### Motivation and Context
Make color key behave the same.

### How Has This Been Tested?
Verified broken test case now behaves as before. Chroma key shader looks similar.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.