### PR TITLE
UI: Fix filters changes not properly being added to undo stack

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -253,6 +253,9 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 			obs_source_release(filter);
 			obs_source_release(parent_source);
 		};
+
+		main->undo_s.enable();
+
 		std::string name = std::string(obs_source_get_name(source));
 		std::string undo_data = obs_data_get_json(undo_wrapper);
 		std::string redo_data = obs_data_get_json(redo_wrapper);
@@ -266,8 +269,6 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 		obs_data_release(filter_settings);
 
 		obs_source_update(source, new_settings);
-
-		main->undo_s.enable();
 	};
 
 	auto disabled_undo = [](void *vp, obs_data_t *settings) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
After changes to enable/disable filters stopped working. This was because undo/redo would be disabled 

### Motivation and Context
Fixes bug.

### How Has This Been Tested?
I tested this on my machine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
