### PR TITLE
Only register available PipeWire captures

### DIFF
--- a/plugins/linux-capture/CMakeLists.txt
+++ b/plugins/linux-capture/CMakeLists.txt
@@ -72,11 +72,13 @@ if(ENABLE_PIPEWIRE)
 		${linux-capture_SOURCES}
 		pipewire.c
 		pipewire-capture.c
+		portal.c
 	)
 	set(linux-capture_HEADERS
 		${linux-capture_HEADERS}
 		pipewire.h
 		pipewire-capture.h
+		portal.h
 	)
 	set(linux-capture_LIBRARIES
 		${linux-capture_LIBRARIES}

--- a/plugins/linux-capture/pipewire-capture.c
+++ b/plugins/linux-capture/pipewire-capture.c
@@ -19,6 +19,7 @@
  */
 
 #include "pipewire.h"
+#include "portal.h"
 
 /* obs_source_info methods */
 
@@ -106,6 +107,23 @@ static void pipewire_capture_video_render(void *data, gs_effect_t *effect)
 
 void pipewire_capture_load(void)
 {
+	uint32_t available_capture_types = portal_get_available_capture_types();
+	bool desktop_capture_available =
+		(available_capture_types & DESKTOP_CAPTURE) != 0;
+	bool window_capture_available =
+		(available_capture_types & WINDOW_CAPTURE) != 0;
+
+	if (available_capture_types == 0) {
+		blog(LOG_INFO, "[pipewire] No captures available");
+		return;
+	}
+
+	blog(LOG_INFO, "[pipewire] Available captures:");
+	if (desktop_capture_available)
+		blog(LOG_INFO, "[pipewire]     - Desktop capture");
+	if (window_capture_available)
+		blog(LOG_INFO, "[pipewire]     - Window capture");
+
 	// Desktop capture
 	const struct obs_source_info pipewire_desktop_capture_info = {
 		.id = "pipewire-desktop-capture-source",
@@ -124,7 +142,8 @@ void pipewire_capture_load(void)
 		.video_render = pipewire_capture_video_render,
 		.icon_type = OBS_ICON_TYPE_DESKTOP_CAPTURE,
 	};
-	obs_register_source(&pipewire_desktop_capture_info);
+	if (desktop_capture_available)
+		obs_register_source(&pipewire_desktop_capture_info);
 
 	// Window capture
 	const struct obs_source_info pipewire_window_capture_info = {
@@ -144,7 +163,8 @@ void pipewire_capture_load(void)
 		.video_render = pipewire_capture_video_render,
 		.icon_type = OBS_ICON_TYPE_WINDOW_CAPTURE,
 	};
-	obs_register_source(&pipewire_window_capture_info);
+	if (window_capture_available)
+		obs_register_source(&pipewire_window_capture_info);
 
 	pw_init(NULL, NULL);
 }

--- a/plugins/linux-capture/pipewire.c
+++ b/plugins/linux-capture/pipewire.c
@@ -20,6 +20,8 @@
 
 #include "pipewire.h"
 
+#include "portal.h"
+
 #include <util/dstr.h>
 
 #include <gio/gio.h>
@@ -58,8 +60,6 @@
 		    '4') /* [31:0] A:B:G:R 8:8:8:8 little endian */
 
 struct _obs_pipewire_data {
-	GDBusConnection *connection;
-	GDBusProxy *proxy;
 	GCancellable *cancellable;
 
 	char *sender_name;
@@ -180,7 +180,7 @@ static void on_cancelled_cb(GCancellable *cancellable, void *data)
 	blog(LOG_INFO, "[pipewire] screencast session cancelled");
 
 	g_dbus_connection_call(
-		call->obs_pw->connection, "org.freedesktop.portal.Desktop",
+		portal_get_dbus_connection(), "org.freedesktop.portal.Desktop",
 		call->request_path, "org.freedesktop.portal.Request", "Close",
 		NULL, NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL, NULL);
 }
@@ -198,7 +198,7 @@ static struct dbus_call_data *subscribe_to_signal(obs_pipewire_data *obs_pw,
 					      G_CALLBACK(on_cancelled_cb),
 					      call);
 	call->signal_id = g_dbus_connection_signal_subscribe(
-		obs_pw->connection, "org.freedesktop.portal.Desktop",
+		portal_get_dbus_connection(), "org.freedesktop.portal.Desktop",
 		"org.freedesktop.portal.Request", "Response",
 		call->request_path, NULL, G_DBUS_SIGNAL_FLAGS_NO_MATCH_RULE,
 		callback, call, NULL);
@@ -212,8 +212,8 @@ static void dbus_call_data_free(struct dbus_call_data *call)
 		return;
 
 	if (call->signal_id)
-		g_dbus_connection_signal_unsubscribe(call->obs_pw->connection,
-						     call->signal_id);
+		g_dbus_connection_signal_unsubscribe(
+			portal_get_dbus_connection(), call->signal_id);
 
 	if (call->cancelled_id > 0)
 		g_signal_handler_disconnect(call->obs_pw->cancellable,
@@ -247,11 +247,13 @@ static void teardown_pipewire(obs_pipewire_data *obs_pw)
 static void destroy_session(obs_pipewire_data *obs_pw)
 {
 	if (obs_pw->session_handle) {
-		g_dbus_connection_call(
-			obs_pw->connection, "org.freedesktop.portal.Desktop",
-			obs_pw->session_handle,
-			"org.freedesktop.portal.Session", "Close", NULL, NULL,
-			G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL, NULL);
+		g_dbus_connection_call(portal_get_dbus_connection(),
+				       "org.freedesktop.portal.Desktop",
+				       obs_pw->session_handle,
+				       "org.freedesktop.portal.Session",
+				       "Close", NULL, NULL,
+				       G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL,
+				       NULL);
 
 		g_clear_pointer(&obs_pw->session_handle, g_free);
 	}
@@ -261,8 +263,6 @@ static void destroy_session(obs_pipewire_data *obs_pw)
 	g_clear_pointer(&obs_pw->texture, gs_texture_destroy);
 	g_cancellable_cancel(obs_pw->cancellable);
 	g_clear_object(&obs_pw->cancellable);
-	g_clear_object(&obs_pw->connection);
-	g_clear_object(&obs_pw->proxy);
 }
 
 static inline bool has_effective_crop(obs_pipewire_data *obs_pw)
@@ -730,7 +730,7 @@ static void open_pipewire_remote(obs_pipewire_data *obs_pw)
 	g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
 
 	g_dbus_proxy_call_with_unix_fd_list(
-		obs_pw->proxy, "OpenPipeWireRemote",
+		portal_get_dbus_proxy(), "OpenPipeWireRemote",
 		g_variant_new("(oa{sv})", obs_pw->session_handle, &builder),
 		G_DBUS_CALL_FLAGS_NONE, -1, NULL, obs_pw->cancellable,
 		on_pipewire_remote_opened_cb, obs_pw);
@@ -841,7 +841,7 @@ static void start(obs_pipewire_data *obs_pw)
 	g_variant_builder_add(&builder, "{sv}", "handle_token",
 			      g_variant_new_string(request_token));
 
-	g_dbus_proxy_call(obs_pw->proxy, "Start",
+	g_dbus_proxy_call(portal_get_dbus_proxy(), "Start",
 			  g_variant_new("(osa{sv})", obs_pw->session_handle, "",
 					&builder),
 			  G_DBUS_CALL_FLAGS_NONE, -1, obs_pw->cancellable,
@@ -932,7 +932,7 @@ static void select_source(obs_pipewire_data *obs_pw)
 		g_variant_builder_add(&builder, "{sv}", "cursor_mode",
 				      g_variant_new_uint32(1));
 
-	g_dbus_proxy_call(obs_pw->proxy, "SelectSources",
+	g_dbus_proxy_call(portal_get_dbus_proxy(), "SelectSources",
 			  g_variant_new("(oa{sv})", obs_pw->session_handle,
 					&builder),
 			  G_DBUS_CALL_FLAGS_NONE, -1, obs_pw->cancellable,
@@ -1016,7 +1016,7 @@ static void create_session(obs_pipewire_data *obs_pw)
 	g_variant_builder_add(&builder, "{sv}", "session_handle_token",
 			      g_variant_new_string(session_token));
 
-	g_dbus_proxy_call(obs_pw->proxy, "CreateSession",
+	g_dbus_proxy_call(portal_get_dbus_proxy(), "CreateSession",
 			  g_variant_new("(a{sv})", &builder),
 			  G_DBUS_CALL_FLAGS_NONE, -1, obs_pw->cancellable,
 			  on_session_created_cb, call);
@@ -1028,13 +1028,14 @@ static void create_session(obs_pipewire_data *obs_pw)
 
 /* ------------------------------------------------- */
 
-static void update_available_cursor_modes(obs_pipewire_data *obs_pw)
+static void update_available_cursor_modes(obs_pipewire_data *obs_pw,
+					  GDBusProxy *proxy)
 {
 	g_autoptr(GVariant) cached_cursor_modes = NULL;
 	uint32_t available_cursor_modes;
 
-	cached_cursor_modes = g_dbus_proxy_get_cached_property(
-		obs_pw->proxy, "AvailableCursorModes");
+	cached_cursor_modes =
+		g_dbus_proxy_get_cached_property(proxy, "AvailableCursorModes");
 	available_cursor_modes =
 		cached_cursor_modes ? g_variant_get_uint32(cached_cursor_modes)
 				    : 0;
@@ -1050,52 +1051,26 @@ static void update_available_cursor_modes(obs_pipewire_data *obs_pw)
 		blog(LOG_INFO, "[pipewire]     - Hidden");
 }
 
-static void on_proxy_created_cb(GObject *source, GAsyncResult *res,
-				void *user_data)
-{
-	UNUSED_PARAMETER(source);
-
-	g_autoptr(GError) error = NULL;
-	obs_pipewire_data *obs_pw = user_data;
-
-	obs_pw->proxy = g_dbus_proxy_new_finish(res, &error);
-
-	if (error) {
-		if (!g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
-			blog(LOG_ERROR, "[pipewire] Error creating proxy: %s",
-			     error->message);
-		return;
-	}
-
-	update_available_cursor_modes(obs_pw);
-	create_session(obs_pw);
-}
-
-static void create_proxy(obs_pipewire_data *obs_pw)
-{
-	g_dbus_proxy_new(obs_pw->connection, G_DBUS_PROXY_FLAGS_NONE, NULL,
-			 "org.freedesktop.portal.Desktop",
-			 "/org/freedesktop/portal/desktop",
-			 "org.freedesktop.portal.ScreenCast",
-			 obs_pw->cancellable, on_proxy_created_cb, obs_pw);
-}
-
 /* ------------------------------------------------- */
 
 static gboolean init_obs_pipewire(obs_pipewire_data *obs_pw)
 {
-	g_autoptr(GError) error = NULL;
+	GDBusConnection *connection;
+	GDBusProxy *proxy;
 	char *aux;
 
 	obs_pw->cancellable = g_cancellable_new();
-	obs_pw->connection = g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, &error);
-	if (error) {
-		g_error("Error getting session bus: %s", error->message);
+	connection = portal_get_dbus_connection();
+	if (!connection)
 		return FALSE;
-	}
+	proxy = portal_get_dbus_proxy();
+	if (!proxy)
+		return FALSE;
 
-	obs_pw->sender_name = bstrdup(
-		g_dbus_connection_get_unique_name(obs_pw->connection) + 1);
+	update_available_cursor_modes(obs_pw, proxy);
+
+	obs_pw->sender_name =
+		bstrdup(g_dbus_connection_get_unique_name(connection) + 1);
 
 	/* Replace dots by underscores */
 	while ((aux = strstr(obs_pw->sender_name, ".")) != NULL)
@@ -1104,7 +1079,7 @@ static gboolean init_obs_pipewire(obs_pipewire_data *obs_pw)
 	blog(LOG_INFO, "PipeWire initialized (sender name: %s)",
 	     obs_pw->sender_name);
 
-	create_proxy(obs_pw);
+	create_session(obs_pw);
 
 	return TRUE;
 }

--- a/plugins/linux-capture/portal.c
+++ b/plugins/linux-capture/portal.c
@@ -72,3 +72,15 @@ uint32_t portal_get_available_capture_types(void)
 
 	return available_source_types;
 }
+
+GDBusConnection *portal_get_dbus_connection(void)
+{
+	ensure_proxy();
+	return connection;
+}
+
+GDBusProxy *portal_get_dbus_proxy(void)
+{
+	ensure_proxy();
+	return proxy;
+}

--- a/plugins/linux-capture/portal.c
+++ b/plugins/linux-capture/portal.c
@@ -1,0 +1,74 @@
+/* portal.c
+ *
+ * Copyright 2021 Georges Basile Stavracas Neto <georges.stavracas@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "portal.h"
+#include "pipewire.h"
+
+static GDBusConnection *connection = NULL;
+static GDBusProxy *proxy = NULL;
+
+static void ensure_proxy(void)
+{
+	g_autoptr(GError) error = NULL;
+	if (!connection) {
+		connection = g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, &error);
+
+		if (error) {
+			blog(LOG_WARNING,
+			     "[portals] Error retrieving D-Bus connection: %s",
+			     error->message);
+			return;
+		}
+	}
+
+	if (!proxy) {
+		proxy = g_dbus_proxy_new_sync(
+			connection, G_DBUS_PROXY_FLAGS_NONE, NULL,
+			"org.freedesktop.portal.Desktop",
+			"/org/freedesktop/portal/desktop",
+			"org.freedesktop.portal.ScreenCast", NULL, &error);
+
+		if (error) {
+			blog(LOG_WARNING,
+			     "[portals] Error retrieving D-Bus proxy: %s",
+			     error->message);
+			return;
+		}
+	}
+}
+
+uint32_t portal_get_available_capture_types(void)
+{
+	g_autoptr(GVariant) cached_source_types = NULL;
+	uint32_t available_source_types;
+
+	ensure_proxy();
+
+	if (!proxy)
+		return 0;
+
+	cached_source_types =
+		g_dbus_proxy_get_cached_property(proxy, "AvailableSourceTypes");
+	available_source_types =
+		cached_source_types ? g_variant_get_uint32(cached_source_types)
+				    : 0;
+
+	return available_source_types;
+}

--- a/plugins/linux-capture/portal.h
+++ b/plugins/linux-capture/portal.h
@@ -1,0 +1,25 @@
+/* portal.c
+ *
+ * Copyright 2021 Georges Basile Stavracas Neto <georges.stavracas@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+uint32_t portal_get_available_capture_types(void);

--- a/plugins/linux-capture/portal.h
+++ b/plugins/linux-capture/portal.h
@@ -21,5 +21,9 @@
 #pragma once
 
 #include <stdint.h>
+#include <gio/gio.h>
 
 uint32_t portal_get_available_capture_types(void);
+
+GDBusConnection *portal_get_dbus_connection(void);
+GDBusProxy *portal_get_dbus_proxy(void);


### PR DESCRIPTION
### Description

Don't register captures (window, desktop) that are not supported by the portal implementation. Also, don't create new D-Bus connections and proxies for each capture - do it only once, globally, and reuse these objects.

### Motivation and Context

This was originally noticed at https://github.com/obsproject/obs-studio/issues/4815 - we shouldn't show captures that are not supported by the portal implementation. The fix for this issue made realize we could add an extra optimization on top of it.

### How Has This Been Tested?

 - Open OBS Studio on any wlroots-based compositor (e.g. Sway)
 - Observe that "Window capture (PipeWire)" is not shown

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)
 - Performance enhancement (non-breaking change which improves efficiency)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
