### PR TITLE
Render cursor with proper color space on PipeWire-based captures

### DIFF
--- a/plugins/linux-capture/pipewire.c
+++ b/plugins/linux-capture/pipewire.c
@@ -1213,6 +1213,21 @@ uint32_t obs_pipewire_get_height(obs_pipewire_data *obs_pw)
 		return obs_pw->format.info.raw.size.height;
 }
 
+static void render_cursor(obs_pipewire_data *obs_pw, gs_effect_t *effect)
+{
+	gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
+
+	gs_matrix_push();
+	gs_matrix_translate3f((float)obs_pw->cursor.x,
+			      (float)obs_pw->cursor.y, 0.0f);
+
+	gs_effect_set_texture(image, obs_pw->cursor.texture);
+	gs_draw_sprite(obs_pw->texture, 0, obs_pw->cursor.width,
+		       obs_pw->cursor.height);
+
+	gs_matrix_pop();
+}
+
 void obs_pipewire_video_render(obs_pipewire_data *obs_pw, gs_effect_t *effect)
 {
 	gs_eparam_t *image;
@@ -1234,15 +1249,7 @@ void obs_pipewire_video_render(obs_pipewire_data *obs_pw, gs_effect_t *effect)
 
 	if (obs_pw->cursor.visible && obs_pw->cursor.valid &&
 	    obs_pw->cursor.texture) {
-		gs_matrix_push();
-		gs_matrix_translate3f((float)obs_pw->cursor.x,
-				      (float)obs_pw->cursor.y, 0.0f);
-
-		gs_effect_set_texture(image, obs_pw->cursor.texture);
-		gs_draw_sprite(obs_pw->texture, 0, obs_pw->cursor.width,
-			       obs_pw->cursor.height);
-
-		gs_matrix_pop();
+		render_cursor(obs_pw, effect);
 	}
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description

From the second commit:

```
Cursor textures almost always have the alpha channel enabled. With
the recent update in OBS Studio to improve color space handling,
the alpha channel of cursors was fighting over the alpha channel
handling of the framebuffer.

Fix that by setting a proper blend function, and setting the effect's
texture using the gs_effect_set_texture_srgb() for SRGB framebuffers,
or gs_effect_set_texture() for regular ones, all this under an alpha-
less context.
```

Fixes #4711

### Motivation and Context

The cursor of PipeWire-based captures is misrendered when any filter was applied to the PipeWire capture.

### How Has This Been Tested?

 - Run OBS Studio with this PR applied on Linux
 - Add any PipeWire capture (monitor or window) with cursor
 - Add any filter to this capture (e.g. crop)
 - Observe that the cursor renders with the proper opacity

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
