### PR TITLE
Resolve potential symbol clash on MSVC

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -77,6 +77,8 @@ include_directories(${LIBCURL_INCLUDE_DIRS})
 add_definitions(${LIBCURL_DEFINITIONS})
 
 if(WIN32)
+	add_definitions(-DNOMINMAX)
+
 	include_directories(${BLAKE2_INCLUDE_DIR})
 
 	set(obs_PLATFORM_SOURCES

--- a/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
@@ -42,6 +42,7 @@ set(decklink-ouput-ui_UI
 	)
 
 if(WIN32)
+	add_definitions(-DNOMINMAX)
 	set(MODULE_DESCRIPTION "OBS DeckLink Output UI")
 	configure_file(${CMAKE_SOURCE_DIR}/cmake/winrc/obs-module.rc.in decklink-ouput-ui.rc)
 	list(APPEND decklink-ouput-ui_SOURCES

--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -73,6 +73,7 @@ if(SCRIPTING_ENABLED)
 endif()
 
 if(WIN32)
+	add_definitions(-DNOMINMAX)
 	set(MODULE_DESCRIPTION "OBS Frontend Tools")
 	configure_file(${CMAKE_SOURCE_DIR}/cmake/winrc/obs-module.rc.in frontend-tools.rc)
 	set(frontend-tools_PLATFORM_SOURCES

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -28,6 +28,11 @@
 #include "effect-parser.h"
 #include "effect.h"
 
+#ifdef _MSC_VER
+#undef near
+#undef far
+#endif
+
 static THREAD_LOCAL graphics_t *thread_graphics = NULL;
 
 static inline bool gs_obj_valid(const void *obj, const char *f,

--- a/libobs/obs-hotkey-name-map.c
+++ b/libobs/obs-hotkey-name-map.c
@@ -15,6 +15,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #include <string.h>
 #include <assert.h>
 

--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -15,6 +15,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #include <obs.h>
 #include <stdio.h>
 #include <util/dstr.h>

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -15,6 +15,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #include <obs-module.h>
 #include <obs-avc.h>
 #include <util/platform.h>

--- a/plugins/obs-outputs/obs-outputs.c
+++ b/plugins/obs-outputs/obs-outputs.c
@@ -1,3 +1,7 @@
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #include <obs-module.h>
 
 #include "obs-outputs-config.h"

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -15,6 +15,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #include "rtmp-stream.h"
 
 #ifndef SEC_TO_NSEC

--- a/plugins/obs-outputs/rtmp-windows.c
+++ b/plugins/obs-outputs/rtmp-windows.c
@@ -1,3 +1,7 @@
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #ifdef _WIN32
 #include "rtmp-stream.h"
 #include <winsock2.h>


### PR DESCRIPTION
### Description
Windows headers are giving numerous compile-time errors when trying to do a manual build using Visual Studio targeting ARM64. Most of them are symbol redefinition caused by rouge Windows headers.

Notable clashes are `timeval`, `connect()` (`winsock.h`), `near`, `far` (`minwindef.h`), `min()` (against `std::min()`) and `max()` (against `std::max()`).


### Motivation and Context
Windows headers are legit messes due to its legacy. You think you included `Windows.h`, actually it is MUCH more than that. 

`WIN32_LEAN_AND_MEAN` is designed to speed up build when computers are not as powerful as today by tell the headers do their own job and don't invite others into compilation. Now it has a new job, that is to stop others messing around with symbol table. 

There's more. `winsock.h` and `WinSock2.h` are never meant to be mixed together, especially when `winsock.h` is included before `WinSock2.h`. When compilation errors are spamming your screen, it is very hard or impossible to find out where went wrong, especially in large projects like OBS Studio when multiple headers are included in one source file.

This actually caused numerous compile time errors (redefinition) when cross-compiling to Windows ARM64 when using MSVC 2019 toolchain. 

Strangely enough, this clash wasn't a thing on CI using `msbuild`, but it happened when I trying to do a manual build using Visual Studio targeting to Windows ARM64 Platform.

References:
https://devblogs.microsoft.com/oldnewthing/20091130-00/?p=15863
https://devblogs.microsoft.com/oldnewthing/20200728-00/?p=104012
https://github.com/godotengine/godot/pull/11712

### How Has This Been Tested?
After added this preprocessor definition, redefinition errors are gone, thus made compilation possible.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
