### PR TITLE
Handle HTTP errors in log uploader & file downloader

### DIFF
--- a/UI/remote-text.cpp
+++ b/UI/remote-text.cpp
@@ -157,6 +157,7 @@ bool GetRemoteFile(const char *url, std::string &str, std::string &error,
 		curl_easy_setopt(curl.get(), CURLOPT_ACCEPT_ENCODING, "");
 		curl_easy_setopt(curl.get(), CURLOPT_HTTPHEADER, header);
 		curl_easy_setopt(curl.get(), CURLOPT_ERRORBUFFER, error_in);
+		curl_easy_setopt(curl.get(), CURLOPT_FAILONERROR, 1L);
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION,
 				 string_write);
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &str);

--- a/UI/remote-text.cpp
+++ b/UI/remote-text.cpp
@@ -67,6 +67,7 @@ void RemoteTextThread::run()
 		curl_easy_setopt(curl.get(), CURLOPT_ACCEPT_ENCODING, "");
 		curl_easy_setopt(curl.get(), CURLOPT_HTTPHEADER, header);
 		curl_easy_setopt(curl.get(), CURLOPT_ERRORBUFFER, error);
+		curl_easy_setopt(curl.get(), CURLOPT_FAILONERROR, 1L);
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION,
 				 string_write);
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &str);
@@ -88,6 +89,9 @@ void RemoteTextThread::run()
 
 		code = curl_easy_perform(curl.get());
 		if (code != CURLE_OK) {
+			blog(LOG_WARNING,
+			     "RemoteTextThread: HTTP request failed. %s",
+			     error);
 			emit Result(QString(), QT_UTF8(error));
 		} else {
 			emit Result(QT_UTF8(str.c_str()), QString());


### PR DESCRIPTION
### Description

Rather than silently succeeding, terminate early if a HTTP error (4xx clientside or 500x serverside) is detected. The new messages are from curl directly.

New log uploader error dialog:

![2021-06-08_10-55-49](https://user-images.githubusercontent.com/941350/121521090-002ea100-ca37-11eb-8687-3a8f4d29ac25.png)

Log upload failures are now also logged too.

New Twitch OAuth error dialog:

![2021-06-08_20-29-40](https://user-images.githubusercontent.com/941350/121521157-10df1700-ca37-11eb-9534-43980f57ea25.png)

### Motivation and Context

In most cases, if a HTTP server responds with a 4xx or 5xx error, the data included may not be in the expected format, and would have to be specially handled. 

Currently, if the log uploader fails, it shows an empty box:

![2021-06-08_10-57-56](https://user-images.githubusercontent.com/941350/121520902-cfe70280-ca36-11eb-9ad3-35d102dad117.png)

If `GetRemoteFile` fails, the user is more likely to see an unhelpful error dialog, such as when Fastly went down & the Twitch OAuth API responded with HTML instead of JSON:

![2021-06-08_20-26-59](https://user-images.githubusercontent.com/941350/121521017-ee4cfe00-ca36-11eb-9826-db886daeca21.png)

### How Has This Been Tested?

Change this URL:

https://github.com/obsproject/obs-studio/blob/e0edd753ad88230275441d60b3c1832acf1da0e7/UI/window-basic-main.cpp#L5772

To a URL from https://httpstat.us/ - such as `https://httpstat.us/404`

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
