### PR TITLE
obs-filters: Fix swapped chroma distance values

### DIFF
--- a/plugins/obs-filters/data/chroma_key_filter_v2.effect
+++ b/plugins/obs-filters/data/chroma_key_filter_v2.effect
@@ -43,7 +43,7 @@ float GetChromaDist(float3 rgb)
 {
 	float cb = dot(rgb.rgb, cb_v4.xyz) + cb_v4.w;
 	float cr = dot(rgb.rgb, cr_v4.xyz) + cr_v4.w;
-	return distance(chroma_key, float2(cr, cb));
+	return distance(chroma_key, float2(cb, cr));
 }
 
 float GetNonlinearChannel(float u)


### PR DESCRIPTION
### Description
Not easy to tell with green where Cb and Cr are close to each other (0.16, 0.10), but obvious when using a bluish hue (0.84, 0.50).

### Motivation and Context
Some reported problem with blue chrome key.

### How Has This Been Tested?
Blue case works now.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.