### PR TITLE
obs-scripting: Typemapping for gs_stagesurface_map added

### DIFF
--- a/deps/obs-scripting/obspython/obspython.i
+++ b/deps/obs-scripting/obspython/obspython.i
@@ -80,6 +80,78 @@ static inline void wrap_blog(int log_level, const char *message)
 %ignore obs_hotkey_pair_register_service;
 %ignore obs_hotkey_pair_register_source;
 
+/* Typemap for gs_stagesurface_map */
+%typemap(arginit, noblock = 1) uint32_t *OUTREF
+{
+	$*1_type temp$argnum = 0;
+	$1 = &temp$argnum;
+}
+
+%typemap(argout, noblock = 1, doc = "bytearray") uint32_t *OUTREF
+{
+}
+
+%typemap(in, numinputs = 0) uint32_t *OUTREF "// typemap(in)";
+
+%typemap(arginit) uint8_t **OUTREF = uint32_t * OUTREF;
+%typemap(in) uint8_t **OUTREF = uint32_t * OUTREF;
+
+%typemap(argout, noblock = 1) uint8_t **OUTREF
+{
+	size_t len = gs_stagesurface_get_height(arg1) * (*arg3);
+
+	const unsigned char *in = temp$argnum;
+	const char b64chars[] =
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+	char *out;
+	size_t elen;
+	size_t i;
+	size_t j;
+	size_t v;
+
+	elen = len;
+	if (len % 3 != 0) {
+		elen += 3 - (len % 3);
+	}
+	elen /= 3;
+	elen *= 4;
+
+	out = malloc(elen + 1);
+	out[elen] = '\0';
+
+	for (i = 0, j = 0; i < len; i += 3, j += 4) {
+		v = in[i];
+		v = i + 1 < len ? v << 8 | in[i + 1] : v << 8;
+		v = i + 2 < len ? v << 8 | in[i + 2] : v << 8;
+
+		out[j] = b64chars[(v >> 18) & 0x3F];
+		out[j + 1] = b64chars[(v >> 12) & 0x3F];
+		if (i + 1 < len) {
+			out[j + 2] = b64chars[(v >> 6) & 0x3F];
+		} else {
+			out[j + 2] = '=';
+		}
+		if (i + 2 < len) {
+			out[j + 3] = b64chars[v & 0x3F];
+		} else {
+			out[j + 3] = '=';
+		}
+	}
+
+	$result = SWIG_Python_AppendOutput(
+		$result,
+		PyByteArray_FromStringAndSize((const char *)temp$argnum, len));
+	$result = SWIG_Python_AppendOutput(
+		$result, SWIG_From_unsigned_SS_int(*arg3));
+	$result = SWIG_Python_AppendOutput(
+		$result, PyUnicode_FromStringAndSize((const char *)out, elen));
+	free(out);
+}
+
+bool gs_stagesurface_map(gs_stagesurf_t *stagesurf, uint8_t **OUTREF,
+			 uint32_t *OUTREF);
+
 %include "graphics/graphics.h"
 %include "graphics/vec4.h"
 %include "graphics/vec3.h"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Added in typemap SWIG bindings for [gs_stagesurface_map ](https://obsproject.com/docs/reference-libobs-graphics-graphics.html#c.gs_stagesurface_map) for both Python and LUA.
This is a non-breaking change as the function cannot currently be used from either language due to requiring passing pointers.
This makes it accessible with the following syntax:
``successful, data, linesize, base64_data = obs.gs_stagesurface_map(stage_surface)``
Where:
- `successful` is true/false depending on the outcome of `gs_stagesurface_map`
- `data` is a language appropriate representation of the texture data. In Python this is a `bytearray` and in Lua this is a `string` (passed via `lua_pushlstring`, byte data can be access at a per character basis)
- `linesize` the line size (pitch) of the texture data
- `base64_data` contains the data preformatted into a base64 string, useful for passing to other applications (this is done in the binding for performance, both Python and Lua hang for 10+seconds trying to map the data to a base64 string otherwise)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This change allows for OBS sources to have screenshots taken into RAM by scripts, upon which neural networks and other post-processing can be applied.
One such usecase is for automatically taking screenshots of a specific source every time the replay buffer is triggered to act as a thumbnail. Another usecase is for capturing output from a source and running a neural network (such as on a webcamera).
There have been community requests on the scripting channel of the OBS Discord (for example by muad_dib: https://discord.com/channels/348973006581923840/731208645848727593/812421509430640680) for this feature.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I have tested on x64 Windows 10 on 3 machines (Laptop with iGPU, Desktop with Nvidia GPU and Desktop with AMD GPU) with no issues.
Main testing enviroment is a x64 Windows 10 Pro machine with AMD 5950x, 32GB RAM, NVIDIA RTX 3090, Samsung 980 Pro SSD. I've been testing on various monitors from 720p to 1440p (I do not own a 4k) and couldn't find any issue with texture sizing. I've run the function on sources as low as 2px x 2px and up to 1440p resolution.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.

### Further comments:
Clang formatting breaks SWIG typemaps (as I found out creating this PR) so it has not been used.

I'm unsure if this is documented anywhere, so I haven't updated any documentation.

I believe the base64 output is important especially when passing between different software (such as to nerual network software or to browser sources), and having it as a native output of the function cuts the time down from >10s to <0.1s.

I've also attached a .zip of example scripts (python and lua). This can be extracted into the OBS root directory (where the .exe is) and the scripts will generate a .js file that is used by the included .html to recreate the texture in the browser.
[Script Example.zip](https://github.com/obsproject/obs-studio/files/6571777/Script.Example.zip)


Also a big thanks to @bfxdev with his help on this on the forums.

