### PR TITLE
CI: Update build script to create arm64 builds for Apple silicon

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
       - master
 
 env:
-  MACOS_CEF_BUILD_VERSION: '4183'
+  MACOS_CEF_BUILD_VERSION: '4280'
   LINUX_CEF_BUILD_VERSION: '4280'
   CEF_VERSION: '75.1.16+g16a67c4+chromium-75.0.3770.100'
   TWITCH_CLIENTID: ${{ secrets.TWITCH_CLIENT_ID }}
@@ -31,7 +31,7 @@ jobs:
       MIN_MACOS_VERSION: '10.13'
       MACOS_DEPS_VERSION: '2021-03-25'
       VLC_VERSION: '3.0.8'
-      SPARKLE_VERSION: '1.23.0'
+      SPARKLE_VERSION: '1.26.0'
       QT_VERSION: '5.15.2'
       SIGN_IDENTITY: ''
     steps:
@@ -136,9 +136,9 @@ jobs:
         if: steps.cef-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          curl -L -O https://cdn-fastly.obsproject.com/downloads/cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macosx64.tar.bz2
-          tar -xf ./cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macosx64.tar.bz2 -C ${{ github.workspace }}/cmbuild/
-          cd ${{ github.workspace }}/cmbuild/cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macosx64
+          curl -L -O https://cdn-fastly.obsproject.com/downloads/cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macos${{ env.CURRENT_ARCH }}.tar.bz2
+          tar -xf ./cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macos${{ env.CURRENT_ARCH }}.tar.bz2 -C ${{ github.workspace }}/cmbuild/
+          cd ${{ github.workspace }}/cmbuild/cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macos${{ env.CURRENT_ARCH }}
           /usr/bin/sed -i '.orig' '/add_subdirectory(tests\/ceftests)/d' ./CMakeLists.txt
           /usr/bin/sed -i '.orig' s/\"10.9\"/\"${{ env.MIN_MACOS_VERSION }}\"/ ./cmake/cef_variables.cmake
           mkdir build && cd build

--- a/CI/scripts/macos/cef.patch
+++ b/CI/scripts/macos/cef.patch
@@ -1,0 +1,12 @@
+diff --git a/./cmake/cef_variables.cmake b/./cmake/cef_variables.cmake.fixed
+index f29c6f1..97358e4 100644
+--- a/./cmake/cef_variables.cmake
++++ b/./cmake/cef_variables.cmake.fixed
+@@ -263,6 +263,7 @@ if(OS_MAC)
+     -Wnewline-eof                   # Warn about no newline at end of file
+     -Wno-missing-field-initializers # Don't warn about missing field initializers
+     -Wno-unused-parameter           # Don't warn about unused parameters
++    -Wno-deprecated-copy            # Don't warn about deprecated copy
+     )
+   list(APPEND CEF_C_COMPILER_FLAGS
+     -std=c99                        # Use the C99 language standard


### PR DESCRIPTION
### Description
- Update Sparkle to universal
- Update full-build-macos to support arch
- Point at an arm64 CEF variant

### Motivation and Context
The resulting OBS Studio app will build native and run on Apple silicon without Rosetta, **however the Browser plugin will not function without the additional CEF patches unique to OBS Studio.**  These do not appear to be available anywhere for integration at this time.  This should probably be considered a WIP until we can integrate those changes.

### How Has This Been Tested?
- Tested on 11.3
 - 24" iMac (M1)
 - 13" MBP (M1)

Built using ./CI/full-build-macos.sh -b

Able to capture video, start a stream

### Types of changes
- Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
