### PR TITLE
obs-ffmpeg: Don't purge packets when there are none

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -724,6 +724,9 @@ static bool purge_front(struct ffmpeg_muxer *stream)
 	struct encoder_packet pkt;
 	bool keyframe;
 
+	if (!stream->packets.size)
+		return false;
+
 	circlebuf_pop_front(&stream->packets, &pkt, sizeof(pkt));
 
 	keyframe = pkt.type == OBS_ENCODER_VIDEO && pkt.keyframe;
@@ -751,6 +754,8 @@ static inline void purge(struct ffmpeg_muxer *stream)
 		struct encoder_packet pkt;
 
 		for (;;) {
+			if (!stream->packets.size)
+				return;
 			circlebuf_peek_front(&stream->packets, &pkt,
 					     sizeof(pkt));
 			if (pkt.type == OBS_ENCODER_VIDEO && pkt.keyframe)


### PR DESCRIPTION
### Description
Don't purge packets when there are none

### Motivation and Context
The replay buffer sometimes tries to purge packets while there are no packets to purge

### How Has This Been Tested?
With my source record plugin on windows 64 bit

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
