### PR TITLE
Handle mac-vth264 encoder ID changes

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1188,6 +1188,17 @@ static void ApplyEncoderDefaults(OBSData &settings,
 
 #define ADV_ARCHIVE_NAME "adv_archive_aac"
 
+#ifdef __APPLE__
+static void translate_macvth264_encoder(const char *&encoder)
+{
+	if (strcmp(encoder, "vt_h264_hw") == 0) {
+		encoder = "com.apple.videotoolbox.videoencoder.h264.gva";
+	} else if (strcmp(encoder, "vt_h264_sw") == 0) {
+		encoder = "com.apple.videotoolbox.videoencoder.h264";
+	}
+}
+#endif
+
 AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 {
 	const char *recType =
@@ -1196,6 +1207,10 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 		config_get_string(main->Config(), "AdvOut", "Encoder");
 	const char *recordEncoder =
 		config_get_string(main->Config(), "AdvOut", "RecEncoder");
+#ifdef __APPLE__
+	translate_macvth264_encoder(streamEncoder);
+	translate_macvth264_encoder(recordEncoder);
+#endif
 
 	ffmpegOutput = astrcmpi(recType, "FFmpeg") == 0;
 	ffmpegRecording =


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR contains two commits which are separate approaches to solving #4799.  There was some debate about which approach was better, so I'm presenting both as options here for review.

The first commit adds a permanent translation to the active profile config file in `UI/obs-app.cpp` with other upgrade functions.  This approach means that if a user downgraded OBS after this, they would experience #4799, except it wouldn't find the new encoder IDs.

The second commit adds an in-place translation in `UI/window-basic-main-outputs.cpp` before an AdvancedOutput creates a video encoder.  This approach means that the translation happens every time an encoder is created, but it doesn't create new issues if the user chooses to downgrade OBS.

If this PR produces artifacts, or you build with both commits, the first one will effectively render the second commit moot, since the first commit permanently changes the encoder ID in the active profile's config file.
Once one is chosen, I can remove the other commit.  Both commits are in UI.

#### Commit message
UI: Handle mac-vth264 encoder ID change

Before OBS Studio 27, we used our own hard-coded internal encoder IDs on for the mac-vth264 plugin: vt_h264_hw and vt_h264_sw. As of OBS Studio 27, we changed to using the encoder IDs that Apple's API reports. Specifically, this behavior occurs due to PR #4105 and commit 6a9f25c8ea1b244b4a439667be33f4a5cc6cdf4b.

Unfortunately, this change in encoder IDs failed to take into account existing user configurations, resulting in users with broken encoder settings. This change attempts to gracefully upgrade user configurations to handle the changed encoder IDs.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #4799.  Allow seamless upgrades from OBS 26.1.2 to 27.0.0.  Prevent broken user configs.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Beyond checking that it compiles, I haven't tested this.  This will need to be tested by people on macOS after configuring an encoder in OBS 26.1.2 or earlier and then upgrading to a build with one of these commits.

I also don't know if the VideoToolbox encoders can be selected in Simple Output Mode.  I've been told that's not possible, but double checking would be appreciated.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
