### PR TITLE
D3D12 hook improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -482,6 +482,7 @@ jobs:
       CMAKE_GENERATOR: "Visual Studio 16 2019"
       CMAKE_SYSTEM_VERSION: "10.0.18363.657"
       WINDOWS_DEPS_VERSION: '2019'
+      WINDOWS_DEPS_CACHE_VERSION: '1'
       VLC_VERSION: '3.0.0-git'
       VIRTUALCAM-GUID: "A3FCE0F5-3493-419F-958A-ABA1250EC20B"
     steps:
@@ -524,7 +525,7 @@ jobs:
           CACHE_NAME: 'windows-deps-cache'
         with:
           path: ${{ github.workspace }}/cmbuild/deps
-          key: ${{ runner.os }}-pr-${{ env.CACHE_NAME }}-${{ env.WINDOWS_DEPS_VERSION }}
+          key: ${{ runner.os }}-pr-${{ env.CACHE_NAME }}-${{ env.WINDOWS_DEPS_VERSION }}-${{ env.WINDOWS_DEPS_CACHE_VERSION }}
       - name: 'Restore VLC dependency from cache'
         id: vlc-cache
         uses: actions/cache@v2.1.2
@@ -591,6 +592,7 @@ jobs:
       CMAKE_GENERATOR: "Visual Studio 16 2019"
       CMAKE_SYSTEM_VERSION: "10.0.18363.657"
       WINDOWS_DEPS_VERSION: '2019'
+      WINDOWS_DEPS_CACHE_VERSION: '1'
       VIRTUALCAM-GUID: "A3FCE0F5-3493-419F-958A-ABA1250EC20B"
     steps:
       - name: 'Add msbuild to PATH'
@@ -632,7 +634,7 @@ jobs:
           CACHE_NAME: 'deps-cache'
         with:
           path: ${{ github.workspace }}/cmbuild/deps
-          key: ${{ runner.os }}-pr-${{ env.CACHE_NAME }}-${{ env.WINDOWS_DEPS_VERSION }}
+          key: ${{ runner.os }}-pr-${{ env.CACHE_NAME }}-${{ env.WINDOWS_DEPS_VERSION }}-${{ env.WINDOWS_DEPS_CACHE_VERSION }}
       - name: 'Restore VLC dependency from cache'
         id: vlc-cache
         uses: actions/cache@v2.1.2

--- a/cmake/Modules/FindDetours.cmake
+++ b/cmake/Modules/FindDetours.cmake
@@ -1,0 +1,68 @@
+# Once done these will be defined:
+#
+#  DETOURS_FOUND
+#  DETOURS_INCLUDE_DIRS
+#  DETOURS_LIBRARIES
+#
+# For use in OBS:
+#
+#  DETOURS_INCLUDE_DIR
+
+find_package(PkgConfig QUIET)
+if (PKG_CONFIG_FOUND)
+	pkg_check_modules(_DETOURS QUIET detours)
+endif()
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	set(_lib_suffix 64)
+else()
+	set(_lib_suffix 32)
+endif()
+
+find_path(DETOURS_INCLUDE_DIR
+	NAMES detours.h
+	HINTS
+		ENV detoursPath${_lib_suffix}
+		ENV detoursPath
+		ENV DepsPath${_lib_suffix}
+		ENV DepsPath
+		${detoursPath${_lib_suffix}}
+		${detoursPath}
+		${DepsPath${_lib_suffix}}
+		${DepsPath}
+		${_DETOURS_INCLUDE_DIRS}
+	PATHS
+		/usr/include /usr/local/include /opt/local/include /sw/include
+	PATH_SUFFIXES
+		include)
+
+find_library(DETOURS_LIB
+	NAMES ${_DETOURS_LIBRARIES} detours
+	HINTS
+		ENV detoursPath${_lib_suffix}
+		ENV detoursPath
+		ENV DepsPath${_lib_suffix}
+		ENV DepsPath
+		${detoursPath${_lib_suffix}}
+		${detoursPath}
+		${DepsPath${_lib_suffix}}
+		${DepsPath}
+		${_DETOURS_LIBRARY_DIRS}
+	PATHS
+		/usr/lib /usr/local/lib /opt/local/lib /sw/lib
+	PATH_SUFFIXES
+		lib${_lib_suffix} lib
+		libs${_lib_suffix} libs
+		bin${_lib_suffix} bin
+		../lib${_lib_suffix} ../lib
+		../libs${_lib_suffix} ../libs
+		../bin${_lib_suffix} ../bin)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(DETOURS DEFAULT_MSG DETOURS_LIB DETOURS_INCLUDE_DIR)
+mark_as_advanced(DETOURS_INCLUDE_DIR DETOURS_LIB)
+
+if(DETOURS_FOUND)
+	set(DETOURS_INCLUDE_DIRS ${DETOURS_INCLUDE_DIR})
+	set(DETOURS_LIBRARIES ${DETOURS_LIB})
+endif()

--- a/plugins/win-capture/graphics-hook-ver.h
+++ b/plugins/win-capture/graphics-hook-ver.h
@@ -12,7 +12,7 @@
  * THIS IS YOUR ONLY WARNING. */
 
 #define HOOK_VER_MAJOR 1
-#define HOOK_VER_MINOR 4
+#define HOOK_VER_MINOR 5
 #define HOOK_VER_PATCH 0
 
 #define STRINGIFY(s) #s

--- a/plugins/win-capture/graphics-hook/CMakeLists.txt
+++ b/plugins/win-capture/graphics-hook/CMakeLists.txt
@@ -2,6 +2,7 @@ project(graphics-hook)
 
 set(COMPILE_D3D12_HOOK FALSE CACHE BOOL "Compile D3D12 hook support (required windows 10 SDK)")
 
+find_package(Detours REQUIRED)
 find_package(Vulkan REQUIRED)
 include_directories(${VULKAN_INCLUDE_DIR})
 
@@ -55,7 +56,8 @@ target_include_directories(graphics-hook PUBLIC
 target_link_libraries(graphics-hook
 	dxguid
 	ipc-util
-	psapi)
+	psapi
+	${DETOURS_LIBRARIES})
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
 	set(_output_suffix "64")

--- a/plugins/win-capture/graphics-hook/d3d12-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d12-capture.cpp
@@ -46,7 +46,8 @@ struct d3d12_data {
 static struct d3d12_data data = {};
 
 extern thread_local bool dxgi_presenting;
-extern ID3D12CommandQueue *dxgi_possible_swap_queue;
+extern ID3D12CommandQueue *dxgi_possible_swap_queues[8];
+extern size_t dxgi_possible_swap_queue_count;
 extern bool dxgi_present_attempted;
 
 void d3d12_free(void)
@@ -149,7 +150,6 @@ static bool d3d12_init_11on12(ID3D12Device *device)
 	static PFN_D3D11ON12_CREATE_DEVICE create_11_on_12 = nullptr;
 	static bool initialized_11 = false;
 	static bool initialized_func = false;
-	HRESULT hr;
 
 	if (!initialized_11 && !d3d11) {
 		d3d11 = load_system_library("d3d11.dll");
@@ -178,29 +178,47 @@ static bool d3d12_init_11on12(ID3D12Device *device)
 		return false;
 	}
 
-	IUnknown *queue = nullptr;
-	IUnknown *const *queues = nullptr;
-	UINT num_queues = 0;
+	bool created = false;
+
 	if (global_hook_info->d3d12_use_swap_queue) {
-		hlog("d3d12_init_11on12: creating 11 device with swap queue: 0x%" PRIX64,
-		     (uint64_t)(uintptr_t)dxgi_possible_swap_queue);
-		queue = dxgi_possible_swap_queue;
-		queues = &queue;
-		num_queues = 1;
+		for (size_t i = 0; i < dxgi_possible_swap_queue_count; ++i) {
+			hlog("d3d12_init_11on12: creating 11 device with swap queue: 0x%" PRIX64,
+			     (uint64_t)(uintptr_t)dxgi_possible_swap_queues[i]);
+			IUnknown *const queue = dxgi_possible_swap_queues[i];
+			const HRESULT hr = create_11_on_12(
+				device, 0, nullptr, 0, &queue, 1, 0,
+				&data.device11, &data.context11, nullptr);
+			created = SUCCEEDED(hr);
+			if (created) {
+				break;
+			}
+
+			hlog_hr("d3d12_init_11on12: failed to create 11 device",
+				hr);
+		}
 	} else {
 		hlog("d3d12_init_11on12: creating 11 device without swap queue");
+		const HRESULT hr = create_11_on_12(device, 0, nullptr, 0,
+						   nullptr, 0, 0,
+						   &data.device11,
+						   &data.context11, nullptr);
+		created = SUCCEEDED(hr);
+		if (!created) {
+			hlog_hr("d3d12_init_11on12: failed to create 11 device",
+				hr);
+		}
 	}
 
-	hr = create_11_on_12(device, 0, nullptr, 0, queues, num_queues, 0,
-			     &data.device11, &data.context11, nullptr);
-
-	if (FAILED(hr)) {
-		hlog_hr("d3d12_init_11on12: failed to create 11 device", hr);
+	if (!created) {
 		return false;
 	}
 
-	data.device11->QueryInterface(__uuidof(ID3D11On12Device),
-				      (void **)&data.device11on12);
+	memset(dxgi_possible_swap_queues, 0, sizeof(dxgi_possible_swap_queues));
+	dxgi_possible_swap_queue_count = 0;
+	dxgi_present_attempted = false;
+
+	const HRESULT hr =
+		data.device11->QueryInterface(IID_PPV_ARGS(&data.device11on12));
 	if (FAILED(hr)) {
 		hlog_hr("d3d12_init_11on12: failed to query 11on12 device", hr);
 		return false;
@@ -363,6 +381,18 @@ void d3d12_capture(void *swap_ptr, void *, bool capture_overlay)
 	}
 }
 
+static bool try_append_queue_if_unique(ID3D12CommandQueue *queue)
+{
+	for (size_t i = 0; i < dxgi_possible_swap_queue_count; ++i) {
+		if (dxgi_possible_swap_queues[i] == queue)
+			return false;
+	}
+
+	dxgi_possible_swap_queues[dxgi_possible_swap_queue_count] = queue;
+	++dxgi_possible_swap_queue_count;
+	return true;
+}
+
 static HRESULT STDMETHODCALLTYPE
 hook_execute_command_lists(ID3D12CommandQueue *queue, UINT NumCommandLists,
 			   ID3D12CommandList *const *ppCommandLists)
@@ -370,17 +400,24 @@ hook_execute_command_lists(ID3D12CommandQueue *queue, UINT NumCommandLists,
 	hlog_verbose("ExecuteCommandLists callback: queue=0x%" PRIX64,
 		     (uint64_t)(uintptr_t)queue);
 
-	if (!dxgi_possible_swap_queue) {
-		if (dxgi_presenting) {
-			hlog("Remembering D3D12 queue from present");
-			dxgi_possible_swap_queue = queue;
+	if (dxgi_possible_swap_queue_count <
+	    _countof(dxgi_possible_swap_queues)) {
+		if (dxgi_presenting &&
+		    (queue->GetDesc().Type == D3D12_COMMAND_LIST_TYPE_DIRECT)) {
+			if (try_append_queue_if_unique(queue)) {
+				hlog("Remembering D3D12 queue from present: queue=0x%" PRIX64,
+				     (uint64_t)(uintptr_t)queue);
+			}
 		} else if (dxgi_present_attempted &&
 			   (queue->GetDesc().Type ==
 			    D3D12_COMMAND_LIST_TYPE_DIRECT)) {
-			hlog("Remembering D3D12 queue from first direct submit after present");
-			dxgi_possible_swap_queue = queue;
+			if (try_append_queue_if_unique(queue)) {
+				hlog("Remembering D3D12 queue from first direct submit after present: queue=0x%" PRIX64,
+				     (uint64_t)(uintptr_t)queue);
+			}
 		} else {
-			hlog_verbose("Ignoring D3D12 queue");
+			hlog_verbose("Ignoring D3D12 queue=0x%" PRIX64,
+				     (uint64_t)(uintptr_t)queue);
 		}
 	}
 

--- a/plugins/win-capture/graphics-hook/dxgi-capture.cpp
+++ b/plugins/win-capture/graphics-hook/dxgi-capture.cpp
@@ -100,12 +100,13 @@ static ULONG STDMETHODCALLTYPE hook_release(IUnknown *unknown)
 	rehook(&release);
 
 	if (unknown == data.swap && refs == 0) {
-		data.free();
 		data.swap = nullptr;
-		data.free = nullptr;
 		data.capture = nullptr;
 		dxgi_possible_swap_queue = nullptr;
 		dxgi_present_attempted = false;
+
+		data.free();
+		data.free = nullptr;
 	}
 
 	return refs;
@@ -121,14 +122,14 @@ static HRESULT STDMETHODCALLTYPE hook_resize_buffers(IDXGISwapChain *swap,
 {
 	HRESULT hr;
 
-	if (!!data.free)
-		data.free();
-
 	data.swap = nullptr;
-	data.free = nullptr;
 	data.capture = nullptr;
 	dxgi_possible_swap_queue = nullptr;
 	dxgi_present_attempted = false;
+
+	if (data.free)
+		data.free();
+	data.free = nullptr;
 
 	unhook(&resize_buffers);
 	resize_buffers_t call = (resize_buffers_t)resize_buffers.call_addr;

--- a/plugins/win-capture/graphics-hook/dxgi-capture.cpp
+++ b/plugins/win-capture/graphics-hook/dxgi-capture.cpp
@@ -42,7 +42,7 @@ static bool setup_dxgi(IDXGISwapChain *swap)
 
 	hr = swap->GetDevice(__uuidof(ID3D11Device), (void **)&device);
 	if (SUCCEEDED(hr)) {
-		ID3D11Device *d3d11 = reinterpret_cast<ID3D11Device *>(device);
+		ID3D11Device *d3d11 = static_cast<ID3D11Device *>(device);
 		D3D_FEATURE_LEVEL level = d3d11->GetFeatureLevel();
 		device->Release();
 
@@ -56,31 +56,34 @@ static bool setup_dxgi(IDXGISwapChain *swap)
 
 	hr = swap->GetDevice(__uuidof(ID3D10Device), (void **)&device);
 	if (SUCCEEDED(hr)) {
+		device->Release();
+
 		data.swap = swap;
 		data.capture = d3d10_capture;
 		data.free = d3d10_free;
-		device->Release();
 		return true;
 	}
 
 	hr = swap->GetDevice(__uuidof(ID3D11Device), (void **)&device);
 	if (SUCCEEDED(hr)) {
+		device->Release();
+
 		data.swap = swap;
 		data.capture = d3d11_capture;
 		data.free = d3d11_free;
-		device->Release();
 		return true;
 	}
 
 #if COMPILE_D3D12_HOOK
 	hr = swap->GetDevice(__uuidof(ID3D12Device), (void **)&device);
 	if (SUCCEEDED(hr)) {
+		device->Release();
+
 		if (!global_hook_info->d3d12_use_swap_queue ||
 		    dxgi_possible_swap_queue) {
 			data.swap = swap;
 			data.capture = d3d12_capture;
 			data.free = d3d12_free;
-			device->Release();
 			return true;
 		}
 	}

--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -68,12 +68,12 @@ bool init_pipe(void)
 	char new_name[64];
 	sprintf(new_name, "%s%lu", PIPE_NAME, GetCurrentProcessId());
 
-	if (!ipc_pipe_client_open(&pipe, new_name)) {
+	const bool success = ipc_pipe_client_open(&pipe, new_name);
+	if (!success) {
 		DbgOut("[OBS] Failed to open pipe\n");
-		return false;
 	}
 
-	return true;
+	return success;
 }
 
 static HANDLE init_event(const wchar_t *name, DWORD pid)

--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -391,6 +391,24 @@ static inline bool attempt_hook(void)
 		}
 	}*/
 
+#if HOOK_VERBOSE_LOGGING
+	DbgOut("[OBS] Attempt hook: D3D8=");
+	DbgOut(d3d8_hooked ? "1" : "0");
+	DbgOut(", D3D9=");
+	DbgOut(d3d9_hooked ? "1" : "0");
+	DbgOut(", D3D12=");
+	DbgOut(d3d12_hooked ? "1" : "0");
+	DbgOut(", DXGI=");
+	DbgOut(dxgi_hooked ? "1" : "0");
+	DbgOut(", GL=");
+	DbgOut(gl_hooked ? "1" : "0");
+#if COMPILE_VULKAN_HOOK
+	DbgOut(", VK=");
+	DbgOut(vulkan_hooked ? "1" : "0");
+#endif
+	DbgOut("\n");
+#endif
+
 	return false;
 }
 

--- a/plugins/win-capture/graphics-hook/graphics-hook.h
+++ b/plugins/win-capture/graphics-hook/graphics-hook.h
@@ -20,6 +20,13 @@ extern "C" {
 #endif
 
 #define NUM_BUFFERS 3
+#define HOOK_VERBOSE_LOGGING 0
+
+#if HOOK_VERBOSE_LOGGING
+#define hlog_verbose(...) hlog(__VA_ARGS__)
+#else
+#define hlog_verbose(...) (void)0
+#endif
 
 extern void hlog(const char *format, ...);
 extern void hlog_hr(const char *text, HRESULT hr);
@@ -220,16 +227,27 @@ extern bool init_pipe(void);
 
 static inline bool capture_should_init(void)
 {
-	if (!capture_active() && capture_restarted()) {
-		if (capture_alive()) {
-			if (!ipc_pipe_client_valid(&pipe)) {
-				init_pipe();
+	bool should_init = false;
+
+	if (!capture_active()) {
+		if (capture_restarted()) {
+			if (capture_alive()) {
+				if (!ipc_pipe_client_valid(&pipe)) {
+					init_pipe();
+				}
+
+				should_init = true;
+			} else {
+				hlog_verbose(
+					"capture_should_init: inactive, restarted, not alive");
 			}
-			return true;
+		} else {
+			hlog_verbose(
+				"capture_should_init: inactive, not restarted");
 		}
 	}
 
-	return false;
+	return should_init;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Description
Make a number of changes to try to stabilize D3D12 game capture.

- Integrate Detours to hook D3D12 ExecuteCommandLists rather than using our own ad-hoc hooking code. I would like to replace everything with Detours, but this seems to be the only hook function that somehow gets undone, and we're trying to get 27 shipped. Will do more extensive Detours integration later.
- Fix potential D3D12 device leak.
- Prevent potential recursive free.
- Add "timeout" for the expected DXGI swap chain if 16 Present() calls happen on a different swap chain.
- Add more logging to help debug issues, which we used to find the ExecuteCommandLists hook failure.

### Motivation and Context
D3D12 game capture has some stability issues.

### How Has This Been Tested?
Tested against very basic D3D12 sample, both 32-bit and 64-bit builds.

Matt has verified D3D12 hook reconnects after windowed/fullscreen switches in Borderlands 3 and Division 2.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.