### PR TITLE
UI: Fix unused parameter warning

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3680,6 +3680,8 @@ void OBSBasic::DuplicateSelectedScene()
 static bool save_undo_source_enum(obs_scene_t *scene, obs_sceneitem_t *item,
 				  void *p)
 {
+	UNUSED_PARAMETER(scene);
+
 	obs_source_t *source = obs_sceneitem_get_source(item);
 	if (obs_obj_is_private(source) && !obs_source_removed(source))
 		return true;


### PR DESCRIPTION
### Description
Warp unused parameter with UNUSED_PARAMETER.

### Motivation and Context
Don't like compiler warnings.

### How Has This Been Tested?
OBS compiles and runs.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.