### PR TITLE
List Flatpak search paths

### DIFF
--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -51,13 +51,18 @@ const char *get_module_extension(void)
 #define BIT_STRING "32bit"
 #endif
 
-static const char *module_bin[] = {"../../obs-plugins/" BIT_STRING,
-				   OBS_INSTALL_PREFIX
-				   "/" OBS_PLUGIN_DESTINATION};
+#define FLATPAK_PLUGIN_PATH "/app/plugins"
+
+static const char *module_bin[] = {
+	"../../obs-plugins/" BIT_STRING,
+	OBS_INSTALL_PREFIX "/" OBS_PLUGIN_DESTINATION,
+	FLATPAK_PLUGIN_PATH "/" OBS_PLUGIN_DESTINATION,
+};
 
 static const char *module_data[] = {
 	OBS_DATA_PATH "/obs-plugins/%module%",
 	OBS_INSTALL_DATA_PATH "/obs-plugins/%module%",
+	FLATPAK_PLUGIN_PATH "/share/obs/obs-plugins/%module%",
 };
 
 static const int module_patterns_size =


### PR DESCRIPTION
### Description

The proposed way to handle plugin distribution through Flatpak depends on these directories to be read. It goes as follows:

 1. Flatpak's extension point merges the 'lib' and 'share' directories at /app/plugin
 2. Plugins prefix their install paths in the Flatpak manifest to /app/plugins/\<plugin name\>
 3. OBS Studio lists /app/plugin as one of the search paths in OBS Studio code

This commit implements the third step of this process, which is the only one that actually involves OBS Studio itself.

Related: https://github.com/flathub/com.obsproject.Studio/issues/135



### Motivation and Context

This change is one of the necessary steps to formalize plugin distribution through Flatpak. With it, it is possible to distribute plugins as Flatpak extensions, which in turn allows them to be listed at app stores such as GNOME Software, elementary's app store, and KDE's Discover.

### How Has This Been Tested?

Run OBS Studio (Flatpak) with any plugins installed from Flathub (for example, `com.obsproject.Studio.Plugins.InputOverlay`) - the plugin needs to be listed, and work properly.

### Types of changes

 - New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
