### PR TITLE
obs-ffmpeg: Add missing return statement

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -399,6 +399,8 @@ static void *nvenc_create(obs_data_t *settings, obs_encoder_t *encoder)
 		     "trying again without Psycho Visual Tuning");
 		enc = nvenc_create_internal(settings, encoder, false);
 	}
+
+	return enc;
 }
 
 static inline void copy_data(AVFrame *pic, const struct encoder_frame *frame,


### PR DESCRIPTION
### Description
nvenc_create needs to return a value.

### Motivation and Context
Noticed compiler warning. Was very (un)lucky that leftover rax value is the proper value.

### How Has This Been Tested?
Breakpoint inspection. Played back recorded video in VLC.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.