### PR TITLE
libobs-opengl: Add support for array uniforms

### DIFF
--- a/libobs-opengl/gl-shaderparser.c
+++ b/libobs-opengl/gl-shaderparser.c
@@ -118,6 +118,9 @@ static void gl_write_var(struct gl_shader_parser *glsp, struct shader_var *var)
 	gl_write_type(glsp, var->type);
 	dstr_cat(&glsp->gl_string, " ");
 	dstr_cat(&glsp->gl_string, var->name);
+	if (var->array_count) {
+		dstr_catf(&glsp->gl_string, "[%zu]", var->array_count);
+	}
 }
 
 static inline void gl_write_params(struct gl_shader_parser *glsp)


### PR DESCRIPTION
### Description
Adds support for array uniforms to the OpenGL renderer on all platforms. Array uniforms are slightly more efficient than using a texture unit and sampling a texture, as long as the texture is small (usually at minimum 1024 floats).

### Motivation and Context
OpenGL and Direct3D11 should behave the same, but didn't.

### How Has This Been Tested?
Fixes #4856.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
