### PR TITLE
CI: Fix dmgbuild breaking CI by pinning its version number

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
         if: success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1')
         shell: bash
         run: |
-          pip3 install dmgbuild
+          pip3 install dmgbuild==1.4.2
       - name: 'Install Apple Developer Certificate'
         if: success() && startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && env.HAVE_CODESIGN_IDENTITY == 'true'
         uses: apple-actions/import-codesign-certs@253ddeeac23f2bdad1646faac5c8c2832e800071


### PR DESCRIPTION
### Description
Pins `dmgbuild` version on GitHub Actions to avoid breakage introduced with its 1.5 update.

### Motivation and Context
Restore macOS builds on GitHub Actions.

### How Has This Been Tested?
Tests require CI runs (pending).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
