### PR TITLE
libobs: Make pkg-config file usable

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -509,7 +509,6 @@ set(libobs_PLATFORM_DEPS
 
 add_library(libobs SHARED ${libobs_SOURCES} ${libobs_HEADERS})
 if(UNIX AND NOT APPLE)
-	set(DEST_DIR "${CMAKE_INSTALL_PREFIX}")
 	foreach(LIB "obs" "rt")
 		set(PRIVATE_LIBS "${PRIVATE_LIBS} -l${LIB}")
 	endforeach()
@@ -517,7 +516,7 @@ if(UNIX AND NOT APPLE)
 		set(PPC64_CFLAGS "-DNO_WARN_X86_INTRINSICS -mvsx")
 	endif()
 	CONFIGURE_FILE("libobs.pc.in" "libobs.pc" @ONLY)
-	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libobs.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libobs.pc" DESTINATION "${CMAKE_INSTALL_PREFIX}/${OBS_LIBRARY_DESTINATION}/pkgconfig")
 endif()
 
 set_target_properties(libobs PROPERTIES

--- a/libobs/libobs.pc.in
+++ b/libobs/libobs.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+libdir=${prefix}/@OBS_LIBRARY_DESTINATION@
+includedir=${prefix}/include
 
 Name: libobs
 Description: OBS Studio Library


### PR DESCRIPTION
Install libobs.pc in the same lib directory as the actual library files. Also in
the libobs.pc file properly set the `libdir` to the location of the library,
OBS_LIBRARY_DESTINATION has to be used, its value is either "lib" or "lib64".

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
The generated `libobs.pc` was not advertising the library path correctly. It was set to `lib64` in my Fedora 34 whereas the actual lib files are installed in `lib`.

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
I wanted to build the obs-gstreamer plugin but it couldn't find the libobs due to its broken .pc file, as described above.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
This was tested in Fedora 34. This change affects only Linux platforms.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.

Last checkbox doesn't apply I believe?