### PR TITLE
Disable Copy Filter menu items when source/scene has no filters

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3337,6 +3337,9 @@ void OBSBasic::VolControlContextMenu()
 
 	/* ------------------- */
 
+	copyFiltersAction.setEnabled(obs_source_filter_count(vol->GetSource()) >
+				     0);
+
 	if (copyFiltersString == nullptr)
 		pasteFiltersAction.setEnabled(false);
 	else

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4729,6 +4729,10 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 			SLOT(on_actionAddScene_triggered()));
 
 	if (item) {
+		QAction *copyFilters = new QAction(QTStr("Copy.Filters"), this);
+		copyFilters->setEnabled(false);
+		connect(copyFilters, SIGNAL(triggered()), this,
+			SLOT(SceneCopyFilters()));
 		QAction *pasteFilters =
 			new QAction(QTStr("Paste.Filters"), this);
 		pasteFilters->setEnabled(copyFiltersString);
@@ -4738,8 +4742,7 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 		popup.addSeparator();
 		popup.addAction(QTStr("Duplicate"), this,
 				SLOT(DuplicateSelectedScene()));
-		popup.addAction(QTStr("Copy.Filters"), this,
-				SLOT(SceneCopyFilters()));
+		popup.addAction(copyFilters);
 		popup.addAction(pasteFilters);
 		popup.addSeparator();
 		popup.addAction(QTStr("Rename"), this, SLOT(EditSceneName()));
@@ -4806,6 +4809,8 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 
 		connect(multiviewAction, &QAction::triggered,
 			std::bind(showInMultiview, data));
+
+		copyFilters->setEnabled(obs_source_filter_count(source) > 0);
 	}
 
 	popup.addSeparator();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When you right-click on a source in the Sources list that does not have any filters, the "Copy Filters" item is disabled. When you right-click on an audio source in the Audio Mixer that does not have any filters, the "Copy Filters" item is enabled. This fixes the Audio Mixer context menu to behave like the Sources context menu.

When you right-click on a source in the Sources list that does not have any filters, the "Copy Filters" item is disabled. When you right-click on a scene in the Scenes list that does not have any filters, the "Copy Filters" item is enabled. This fixes the Scenes context menu to behave like the Sources context menu.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Consistency is good.  Fixes #4790.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled and ran OBS on Windows 10 after these changes and checked context menus for the Audio Mixer and the Scenes list.  I compared the new behavior to the current behavior in OBS 27.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
