### PR TITLE
More filter color fixes

### DIFF
--- a/plugins/obs-filters/color-grade-filter.c
+++ b/plugins/obs-filters/color-grade-filter.c
@@ -452,8 +452,13 @@ static void color_grade_filter_render(void *data, gs_effect_t *effect)
 	param = gs_effect_get_param_by_name(filter->effect, "cube_width_i");
 	gs_effect_set_float(param, 1.0f / filter->cube_width);
 
+	gs_blend_state_push();
+	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+
 	obs_source_process_filter_tech_end(filter->context, filter->effect, 0,
 					   0, tech_name);
+
+	gs_blend_state_pop();
 
 	UNUSED_PARAMETER(effect);
 }

--- a/plugins/obs-filters/data/color_grade_filter.effect
+++ b/plugins/obs-filters/data/color_grade_filter.effect
@@ -171,6 +171,7 @@ float4 LUT3D(VertDataOut v_in) : TARGET
 	}
 
 	textureColor.rgb = srgb_nonlinear_to_linear(textureColor.rgb);
+	textureColor.rgb *= textureColor.a;
 	return textureColor;
 }
 

--- a/plugins/obs-filters/data/luma_key_filter_v2.effect
+++ b/plugins/obs-filters/data/luma_key_filter_v2.effect
@@ -38,8 +38,10 @@ float4 PSALumaKeyRGBA(VertData v_in) : TARGET
 	float chi = 1. - smoothstep(lumaMax - lumaMaxSmooth, lumaMax, luminance);
 
 	float amask = clo * chi;
+	rgba.a *= amask;
+	rgba.rgb *= rgba.a;
 
-	return float4(rgba.rgb, rgba.a * amask);
+	return rgba;
 }
 
 technique Draw

--- a/plugins/obs-filters/scale-filter.c
+++ b/plugins/obs-filters/scale-filter.c
@@ -297,9 +297,14 @@ static void scale_filter_render(void *data, gs_effect_t *effect)
 		gs_effect_set_next_sampler(filter->image_param,
 					   filter->point_sampler);
 
+	gs_blend_state_push();
+	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+
 	obs_source_process_filter_tech_end(filter->context, filter->effect,
 					   filter->cx_out, filter->cy_out,
 					   technique);
+
+	gs_blend_state_pop();
 
 	UNUSED_PARAMETER(effect);
 }


### PR DESCRIPTION
### Description
Fix scale filter using the wrong blend setup, which altered colors for semi-transparent inputs.

Also update blend setups to have extra precision for Apply LUT and Luma Key.

### Motivation and Context
Better color handling.

### How Has This Been Tested?
Tested colors using opaque and semi-transparent textures are stable and expected.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.