### PR TITLE
CI: Bump dmgbuild to 1.5.2 to fix detach error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
         if: success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1')
         shell: bash
         run: |
-          pip3 install dmgbuild==1.4.2
+          pip3 install dmgbuild==1.5.2
       - name: 'Install Apple Developer Certificate'
         if: success() && startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && env.HAVE_CODESIGN_IDENTITY == 'true'
         uses: apple-actions/import-codesign-certs@253ddeeac23f2bdad1646faac5c8c2832e800071


### PR DESCRIPTION
### Description

This bumps dmgbuild to the latest version in CI.

This is a stopgap until #4560 is reviewed & merged (after 27 is considered stable).

### Motivation and Context

Follow up from #4780. 

Once again, a CI build today failed due to the detach error. We don't want that.

### How Has This Been Tested?

Yes, CI passed with Seeking Testers flag.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
