### PR TITLE
libobs: Straight alpha blend for filtered inputs

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3739,8 +3739,9 @@ bool obs_source_process_filter_begin(obs_source_t *filter,
 
 	if (gs_texrender_begin(filter->filter_texrender, cx, cy)) {
 		gs_blend_state_push();
-		gs_blend_function_separate(GS_BLEND_SRCALPHA, GS_BLEND_ZERO,
-					   GS_BLEND_ONE, GS_BLEND_ZERO);
+		gs_blend_function_separate(GS_BLEND_SRCALPHA,
+					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
+					   GS_BLEND_INVSRCALPHA);
 
 		bool custom_draw = (parent_flags & OBS_SOURCE_CUSTOM_DRAW) != 0;
 		bool async = (parent_flags & OBS_SOURCE_ASYNC) != 0;


### PR DESCRIPTION
### Description
This is necessary if the source contains overlapping draws.

Fixes #4711.

### Motivation and Context
Wayland cursor capture was not rendering correctly.

### How Has This Been Tested?
Cursor looks fine now.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.