### PR TITLE
obs-transitions: Make sure gs calls are in graphics context

### DIFF
--- a/plugins/obs-transitions/transition-stinger.c
+++ b/plugins/obs-transitions/transition-stinger.c
@@ -143,6 +143,8 @@ static void stinger_update(void *data, obs_data_t *settings)
 	}
 
 	if (s->track_matte_enabled != track_matte_was_enabled) {
+		obs_enter_graphics();
+
 		gs_texrender_destroy(s->matte_tex);
 		gs_texrender_destroy(s->stinger_tex);
 		s->matte_tex = NULL;
@@ -153,6 +155,8 @@ static void stinger_update(void *data, obs_data_t *settings)
 			s->stinger_tex =
 				gs_texrender_create(GS_RGBA, GS_ZS_NONE);
 		}
+
+		obs_leave_graphics();
 	}
 }
 


### PR DESCRIPTION
### Description
This would cause a memory leak when toggling the track matte
transition.

### Motivation and Context
Don't like memory leaks.

### How Has This Been Tested?
Toggled track matte to make sure memory leak was gone.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
