### PR TITLE
libobs,deps/media-playback: Avoid bitfields

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -419,7 +419,7 @@ static void mp_media_next_video(mp_media_t *m, bool preload)
 
 	frame->width = f->width;
 	frame->height = f->height;
-	frame->flags = flip ? OBS_SOURCE_FRAME_FLIP : 0;
+	frame->flip = flip;
 	frame->flags |= m->is_linear_alpha ? OBS_SOURCE_FRAME_LINEAR_ALPHA : 0;
 
 	if (!m->is_local_file && !d->got_first_keyframe) {

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2019,7 +2019,7 @@ bool update_async_textures(struct obs_source *source,
 {
 	enum convert_type type;
 
-	source->async_flip = (frame->flags & OBS_SOURCE_FRAME_FLIP) != 0;
+	source->async_flip = frame->flip;
 	source->async_linear_alpha =
 		(frame->flags & OBS_SOURCE_FRAME_LINEAR_ALPHA) != 0;
 
@@ -2724,6 +2724,7 @@ static inline void copy_frame_data_plane(struct obs_source_frame *dst,
 static void copy_frame_data(struct obs_source_frame *dst,
 			    const struct obs_source_frame *src)
 {
+	dst->flip = src->flip;
 	dst->flags = src->flags;
 	dst->full_range = src->full_range;
 	dst->timestamp = src->timestamp;
@@ -2955,6 +2956,7 @@ void obs_source_output_video2(obs_source_t *source,
 	new_frame.timestamp = frame->timestamp;
 	new_frame.format = frame->format;
 	new_frame.full_range = range == VIDEO_RANGE_FULL;
+	new_frame.flip = frame->flip;
 	new_frame.flags = frame->flags;
 
 	memcpy(&new_frame.color_matrix, &frame->color_matrix,
@@ -3086,6 +3088,7 @@ void obs_source_preload_video2(obs_source_t *source,
 	new_frame.timestamp = frame->timestamp;
 	new_frame.format = frame->format;
 	new_frame.full_range = range == VIDEO_RANGE_FULL;
+	new_frame.flip = frame->flip;
 	new_frame.flags = frame->flags;
 
 	memcpy(&new_frame.color_matrix, &frame->color_matrix,
@@ -3190,6 +3193,7 @@ void obs_source_set_video_frame2(obs_source_t *source,
 	new_frame.timestamp = frame->timestamp;
 	new_frame.format = frame->format;
 	new_frame.full_range = range == VIDEO_RANGE_FULL;
+	new_frame.flip = frame->flip;
 	new_frame.flags = frame->flags;
 
 	memcpy(&new_frame.color_matrix, &frame->color_matrix,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -219,8 +219,7 @@ struct obs_source_cea_708 {
 	uint64_t timestamp;
 };
 
-#define OBS_SOURCE_FRAME_FLIP (1 << 0)
-#define OBS_SOURCE_FRAME_LINEAR_ALPHA (1 << 1)
+#define OBS_SOURCE_FRAME_LINEAR_ALPHA (1 << 0)
 
 /**
  * Source asynchronous video output structure.  Used with
@@ -247,10 +246,8 @@ struct obs_source_frame {
 	bool full_range;
 	float color_range_min[3];
 	float color_range_max[3];
-	union {
-		uint8_t flip : 1; /* deprecated */
-		uint8_t flags;
-	};
+	bool flip;
+	uint8_t flags;
 
 	/* used internally by libobs */
 	volatile long refs;
@@ -269,10 +266,8 @@ struct obs_source_frame2 {
 	float color_matrix[16];
 	float color_range_min[3];
 	float color_range_max[3];
-	union {
-		uint8_t flip : 1; /* deprecated */
-		uint8_t flags;
-	};
+	bool flip;
+	uint8_t flags;
 };
 
 /** Access to the argc/argv used to start OBS. What you see is what you get. */


### PR DESCRIPTION
### Description
Use unused padding of obs_source_frame/obs_source_frame2 instead.

### Motivation and Context
Bitfields are tough to use portably.

### How Has This Been Tested?
Linear alpha checkbox for media source still works.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.