### PR TITLE
text-freetype2: Add alpha channel property

### DIFF
--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -170,9 +170,11 @@ static obs_properties_t *ft2_source_properties(void *unused)
 				OBS_PATH_FILE,
 				obs_module_text("TextFileFilter"), NULL);
 
-	obs_properties_add_color(props, "color1", obs_module_text("Color1"));
+	obs_properties_add_color_alpha(props, "color1",
+				       obs_module_text("Color1"));
 
-	obs_properties_add_color(props, "color2", obs_module_text("Color2"));
+	obs_properties_add_color_alpha(props, "color2",
+				       obs_module_text("Color2"));
 
 	obs_properties_add_bool(props, "outline", obs_module_text("Outline"));
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
Use `obs_properties_add_color_alpha` instead of `obs_properties_add_color` to set alpha channel for text colors.

<!--- If this change includes UI elements, please include screenshots. -->
Alpha channel is added to the color picker for each color.
![color-picker-alpha](https://user-images.githubusercontent.com/780600/121808742-f1ddc080-cc94-11eb-8053-8c9671d446ce.png)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Text (GDI+) has alpha property but Text (Freetype 2) does not.
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I checked several color and alpha combinations.
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
Tested on CentOS 8, Intel Core i7700, and its built-in GPU.
<!--- and the tests you ran, including how it may affect other areas of code. -->
Since the defaults for `color1` and `color2` are set to 0xFFFFFFFF, I don't think it broke existing behavior. Since the old color picker returns with alpha channel as 255, existing instances of the source should work without touching.

I reviewed the implementation and checked `gs_reset_blend_state` is called from the `video_render` call back. It expects non premultiplied alpha hence I don't need to touch R, G, and B channels.

I reviewed other plugins and I don't find any other plugin that can use `obs_properties_add_color_alpha` instead of `obs_properties_add_color`. Sources such as Text (GDI+) and Mask Filter have separated opacity setting so that it is not necessary to change.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
  - I don't think there is a document to be updated by this change.
