### PR TITLE
UI: Correct add_action repeatable arg type

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -1229,7 +1229,7 @@ void OBSBasicFilters::delete_filter(OBSSource filter)
 	std::string redo_data(obs_data_get_json(rwrapper));
 	main->undo_s.add_action(
 		QTStr("Undo.Delete").arg(obs_source_get_name(filter)), undo,
-		redo, undo_data, redo_data, NULL);
+		redo, undo_data, redo_data, false);
 	obs_source_filter_remove(source, filter);
 
 	obs_data_release(wrapper);


### PR DESCRIPTION
FreeBSD build fix.  repeatable is a bool, so pass false instead of NULL.

### Description
Correct type to fix build on FreeSD.

### Motivation and Context
Build failed with
```
../../UI/window-basic-filters.cpp:1232:31: error: cannot initialize a parameter of type 'bool' with an rvalue of type 'nullptr_t'
                redo, undo_data, redo_data, NULL);
                                            ^~~~
/usr/include/sys/_null.h:37:14: note: expanded from macro 'NULL'
#define NULL    nullptr
                ^~~~~~~
../../UI/undo-stack-obs.hpp:58:32: note: passing argument to parameter 'repeatable' here
                        std::string redo_data, bool repeatable = false);
                                                    ^
1 error generated.
```

### How Has This Been Tested?
Build-tested on FreeBSD 13 with Clang 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
