### PR TITLE
UI: Remove macOS-Default Full Screen Menu Item

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2674,6 +2674,10 @@ int main(int argc, char *argv[])
 	}
 #endif
 
+#ifdef __APPLE__
+	DisableFullScreenViewMenuItem();
+#endif
+
 #ifdef _WIN32
 	obs_init_win32_crash_handler();
 	SetErrorMode(SEM_FAILCRITICALERRORS);

--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -235,6 +235,13 @@ void EnableOSXDockIcon(bool enable)
 				NSApplicationActivationPolicyProhibited];
 }
 
+void DisableFullScreenViewMenuItem()
+{
+	[[NSUserDefaults standardUserDefaults]
+		setBool:NO
+		 forKey:@"NSFullScreenMenuItemEverywhere"];
+}
+
 /*
  * This custom NSApplication subclass makes the app compatible with CEF. Qt
  * also has an NSApplication subclass, but it doesn't conflict thanks to Qt

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -69,6 +69,7 @@ void EnableOSXDockIcon(bool enable);
 void InstallNSApplicationSubclass();
 void disableColorSpaceConversion(QWidget *window);
 void CheckAppWithSameBundleID(bool &already_running);
+void DisableFullScreenViewMenuItem();
 #endif
 #ifdef __linux__
 void RunningInstanceCheck(bool &already_running);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
macOS looks if the NSUserDefault NSFullScreenMenuItemEverywhere is set
to true, and if it is, it adds its own full screen menu item.
Sets this NSUserDefault to false since it defaults to true.

Before: 
<img width="293" alt="Bildschirmfoto 2021-05-26 um 21 29 13" src="https://user-images.githubusercontent.com/59806498/120026997-2134d200-bff3-11eb-9df6-96cb79d38403.png">

After:
<img width="264" alt="image" src="https://user-images.githubusercontent.com/59806498/120027403-9d2f1a00-bff3-11eb-8723-201e251b9264.png">

One drawback is that the call to save the setting is made every time OBS is opened.
Now, while NSUserDefaults is thread safe and doesn't interrupt anything else, it isn't the most pretty thing to do.
The problem is that, to my knowledge, there is no macOS onboarding process or something that runs on install-time, and creating something like that is out of scope. If someone ever creates one, this should get moved there.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
There currently are two menu items that let the user switch to full screen, one added by OBS and one by macOS.
Removes the one macOS adds by default, while leaving the one OBS adds.
(Not the other way around for uniformity between platforms and because the one added by OBS gives OBS more control over what it does.)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 11.2.3, compiled and ran,
menu item is gone as intended.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality)-->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
