### PR TITLE
UI: Add option to disable missing files dialog

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -779,6 +779,7 @@ Basic.Settings.General.MultiviewLayout.Horizontal.Bottom="Horizontal, Bottom (8 
 Basic.Settings.General.MultiviewLayout.Vertical.Left="Vertical, Left (8 Scenes)"
 Basic.Settings.General.MultiviewLayout.Vertical.Right="Vertical, Right (8 Scenes)"
 Basic.Settings.General.MultiviewLayout.Horizontal.Extended.Top="Horizontal, Top (24 Scenes)"
+Basic.Settings.General.ShowMissingFilesDialog="Show missing files dialog"
 
 # basic mode 'stream' settings
 Basic.Settings.Stream="Stream"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -245,6 +245,16 @@
                      </property>
                     </widget>
                    </item>
+                   <item row="4" column="1">
+                    <widget class="QCheckBox" name="showMissingFiles">
+                     <property name="text">
+                      <string>Basic.Settings.General.ShowMissingFilesDialog</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
                   </layout>
                  </widget>
                 </item>

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -411,6 +411,8 @@ bool OBSApp::InitGlobalConfigDefaults()
 				  "Normal");
 	config_set_default_bool(globalConfig, "General", "EnableAutoUpdates",
 				true);
+	config_set_default_bool(globalConfig, "General",
+				"ShowMissingFilesDialog", true);
 
 #if _WIN32
 	config_set_default_string(globalConfig, "Video", "Renderer",

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1161,7 +1161,10 @@ retryScene:
 
 	LogScenes();
 
-	if (obs_missing_files_count(files) > 0) {
+	bool missingFilesShow = config_get_bool(GetGlobalConfig(), "General",
+						"ShowMissingFilesDialog");
+
+	if (obs_missing_files_count(files) > 0 && missingFilesShow) {
 		/* the window hasn't fully initialized by this point on macOS,
 		 * so put this at the end of the current task queue. Fixes a
 		 * bug where the window be behind OBS on startup */

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -387,6 +387,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->theme, 		     COMBO_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->enableAutoUpdates,    CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->openStatsOnStartup,   CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->showMissingFiles,     CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStart,CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStop, CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeRecordStop, CHECK_CHANGED,  GENERAL_CHANGED);
@@ -1223,6 +1224,10 @@ void OBSBasicSettings::LoadGeneralSettings()
 	bool openStatsOnStartup = config_get_bool(main->Config(), "General",
 						  "OpenStatsOnStartup");
 	ui->openStatsOnStartup->setChecked(openStatsOnStartup);
+
+	bool missingFiles = config_get_bool(GetGlobalConfig(), "General",
+					    "ShowMissingFilesDialog");
+	ui->showMissingFiles->setChecked(missingFiles);
 
 	bool recordWhenStreaming = config_get_bool(
 		GetGlobalConfig(), "BasicWindow", "RecordWhenStreaming");
@@ -2981,6 +2986,10 @@ void OBSBasicSettings::SaveGeneralSettings()
 	if (WidgetChanged(ui->openStatsOnStartup))
 		config_set_bool(main->Config(), "General", "OpenStatsOnStartup",
 				ui->openStatsOnStartup->isChecked());
+	if (WidgetChanged(ui->showMissingFiles))
+		config_set_bool(GetGlobalConfig(), "General",
+				"ShowMissingFilesDialog",
+				ui->showMissingFiles->isChecked());
 	if (WidgetChanged(ui->snappingEnabled))
 		config_set_bool(GetGlobalConfig(), "BasicWindow",
 				"SnappingEnabled",


### PR DESCRIPTION
### Description
This adds an option in the general settings to show the missing
files dialog.

### Motivation and Context
Making the dialog optional.

### How Has This Been Tested?
Added an image source and deleted the image to make sure the code worked properly.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
