### PR TITLE
Fix win-capture null pointer

### DIFF
--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -628,6 +628,9 @@ static bool display_capture_method_changed(obs_properties_t *props,
 	UNUSED_PARAMETER(p);
 
 	struct duplicator_capture *capture = obs_properties_get_param(props);
+	if (!capture)
+		return false;
+
 	update_settings(capture, settings);
 
 	update_settings_visibility(props, capture);

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -306,6 +306,8 @@ static bool load_winrt_imports(struct winrt_exports *exports, void *module,
 	return success;
 }
 
+extern bool graphics_uses_d3d11;
+
 static void *duplicator_capture_create(obs_data_t *settings,
 				       obs_source_t *source)
 {
@@ -316,11 +318,7 @@ static void *duplicator_capture_create(obs_data_t *settings,
 
 	pthread_mutex_init(&capture->update_mutex, NULL);
 
-	obs_enter_graphics();
-	const bool uses_d3d11 = gs_get_device_type() == GS_DEVICE_DIRECT3D_11;
-	obs_leave_graphics();
-
-	if (uses_d3d11) {
+	if (graphics_uses_d3d11) {
 		static const char *const module = "libobs-winrt";
 		capture->winrt_module = os_dlopen(module);
 		if (capture->winrt_module &&

--- a/plugins/win-capture/plugin-main.c
+++ b/plugins/win-capture/plugin-main.c
@@ -68,6 +68,8 @@ void wait_for_hook_initialization(void)
 
 void init_hook_files(void);
 
+bool graphics_uses_d3d11 = false;
+
 bool obs_module_load(void)
 {
 	struct win_version_info ver;
@@ -85,13 +87,13 @@ bool obs_module_load(void)
 	win8_or_above = ver.major > 6 || (ver.major == 6 && ver.minor >= 2);
 
 	obs_enter_graphics();
+	graphics_uses_d3d11 = gs_get_device_type() == GS_DEVICE_DIRECT3D_11;
+	obs_leave_graphics();
 
-	if (win8_or_above && gs_get_device_type() == GS_DEVICE_DIRECT3D_11)
+	if (win8_or_above && graphics_uses_d3d11)
 		obs_register_source(&duplicator_capture_info);
 	else
 		obs_register_source(&monitor_capture_info);
-
-	obs_leave_graphics();
 
 	obs_register_source(&window_capture_info);
 

--- a/plugins/win-capture/plugin-main.c
+++ b/plugins/win-capture/plugin-main.c
@@ -69,12 +69,16 @@ void wait_for_hook_initialization(void)
 void init_hook_files(void);
 
 bool graphics_uses_d3d11 = false;
+bool wgc_supported = false;
 
 bool obs_module_load(void)
 {
 	struct win_version_info ver;
 	bool win8_or_above = false;
 	char *config_dir;
+
+	struct win_version_info win1903 = {
+		.major = 10, .minor = 0, .build = 18362, .revis = 0};
 
 	config_dir = obs_module_config_path(NULL);
 	if (config_dir) {
@@ -89,6 +93,9 @@ bool obs_module_load(void)
 	obs_enter_graphics();
 	graphics_uses_d3d11 = gs_get_device_type() == GS_DEVICE_DIRECT3D_11;
 	obs_leave_graphics();
+
+	if (graphics_uses_d3d11)
+		wgc_supported = win_version_compare(&ver, &win1903) >= 0;
 
 	if (win8_or_above && graphics_uses_d3d11)
 		obs_register_source(&duplicator_capture_info);

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -363,6 +363,9 @@ static bool wc_capture_method_changed(obs_properties_t *props,
 	UNUSED_PARAMETER(p);
 
 	struct window_capture *wc = obs_properties_get_param(props);
+	if (!wc)
+		return false;
+
 	update_settings(wc, settings);
 
 	update_settings_visibility(props, wc);
@@ -379,6 +382,9 @@ static bool wc_window_changed(obs_properties_t *props, obs_property_t *p,
 			      obs_data_t *settings)
 {
 	struct window_capture *wc = obs_properties_get_param(props);
+	if (!wc)
+		return false;
+
 	update_settings(wc, settings);
 
 	update_settings_visibility(props, wc);

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -236,6 +236,8 @@ static bool load_winrt_imports(struct winrt_exports *exports, void *module,
 	return success;
 }
 
+extern bool graphics_uses_d3d11;
+
 static void *wc_create(obs_data_t *settings, obs_source_t *source)
 {
 	struct window_capture *wc = bzalloc(sizeof(struct window_capture));
@@ -243,11 +245,7 @@ static void *wc_create(obs_data_t *settings, obs_source_t *source)
 
 	pthread_mutex_init(&wc->update_mutex, NULL);
 
-	obs_enter_graphics();
-	const bool uses_d3d11 = gs_get_device_type() == GS_DEVICE_DIRECT3D_11;
-	obs_leave_graphics();
-
-	if (uses_d3d11) {
+	if (graphics_uses_d3d11) {
 		static const char *const module = "libobs-winrt";
 		wc->winrt_module = os_dlopen(module);
 		if (wc->winrt_module &&


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Check for the device type (OBS renderer) and Windows features when the plugin loads instead of every time a source is created.  The device type (OBS renderer) can only be changed with an application restart, so there's no need to check this whenever a source is created.  Windows Graphics Capture is either supported on the system or it isn't, so we shouldn't have to check whenever a source is created.

Return early in property modified callbacks for `duplicator-monitor-capture.c` and `window-capture.c` if the returned param is null.

Many thanks to @jpark37 for helping me with this.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #4832.  Less calls to `obs_enter_graphics()`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I used the code sample from #4832 and compiled on Windows 10 and tested before and after these changes.  After these changes, OBS doesn't crash.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
