### PR TITLE
UI: Fix null string being passed to blog()

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -561,8 +561,9 @@ void OBSAdvAudioCtrl::monitoringTypeChanged(int index)
 		break;
 	}
 
+	const char *name = obs_source_get_name(source);
 	blog(LOG_INFO, "User changed audio monitoring for source '%s' to: %s",
-	     obs_source_get_name(source), type);
+	     name ? name : "(null)", type);
 
 	auto undo_redo = [](const std::string &name, obs_monitoring_type val) {
 		obs_source_t *source = obs_get_source_by_name(name.c_str());
@@ -570,7 +571,6 @@ void OBSAdvAudioCtrl::monitoringTypeChanged(int index)
 		obs_source_release(source);
 	};
 
-	const char *name = obs_source_get_name(source);
 	OBSBasic::Get()->undo_s.add_action(
 		QTStr("Undo.MonitoringType.Change").arg(name),
 		std::bind(undo_redo, std::placeholders::_1, prev),


### PR DESCRIPTION
### Description
String format with null is bad.

### Motivation and Context
GCC warning.

### How Has This Been Tested?
GCC warning is fixed. Log output still looks good.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.