### PR TITLE
Fix scene collection importer OS translation

### DIFF
--- a/UI/importers/studio.cpp
+++ b/UI/importers/studio.cpp
@@ -31,15 +31,17 @@ void TranslateOSStudio(Json &res)
 
 		string id = source["id"].string_value();
 
-#define DirectTranslation(before, after) \
-	if (id == before) {              \
-		source["id"] = after;    \
+#define DirectTranslation(before, after)                                      \
+	if (id == before) {                                                   \
+		source["id"] = after;                                         \
+		source["versioned_id"] = obs_get_latest_input_type_id(after); \
 	}
 
-#define ClearTranslation(before, after)              \
-	if (id == before) {                          \
-		source["id"] = after;                \
-		source["settings"] = Json::object{}; \
+#define ClearTranslation(before, after)                                       \
+	if (id == before) {                                                   \
+		source["id"] = after;                                         \
+		source["settings"] = Json::object{};                          \
+		source["versioned_id"] = obs_get_latest_input_type_id(after); \
 	}
 
 #ifdef __APPLE__

--- a/UI/importers/studio.cpp
+++ b/UI/importers/studio.cpp
@@ -143,6 +143,7 @@ void TranslateOSStudio(Json &res)
 #undef ClearTranslation
 	}
 
+	out["sources"] = sources;
 	res = out;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Two changes.

UI: Fix scene collection importer OS translation 

The OS translation in the Scene Collection Importer seems to have been broken since the feature was added because the translated sources were not added back to the output JSON object. Add the translated sources to the output JSON object to get the feature to work. 

----

UI: Add versioned sources to scene collection importer 

Versioned sources were added in commit b2302902a3b3e1cce140a6417f4c5e490869a3f2 after the scene collection importer was added in commit 191165c7210f2b8adf8756cf121341075bf16b3d. When a versioned source gets converted in TranslateOSStudio, it can end up with a translated "id" but an untranslated "versioned_id". When OBS loads the resulting JSON, it will rely on the versioned_id, and rewrite the id to the corresponding value. Use obs_get_latest_input_type_id on the translated source id to get the correct versioned_id when using TranslateOSStudio.



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We want OS translation to work since OBS Studio supports Windows, macOS, and Linux.  Fixes #4391.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I imported a simple scene collection file from macOS that contained a FreeType 2 source ("id": "text_ft2_source", "versioned_id": "text_ft2_source_v2") and confirmed that it was converted to a GDI+ text source ("id": "text_gdiplus", "versioned_id": "text_gdiplus_v2").

I'd appreciate additional testing for dshow_input <-> av_capture_input or any other source types that require OS translation.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
