### PR TITLE
UI: Don't execute or track empty SceneItem move actions

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5626,13 +5626,17 @@ void OBSBasic::on_actionSourceProperties_triggered()
 void OBSBasic::MoveSceneItem(enum obs_order_movement movement,
 			     const QString &action_name)
 {
+	OBSSceneItem item = GetCurrentSceneItem();
+	obs_source_t *source = obs_sceneitem_get_source(item);
+
+	if (!source)
+		return;
+
 	OBSSource scene_source = GetCurrentSceneSource();
 	OBSData undo_data = BackupScene(scene_source);
 
-	OBSSceneItem item = GetCurrentSceneItem();
 	obs_sceneitem_set_order(item, movement);
 
-	obs_source_t *source = obs_sceneitem_get_source(item);
 	const char *source_name = obs_source_get_name(source);
 	const char *scene_name = obs_source_get_name(scene_source);
 


### PR DESCRIPTION
### Description

Cancels/ignores a Scene Item move event if there is no source associated with it.

![image](https://user-images.githubusercontent.com/941350/120910822-852b5a80-c6c5-11eb-96dd-0d7df09a3a59.png)


### Motivation and Context

Avoids filling the undo stack with unnecessary noise/data. Also probably avoids some (currently unknown) side effects.

This would appear as `"Undo Move '' in 'Scene Name'"` in the undo stack.

### How Has This Been Tested?

* Deselect all sources in the Sources list
* Click the up or down arrows in the Sources list
* Watch the Edit -> Undo menu & the log

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
