### PR TITLE
CI: Add check for code signing credentials used by notarization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,7 @@ jobs:
       SPARKLE_VERSION: '1.23.0'
       QT_VERSION: '5.15.2'
       SIGN_IDENTITY: ''
+      HAVE_CODESIGN_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY != '' && secrets.MACOS_SIGNING_CERT != '' }}
     steps:
       - name: Get Current Arch
         shell: bash
@@ -167,13 +168,13 @@ jobs:
         run: |
           pip3 install dmgbuild
       - name: 'Install Apple Developer Certificate'
-        if: success() && startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request'
+        if: success() && startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && env.HAVE_CODESIGN_IDENTITY == 'true'
         uses: apple-actions/import-codesign-certs@253ddeeac23f2bdad1646faac5c8c2832e800071
         with:
           p12-file-base64: ${{ secrets.MACOS_SIGNING_CERT }}
           p12-password: ${{ secrets.MACOS_SIGNING_CERT_PASSWORD }}
       - name: 'Set Signing Identity'
-        if: success() && startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request'
+        if: success() && startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && env.HAVE_CODESIGN_IDENTITY == 'true'
         run: |
           echo "SIGN_IDENTITY=${{ secrets.MACOS_SIGNING_IDENTITY }}" >> $GITHUB_ENV
       - name: 'Create macOS application bundle'
@@ -326,7 +327,7 @@ jobs:
           name: '${{ env.FILE_NAME }}'
           path: ./nightly/*.dmg
       - name: 'Package Release'
-        if: success() && startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request'
+        if: success() && startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && env.HAVE_CODESIGN_IDENTITY == 'true'
         working-directory: ${{ github.workspace }}/build
         shell: bash
         run: |
@@ -348,7 +349,7 @@ jobs:
           mkdir ../release
           sudo mv ./$FILE_NAME ../release/$RELEASE_FILE_NAME
       - name: 'Publish Release'
-        if: success() && startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request'
+        if: success() && startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && env.HAVE_CODESIGN_IDENTITY == 'true'
         uses: actions/upload-artifact@v2.2.0
         with:
           name: '${{ env.RELEASE_FILE_NAME }}'


### PR DESCRIPTION
### Description
Adds a check for macOS code signing credentials configured in the repository and skips notarization if necessary secrets are not configured.

### Motivation and Context
Fixes CI runs breaking on forks without code signing credentials set when a run is triggered by a version tag.

### How Has This Been Tested?
* Needs to be tested on CI
* 
### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
