### PR TITLE
decklink: Fix crash during shutdown when output is on

### DIFF
--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -104,10 +104,6 @@ static void decklink_output_stop(void *data, uint64_t)
 
 	obs_output_end_data_capture(decklink->GetOutput());
 
-	ComPtr<DeckLinkDevice> device;
-
-	device.Set(deviceEnum->FindByHash(decklink->deviceHash));
-
 	decklink->Deactivate();
 }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes a segfault in decklink_output_stop() while also removing unused code.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
OBS kept crashing while im testing Decklink stuff.

The actual crash is caused because obs_module_unload() is called before the decklink outputs are stopped. In obs_module_unload(), the deviceEnum pointer is freed. During decklink_output_stop(), the removed code tries to retrieve a reference of the decklink device from the deviceEnum and crashes because it has already been freed. This code appears to serve no purpose anyway, so we remove it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Ubuntu 20.04, using master HEAD: No crashes after removing the extra code.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
