### PR TITLE
libobs: Restrict direct filtering to SRGB match

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3683,8 +3683,8 @@ static inline bool can_bypass(obs_source_t *target, obs_source_t *parent,
 	       (allow_direct == OBS_ALLOW_DIRECT_RENDERING) &&
 	       ((parent_flags & OBS_SOURCE_CUSTOM_DRAW) == 0) &&
 	       ((parent_flags & OBS_SOURCE_ASYNC) == 0) &&
-	       (((filter_flags & OBS_SOURCE_SRGB) == 0) ||
-		((parent_flags & OBS_SOURCE_SRGB) != 0));
+	       ((filter_flags & OBS_SOURCE_SRGB) ==
+		(parent_flags & OBS_SOURCE_SRGB));
 }
 
 bool obs_source_process_filter_begin(obs_source_t *filter,


### PR DESCRIPTION
### Description
Fixes issue where color-correction filter v1 changes from v26 to v27.

### Motivation and Context
Don't want v1 filter behavior to change.

### How Has This Been Tested?
Screenshots match now.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.