### PR TITLE
mac-capture: Improve window capture performance

### DIFF
--- a/plugins/mac-capture/mac-display-capture.m
+++ b/plugins/mac-capture/mac-display-capture.m
@@ -134,7 +134,7 @@ static inline void update_window_params(struct display_capture *dc)
 			[dc->screen convertRectToBacking:dc->window_rect];
 
 	} else {
-		if (find_window(&dc->window, NULL, false))
+		if (find_window(&dc->window, NULL))
 			update_window_params(dc);
 		else
 			dc->on_screen = false;

--- a/plugins/mac-capture/window-utils.h
+++ b/plugins/mac-capture/window-utils.h
@@ -8,17 +8,18 @@ struct cocoa_window {
 	CGWindowID window_id;
 	int owner_pid;
 
-	pthread_mutex_t name_lock;
 	NSString *owner_name;
 	NSString *window_name;
 
-	uint64_t next_search_time;
+	uint64_t last_search_time;
+
+	pthread_mutex_t mutex;
 };
 typedef struct cocoa_window *cocoa_window_t;
 
-NSArray *enumerate_cocoa_windows(void);
+NSArray *enumerate_windows(void);
 
-bool find_window(cocoa_window_t cw, obs_data_t *settings, bool force);
+bool find_window(cocoa_window_t cw, obs_data_t *settings);
 
 void init_window(cocoa_window_t cw, obs_data_t *settings);
 


### PR DESCRIPTION
### Description

Reduce CPU utilization on macOS when using Window Capture.

### Motivation and Context

The current implementation of Window Capture on macOS uses Core Graphics to render a bitmap raster which is then handed off to OBS.

This PR replaces that with an implementation that accesses the window's CGImage bitmap directly and blits it and hands that off as a frame to OBS, instead.

### How Has This Been Tested?

Tested on a 2020 iMac 27" w/ 3.6 GHz 10-Core Intel Core i9, AMD Radeon Pro 5700 XT 16 GB, macOS Catalina 10.15.7.

Tested with OBS 26.1.2 and Riot Games League of Legends, with an empty scene with only the Window Capture input source, OBS was consuming 55%-70% CPU.

Tested with the changes in this PR, OBS only consumed 30-35% CPU.

### Types of changes

- Performance enhancement (non-breaking change which improves efficiency)
- Code cleanup (non-breaking change which makes code smaller or more readable)

#### Summary of changes

* I removed any code that was solely used by the previous `CGBitmap`-based implementation, as it's no longer needed.
* I added a small quality-of-life improvement in `capture_thread()` that names the thread using the source name to make debugging easier when you have multiple instances of the input source in a scene.
* I added an `assert()` in `window_capture_create_internal()` to ensure that [the Cocoa Framework is properly multithreaded](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html#//apple_ref/doc/uid/10000057i-CH15-SW21).
* Renamed the locally scoped variable `cap` to `wc` in `window_capture_destroy()` to be consistent with the rest of the file's name for the `window_capture` structure ptr.
* Reordered the setting of property defaults in `window_capture_defaults()` so that anything defined in `mac-window-capture` would override what was defined by `window_defaults()`.
* Renamed `next_search_time` to `last_search_time` to improve the semantics and, I suppose, indirectly fix a bug that resulted from `next_search_time` never being initialized, resulting in `cw->next_search_time > os_gettime_ns()` always evaluating to false, which effectively made `find_window()` a no-op.
* After fixing the issue with `find_window()`, I had to fix the implementation to properly find the correct window, including applications whose window names were `NULL` (such as the League of Legends client).
* I removed the unnecessary `pthread_{lock, unlock}`ing in `init_window()` as that is called from the main thread, before the `capture_thread()` is started, so the locks are unnecessary there.
* Eliminated some NS-value local variable ptrs to make the code easier to read.
* Changed `destroy_window()` to destroy the mutex after the retained vars are released, not before.  In this particular case the order of operations doesn't really matter, but this is just good hygiene.
* Wrapped the `pthread_{lock, unlock}` and other related calls with `assert()` as basic error checking.  Presumably if any of those syscalls actually fail, your process is likely in a state that is unrecoverable and should be terminated, anyway.
* Changed the implementation of `make_name()` because I thought ARC was `free()`ing the buffer before `obs_property_list_add_int()` could `bstrdup()` it, because I was seeing a hard-to-explain crash.  Turns out, that crash was likely fixed by [2d524580](https://github.com/obsproject/obs-studio/commit/2d524580fe7251336169efc46466277a6af8aeff), so I may be able to revert the change relating to the change of this function's implementation.
* Inlined the contents of `find_window_dict()` into its only caller, as it didn't really aid in comprehension of the code having it in its own function, and wasn't called from anywhere else, anyway.
* Fixed the implementation in `window_changed_internal()` to repopulate the window list combobox while matching the currently selected window and disabling it.

I think this is a fairly complete summary of the changes in this PR.  Please let me know if you feel I missed anything, or would like me to elaborate further on any of these.

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
