### PR TITLE
graphics-hook: Add Detours include dir

### DIFF
--- a/plugins/win-capture/graphics-hook/CMakeLists.txt
+++ b/plugins/win-capture/graphics-hook/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(graphics-hook MODULE
 	${graphics-hook_HEADERS})
 
 target_include_directories(graphics-hook PUBLIC
+	${DETOURS_INCLUDE_DIR}
 	"${CMAKE_BINARY_DIR}/plugins/win-capture/graphics-hook/config")
 
 target_link_libraries(graphics-hook


### PR DESCRIPTION
### Description
Need to include Detours include dir. Build currently only works if Vulkan SDK is not installed.

### Motivation and Context
Want to be able to build with Vulkan SDK installed.

### How Has This Been Tested?
Can now build with Vulkan SDK installed.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.