### PR TITLE
UI: Add ability to toggle visibility of control buttons

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -101,6 +101,9 @@ LogViewer="Log Viewer"
 ShowOnStartup="Show on startup"
 OpenFile="Open file"
 AddValue="Add %1"
+Streaming="Streaming"
+Recording="Recording"
+VirtualCamera="Virtual Camera"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -646,6 +646,18 @@
      <addaction name="toggleControls"/>
      <addaction name="toggleStats"/>
     </widget>
+    <widget class="QMenu" name="viewMenuControls">
+     <property name="title">
+      <string>Basic.Main.Controls</string>
+     </property>
+     <addaction name="toggleStream"/>
+     <addaction name="toggleRecording"/>
+     <addaction name="toggleReplay"/>
+     <addaction name="toggleVirtualCam"/>
+     <addaction name="toggleStudioMode"/>
+     <addaction name="toggleSettings"/>
+     <addaction name="toggleExit"/>
+    </widget>
     <action name="actionFullscreenInterface">
      <property name="text">
       <string>Basic.MainMenu.View.Fullscreen.Interface</string>
@@ -657,6 +669,7 @@
     <addaction name="actionFullscreenInterface"/>
     <addaction name="separator"/>
     <addaction name="viewMenuDocks"/>
+    <addaction name="viewMenuControls"/>
     <addaction name="toggleListboxToolbars"/>
     <addaction name="toggleContextBar"/>
     <addaction name="toggleSourceIcons"/>
@@ -2053,6 +2066,83 @@
     <property name="text">
       <string>Undo.Redo</string>
     </property>
+    </action>
+    <action name="toggleStream">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Streaming</string>
+     </property>
+    </action>
+    <action name="toggleRecording">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Recording</string>
+     </property>
+    </action>
+    <action name="toggleReplay">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>ReplayBuffer</string>
+     </property>
+    </action>
+     <action name="toggleVirtualCam">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>VirtualCamera</string>
+     </property>
+    </action>
+    <action name="toggleStudioMode">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Basic.TogglePreviewProgramMode</string>
+     </property>
+    </action>
+    <action name="toggleSettings">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Settings</string>
+     </property>
+    </action>
+    <action name="toggleExit">
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Exit</string>
+     </property>
     </action>
   </widget>
  <customwidgets>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1837,6 +1837,13 @@ void OBSBasic::OBSInit()
 
 	SET_VISIBILITY("ShowListboxToolbars", toggleListboxToolbars);
 	SET_VISIBILITY("ShowStatusBar", toggleStatusBar);
+	SET_VISIBILITY("ShowStreamButton", toggleStream);
+	SET_VISIBILITY("ShowRecordingButton", toggleRecording);
+	SET_VISIBILITY("ShowReplayBufferButton", toggleReplay);
+	SET_VISIBILITY("ShowVirtualCameraButton", toggleVirtualCam);
+	SET_VISIBILITY("ShowStudioModeButton", toggleStudioMode);
+	SET_VISIBILITY("ShowSettingsButton", toggleSettings);
+	SET_VISIBILITY("ShowExitButton", toggleExit);
 #undef SET_VISIBILITY
 
 	bool sourceIconsVisible = config_get_bool(
@@ -9213,4 +9220,74 @@ void OBSBasic::ShowStatusBarMessage(const QString &message)
 {
 	ui->statusbar->clearMessage();
 	ui->statusbar->showMessage(message, 10000);
+}
+
+void OBSBasic::on_viewMenuControls_aboutToShow()
+{
+	ui->toggleReplay->setEnabled(replayBufferButton);
+	ui->toggleVirtualCam->setEnabled(vcamButton);
+}
+
+void OBSBasic::on_toggleStream_toggled(bool visible)
+{
+	ui->streamButton->setVisible(visible);
+
+	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+			"ShowStreamButton", visible);
+}
+
+void OBSBasic::on_toggleRecording_toggled(bool visible)
+{
+	ui->recordButton->setVisible(visible);
+
+	if (pause)
+		pause->setVisible(visible);
+
+	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+			"ShowRecordingButton", visible);
+}
+
+void OBSBasic::on_toggleReplay_toggled(bool visible)
+{
+	if (replayBufferButton)
+		replayBufferButton->setVisible(visible);
+
+	if (replay)
+		replay->setVisible(visible);
+
+	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+			"ShowReplayBufferButton", visible);
+}
+
+void OBSBasic::on_toggleVirtualCam_toggled(bool visible)
+{
+	if (vcamButton)
+		vcamButton->setVisible(visible);
+
+	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+			"ShowVirtualCameraButton", visible);
+}
+
+void OBSBasic::on_toggleStudioMode_toggled(bool visible)
+{
+	ui->modeSwitch->setVisible(visible);
+
+	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+			"ShowStudioModeButton", visible);
+}
+
+void OBSBasic::on_toggleSettings_toggled(bool visible)
+{
+	ui->settingsButton->setVisible(visible);
+
+	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+			"ShowSettingsButton", visible);
+}
+
+void OBSBasic::on_toggleExit_toggled(bool visible)
+{
+	ui->exitButton->setVisible(visible);
+
+	config_set_bool(App()->GlobalConfig(), "BasicWindow", "ShowExitButton",
+			visible);
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -983,6 +983,15 @@ private slots:
 	void on_toggleStatusBar_toggled(bool visible);
 	void on_toggleSourceIcons_toggled(bool visible);
 
+	void on_viewMenuControls_aboutToShow();
+	void on_toggleStream_toggled(bool visible);
+	void on_toggleRecording_toggled(bool visible);
+	void on_toggleReplay_toggled(bool visible);
+	void on_toggleVirtualCam_toggled(bool visible);
+	void on_toggleStudioMode_toggled(bool visible);
+	void on_toggleSettings_toggled(bool visible);
+	void on_toggleExit_toggled(bool visible);
+
 	void on_transitions_currentIndexChanged(int index);
 	void RemoveTransitionClicked();
 	void on_transitionProps_clicked();


### PR DESCRIPTION
### Description
This allows to toggle the visibility of individual buttons
in the controls dock.

### Motivation and Context
Users might want to hide certain buttons.

### How Has This Been Tested?
Toggling buttons on and off.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
