### PR TITLE
obs-qsv11: Update Intel Media SDK to 2021 R1

### DIFF
--- a/plugins/obs-qsv11/CMakeLists.txt
+++ b/plugins/obs-qsv11/CMakeLists.txt
@@ -8,6 +8,7 @@ set(obs-qsv11_libmfx_SOURCES
 	libmfx/src/mfx_critical_section.cpp
 	libmfx/src/mfx_dispatcher.cpp
 	libmfx/src/mfx_dispatcher_log.cpp
+	libmfx/src/mfx_driver_store_loader.cpp
 	libmfx/src/mfx_dxva2_device.cpp
 	libmfx/src/mfx_function_table.cpp
 	libmfx/src/mfx_library_iterator.cpp
@@ -18,6 +19,7 @@ set(obs-qsv11_libmfx_SOURCES
 	)
 
 set(obs-qsv11_libmfx_HEADERS
+	libmfx/include/msdk/include/mfxadapter.h
 	libmfx/include/msdk/include/mfxastructures.h
 	libmfx/include/msdk/include/mfxaudio.h
 	libmfx/include/msdk/include/mfxaudio++.h
@@ -36,6 +38,7 @@ set(obs-qsv11_libmfx_HEADERS
 	libmfx/include/mfx_dispatcher.h
 	libmfx/include/mfx_dispatcher_defs.h
 	libmfx/include/mfx_dispatcher_log.h
+	libmfx/include/mfx_driver_store_loader.h
 	libmfx/include/mfx_dxva2_device.h
 	libmfx/include/mfx_exposed_functions_list.h
 	libmfx/include/mfx_library_iterator.h

--- a/plugins/obs-qsv11/libmfx/include/mfx_critical_section.h
+++ b/plugins/obs-qsv11/libmfx/include/mfx_critical_section.h
@@ -1,32 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2013 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_critical_section.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2012-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #if !defined(__MFX_CRITICAL_SECTION_H)
 #define __MFX_CRITICAL_SECTION_H

--- a/plugins/obs-qsv11/libmfx/include/mfx_dispatcher.h
+++ b/plugins/obs-qsv11/libmfx/include/mfx_dispatcher.h
@@ -1,32 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2017 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_dispatcher.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2012-2020 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #if !defined(__MFX_DISPATCHER_H)
 #define __MFX_DISPATCHER_H
@@ -43,6 +33,8 @@ File Name: mfx_dispatcher.h
 #define INTEL_VENDOR_ID 0x8086
 
 mfxStatus MFXQueryVersion(mfxSession session, mfxVersion *version);
+
+
 
 enum
 {
@@ -119,7 +111,7 @@ enum eMfxImplType
 enum
 {
     MFX_DISPATCHER_VERSION_MAJOR = 1,
-    MFX_DISPATCHER_VERSION_MINOR = 2
+    MFX_DISPATCHER_VERSION_MINOR = 3
 };
 
 struct _mfxSession
@@ -144,7 +136,7 @@ struct MFX_DISP_HANDLE : public _mfxSession
     ~MFX_DISP_HANDLE(void);
 
     // Load the library's module
-    mfxStatus LoadSelectedDLL(const msdk_disp_char *pPath, eMfxImplType implType, mfxIMPL impl, mfxIMPL implInterface, mfxInitParam &par);
+    mfxStatus LoadSelectedDLL(const wchar_t *pPath, eMfxImplType implType, mfxIMPL impl, mfxIMPL implInterface, mfxInitParam &par);
     // Unload the library's module
     mfxStatus UnLoadSelectedDLL(void);
 
@@ -169,7 +161,7 @@ struct MFX_DISP_HANDLE : public _mfxSession
     // Status of loaded dll
     mfxStatus loadStatus;
     // Resgistry subkey name for windows version
-    msdk_disp_char subkeyName[MFX_MAX_REGISTRY_KEY_NAME];
+    wchar_t subkeyName[MFX_MAX_REGISTRY_KEY_NAME];
     // Storage ID for windows version
     int storageID;
 
@@ -186,26 +178,37 @@ private:
 
 };
 
+// This struct extends MFX_DISP_HANDLE, we cannot extend MFX_DISP_HANDLE itself due to possible compatibility issues
+// This struct was added in dispatcher version 1.3
+// Check dispatcher handle's version when you cast session struct which came from outside of MSDK API function to this
+struct MFX_DISP_HANDLE_EX : public MFX_DISP_HANDLE
+{
+    MFX_DISP_HANDLE_EX(const mfxVersion requiredVersion);
+
+    mfxU16 mediaAdapterType;
+    mfxU16 reserved[10];
+};
+
 // declare comparison operator
 inline
 bool operator == (const mfxVersion &one, const mfxVersion &two)
 {
     return (one.Version == two.Version);
 
-} // bool operator == (const mfxVersion &one, const mfxVersion &two)
+}
 
 inline
 bool operator < (const mfxVersion &one, const mfxVersion &two)
 {
-    return (one.Major == two.Major) && (one.Minor < two.Minor);
+    return (one.Major < two.Major) || ((one.Major == two.Major) && (one.Minor < two.Minor));
 
-} // bool operator < (const mfxVersion &one, const mfxVersion &two)
+}
 
 inline
 bool operator <= (const mfxVersion &one, const mfxVersion &two)
 {
     return (one == two) || (one < two);
-} // bool operator <= (const mfxVersion &one, const mfxVersion &two)
+}
 
 
 //

--- a/plugins/obs-qsv11/libmfx/include/mfx_dispatcher_log.h
+++ b/plugins/obs-qsv11/libmfx/include/mfx_dispatcher_log.h
@@ -1,32 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2014 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_dispatcher_log.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2012-2020 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #if !defined(__MFX_DISPATCHER_LOG_H)
 #define __MFX_DISPATCHER_LOG_H
@@ -91,7 +81,6 @@ enum
 //is a vital if mediasdk wont use
 #define DISPATCHER_LOG_HEAP_SINGLETONES
 
-#if defined(_WIN32) || defined(_WIN64)
 // guid for all dispatcher events
 #define DISPATCHER_LOG_EVENT_GUID L"{EB0538CC-4FEE-484d-ACEE-1182E9F37A57}"
 
@@ -101,8 +90,6 @@ enum
 //puts a sink into listeners list
 //#define DISPATCHER_LOG_REGISTER_FILE_WRITER
 #define DISPACTHER_LOG_FW_PATH "c:\\dispatcher.log"
-
-#endif // #if defined(_WIN32) || defined(_WIN64)
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -115,7 +102,6 @@ public:
     virtual void Write(int level, int opcode, const char * msg, va_list argptr) = 0;
 };
 
-#if defined(_WIN32) || defined(_WIN64)
 #if  DISPATCHER_LOG_USE_FORMATING
 
     #define DISPATCHER_LOG(lvl, opcode, str)\
@@ -135,10 +121,6 @@ public:
 #endif//DISPATCHER_LOG_USE_FORMATING
 
 #define DISPATCHER_LOG_OPERATION(operation) operation
-#else
-#define DISPATCHER_LOG(lvl, opcode, str)
-#define DISPATCHER_LOG_OPERATION(operation)
-#endif
 
 #define __name_from_line( name, line ) name ## line
 #define _name_from_line( name , line) __name_from_line( name, line ) 
@@ -182,7 +164,7 @@ private:
     //if obj != NULL then it store obj
     inline static T * store_or_load(T * obj = NULL)
     {
-        static std::auto_ptr<T> instance;
+        static std::unique_ptr<T> instance;
         if (NULL != obj)
         {
             instance.reset(obj);
@@ -237,7 +219,6 @@ struct DispatchLogBlockHelper
 };
 
 //----utility sinks-----
-#if defined(_WIN32) || defined(_WIN64)
 #if defined(DISPATCHER_LOG_REGISTER_EVENT_PROVIDER)
 class ETWHandlerFactory
     : public DSSingleTone<ETWHandlerFactory>
@@ -254,7 +235,6 @@ protected:
     ETWHandlerFactory(){}
 };
 #endif
-#endif // #if defined(_WIN32) || defined(_WIN64)
 
 #if defined(DISPATCHER_LOG_REGISTER_FILE_WRITER)
 class FileSink 
@@ -264,6 +244,10 @@ class FileSink
     friend class DSSingleTone<FileSink>;
 public:
     virtual void Write(int level, int opcode, const char * msg, va_list argptr);
+    FileSink()
+        : m_hdl(NULL)
+    {
+    }
     ~FileSink()
     {
         if (NULL != m_hdl)
@@ -273,11 +257,7 @@ private:
     FILE * m_hdl;
     FileSink(const std::string & log_file)
     {
-#if defined(_WIN32) || defined(_WIN64)
         fopen_s(&m_hdl, log_file.c_str(), "a");
-#else
-        m_hdl = fopen(log_file.c_str(), "a");
-#endif
     }
     
 };

--- a/plugins/obs-qsv11/libmfx/include/mfx_driver_store_loader.h
+++ b/plugins/obs-qsv11/libmfx/include/mfx_driver_store_loader.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2019-2020 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if !defined(__MFX_DRIVER_STORE_LOADER_H)
+#define __MFX_DRIVER_STORE_LOADER_H
+
+#include <windows.h>
+#include <cfgmgr32.h>
+#include <devguid.h>
+
+#include "mfx_dispatcher_defs.h"
+
+namespace MFX
+{
+
+typedef CONFIGRET(WINAPI *Func_CM_Get_Device_ID_List_SizeW)(PULONG pulLen, PCWSTR pszFilter, ULONG ulFlags);
+typedef CONFIGRET(WINAPI *Func_CM_Get_Device_ID_ListW)(PCWSTR pszFilter, PZZWSTR Buffer, ULONG BufferLen, ULONG ulFlags);
+typedef CONFIGRET(WINAPI *Func_CM_Locate_DevNodeW)(PDEVINST pdnDevInst, DEVINSTID_W pDeviceID, ULONG ulFlags);
+typedef CONFIGRET(WINAPI *Func_CM_Open_DevNode_Key)(DEVINST dnDevNode, REGSAM samDesired, ULONG ulHardwareProfile, REGDISPOSITION Disposition, PHKEY phkDevice, ULONG ulFlags);
+
+class DriverStoreLoader
+{
+public:
+    DriverStoreLoader(void);
+    ~DriverStoreLoader(void);
+
+    bool GetDriverStorePath(wchar_t *path, DWORD dwPathSize, mfxU32 deviceID);
+
+protected:
+    bool LoadCfgMgr();
+    bool LoadCmFuncs();
+
+    mfxModuleHandle                  m_moduleCfgMgr;
+    Func_CM_Get_Device_ID_List_SizeW m_pCM_Get_Device_ID_List_Size;
+    Func_CM_Get_Device_ID_ListW      m_pCM_Get_Device_ID_List;
+    Func_CM_Locate_DevNodeW          m_pCM_Locate_DevNode;
+    Func_CM_Open_DevNode_Key         m_pCM_Open_DevNode_Key;
+
+private:
+    // unimplemented by intent to make this class non-copyable
+    DriverStoreLoader(const DriverStoreLoader &);
+    void operator=(const DriverStoreLoader &);
+
+};
+
+} // namespace MFX
+
+#endif // __MFX_DRIVER_STORE_LOADER_H

--- a/plugins/obs-qsv11/libmfx/include/mfx_dxva2_device.h
+++ b/plugins/obs-qsv11/libmfx/include/mfx_dxva2_device.h
@@ -1,46 +1,34 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2017 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_dxva2_device.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2012-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #if !defined(__MFX_DXVA2_DEVICE_H)
 #define __MFX_DXVA2_DEVICE_H
 
-#if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 
 #define TOSTRING(L) #L
 #define STRINGIFY(L) TOSTRING(L)
 
-#if defined(MEDIASDK_UWP_LOADER) || defined(MEDIASDK_UWP_PROCTABLE)
+#if defined(MEDIASDK_UWP_DISPATCHER)
     #if defined(MFX_D3D9_ENABLED) && !defined(MFX_FORCE_D3D9_ENABLED)
         #undef MFX_D3D9_ENABLED
-        // if you really like to use D3D9 from intel_gfx_api-x64/x86.dll, use MFX_FORCE_D3D9_ENABLED
         #pragma message("\n\nATTENTION:\nin file\n\t" __FILE__ " (" STRINGIFY(__LINE__) "):\nUsing of D3D9 disabled for UWP!\n\n")
     #endif
     #if defined(MFX_FORCE_D3D9_ENABLED)
@@ -50,8 +38,6 @@ File Name: mfx_dxva2_device.h
     #define MFX_D3D9_ENABLED
     #pragma message("\n\nATTENTION:\nin file\n\t" __FILE__ " (" STRINGIFY(__LINE__) "):\nUsing of D3D9 enabled!\n\n")
 #endif
-
-#endif // #if defined(_WIN32) || defined(_WIN64)
 
 #include <mfxdefs.h>
 
@@ -101,10 +87,8 @@ protected:
     // Free DLL module
     void UnloadDLLModule(void);
 
-#if defined(_WIN32) || defined(_WIN64)
     // Handle to the DLL library
     HMODULE m_hModule;
-#endif // #if defined(_WIN32) || defined(_WIN64)
 
     // Number of adapters available
     mfxU32 m_numAdapters;
@@ -123,9 +107,6 @@ private:
     DXDevice(const DXDevice &);
     void operator=(const DXDevice &);
 };
-
-
-#if defined(_WIN32) || defined(_WIN64)
 
 #ifdef MFX_D3D9_ENABLED
 class D3D9Device : public DXDevice
@@ -180,7 +161,6 @@ protected:
     void *m_pDXGIAdapter1;
 
 };
-#endif // #if defined(_WIN32) || defined(_WIN64)
 
 class DXVA2Device
 {

--- a/plugins/obs-qsv11/libmfx/include/mfx_exposed_functions_list.h
+++ b/plugins/obs-qsv11/libmfx/include/mfx_exposed_functions_list.h
@@ -1,32 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2016 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_exposed_functions_list.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2012-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 //
 // WARNING:

--- a/plugins/obs-qsv11/libmfx/include/mfx_library_iterator.h
+++ b/plugins/obs-qsv11/libmfx/include/mfx_library_iterator.h
@@ -1,32 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2018 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_library_iterator.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2012-2020 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #if !defined(__MFX_LIBRARY_ITERATOR_H)
 #define __MFX_LIBRARY_ITERATOR_H
@@ -34,68 +24,41 @@ File Name: mfx_library_iterator.h
 
 #include <mfxvideo.h>
 
-#if !defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
+#if !defined(MEDIASDK_UWP_DISPATCHER)
 #include "mfx_win_reg_key.h"
 #endif
 
+#include "mfx_driver_store_loader.h"
+
 #include "mfx_dispatcher.h"
-
-#if !defined(_WIN32) && !defined(_WIN64)
-struct mfx_disp_adapters
-{
-    mfxU32 vendor_id;
-    mfxU32 device_id;
-};
-
-#ifndef __APPLE__
-#define MFX_SO_BASE_NAME_LEN 15 // sizeof("libmfxhw32-p.so") = 15
-#else
-
-#define MFX_SO_BASE_NAME_LEN 16 // sizeof("libmfxhw64.dylib") = 16
-#endif
-
-#define MFX_MIN_REAL_LIBNAME MFX_SO_BASE_NAME_LEN + 4 // sizeof("libmfxhw32-p.so.0.0") >= 19
-#define MFX_MAX_REAL_LIBNAME MFX_MIN_REAL_LIBNAME + 8 // sizeof("libmfxhw32-p.so.<mj>.<mn>") <= 27, max(sizeof(<mj>))=sizeof(0xFFFF) = sizeof(65535) = 5
-
-struct mfx_libs
-{
-    char name[MFX_MAX_REAL_LIBNAME+1];
-    mfxVersion version;
-};
-#endif
 
 namespace MFX
 {
 
 // declare desired storage ID
-#if defined(_WIN32) || defined(_WIN64)
 enum
 {
+#if defined (MFX_TRACER_WA_FOR_DS)
     MFX_UNKNOWN_KEY             = -1,
-    MFX_CURRENT_USER_KEY        = 0,
-    MFX_LOCAL_MACHINE_KEY       = 1,
-    MFX_APP_FOLDER              = 2,
-#if defined(MEDIASDK_USE_REGISTRY) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
-    MFX_PATH_MSDK_FOLDER = 3,
-    MFX_STORAGE_ID_FIRST    = MFX_CURRENT_USER_KEY,
-    MFX_STORAGE_ID_LAST     = MFX_PATH_MSDK_FOLDER
-#else
-    MFX_PATH_MSDK_FOLDER = 3,
-    MFX_STORAGE_ID_FIRST = MFX_PATH_MSDK_FOLDER,
+    MFX_TRACER                  = 0,
+    MFX_DRIVER_STORE            = 1,
+    MFX_CURRENT_USER_KEY        = 2,
+    MFX_LOCAL_MACHINE_KEY       = 3,
+    MFX_APP_FOLDER              = 4,
+    MFX_PATH_MSDK_FOLDER        = 5,
+    MFX_STORAGE_ID_FIRST = MFX_TRACER,
     MFX_STORAGE_ID_LAST = MFX_PATH_MSDK_FOLDER
-#endif // !defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
-};
 #else
-enum
-{
-    MFX_UNKNOWN_KEY     = -1,
-    MFX_STORAGE_ID_OPT  = 0, // storage is: MFX_MODULES_DIR
-    MFX_APP_FOLDER      = 1,
-
-    MFX_STORAGE_ID_FIRST   =  MFX_STORAGE_ID_OPT,
-    MFX_STORAGE_ID_LAST    = MFX_STORAGE_ID_OPT
-};
+    MFX_UNKNOWN_KEY             = -1,
+    MFX_DRIVER_STORE            = 0,
+    MFX_CURRENT_USER_KEY        = 1,
+    MFX_LOCAL_MACHINE_KEY       = 2,
+    MFX_APP_FOLDER              = 3,
+    MFX_PATH_MSDK_FOLDER        = 4,
+    MFX_STORAGE_ID_FIRST    = MFX_DRIVER_STORE,
+    MFX_STORAGE_ID_LAST     = MFX_PATH_MSDK_FOLDER
 #endif
+};
 
 // Try to initialize using given implementation type. Select appropriate type automatically in case of MFX_IMPL_VIA_ANY.
 // Params: adapterNum - in, pImplInterface - in/out, pVendorID - out, pDeviceID - out
@@ -115,14 +78,14 @@ public:
     mfxStatus Init(eMfxImplType implType, mfxIMPL implInterface, const mfxU32 adapterNum, int storageID);
 
     // Get the next library path
-    mfxStatus SelectDLLVersion(msdk_disp_char *pPath, size_t pathSize,
+    mfxStatus SelectDLLVersion(wchar_t *pPath, size_t pathSize,
                                eMfxImplType *pImplType, mfxVersion minVersion);
 
     // Return interface type on which Intel adapter was found (if any): D3D9 or D3D11
     mfxIMPL GetImplementationType();
 
     // Retrun registry subkey name on which dll was selected after sucesfull call to selectDllVesion
-    bool GetSubKeyName(msdk_disp_char *subKeyName, size_t length) const;
+    bool GetSubKeyName(wchar_t *subKeyName, size_t length) const;
 
     int  GetStorageID() const { return m_StorageID; }
 protected:
@@ -131,9 +94,13 @@ protected:
     void Release(void);
 
     // Initialize the registry iterator
-    mfxStatus InitRegistry(eMfxImplType implType, mfxIMPL implInterface, const mfxU32 adapterNum, int storageID);
-    // Initialize the app folder iterator
-    mfxStatus InitFolder(eMfxImplType implType, mfxIMPL implInterface, const mfxU32 adapterNum, const msdk_disp_char * path);
+    mfxStatus InitRegistry(int storageID);
+#if defined(MFX_TRACER_WA_FOR_DS)
+    // Initialize the registry iterator for searching for tracer
+    mfxStatus InitRegistryTracer();
+#endif
+    // Initialize the app/module folder iterator
+    mfxStatus InitFolder(eMfxImplType implType, const wchar_t * path, const int storageID);
 
 
     eMfxImplType m_implType;                                    // Required library implementation
@@ -145,25 +112,16 @@ protected:
     wchar_t m_SubKeyName[MFX_MAX_REGISTRY_KEY_NAME];            // registry subkey for selected module loaded
     int    m_StorageID;
 
-#if defined(_WIN32) || defined(_WIN64)
-
-#if defined(MEDIASDK_USE_REGISTRY) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
+#if !defined(MEDIASDK_UWP_DISPATCHER)
     WinRegKey m_baseRegKey;                                     // (WinRegKey) main registry key
 #endif
 
     mfxU32 m_lastLibIndex;                                      // (mfxU32) index of previously returned library
     mfxU32 m_lastLibMerit;                                      // (mfxU32) merit of previously returned library
-#else
-    int                       m_lastLibIndex;                   // (mfxU32) index of previously returned library
 
-    mfxU32                    m_adapters_num;
-    struct mfx_disp_adapters* m_adapters;
-    int                       m_selected_adapter;
-    mfxU32                    m_libs_num;
-    struct mfx_libs*          m_libs;
-#endif // #if defined(_WIN32) || defined(_WIN64)
+    wchar_t  m_path[msdk_disp_path_len];
 
-    msdk_disp_char  m_path[msdk_disp_path_len];
+    DriverStoreLoader m_driverStoreLoader;                      // for loading MediaSDK from DriverStore
 
 private:
     // unimplemented by intent to make this class non-copyable

--- a/plugins/obs-qsv11/libmfx/include/mfx_load_dll.h
+++ b/plugins/obs-qsv11/libmfx/include/mfx_load_dll.h
@@ -1,32 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2014 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_load_dll.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2012-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #if !defined(__MFX_LOAD_DLL_H)
 #define __MFX_LOAD_DLL_H
@@ -41,16 +31,19 @@ namespace MFX
     // declare DLL loading routines
     //
 
-    mfxStatus mfx_get_rt_dll_name(msdk_disp_char *pPath, size_t pathSize);
-    mfxStatus mfx_get_default_dll_name(msdk_disp_char *pPath, size_t pathSize, eMfxImplType implType);
-    mfxStatus mfx_get_default_plugin_name(msdk_disp_char *pPath, size_t pathSize, eMfxImplType implType);
+    mfxStatus mfx_get_rt_dll_name(wchar_t *pPath, size_t pathSize);
+    mfxStatus mfx_get_default_dll_name(wchar_t *pPath, size_t pathSize, eMfxImplType implType);
+    mfxStatus mfx_get_default_plugin_name(wchar_t *pPath, size_t pathSize, eMfxImplType implType);
+#if defined(MEDIASDK_UWP_DISPATCHER)
+    mfxStatus mfx_get_default_intel_gfx_api_dll_name(wchar_t *pPath, size_t pathSize);
+#endif
 
-    mfxStatus mfx_get_default_audio_dll_name(msdk_disp_char *pPath, size_t pathSize, eMfxImplType implType);
+    mfxStatus mfx_get_default_audio_dll_name(wchar_t *pPath, size_t pathSize, eMfxImplType implType);
     
 
-    mfxModuleHandle mfx_dll_load(const msdk_disp_char *file_name);
+    mfxModuleHandle mfx_dll_load(const wchar_t *file_name);
     //increments reference counter
-    mfxModuleHandle mfx_get_dll_handle(const msdk_disp_char *file_name);
+    mfxModuleHandle mfx_get_dll_handle(const wchar_t *file_name);
     mfxFunctionPointer mfx_dll_get_addr(mfxModuleHandle handle, const char *func_name);
     bool mfx_dll_free(mfxModuleHandle handle);
 

--- a/plugins/obs-qsv11/libmfx/include/mfx_load_plugin.h
+++ b/plugins/obs-qsv11/libmfx/include/mfx_load_plugin.h
@@ -1,32 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2013-2016 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_load_plugin.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2013-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #pragma once
 #include "mfxplugin.h"
@@ -41,11 +31,11 @@ namespace MFX
     {
         mfxModuleHandle mHmodule;
         CreatePluginPtr_t mCreatePluginPtr;
-        msdk_disp_char mPath[MAX_PLUGIN_PATH];
+        wchar_t mPath[MAX_PLUGIN_PATH];
         
     public:
         PluginModule();
-        PluginModule(const msdk_disp_char * path);
+        PluginModule(const wchar_t * path);
         PluginModule(const PluginModule & that) ;
         PluginModule & operator = (const PluginModule & that);
         bool Create(mfxPluginUID guid, mfxPlugin&);
@@ -61,7 +51,7 @@ namespace MFX
             PluginModule module;
             mfxPlugin plugin;
             FactoryRecord ()
-                : plugin()
+                : plgParams(), plugin()
             {}
             FactoryRecord(const mfxPluginParam &plgParams,
                           PluginModule &module,

--- a/plugins/obs-qsv11/libmfx/include/mfx_plugin_hive.h
+++ b/plugins/obs-qsv11/libmfx/include/mfx_plugin_hive.h
@@ -1,32 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2013-2018 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_plugin_hive.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2013-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #pragma once
 
@@ -58,7 +48,7 @@ namespace MFX {
     class PluginDescriptionRecord :  public mfxPluginParam 
     {
     public:
-        msdk_disp_char sPath[MAX_PLUGIN_PATH];
+        wchar_t sPath[MAX_PLUGIN_PATH];
         char sName[MAX_PLUGIN_NAME];
         //used for FS plugins that has poor description
         bool onlyVersionRegistered;
@@ -91,14 +81,15 @@ namespace MFX {
         }
     };
 
+#if !defined(MEDIASDK_UWP_DISPATCHER)
+
     //populated from registry
     class MFXPluginsInHive : public MFXPluginStorageBase
     {
     public:
-        MFXPluginsInHive(int mfxStorageID, const msdk_disp_char *msdkLibSubKey, mfxVersion currentAPIVersion);
+        MFXPluginsInHive(int mfxStorageID, const wchar_t *msdkLibSubKey, mfxVersion currentAPIVersion);
     };
 
-#if defined(MEDIASDK_USE_CFGFILES) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
     //plugins are loaded from FS close to executable
     class MFXPluginsInFS : public MFXPluginStorageBase
     {
@@ -108,9 +99,10 @@ namespace MFX {
         MFXPluginsInFS(mfxVersion currentAPIVersion);
     private:
         bool ParseFile(FILE * f, PluginDescriptionRecord & des);
-        bool ParseKVPair( msdk_disp_char *key, msdk_disp_char * value, PluginDescriptionRecord & des);
+        bool ParseKVPair( wchar_t *key, wchar_t * value, PluginDescriptionRecord & des);
     };
-#endif //#if defined(MEDIASDK_USE_CFGFILES) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
+
+#endif //#if !defined(MEDIASDK_UWP_DISPATCHER)
 
     //plugins are loaded from FS close to Runtime library
     class MFXDefaultPlugins : public MFXPluginStorageBase

--- a/plugins/obs-qsv11/libmfx/include/mfx_vector.h
+++ b/plugins/obs-qsv11/libmfx/include/mfx_vector.h
@@ -1,81 +1,71 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2013-2014 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_vector.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2013-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #pragma once
 #include "mfxstructures.h"
 #include <exception>
 
-namespace MFX 
+namespace MFX
 {
     template <class T>
-    class iterator_tmpl 
+    class iterator_tmpl
     {
         template <class U> friend class MFXVector;
         mfxU32 mIndex;
         T* mRecords;
-        iterator_tmpl(mfxU32 index , T * records) 
+        iterator_tmpl(mfxU32 index , T * records)
             : mIndex (index)
             , mRecords(records)
         {}
     public:
-        iterator_tmpl() 
+        iterator_tmpl()
             : mIndex ()
-            , mRecords() 
+            , mRecords()
         {}
-        bool  operator ==(const iterator_tmpl<T> & that )const 
+        bool  operator ==(const iterator_tmpl<T> & that )const
         {
             return mIndex == that.mIndex;
         }
-        bool  operator !=(const iterator_tmpl<T> & that )const 
+        bool  operator !=(const iterator_tmpl<T> & that )const
         {
             return mIndex != that.mIndex;
         }
-        mfxU32 operator - (const iterator_tmpl<T> &that) const 
+        mfxU32 operator - (const iterator_tmpl<T> &that) const
         {
             return mIndex - that.mIndex;
         }
-        iterator_tmpl<T> & operator ++() 
+        iterator_tmpl<T> & operator ++()
         {
             mIndex++;
             return * this;
         }
-        iterator_tmpl<T> & operator ++(int) 
+        iterator_tmpl<T> & operator ++(int)
         {
             mIndex++;
             return * this;
         }
-        T & operator *() 
+        T & operator *()
         {
             return mRecords[mIndex];
         }
-        T * operator ->() 
+        T * operator ->()
         {
             return mRecords + mIndex;
         }
@@ -86,7 +76,7 @@ namespace MFX
     };
 
     template <class T>
-    class MFXVector  
+    class MFXVector
     {
         T*      mRecords;
         mfxU32  mNrecords;
@@ -103,7 +93,7 @@ namespace MFX
         }
         MFXVector & operator = (const MFXVector & rhs)
         {
-            if (this != &rhs) 
+            if (this != &rhs)
             {
                 clear();
                 insert(end(), rhs.begin(), rhs.end());
@@ -116,15 +106,15 @@ namespace MFX
         }
         typedef iterator_tmpl<T> iterator;
 
-        iterator begin() const 
+        iterator begin() const
         {
             return iterator(0u, mRecords);
         }
-        iterator end() const 
+        iterator end() const
         {
             return iterator(mNrecords, mRecords);
         }
-        void insert(iterator where, iterator beg_iter, iterator end_iter) 
+        void insert(iterator where, iterator beg_iter, iterator end_iter)
         {
             mfxU32 elementsToInsert = (end_iter - beg_iter);
             if (!elementsToInsert)
@@ -138,20 +128,20 @@ namespace MFX
 
             T *newRecords = new T[mNrecords + elementsToInsert]();
             mfxU32 i = 0;
-            
+
             // save left
-            for (; i < where.mIndex; i++) 
+            for (; i < where.mIndex; i++)
             {
                 newRecords[i] = mRecords[i];
             }
             // insert
-            for (; beg_iter != end_iter; beg_iter++, i++) 
+            for (; beg_iter != end_iter; beg_iter++, i++)
             {
                 newRecords[i] = *beg_iter;
             }
-    
+
             //save right
-            for (; i < mNrecords + elementsToInsert; i++) 
+            for (; i < mNrecords + elementsToInsert; i++)
             {
                 newRecords[i] = mRecords[i - elementsToInsert];
             }
@@ -161,15 +151,15 @@ namespace MFX
             mRecords = newRecords;
             mNrecords = i;
         }
-        T& operator [] (mfxU32 idx) 
+        T& operator [] (mfxU32 idx)
         {
           return mRecords[idx];
         }
-        void push_back(const T& obj) 
+        void push_back(const T& obj)
         {
             T *newRecords = new T[mNrecords + 1]();
             mfxU32 i = 0;
-            for (; i <mNrecords; i++) 
+            for (; i <mNrecords; i++)
             {
                 newRecords[i] = mRecords[i];
             }
@@ -178,15 +168,14 @@ namespace MFX
 
             mRecords = newRecords;
             mNrecords = i + 1;
-            
         }
-        void erase (iterator at) 
+        void erase (iterator at)
         {
             if (at.mIndex >= mNrecords)
             {
                 throw MFXVectorRangeError();
             }
-            mNrecords--; 
+            mNrecords--;
             mfxU32 i = at.mIndex;
             for (; i != mNrecords; i++)
             {
@@ -195,10 +184,10 @@ namespace MFX
             //destroy last element
             mRecords[i] = T();
         }
-        void resize(mfxU32 nSize) 
+        void resize(mfxU32 nSize)
         {
             T * newRecords = new T[nSize]();
-            for (mfxU32 i = 0; i <mNrecords; i++) 
+            for (mfxU32 i = 0; i <mNrecords; i++)
             {
                 newRecords[i] = mRecords[i];
             }
@@ -206,15 +195,23 @@ namespace MFX
             mRecords = newRecords;
             mNrecords = nSize;
         }
-        mfxU32 size() const 
+        mfxU32 size() const
         {
             return mNrecords;
         }
-        void clear() 
+        void clear()
         {
             delete [] mRecords;
             mRecords = 0;
             mNrecords = 0;
+        }
+        bool empty()
+        {
+            return !mRecords;
+        }
+        T * data() const
+        {
+            return mRecords;
         }
     };
 }

--- a/plugins/obs-qsv11/libmfx/include/mfx_win_reg_key.h
+++ b/plugins/obs-qsv11/libmfx/include/mfx_win_reg_key.h
@@ -1,42 +1,31 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2014 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_win_reg_key.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2012-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #if !defined(__MFX_WIN_REG_KEY_H)
 #define __MFX_WIN_REG_KEY_H
-
-#if defined(_WIN32) || defined(_WIN64)
 
 #include <windows.h>
 #include "mfxplugin.h"
 #include "mfx_dispatcher_log.h"
 
+#if !defined(MEDIASDK_UWP_DISPATCHER)
 namespace MFX {
 
 template<class T> struct RegKey{};
@@ -110,7 +99,6 @@ inline bool QueryKey<bool>(WinRegKey & key, const wchar_t *pValueName, bool &dat
 
 
 } // namespace MFX
-
-#endif // #if defined(_WIN32) || defined(_WIN64)
+#endif // #if !defined(MEDIASDK_UWP_DISPATCHER)
 
 #endif // __MFX_WIN_REG_KEY_H

--- a/plugins/obs-qsv11/libmfx/include/mfxaudio_exposed_functions_list.h
+++ b/plugins/obs-qsv11/libmfx/include/mfxaudio_exposed_functions_list.h
@@ -1,32 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2013-2014 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfxaudio_exposed_function_list.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2013-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 //
 // WARNING:

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxadapter.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxadapter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2020 Intel Corporation
+// Copyright (c) 2019-2020 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,30 +18,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#pragma once
 #include "mfxdefs.h"
-#include <cstring>
-#include <cstdio>
+#if (MFX_VERSION >= 1031)
+#ifndef __MFXADAPTER_H__
+#define __MFXADAPTER_H__
 
-#if defined(MFX_DISPATCHER_LOG)
-#include <string>
-#include <string.h>
+#include "mfxstructures.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+mfxStatus MFX_CDECL MFXQueryAdapters(mfxComponentInfo* input_info, mfxAdaptersInfo* adapters);
+mfxStatus MFX_CDECL MFXQueryAdaptersDecode(mfxBitstream* bitstream, mfxU32 codec_id, mfxAdaptersInfo* adapters);
+mfxStatus MFX_CDECL MFXQueryAdaptersNumber(mfxU32* num_adapters);
+#ifdef __cplusplus
+} // extern "C"
 #endif
 
-#define MAX_PLUGIN_PATH 4096
-#define MAX_PLUGIN_NAME 4096
-
-#if _MSC_VER < 1400
-#define wcscpy_s(to,to_size, from) wcscpy(to, from)
-#define wcscat_s(to,to_size, from) wcscat(to, from)
+#endif // __MFXADAPTER_H__
 #endif
-
-// declare library module's handle
-typedef void * mfxModuleHandle;
-
-typedef void (MFX_CDECL * mfxFunctionPointer)(void);
-
-// Tracer uses lib loading from Program Files logic (via Dispatch reg key) to make dispatcher load tracer dll.
-// With DriverStore loading put at 1st place, dispatcher loads real lib before it finds tracer dll.
-// This workaround explicitly checks tracer presence in Dispatch reg key and loads tracer dll before the search for lib in all other places.
-#define MFX_TRACER_WA_FOR_DS 1

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxastructures.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxastructures.h
@@ -1,32 +1,22 @@
-/*******************************************************************************
-
-Copyright (C) 2013 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfxastructures.h
-
-*******************************************************************************/
+// Copyright (c) 2017-2019 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 #ifndef __MFXASTRUCTURES_H__
 #define __MFXASTRUCTURES_H__
 #include "mfxcommon.h"
@@ -103,6 +93,7 @@ enum
     MFX_AUDIO_AAC_JOINT_STEREO=    3
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxU32                CodecId;
     mfxU16                CodecProfile;
@@ -129,7 +120,9 @@ typedef struct {
         };
     };
 } mfxAudioInfoMFX;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
     mfxU16  AsyncDepth;
     mfxU16  Protected;
@@ -139,13 +132,17 @@ typedef struct {
     mfxExtBuffer**    ExtParam;
     mfxU16            NumExtParam;
 } mfxAudioParam;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxU32  SuggestedInputSize;
     mfxU32  SuggestedOutputSize;
     mfxU32  reserved[6];
 } mfxAudioAllocRequest;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_L_TYPE()
 typedef struct {
     mfxU64  TimeStamp; /* 1/90KHz */
     mfxU16  Locked;
@@ -162,6 +159,7 @@ typedef struct {
     mfxU32  NumExtParam;
     mfxExtBuffer **ExtParam;
 } mfxAudioFrame;
+MFX_PACK_END()
 
 #ifdef __cplusplus
 }

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxaudio++.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxaudio++.h
@@ -1,34 +1,22 @@
-/*******************************************************************************
-
-Copyright (C) 2013 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-File Name: mfxaudio++.h
-
-
-*******************************************************************************/
+// Copyright (c) 2017 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 #ifndef __MFXAUDIOPLUSPLUS_H
 #define __MFXAUDIOPLUSPLUS_H
 

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxaudio.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxaudio.h
@@ -1,32 +1,22 @@
-/*******************************************************************************
-
-Copyright (C) 2013 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfxaudio.h
-
-*******************************************************************************/
+// Copyright (c) 2017 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #ifndef __MFXAUDIO_H__
 #define __MFXAUDIO_H__
@@ -42,26 +32,26 @@ extern "C"
 #endif
 
 /* AudioCORE */
-mfxStatus MFX_CDECL MFXAudioCORE_SyncOperation(mfxSession session, mfxSyncPoint syncp, mfxU32 wait);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioCORE_SyncOperation(mfxSession session, mfxSyncPoint syncp, mfxU32 wait);
 
 /* AudioENCODE */
-mfxStatus MFX_CDECL MFXAudioENCODE_Query(mfxSession session, mfxAudioParam *in, mfxAudioParam *out);
-mfxStatus MFX_CDECL MFXAudioENCODE_QueryIOSize(mfxSession session, mfxAudioParam *par, mfxAudioAllocRequest *request);
-mfxStatus MFX_CDECL MFXAudioENCODE_Init(mfxSession session, mfxAudioParam *par);
-mfxStatus MFX_CDECL MFXAudioENCODE_Reset(mfxSession session, mfxAudioParam *par);
-mfxStatus MFX_CDECL MFXAudioENCODE_Close(mfxSession session);
-mfxStatus MFX_CDECL MFXAudioENCODE_GetAudioParam(mfxSession session, mfxAudioParam *par);
-mfxStatus MFX_CDECL MFXAudioENCODE_EncodeFrameAsync(mfxSession session, mfxAudioFrame *frame, mfxBitstream *bs, mfxSyncPoint *syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_Query(mfxSession session, mfxAudioParam *in, mfxAudioParam *out);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_QueryIOSize(mfxSession session, mfxAudioParam *par, mfxAudioAllocRequest *request);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_Init(mfxSession session, mfxAudioParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_Reset(mfxSession session, mfxAudioParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_Close(mfxSession session);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_GetAudioParam(mfxSession session, mfxAudioParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioENCODE_EncodeFrameAsync(mfxSession session, mfxAudioFrame *frame, mfxBitstream *bs, mfxSyncPoint *syncp);
 
 /* AudioDECODE */
-mfxStatus MFX_CDECL MFXAudioDECODE_Query(mfxSession session, mfxAudioParam *in, mfxAudioParam *out);
-mfxStatus MFX_CDECL MFXAudioDECODE_DecodeHeader(mfxSession session, mfxBitstream *bs, mfxAudioParam* par);
-mfxStatus MFX_CDECL MFXAudioDECODE_Init(mfxSession session, mfxAudioParam *par);
-mfxStatus MFX_CDECL MFXAudioDECODE_Reset(mfxSession session, mfxAudioParam *par);
-mfxStatus MFX_CDECL MFXAudioDECODE_Close(mfxSession session);
-mfxStatus MFX_CDECL MFXAudioDECODE_QueryIOSize(mfxSession session, mfxAudioParam *par, mfxAudioAllocRequest *request);
-mfxStatus MFX_CDECL MFXAudioDECODE_GetAudioParam(mfxSession session, mfxAudioParam *par);
-mfxStatus MFX_CDECL MFXAudioDECODE_DecodeFrameAsync(mfxSession session, mfxBitstream *bs, mfxAudioFrame *frame, mfxSyncPoint *syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_Query(mfxSession session, mfxAudioParam *in, mfxAudioParam *out);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_DecodeHeader(mfxSession session, mfxBitstream *bs, mfxAudioParam* par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_Init(mfxSession session, mfxAudioParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_Reset(mfxSession session, mfxAudioParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_Close(mfxSession session);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_QueryIOSize(mfxSession session, mfxAudioParam *par, mfxAudioAllocRequest *request);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_GetAudioParam(mfxSession session, mfxAudioParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioDECODE_DecodeFrameAsync(mfxSession session, mfxBitstream *bs, mfxAudioFrame *frame, mfxSyncPoint *syncp);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxcommon.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxcommon.h
@@ -1,32 +1,22 @@
-/*******************************************************************************
-
-Copyright (C) 2013-2018 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfxcommon.h
-
-*******************************************************************************/
+// Copyright (c) 2018-2020 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 #ifndef __MFXCOMMON_H__
 #define __MFXCOMMON_H__
 #include "mfxdefs.h"
@@ -43,10 +33,12 @@ extern "C"
 #define MFX_MAKEFOURCC(A,B,C,D)    ((((int)A))+(((int)B)<<8)+(((int)C)<<16)+(((int)D)<<24))
 
 /* Extended Configuration Header Structure */
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxU32  BufferId;
     mfxU32  BufferSz;
 } mfxExtBuffer;
+MFX_PACK_END()
 
 /* Library initialization and deinitialization */
 typedef mfxI32 mfxIMPL;
@@ -62,17 +54,24 @@ enum  {
     MFX_IMPL_HARDWARE3    = 0x0006,  /* Hardware accelerated implementation (3rd device) */
     MFX_IMPL_HARDWARE4    = 0x0007,  /* Hardware accelerated implementation (4th device) */
     MFX_IMPL_RUNTIME      = 0x0008,
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    MFX_IMPL_SINGLE_THREAD= 0x0009,
+#endif
     MFX_IMPL_VIA_ANY      = 0x0100,
     MFX_IMPL_VIA_D3D9     = 0x0200,
     MFX_IMPL_VIA_D3D11    = 0x0300,
     MFX_IMPL_VIA_VAAPI    = 0x0400,
 
     MFX_IMPL_AUDIO                     = 0x8000,
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    MFX_IMPL_EXTERNAL_THREADING        = 0x10000,
+#endif
 
     MFX_IMPL_UNSUPPORTED  = 0x0000  /* One of the MFXQueryIMPL returns */
 };
 
 /* Version Info */
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef union {
     struct {
         mfxU16  Minor;
@@ -80,6 +79,7 @@ typedef union {
     };
     mfxU32  Version;
 } mfxVersion;
+MFX_PACK_END()
 
 /* session priority */
 typedef enum
@@ -91,6 +91,7 @@ typedef enum
 } mfxPriority;
 
 typedef struct _mfxEncryptedData mfxEncryptedData;
+MFX_PACK_BEGIN_STRUCT_W_L_TYPE()
 typedef struct {
      union {
         struct {
@@ -100,7 +101,7 @@ typedef struct {
         };
          mfxU32  reserved[6];
      };
-    mfxI64  DecodeTimeStamp; 
+    mfxI64  DecodeTimeStamp;
     mfxU64  TimeStamp;
     mfxU8*  Data;
     mfxU32  DataOffset;
@@ -112,6 +113,7 @@ typedef struct {
     mfxU16  DataFlag;
     mfxU16  reserved2;
 } mfxBitstream;
+MFX_PACK_END()
 
 typedef struct _mfxSyncPoint *mfxSyncPoint;
 
@@ -122,6 +124,7 @@ enum {
     MFX_GPUCOPY_OFF     = 2
 };
 
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
     mfxIMPL     Implementation;
     mfxVersion  Version;
@@ -136,11 +139,13 @@ typedef struct {
     mfxU16      GPUCopy;
     mfxU16      reserved[21];
 } mfxInitParam;
+MFX_PACK_END()
 
 enum {
     MFX_EXTBUFF_THREADS_PARAM = MFX_MAKEFOURCC('T','H','D','P')
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -149,6 +154,7 @@ typedef struct {
     mfxI32       Priority;
     mfxU16       reserved[55];
 } mfxExtThreadsParam;
+MFX_PACK_END()
 
 /* PlatformCodeName */
 enum {
@@ -162,17 +168,43 @@ enum {
     MFX_PLATFORM_SKYLAKE        = 7,
     MFX_PLATFORM_APOLLOLAKE     = 8,
     MFX_PLATFORM_KABYLAKE       = 9,
+#if (MFX_VERSION >= 1025)
     MFX_PLATFORM_GEMINILAKE     = 10,
     MFX_PLATFORM_COFFEELAKE     = 11,
     MFX_PLATFORM_CANNONLAKE     = 20,
-    MFX_PLATFORM_ICELAKE = 30,
+#endif
+#if (MFX_VERSION >= 1027)
+    MFX_PLATFORM_ICELAKE        = 30,
+#endif
+    MFX_PLATFORM_JASPERLAKE     = 32,
+    MFX_PLATFORM_ELKHARTLAKE    = 33,
+    MFX_PLATFORM_TIGERLAKE      = 40,
+    MFX_PLATFORM_ROCKETLAKE     = 42,
+    MFX_PLATFORM_ALDERLAKE_S    = 43,
+    MFX_PLATFORM_KEEMBAY        = 50,
 };
 
+#if (MFX_VERSION >= 1031)
+typedef enum
+{
+    MFX_MEDIA_UNKNOWN           = 0xffff,
+    MFX_MEDIA_INTEGRATED        = 0,
+    MFX_MEDIA_DISCRETE          = 1
+} mfxMediaAdapterType;
+#endif
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxU16 CodeName;
     mfxU16 DeviceId;
+#if (MFX_VERSION >= 1031)
+    mfxU16 MediaAdapterType;
+    mfxU16 reserved[13];
+#else
     mfxU16 reserved[14];
+#endif
 } mfxPlatform;
+MFX_PACK_END()
 
 #ifdef __cplusplus
 }

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxenc.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxenc.h
@@ -1,32 +1,22 @@
-/******************************************************************************* *\
-
-Copyright (C) 2014-2018 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfxenc.h
-
-*******************************************************************************/
+// Copyright (c) 2017-2019 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 #ifndef __MFXENC_H__
 #define __MFXENC_H__
 #include "mfxdefs.h"
@@ -37,8 +27,8 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-typedef struct _mfxENCInput mfxENCInput;
-struct _mfxENCInput{
+MFX_PACK_BEGIN_STRUCT_W_PTR()
+MFX_DEPRECATED typedef struct _mfxENCInput{
     mfxU32  reserved[32];
 
     mfxFrameSurface1 *InSurface;
@@ -50,28 +40,30 @@ struct _mfxENCInput{
 
     mfxU16  NumExtParam;
     mfxExtBuffer    **ExtParam;
-} ;
+} mfxENCInput;
+MFX_PACK_END()
 
-typedef struct _mfxENCOutput mfxENCOutput;
-struct _mfxENCOutput{
+MFX_PACK_BEGIN_STRUCT_W_PTR()
+MFX_DEPRECATED typedef struct _mfxENCOutput{
     mfxU32  reserved[32];
 
     mfxFrameSurface1 *OutSurface;
 
     mfxU16  NumExtParam;
     mfxExtBuffer    **ExtParam;
-} ;
+} mfxENCOutput;
+MFX_PACK_END()
 
 
-mfxStatus MFX_CDECL MFXVideoENC_Query(mfxSession session, mfxVideoParam *in, mfxVideoParam *out);
-mfxStatus MFX_CDECL MFXVideoENC_QueryIOSurf(mfxSession session, mfxVideoParam *par, mfxFrameAllocRequest *request);
-mfxStatus MFX_CDECL MFXVideoENC_Init(mfxSession session, mfxVideoParam *par);
-mfxStatus MFX_CDECL MFXVideoENC_Reset(mfxSession session, mfxVideoParam *par);
-mfxStatus MFX_CDECL MFXVideoENC_Close(mfxSession session);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_Query(mfxSession session, mfxVideoParam *in, mfxVideoParam *out);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_QueryIOSurf(mfxSession session, mfxVideoParam *par, mfxFrameAllocRequest *request);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_Init(mfxSession session, mfxVideoParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_Reset(mfxSession session, mfxVideoParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_Close(mfxSession session);
 
-mfxStatus MFX_CDECL MFXVideoENC_ProcessFrameAsync(mfxSession session, mfxENCInput *in, mfxENCOutput *out, mfxSyncPoint *syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_ProcessFrameAsync(mfxSession session, mfxENCInput *in, mfxENCOutput *out, mfxSyncPoint *syncp);
 
-mfxStatus MFX_CDECL MFXVideoENC_GetVideoParam(mfxSession session, mfxVideoParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoENC_GetVideoParam(mfxSession session, mfxVideoParam *par);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxjpeg.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxjpeg.h
@@ -1,32 +1,22 @@
-/******************************************************************************* *\
-
-Copyright (C) 2010-2018 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfxjpeg.h
-
-*******************************************************************************/
+// Copyright (c) 2017-2019 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 #ifndef __MFX_JPEG_H__
 #define __MFX_JPEG_H__
 
@@ -77,6 +67,7 @@ enum {
     MFX_CHROMAFORMAT_JPEG_SAMPLING = 6
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
 
@@ -85,7 +76,9 @@ typedef struct {
 
     mfxU16    Qm[4][64];
 } mfxExtJPEGQuantTables;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
 
@@ -103,6 +96,7 @@ typedef struct {
         mfxU8   Values[162];
     } ACTables[4];
 } mfxExtJPEGHuffmanTables;
+MFX_PACK_END()
 
 #ifdef __cplusplus
 } // extern "C"

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxmvc.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxmvc.h
@@ -1,32 +1,22 @@
-/******************************************************************************* *\
-
-Copyright (C) 2010-2013 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfxmvc.h
-
-*******************************************************************************/
+// Copyright (c) 2017-2019 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 #ifndef __MFXMVC_H__
 #define __MFXMVC_H__
 
@@ -49,6 +39,7 @@ enum {
     MFX_EXTBUFF_MVC_TARGET_VIEWS    =   MFX_MAKEFOURCC('M','V','C','T')
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct  {
     mfxU16 ViewId;
 
@@ -62,7 +53,9 @@ typedef struct  {
     mfxU16 NonAnchorRefL0[16];
     mfxU16 NonAnchorRefL1[16];
 } mfxMVCViewDependency;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
     mfxU16 TemporalId;
     mfxU16 LevelIdc;
@@ -71,7 +64,9 @@ typedef struct {
     mfxU16 NumTargetViews;
     mfxU16 *TargetViewId;
 } mfxMVCOperationPoint;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct  {
     mfxExtBuffer Header;
 
@@ -91,7 +86,9 @@ typedef struct  {
     mfxU32 Reserved[16];
 
 } mfxExtMVCSeqDesc;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
 
@@ -99,7 +96,7 @@ typedef struct {
     mfxU32 NumView;
     mfxU16 ViewId[1024];
 } mfxExtMVCTargetViews ;
-
+MFX_PACK_END()
 
 #ifdef __cplusplus
 } // extern "C"

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxpak.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxpak.h
@@ -1,32 +1,22 @@
-/******************************************************************************* *\
-
-Copyright (C) 2014-2017 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfxpak.h
-
-*******************************************************************************/
+// Copyright (c) 2017-2019 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 #ifndef __MFXPAK_H__
 #define __MFXPAK_H__
 #include "mfxdefs.h"
@@ -37,7 +27,8 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-typedef struct {
+MFX_PACK_BEGIN_STRUCT_W_PTR()
+MFX_DEPRECATED typedef struct {
     mfxU16 reserved[32];
 
     mfxFrameSurface1 *InSurface;
@@ -53,8 +44,10 @@ typedef struct {
     mfxU16 NumPayload;
     mfxPayload      **Payload;
 } mfxPAKInput;
+MFX_PACK_END()
 
-typedef struct {
+MFX_PACK_BEGIN_STRUCT_W_PTR()
+MFX_DEPRECATED typedef struct {
     mfxU16  reserved[32];
 
     mfxBitstream     *Bs;
@@ -64,17 +57,18 @@ typedef struct {
     mfxU16            NumExtParam;
     mfxExtBuffer    **ExtParam;
 } mfxPAKOutput;
+MFX_PACK_END()
 
 typedef struct _mfxSession *mfxSession;
-mfxStatus MFX_CDECL MFXVideoPAK_Query(mfxSession session, mfxVideoParam *in, mfxVideoParam *out);
-mfxStatus MFX_CDECL MFXVideoPAK_QueryIOSurf(mfxSession session, mfxVideoParam *par, mfxFrameAllocRequest request[2]);
-mfxStatus MFX_CDECL MFXVideoPAK_Init(mfxSession session, mfxVideoParam *par);
-mfxStatus MFX_CDECL MFXVideoPAK_Reset(mfxSession session, mfxVideoParam *par);
-mfxStatus MFX_CDECL MFXVideoPAK_Close(mfxSession session);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_Query(mfxSession session, mfxVideoParam *in, mfxVideoParam *out);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_QueryIOSurf(mfxSession session, mfxVideoParam *par, mfxFrameAllocRequest request[2]);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_Init(mfxSession session, mfxVideoParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_Reset(mfxSession session, mfxVideoParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_Close(mfxSession session);
 
-mfxStatus MFX_CDECL MFXVideoPAK_ProcessFrameAsync(mfxSession session, mfxPAKInput *in, mfxPAKOutput *out,  mfxSyncPoint *syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_ProcessFrameAsync(mfxSession session, mfxPAKInput *in, mfxPAKOutput *out,  mfxSyncPoint *syncp);
 
-mfxStatus MFX_CDECL MFXVideoPAK_GetVideoParam(mfxSession session, mfxVideoParam *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoPAK_GetVideoParam(mfxSession session, mfxVideoParam *par);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxplugin++.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxplugin++.h
@@ -1,33 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2007-2016 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-File Name: mfxplugin++.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2017-2020 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #ifndef __MFXPLUGINPLUSPLUS_H
 #define __MFXPLUGINPLUSPLUS_H
@@ -41,7 +30,7 @@ public:
     explicit MFXBaseUSER(mfxSession session = NULL)
         : m_session(session){}
 
-    virtual ~MFXBaseUSER() {};
+    virtual ~MFXBaseUSER() {}
 
     virtual mfxStatus Register(mfxU32 type, const mfxPlugin *par) = 0;
     virtual mfxStatus Unregister(mfxU32 type) = 0;
@@ -574,15 +563,11 @@ namespace detail
     private:
         void SetupCallbacks() {
             m_codecPlg.DecodeHeader = _DecodeHeader;
-//            m_codecPlg.GetPayload = _GetPayload;
             m_codecPlg.DecodeFrameSubmit = _DecodeFrameSubmit;
         }
         static mfxStatus _DecodeHeader(mfxHDL pthis, mfxBitstream *bs, mfxAudioParam *par) {
             return reinterpret_cast<MFXAudioDecoderPlugin*>(pthis)->DecodeHeader(bs, par);
         }
-//        static mfxStatus _GetPayload(mfxHDL pthis, mfxU64 *ts, mfxPayload *payload) {
-  //          return reinterpret_cast<MFXAudioDecoderPlugin*>(pthis)->GetPayload(ts, payload);
-    //    }
         static mfxStatus _DecodeFrameSubmit(mfxHDL pthis, mfxBitstream *in, mfxAudioFrame *out, mfxThreadTask *task) {
             return reinterpret_cast<MFXAudioDecoderPlugin*>(pthis)->DecodeFrameSubmit(in, out, task);
         }

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxplugin.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxplugin.h
@@ -1,32 +1,22 @@
-/******************************************************************************* *\
-
-Copyright (C) 2007-2018 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfxplugin.h
-
-*******************************************************************************/
+// Copyright (c) 2018-2019 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 #ifndef __MFXPLUGIN_H__
 #define __MFXPLUGIN_H__
 #include "mfxvideo.h"
@@ -37,46 +27,62 @@ extern "C"
 {
 #endif /* __cplusplus */
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxU8  Data[16];
 } mfxPluginUID;
+MFX_PACK_END()
 
-static const mfxPluginUID  MFX_PLUGINID_HEVCD_SW        = {{0x15, 0xdd, 0x93, 0x68, 0x25, 0xad, 0x47, 0x5e, 0xa3, 0x4e, 0x35, 0xf3, 0xf5, 0x42, 0x17, 0xa6}};
-static const mfxPluginUID  MFX_PLUGINID_HEVCD_HW        = {{0x33, 0xa6, 0x1c, 0x0b, 0x4c, 0x27, 0x45, 0x4c, 0xa8, 0xd8, 0x5d, 0xde, 0x75, 0x7c, 0x6f, 0x8e}};
-static const mfxPluginUID  MFX_PLUGINID_HEVCE_SW        = {{0x2f, 0xca, 0x99, 0x74, 0x9f, 0xdb, 0x49, 0xae, 0xb1, 0x21, 0xa5, 0xb6, 0x3e, 0xf5, 0x68, 0xf7}};
-static const mfxPluginUID  MFX_PLUGINID_HEVCE_GACC      = {{0xe5, 0x40, 0x0a, 0x06, 0xc7, 0x4d, 0x41, 0xf5, 0xb1, 0x2d, 0x43, 0x0b, 0xba, 0xa2, 0x3d, 0x0b}};
-static const mfxPluginUID  MFX_PLUGINID_HEVCE_DP_GACC   = {{0x2b, 0xad, 0x6f, 0x9d, 0x77, 0x54, 0x41, 0x2d, 0xbf, 0x63, 0x03, 0xed, 0x4b, 0xb5, 0x09, 0x68}};
-static const mfxPluginUID  MFX_PLUGINID_HEVCE_HW        = {{0x6f, 0xad, 0xc7, 0x91, 0xa0, 0xc2, 0xeb, 0x47, 0x9a, 0xb6, 0xdc, 0xd5, 0xea, 0x9d, 0xa3, 0x47}};
-static const mfxPluginUID  MFX_PLUGINID_VP8D_HW         = {{0xf6, 0x22, 0x39, 0x4d, 0x8d, 0x87, 0x45, 0x2f, 0x87, 0x8c, 0x51, 0xf2, 0xfc, 0x9b, 0x41, 0x31}};
-static const mfxPluginUID  MFX_PLUGINID_VP8E_HW         = {{0xbf, 0xfc, 0x51, 0x8c, 0xde, 0x13, 0x4d, 0xf9, 0x8a, 0x96, 0xf4, 0xcf, 0x81, 0x6c, 0x0f, 0xac}};
-static const mfxPluginUID  MFX_PLUGINID_VP9E_HW         = {{0xce, 0x44, 0xef, 0x6f, 0x1a, 0x6d, 0x22, 0x46, 0xb4, 0x12, 0xbb, 0x38, 0xd6, 0xe4, 0x51, 0x82}};
-static const mfxPluginUID  MFX_PLUGINID_VP9D_HW         = {{0xa9, 0x22, 0x39, 0x4d, 0x8d, 0x87, 0x45, 0x2f, 0x87, 0x8c, 0x51, 0xf2, 0xfc, 0x9b, 0x41, 0x31}};
-static const mfxPluginUID  MFX_PLUGINID_CAMERA_HW       = {{0x54, 0x54, 0x26, 0x16, 0x24, 0x33, 0x41, 0xe6, 0x93, 0xae, 0x89, 0x99, 0x42, 0xce, 0x73, 0x55}};
-static const mfxPluginUID  MFX_PLUGINID_CAPTURE_HW      = {{0x22, 0xd6, 0x2c, 0x07, 0xe6, 0x72, 0x40, 0x8f, 0xbb, 0x4c, 0xc2, 0x0e, 0xd7, 0xa0, 0x53, 0xe4}};
-static const mfxPluginUID  MFX_PLUGINID_ITELECINE_HW    = {{0xe7, 0x44, 0x75, 0x3a, 0xcd, 0x74, 0x40, 0x2e, 0x89, 0xa2, 0xee, 0x06, 0x35, 0x49, 0x61, 0x79}};
-static const mfxPluginUID  MFX_PLUGINID_H264LA_HW       = {{0x58, 0x8f, 0x11, 0x85, 0xd4, 0x7b, 0x42, 0x96, 0x8d, 0xea, 0x37, 0x7b, 0xb5, 0xd0, 0xdc, 0xb4}};
-static const mfxPluginUID  MFX_PLUGINID_AACD            = {{0xe9, 0x34, 0x67, 0x25, 0xac, 0x2f, 0x4c, 0x93, 0xaa, 0x58, 0x5c, 0x11, 0xc7, 0x08, 0x7c, 0xf4}};
-static const mfxPluginUID  MFX_PLUGINID_AACE            = {{0xb2, 0xa2, 0xa0, 0x5a, 0x4e, 0xac, 0x46, 0xbf, 0xa9, 0xde, 0x7e, 0x80, 0xc9, 0x8d, 0x2e, 0x18}};
-static const mfxPluginUID  MFX_PLUGINID_HEVCE_FEI_HW    = {{0x87, 0xe0, 0xe8, 0x02, 0x07, 0x37, 0x52, 0x40, 0x85, 0x25, 0x15, 0xcf, 0x4a, 0x5e, 0xdd, 0xe6}};
-static const mfxPluginUID  MFX_PLUGINID_HEVC_FEI_ENCODE = {{0x54, 0x18, 0xa7, 0x06, 0x66, 0xf9, 0x4d, 0x5c, 0xb4, 0xf7, 0xb1, 0xca, 0xee, 0x86, 0x33, 0x9b}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_HEVCD_SW        = {{0x15, 0xdd, 0x93, 0x68, 0x25, 0xad, 0x47, 0x5e, 0xa3, 0x4e, 0x35, 0xf3, 0xf5, 0x42, 0x17, 0xa6}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_HEVCD_HW        = {{0x33, 0xa6, 0x1c, 0x0b, 0x4c, 0x27, 0x45, 0x4c, 0xa8, 0xd8, 0x5d, 0xde, 0x75, 0x7c, 0x6f, 0x8e}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_HEVCE_SW        = {{0x2f, 0xca, 0x99, 0x74, 0x9f, 0xdb, 0x49, 0xae, 0xb1, 0x21, 0xa5, 0xb6, 0x3e, 0xf5, 0x68, 0xf7}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_HEVCE_GACC      = {{0xe5, 0x40, 0x0a, 0x06, 0xc7, 0x4d, 0x41, 0xf5, 0xb1, 0x2d, 0x43, 0x0b, 0xba, 0xa2, 0x3d, 0x0b}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_HEVCE_DP_GACC   = {{0x2b, 0xad, 0x6f, 0x9d, 0x77, 0x54, 0x41, 0x2d, 0xbf, 0x63, 0x03, 0xed, 0x4b, 0xb5, 0x09, 0x68}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_HEVCE_HW        = {{0x6f, 0xad, 0xc7, 0x91, 0xa0, 0xc2, 0xeb, 0x47, 0x9a, 0xb6, 0xdc, 0xd5, 0xea, 0x9d, 0xa3, 0x47}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_VP8D_HW         = {{0xf6, 0x22, 0x39, 0x4d, 0x8d, 0x87, 0x45, 0x2f, 0x87, 0x8c, 0x51, 0xf2, 0xfc, 0x9b, 0x41, 0x31}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_VP8E_HW         = {{0xbf, 0xfc, 0x51, 0x8c, 0xde, 0x13, 0x4d, 0xf9, 0x8a, 0x96, 0xf4, 0xcf, 0x81, 0x6c, 0x0f, 0xac}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_VP9E_HW         = {{0xce, 0x44, 0xef, 0x6f, 0x1a, 0x6d, 0x22, 0x46, 0xb4, 0x12, 0xbb, 0x38, 0xd6, 0xe4, 0x51, 0x82}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_VP9D_HW         = {{0xa9, 0x22, 0x39, 0x4d, 0x8d, 0x87, 0x45, 0x2f, 0x87, 0x8c, 0x51, 0xf2, 0xfc, 0x9b, 0x41, 0x31}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_CAMERA_HW       = {{0x54, 0x54, 0x26, 0x16, 0x24, 0x33, 0x41, 0xe6, 0x93, 0xae, 0x89, 0x99, 0x42, 0xce, 0x73, 0x55}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_CAPTURE_HW      = {{0x22, 0xd6, 0x2c, 0x07, 0xe6, 0x72, 0x40, 0x8f, 0xbb, 0x4c, 0xc2, 0x0e, 0xd7, 0xa0, 0x53, 0xe4}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_ITELECINE_HW    = {{0xe7, 0x44, 0x75, 0x3a, 0xcd, 0x74, 0x40, 0x2e, 0x89, 0xa2, 0xee, 0x06, 0x35, 0x49, 0x61, 0x79}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_H264LA_HW       = {{0x58, 0x8f, 0x11, 0x85, 0xd4, 0x7b, 0x42, 0x96, 0x8d, 0xea, 0x37, 0x7b, 0xb5, 0xd0, 0xdc, 0xb4}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_AACD            = {{0xe9, 0x34, 0x67, 0x25, 0xac, 0x2f, 0x4c, 0x93, 0xaa, 0x58, 0x5c, 0x11, 0xc7, 0x08, 0x7c, 0xf4}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_AACE            = {{0xb2, 0xa2, 0xa0, 0x5a, 0x4e, 0xac, 0x46, 0xbf, 0xa9, 0xde, 0x7e, 0x80, 0xc9, 0x8d, 0x2e, 0x18}};
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_HEVCE_FEI_HW    = {{0x87, 0xe0, 0xe8, 0x02, 0x07, 0x37, 0x52, 0x40, 0x85, 0x25, 0x15, 0xcf, 0x4a, 0x5e, 0xdd, 0xe6}};
+#if (MFX_VERSION >= 1027)
+MFX_DEPRECATED static const mfxPluginUID  MFX_PLUGINID_HEVC_FEI_ENCODE = {{0x54, 0x18, 0xa7, 0x06, 0x66, 0xf9, 0x4d, 0x5c, 0xb4, 0xf7, 0xb1, 0xca, 0xee, 0x86, 0x33, 0x9b}};
+#endif
 
 
 typedef enum {
-    MFX_PLUGINTYPE_VIDEO_GENERAL   = 0,
-    MFX_PLUGINTYPE_VIDEO_DECODE    = 1,
-    MFX_PLUGINTYPE_VIDEO_ENCODE    = 2,
-    MFX_PLUGINTYPE_VIDEO_VPP       = 3,
-    MFX_PLUGINTYPE_VIDEO_ENC       = 4,
-    MFX_PLUGINTYPE_AUDIO_DECODE    = 5,
-    MFX_PLUGINTYPE_AUDIO_ENCODE    = 6
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_PLUGINTYPE_VIDEO_GENERAL)   = 0,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_PLUGINTYPE_VIDEO_DECODE)    = 1,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_PLUGINTYPE_VIDEO_ENCODE)    = 2,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_PLUGINTYPE_VIDEO_VPP)       = 3,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_PLUGINTYPE_VIDEO_ENC)       = 4,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_PLUGINTYPE_AUDIO_DECODE)    = 5,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_PLUGINTYPE_AUDIO_ENCODE)    = 6
 } mfxPluginType;
 
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_PLUGINTYPE_VIDEO_GENERAL);
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_PLUGINTYPE_VIDEO_DECODE);
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_PLUGINTYPE_VIDEO_ENCODE);
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_PLUGINTYPE_VIDEO_VPP);
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_PLUGINTYPE_VIDEO_ENC);
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_PLUGINTYPE_AUDIO_DECODE);
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_PLUGINTYPE_AUDIO_ENCODE);
+
 typedef enum {
-    MFX_THREADPOLICY_SERIAL    = 0,
-    MFX_THREADPOLICY_PARALLEL  = 1
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_THREADPOLICY_SERIAL)    = 0,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_THREADPOLICY_PARALLEL)  = 1
 } mfxThreadPolicy;
 
-typedef struct mfxPluginParam {
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_THREADPOLICY_SERIAL);
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_THREADPOLICY_PARALLEL);
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
+MFX_DEPRECATED typedef struct mfxPluginParam {
     mfxU32          reserved[6];
     mfxU16          reserved1;
     mfxU16          PluginVersion;
@@ -87,15 +93,19 @@ typedef struct mfxPluginParam {
     mfxThreadPolicy ThreadPolicy;
     mfxU32          MaxThreadNum;
 } mfxPluginParam;
+MFX_PACK_END()
 
-typedef struct mfxCoreParam{
+MFX_PACK_BEGIN_USUAL_STRUCT()
+MFX_DEPRECATED typedef struct mfxCoreParam{
     mfxU32     reserved[13];
     mfxIMPL    Impl;
     mfxVersion Version;
     mfxU32     NumWorkingThread;
 } mfxCoreParam;
+MFX_PACK_END()
 
-typedef struct mfxCoreInterface {
+MFX_PACK_BEGIN_STRUCT_W_PTR()
+MFX_DEPRECATED typedef struct mfxCoreInterface {
     mfxHDL pthis;
 
     mfxHDL reserved1[2];
@@ -121,11 +131,13 @@ typedef struct mfxCoreInterface {
 
     mfxHDL reserved4[1];
 } mfxCoreInterface;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 /* video codec plugin extension */
-typedef struct _mfxENCInput mfxENCInput;
-typedef struct _mfxENCOutput mfxENCOutput;
-typedef struct mfxVideoCodecPlugin{
+MFX_DEPRECATED typedef struct _mfxENCInput mfxENCInput;
+MFX_DEPRECATED typedef struct _mfxENCOutput mfxENCOutput;
+MFX_DEPRECATED typedef struct mfxVideoCodecPlugin{
     mfxStatus (MFX_CDECL *Query)(mfxHDL pthis, mfxVideoParam *in, mfxVideoParam *out);
     mfxStatus (MFX_CDECL *QueryIOSurf)(mfxHDL pthis, mfxVideoParam *par, mfxFrameAllocRequest *in, mfxFrameAllocRequest *out);
     mfxStatus (MFX_CDECL *Init)(mfxHDL pthis, mfxVideoParam *par);
@@ -147,8 +159,10 @@ typedef struct mfxVideoCodecPlugin{
     mfxHDL reserved1[3];
     mfxU32 reserved2[8];
 } mfxVideoCodecPlugin;
+MFX_PACK_END()
 
-typedef struct mfxAudioCodecPlugin{
+MFX_PACK_BEGIN_STRUCT_W_PTR()
+MFX_DEPRECATED typedef struct mfxAudioCodecPlugin{
     mfxStatus (MFX_CDECL *Query)(mfxHDL pthis, mfxAudioParam *in, mfxAudioParam *out);
     mfxStatus (MFX_CDECL *QueryIOSize)(mfxHDL pthis, mfxAudioParam *par, mfxAudioAllocRequest *request);
     mfxStatus (MFX_CDECL *Init)(mfxHDL pthis, mfxAudioParam *par);
@@ -165,8 +179,10 @@ typedef struct mfxAudioCodecPlugin{
     mfxHDL reserved1[6];
     mfxU32 reserved2[8];
 } mfxAudioCodecPlugin;
+MFX_PACK_END()
 
-typedef struct mfxPlugin{
+MFX_PACK_BEGIN_STRUCT_W_PTR()
+MFX_DEPRECATED typedef struct mfxPlugin{
     mfxHDL pthis;
 
     mfxStatus (MFX_CDECL *PluginInit) (mfxHDL pthis, mfxCoreInterface *core);
@@ -185,24 +201,24 @@ typedef struct mfxPlugin{
 
     mfxHDL reserved[8];
 } mfxPlugin;
+MFX_PACK_END()
 
 
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_Register(mfxSession session, mfxU32 type, const mfxPlugin *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_Unregister(mfxSession session, mfxU32 type);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_GetPlugin(mfxSession session, mfxU32 type, mfxPlugin *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_ProcessFrameAsync(mfxSession session, const mfxHDL *in, mfxU32 in_num, const mfxHDL *out, mfxU32 out_num, mfxSyncPoint *syncp);
 
-mfxStatus MFX_CDECL MFXVideoUSER_Register(mfxSession session, mfxU32 type, const mfxPlugin *par);
-mfxStatus MFX_CDECL MFXVideoUSER_Unregister(mfxSession session, mfxU32 type);
-mfxStatus MFX_CDECL MFXVideoUSER_GetPlugin(mfxSession session, mfxU32 type, mfxPlugin *par);
-mfxStatus MFX_CDECL MFXVideoUSER_ProcessFrameAsync(mfxSession session, const mfxHDL *in, mfxU32 in_num, const mfxHDL *out, mfxU32 out_num, mfxSyncPoint *syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32 version);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_LoadByPath(mfxSession session, const mfxPluginUID *uid, mfxU32 version, const mfxChar *path, mfxU32 len);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoUSER_UnLoad(mfxSession session, const mfxPluginUID *uid);
 
-mfxStatus MFX_CDECL MFXVideoUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32 version);
-mfxStatus MFX_CDECL MFXVideoUSER_LoadByPath(mfxSession session, const mfxPluginUID *uid, mfxU32 version, const mfxChar *path, mfxU32 len);
-mfxStatus MFX_CDECL MFXVideoUSER_UnLoad(mfxSession session, const mfxPluginUID *uid);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_Register(mfxSession session, mfxU32 type, const mfxPlugin *par);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_Unregister(mfxSession session, mfxU32 type);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_ProcessFrameAsync(mfxSession session, const mfxHDL *in, mfxU32 in_num, const mfxHDL *out, mfxU32 out_num, mfxSyncPoint *syncp);
 
-mfxStatus MFX_CDECL MFXAudioUSER_Register(mfxSession session, mfxU32 type, const mfxPlugin *par);
-mfxStatus MFX_CDECL MFXAudioUSER_Unregister(mfxSession session, mfxU32 type);
-mfxStatus MFX_CDECL MFXAudioUSER_ProcessFrameAsync(mfxSession session, const mfxHDL *in, mfxU32 in_num, const mfxHDL *out, mfxU32 out_num, mfxSyncPoint *syncp);
-
-mfxStatus MFX_CDECL MFXAudioUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32 version);
-mfxStatus MFX_CDECL MFXAudioUSER_UnLoad(mfxSession session, const mfxPluginUID *uid);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32 version);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXAudioUSER_UnLoad(mfxSession session, const mfxPluginUID *uid);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxsession.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxsession.h
@@ -1,32 +1,22 @@
-/*******************************************************************************
-
-Copyright (C) 2013 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfxsession.h
-
-*******************************************************************************/
+// Copyright (c) 2017 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 #ifndef __MFXSESSION_H__
 #define __MFXSESSION_H__
 #include "mfxcommon.h"
@@ -50,7 +40,7 @@ mfxStatus MFX_CDECL MFXDisjoinSession(mfxSession session);
 mfxStatus MFX_CDECL MFXCloneSession(mfxSession session, mfxSession *clone);
 mfxStatus MFX_CDECL MFXSetPriority(mfxSession session, mfxPriority priority);
 mfxStatus MFX_CDECL MFXGetPriority(mfxSession session, mfxPriority *priority);
-mfxStatus MFX_CDECL MFXDoWork(mfxSession session);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXDoWork(mfxSession session);
 
 #ifdef __cplusplus
 }

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxstructures.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxstructures.h
@@ -1,32 +1,22 @@
-/******************************************************************************* *\
-
-Copyright (C) 2007-2018 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfxstructures.h
-
-*******************************************************************************/
+// Copyright (c) 2018-2020 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 #ifndef __MFXSTRUCTURES_H__
 #define __MFXSTRUCTURES_H__
 #include "mfxcommon.h"
@@ -41,6 +31,7 @@ extern "C" {
 
 
 /* Frame ID for SVC and MVC */
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxU16      TemporalId;
     mfxU16      PriorityId;
@@ -54,8 +45,10 @@ typedef struct {
         };
     };
 } mfxFrameId;
+MFX_PACK_END()
 
-#pragma pack(push, 4)
+/* This struct has 4-byte alignment for binary compatibility with previously released versions of API */
+MFX_PACK_BEGIN_USUAL_STRUCT()
 /* Frame Info */
 typedef struct {
     mfxU32  reserved[4];
@@ -94,7 +87,7 @@ typedef struct {
     mfxU16  ChromaFormat;
     mfxU16  reserved2;
 } mfxFrameInfo;
-#pragma pack(pop)
+MFX_PACK_END()
 
 /* FourCC */
 enum {
@@ -102,11 +95,18 @@ enum {
     MFX_FOURCC_YV12         = MFX_MAKEFOURCC('Y','V','1','2'),
     MFX_FOURCC_NV16         = MFX_MAKEFOURCC('N','V','1','6'),
     MFX_FOURCC_YUY2         = MFX_MAKEFOURCC('Y','U','Y','2'),
+#if (MFX_VERSION >= 1028)
+    MFX_FOURCC_RGB565       = MFX_MAKEFOURCC('R','G','B','2'),   /* 2 bytes per pixel, uint16 in little-endian format, where 0-4 bits are blue, bits 5-10 are green and bits 11-15 are red */
+    MFX_FOURCC_RGBP         = MFX_MAKEFOURCC('R','G','B','P'),
+#endif
     MFX_FOURCC_RGB3         = MFX_MAKEFOURCC('R','G','B','3'),   /* deprecated */
     MFX_FOURCC_RGB4         = MFX_MAKEFOURCC('R','G','B','4'),   /* ARGB in that order, A channel is 8 MSBs */
     MFX_FOURCC_P8           = 41,                                /*  D3DFMT_P8   */
     MFX_FOURCC_P8_TEXTURE   = MFX_MAKEFOURCC('P','8','M','B'),
     MFX_FOURCC_P010         = MFX_MAKEFOURCC('P','0','1','0'),
+#if (MFX_VERSION >= 1031)
+    MFX_FOURCC_P016         = MFX_MAKEFOURCC('P','0','1','6'),
+#endif
     MFX_FOURCC_P210         = MFX_MAKEFOURCC('P','2','1','0'),
     MFX_FOURCC_BGR4         = MFX_MAKEFOURCC('B','G','R','4'),   /* ABGR in that order, A channel is 8 MSBs */
     MFX_FOURCC_A2RGB10      = MFX_MAKEFOURCC('R','G','1','0'),   /* ARGB in that order, A channel is two MSBs */
@@ -116,8 +116,17 @@ enum {
     MFX_FOURCC_AYUV         = MFX_MAKEFOURCC('A','Y','U','V'),   /* YUV 4:4:4, AYUV in that order, A channel is 8 MSBs */
     MFX_FOURCC_AYUV_RGB4    = MFX_MAKEFOURCC('A','V','U','Y'),   /* ARGB in that order, A channel is 8 MSBs stored in AYUV surface*/
     MFX_FOURCC_UYVY         = MFX_MAKEFOURCC('U','Y','V','Y'),
+#if (MFX_VERSION >= 1027)
     MFX_FOURCC_Y210         = MFX_MAKEFOURCC('Y','2','1','0'),
     MFX_FOURCC_Y410         = MFX_MAKEFOURCC('Y','4','1','0'),
+#endif
+#if (MFX_VERSION >= 1031)
+    MFX_FOURCC_Y216         = MFX_MAKEFOURCC('Y','2','1','6'),
+    MFX_FOURCC_Y416         = MFX_MAKEFOURCC('Y','4','1','6'),
+#endif
+    MFX_FOURCC_NV21         = MFX_MAKEFOURCC('N', 'V', '2', '1'), /* Same as NV12 but with weaved V and U values. */
+    MFX_FOURCC_IYUV         = MFX_MAKEFOURCC('I', 'Y', 'U', 'V'), /* Same as  YV12 except that the U and V plane order is reversed. */
+    MFX_FOURCC_I010         = MFX_MAKEFOURCC('I', '0', '1', '0'), /* 10-bit YUV 4:2:0, each component has its own plane. */
 };
 
 /* PicStruct */
@@ -174,7 +183,8 @@ enum {
     MFX_CORRUPTION_REFERENCE_LIST  = 0x0020
 };
 
-#pragma pack(push, 4)
+#if (MFX_VERSION >= 1027)
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct
 {
     mfxU32 U : 10;
@@ -182,9 +192,11 @@ typedef struct
     mfxU32 V : 10;
     mfxU32 A :  2;
 } mfxY410;
-#pragma pack(pop)
+MFX_PACK_END()
+#endif
 
-#pragma pack(push, 4)
+#if (MFX_VERSION >= 1025)
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct
 {
     mfxU32 B : 10;
@@ -192,10 +204,11 @@ typedef struct
     mfxU32 R : 10;
     mfxU32 A :  2;
 } mfxA2RGB10;
-#pragma pack(pop)
-
+MFX_PACK_END()
+#endif
 
 /* Frame Data Info */
+MFX_PACK_BEGIN_STRUCT_W_L_TYPE()
 typedef struct {
     union {
         mfxExtBuffer **ExtParam;
@@ -230,14 +243,18 @@ typedef struct {
         mfxU8   *U;
         mfxU16  *U16;
         mfxU8   *G;
+#if (MFX_VERSION >= 1027)
         mfxY410 *Y410;          /* for Y410 format (merged AVYU) */
+#endif
     };
     union {
         mfxU8   *Cr;
         mfxU8   *V;
         mfxU16  *V16;
         mfxU8   *B;
+#if (MFX_VERSION >= 1025)
         mfxA2RGB10 *A2RGB10;    /* for A2RGB10 format (merged ARGB) */
+#endif
     };
     mfxU8       *A;
     mfxMemId    MemId;
@@ -246,13 +263,16 @@ typedef struct {
     mfxU16  Corrupted;
     mfxU16  DataFlag;
 } mfxFrameData;
+MFX_PACK_END()
 
 /* Frame Surface */
+MFX_PACK_BEGIN_STRUCT_W_L_TYPE()
 typedef struct {
     mfxU32  reserved[4];
     mfxFrameInfo    Info;
     mfxFrameData    Data;
 } mfxFrameSurface1;
+MFX_PACK_END()
 
 enum {
     MFX_TIMESTAMPCALC_UNKNOWN = 0,
@@ -260,6 +280,7 @@ enum {
 };
 
 /* Transcoding Info */
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxU32  reserved[7];
 
@@ -310,7 +331,13 @@ typedef struct {
             mfxU16  SliceGroupsPresent;
             mfxU16  MaxDecFrameBuffering;
             mfxU16  EnableReallocRequest;
+#if (MFX_VERSION >= 1034)
+            mfxU16  FilmGrain;
+            mfxU16  IgnoreLevelConstrain;
+            mfxU16  reserved2[5];
+#else
             mfxU16  reserved2[7];
+#endif
         };
         struct {   /* JPEG Decoding Options */
             mfxU16  JPEGChromaFormat;
@@ -329,13 +356,17 @@ typedef struct {
         };
     };
 } mfxInfoMFX;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxU32  reserved[8];
     mfxFrameInfo    In;
     mfxFrameInfo    Out;
 } mfxInfoVPP;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
     mfxU32  AllocId;
     mfxU32  reserved[2];
@@ -352,16 +383,20 @@ typedef struct {
     mfxU16  NumExtParam;
     mfxU16  reserved2;
 } mfxVideoParam;
+MFX_PACK_END()
 
 /* IOPattern */
 enum {
     MFX_IOPATTERN_IN_VIDEO_MEMORY   = 0x01,
     MFX_IOPATTERN_IN_SYSTEM_MEMORY  = 0x02,
-    MFX_IOPATTERN_IN_OPAQUE_MEMORY  = 0x04,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_IOPATTERN_IN_OPAQUE_MEMORY)  = 0x04,
     MFX_IOPATTERN_OUT_VIDEO_MEMORY  = 0x10,
     MFX_IOPATTERN_OUT_SYSTEM_MEMORY = 0x20,
-    MFX_IOPATTERN_OUT_OPAQUE_MEMORY = 0x40
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_IOPATTERN_OUT_OPAQUE_MEMORY) = 0x40
 };
+
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_IOPATTERN_IN_OPAQUE_MEMORY);
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_IOPATTERN_OUT_OPAQUE_MEMORY);
 
 /* CodecId */
 enum {
@@ -391,6 +426,7 @@ enum {
     MFX_PROFILE_AVC_MAIN                    =77,
     MFX_PROFILE_AVC_EXTENDED                =88,
     MFX_PROFILE_AVC_HIGH                    =100,
+    MFX_PROFILE_AVC_HIGH10                  =110,
     MFX_PROFILE_AVC_HIGH_422                =122,
     MFX_PROFILE_AVC_CONSTRAINED_BASELINE    =MFX_PROFILE_AVC_BASELINE + MFX_PROFILE_AVC_CONSTRAINT_SET1,
     MFX_PROFILE_AVC_CONSTRAINED_HIGH        =MFX_PROFILE_AVC_HIGH     + MFX_PROFILE_AVC_CONSTRAINT_SET4
@@ -414,6 +450,11 @@ enum {
     MFX_LEVEL_AVC_5                         =50,
     MFX_LEVEL_AVC_51                        =51,
     MFX_LEVEL_AVC_52                        =52,
+#if (MFX_VERSION >= 1035)
+    MFX_LEVEL_AVC_6                         =60,
+    MFX_LEVEL_AVC_61                        =61,
+    MFX_LEVEL_AVC_62                        =62,
+#endif
 
     /* MPEG-2 Profiles & Levels */
     MFX_PROFILE_MPEG2_SIMPLE                =0x50,
@@ -447,6 +488,9 @@ enum {
     MFX_PROFILE_HEVC_MAIN10           =2,
     MFX_PROFILE_HEVC_MAINSP           =3,
     MFX_PROFILE_HEVC_REXT             =4,
+#if (MFX_VERSION >= 1032)
+    MFX_PROFILE_HEVC_SCC              =9,
+#endif
 
     MFX_LEVEL_HEVC_1   = 10,
     MFX_LEVEL_HEVC_2   = 20,
@@ -471,6 +515,33 @@ enum {
     MFX_PROFILE_VP9_2                       = 3,
     MFX_PROFILE_VP9_3                       = 4,
 
+#if (MFX_VERSION >= 1034)
+    /* AV1 Profiles */
+    MFX_PROFILE_AV1_MAIN                    = 1,
+    MFX_PROFILE_AV1_HIGH                    = 2,
+    MFX_PROFILE_AV1_PRO                     = 3,
+
+    MFX_LEVEL_AV1_2                         = 20,
+    MFX_LEVEL_AV1_21                        = 21,
+    MFX_LEVEL_AV1_22                        = 22,
+    MFX_LEVEL_AV1_23                        = 23,
+    MFX_LEVEL_AV1_3                         = 30,
+    MFX_LEVEL_AV1_31                        = 31,
+    MFX_LEVEL_AV1_32                        = 32,
+    MFX_LEVEL_AV1_33                        = 33,
+    MFX_LEVEL_AV1_4                         = 40,
+    MFX_LEVEL_AV1_41                        = 41,
+    MFX_LEVEL_AV1_42                        = 42,
+    MFX_LEVEL_AV1_43                        = 43,
+    MFX_LEVEL_AV1_5                         = 50,
+    MFX_LEVEL_AV1_51                        = 51,
+    MFX_LEVEL_AV1_52                        = 52,
+    MFX_LEVEL_AV1_53                        = 53,
+    MFX_LEVEL_AV1_6                         = 60,
+    MFX_LEVEL_AV1_61                        = 61,
+    MFX_LEVEL_AV1_62                        = 62,
+    MFX_LEVEL_AV1_63                        = 63,
+#endif
 };
 
 /* GopOptFlag */
@@ -523,6 +594,7 @@ enum {
     MFX_TRELLIS_B       =0x08
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -557,6 +629,7 @@ typedef struct {
     mfxU16      PicTimingSEI;           /* tri-state option */
     mfxU16      VuiNalHrdParameters;    /* tri-state option */
 } mfxExtCodingOption;
+MFX_PACK_END()
 
 enum {
     MFX_B_REF_UNKNOWN = 0,
@@ -565,11 +638,16 @@ enum {
 };
 
 enum {
-    MFX_LOOKAHEAD_DS_UNKNOWN = 0,
-    MFX_LOOKAHEAD_DS_OFF     = 1,
-    MFX_LOOKAHEAD_DS_2x      = 2,
-    MFX_LOOKAHEAD_DS_4x      = 3
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_LOOKAHEAD_DS_UNKNOWN) = 0,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_LOOKAHEAD_DS_OFF)     = 1,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_LOOKAHEAD_DS_2x)      = 2,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_LOOKAHEAD_DS_4x)      = 3
 };
+
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_LOOKAHEAD_DS_UNKNOWN);
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_LOOKAHEAD_DS_OFF);
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_LOOKAHEAD_DS_2x);
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_LOOKAHEAD_DS_4x);
 
 enum {
     MFX_BPSEI_DEFAULT = 0x00,
@@ -591,6 +669,7 @@ enum {
         MFX_REFRESH_SLICE          = 3
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -626,6 +705,7 @@ typedef struct {
     mfxU16      EnableMAD;              /* tri-state option */
     mfxU16      UseRawRef;              /* tri-state option */
 } mfxExtCodingOption2;
+MFX_PACK_END()
 
 /* WeightedPred */
 enum {
@@ -662,7 +742,32 @@ enum {
     MFX_P_REF_PYRAMID = 2
 };
 
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
 
+/* QuantScaleType */
+enum {
+    MFX_MPEG2_QUANT_SCALE_TYPE_DEFAULT    = 0,
+    MFX_MPEG2_QUANT_SCALE_TYPE_LINEAR     = 1, /* q_scale_type = 0 */
+    MFX_MPEG2_QUANT_SCALE_TYPE_NONLINEAR  = 2  /* q_scale_type = 1 */
+};
+
+/* IntraVLCFormat */
+enum {
+    MFX_MPEG2_INTRA_VLC_FORMAT_DEFAULT    = 0,
+    MFX_MPEG2_INTRA_VLC_FORMAT_B14        = 1, /* use table B.14 */
+    MFX_MPEG2_INTRA_VLC_FORMAT_B15        = 2  /* use table B.15 */
+};
+
+/* ScanType */
+enum {
+    MFX_MPEG2_SCAN_TYPE_DEFAULT   = 0,
+    MFX_MPEG2_SCAN_TYPE_ZIGZAG    = 1, /* alternate_scan = 0 */
+    MFX_MPEG2_SCAN_TYPE_ALTERNATE = 2  /* alternate_scan = 1 */
+};
+
+#endif
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -691,14 +796,24 @@ typedef struct {
     mfxU16      BitstreamRestriction;           /* tri-state option */
     mfxU16      LowDelayHrd;                    /* tri-state option */
     mfxU16      MotionVectorsOverPicBoundaries; /* tri-state option */
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    mfxU16      Log2MaxMvLengthHorizontal;      /* 0..16 */
+    mfxU16      Log2MaxMvLengthVertical;        /* 0..16 */
+#else
     mfxU16      reserved1[2];
+#endif
 
     mfxU16      ScenarioInfo;
     mfxU16      ContentInfo;
 
     mfxU16      PRefType;
     mfxU16      FadeDetection;            /* tri-state option */
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    mfxI16      DeblockingAlphaTcOffset;  /* -12..12 (slice_alpha_c0_offset_div2 << 1) */
+    mfxI16      DeblockingBetaOffset;     /* -12..12 (slice_beta_offset_div2 << 1) */
+#else
     mfxU16      reserved2[2];
+#endif
     mfxU16      GPB;                      /* tri-state option */
 
     mfxU32      MaxFrameSizeI;
@@ -712,11 +827,23 @@ typedef struct {
     mfxU16      NumRefActiveBL0[8];
     mfxU16      NumRefActiveBL1[8];
 
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    mfxU16      ConstrainedIntraPredFlag;  /* tri-state option */
+#else
     mfxU16      reserved6;
+#endif
+#if (MFX_VERSION >= 1026)
     mfxU16      TransformSkip;  /* tri-state option; HEVC transform_skip_enabled_flag */
+#else
+    mfxU16      reserved7;
+#endif
+#if (MFX_VERSION >= 1027)
     mfxU16      TargetChromaFormatPlus1;   /* Minus 1 specifies target encoding chroma format (see ColorFormat enum). May differ from input one. */
     mfxU16      TargetBitDepthLuma;        /* Target encoding bit depth for luma samples. May differ from input one. */
     mfxU16      TargetBitDepthChroma;      /* Target encoding bit depth for chroma samples. May differ from input one. */
+#else
+    mfxU16      reserved4[3];
+#endif
     mfxU16      BRCPanicMode;              /* tri-state option */
 
     mfxU16      LowDelayBRC;               /* tri-state option */
@@ -724,12 +851,27 @@ typedef struct {
     mfxU16      AdaptiveMaxFrameSize;      /* tri-state option */
 
     mfxU16      RepartitionCheckEnable;    /* tri-state option */
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    mfxU16      QuantScaleType;            /* For MPEG2 specifies mapping between quantiser_scale_code and quantiser_scale (see QuantScaleType enum) */
+    mfxU16      IntraVLCFormat;            /* For MPEG2 specifies which table shall be used for coding of DCT coefficients of intra macroblocks (see IntraVLCFormat enum) */
+    mfxU16      ScanType;                  /* For MPEG2 specifies transform coefficients scan pattern (see ScanType enum) */
+#else
     mfxU16      reserved5[3];
+#endif
+#if (MFX_VERSION >= 1025)
     mfxU16      EncodedUnitsInfo;          /* tri-state option */
     mfxU16      EnableNalUnitType;         /* tri-state option */
+#else
+    mfxU16      reserved8[2];
+#endif
+#if (MFX_VERSION >= 1026)
     mfxU16      ExtBrcAdaptiveLTR;         /* tri-state option for ExtBRC */
+#else
+    mfxU16      reserved9;
+#endif
     mfxU16      reserved[163];
 } mfxExtCodingOption3;
+MFX_PACK_END()
 
 /* IntraPredBlockSize/InterPredBlockSize */
 enum {
@@ -772,7 +914,7 @@ enum {
     MFX_EXTBUFF_VPP_DETAIL                      = MFX_MAKEFOURCC('D','E','T',' '),
     MFX_EXTBUFF_VIDEO_SIGNAL_INFO               = MFX_MAKEFOURCC('V','S','I','N'),
     MFX_EXTBUFF_VPP_DOUSE                       = MFX_MAKEFOURCC('D','U','S','E'),
-    MFX_EXTBUFF_OPAQUE_SURFACE_ALLOCATION       = MFX_MAKEFOURCC('O','P','Q','S'),
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_EXTBUFF_OPAQUE_SURFACE_ALLOCATION)       = MFX_MAKEFOURCC('O','P','Q','S'),
     MFX_EXTBUFF_AVC_REFLIST_CTRL                = MFX_MAKEFOURCC('R','L','S','T'),
     MFX_EXTBUFF_VPP_FRAME_RATE_CONVERSION       = MFX_MAKEFOURCC('F','R','C',' '),
     MFX_EXTBUFF_PICTURE_TIMING_SEI              = MFX_MAKEFOURCC('P','T','S','E'),
@@ -813,6 +955,7 @@ enum {
     MFX_EXTBUFF_VPP_MIRRORING                   = MFX_MAKEFOURCC('M','I','R','R'),
     MFX_EXTBUFF_MV_OVER_PIC_BOUNDARIES          = MFX_MAKEFOURCC('M','V','P','B'),
     MFX_EXTBUFF_VPP_COLORFILL                   = MFX_MAKEFOURCC('V','C','L','F'),
+#if (MFX_VERSION >= 1025)
     MFX_EXTBUFF_DECODE_ERROR_REPORT             = MFX_MAKEFOURCC('D', 'E', 'R', 'R'),
     MFX_EXTBUFF_VPP_COLOR_CONVERSION            = MFX_MAKEFOURCC('V', 'C', 'S', 'C'),
     MFX_EXTBUFF_CONTENT_LIGHT_LEVEL_INFO        = MFX_MAKEFOURCC('L', 'L', 'I', 'S'),
@@ -820,30 +963,64 @@ enum {
     MFX_EXTBUFF_MULTI_FRAME_PARAM               = MFX_MAKEFOURCC('M', 'F', 'R', 'P'),
     MFX_EXTBUFF_MULTI_FRAME_CONTROL             = MFX_MAKEFOURCC('M', 'F', 'R', 'C'),
     MFX_EXTBUFF_ENCODED_UNITS_INFO              = MFX_MAKEFOURCC('E', 'N', 'U', 'I'),
+#endif
+#if (MFX_VERSION >= 1026)
     MFX_EXTBUFF_VPP_MCTF                        = MFX_MAKEFOURCC('M', 'C', 'T', 'F'),
     MFX_EXTBUFF_VP9_SEGMENTATION                = MFX_MAKEFOURCC('9', 'S', 'E', 'G'),
     MFX_EXTBUFF_VP9_TEMPORAL_LAYERS             = MFX_MAKEFOURCC('9', 'T', 'M', 'L'),
     MFX_EXTBUFF_VP9_PARAM                       = MFX_MAKEFOURCC('9', 'P', 'A', 'R'),
+#endif
+#if (MFX_VERSION >= 1027)
     MFX_EXTBUFF_AVC_ROUNDING_OFFSET             = MFX_MAKEFOURCC('R','N','D','O'),
+#endif
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    MFX_EXTBUFF_DPB                             = MFX_MAKEFOURCC('E','D','P','B'),
+    MFX_EXTBUFF_TEMPORAL_LAYERS                 = MFX_MAKEFOURCC('T','M','P','L'),
+    MFX_EXTBUFF_AVC_SCALING_MATRIX              = MFX_MAKEFOURCC('A','V','S','M'),
+    MFX_EXTBUFF_MPEG2_QUANT_MATRIX              = MFX_MAKEFOURCC('M','2','Q','M'),
+    MFX_EXTBUFF_TASK_DEPENDENCY                 = MFX_MAKEFOURCC('S','Y','N','C'),
+#endif
+#if (MFX_VERSION >= 1031)
+    MFX_EXTBUFF_PARTIAL_BITSTREAM_PARAM         = MFX_MAKEFOURCC('P','B','O','P'),
+#endif
+    MFX_EXTBUFF_ENCODER_IPCM_AREA               = MFX_MAKEFOURCC('P', 'C', 'M', 'R'),
+    MFX_EXTBUFF_INSERT_HEADERS                  = MFX_MAKEFOURCC('S', 'P', 'R', 'E'),
+#if (MFX_VERSION >= 1034)
+    MFX_EXTBUFF_AV1_FILM_GRAIN_PARAM            = MFX_MAKEFOURCC('A','1','F','G'),
+    MFX_EXTBUFF_AV1_LST_PARAM                   = MFX_MAKEFOURCC('A', '1', 'L', 'S'),
+    MFX_EXTBUFF_AV1_SEGMENTATION                = MFX_MAKEFOURCC('1', 'S', 'E', 'G'),
+    MFX_EXTBUFF_AV1_PARAM                       = MFX_MAKEFOURCC('1', 'P', 'A', 'R'),
+    MFX_EXTBUFF_AV1_AUXDATA                     = MFX_MAKEFOURCC('1', 'A', 'U', 'X'),
+    MFX_EXTBUFF_AV1_TEMPORAL_LAYERS             = MFX_MAKEFOURCC('1', 'T', 'M', 'L')
+#endif
 };
 
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_EXTBUFF_OPAQUE_SURFACE_ALLOCATION);
+
 /* VPP Conf: Do not use certain algorithms  */
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU32          NumAlg;
     mfxU32*         AlgList;
 } mfxExtVPPDoNotUse;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU16  DenoiseFactor;
 } mfxExtVPPDenoise;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU16  DetailFactor;
 } mfxExtVPPDetail;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_L_TYPE()
 typedef struct {
     mfxExtBuffer    Header;
     mfxF64   Brightness;
@@ -851,15 +1028,19 @@ typedef struct {
     mfxF64   Hue;
     mfxF64   Saturation;
 } mfxExtVPPProcAmp;
+MFX_PACK_END()
 
 /* statistics collected for decode, encode and vpp */
+MFX_PACK_BEGIN_STRUCT_W_L_TYPE()
 typedef struct {
     mfxU32  reserved[16];
     mfxU32  NumFrame;
     mfxU64  NumBit;
     mfxU32  NumCachedFrame;
 } mfxEncodeStat;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxU32  reserved[16];
     mfxU32  NumFrame;
@@ -867,13 +1048,17 @@ typedef struct {
     mfxU32  NumError;
     mfxU32  NumCachedFrame;
 } mfxDecodeStat;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxU32  reserved[16];
     mfxU32  NumFrame;
     mfxU32  NumCachedFrame;
 } mfxVPPStat;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
 
@@ -890,12 +1075,14 @@ typedef struct {
     mfxU16          SceneChangeRate;
     mfxU16          RepeatedFrame;
 } mfxExtVppAuxData;
+MFX_PACK_END()
 
 /* CtrlFlags */
 enum {
     MFX_PAYLOAD_CTRL_SUFFIX = 0x00000001 /* HEVC suffix SEI */
 };
 
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
     mfxU32      CtrlFlags;
     mfxU32      reserved[3];
@@ -904,12 +1091,18 @@ typedef struct {
     mfxU16      Type;       /* SEI message type in H.264 or user data start_code in MPEG-2 */
     mfxU16      BufSize;    /* payload buffer size in bytes */
 } mfxPayload;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
     mfxExtBuffer    Header;
+#if (MFX_VERSION >= 1025)
     mfxU32  reserved[4];
     mfxU16  reserved1;
     mfxU16  MfxNalUnitType;
+#else
+    mfxU32  reserved[5];
+#endif
     mfxU16  SkipFrame;
 
     mfxU16  QP; /* per frame QP */
@@ -922,6 +1115,7 @@ typedef struct {
     mfxExtBuffer    **ExtParam;
     mfxPayload      **Payload;      /* for field pair, first field uses even payloads and second field uses odd payloads */
 } mfxEncodeCtrl;
+MFX_PACK_END()
 
 /* Buffer Memory Types */
 enum {
@@ -949,12 +1143,19 @@ enum {
 
     MFX_MEMTYPE_INTERNAL_FRAME  = 0x0001,
     MFX_MEMTYPE_EXTERNAL_FRAME  = 0x0002,
-    MFX_MEMTYPE_OPAQUE_FRAME    = 0x0004,
+    MFX_DEPRECATED_ENUM_FIELD_INSIDE(MFX_MEMTYPE_OPAQUE_FRAME)    = 0x0004,
     MFX_MEMTYPE_EXPORT_FRAME    = 0x0008,
     MFX_MEMTYPE_SHARED_RESOURCE = MFX_MEMTYPE_EXPORT_FRAME,
+#if (MFX_VERSION >= 1025)
     MFX_MEMTYPE_VIDEO_MEMORY_ENCODER_TARGET = 0x1000
+#else
+    MFX_MEMTYPE_RESERVED2       = 0x1000
+#endif
 };
 
+MFX_DEPRECATED_ENUM_FIELD_OUTSIDE(MFX_MEMTYPE_OPAQUE_FRAME);
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     union {
         mfxU32  AllocId;
@@ -967,14 +1168,21 @@ typedef struct {
     mfxU16  NumFrameSuggested;
     mfxU16  reserved2;
 } mfxFrameAllocRequest;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
     mfxU32      AllocId;
     mfxU32      reserved[3];
     mfxMemId    *mids;      /* the array allocated by application */
     mfxU16      NumFrameActual;
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    mfxU16      MemType;
+#else
     mfxU16      reserved2;
+#endif
 } mfxFrameAllocResponse;
+MFX_PACK_END()
 
 /* FrameType */
 enum {
@@ -997,6 +1205,7 @@ enum {
     MFX_FRAMETYPE_xIDR          =0x8000
 };
 
+#if (MFX_VERSION >= 1025)
 enum {
     MFX_HEVC_NALU_TYPE_UNKNOWN    =      0,
     MFX_HEVC_NALU_TYPE_TRAIL_N    = ( 0+1),
@@ -1009,6 +1218,7 @@ enum {
     MFX_HEVC_NALU_TYPE_IDR_N_LP   = (20+1),
     MFX_HEVC_NALU_TYPE_CRA_NUT    = (21+1)
 };
+#endif
 
 typedef enum {
     MFX_HANDLE_DIRECT3D_DEVICE_MANAGER9         =1,      /* IDirect3DDeviceManager9      */
@@ -1017,6 +1227,13 @@ typedef enum {
     MFX_HANDLE_D3D11_DEVICE                     = 3,
     MFX_HANDLE_VA_DISPLAY                       = 4,
     MFX_HANDLE_RESERVED3                        = 5,
+#if (MFX_VERSION >= 1030)
+    MFX_HANDLE_VA_CONFIG_ID                     = 6,
+    MFX_HANDLE_VA_CONTEXT_ID                    = 7,
+#endif
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    MFX_HANDLE_CM_DEVICE                        = 8
+#endif
 } mfxHandleType;
 
 typedef enum {
@@ -1025,6 +1242,7 @@ typedef enum {
     MFX_SKIPMODE_LESS=2
 } mfxSkipMode;
 
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU8           *SPSBuffer;
@@ -1034,7 +1252,9 @@ typedef struct {
     mfxU16          SPSId;
     mfxU16          PPSId;
 } mfxExtCodingOptionSPSPPS;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_L_TYPE()
 typedef struct {
     mfxExtBuffer    Header;
 
@@ -1047,7 +1267,9 @@ typedef struct {
 
     mfxU16          reserved[6];
 } mfxExtCodingOptionVPS;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU16          VideoFormat;
@@ -1057,14 +1279,18 @@ typedef struct {
     mfxU16          TransferCharacteristics;
     mfxU16          MatrixCoefficients;
 } mfxExtVideoSignalInfo;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU32          NumAlg;
     mfxU32          *AlgList;
 } mfxExtVPPDoUse;
+MFX_PACK_END()
 
-typedef struct {
+MFX_PACK_BEGIN_STRUCT_W_PTR()
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer    Header;
     mfxU32      reserved1[2];
     struct {
@@ -1074,7 +1300,9 @@ typedef struct {
         mfxU16  NumSurface;
     } In, Out;
 } mfxExtOpaqueSurfaceAlloc;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU16          NumRefIdxL0Active;
@@ -1091,6 +1319,7 @@ typedef struct {
     mfxU16      ApplyLongTermIdx;
     mfxU16      reserved[15];
 } mfxExtAVCRefListCtrl;
+MFX_PACK_END()
 
 enum {
     MFX_FRCALGM_PRESERVE_TIMESTAMP    = 0x0001,
@@ -1098,30 +1327,36 @@ enum {
     MFX_FRCALGM_FRAME_INTERPOLATION   = 0x0004
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU16      Algorithm;
     mfxU16      reserved;
     mfxU32      reserved2[15];
 } mfxExtVPPFrameRateConversion;
+MFX_PACK_END()
 
 enum {
     MFX_IMAGESTAB_MODE_UPSCALE = 0x0001,
     MFX_IMAGESTAB_MODE_BOXING  = 0x0002
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU16  Mode;
     mfxU16  reserved[11];
 } mfxExtVPPImageStab;
+MFX_PACK_END()
 
+#if (MFX_VERSION >= 1025)
 
 enum {
     MFX_PAYLOAD_OFF = 0,
     MFX_PAYLOAD_IDR = 1
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU16      reserved[15];
@@ -1134,8 +1369,9 @@ typedef struct {
     mfxU32 MaxDisplayMasteringLuminance;
     mfxU32 MinDisplayMasteringLuminance;
 } mfxExtMasteringDisplayColourVolume;
+MFX_PACK_END()
 
-
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU16      reserved[9];
@@ -1144,8 +1380,10 @@ typedef struct {
     mfxU16 MaxContentLightLevel;
     mfxU16 MaxPicAverageLightLevel;
 } mfxExtContentLightLevelInfo;
+MFX_PACK_END()
+#endif
 
-
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
   mfxExtBuffer    Header;
   mfxU32      reserved[14];
@@ -1168,7 +1406,9 @@ typedef struct {
       mfxU32    TimeOffset;
   } TimeStamp[3];
 } mfxExtPictureTimingSEI;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU32          reserved1[4];
@@ -1180,27 +1420,32 @@ typedef struct {
         mfxU16 reserved[3];
     }Layer[8];
 } mfxExtAvcTemporalLayers;
+MFX_PACK_END()
 
-
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
     mfxU32      MBPerSec;
     mfxU16      reserved[58];
 } mfxExtEncoderCapability;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
     mfxU16      StartNewSequence;
     mfxU16      reserved[11];
 } mfxExtEncoderResetOption;
+MFX_PACK_END()
 
 /*LongTermIdx*/
 enum {
     MFX_LONGTERM_IDX_NO_IDX = 0xFFFF
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
 
@@ -1220,7 +1465,9 @@ typedef struct {
         mfxU16      reserved[4];
     } UsedRefListL0[32], UsedRefListL1[32];
 } mfxExtAVCEncodedFrameInfo;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct mfxVPPCompInputStream {
     mfxU32  DstX;
     mfxU32  DstY;
@@ -1239,7 +1486,9 @@ typedef struct mfxVPPCompInputStream {
 
     mfxU16  reserved2[17];
 } mfxVPPCompInputStream;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
     mfxExtBuffer    Header;
 
@@ -1262,6 +1511,7 @@ typedef struct {
     mfxU16       NumInputStream;
     mfxVPPCompInputStream *InputStream;
 } mfxExtVPPComposite;
+MFX_PACK_END()
 
 /* TransferMatrix */
 enum {
@@ -1277,6 +1527,7 @@ enum {
     MFX_NOMINALRANGE_16_235    = 2
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU16          reserved1[4];
@@ -1296,13 +1547,16 @@ typedef struct {
         };
     };
 } mfxExtVPPVideoSignalInfo;
+MFX_PACK_END()
 
 /* ROI encoding mode */
 enum {
     MFX_ROI_MODE_PRIORITY =  0,
-    MFX_ROI_MODE_QP_DELTA =  1
+    MFX_ROI_MODE_QP_DELTA =  1,
+    MFX_ROI_MODE_QP_VALUE =  2 
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
 
@@ -1322,6 +1576,7 @@ typedef struct {
         mfxU16  reserved2[7];
     } ROI[256];
 } mfxExtEncoderROI;
+MFX_PACK_END()
 
 /*Deinterlacing Mode*/
 enum {
@@ -1349,6 +1604,7 @@ enum {
     MFX_TELECINE_POSITION_PROVIDED    = 4
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU16  Mode;
@@ -1356,7 +1612,9 @@ typedef struct {
     mfxU16  TelecineLocation;
     mfxU16  reserved[9];
 } mfxExtVPPDeinterlacing;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
     mfxU16          NumRefIdxL0Active;
@@ -1370,6 +1628,7 @@ typedef struct {
     } RefPicList0[32], RefPicList1[32];
 
 }mfxExtAVCRefLists;
+MFX_PACK_END()
 
 enum {
     MFX_VPP_COPY_FRAME      =0x01,
@@ -1385,6 +1644,7 @@ enum {
     MFX_PICTYPE_BOTTOMFIELD =0x04
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
 
@@ -1393,7 +1653,9 @@ typedef struct {
     mfxU16          OutField;
     mfxU16          reserved[25];
 } mfxExtVPPFieldProcessing;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
 
@@ -1422,7 +1684,9 @@ typedef struct {
 
     mfxU16  reserved[13];
 } mfxExtDecVideoProcessing;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1431,13 +1695,26 @@ typedef struct {
     mfxU16       ChromaSampleLocTypeBottomField;
     mfxU16       reserved[9];
 } mfxExtChromaLocInfo;
+MFX_PACK_END()
 
 /* MBQPMode */
 enum {
     MFX_MBQP_MODE_QP_VALUE = 0, // supported in CQP mode only
-    MFX_MBQP_MODE_QP_DELTA = 1
+    MFX_MBQP_MODE_QP_DELTA = 1,
+    MFX_MBQP_MODE_QP_ADAPTIVE = 2
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
+typedef struct{
+    union {
+        mfxU8 QP;
+        mfxI8 DeltaQP;
+    };
+    mfxU16 Mode;
+} mfxQPandMode;
+MFX_PACK_END()
+
+MFX_PACK_BEGIN_STRUCT_W_L_TYPE()
 typedef struct {
     mfxExtBuffer    Header;
 
@@ -1448,10 +1725,41 @@ typedef struct {
     union {
         mfxU8  *QP;         // Block QP value. Valid when Mode = MFX_MBQP_MODE_QP_VALUE
         mfxI8  *DeltaQP;    // For block i: QP[i] = BrcQP[i] + DeltaQP[i]. Valid when Mode = MFX_MBQP_MODE_QP_DELTA
+#if (MFX_VERSION >= 1034)
+        mfxQPandMode *QPmode; // Block-granularity modes when MFX_MBQP_MODE_QP_ADAPTIVE is set
+#endif
         mfxU64 reserved2;
     };
 } mfxExtMBQP;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
+typedef struct {
+    mfxExtBuffer    Header; /* Extension buffer header. Header.BufferId must be equal to MFX_EXTBUFF_INSERT_HEADERS. */
+    mfxU16          SPS;      /* tri-state option to insert SPS */
+    mfxU16          PPS;      /* tri-state option to insert PPS */
+    mfxU16          reserved[8];
+} mfxExtInsertHeaders;
+MFX_PACK_END()
+
+MFX_PACK_BEGIN_STRUCT_W_PTR() 
+typedef struct {
+    mfxExtBuffer    Header; /* Extension buffer header. Header.BufferId must be equal to MFX_EXTBUFF_ENCODER_IPCM_AREA. */
+    mfxU16          reserve1[10];
+
+    mfxU16          NumArea;  /* Number of Area's */
+    struct area {
+        mfxU32      Left; /* Left Area's coordinate. */
+        mfxU32      Top;  /* Top  Area's coordinate. */
+        mfxU32      Right; /* Right Area's coordinate. */
+        mfxU32      Bottom; /* Bottom Area's coordinate. */
+
+        mfxU16      reserved2[8];
+    } * Areas; /* Array of areas. */
+} mfxExtEncoderIPCMArea;
+MFX_PACK_END()
+
+MFX_PACK_BEGIN_STRUCT_W_L_TYPE()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1462,7 +1770,9 @@ typedef struct {
         mfxU64  reserved2;
     };
 } mfxExtMBForceIntra;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1470,7 +1780,9 @@ typedef struct {
     mfxU16 NumTileColumns;
     mfxU16 reserved[74];
 }mfxExtHEVCTiles;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_L_TYPE()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1481,7 +1793,26 @@ typedef struct {
         mfxU64  reserved2;
     };
 } mfxExtMBDisableSkipMap;
+MFX_PACK_END()
 
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+MFX_PACK_BEGIN_USUAL_STRUCT()
+typedef struct {
+    mfxExtBuffer    Header;
+
+    mfxU16          DPBSize;
+    mfxU16          reserved[11];
+
+    struct {
+        mfxU32      FrameOrder;
+        mfxU16      PicType;
+        mfxU16      LongTermIdx;
+        mfxU16      reserved[4];
+    } DPB[32];
+} mfxExtDPB;
+MFX_PACK_END()
+
+#endif
 
 /*GeneralConstraintFlags*/
 enum {
@@ -1497,6 +1828,7 @@ enum {
     MFX_HEVC_CONSTR_REXT_LOWER_BIT_RATE     = (1 << 8)
 };
 
+#if (MFX_VERSION >= 1026)
 
 /* SampleAdaptiveOffset */
 enum {
@@ -1506,20 +1838,27 @@ enum {
     MFX_SAO_ENABLE_CHROMA = 0x04
 };
 
+#endif
 
-#pragma pack(push, 4)
+/* This struct has 4-byte alignment for binary compatibility with previously released versions of API */
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
 
     mfxU16          PicWidthInLumaSamples;
     mfxU16          PicHeightInLumaSamples;
     mfxU64          GeneralConstraintFlags;
+#if (MFX_VERSION >= 1026)
     mfxU16          SampleAdaptiveOffset;   /* see enum SampleAdaptiveOffset, valid during Init and Runtime */
     mfxU16          LCUSize;
     mfxU16          reserved[116];
+#else
+    mfxU16          reserved[118];
+#endif
 } mfxExtHEVCParam;
-#pragma pack(pop)
+MFX_PACK_END()
 
+#if (MFX_VERSION >= 1025)
 /*ErrorTypes in mfxExtDecodeErrorReport*/
 enum {
     MFX_ERROR_PPS           = (1 << 0),
@@ -1529,21 +1868,27 @@ enum {
     MFX_ERROR_FRAME_GAP     = (1 << 4),
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer    Header;
 
     mfxU32          ErrorTypes;
     mfxU16          reserved[10];
 } mfxExtDecodeErrorReport;
+MFX_PACK_END()
 
+#endif
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
     mfxU16       FrameType;
     mfxU16       reserved[59];
 } mfxExtDecodedFrameInfo;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1554,6 +1899,7 @@ typedef struct {
     mfxU16       TimeCodePictures;
     mfxU16       reserved[7];
 } mfxExtTimeCode;
+MFX_PACK_END()
 
 /*RegionType*/
 enum {
@@ -1566,6 +1912,7 @@ enum {
     MFX_HEVC_REGION_ENCODING_OFF = 1
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1574,7 +1921,9 @@ typedef struct {
     mfxU16       RegionEncoding;
     mfxU16       reserved[24];
 } mfxExtHEVCRegion;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1585,7 +1934,10 @@ typedef struct {
     mfxI16       Weights[2][32][3][2];      // [list][list entry][Y, Cb, Cr][weight, offset]
     mfxU16       reserved[58];
 } mfxExtPredWeightTable;
+MFX_PACK_END()
 
+#if (MFX_VERSION >= 1027)
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1596,8 +1948,33 @@ typedef struct {
 
     mfxU16       reserved[24];
 } mfxExtAVCRoundingOffset;
+MFX_PACK_END()
+#endif
 
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+MFX_PACK_BEGIN_USUAL_STRUCT()
+typedef struct {
+    mfxExtBuffer Header;
 
+    mfxU16       reserved[12];
+
+    struct {
+        mfxU16   Scale;
+        mfxU16   QPI;
+        mfxU16   QPP;
+        mfxU16   QPB;
+        mfxU32   TargetKbps;
+        mfxU32   MaxKbps;
+        mfxU32   BufferSizeInKB;
+        mfxU32   InitialDelayInKB;
+        mfxU16   reserved1[20];
+    } Layer[8];
+} mfxExtTemporalLayers;
+MFX_PACK_END()
+
+#endif
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1613,7 +1990,9 @@ typedef struct {
         mfxU16  reserved2[8];
     } Rect[256];
 } mfxExtDirtyRect;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1631,7 +2010,51 @@ typedef struct {
         mfxU16  reserved2[4];
     } Rect[256];
 } mfxExtMoveRect;
+MFX_PACK_END()
 
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+
+/* ScalingMatrixType */
+enum {
+    MFX_SCALING_MATRIX_SPS = 1,
+    MFX_SCALING_MATRIX_PPS = 2
+};
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
+typedef struct {
+    mfxExtBuffer Header;
+
+    mfxU16 Type;
+    mfxU16 reserved[5];
+
+    /* [4x4_Intra_Y,  4x4_Intra_Cb, 4x4_Intra_Cr,
+        4x4_Inter_Y,  4x4_Inter_Cb, 4x4_Inter_Cr,
+        8x8_Intra_Y,  8x8_Inter_Y,  8x8_Intra_Cb,
+        8x8_Inter_Cb, 8x8_Intra_Cr, 8x8_Inter_Cr] */
+    mfxU8  ScalingListPresent[12];
+
+    /* [Intra_Y,  Intra_Cb, Intra_Cr,
+        Inter_Y,  Inter_Cb, Inter_Cr] */
+    mfxU8  ScalingList4x4[6][16];
+
+    /* [Intra_Y,  Inter_Y,  Intra_Cb,
+        Inter_Cb, Intra_Cr, Inter_Cr] */
+    mfxU8  ScalingList8x8[6][64];
+} mfxExtAVCScalingMatrix;
+MFX_PACK_END()
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
+typedef struct {
+    mfxExtBuffer Header;
+
+    mfxU16 reserved[28];
+
+    mfxU8  LoadMatrix[4]; // [LumaIntra, LumaInter, ChromaIntra, ChromaInter]
+    mfxU8  Matrix[4][64]; // [LumaIntra, LumaInter, ChromaIntra, ChromaInter]
+} mfxExtMPEG2QuantMatrix;
+MFX_PACK_END()
+
+#endif
 
 /* Angle */
 enum {
@@ -1641,13 +2064,16 @@ enum {
     MFX_ANGLE_270   = 270
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
     mfxU16 Angle;
     mfxU16 reserved[11];
 } mfxExtVPPRotation;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_L_TYPE()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1662,6 +2088,7 @@ typedef struct {
 
     mfxU16 reserved[20];
 } mfxExtEncodedSlicesInfo;
+MFX_PACK_END()
 
 /* ScalingMode */
 enum {
@@ -1670,13 +2097,49 @@ enum {
     MFX_SCALING_MODE_QUALITY    = 2
 };
 
+#if (MFX_VERSION >= 1033)
+/* Interpolation Method */
+enum {
+    MFX_INTERPOLATION_DEFAULT                = 0,
+    MFX_INTERPOLATION_NEAREST_NEIGHBOR       = 1,
+    MFX_INTERPOLATION_BILINEAR               = 2,
+    MFX_INTERPOLATION_ADVANCED               = 3
+};
+#endif
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
     mfxU16 ScalingMode;
+#if (MFX_VERSION >= 1033)
+    mfxU16 InterpolationMethod;
+    mfxU16 reserved[10];
+#else
     mfxU16 reserved[11];
+#endif
 } mfxExtVPPScaling;
+MFX_PACK_END()
 
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+
+/* SceneChangeType */
+enum {
+    MFX_SCENE_NO_CHANGE = 0,
+    MFX_SCENE_START     = 1,
+    MFX_SCENE_END       = 2
+};
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
+typedef struct {
+    mfxExtBuffer Header;
+
+    mfxU16 Type;
+    mfxU16 reserved[11];
+} mfxExtSceneChange;
+MFX_PACK_END()
+
+#endif
 
 typedef mfxExtAVCRefListCtrl mfxExtHEVCRefListCtrl;
 typedef mfxExtAVCRefLists mfxExtHEVCRefLists;
@@ -1690,13 +2153,16 @@ enum
     MFX_MIRRORING_VERTICAL   = 2
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
     mfxU16 Type;
     mfxU16 reserved[11];
 } mfxExtVPPMirroring;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1706,14 +2172,18 @@ typedef struct {
     mfxU16 StickRight;   /* tri-state option */
     mfxU16 reserved[8];
 } mfxExtMVOverPicBoundaries;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
     mfxU16 Enable;        /* tri-state option */
     mfxU16 reserved[11];
 } mfxExtVPPColorFill;
+MFX_PACK_END()
 
+#if (MFX_VERSION >= 1025)
 
 /* ChromaSiting */
 enum {
@@ -1725,14 +2195,18 @@ enum {
     MFX_CHROMA_SITING_HORIZONTAL_CENTER   = 0x0020  /* Chroma samples are not co-sited horizontally with the luma samples. */
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
     mfxU16 ChromaSiting;
     mfxU16 reserved[27];
 } mfxExtColorConversion;
+MFX_PACK_END()
 
+#endif
 
+#if (MFX_VERSION >= 1026)
 /* VP9ReferenceFrame */
 enum {
     MFX_VP9_REF_INTRA   = 0,
@@ -1758,6 +2232,7 @@ enum {
     MFX_VP9_SEGMENT_FEATURE_SKIP        = 0x0008 /* (0,0) MV, no residual */
 };
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxU16  FeatureEnabled;         /* see enum SegmentFeature */
     mfxI16  QIndexDelta;
@@ -1765,7 +2240,9 @@ typedef struct {
     mfxU16  ReferenceFrame;        /* see enum VP9ReferenceFrame */
     mfxU16  reserved[12];
 } mfxVP9SegmentParam;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_L_TYPE()
 typedef struct {
     mfxExtBuffer        Header;
     mfxU16              NumSegments;            /* 0..8 */
@@ -1778,19 +2255,25 @@ typedef struct {
     };
     mfxU16  reserved[52];
 } mfxExtVP9Segmentation;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxU16 FrameRateScale;  /* Layer[n].FrameRateScale = Layer[n - 1].FrameRateScale * (uint)m */
     mfxU16 TargetKbps;      /* affected by BRCParamMultiplier, Layer[n].TargetKbps > Layer[n - 1].TargetKbps */
     mfxU16 reserved[14];
 } mfxVP9TemporalLayer;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer        Header;
     mfxVP9TemporalLayer Layer[8];
     mfxU16              reserved[60];
 } mfxExtVP9TemporalLayers;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1799,14 +2282,28 @@ typedef struct {
 
     mfxU16  WriteIVFHeaders;        /* tri-state option */
 
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    mfxI16  LoopFilterRefDelta[4];
+    mfxI16  LoopFilterModeDelta[2];
+#else // API 1.26
     mfxI16  reserved1[6];
+#endif
     mfxI16  QIndexDeltaLumaDC;
     mfxI16  QIndexDeltaChromaAC;
     mfxI16  QIndexDeltaChromaDC;
+#if (MFX_VERSION >= 1029)
+    mfxU16  NumTileRows;
+    mfxU16  NumTileColumns;
+    mfxU16  reserved[110];
+#else
     mfxU16  reserved[112];
+#endif
 } mfxExtVP9Param;
+MFX_PACK_END()
 
+#endif // #if (MFX_VERSION >= 1026)
 
+#if (MFX_VERSION >= 1025)
 /* Multi-Frame Mode */
 enum {
     MFX_MF_DEFAULT = 0,
@@ -1816,7 +2313,8 @@ enum {
 };
 
 /* Multi-Frame Initialization parameters */
-typedef struct {
+MFX_PACK_BEGIN_USUAL_STRUCT()
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer Header;
 
     mfxU16      MFMode;
@@ -1824,9 +2322,11 @@ typedef struct {
 
     mfxU16      reserved[58];
 } mfxExtMultiFrameParam;
+MFX_PACK_END()
 
 /* Multi-Frame Run-time controls */
-typedef struct {
+MFX_PACK_BEGIN_USUAL_STRUCT()
+MFX_DEPRECATED typedef struct {
     mfxExtBuffer Header;
 
     mfxU32      Timeout;      /* timeout in millisecond */
@@ -1834,7 +2334,9 @@ typedef struct {
 
     mfxU16      reserved[57];
 } mfxExtMultiFrameControl;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxU16 Type;
     mfxU16 reserved1;
@@ -1842,7 +2344,9 @@ typedef struct {
     mfxU32 Size;
     mfxU32 reserved[5];
 } mfxEncodedUnitInfo;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_L_TYPE()
 typedef struct {
     mfxExtBuffer Header;
 
@@ -1855,16 +2359,160 @@ typedef struct {
 
     mfxU16 reserved[22];
 } mfxExtEncodedUnitsInfo;
+MFX_PACK_END()
 
+#endif
 
+#if (MFX_VERSION >= 1026)
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+/* MCTFTemporalMode */
+enum {
+    MFX_MCTF_TEMPORAL_MODE_UNKNOWN  = 0,
+    MFX_MCTF_TEMPORAL_MODE_SPATIAL  = 1,
+    MFX_MCTF_TEMPORAL_MODE_1REF     = 2,
+    MFX_MCTF_TEMPORAL_MODE_2REF     = 3,
+    MFX_MCTF_TEMPORAL_MODE_4REF     = 4
+};
+#endif
 
 /* MCTF initialization & runtime */
+MFX_PACK_BEGIN_USUAL_STRUCT()
 typedef struct {
     mfxExtBuffer Header;
     mfxU16       FilterStrength;
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    mfxU16       Overlap;               /* tri-state option */
+    mfxU32       BitsPerPixelx100k;
+    mfxU16       Deblocking;            /* tri-state option */
+    mfxU16       TemporalMode;
+    mfxU16       MVPrecision;
+    mfxU16       reserved[21];
+#else
     mfxU16       reserved[27];
+#endif
 } mfxExtVppMctf;
+MFX_PACK_END()
 
+#endif
+
+#if (MFX_VERSION >= 1031)
+/* Multi-adapters Querying structs */
+typedef enum
+{
+    MFX_COMPONENT_ENCODE = 1,
+    MFX_COMPONENT_DECODE = 2,
+    MFX_COMPONENT_VPP    = 3
+} mfxComponentType;
+
+MFX_PACK_BEGIN_STRUCT_W_PTR()
+typedef struct
+{
+    mfxComponentType Type;
+    mfxVideoParam    Requirements;
+
+    mfxU16           reserved[4];
+} mfxComponentInfo;
+MFX_PACK_END()
+
+/* Adapter description */
+MFX_PACK_BEGIN_USUAL_STRUCT()
+typedef struct
+{
+    mfxPlatform Platform;
+    mfxU32      Number;
+
+    mfxU16      reserved[14];
+} mfxAdapterInfo;
+MFX_PACK_END()
+
+MFX_PACK_BEGIN_STRUCT_W_PTR()
+typedef struct
+{
+    mfxAdapterInfo * Adapters;
+    mfxU32           NumAlloc;
+    mfxU32           NumActual;
+
+    mfxU16           reserved[4];
+} mfxAdaptersInfo;
+MFX_PACK_END()
+
+#endif
+
+#if (MFX_VERSION >= 1034)
+/* FilmGrainFlags */
+enum {
+    MFX_FILM_GRAIN_APPLY                    = (1 << 0),
+    MFX_FILM_GRAIN_UPDATE                   = (1 << 1),
+    MFX_FILM_GRAIN_CHROMA_SCALING_FROM_LUMA = (1 << 2),
+    MFX_FILM_GRAIN_OVERLAP                  = (1 << 3),
+    MFX_FILM_GRAIN_CLIP_TO_RESTRICTED_RANGE = (1 << 4)
+};
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
+typedef struct {
+    mfxU8 Value;
+    mfxU8 Scaling;
+} mfxAV1FilmGrainPoint;
+MFX_PACK_END()
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
+typedef struct {
+    mfxExtBuffer Header;
+
+    mfxU16 FilmGrainFlags;  /* FilmGrainFlags */
+    mfxU16 GrainSeed;       /* 0..65535 */
+
+    mfxU8  RefIdx;          /* 0..6  */
+    mfxU8  NumYPoints;      /* 0..14 */
+    mfxU8  NumCbPoints;     /* 0..10 */
+    mfxU8  NumCrPoints;     /* 0..10 */
+
+    mfxAV1FilmGrainPoint PointY[14];
+    mfxAV1FilmGrainPoint PointCb[10];
+    mfxAV1FilmGrainPoint PointCr[10];
+
+    mfxU8 GrainScalingMinus8; /* 0..3 */
+    mfxU8 ArCoeffLag;         /* 0..3 */
+
+    mfxU8 ArCoeffsYPlus128[24];  /* 0..255 */
+    mfxU8 ArCoeffsCbPlus128[25]; /* 0..255 */
+    mfxU8 ArCoeffsCrPlus128[25]; /* 0..255 */
+
+    mfxU8 ArCoeffShiftMinus6;  /* 0..3 */
+    mfxU8 GrainScaleShift;     /* 0..3 */
+
+    mfxU8  CbMult;     /* 0..255 */
+    mfxU8  CbLumaMult; /* 0..255 */
+    mfxU16 CbOffset;   /* 0..511 */
+
+    mfxU8  CrMult;     /* 0..255 */
+    mfxU8  CrLumaMult; /* 0..255 */
+    mfxU16 CrOffset;   /* 0..511 */
+
+    mfxU16 reserved[43];
+} mfxExtAV1FilmGrainParam;
+MFX_PACK_END()
+
+#endif
+
+#if (MFX_VERSION >= 1031)
+/* PartialBitstreamOutput */
+enum {
+    MFX_PARTIAL_BITSTREAM_NONE    = 0,     /* Don't use partial output */
+    MFX_PARTIAL_BITSTREAM_SLICE   = 1,     /* Partial bitstream output will be aligned to slice granularity */
+    MFX_PARTIAL_BITSTREAM_BLOCK   = 2,     /* Partial bitstream output will be aligned to user-defined block size granularity */
+    MFX_PARTIAL_BITSTREAM_ANY     = 3      /* Partial bitstream output will be return any coded data avilable at the end of SyncOperation timeout */
+};
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
+typedef struct {
+    mfxExtBuffer    Header;
+    mfxU32          BlockSize;        /* output block granulatiry for Granularity = MFX_PARTIAL_BITSTREAM_BLOCK */
+    mfxU16          Granularity;      /* granulatiry of the partial bitstream: slice/block/any */
+    mfxU16          reserved[8];
+} mfxExtPartialBitstreamParam;
+MFX_PACK_END()
+#endif
 
 #ifdef __cplusplus
 } // extern "C"

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxvideo++.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxvideo++.h
@@ -1,33 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2007-2018 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-File Name: mfxvideo++.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2017 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #ifndef __MFXVIDEOPLUSPLUS_H
 #define __MFXVIDEOPLUSPLUS_H
@@ -60,7 +49,7 @@ public:
     virtual mfxStatus SetPriority( mfxPriority priority) { return MFXSetPriority(m_session, priority);}
     virtual mfxStatus GetPriority( mfxPriority *priority) { return MFXGetPriority(m_session, priority);}
 
-    virtual mfxStatus SetBufferAllocator(mfxBufferAllocator *allocator) { return MFXVideoCORE_SetBufferAllocator(m_session, allocator); }
+    MFX_DEPRECATED virtual mfxStatus SetBufferAllocator(mfxBufferAllocator *allocator) { return MFXVideoCORE_SetBufferAllocator(m_session, allocator); }
     virtual mfxStatus SetFrameAllocator(mfxFrameAllocator *allocator) { return MFXVideoCORE_SetFrameAllocator(m_session, allocator); }
     virtual mfxStatus SetHandle(mfxHandleType type, mfxHDL hdl) { return MFXVideoCORE_SetHandle(m_session, type, hdl); }
     virtual mfxStatus GetHandle(mfxHandleType type, mfxHDL *hdl) { return MFXVideoCORE_GetHandle(m_session, type, hdl); }

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxvideo.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxvideo.h
@@ -1,32 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2007-2017 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfxvideo.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2017-2019 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 #ifndef __MFXVIDEO_H__
 #define __MFXVIDEO_H__
 #include "mfxsession.h"
@@ -38,6 +28,7 @@ extern "C"
 #endif
 
 /* MFXVideoCORE */
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
     mfxU32      reserved[4];
     mfxHDL      pthis;
@@ -46,7 +37,9 @@ typedef struct {
     mfxStatus  (MFX_CDECL *Unlock)   (mfxHDL pthis, mfxMemId mid);
     mfxStatus  (MFX_CDECL *Free)     (mfxHDL pthis, mfxMemId mid);
 } mfxBufferAllocator;
+MFX_PACK_END()
 
+MFX_PACK_BEGIN_STRUCT_W_PTR()
 typedef struct {
     mfxU32      reserved[4];
     mfxHDL      pthis;
@@ -57,9 +50,10 @@ typedef struct {
     mfxStatus  (MFX_CDECL  *GetHDL)   (mfxHDL pthis, mfxMemId mid, mfxHDL *handle);
     mfxStatus  (MFX_CDECL  *Free)     (mfxHDL pthis, mfxFrameAllocResponse *response);
 } mfxFrameAllocator;
+MFX_PACK_END()
 
 /* VideoCORE */
-mfxStatus MFX_CDECL MFXVideoCORE_SetBufferAllocator(mfxSession session, mfxBufferAllocator *allocator);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoCORE_SetBufferAllocator(mfxSession session, mfxBufferAllocator *allocator);
 mfxStatus MFX_CDECL MFXVideoCORE_SetFrameAllocator(mfxSession session, mfxFrameAllocator *allocator);
 mfxStatus MFX_CDECL MFXVideoCORE_SetHandle(mfxSession session, mfxHandleType type, mfxHDL hdl);
 mfxStatus MFX_CDECL MFXVideoCORE_GetHandle(mfxSession session, mfxHandleType type, mfxHDL *hdl);
@@ -101,7 +95,7 @@ mfxStatus MFX_CDECL MFXVideoVPP_Close(mfxSession session);
 mfxStatus MFX_CDECL MFXVideoVPP_GetVideoParam(mfxSession session, mfxVideoParam *par);
 mfxStatus MFX_CDECL MFXVideoVPP_GetVPPStat(mfxSession session, mfxVPPStat *stat);
 mfxStatus MFX_CDECL MFXVideoVPP_RunFrameVPPAsync(mfxSession session, mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp);
-mfxStatus MFX_CDECL MFXVideoVPP_RunFrameVPPAsyncEx(mfxSession session, mfxFrameSurface1 *in, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, mfxSyncPoint *syncp);
+MFX_DEPRECATED mfxStatus MFX_CDECL MFXVideoVPP_RunFrameVPPAsyncEx(mfxSession session, mfxFrameSurface1 *in, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, mfxSyncPoint *syncp);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/plugins/obs-qsv11/libmfx/include/msdk/include/mfxvstructures.h
+++ b/plugins/obs-qsv11/libmfx/include/msdk/include/mfxvstructures.h
@@ -1,32 +1,22 @@
-/*******************************************************************************
-
-Copyright (C) 2013 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfxvstructures.h
-
-*******************************************************************************/
+// Copyright (c) 2017 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 #include "mfxstructures.h"
 
 

--- a/plugins/obs-qsv11/libmfx/src/main.cpp
+++ b/plugins/obs-qsv11/libmfx/src/main.cpp
@@ -1,32 +1,25 @@
-/* ****************************************************************************** *\
+// Copyright (c) 2012-2020 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
-Copyright (C) 2012-2018 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: main.cpp
-
-\* ****************************************************************************** */
+#include <windows.h>
+#include <stringapiset.h>
 
 #include <new>
 #include <memory>
@@ -36,6 +29,10 @@ File Name: main.cpp
 #include "mfx_dispatcher_log.h"
 #include "mfx_library_iterator.h"
 #include "mfx_critical_section.h"
+
+#if defined(MEDIASDK_UWP_DISPATCHER)
+#include "mfx_dispatcher_uwp.h"
+#endif
 
 #include <string.h> /* for memset on Linux */
 
@@ -70,6 +67,13 @@ namespace
         {MFX_LIB_HARDWARE, MFX_IMPL_HARDWARE4, 3},
         {MFX_LIB_SOFTWARE, MFX_IMPL_SOFTWARE,  0},
         {MFX_LIB_SOFTWARE, MFX_IMPL_SOFTWARE | MFX_IMPL_AUDIO,  0},
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+        //MFX_SINGLE_THREAD case
+        {MFX_LIB_HARDWARE, MFX_IMPL_HARDWARE | MFX_IMPL_EXTERNAL_THREADING, 0},
+        {MFX_LIB_HARDWARE, MFX_IMPL_HARDWARE2 | MFX_IMPL_EXTERNAL_THREADING, 1},
+        {MFX_LIB_HARDWARE, MFX_IMPL_HARDWARE3 | MFX_IMPL_EXTERNAL_THREADING, 2},
+        {MFX_LIB_HARDWARE, MFX_IMPL_HARDWARE4 | MFX_IMPL_EXTERNAL_THREADING, 3},
+#endif
     };
 
     const
@@ -91,7 +95,9 @@ namespace
         {4, 4},  // MFX_IMPL_HARDWARE3
         {5, 5},  // MFX_IMPL_HARDWARE4
         {2, 6},  // MFX_IMPL_RUNTIME, same as MFX_IMPL_HARDWARE_ANY
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
         {8, 11},  // MFX_SINGLE_THREAD,
+#endif
         {7, 7}   // MFX_IMPL_AUDIO
     };
 
@@ -101,34 +107,7 @@ namespace
 
 using namespace MFX;
 
-#if defined(MEDIASDK_UWP_LOADER)
-
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
-    //
-    // intel_gfx_api-*.dll calls these functions to do not mix MFXInitEx exposed 
-    // from dispatcher_proc_table.lib with the libmfx[hw/sw] engines' call MFXInitEx
-    //
-
-    mfxStatus InitMediaSDKSession(mfxInitParam par, mfxSession* session)
-    {
-        return MFXInitEx(par, session);
-    }
-
-    mfxStatus DisposeMediaSDKSession(mfxSession session)
-    {
-        return MFXClose(session);
-    }
-
-#ifdef __cplusplus
-}; //extern "C"
-#endif /* __cplusplus */
-
-#endif // defined(MEDIASDK_UWP_LOADER)
-
-#if !defined(MEDIASDK_UWP_PROCTABLE)
+#if !defined(MEDIASDK_UWP_DISPATCHER)
 
 //
 // Implement DLL exposed functions. MFXInit and MFXClose have to do
@@ -136,7 +115,7 @@ extern "C" {
 // All other functions are implemented implicitly.
 //
 
-typedef MFXVector<MFX_DISP_HANDLE*> HandleVector;
+typedef MFXVector<MFX_DISP_HANDLE_EX*> HandleVector;
 typedef MFXVector<mfxStatus>        StatusVector;
 
 struct VectorHandleGuard
@@ -158,11 +137,32 @@ private:
 };
 
 
-int HandleSort (const void * plhs, const void * prhs)
+static int HandleSort (const void * plhs, const void * prhs)
 {
-    const MFX_DISP_HANDLE * lhs = *(const MFX_DISP_HANDLE **)plhs;
-    const MFX_DISP_HANDLE * rhs = *(const MFX_DISP_HANDLE **)prhs;
+    const MFX_DISP_HANDLE_EX * lhs = *(const MFX_DISP_HANDLE_EX **)plhs;
+    const MFX_DISP_HANDLE_EX * rhs = *(const MFX_DISP_HANDLE_EX **)prhs;
 
+    // prefer HW implementation
+    if (lhs->implType != MFX_LIB_HARDWARE && rhs->implType == MFX_LIB_HARDWARE)
+    {
+        return 1;
+    }
+    if (lhs->implType == MFX_LIB_HARDWARE && rhs->implType != MFX_LIB_HARDWARE)
+    {
+        return -1;
+    }
+
+    // prefer integrated GPU
+    if (lhs->mediaAdapterType != MFX_MEDIA_INTEGRATED && rhs->mediaAdapterType == MFX_MEDIA_INTEGRATED)
+    {
+        return 1;
+    }
+    if (lhs->mediaAdapterType == MFX_MEDIA_INTEGRATED && rhs->mediaAdapterType != MFX_MEDIA_INTEGRATED)
+    {
+        return -1;
+    }
+
+    // prefer dll with lower API version
     if (lhs->actualApiVersion < rhs->actualApiVersion)
     {
         return -1;
@@ -185,9 +185,6 @@ int HandleSort (const void * plhs, const void * prhs)
     return 0;
 }
 
-// for LEGACY and UWP_LOADER purposes implementation of MFXinitEx is traditionally loading
-// required libmfx*.dll and fill the array of API functions' with corresponded pointers to instantiated libmfx*.dll
-
 mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
 {
     MFX::MFXAutomaticCriticalSection guard(&dispGuard);
@@ -199,24 +196,26 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
         , par.ExternalThreads
         , session));
 
-    mfxStatus mfxRes;
+    mfxStatus mfxRes = MFX_ERR_UNSUPPORTED;
     HandleVector allocatedHandle;
     VectorHandleGuard handleGuard(allocatedHandle);
 
-    MFX_DISP_HANDLE *pHandle;
-    msdk_disp_char dllName[MFX_MAX_DLL_PATH] = { 0 };
+    MFX_DISP_HANDLE_EX *pHandle;
+    wchar_t dllName[MFX_MAX_DLL_PATH] = { 0 };
     MFX::MFXLibraryIterator libIterator;
 
     // there iterators are used only if the caller specified implicit type like AUTO
     mfxU32 curImplIdx, maxImplIdx;
-    // particular implementation value
-    mfxIMPL curImpl;
     // implementation method masked from the input parameter
     // special case for audio library
     const mfxIMPL implMethod = (par.Implementation & MFX_IMPL_AUDIO) ? (sizeof(implTypesRange) / sizeof(implTypesRange[0]) - 1) : (par.Implementation & (MFX_IMPL_VIA_ANY - 1));
 
     // implementation interface masked from the input parameter
     mfxIMPL implInterface = par.Implementation & -MFX_IMPL_VIA_ANY;
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    bool isSingleThread = (implInterface & MFX_IMPL_EXTERNAL_THREADING) > 0;
+    implInterface &= ~MFX_IMPL_EXTERNAL_THREADING;
+#endif
     mfxIMPL implInterfaceOrig = implInterface;
     mfxVersion requiredVersion = {{MFX_VERSION_MINOR, MFX_VERSION_MAJOR}};
 
@@ -225,7 +224,12 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
     {
         return MFX_ERR_NULL_PTR;
     }
+
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    if (((MFX_IMPL_AUTO > implMethod) || (MFX_IMPL_SINGLE_THREAD < implMethod)) && !(par.Implementation & MFX_IMPL_AUDIO))
+#else
     if (((MFX_IMPL_AUTO > implMethod) || (MFX_IMPL_RUNTIME < implMethod)) && !(par.Implementation & MFX_IMPL_AUDIO))
+#endif
     {
         return MFX_ERR_UNSUPPORTED;
     }
@@ -239,7 +243,7 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
         *session = 0;
 
         // allocate the dispatching handle and call-table
-        pHandle = new MFX_DISP_HANDLE(requiredVersion);
+        pHandle = new MFX_DISP_HANDLE_EX(requiredVersion);
     }
     catch(...)
     {
@@ -247,16 +251,30 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
     }
 
     DISPATCHER_LOG_INFO((("Required API version is %u.%u\n"), requiredVersion.Major, requiredVersion.Minor));
+    // particular implementation value
+    mfxIMPL curImpl;
 
     // Load HW library or RT from system location
     curImplIdx = implTypesRange[implMethod].minIndex;
     maxImplIdx = implTypesRange[implMethod].maxIndex;
     do
     {
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+        if (isSingleThread && implTypes[curImplIdx].implType != MFX_LIB_HARDWARE)
+            continue;
+#endif
+
         int currentStorage = MFX::MFX_STORAGE_ID_FIRST;
         implInterface = implInterfaceOrig;
         do
         {
+            // this storage will be checked below
+            if (currentStorage == MFX::MFX_APP_FOLDER)
+            {
+                currentStorage += 1;
+                continue;
+            }
+
             // initialize the library iterator
             mfxRes = libIterator.Init(implTypes[curImplIdx].implType,
                 implInterface,
@@ -289,22 +307,39 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
                     {
                         break;
                     }
-                    DISPATCHER_LOG_INFO((("loading library %S\n"), MSDK2WIDE(dllName)));
+                    DISPATCHER_LOG_INFO((("loading library %S\n"), dllName));
                     // try to load the selected DLL
                     curImpl = implTypes[curImplIdx].impl;
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+                    if (isSingleThread)
+                        curImpl |= MFX_IMPL_EXTERNAL_THREADING;
+#endif
                     mfxRes = pHandle->LoadSelectedDLL(dllName, implType, curImpl, implInterface, par);
                     // unload the failed DLL
                     if (MFX_ERR_NONE != mfxRes)
                     {
                         pHandle->Close();
+                        continue;
                     }
-                    else
+
+                    mfxPlatform platform = { MFX_PLATFORM_UNKNOWN, 0, MFX_MEDIA_UNKNOWN };
+                    if (pHandle->callTable[eMFXVideoCORE_QueryPlatform])
                     {
-                        libIterator.GetSubKeyName(pHandle->subkeyName, sizeof(pHandle->subkeyName) / sizeof(pHandle->subkeyName[0]));
-                        pHandle->storageID = libIterator.GetStorageID();
-                        allocatedHandle.push_back(pHandle);
-                        pHandle = new MFX_DISP_HANDLE(requiredVersion);
+                        mfxRes = MFXVideoCORE_QueryPlatform((mfxSession)pHandle, &platform);
+                        if (MFX_ERR_NONE != mfxRes)
+                        {
+                            DISPATCHER_LOG_WRN(("MFXVideoCORE_QueryPlatform failed, rejecting loaded library\n"));
+                            pHandle->Close();
+                            continue;
+                        }
                     }
+                    pHandle->mediaAdapterType = platform.MediaAdapterType;
+                    DISPATCHER_LOG_INFO((("media adapter type is %d\n"), pHandle->mediaAdapterType));
+
+                    libIterator.GetSubKeyName(pHandle->subkeyName, sizeof(pHandle->subkeyName) / sizeof(pHandle->subkeyName[0]));
+                    pHandle->storageID = libIterator.GetStorageID();
+                    allocatedHandle.push_back(pHandle);
+                    pHandle = new MFX_DISP_HANDLE_EX(requiredVersion);
 
                 } while (MFX_ERR_NONE != mfxRes);
             }
@@ -314,18 +349,19 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
 
         } while ((MFX_ERR_NONE != mfxRes) && (MFX::MFX_STORAGE_ID_LAST >= currentStorage));
 
-    } while ((MFX_ERR_NONE != mfxRes) && (++curImplIdx <= maxImplIdx));
-
+    } while (++curImplIdx <= maxImplIdx);
 
     curImplIdx = implTypesRange[implMethod].minIndex;
     maxImplIdx = implTypesRange[implMethod].maxIndex;
 
-    // SOLID dispatcher checks if there are other available media sdk engines implementations in working dir
-    // UWP dispatcher does not use libraries other than in System32 folder
-#if !defined(MEDIASDK_UWP_LOADER)
     // Load RT from app folder (libmfxsw64 with API >= 1.10)
     do
     {
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+        if (isSingleThread && implTypes[curImplIdx].implType != MFX_LIB_HARDWARE)
+            continue;
+#endif
+
         implInterface = implInterfaceOrig;
         // initialize the library iterator
         mfxRes = libIterator.Init(implTypes[curImplIdx].implType,
@@ -357,10 +393,14 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
                 {
                     break;
                 }
-                DISPATCHER_LOG_INFO((("loading library %S\n"), MSDK2WIDE(dllName)));
+                DISPATCHER_LOG_INFO((("loading library %S\n"), dllName));
 
                 // try to load the selected DLL
                 curImpl = implTypes[curImplIdx].impl;
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+                if (isSingleThread)
+                    curImpl |= MFX_IMPL_EXTERNAL_THREADING;
+#endif
                 mfxRes = pHandle->LoadSelectedDLL(dllName, implType, curImpl, implInterface, par);
                 // unload the failed DLL
                 if (MFX_ERR_NONE != mfxRes)
@@ -377,20 +417,23 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
                     }
                     pHandle->storageID = MFX::MFX_UNKNOWN_KEY;
                     allocatedHandle.push_back(pHandle);
-                    pHandle = new MFX_DISP_HANDLE(requiredVersion);
+                    pHandle = new MFX_DISP_HANDLE_EX(requiredVersion);
                 }
 
             } while (MFX_ERR_NONE != mfxRes);
         }
     } while ((MFX_ERR_NONE != mfxRes) && (++curImplIdx <= maxImplIdx));
 
-#endif // !defined(MEDIASDK_UWP_LOADER)
-
     // Load HW and SW libraries using legacy default DLL search mechanism
     // set current library index again
     curImplIdx = implTypesRange[implMethod].minIndex;
     do
     {
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+        if (isSingleThread && implTypes[curImplIdx].implType != MFX_LIB_HARDWARE)
+            continue;
+#endif
+
         implInterface = implInterfaceOrig;
 
         if (par.Implementation & MFX_IMPL_AUDIO)
@@ -408,7 +451,7 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
 
         if (MFX_ERR_NONE == mfxRes)
         {
-            DISPATCHER_LOG_INFO((("loading default library %S\n"), MSDK2WIDE(dllName)))
+            DISPATCHER_LOG_INFO((("loading default library %S\n"), dllName))
 
                 // try to load the selected DLL using default DLL search mechanism
                 if (MFX_LIB_HARDWARE == implTypes[curImplIdx].implType)
@@ -424,10 +467,15 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
                 }
                 if (MFX_ERR_NONE == mfxRes)
                 {
+                    curImpl = implTypes[curImplIdx].impl;
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+                    if (isSingleThread)
+                        curImpl |= MFX_IMPL_EXTERNAL_THREADING;
+#endif
                     // try to load the selected DLL using default DLL search mechanism
                     mfxRes = pHandle->LoadSelectedDLL(dllName,
                         implTypes[curImplIdx].implType,
-                        implTypes[curImplIdx].impl,
+                        curImpl,
                         implInterface,
                         par);
                 }
@@ -441,7 +489,7 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
                 {
                     pHandle->storageID = MFX::MFX_UNKNOWN_KEY;
                     allocatedHandle.push_back(pHandle);
-                    pHandle = new MFX_DISP_HANDLE(requiredVersion);
+                    pHandle = new MFX_DISP_HANDLE_EX(requiredVersion);
                 }
         }
     }
@@ -460,9 +508,9 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
             if (HandleSort(&(*first), &(*it)) != 0)
                 NeedSort = true;
 
-        // select dll with version with lowest version number still greater or equal to requested
+        // sort allocatedHandle so that the most preferred dll is at the beginning
         if (NeedSort)
-            qsort(&(*allocatedHandle.begin()), allocatedHandle.size(), sizeof(MFX_DISP_HANDLE*), &HandleSort);
+            qsort(&(*allocatedHandle.begin()), allocatedHandle.size(), sizeof(MFX_DISP_HANDLE_EX*), &HandleSort);
     }
     HandleVector::iterator candidate = allocatedHandle.begin();
     // check the final result of loading
@@ -470,7 +518,7 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
     {
         pHandle = *candidate;
         //pulling up current mediasdk version, that required to match plugin version
-        mfxVersion apiVerActual = { 0 };
+        mfxVersion apiVerActual = { { 0, 0 } };
         mfxStatus stsQueryVersion = MFXQueryVersion((mfxSession)pHandle, &apiVerActual);
 
         if (MFX_ERR_NONE !=  stsQueryVersion)
@@ -504,14 +552,11 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
                 hive.insert(hive.end(), plgsInHive.begin(), plgsInHive.end());
             }
 
-#if defined(MEDIASDK_USE_CFGFILES) || !defined(MEDIASDK_UWP_LOADER)
             // SOLID dispatcher also loads plug-ins from file system
             MFX::MFXPluginsInFS plgsInFS(apiVerActual);
             hive.insert(hive.end(), plgsInFS.begin(), plgsInFS.end());
-#endif // defined(MEDIASDK_USE_CFGFILES) || !defined(MEDIASDK_UWP_LOADER)
         }
 
-        // UWP dispatcher uses stubs
         pHandle->callPlugInsTable[eMFXVideoUSER_Load] = (mfxFunctionPointer)MFXVideoUSER_Load;
         pHandle->callPlugInsTable[eMFXVideoUSER_LoadByPath] = (mfxFunctionPointer)MFXVideoUSER_LoadByPath;
         pHandle->callPlugInsTable[eMFXVideoUSER_UnLoad] = (mfxFunctionPointer)MFXVideoUSER_UnLoad;
@@ -526,7 +571,41 @@ mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
 
     // everything is OK. Save pointers to the output variable
     *candidate = 0; // keep this one safe from guard destructor
-    *((MFX_DISP_HANDLE **) session) = pHandle;
+
+
+    //===================================
+
+    // MFXVideoCORE_QueryPlatform call creates d3d device handle, so we have handle right after MFXInit and can't accept external handle
+    // This is a workaround which calls close-init to remove that handle
+
+    mfxFunctionPointer *actualTable = (pHandle->impl & MFX_IMPL_AUDIO) ? pHandle->callAudioTable : pHandle->callTable;
+    mfxFunctionPointer pFunc;
+
+    pFunc = actualTable[eMFXClose];
+    mfxRes = (*(mfxStatus(MFX_CDECL *) (mfxSession)) pFunc) (pHandle->session);
+    if (mfxRes != MFX_ERR_NONE)
+        return mfxRes;
+
+    pHandle->session = 0;
+    bool callOldInit = (pHandle->impl & MFX_IMPL_AUDIO) || !actualTable[eMFXInitEx];
+    pFunc = actualTable[(callOldInit) ? eMFXInit : eMFXInitEx];
+
+    mfxVersion version(pHandle->apiVersion);
+    if (callOldInit)
+    {
+        pHandle->loadStatus = (*(mfxStatus(MFX_CDECL *) (mfxIMPL, mfxVersion *, mfxSession *)) pFunc) (pHandle->impl | pHandle->implInterface, &version, &pHandle->session);
+    }
+    else
+    {
+        mfxInitParam initPar = par;
+        initPar.Implementation = pHandle->impl | pHandle->implInterface;
+        initPar.Version = version;
+        pHandle->loadStatus = (*(mfxStatus(MFX_CDECL *) (mfxInitParam, mfxSession *)) pFunc) (initPar, &pHandle->session);
+    }
+
+    //===================================
+
+    *((MFX_DISP_HANDLE_EX **) session) = pHandle;
 
     return pHandle->loadStatus;
 
@@ -569,12 +648,12 @@ mfxStatus MFXVideoUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32 
 {
     mfxStatus sts = MFX_ERR_NONE;
     bool ErrFlag = false;
-    MFX_DISP_HANDLE &pHandle = *(MFX_DISP_HANDLE *) session;
-    if (!&pHandle)
+    if (!session)
     {
         DISPATCHER_LOG_ERROR((("MFXVideoUSER_Load: session=NULL\n")));
         return MFX_ERR_NULL_PTR;
     }
+    MFX_DISP_HANDLE &pHandle = *(MFX_DISP_HANDLE *) session;
     if (!uid)
     {
         DISPATCHER_LOG_ERROR((("MFXVideoUSER_Load: uid=NULL\n")));
@@ -649,12 +728,12 @@ mfxStatus MFXVideoUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32 
 
 mfxStatus MFXVideoUSER_LoadByPath(mfxSession session, const mfxPluginUID *uid, mfxU32 version, const mfxChar *path, mfxU32 len)
 {
-    MFX_DISP_HANDLE &pHandle = *(MFX_DISP_HANDLE *) session;
-    if (!&pHandle)
+    if (!session)
     {
         DISPATCHER_LOG_ERROR((("MFXVideoUSER_LoadByPath: session=NULL\n")));
         return MFX_ERR_NULL_PTR;
     }
+    MFX_DISP_HANDLE &pHandle = *(MFX_DISP_HANDLE *) session;
     if (!uid)
     {
         DISPATCHER_LOG_ERROR((("MFXVideoUSER_LoadByPath: uid=NULL\n")));
@@ -662,27 +741,24 @@ mfxStatus MFXVideoUSER_LoadByPath(mfxSession session, const mfxPluginUID *uid, m
     }
 
     DISPATCHER_LOG_INFO((("MFXVideoUSER_LoadByPath: %S uid=" MFXGUIDTYPE()" version=%d\n")
-        , MSDK2WIDE(path)
+        , path
         , MFXGUIDTOHEX(uid)
         , version))
 
     PluginDescriptionRecord record;
     record.sName[0] = 0;
 
-#ifdef _WIN32
-    msdk_disp_char wPath[MAX_PLUGIN_PATH];
-    int res = ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, len<MAX_PLUGIN_PATH-1 ? len : MAX_PLUGIN_PATH-1, wPath, MAX_PLUGIN_PATH);
-    wPath[res]=0;
+    wchar_t wPath[MAX_PLUGIN_PATH];
+    int res = ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, len, wPath, MAX_PLUGIN_PATH-1);
 
     if (!res)
     {
-        DISPATCHER_LOG_ERROR((("MFXVideoUSER_LoadByPath: cant convert UTF-8 path to UTF-16\n")));
+        DISPATCHER_LOG_ERROR((("MFXVideoUSER_LoadByPath: can't convert UTF-8 path to UTF-16\n")));
         return MFX_ERR_NOT_FOUND;
     }
-    msdk_disp_char_cpy_s(record.sPath, MAX_PLUGIN_PATH, wPath);
-#else // Linux/Android
-    msdk_disp_char_cpy_s(record.sPath, MAX_PLUGIN_PATH, path);
-#endif
+    wPath[res]=0;
+
+    wcscpy_s(record.sPath, MAX_PLUGIN_PATH, wPath);
 
     record.PluginUID = *uid;
     record.PluginVersion = (mfxU16)version;
@@ -701,12 +777,12 @@ mfxStatus MFXVideoUSER_LoadByPath(mfxSession session, const mfxPluginUID *uid, m
 
 mfxStatus MFXVideoUSER_UnLoad(mfxSession session, const mfxPluginUID *uid)
 {
-    MFX_DISP_HANDLE &rHandle = *(MFX_DISP_HANDLE *) session;
-    if (!&rHandle)
+    if (!session)
     {
         DISPATCHER_LOG_ERROR((("MFXVideoUSER_UnLoad: session=NULL\n")));
         return MFX_ERR_NULL_PTR;
     }
+    MFX_DISP_HANDLE &rHandle = *(MFX_DISP_HANDLE *) session;
     if (!uid)
     {
         DISPATCHER_LOG_ERROR((("MFXVideoUSER_UnLoad: uid=NULL\n")));
@@ -727,12 +803,12 @@ mfxStatus MFXVideoUSER_UnLoad(mfxSession session, const mfxPluginUID *uid)
 
 mfxStatus MFXAudioUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32 version)
 {
-    MFX_DISP_HANDLE &pHandle = *(MFX_DISP_HANDLE *) session;
-    if (!&pHandle)
+    if (!session)
     {
         DISPATCHER_LOG_ERROR((("MFXAudioUSER_Load: session=NULL\n")));
         return MFX_ERR_NULL_PTR;
     }
+    MFX_DISP_HANDLE &pHandle = *(MFX_DISP_HANDLE *) session;
     if (!uid)
     {
         DISPATCHER_LOG_ERROR((("MFXAudioUSER_Load: uid=NULL\n")));
@@ -789,12 +865,12 @@ mfxStatus MFXAudioUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32 
 
 mfxStatus MFXAudioUSER_UnLoad(mfxSession session, const mfxPluginUID *uid)
 {
-    MFX_DISP_HANDLE &rHandle = *(MFX_DISP_HANDLE *) session;
-    if (!&rHandle)
+    if (!session)
     {
         DISPATCHER_LOG_ERROR((("MFXAudioUSER_UnLoad: session=NULL\n")));
         return MFX_ERR_NULL_PTR;
     }
+    MFX_DISP_HANDLE &rHandle = *(MFX_DISP_HANDLE *) session;
     if (!uid)
     {
         DISPATCHER_LOG_ERROR((("MFXAudioUSER_Load: uid=NULL\n")));
@@ -812,30 +888,74 @@ mfxStatus MFXAudioUSER_UnLoad(mfxSession session, const mfxPluginUID *uid)
 
     return bDestroyed ? MFX_ERR_NONE : MFX_ERR_NOT_FOUND;
 }
-#else // relates to !defined (MEDIASDK_UWP_PROCTABLE) from line 137, i.e. #else part as if MEDIASDK_UWP_PROCTABLE defined
+#else // relates to !defined (MEDIASDK_UWP_DISPATCHER), i.e. #else part as if MEDIASDK_UWP_DISPATCHER defined
 
-#include <windows.h>
-#include "intel_api_factory.h"
+static mfxModuleHandle hModule;
 
-// for the UWP_PROCTABLE purposes implementation of MFXinitEx is calling
-// InitializeInstance() implemented in intel_uwp-api.dll
+// for the UWP_DISPATCHER purposes implementation of MFXinitEx is calling
+// InitialiseMediaSession() implemented in intel_gfx_api.dll
 mfxStatus MFXInitEx(mfxInitParam par, mfxSession *session)
 {
-    HRESULT hr = InitialiseMediaSession((HANDLE*)session, &par, nullptr);
-    return (hr == S_OK) ? mfxStatus::MFX_ERR_NONE : (mfxStatus)hr;
+#if defined(MEDIASDK_ARM_LOADER)
+
+    return MFX_ERR_UNSUPPORTED;
+
+#else
+
+    wchar_t IntelGFXAPIdllName[MFX_MAX_DLL_PATH] = { 0 };
+    mfxI32 adapterNum = -1;
+
+    switch (par.Implementation & 0xf)
+    {
+    case MFX_IMPL_SOFTWARE:
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    case MFX_IMPL_SINGLE_THREAD:
+#endif
+        return MFX_ERR_UNSUPPORTED;
+    case MFX_IMPL_AUTO:
+    case MFX_IMPL_HARDWARE:
+        adapterNum = 0;
+        break;
+    case MFX_IMPL_HARDWARE2:
+        adapterNum = 1;
+        break;
+    case MFX_IMPL_HARDWARE3:
+        adapterNum = 2;
+        break;
+    case MFX_IMPL_HARDWARE4:
+        adapterNum = 3;
+        break;
+    default:
+        return GfxApiInitPriorityIntegrated(par, session, hModule);
+    }
+
+    return GfxApiInitByAdapterNum(par, adapterNum, session, hModule);
+
+#endif
 }
 
-// for the UWP_PROCTABLE purposes implementation of MFXClose is calling
-// DisposeInstance() implemented in intel_uwp-api.dll
+// for the UWP_DISPATCHER purposes implementation of MFXClose is calling
+// DisposeMediaSession() implemented in intel_gfx_api.dll
 mfxStatus MFXClose(mfxSession session)
 {
-    if (nullptr == session) {
+    if (NULL == session) {
         return MFX_ERR_INVALID_HANDLE;
     }
 
-    HRESULT hr = DisposeMediaSession(HANDLE(session));
+    mfxStatus sts = MFX_ERR_NONE;
+
+#if defined(MEDIASDK_ARM_LOADER)
+
+    sts = MFX_ERR_UNSUPPORTED;
+
+#else
+
+    sts = GfxApiClose(session, hModule);
+
+#endif
+
     session = (mfxSession)NULL;
-    return (hr == S_OK) ? MFX_ERR_NONE : mfxStatus(hr);
+    return sts;
 }
 
 #undef FUNCTION
@@ -865,10 +985,7 @@ FUNCTION(mfxStatus, MFXVideoUSER_UnLoad, (mfxSession session, const mfxPluginUID
 FUNCTION(mfxStatus, MFXAudioUSER_Load, (mfxSession session, const mfxPluginUID *uid, mfxU32 version), (session, uid, version))
 FUNCTION(mfxStatus, MFXAudioUSER_UnLoad, (mfxSession session, const mfxPluginUID *uid), (session, uid))
 
-#endif //!defined(MEDIASDK_UWP_PROCTABLE)
-
-
-#if !defined(MEDIASDK_UWP_LOADER)
+#endif //!defined(MEDIASDK_UWP_DISPATCHER)
 
 mfxStatus MFXJoinSession(mfxSession session, mfxSession child_session)
 {
@@ -877,7 +994,7 @@ mfxStatus MFXJoinSession(mfxSession session, mfxSession child_session)
     MFX_DISP_HANDLE *pChildHandle = (MFX_DISP_HANDLE *)child_session;
 
     // get the function's address and make a call
-    if ((pHandle) && (pChildHandle) && (pHandle->apiVersion == pChildHandle->apiVersion))
+    if ((pHandle) && (pChildHandle) && (pHandle->actualApiVersion == pChildHandle->actualApiVersion))
     {
         /* check whether it is audio session or video */
         int tableIndex = eMFXJoinSession;
@@ -935,8 +1052,6 @@ mfxStatus MFXCloneSession(mfxSession session, mfxSession *clone)
     return mfxRes;
 
 } // mfxStatus MFXCloneSession(mfxSession session, mfxSession *clone)
-
-#endif // !defined(MEDIASDK_UWP_LOADER)
 
 mfxStatus MFXInit(mfxIMPL impl, mfxVersion *pVer, mfxSession *session)
 {
@@ -998,15 +1113,12 @@ mfxStatus MFXInit(mfxIMPL impl, mfxVersion *pVer, mfxSession *session)
 FUNCTION(mfxStatus, MFXQueryIMPL, (mfxSession session, mfxIMPL *impl), (session, impl))
 FUNCTION(mfxStatus, MFXQueryVersion, (mfxSession session, mfxVersion *version), (session, version))
 
-#if !defined(MEDIASDK_UWP_LOADER)
 // these functions are not necessary in LOADER part of dispatcher and
 // need to be included only in in SOLID dispatcher or PROCTABLE part of dispatcher
 
 FUNCTION(mfxStatus, MFXDisjoinSession, (mfxSession session), (session))
 FUNCTION(mfxStatus, MFXSetPriority, (mfxSession session, mfxPriority priority), (session, priority))
 FUNCTION(mfxStatus, MFXGetPriority, (mfxSession session, mfxPriority *priority), (session, priority))
-
-#endif // !defined(MEDIASDK_UWP_LOADER)
 
 #undef FUNCTION
 #define FUNCTION(return_value, func_name, formal_param_list, actual_param_list) \

--- a/plugins/obs-qsv11/libmfx/src/mfx_critical_section.cpp
+++ b/plugins/obs-qsv11/libmfx/src/mfx_critical_section.cpp
@@ -1,36 +1,24 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2013 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_critical_section.cpp
-
-\* ****************************************************************************** */
+// Copyright (c) 2012-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #include "mfx_critical_section.h"
-
-#if defined(_WIN32) || defined(_WIN64)
 
 #include <windows.h>
 // SDK re-declares the following functions with different call declarator.
@@ -84,5 +72,3 @@ void mfxLeaveCriticalSection(mfxCriticalSection *pCSection)
 } // void mfxLeaveCriticalSection(mfxCriticalSection *pCSection)
 
 } // namespace MFX
-
-#endif // #if defined(_WIN32) || defined(_WIN64)

--- a/plugins/obs-qsv11/libmfx/src/mfx_dispatcher.cpp
+++ b/plugins/obs-qsv11/libmfx/src/mfx_dispatcher.cpp
@@ -1,32 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2018 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_dispatcher.cpp
-
-\* ****************************************************************************** */
+// Copyright (c) 2012-2020 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #include "mfx_dispatcher.h"
 #include "mfx_dispatcher_log.h"
@@ -35,18 +25,20 @@ File Name: mfx_dispatcher.cpp
 #include <assert.h>
 
 #include <string.h>
-#if defined(_WIN32) || defined(_WIN64)
-    #include <windows.h>
-    #pragma warning(disable:4355)
-#else
-    #include <dlfcn.h>
-    #include <iostream>
-#endif // defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
 
+#include "mfx_dxva2_device.h"
+#include "mfxvideo++.h"
+#include "mfx_vector.h"
+#include "mfxadapter.h"
+#include <algorithm>
+
+#pragma warning(disable:4355)
 
 MFX_DISP_HANDLE::MFX_DISP_HANDLE(const mfxVersion requiredVersion) :
     _mfxSession()
     ,apiVersion(requiredVersion)
+    ,pluginHive()
     ,pluginFactory((mfxSession)this)
 {
     actualApiVersion.Version = 0;
@@ -74,7 +66,7 @@ mfxStatus MFX_DISP_HANDLE::Close(void)
 
     mfxRes = UnLoadSelectedDLL();
 
-    // the library wasn't unloaded
+    // need to reset dispatcher state after unloading dll
     if (MFX_ERR_NONE == mfxRes)
     {
         implType = MFX_LIB_SOFTWARE;
@@ -90,7 +82,7 @@ mfxStatus MFX_DISP_HANDLE::Close(void)
 
 } // mfxStatus MFX_DISP_HANDLE::Close(void)
 
-mfxStatus MFX_DISP_HANDLE::LoadSelectedDLL(const msdk_disp_char *pPath, eMfxImplType reqImplType,
+mfxStatus MFX_DISP_HANDLE::LoadSelectedDLL(const wchar_t *pPath, eMfxImplType reqImplType,
                                            mfxIMPL reqImpl, mfxIMPL reqImplInterface, mfxInitParam &par)
 {
     mfxStatus mfxRes = MFX_ERR_NONE;
@@ -105,6 +97,9 @@ mfxStatus MFX_DISP_HANDLE::LoadSelectedDLL(const msdk_disp_char *pPath, eMfxImpl
     }
     // only exact types of implementation is allowed
     if (!(reqImpl & MFX_IMPL_AUDIO) &&
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+        !(reqImpl & MFX_IMPL_EXTERNAL_THREADING) &&
+#endif
         (MFX_IMPL_SOFTWARE != reqImpl) &&
         (MFX_IMPL_HARDWARE != reqImpl) &&
         (MFX_IMPL_HARDWARE2 != reqImpl) &&
@@ -141,7 +136,7 @@ mfxStatus MFX_DISP_HANDLE::LoadSelectedDLL(const msdk_disp_char *pPath, eMfxImpl
 
     {
         assert(hModule == (mfxModuleHandle)0);
-        DISPATCHER_LOG_BLOCK(("invoking LoadLibrary(%S)\n", MSDK2WIDE(pPath)));
+        DISPATCHER_LOG_BLOCK(("invoking LoadLibrary(%S)\n", pPath));
 
         // load the DLL into the memory
         hModule = MFX::mfx_dll_load(pPath);
@@ -151,9 +146,9 @@ mfxStatus MFX_DISP_HANDLE::LoadSelectedDLL(const msdk_disp_char *pPath, eMfxImpl
             int i;
 
             DISPATCHER_LOG_OPERATION({
-                msdk_disp_char modulePath[1024];
+                wchar_t modulePath[1024];
                 GetModuleFileNameW((HMODULE)hModule, modulePath, sizeof(modulePath)/sizeof(modulePath[0]));
-                DISPATCHER_LOG_INFO((("loaded module %S\n"), MSDK2WIDE(modulePath)))
+                DISPATCHER_LOG_INFO((("loaded module %S\n"), modulePath))
             });
 
             if (impl & MFX_IMPL_AUDIO)
@@ -164,10 +159,6 @@ mfxStatus MFX_DISP_HANDLE::LoadSelectedDLL(const msdk_disp_char *pPath, eMfxImpl
                     // construct correct name of the function - remove "_a" postfix
 
                     mfxFunctionPointer pProc = (mfxFunctionPointer) MFX::mfx_dll_get_addr(hModule, APIAudioFunc[i].pName);
-    #ifdef ANDROID
-                    // on Android very first call to dlsym may fail
-                    if (!pProc) pProc = (mfxFunctionPointer) MFX::mfx_dll_get_addr(hModule, APIAudioFunc[i].pName);
-    #endif
                     if (pProc)
                     {
                         // function exists in the library,
@@ -193,10 +184,6 @@ mfxStatus MFX_DISP_HANDLE::LoadSelectedDLL(const msdk_disp_char *pPath, eMfxImpl
                 for (i = 0; i < eVideoFuncTotal; i += 1)
                 {
                     mfxFunctionPointer pProc = (mfxFunctionPointer) MFX::mfx_dll_get_addr(hModule, APIFunc[i].pName);
-    #ifdef ANDROID
-                    // on Android very first call to dlsym may fail
-                    if (!pProc) pProc = (mfxFunctionPointer) MFX::mfx_dll_get_addr(hModule, APIFunc[i].pName);
-    #endif
                     if (pProc)
                     {
                         // function exists in the library,
@@ -219,11 +206,7 @@ mfxStatus MFX_DISP_HANDLE::LoadSelectedDLL(const msdk_disp_char *pPath, eMfxImpl
         }
         else
         {
-#if defined(_WIN32) || defined(_WIN64)
             DISPATCHER_LOG_WRN((("can't find DLL: GetLastErr()=0x%x\n"), GetLastError()))
-#else
-            DISPATCHER_LOG_WRN((("can't find DLL: dlerror() = \"%s\"\n"), dlerror()));
-#endif
             mfxRes = MFX_ERR_UNSUPPORTED;
         }
     }
@@ -295,7 +278,7 @@ mfxStatus MFX_DISP_HANDLE::LoadSelectedDLL(const msdk_disp_char *pPath, eMfxImpl
     loadStatus = mfxRes;
     return mfxRes;
 
-} // mfxStatus MFX_DISP_HANDLE::LoadSelectedDLL(const msdk_disp_char *pPath, eMfxImplType implType, mfxIMPL impl)
+} // mfxStatus MFX_DISP_HANDLE::LoadSelectedDLL(const wchar_t *pPath, eMfxImplType implType, mfxIMPL impl)
 
 mfxStatus MFX_DISP_HANDLE::UnLoadSelectedDLL(void)
 {
@@ -345,3 +328,334 @@ mfxStatus MFX_DISP_HANDLE::UnLoadSelectedDLL(void)
     return mfxRes;
 
 } // mfxStatus MFX_DISP_HANDLE::UnLoadSelectedDLL(void)
+
+
+MFX_DISP_HANDLE_EX::MFX_DISP_HANDLE_EX(const mfxVersion requiredVersion)
+    : MFX_DISP_HANDLE(requiredVersion)
+    , mediaAdapterType(MFX_MEDIA_UNKNOWN)
+{}
+
+
+#if (defined(_WIN64) || defined(_WIN32)) && (MFX_VERSION >= 1031)
+static mfxStatus InitDummySession(mfxU32 adapter_n, MFXVideoSession & dummy_session)
+{
+    mfxInitParam initPar;
+    memset(&initPar, 0, sizeof(initPar));
+
+    initPar.Version.Major = 1;
+    initPar.Version.Minor = 0;
+
+    switch (adapter_n)
+    {
+    case 0:
+        initPar.Implementation = MFX_IMPL_HARDWARE;
+        break;
+    case 1:
+        initPar.Implementation = MFX_IMPL_HARDWARE2;
+        break;
+    case 2:
+        initPar.Implementation = MFX_IMPL_HARDWARE3;
+        break;
+    case 3:
+        initPar.Implementation = MFX_IMPL_HARDWARE4;
+        break;
+
+    default:
+        // try searching on all display adapters
+        initPar.Implementation = MFX_IMPL_HARDWARE_ANY;
+        break;
+    }
+
+    initPar.Implementation |= MFX_IMPL_VIA_D3D11;
+
+    return dummy_session.InitEx(initPar);
+}
+
+static inline bool is_iGPU(const mfxAdapterInfo& adapter_info)
+{
+    return adapter_info.Platform.MediaAdapterType == MFX_MEDIA_INTEGRATED;
+}
+
+static inline bool is_dGPU(const mfxAdapterInfo& adapter_info)
+{
+    return adapter_info.Platform.MediaAdapterType == MFX_MEDIA_DISCRETE;
+}
+
+// This function implies that iGPU has higher priority
+static inline mfxI32 iGPU_priority(const void* ll, const void* rr)
+{
+    const mfxAdapterInfo& l = *(reinterpret_cast<const mfxAdapterInfo*>(ll));
+    const mfxAdapterInfo& r = *(reinterpret_cast<const mfxAdapterInfo*>(rr));
+
+    if (is_iGPU(l) && is_iGPU(r) || is_dGPU(l) && is_dGPU(r))
+        return 0;
+
+    if (is_iGPU(l) && is_dGPU(r))
+        return -1;
+
+    // The only combination left is_dGPU(l) && is_iGPU(r))
+    return 1;
+}
+
+
+static void RearrangeInPriorityOrder(const mfxComponentInfo & info, MFX::MFXVector<mfxAdapterInfo> & vec)
+{
+	(void)info;
+    {
+        // Move iGPU to top priority
+        qsort(vec.data(), vec.size(), sizeof(mfxAdapterInfo), &iGPU_priority);
+    }
+}
+
+static mfxStatus PrepareAdaptersInfo(const mfxComponentInfo * info, MFX::MFXVector<mfxAdapterInfo> & vec, mfxAdaptersInfo& adapters)
+{
+    // No suitable adapters on system to handle user's workload
+    if (vec.empty())
+    {
+        adapters.NumActual = 0;
+        return MFX_ERR_NOT_FOUND;
+    }
+
+    if (info)
+    {
+        RearrangeInPriorityOrder(*info, vec);
+    }
+
+    mfxU32 num_to_copy = (std::min)(mfxU32(vec.size()), adapters.NumAlloc);
+    for (mfxU32 i = 0; i < num_to_copy; ++i)
+    {
+        adapters.Adapters[i] = vec[i];
+    }
+
+    adapters.NumActual = num_to_copy;
+
+    if (vec.size() > adapters.NumAlloc)
+    {
+        return MFX_WRN_OUT_OF_RANGE;
+    }
+
+    return MFX_ERR_NONE;
+}
+
+static inline bool QueryAdapterInfo(mfxU32 adapter_n, mfxU32& VendorID, mfxU32& DeviceID)
+{
+    MFX::DXVA2Device dxvaDevice;
+
+    if (!dxvaDevice.InitDXGI1(adapter_n))
+        return false;
+
+    VendorID = dxvaDevice.GetVendorID();
+    DeviceID = dxvaDevice.GetDeviceID();
+
+    return true;
+}
+
+static inline mfxU32 MakeVersion(mfxU16 major, mfxU16 minor)
+{
+    return major * 1000 + minor;
+}
+
+mfxStatus MFXQueryAdaptersDecode(mfxBitstream* bitstream, mfxU32 codec_id, mfxAdaptersInfo* adapters)
+{
+    if (!adapters || !bitstream)
+        return MFX_ERR_NULL_PTR;
+
+    MFX::MFXVector<mfxAdapterInfo> obtained_info;
+
+    mfxU32 adapter_n = 0, VendorID, DeviceID;
+
+    mfxComponentInfo input_info;
+    memset(&input_info, 0, sizeof(input_info));
+    input_info.Type                     = mfxComponentType::MFX_COMPONENT_DECODE;
+    input_info.Requirements.mfx.CodecId = codec_id;
+
+    for(;;)
+    {
+        if (!QueryAdapterInfo(adapter_n, VendorID, DeviceID))
+            break;
+
+        ++adapter_n;
+
+        if (VendorID != INTEL_VENDOR_ID)
+            continue;
+
+        // Check if requested capabilities are supported
+        MFXVideoSession dummy_session;
+
+        mfxStatus sts = InitDummySession(adapter_n - 1, dummy_session);
+        if (sts != MFX_ERR_NONE)
+        {
+            continue;
+        }
+
+        mfxVideoParam stream_params, out;
+        memset(&out, 0, sizeof(out));
+        memset(&stream_params, 0, sizeof(stream_params));
+        out.mfx.CodecId = stream_params.mfx.CodecId = codec_id;
+
+        sts = MFXVideoDECODE_DecodeHeader(dummy_session.operator mfxSession(), bitstream, &stream_params);
+
+        if (sts != MFX_ERR_NONE)
+        {
+            continue;
+        }
+
+        sts = MFXVideoDECODE_Query(dummy_session.operator mfxSession(), &stream_params, &out);
+
+        if (sts != MFX_ERR_NONE) // skip MFX_ERR_UNSUPPORTED as well as MFX_WRN_INCOMPATIBLE_VIDEO_PARAM
+            continue;
+
+        mfxAdapterInfo info;
+        memset(&info, 0, sizeof(info));
+
+        //WA for initialization when application built w/ new API, but lib w/ old one.
+        mfxVersion apiVersion;
+        sts = dummy_session.QueryVersion(&apiVersion);
+        if (sts != MFX_ERR_NONE)
+            continue;
+
+        mfxU32 version = MakeVersion(apiVersion.Major, apiVersion.Minor);
+
+        if (version >= 1019)
+        {
+            sts = MFXVideoCORE_QueryPlatform(dummy_session.operator mfxSession(), &info.Platform);
+
+            if (sts != MFX_ERR_NONE)
+            {
+                continue;
+            }
+        }
+        else
+        {
+            // for API versions greater than 1.19 Device id is set inside QueryPlatform call
+            info.Platform.DeviceId = static_cast<mfxU16>(DeviceID);
+        }
+
+        info.Number = adapter_n - 1;
+
+        obtained_info.push_back(info);
+    }
+
+    return PrepareAdaptersInfo(&input_info, obtained_info, *adapters);
+}
+
+mfxStatus MFXQueryAdapters(mfxComponentInfo* input_info, mfxAdaptersInfo* adapters)
+{
+    if (!adapters)
+        return MFX_ERR_NULL_PTR;
+
+    MFX::MFXVector<mfxAdapterInfo> obtained_info;
+    //obtained_info.reserve(adapters->NumAdaptersAlloc);
+
+    mfxU32 adapter_n = 0, VendorID, DeviceID;
+
+    for (;;)
+    {
+        if (!QueryAdapterInfo(adapter_n, VendorID, DeviceID))
+            break;
+
+        ++adapter_n;
+
+        if (VendorID != INTEL_VENDOR_ID)
+            continue;
+
+        // Check if requested capabilities are supported
+        MFXVideoSession dummy_session;
+
+        mfxStatus sts = InitDummySession(adapter_n - 1, dummy_session);
+        if (sts != MFX_ERR_NONE)
+        {
+            continue;
+        }
+
+        // If input_info is NULL just return all Intel adapters and information about them
+        if (input_info)
+        {
+            mfxVideoParam out;
+            memset(&out, 0, sizeof(out));
+
+            switch (input_info->Type)
+            {
+            case mfxComponentType::MFX_COMPONENT_ENCODE:
+                {
+                    out.mfx.CodecId = input_info->Requirements.mfx.CodecId;
+
+                    sts = MFXVideoENCODE_Query(dummy_session.operator mfxSession(), &input_info->Requirements, &out);
+                }
+                break;
+            case mfxComponentType::MFX_COMPONENT_DECODE:
+                {
+                    out.mfx.CodecId = input_info->Requirements.mfx.CodecId;
+
+                    sts = MFXVideoDECODE_Query(dummy_session.operator mfxSession(), &input_info->Requirements, &out);
+                }
+                break;
+            case mfxComponentType::MFX_COMPONENT_VPP:
+                {
+                    sts = MFXVideoVPP_Query(dummy_session.operator mfxSession(), &input_info->Requirements, &out);
+                }
+                break;
+            default:
+                sts = MFX_ERR_UNSUPPORTED;
+            }
+        }
+
+        if (sts != MFX_ERR_NONE) // skip MFX_ERR_UNSUPPORTED as well as MFX_WRN_INCOMPATIBLE_VIDEO_PARAM
+            continue;
+
+        mfxAdapterInfo info;
+        memset(&info, 0, sizeof(info));
+
+        //WA for initialization when application built w/ new API, but lib w/ old one.
+        mfxVersion apiVersion;
+        sts = dummy_session.QueryVersion(&apiVersion);
+        if (sts != MFX_ERR_NONE)
+            continue;
+
+        mfxU32 version = MakeVersion(apiVersion.Major, apiVersion.Minor);
+
+        if (version >= 1019)
+        {
+            sts = MFXVideoCORE_QueryPlatform(dummy_session.operator mfxSession(), &info.Platform);
+
+            if (sts != MFX_ERR_NONE)
+            {
+                continue;
+            }
+        }
+        else
+        {
+            // for API versions greater than 1.19 Device id is set inside QueryPlatform call
+            info.Platform.DeviceId = static_cast<mfxU16>(DeviceID);
+        }
+
+        info.Number = adapter_n - 1;
+
+        obtained_info.push_back(info);
+    }
+
+    return PrepareAdaptersInfo(input_info, obtained_info, *adapters);
+}
+
+mfxStatus MFXQueryAdaptersNumber(mfxU32* num_adapters)
+{
+    if (!num_adapters)
+        return MFX_ERR_NULL_PTR;
+
+    mfxU32 intel_adapter_count = 0, VendorID, DeviceID;
+
+    for (mfxU32 cur_adapter = 0; ; ++cur_adapter)
+    {
+        if (!QueryAdapterInfo(cur_adapter, VendorID, DeviceID))
+            break;
+
+        if (VendorID == INTEL_VENDOR_ID)
+            ++intel_adapter_count;
+    }
+
+    *num_adapters = intel_adapter_count;
+
+    return MFX_ERR_NONE;
+}
+
+#endif // (defined(_WIN64) || defined(_WIN32)) && (MFX_VERSION >= 1031)

--- a/plugins/obs-qsv11/libmfx/src/mfx_dispatcher_log.cpp
+++ b/plugins/obs-qsv11/libmfx/src/mfx_dispatcher_log.cpp
@@ -1,44 +1,32 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2014 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_dispatcher_log.h
-
-\* ****************************************************************************** */
+// Copyright (c) 2012-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #if defined(MFX_DISPATCHER_LOG)
 
 #include "mfx_dispatcher_log.h"
 #include "mfxstructures.h"
-#if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 #if defined(DISPATCHER_LOG_REGISTER_EVENT_PROVIDER)
 #include <evntprov.h>
 #include <winmeta.h>
 #endif
-#endif // #if defined(_WIN32) || defined(_WIN64)
 #include <stdarg.h>
 #include <algorithm>
 #include <string>

--- a/plugins/obs-qsv11/libmfx/src/mfx_driver_store_loader.cpp
+++ b/plugins/obs-qsv11/libmfx/src/mfx_driver_store_loader.cpp
@@ -1,0 +1,218 @@
+// Copyright (c) 2019-2020 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <tchar.h>
+
+#include "mfx_driver_store_loader.h"
+#include "mfx_dispatcher_log.h"
+#include "mfx_load_dll.h"
+
+namespace MFX
+{
+
+
+inline bool IsIntelDeviceInstanceID(const wchar_t * DeviceID)
+{
+    return wcsstr(DeviceID, L"VEN_8086") || wcsstr(DeviceID, L"ven_8086");
+}
+
+inline bool ExctractDeviceID(const wchar_t* descrString, mfxU32& deviceID)
+{
+    const wchar_t *begin = wcsstr(descrString, L"DEV_");
+
+    if (!begin)
+    {
+        begin = wcsstr(descrString, L"dev_");
+        if (!begin)
+        {
+            DISPATCHER_LOG_WRN(("exctracting device id: failed to find device id substring\n"));
+            return false;
+        }
+    }
+
+    begin += wcslen(L"DEV_");
+    deviceID = wcstoul(begin, NULL, 16);
+    if (!deviceID)
+    {
+        DISPATCHER_LOG_WRN(("exctracting device id: failed to convert device id str to int\n"));
+        return false;
+    }
+
+    return true;
+}
+
+
+
+DriverStoreLoader::DriverStoreLoader(void)
+    : m_moduleCfgMgr(NULL)
+    , m_pCM_Get_Device_ID_List_Size(NULL)
+    , m_pCM_Get_Device_ID_List(NULL)
+    , m_pCM_Locate_DevNode(NULL)
+    , m_pCM_Open_DevNode_Key(NULL)
+{
+}
+
+DriverStoreLoader::~DriverStoreLoader(void)
+{
+}
+
+bool DriverStoreLoader::GetDriverStorePath(wchar_t * path, DWORD dwPathSize, mfxU32 deviceID)
+{
+    if (path == NULL || dwPathSize == 0)
+    {
+        return false;
+    }
+
+    // Obtain a PnP handle to the Intel graphics adapter
+    CONFIGRET    result = CR_SUCCESS;
+    ULONG        DeviceIDListSize = 0;
+    MFXVector<WCHAR> DeviceIDList;
+    wchar_t      DisplayGUID[40];
+    DEVINST      DeviceInst;
+
+    DISPATCHER_LOG_INFO(("Looking for MediaSDK in DriverStore\n"));
+
+    if (!LoadCfgMgr() || !LoadCmFuncs())
+    {
+        return false;
+    }
+
+    if (StringFromGUID2(GUID_DEVCLASS_DISPLAY, DisplayGUID, sizeof(DisplayGUID)) == 0)
+    {
+        DISPATCHER_LOG_WRN(("Couldn't prepare string from GUID\n"));
+        return false;
+    }
+
+    do
+    {
+        result = m_pCM_Get_Device_ID_List_Size(&DeviceIDListSize, DisplayGUID, CM_GETIDLIST_FILTER_CLASS | CM_GETIDLIST_FILTER_PRESENT);
+        if (result != CR_SUCCESS)
+        {
+            break;
+        }
+
+        try
+        {
+            DeviceIDList.resize(DeviceIDListSize);
+        }
+        catch (...)
+        {
+            return false;
+        }
+        result = m_pCM_Get_Device_ID_List(DisplayGUID, DeviceIDList.data(), DeviceIDListSize, CM_GETIDLIST_FILTER_CLASS | CM_GETIDLIST_FILTER_PRESENT);
+
+    } while (result == CR_BUFFER_SMALL);
+
+    if (result != CR_SUCCESS)
+    {
+        return false;
+    }
+
+    //Look for MediaSDK record
+    wchar_t *begin = DeviceIDList.data();
+    wchar_t *end = begin + DeviceIDList.size();
+    size_t len = 0;
+
+    for (; (begin < end) && (len = wcslen(begin)) > 0; begin += len + 1)
+    {
+        if (IsIntelDeviceInstanceID(begin))
+        {
+            mfxU32 curDeviceID = 0;
+            if (!ExctractDeviceID(begin, curDeviceID) || curDeviceID != deviceID)
+            {
+                continue;
+            }
+
+            result = m_pCM_Locate_DevNode(&DeviceInst, begin, CM_LOCATE_DEVNODE_NORMAL);
+            if (result != CR_SUCCESS)
+            {
+                continue;
+            }
+
+            HKEY hKey_sw;
+            result = m_pCM_Open_DevNode_Key(DeviceInst, KEY_READ, 0, RegDisposition_OpenExisting, &hKey_sw, CM_REGISTRY_SOFTWARE);
+            if (result != CR_SUCCESS)
+            {
+                continue;
+            }
+
+            ULONG nError;
+
+            DWORD pathSize = dwPathSize;
+
+            nError = RegQueryValueExW(hKey_sw, L"DriverStorePathForMediaSDK", 0, NULL, (LPBYTE)path, &pathSize);
+
+            RegCloseKey(hKey_sw);
+
+            if (ERROR_SUCCESS == nError)
+            {
+                if (path[wcslen(path) - 1] != '/' && path[wcslen(path) - 1] != '\\')
+                {
+                    wcscat_s(path, MFX_MAX_DLL_PATH, L"\\");
+                }
+                DISPATCHER_LOG_INFO(("DriverStore path is found\n"));
+                return true;
+            }
+        }
+    }
+
+    DISPATCHER_LOG_INFO(("DriverStore path isn't found\n"));
+    return false;
+
+} // bool DriverStoreLoader::GetDriverStorePath(wchar_t * path, DWORD dwPathSize)
+
+bool DriverStoreLoader::LoadCfgMgr()
+{
+    if (!m_moduleCfgMgr)
+    {
+        m_moduleCfgMgr = mfx_dll_load(L"cfgmgr32.dll");
+
+        if (!m_moduleCfgMgr)
+        {
+            DISPATCHER_LOG_WRN(("cfgmgr32.dll couldn't be loaded\n"));
+            return false;
+        }
+    }
+
+    return true;
+
+} // bool DriverStoreLoader::LoadCfgMgr()
+
+bool DriverStoreLoader::LoadCmFuncs()
+{
+    if (!m_pCM_Get_Device_ID_List || !m_pCM_Get_Device_ID_List_Size || !m_pCM_Locate_DevNode || !m_pCM_Open_DevNode_Key)
+    {
+        m_pCM_Get_Device_ID_List      = (Func_CM_Get_Device_ID_ListW)      mfx_dll_get_addr((HMODULE)m_moduleCfgMgr, "CM_Get_Device_ID_ListW");
+        m_pCM_Get_Device_ID_List_Size = (Func_CM_Get_Device_ID_List_SizeW) mfx_dll_get_addr((HMODULE)m_moduleCfgMgr, "CM_Get_Device_ID_List_SizeW");
+        m_pCM_Locate_DevNode          = (Func_CM_Locate_DevNodeW)          mfx_dll_get_addr((HMODULE)m_moduleCfgMgr, "CM_Locate_DevNodeW");
+        m_pCM_Open_DevNode_Key        = (Func_CM_Open_DevNode_Key)         mfx_dll_get_addr((HMODULE)m_moduleCfgMgr, "CM_Open_DevNode_Key");
+
+        if (!m_pCM_Get_Device_ID_List || !m_pCM_Get_Device_ID_List_Size || !m_pCM_Locate_DevNode || !m_pCM_Open_DevNode_Key)
+        {
+            DISPATCHER_LOG_WRN(("One of cfgmgr32.dll function isn't found\n"));
+            return false;
+        }
+    }
+
+    return true;
+
+} // bool DriverStoreLoader::LoadCmFuncs()
+
+} // namespace MFX

--- a/plugins/obs-qsv11/libmfx/src/mfx_dxva2_device.cpp
+++ b/plugins/obs-qsv11/libmfx/src/mfx_dxva2_device.cpp
@@ -1,34 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2017 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_dxva2_device.cpp
-
-\* ****************************************************************************** */
-
-#if defined(_WIN32) || defined(_WIN64)
+// Copyright (c) 2012-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #define INITGUID
 #include <d3d9.h>
@@ -107,27 +95,27 @@ void DXDevice::LoadDLLModule(const wchar_t *pModuleName)
     // unload the module if it is required
     UnloadDLLModule();
 
-#if !defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
+#if !defined(MEDIASDK_UWP_DISPATCHER)
     DWORD prevErrorMode = 0;
     // set the silent error mode
-#if (_WIN32_WINNT >= 0x0600) && !(__GNUC__)
+#if (_WIN32_WINNT >= 0x0600)
     SetThreadErrorMode(SEM_FAILCRITICALERRORS, &prevErrorMode); 
 #else
     prevErrorMode = SetErrorMode(SEM_FAILCRITICALERRORS);
 #endif
-#endif // !defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
+#endif // !defined(MEDIASDK_UWP_DISPATCHER)
 
     // load specified library
     m_hModule = LoadLibraryExW(pModuleName, NULL, 0);
 
-#if !defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
+#if !defined(MEDIASDK_UWP_DISPATCHER)
     // set the previous error mode
-#if (_WIN32_WINNT >= 0x0600) && !(__GNUC__)
+#if (_WIN32_WINNT >= 0x0600)
     SetThreadErrorMode(prevErrorMode, NULL);
 #else
     SetErrorMode(prevErrorMode);
 #endif
-#endif //!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
+#endif // !defined(MEDIASDK_UWP_DISPATCHER)
 
 } // void LoadDLLModule(const wchar_t *pModuleName)
 
@@ -325,6 +313,15 @@ bool DXGI1Device::Init(const mfxU32 adapterNum)
     // release the object before initialization
     Close();
 
+    IDXGIFactory1 *pFactory = NULL;
+    IDXGIAdapter1 *pAdapter = NULL;
+    DXGI_ADAPTER_DESC1 desc = { 0 };
+    mfxU32 curAdapter = 0;
+    mfxU32 maxAdapters = 0;
+    HRESULT hRes = E_FAIL;
+
+    DXGICreateFactoryFunc pFunc = NULL;
+
     // load up the library if it is not loaded
     if (NULL == m_hModule)
     {
@@ -333,81 +330,74 @@ bool DXGI1Device::Init(const mfxU32 adapterNum)
 
     if (m_hModule)
     {
-        DXGICreateFactoryFunc pFunc = NULL;
-        IDXGIFactory1 *pFactory = NULL;
-        IDXGIAdapter1 *pAdapter = NULL;
-        DXGI_ADAPTER_DESC1 desc = { 0 };
-        mfxU32 curAdapter = 0;
-        mfxU32 maxAdapters = 0;
-        HRESULT hRes = E_FAIL;
-
         // load address of procedure to create DXGI 1.1 factory
-        pFunc = (DXGICreateFactoryFunc) GetProcAddress(m_hModule, "CreateDXGIFactory1");
-
-        if (NULL == pFunc)
-        {
-            return false;
-        }
-
-        // create the factory
-#if _MSC_VER >= 1400
-        hRes = pFunc(__uuidof(IDXGIFactory1), (void**) (&pFactory));
-#else
-        hRes = pFunc(IID_IDXGIFactory1, (void**) (&pFactory));
-#endif
-        if (FAILED(hRes))
-        {
-            return false;
-        }
-        m_pDXGIFactory1 = pFactory;
-
-        // get the number of adapters
-        curAdapter = 0;
-        maxAdapters = 0;
-        do
-        {
-            // get the required adapted
-            hRes = pFactory->EnumAdapters1(curAdapter, &pAdapter);
-            if (FAILED(hRes))
-            {
-                break;
-            }
-
-            // if it is the required adapter, save the interface
-            if (curAdapter == adapterNum)
-            {
-                m_pDXGIAdapter1 = pAdapter;
-            }
-            else
-            {
-                pAdapter->Release();
-            }
-
-            // get the next adapter
-            curAdapter += 1;
-
-        } while (SUCCEEDED(hRes));
-        maxAdapters = curAdapter;
-
-        // there is no required adapter
-        if (adapterNum >= maxAdapters)
-        {
-            return false;
-        }
-        pAdapter = (IDXGIAdapter1 *) m_pDXGIAdapter1;
-
-        // get the adapter's parameters
-        hRes = pAdapter->GetDesc1(&desc);
-        if (FAILED(hRes))
-        {
-            return false;
-        }
-
-        // save the parameters
-        m_vendorID = desc.VendorId;
-        m_deviceID = desc.DeviceId;
-        *((LUID *) &m_luid) = desc.AdapterLuid;
+        pFunc = (DXGICreateFactoryFunc)GetProcAddress(m_hModule, "CreateDXGIFactory1");
     }
+
+    if (NULL == pFunc)
+    {
+        return false;
+    }
+
+    // create the factory
+#if _MSC_VER >= 1400
+    hRes = pFunc(__uuidof(IDXGIFactory1), (void**)(&pFactory));
+#else
+    hRes = pFunc(IID_IDXGIFactory1, (void**)(&pFactory));
+#endif
+
+    if (FAILED(hRes))
+    {
+        return false;
+    }
+    m_pDXGIFactory1 = pFactory;
+
+    // get the number of adapters
+    curAdapter = 0;
+    maxAdapters = 0;
+    do
+    {
+        // get the required adapted
+        hRes = pFactory->EnumAdapters1(curAdapter, &pAdapter);
+        if (FAILED(hRes))
+        {
+            break;
+        }
+
+        // if it is the required adapter, save the interface
+        if (curAdapter == adapterNum)
+        {
+            m_pDXGIAdapter1 = pAdapter;
+        }
+        else
+        {
+            pAdapter->Release();
+        }
+
+        // get the next adapter
+        curAdapter += 1;
+
+    } while (SUCCEEDED(hRes));
+    maxAdapters = curAdapter;
+
+    // there is no required adapter
+    if (adapterNum >= maxAdapters)
+    {
+        return false;
+    }
+    pAdapter = (IDXGIAdapter1 *) m_pDXGIAdapter1;
+
+    // get the adapter's parameters
+    hRes = pAdapter->GetDesc1(&desc);
+    if (FAILED(hRes))
+    {
+        return false;
+    }
+
+    // save the parameters
+    m_vendorID = desc.VendorId;
+    m_deviceID = desc.DeviceId;
+    *((LUID *) &m_luid) = desc.AdapterLuid;
 
     return true;
 
@@ -454,6 +444,7 @@ bool DXVA2Device::InitD3D9(const mfxU32 adapterNum)
     {
         return false;
     }
+
 
     m_numAdapters = d3d9Device.GetAdapterCount();
 
@@ -574,4 +565,4 @@ mfxU32 DXVA2Device::GetAdapterCount(void) const
     return m_numAdapters;
 
 } // mfxU32 DXVA2Device::GetAdapterCount(void) const
-#endif
+

--- a/plugins/obs-qsv11/libmfx/src/mfx_function_table.cpp
+++ b/plugins/obs-qsv11/libmfx/src/mfx_function_table.cpp
@@ -1,32 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2014 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_function_table.cpp
-
-\* ****************************************************************************** */
+// Copyright (c) 2012-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #include "mfx_dispatcher.h"
 
@@ -86,9 +76,9 @@ namespace
 mfxStatus pseudoMFXInit(mfxIMPL impl, mfxVersion *ver, mfxSession *session)
 {
     // touch unreferenced parameters
-    impl = impl;
-    ver = ver;
-    session = session;
+    (void) impl;
+    (void) ver;
+    (void) session;
 
     return MFX_ERR_UNKNOWN;
 
@@ -97,7 +87,7 @@ mfxStatus pseudoMFXInit(mfxIMPL impl, mfxVersion *ver, mfxSession *session)
 mfxStatus pseudoMFXClose(mfxSession session)
 {
     // touch unreferenced parameters
-    session = session;
+    (void) session;
 
     return MFX_ERR_UNKNOWN;
 
@@ -106,8 +96,8 @@ mfxStatus pseudoMFXClose(mfxSession session)
 mfxStatus pseudoMFXJoinSession(mfxSession session, mfxSession child_session)
 {
     // touch unreferenced parameters
-    session = session;
-    child_session = child_session;
+    (void) session;
+    (void) child_session;
 
     return MFX_ERR_UNKNOWN;
 
@@ -116,8 +106,8 @@ mfxStatus pseudoMFXJoinSession(mfxSession session, mfxSession child_session)
 mfxStatus pseudoMFXCloneSession(mfxSession session, mfxSession *clone)
 {
     // touch unreferenced parameters
-    session = session;
-    clone = clone;
+    (void) session;
+    (void) clone;
 
     return MFX_ERR_UNKNOWN;
 

--- a/plugins/obs-qsv11/libmfx/src/mfx_library_iterator.cpp
+++ b/plugins/obs-qsv11/libmfx/src/mfx_library_iterator.cpp
@@ -1,34 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2018 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_library_iterator.cpp
-
-\* ****************************************************************************** */
-
-#if defined(_WIN32) || defined(_WIN64)
+// Copyright (c) 2012-2020 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #include "mfx_library_iterator.h"
 
@@ -40,8 +28,6 @@ File Name: mfx_library_iterator.cpp
 
 #include <tchar.h>
 #include <windows.h>
-
-#include <vector>
 
 namespace MFX
 {
@@ -74,7 +60,11 @@ mfxStatus SelectImplementationType(const mfxU32 adapterNum, mfxIMPL *pImplInterf
     {
         return MFX_ERR_NULL_PTR;
     }
+#if (MFX_VERSION >= MFX_VERSION_NEXT)
+    mfxIMPL impl_via = (*pImplInterface & ~MFX_IMPL_EXTERNAL_THREADING);
+#else
     mfxIMPL impl_via = *pImplInterface;
+#endif
 
     DXVA2Device dxvaDevice;
     if (MFX_IMPL_VIA_D3D9 == impl_via)
@@ -82,7 +72,7 @@ mfxStatus SelectImplementationType(const mfxU32 adapterNum, mfxIMPL *pImplInterf
         // try to create the Direct3D 9 device and find right adapter
         if (!dxvaDevice.InitD3D9(adapterNum))
         {
-            DISPATCHER_LOG_INFO((("dxvaDevice.InitD3D9(%d) Failed "), adapterNum ));
+            DISPATCHER_LOG_INFO((("dxvaDevice.InitD3D9(%d) Failed\n"), adapterNum ));
             return MFX_ERR_UNSUPPORTED;
         }
     }
@@ -91,7 +81,7 @@ mfxStatus SelectImplementationType(const mfxU32 adapterNum, mfxIMPL *pImplInterf
         // try to open DXGI 1.1 device to get hardware ID
         if (!dxvaDevice.InitDXGI1(adapterNum))
         {
-            DISPATCHER_LOG_INFO((("dxvaDevice.InitDXGI1(%d) Failed "), adapterNum ));
+            DISPATCHER_LOG_INFO((("dxvaDevice.InitDXGI1(%d) Failed\n"), adapterNum ));
             return MFX_ERR_UNSUPPORTED;
         }
     }
@@ -109,13 +99,13 @@ mfxStatus SelectImplementationType(const mfxU32 adapterNum, mfxIMPL *pImplInterf
         }
         else
         {
-            DISPATCHER_LOG_INFO((("Unsupported adapter %d "), adapterNum ));
+            DISPATCHER_LOG_INFO((("Unsupported adapter %d\n"), adapterNum ));
             return MFX_ERR_UNSUPPORTED;
         }
     }
     else
     {
-        DISPATCHER_LOG_ERROR((("Unknown implementation type %d "), *pImplInterface ));
+        DISPATCHER_LOG_ERROR((("Unknown implementation type %d\n"), *pImplInterface ));
         return MFX_ERR_UNSUPPORTED;
     }
 
@@ -130,6 +120,9 @@ mfxStatus SelectImplementationType(const mfxU32 adapterNum, mfxIMPL *pImplInterf
 }
 
 MFXLibraryIterator::MFXLibraryIterator(void)
+#if !defined(MEDIASDK_UWP_DISPATCHER)
+    : m_baseRegKey()
+#endif
 {
     m_implType = MFX_LIB_PSEUDO;
     m_implInterface = MFX_IMPL_UNSUPPORTED;
@@ -168,7 +161,7 @@ void MFXLibraryIterator::Release(void)
 
 DECLSPEC_NOINLINE HMODULE GetThisDllModuleHandle()
 {
-  HMODULE hDll = HMODULE(-1);
+  HMODULE hDll = NULL;
 
   GetModuleHandleExW( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
                       GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
@@ -176,8 +169,8 @@ DECLSPEC_NOINLINE HMODULE GetThisDllModuleHandle()
   return hDll;
 }
 
-// msdk_disp_char* sImplPath must be allocated with size not less then msdk_disp_path_len
-bool GetImplPath(int storageID, msdk_disp_char* sImplPath)
+// wchar_t* sImplPath must be allocated with size not less then msdk_disp_path_len
+bool GetImplPath(int storageID, wchar_t* sImplPath)
 {
     HMODULE hModule = NULL;
 
@@ -187,17 +180,13 @@ bool GetImplPath(int storageID, msdk_disp_char* sImplPath)
     case MFX_APP_FOLDER:
         hModule = 0;
         break;
-
-#if defined(MEDIASDK_UWP_LOADER) || defined(MEDIASDK_UWP_PROCTABLE)
     case MFX_PATH_MSDK_FOLDER:
         hModule = GetThisDllModuleHandle();
+        HMODULE exeModule = GetModuleHandleW(NULL);
+        //It should works only if Dispatcher is linked with Dynamic Linked Library
+        if (!hModule || !exeModule || hModule == exeModule)
+            return false;
         break;
-#endif
-
-    }
-
-    if(hModule == HMODULE(-1)) {
-        return false;
     }
 
     DWORD nSize = 0;
@@ -214,7 +203,7 @@ bool GetImplPath(int storageID, msdk_disp_char* sImplPath)
     // for any case because WinXP implementation of GetModuleFileName does not add \0 to the end of string
     sImplPath[nSize] = L'\0';
 
-    msdk_disp_char * dirSeparator = wcsrchr(sImplPath, L'\\');
+    wchar_t * dirSeparator = wcsrchr(sImplPath, L'\\');
     if (dirSeparator != NULL && dirSeparator < (sImplPath + msdk_disp_path_len))
     {
         *++dirSeparator = 0;
@@ -235,27 +224,57 @@ mfxStatus MFXLibraryIterator::Init(eMfxImplType implType, mfxIMPL implInterface,
     Release();
     m_StorageID = storageID;
     m_lastLibIndex = 0;
+    m_implType = implType;
+    m_implInterface = implInterface != 0
+        ? implInterface
+        : MFX_IMPL_VIA_ANY;
 
-#if defined(MEDIASDK_USE_REGISTRY) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
+    // for HW impl check impl interface, check adapter, obtain deviceID and vendorID
+    if (m_implType != MFX_LIB_SOFTWARE)
+    {
+        mfxStatus mfxRes = MFX::SelectImplementationType(adapterNum, &m_implInterface, &m_vendorID, &m_deviceID);
+        if (MFX_ERR_NONE != mfxRes)
+        {
+            return mfxRes;
+        }
+    }
+
+#if !defined(MEDIASDK_UWP_DISPATCHER)
     if (storageID == MFX_CURRENT_USER_KEY || storageID == MFX_LOCAL_MACHINE_KEY)
     {
-        return InitRegistry(implType, implInterface, adapterNum, storageID);
+        return InitRegistry(storageID);
+    }
+
+#if defined(MFX_TRACER_WA_FOR_DS)
+    if (storageID == MFX_TRACER)
+    {
+        return InitRegistryTracer();
     }
 #endif
 
-    msdk_disp_char  sCurrentModulePath[msdk_disp_path_len];
+#endif
 
-    if(!GetImplPath(storageID, sCurrentModulePath)) {
+    wchar_t  sMediaSDKPath[msdk_disp_path_len] = {};
+
+    if (storageID == MFX_DRIVER_STORE)
+    {
+        if (!m_driverStoreLoader.GetDriverStorePath(sMediaSDKPath, sizeof(sMediaSDKPath), m_deviceID))
+        {
+            return MFX_ERR_UNSUPPORTED;
+        }
+    }
+    else if(!GetImplPath(storageID, sMediaSDKPath))
+    {
         return MFX_ERR_UNSUPPORTED;
     }
 
-    return InitFolder(implType, implInterface, adapterNum, sCurrentModulePath);
+    return InitFolder(implType, sMediaSDKPath, storageID);
 
 } // mfxStatus MFXLibraryIterator::Init(eMfxImplType implType, const mfxU32 adapterNum, int storageID)
 
-mfxStatus MFXLibraryIterator::InitRegistry(eMfxImplType implType, mfxIMPL implInterface, const mfxU32 adapterNum, int storageID)
+mfxStatus MFXLibraryIterator::InitRegistry(int storageID)
 {
-#if defined(MEDIASDK_USE_REGISTRY) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
+#if !defined(MEDIASDK_UWP_DISPATCHER)
     HKEY rootHKey;
     bool bRes;
 
@@ -270,22 +289,6 @@ mfxStatus MFXLibraryIterator::InitRegistry(eMfxImplType implType, mfxIMPL implIn
             return MFX_ERR_UNKNOWN;
     }
 
-    // set the required library's implementation type
-    m_implType = implType;
-    m_implInterface = implInterface != 0
-        ? implInterface
-        : MFX_IMPL_VIA_ANY;
-
-    //deviceID and vendorID are not actual for SW library loading
-    if (m_implType != MFX_LIB_SOFTWARE)
-    {
-        mfxStatus mfxRes = MFX::SelectImplementationType(adapterNum, &m_implInterface, &m_vendorID, &m_deviceID);
-        if (MFX_ERR_NONE != mfxRes)
-        {
-            return mfxRes;
-        }
-    }
-
     DISPATCHER_LOG_INFO((("Inspecting %s\\%S\n"),
         (MFX_LOCAL_MACHINE_KEY == storageID) ? ("HKEY_LOCAL_MACHINE") : ("HKEY_CURRENT_USER"),
         rootDispPath))
@@ -293,45 +296,53 @@ mfxStatus MFXLibraryIterator::InitRegistry(eMfxImplType implType, mfxIMPL implIn
     return MFX_ERR_NONE;
 #else
     (void) storageID;
-    (void) adapterNum;
-    (void) implInterface;
-    (void) implType;
     return MFX_ERR_UNSUPPORTED;
-#endif // #if !defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
+#endif // #if !defined(MEDIASDK_UWP_DISPATCHER)
 
-} // mfxStatus MFXLibraryIterator::InitRegistry(eMfxImplType implType, mfxIMPL implInterface, const mfxU32 adapterNum, int storageID)
+} // mfxStatus MFXLibraryIterator::InitRegistry(int storageID)
 
-mfxStatus MFXLibraryIterator::InitFolder(eMfxImplType implType, mfxIMPL implInterface, const mfxU32 adapterNum, const msdk_disp_char * path)
+#if defined(MFX_TRACER_WA_FOR_DS)
+mfxStatus MFXLibraryIterator::InitRegistryTracer()
+{
+#if !defined(MEDIASDK_UWP_DISPATCHER)
+
+    const wchar_t tracerRegKeyPath[] = L"Software\\Intel\\MediaSDK\\Dispatch\\tracer";
+
+    if (!m_baseRegKey.Open(HKEY_LOCAL_MACHINE, tracerRegKeyPath, KEY_READ) && !m_baseRegKey.Open(HKEY_CURRENT_USER, tracerRegKeyPath, KEY_READ))
+    {
+        DISPATCHER_LOG_WRN(("can't find tracer registry key\n"))
+        return MFX_ERR_UNKNOWN;
+    }
+
+    DISPATCHER_LOG_INFO(("found tracer registry key\n"))
+    return MFX_ERR_NONE;
+
+#else
+    return MFX_ERR_UNSUPPORTED;
+#endif // #if !defined(MEDIASDK_UWP_DISPATCHER)
+
+} // mfxStatus MFXLibraryIterator::InitRegistryTracer()
+#endif
+
+mfxStatus MFXLibraryIterator::InitFolder(eMfxImplType implType, const wchar_t * path, const int storageID)
 {
      const int maxPathLen = sizeof(m_path)/sizeof(m_path[0]);
      m_path[0] = 0;
-     msdk_disp_char_cpy_s(m_path, maxPathLen, path);
+     wcscpy_s(m_path, maxPathLen, path);
      size_t pathLen = wcslen(m_path);
 
-#if !defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
-     // we looking for runtime in application folder, it should be named libmfxsw64 or libmfxsw32
-     mfx_get_default_dll_name(m_path + pathLen, msdk_disp_path_len - pathLen,  MFX_LIB_SOFTWARE);
-#else
-     mfx_get_default_dll_name(m_path + pathLen, msdk_disp_path_len - pathLen, implType);
-#endif
-
-     // set the required library's implementation type
-     m_implType = implType;
-     m_implInterface = implInterface != 0
-         ? implInterface
-         : MFX_IMPL_VIA_ANY;
-
-     //deviceID and vendorID are not actual for SW library loading
-     if (m_implType != MFX_LIB_SOFTWARE)
+     if(storageID==MFX_APP_FOLDER)
      {
-         mfxStatus mfxRes = MFX::SelectImplementationType(adapterNum, &m_implInterface, &m_vendorID, &m_deviceID);
-         if (MFX_ERR_NONE != mfxRes)
-         {
-             return mfxRes;
-         }
+         // we looking for runtime in application folder, it should be named libmfxsw64 or libmfxsw32
+         mfx_get_default_dll_name(m_path + pathLen, msdk_disp_path_len - pathLen,  MFX_LIB_SOFTWARE);
      }
+     else
+     {
+         mfx_get_default_dll_name(m_path + pathLen, msdk_disp_path_len - pathLen, implType);
+     }
+
      return MFX_ERR_NONE;
-} // mfxStatus MFXLibraryIterator::InitFolder(eMfxImplType implType, mfxIMPL implInterface, const mfxU32 adapterNum, const msdk_disp_char * path)
+} // mfxStatus MFXLibraryIterator::InitFolder(eMfxImplType implType, const wchar_t * path, const int storageID)
 
 mfxStatus MFXLibraryIterator::SelectDLLVersion(wchar_t *pPath
                                              , size_t pathSize
@@ -347,30 +358,48 @@ mfxStatus MFXLibraryIterator::SelectDLLVersion(wchar_t *pPath
             return MFX_ERR_UNKNOWN;
 
         m_lastLibIndex = 1;
-        msdk_disp_char_cpy_s(pPath, pathSize, m_path);
+        wcscpy_s(pPath, pathSize, m_path);
         *pImplType = MFX_LIB_SOFTWARE;
         return MFX_ERR_NONE;
     }
 
-#if defined(MEDIASDK_UWP_LOADER) || defined(MEDIASDK_UWP_PROCTABLE)
-
-    if (m_StorageID == MFX_PATH_MSDK_FOLDER) {
-
+    if (m_StorageID == MFX_PATH_MSDK_FOLDER || m_StorageID == MFX_DRIVER_STORE)
+    {
         if (m_lastLibIndex != 0)
             return MFX_ERR_NOT_FOUND;
         if (m_vendorID != INTEL_VENDOR_ID)
             return MFX_ERR_UNKNOWN;
 
         m_lastLibIndex = 1;
-        msdk_disp_char_cpy_s(pPath, pathSize, m_path);
+        wcscpy_s(pPath, pathSize, m_path);
         // do not change impl type
-        //*pImplType = MFX_LIB_HARDWARE;
         return MFX_ERR_NONE;
     }
 
+#if !defined(MEDIASDK_UWP_DISPATCHER)
+
+#if defined(MFX_TRACER_WA_FOR_DS)
+    if (m_StorageID == MFX_TRACER)
+    {
+        if (m_lastLibIndex != 0)
+            return MFX_ERR_NOT_FOUND;
+        if (m_vendorID != INTEL_VENDOR_ID)
+            return MFX_ERR_UNKNOWN;
+
+        m_lastLibIndex = 1;
+
+        if (m_baseRegKey.Query(pathKeyName, REG_SZ, (LPBYTE)pPath, (DWORD*)&pathSize))
+        {
+            DISPATCHER_LOG_INFO((("loaded %S : %S\n"), pathKeyName, pPath));
+        }
+        else
+        {
+            DISPATCHER_LOG_WRN((("error querying %S : RegQueryValueExA()==0x%x\n"), pathKeyName, GetLastError()));
+        }
+        return MFX_ERR_NONE;
+    }
 #endif
 
-#if defined(MEDIASDK_USE_REGISTRY) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
     wchar_t libPath[MFX_MAX_DLL_PATH] = L"";
     DWORD libIndex = 0;
     DWORD libMerit = 0;
@@ -503,8 +532,8 @@ mfxStatus MFXLibraryIterator::SelectDLLVersion(wchar_t *pPath
                         {
                             DISPATCHER_LOG_INFO((("loaded %S : %S\n"), pathKeyName, tmpPath));
 
-                            msdk_disp_char_cpy_s(libPath, sizeof(libPath) / sizeof(libPath[0]), tmpPath);
-                            msdk_disp_char_cpy_s(m_SubKeyName, sizeof(m_SubKeyName) / sizeof(m_SubKeyName[0]), subKeyName);
+                            wcscpy_s(libPath, sizeof(libPath) / sizeof(libPath[0]), tmpPath);
+                            wcscpy_s(m_SubKeyName, sizeof(m_SubKeyName) / sizeof(m_SubKeyName[0]), subKeyName);
 
                             libMerit = merit;
                             libIndex = index;
@@ -538,7 +567,7 @@ mfxStatus MFXLibraryIterator::SelectDLLVersion(wchar_t *pPath
         return MFX_ERR_NOT_FOUND;
     }
 
-    msdk_disp_char_cpy_s(pPath, pathSize, libPath);
+    wcscpy_s(pPath, pathSize, libPath);
 
     m_lastLibIndex = libIndex;
     m_lastLibMerit = libMerit;
@@ -555,11 +584,9 @@ mfxIMPL MFXLibraryIterator::GetImplementationType()
     return m_implInterface;
 } // mfxIMPL MFXLibraryIterator::GetImplementationType()
 
-bool MFXLibraryIterator::GetSubKeyName(msdk_disp_char *subKeyName, size_t length) const
+bool MFXLibraryIterator::GetSubKeyName(wchar_t *subKeyName, size_t length) const
 {
-    msdk_disp_char_cpy_s(subKeyName, length, m_SubKeyName);
+    wcscpy_s(subKeyName, length, m_SubKeyName);
     return m_bIsSubKeyValid;
 }
 } // namespace MFX
-#endif // #if defined(_WIN32) || defined(_WIN64)
-

--- a/plugins/obs-qsv11/libmfx/src/mfx_load_dll.cpp
+++ b/plugins/obs-qsv11/libmfx/src/mfx_load_dll.cpp
@@ -1,34 +1,22 @@
-/* ****************************************************************************** *\
-
-Copyright (C) 2012-2017 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_load_dll.cpp
-
-\* ****************************************************************************** */
-
-#if defined(_WIN32) || defined(_WIN64)
+// Copyright (c) 2012-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #include "mfx_dispatcher.h"
 #include "mfx_load_dll.h"
@@ -36,8 +24,6 @@ File Name: mfx_load_dll.cpp
 #include <wchar.h>
 #include <string.h>
 #include <windows.h>
-
-#if !defined(_DEBUG)
 
 #if defined(_WIN64)
 const
@@ -50,6 +36,11 @@ wchar_t * const defaultAudioDLLName[2] = {L"libmfxaudiosw64.dll",
 const 
 wchar_t  * const defaultPluginDLLName[2] = {L"mfxplugin64_hw.dll",
                                             L"mfxplugin64_sw.dll"};
+
+#if defined(MEDIASDK_UWP_DISPATCHER)
+const
+wchar_t  * const IntelGFXAPIDLLName = {L"intel_gfx_api-x64.dll"};
+#endif
 
 #elif defined(_WIN32)
 const
@@ -64,45 +55,18 @@ const
 wchar_t  * const defaultPluginDLLName[2] = {L"mfxplugin32_hw.dll",
                                             L"mfxplugin32_sw.dll"};
 
-#endif // (defined(_WIN64))
-
-#else // defined(_DEBUG)
-
-#if defined(_WIN64)
+#if defined(MEDIASDK_UWP_DISPATCHER)
 const
-wchar_t * const defaultDLLName[2] = {L"libmfxhw64_d.dll",
-                                     L"libmfxsw64_d.dll"};
-const
-wchar_t * const defaultAudioDLLName[2] = {L"libmfxaudiosw64_d.dll",
-                                          L"libmfxaudiosw64_d.dll"};
-
-const 
-wchar_t  * const defaultPluginDLLName[2] = {L"mfxplugin64_hw_d.dll",
-                                            L"mfxplugin64_sw_d.dll"};
-
-#elif defined(WIN32)
-const
-wchar_t * const defaultDLLName[2] = {L"libmfxhw32_d.dll",
-                                     L"libmfxsw32_d.dll"};
-
-
-const
-wchar_t * const defaultAudioDLLName[2] = {L"libmfxaudiosw32_d.dll",
-                                          L"libmfxaudiosw32_d.dll"};
-
-const 
-wchar_t  * const defaultPluginDLLName[2] = {L"mfxplugin32_hw_d.dll",
-                                            L"mfxplugin32_sw_d.dll"};
+wchar_t  * const IntelGFXAPIDLLName = {L"intel_gfx_api-x86.dll"};
+#endif
 
 #endif // (defined(_WIN64))
-
-#endif // !defined(_DEBUG)
 
 namespace MFX
 {
 
 
-mfxStatus mfx_get_default_dll_name(msdk_disp_char *pPath, size_t pathSize, eMfxImplType implType)
+mfxStatus mfx_get_default_dll_name(wchar_t *pPath, size_t pathSize, eMfxImplType implType)
 {
     if (!pPath)
     {
@@ -120,7 +84,25 @@ mfxStatus mfx_get_default_dll_name(msdk_disp_char *pPath, size_t pathSize, eMfxI
 #endif
 } // mfxStatus mfx_get_default_dll_name(wchar_t *pPath, size_t pathSize, eMfxImplType implType)
 
-mfxStatus mfx_get_default_plugin_name(msdk_disp_char *pPath, size_t pathSize, eMfxImplType implType)
+#if defined(MEDIASDK_UWP_DISPATCHER)
+mfxStatus mfx_get_default_intel_gfx_api_dll_name(wchar_t *pPath, size_t pathSize)
+{
+    if (!pPath)
+    {
+        return MFX_ERR_NULL_PTR;
+    }
+
+#if _MSC_VER >= 1400
+    return 0 == wcscpy_s(pPath, pathSize, IntelGFXAPIDLLName)
+        ? MFX_ERR_NONE : MFX_ERR_UNKNOWN;
+#else
+    wcscpy(pPath, IntelGFXAPIDLLName);
+    return MFX_ERR_NONE;
+#endif
+} // mfx_get_default_intel_gfx_api_dll_name(wchar_t *pPath, size_t pathSize)
+#endif
+
+mfxStatus mfx_get_default_plugin_name(wchar_t *pPath, size_t pathSize, eMfxImplType implType)
 {
     if (!pPath)
     {
@@ -138,7 +120,7 @@ mfxStatus mfx_get_default_plugin_name(msdk_disp_char *pPath, size_t pathSize, eM
 #endif
 }
 
-mfxStatus mfx_get_default_audio_dll_name(msdk_disp_char *pPath, size_t pathSize, eMfxImplType implType)
+mfxStatus mfx_get_default_audio_dll_name(wchar_t *pPath, size_t pathSize, eMfxImplType implType)
 {
     if (!pPath)
     {
@@ -155,7 +137,7 @@ mfxStatus mfx_get_default_audio_dll_name(msdk_disp_char *pPath, size_t pathSize,
 #endif
 } // mfxStatus mfx_get_default_audio_dll_name(wchar_t *pPath, size_t pathSize, eMfxImplType implType)
 
-mfxModuleHandle mfx_dll_load(const msdk_disp_char *pFileName)
+mfxModuleHandle mfx_dll_load(const wchar_t *pFileName)
 {
     mfxModuleHandle hModule = (mfxModuleHandle) 0;
 
@@ -164,27 +146,29 @@ mfxModuleHandle mfx_dll_load(const msdk_disp_char *pFileName)
     {
         return NULL;
     }
-#if !defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
+#if !defined(MEDIASDK_UWP_DISPATCHER)
     // set the silent error mode
     DWORD prevErrorMode = 0;
-#if (_WIN32_WINNT >= 0x0600) && !(__GNUC__)
+#if (_WIN32_WINNT >= 0x0600)
     SetThreadErrorMode(SEM_FAILCRITICALERRORS, &prevErrorMode);
 #else
     prevErrorMode = SetErrorMode(SEM_FAILCRITICALERRORS);
 #endif
-#endif // !defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
+#endif // !defined(MEDIASDK_UWP_DISPATCHER)
 
-        // load the library's module
-        hModule = LoadLibraryExW(pFileName, NULL, 0);
+    // load the library's module
+#if !defined(MEDIASDK_ARM_LOADER)
+    hModule = LoadLibraryExW(pFileName, NULL, 0);
+#endif
 
-#if !defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
-        // set the previous error mode
-#if (_WIN32_WINNT >= 0x0600) && !(__GNUC__)
+#if !defined(MEDIASDK_UWP_DISPATCHER)
+    // set the previous error mode
+#if (_WIN32_WINNT >= 0x0600)
     SetThreadErrorMode(prevErrorMode, NULL);
 #else
     SetErrorMode(prevErrorMode);
 #endif
-#endif // !defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
+#endif // !defined(MEDIASDK_UWP_DISPATCHER)
 
     return hModule;
 
@@ -212,8 +196,8 @@ bool mfx_dll_free(mfxModuleHandle handle)
     return !!bRes;
 } // bool mfx_dll_free(mfxModuleHandle handle)
 
-#if !defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
-mfxModuleHandle mfx_get_dll_handle(const msdk_disp_char *pFileName)
+#if !defined(MEDIASDK_UWP_DISPATCHER)
+mfxModuleHandle mfx_get_dll_handle(const wchar_t *pFileName)
 {
     mfxModuleHandle hModule = (mfxModuleHandle) 0;
 
@@ -225,7 +209,7 @@ mfxModuleHandle mfx_get_dll_handle(const msdk_disp_char *pFileName)
 
     // set the silent error mode
     DWORD prevErrorMode = 0;
-#if (_WIN32_WINNT >= 0x0600) && !(__GNUC__)
+#if (_WIN32_WINNT >= 0x0600)
     SetThreadErrorMode(SEM_FAILCRITICALERRORS, &prevErrorMode); 
 #else
     prevErrorMode = SetErrorMode(SEM_FAILCRITICALERRORS);
@@ -233,16 +217,14 @@ mfxModuleHandle mfx_get_dll_handle(const msdk_disp_char *pFileName)
     // load the library's module
     GetModuleHandleExW(0, pFileName, (HMODULE*) &hModule);
     // set the previous error mode
-#if (_WIN32_WINNT >= 0x0600) && !(__GNUC__)
+#if (_WIN32_WINNT >= 0x0600)
     SetThreadErrorMode(prevErrorMode, NULL);
 #else
     SetErrorMode(prevErrorMode);
 #endif
     return hModule;
 }
-#endif //!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE)
-
+#endif //!defined(MEDIASDK_UWP_DISPATCHER)
 
 } // namespace MFX
 
-#endif // #if defined(_WIN32) || defined(_WIN64)

--- a/plugins/obs-qsv11/libmfx/src/mfx_win_reg_key.cpp
+++ b/plugins/obs-qsv11/libmfx/src/mfx_win_reg_key.cpp
@@ -1,35 +1,24 @@
-/* ****************************************************************************** *\
+// Copyright (c) 2012-2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
-Copyright (C) 2012-2017 Intel Corporation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-- Neither the name of Intel Corporation nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-File Name: mfx_win_reg_key.cpp
-
-\* ****************************************************************************** */
-
-#if defined(_WIN32) || defined(_WIN64)
-
+#if !defined(MEDIASDK_UWP_DISPATCHER)
 #include "mfx_win_reg_key.h"
 #include "mfx_dispatcher_log.h"
 
@@ -225,4 +214,4 @@ bool WinRegKey::QueryInfo(LPDWORD lpcSubkeys)
 
 } // namespace MFX
 
-#endif // #if defined(_WIN32) || defined(_WIN64)
+#endif // #if !defined(MEDIASDK_UWP_DISPATCHER)


### PR DESCRIPTION
### Description
Verified my Rocket Lake CPU works now.

### Motivation and Context
Want to support newer Intel CPUs.

### How Has This Been Tested?
QSV and FFmpeg fallback both produced sane videos.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.