### PR TITLE
libobs: Restrict emmintrin.h to x86(_64) MSVC platform

### DIFF
--- a/libobs/util/sse-intrin.h
+++ b/libobs/util/sse-intrin.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86)) && \
+	!(defined(_M_ARM64) || defined(_M_ARM64EC))
+
 #include <emmintrin.h>
 #else
 #define SIMDE_ENABLE_NATIVE_ALIASES


### PR DESCRIPTION
### Description
Restrict the use of `emmintrin.h` to Intel MSVC platforms only.

### Motivation and Context
`emmintrin.h` will cause havoc on non-Intel MSVC platforms. 

### How Has This Been Tested?
I tried to rebuild it and it was successful.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
