### PR TITLE
UI: set media before start output

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -934,6 +934,7 @@ bool SimpleOutput::StartStreaming(obs_service_t *service)
 
 	SetupVodTrack(service);
 
+	obs_output_set_media(streamOutput, obs_get_video(), obs_get_audio());
 	if (obs_output_start(streamOutput)) {
 		return true;
 	}
@@ -1043,6 +1044,8 @@ bool SimpleOutput::StartRecording()
 	UpdateRecording();
 	if (!ConfigureRecording(false))
 		return false;
+
+	obs_output_set_media(fileOutput, obs_get_video(), obs_get_audio());
 	if (!obs_output_start(fileOutput)) {
 		QString error_reason;
 		const char *error = obs_output_get_last_error(fileOutput);
@@ -1064,6 +1067,8 @@ bool SimpleOutput::StartReplayBuffer()
 	UpdateRecording();
 	if (!ConfigureRecording(true))
 		return false;
+
+	obs_output_set_media(replayBuffer, obs_get_video(), obs_get_audio());
 	if (!obs_output_start(replayBuffer)) {
 		QMessageBox::critical(main, QTStr("Output.StartReplayFailed"),
 				      QTStr("Output.StartFailedGeneric"));
@@ -1812,6 +1817,7 @@ bool AdvancedOutput::StartStreaming(obs_service_t *service)
 
 	SetupVodTrack(service);
 
+	obs_output_set_media(streamOutput, obs_get_video(), obs_get_audio());
 	if (obs_output_start(streamOutput)) {
 		return true;
 	}
@@ -1880,6 +1886,7 @@ bool AdvancedOutput::StartRecording()
 		obs_data_release(settings);
 	}
 
+	obs_output_set_media(fileOutput, obs_get_video(), obs_get_audio());
 	if (!obs_output_start(fileOutput)) {
 		QString error_reason;
 		const char *error = obs_output_get_last_error(fileOutput);
@@ -1961,6 +1968,7 @@ bool AdvancedOutput::StartReplayBuffer()
 		obs_data_release(settings);
 	}
 
+	obs_output_set_media(replayBuffer, obs_get_video(), obs_get_audio());
 	if (!obs_output_start(replayBuffer)) {
 		QString error_reason;
 		const char *error = obs_output_get_last_error(replayBuffer);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Call obs_output_set_media to update the latest video-io and audio-io context in output before start.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The video-io context stored in obs-core-video (obs->video->video) will be reallocated when we change "Video" settings, but the video-io context stored in each output is not updated every time. 
Although in most cases, the memory area that is released and reallocated is still the same as the original memory area,  but once the original memory area is not accessible, OBS may crash inside following code (_**video_output_get_total_frames(output->video)**_, because output->video is not accessible), :
```
bool obs_output_actual_start(obs_output_t *output)
{
...
	if (success && output->video) {
		output->starting_frame_count =
			video_output_get_total_frames(output->video);
...
	}
...
	return success;
}
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
(1) start output (record or stream)
(2) stop output
(3) change video settings (resolution)
(4) start output again.
(repeat)
This may not show up 100% percent. I've only reproduced it a few times in Debug mode.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
