### PR TITLE
libobs: Fix memory overrun if libobs version mismatches

### DIFF
--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -594,8 +594,8 @@ cleanup:
 		memcpy(&data, info,                                        \
 		       sizeof(data) < size_var ? sizeof(data) : size_var); \
                                                                            \
-		if (info->type_data && info->free_type_data)               \
-			info->free_type_data(info->type_data);             \
+		if (data.type_data && data.free_type_data)                 \
+			data.free_type_data(data.type_data);               \
 	} while (false)
 
 #define source_warn(format, ...) \
@@ -628,6 +628,15 @@ void obs_register_source_s(const struct obs_source_info *info, size_t size)
 		source_warn("Source '%s' already exists!  "
 			    "Duplicate library?",
 			    info->id);
+		goto error;
+	}
+
+	if (size > sizeof(data)) {
+		source_warn("Tried to register obs_source_info with size "
+			    "%llu which is more than libobs currently "
+			    "supports (%llu)",
+			    (long long unsigned)size,
+			    (long long unsigned)sizeof(data));
 		goto error;
 	}
 
@@ -683,15 +692,6 @@ void obs_register_source_s(const struct obs_source_info *info, size_t size)
 		CHECK_REQUIRED_VAL_(info, audio_render, obs_register_source);
 	}
 #undef CHECK_REQUIRED_VAL_
-
-	if (size > sizeof(data)) {
-		source_warn("Tried to register obs_source_info with size "
-			    "%llu which is more than libobs currently "
-			    "supports (%llu)",
-			    (long long unsigned)size,
-			    (long long unsigned)sizeof(data));
-		goto error;
-	}
 
 	/* version-related stuff */
 	data.unversioned_id = data.id;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
-  Size check of obs_source_info is moved before copying in `obs_register_source_s` so that it won't access out of the bounds.
- A macro `HANDLE_ERROR` is fixed to use `data.type_data` and `data.free_type_data` instead of directly accessing `info` to avoid potential out of bounds access if the given `obs_register_source_s` is so small that `type_data` or `free_type_data` is not available.
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To avoid memory access out of bounds if a module is compiled with newer libobs version.
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I applied this change to OBS 26.0 and intentionally put a module compiled with OBS 27.0.
I added extra `blog` just before `memcpy` and confirmed [memcpy](https://github.com/obsproject/obs-studio/blob/3cc4feb8dd0b57137272157836002c350f7a2d54/libobs/obs-module.c#L634) is not called.

<!--- Include details of your testing environment (hardware, OS version, etc.),-->
OS: CentOS 8, hardware: i7-7700.
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
