### PR TITLE
decklink-output-ui: Decklink fixes

### DIFF
--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
@@ -330,3 +330,12 @@ bool obs_module_load(void)
 
 	return true;
 }
+
+void obs_module_unload(void)
+{
+	if (preview_output_running)
+		preview_output_stop();
+
+	if (main_output_running)
+		output_stop();
+}

--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
@@ -105,6 +105,16 @@ OBSData load_preview_settings()
 void on_preview_scene_changed(enum obs_frontend_event event, void *param);
 void render_preview_source(void *param, uint32_t cx, uint32_t cy);
 
+static void preview_tick(void *param, float sec)
+{
+	UNUSED_PARAMETER(sec);
+
+	auto ctx = (struct preview_output *)param;
+
+	if (ctx->texrender)
+		gs_texrender_reset(ctx->texrender);
+}
+
 void preview_output_stop()
 {
 	obs_output_stop(context.output);
@@ -122,6 +132,7 @@ void preview_output_stop()
 	obs_leave_graphics();
 
 	video_output_close(context.video_queue);
+	obs_remove_tick_callback(preview_tick, &context);
 
 	preview_output_running = false;
 	doUI->PreviewOutputStateChanged(false);
@@ -132,6 +143,7 @@ void preview_output_start()
 	OBSData settings = load_preview_settings();
 
 	if (settings != nullptr) {
+		obs_add_tick_callback(preview_tick, &context);
 		context.output = obs_output_create("decklink_output",
 						   "decklink_preview_output",
 						   settings, NULL);
@@ -230,8 +242,6 @@ void render_preview_source(void *param, uint32_t cx, uint32_t cy)
 
 	uint32_t width = obs_source_get_base_width(ctx->current_source);
 	uint32_t height = obs_source_get_base_height(ctx->current_source);
-
-	gs_texrender_reset(ctx->texrender);
 
 	if (gs_texrender_begin(ctx->texrender, width, height)) {
 		struct vec4 background;


### PR DESCRIPTION
### Description
Commit 1: To prevent rendering the texrender more than necessary, only
render it once per frame in a tick callback.

Commit 2: When closing OBS, sometimes it would crash if the Decklink outputs
were active.

### Motivation and Context
Commit 1: Inspired by https://github.com/obsproject/obs-studio/commit/4636413334a9f0418fdb320677939fcc4c73642a, I went looking for other places where this might be happening.

Commit 2: When testing the texrender code, it would sometimes crash on shut down.

### How Has This Been Tested?
Used the Decklink output to make sure everything worked as expected.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
