### PR TITLE
rtmp-services: Add "Bilibili Live"

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -298,6 +298,9 @@ void OBSBasicSettings::UpdateKeyLink()
 			"https://www.openrec.tv/login?keep_login=true&url=https://www.openrec.tv/dashboard/live?from=obs";
 	} else if (serviceName == "Brime Live") {
 		streamKeyLink = "https://brimelive.com/obs-stream-key-link";
+	} else if (serviceName == "Bilibili Live") {
+		streamKeyLink =
+			"https://link.bilibili.com/p/center/index#/my-room/start-live";
 	}
 
 	if (serviceName == "Dacast") {

--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 176,
+	"version": 177,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 176
+			"version": 177
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2193,6 +2193,19 @@
                 "max audio bitrate": 320,
                 "x264opts": "scenecut=0"
             }
+        },
+        {
+            "name": "Bilibili Live",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://live-push.bilivideo.com/live-bvc/"
+                },
+                {
+                    "name": "Tencent Cloud",
+                    "url": "rtmp://txy.live-push.bilivideo.com/live-bvc/"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
### Description
Add [Bilibili Live](https://live.bilibili.com/) to rtmp services list.
A live streaming platform in China mainland.

### Motivation and Context
Add support for "Bilibili Live" in rtmp services.

### How Has This Been Tested?
Local Build & CI Build

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
