### PR TITLE
CI: Crowdin Synchronization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,5 +7,3 @@
 *.vcxproj.filters text eol=crlf
 
 cmake/ALL_BUILD.vcxproj.user.in text eol=crlf
-
-en-US.ini text eol=crlf

--- a/.github/workflows/crowdin-sync-download.yml
+++ b/.github/workflows/crowdin-sync-download.yml
@@ -1,0 +1,21 @@
+name: "Crowdin Sync: Import latest translations"
+on: workflow_dispatch
+jobs:
+  download:
+    name: Import latest translations
+    runs-on: ubuntu-latest
+    env:
+      CROWDIN_PAT: ${{ secrets.CROWDIN_SYNC_CROWDIN_PAT }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          token: ${{ secrets.CROWDIN_SYNC_GITHUB_PAT }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Download Script
+        run: wget -P ./other/ https://raw.githubusercontent.com/obsproject/crowdin-synchronization/0.1.0/dist/download.mjs
+      - name: Import latest translations from Crowdin
+        run: node ./other/download.mjs

--- a/.github/workflows/crowdin-sync-upload.yml
+++ b/.github/workflows/crowdin-sync-upload.yml
@@ -1,0 +1,26 @@
+name: "Crowdin Sync: Upload English strings"
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "**/en-US.ini"
+jobs:
+  upload:
+    name: Upload English strings
+    runs-on: ubuntu-latest
+    env:
+      CROWDIN_PAT: ${{ secrets.CROWDIN_SYNC_CROWDIN_PAT }}
+      GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Download Script
+        run: wget -P ./other/ https://raw.githubusercontent.com/obsproject/crowdin-synchronization/0.1.0/dist/upload.mjs
+      - name: Upload English strings to Crowdin
+        run: node ./other/upload.mjs


### PR DESCRIPTION
### Description

This adds 2 GitHub Actions that streamline the synchronization and localization process between this repository and the Crowdin project.

Features of the 'Download Action':
- Updates all translations in the main repository and all 3 submodules that include translateable content (obs-browser, obs-vst & enc-amf).
- Updates the `AUTHORS` file with both Git contributors and translators.
- Updates the translations of the `UI/xdg-data/com.obsproject.Studio.desktop`.
- Updates the `UI/data/locale.ini`: New languages need 60% to be added, languages with less than 30% will be removed.

Note: The GitHub Action only pushes submodule changes to the main repository if it is even with the main repository to prevent other commits from being implemented without knowing. The translation updates would still get pushed to the submodules, but will be left there waiting for a version bump.

Features of the 'Upload Action':
- Updates the English locales on Crowdin.

**Required Repository Secrets:**
- `CROWDIN_SYNC_CROWDIN_PAT` for authorizing with the Crowdin API. Go to https://crowdin.com/settings#api-key to generate one (needs to come from the owner or a manager).
- `CROWDIN_SYNC_GITHUB_PAT` for pushing changes to the submodules. Get it from https://github.com/settings/tokens. It requires access to `public_repo` and has to come from a person with push access to the main repository and the 3 submodules (obs-browser, obs-vst & enc-amf).

Code: https://github.com/obsproject/crowdin-synchronization

### Motivation and Context

Reduce the amount of manual steps, people and time required for releasing a new version.

_If in some future the release process is automated, it would even allow automated translation updates for release builds._

### How Has This Been Tested?

Download:
https://github.com/crowdin-sync-testing/obs-studio/commit/3d49472066c6a03c93a388ce76f9b02a6c3a564f triggered via https://github.com/crowdin-sync-testing/obs-studio/runs/4014006430?check_suite_focus=true

Upload:
https://github.com/crowdin-sync-testing/obs-studio/runs/4021661956?check_suite_focus=true triggered via https://github.com/crowdin-sync-testing/obs-studio/commit/d3cf4c9e294eb1c2346e6ae4130fdf95c64b1925

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.