### PR TITLE
UI: Preserve position during alignment change

### DIFF
--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -52,7 +52,7 @@ OBSBasicTransform::OBSBasicTransform(OBSBasic *parent)
 	HookWidget(ui->rotation, DSCROLL_CHANGED, SLOT(OnControlChanged()));
 	HookWidget(ui->sizeX, DSCROLL_CHANGED, SLOT(OnControlChanged()));
 	HookWidget(ui->sizeY, DSCROLL_CHANGED, SLOT(OnControlChanged()));
-	HookWidget(ui->align, COMBO_CHANGED, SLOT(OnControlChanged()));
+	HookWidget(ui->align, COMBO_CHANGED, SLOT(OnAlignmentChanged()));
 	HookWidget(ui->boundsType, COMBO_CHANGED, SLOT(OnBoundsType(int)));
 	HookWidget(ui->boundsAlign, COMBO_CHANGED, SLOT(OnControlChanged()));
 	HookWidget(ui->boundsWidth, DSCROLL_CHANGED, SLOT(OnControlChanged()));
@@ -251,6 +251,7 @@ void OBSBasicTransform::RefreshControls()
 	int boundsAlignIndex = AlignToList(osi.bounds_alignment);
 
 	ignoreItemChange = true;
+
 	ui->positionX->setValue(osi.pos.x);
 	ui->positionY->setValue(osi.pos.y);
 	ui->rotation->setValue(osi.rot);
@@ -267,6 +268,9 @@ void OBSBasicTransform::RefreshControls()
 	ui->cropRight->setValue(int(crop.right));
 	ui->cropTop->setValue(int(crop.top));
 	ui->cropBottom->setValue(int(crop.bottom));
+
+	oti_save = osi;
+
 	ignoreItemChange = false;
 
 	std::string name = obs_source_get_name(source);
@@ -324,7 +328,28 @@ void OBSBasicTransform::OnControlChanged()
 
 	ignoreTransformSignal = true;
 	obs_sceneitem_set_info(item, &oti);
+	oti_save = oti;
 	ignoreTransformSignal = false;
+}
+
+void OBSBasicTransform::OnAlignmentChanged()
+{
+	if (ignoreItemChange)
+		return;
+
+	uint32_t newAlignment = listToAlign[ui->align->currentIndex()];
+	struct vec2 offset;
+
+	obs_sceneitem_alignment_get_vecdiff(item, &offset, oti_save.alignment,
+					    newAlignment);
+
+	ignoreItemChange = true;
+
+	ui->positionX->setValue(oti_save.pos.x + offset.x);
+	ui->positionY->setValue(oti_save.pos.y + offset.y);
+
+	ignoreItemChange = false;
+	OnControlChanged();
 }
 
 void OBSBasicTransform::OnCropChanged()

--- a/UI/window-basic-transform.hpp
+++ b/UI/window-basic-transform.hpp
@@ -23,6 +23,7 @@ private:
 	OBSSignal deselectSignal;
 
 	std::string undo_data;
+	obs_transform_info oti_save;
 
 	bool ignoreTransformSignal = false;
 	bool ignoreItemChange = false;
@@ -44,6 +45,7 @@ private slots:
 	void SetItemQt(OBSSceneItem newItem);
 	void OnBoundsType(int index);
 	void OnControlChanged();
+	void OnAlignmentChanged();
 	void OnCropChanged();
 	void on_resetButton_clicked();
 

--- a/docs/sphinx/reference-scenes.rst
+++ b/docs/sphinx/reference-scenes.rst
@@ -458,6 +458,13 @@ Scene Item Functions
 
 ---------------------
 
+.. function:: void obs_sceneitem_alignment_get_vecdiff(const obs_sceneitem_t *item, struct vec2 *offset, uint32_t align_from, uint32_t align_to)
+
+   Gets the positional difference when switching between different alignment 
+   settings for the scene item.
+
+---------------------
+
 .. function:: void obs_sceneitem_get_draw_transform(const obs_sceneitem_t *item, struct matrix4 *transform)
 
    Gets the transform matrix of the scene item used for drawing the

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1819,7 +1819,10 @@ EXPORT void obs_sceneitem_get_info(const obs_sceneitem_t *item,
 				   struct obs_transform_info *info);
 EXPORT void obs_sceneitem_set_info(obs_sceneitem_t *item,
 				   const struct obs_transform_info *info);
-
+EXPORT void obs_sceneitem_alignment_get_vecdiff(const obs_sceneitem_t *item,
+						struct vec2 *offset,
+						uint32_t align_from,
+						uint32_t align_to);
 EXPORT void obs_sceneitem_get_draw_transform(const obs_sceneitem_t *item,
 					     struct matrix4 *transform);
 EXPORT void obs_sceneitem_get_box_transform(const obs_sceneitem_t *item,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changing the alignment of a scene item in the edit transformation dialog now no longer moves the position of the item in the scene.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Better usability of the edit transformation dialog. No issue or idea has been raised as far as known.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
This was tested by visually checking for movement of the scene item when changing 
Developed and tested on 64-bit Ubuntu 20.04 (VM).
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Performance enhancement (non-breaking change which improves efficiency) **(UX)**
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
