### PR TITLE
vlc-video: Improve logging with prefix & VLC version

### DIFF
--- a/plugins/vlc-video/vlc-video-plugin.c
+++ b/plugins/vlc-video/vlc-video-plugin.c
@@ -15,6 +15,7 @@ MODULE_EXPORT const char *obs_module_description(void)
 /* libvlc core */
 LIBVLC_NEW libvlc_new_;
 LIBVLC_RELEASE libvlc_release_;
+LIBVLC_GET_VERSION libvlc_get_version_;
 LIBVLC_CLOCK libvlc_clock_;
 LIBVLC_EVENT_ATTACH libvlc_event_attach_;
 
@@ -82,8 +83,8 @@ static bool load_vlc_funcs(void)
 		func##_ = os_dlsym(libvlc_module, #func);       \
 		if (!func##_) {                                 \
 			blog(LOG_WARNING,                       \
-			     "Could not func VLC function %s, " \
-			     "VLC loading failed",              \
+			     "[vlc-video]: Could not func VLC " \
+			     "function %s, VLC loading failed", \
 			     #func);                            \
 			return false;                           \
 		}                                               \
@@ -92,6 +93,7 @@ static bool load_vlc_funcs(void)
 	/* libvlc core */
 	LOAD_VLC_FUNC(libvlc_new);
 	LOAD_VLC_FUNC(libvlc_release);
+	LOAD_VLC_FUNC(libvlc_get_version);
 	LOAD_VLC_FUNC(libvlc_clock);
 	LOAD_VLC_FUNC(libvlc_event_attach);
 
@@ -202,7 +204,7 @@ bool load_libvlc(void)
 
 	libvlc = libvlc_new_(0, 0);
 	if (!libvlc) {
-		blog(LOG_INFO, "Couldn't create libvlc instance");
+		blog(LOG_INFO, "[vlc-video]: Couldn't create libvlc instance");
 		return false;
 	}
 
@@ -213,15 +215,16 @@ bool load_libvlc(void)
 bool obs_module_load(void)
 {
 	if (!load_libvlc_module()) {
-		blog(LOG_INFO, "Couldn't find VLC installation, VLC video "
-			       "source disabled");
+		blog(LOG_INFO, "[vlc-video]: Couldn't find VLC installation, "
+			       "VLC video source disabled");
 		return true;
 	}
 
 	if (!load_vlc_funcs())
 		return true;
 
-	blog(LOG_INFO, "VLC found, VLC video source enabled");
+	blog(LOG_INFO, "[vlc-video]: VLC %s found, VLC video source enabled",
+	     libvlc_get_version_());
 
 	obs_register_source(&vlc_source_info);
 	return true;

--- a/plugins/vlc-video/vlc-video-plugin.h
+++ b/plugins/vlc-video/vlc-video-plugin.h
@@ -20,6 +20,7 @@ extern bool load_libvlc(void);
 /* libvlc core */
 typedef libvlc_instance_t *(*LIBVLC_NEW)(int argc, const char *const *argv);
 typedef void (*LIBVLC_RELEASE)(libvlc_instance_t *p_instance);
+typedef const char *(*LIBVLC_GET_VERSION)(void);
 typedef int64_t (*LIBVLC_CLOCK)(void);
 typedef int (*LIBVLC_EVENT_ATTACH)(libvlc_event_manager_t *p_event_manager,
 				   libvlc_event_type_t i_event_type,
@@ -113,6 +114,7 @@ typedef int (*LIBVLC_MEDIA_LIST_PLAYER_PREVIOUS)(
 /* libvlc core */
 extern LIBVLC_NEW libvlc_new_;
 extern LIBVLC_RELEASE libvlc_release_;
+extern LIBVLC_GET_VERSION libvlc_get_version_;
 extern LIBVLC_CLOCK libvlc_clock_;
 extern LIBVLC_EVENT_ATTACH libvlc_event_attach_;
 


### PR DESCRIPTION
### Description

Prefixes vlc-video logging with plugin name, and documents the version of the initialised VLC library.

### Motivation and Context

Occasionally support issues crop up related to compatibility issues with VLC that are hard to track down. Logging the VLC version on OBS startup could potentially help with that.

Adding prefixes to log messages makes this consistent with other built-in plugins.

### How Has This Been Tested?

Build OBS with VLC support. Launch, then check log.

Windows:

> `22:36:20.902: [vlc-video]: VLC 3.0.14 Vetinari found, VLC video source enabled`

Linux (Ubuntu 20.04):

> `22:38:34.945: [vlc-video]: VLC 3.0.9.2 Vetinari found, VLC video source enabled`

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
