### PR TITLE
UI: Translate Undo action "Delete Scene" and include scene name

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3769,8 +3769,9 @@ void OBSBasic::RemoveSelectedScene()
 	obs_data_set_array(data, "array", array);
 	obs_data_set_int(data, "index", ui->scenes->currentRow());
 
-	undo_s.add_action("Delete Scene", undo, redo, obs_data_get_json(data),
-			  obs_source_get_name(source));
+	const char *scene_name = obs_source_get_name(source);
+	undo_s.add_action(QTStr("Undo.Delete").arg(scene_name), undo, redo,
+			  obs_data_get_json(data), scene_name);
 
 	obs_data_array_release(array);
 	obs_data_release(data);


### PR DESCRIPTION

### Description

Replaces the untranslated "Delete Scene" text for the undo action of deleting a scene with the existing "Delete 'x'" string.

Before:
![image](https://user-images.githubusercontent.com/941350/120912924-a8123a80-c6d6-11eb-93f0-7d6f6fac6e2b.png)

After:
![image](https://user-images.githubusercontent.com/941350/120912937-bceece00-c6d6-11eb-851b-28bb3fb0fe63.png)


### Motivation and Context

It's not clear which scene would be restored. Additionally, everything should always be translated.

### How Has This Been Tested?

* Delete a scene
* Look in the Edit menu

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
