### PR TITLE
cmake: Fix Detours package name CMake warning

### DIFF
--- a/cmake/Modules/FindDetours.cmake
+++ b/cmake/Modules/FindDetours.cmake
@@ -59,7 +59,7 @@ find_library(DETOURS_LIB
 		../bin${_lib_suffix} ../bin)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(DETOURS DEFAULT_MSG DETOURS_LIB DETOURS_INCLUDE_DIR)
+find_package_handle_standard_args(Detours DEFAULT_MSG DETOURS_LIB DETOURS_INCLUDE_DIR)
 mark_as_advanced(DETOURS_INCLUDE_DIR DETOURS_LIB)
 
 if(DETOURS_FOUND)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Since CMake 3.17, find_package_handle_standard_args (FPHSA) will emit a warning if the package name in the caller and in FPHSA do not match. This normalizes the name "Detours" in CMake calls to prevent this warning.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Prevent warnings.  See #2972.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I configured OBS via cmake-gui before and after this change.  Before, I received the warning pictured below.  After, I did not receive the warning.  OBS built successfully with this change.  I don't have any DX12 games to test game capture on.
![2021-05-20 16_11_43-CMake 3 20 2 - before](https://user-images.githubusercontent.com/624931/119047407-e21bd680-b98b-11eb-908d-20ae3cb369ae.png)


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
