### PR TITLE
Syphon Client opaque draws

### DIFF
--- a/libobs/data/default_rect.effect
+++ b/libobs/data/default_rect.effect
@@ -25,11 +25,25 @@ float4 PSDrawBare(VertInOut vert_in) : TARGET
 	return image.Sample(def_sampler, vert_in.uv);
 }
 
+float4 PSDrawOpaque(VertInOut vert_in) : TARGET
+{
+	return float4(image.Sample(def_sampler, vert_in.uv).rgb, 1.0);
+}
+
 technique Draw
 {
 	pass
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawBare(vert_in);
+	}
+}
+
+technique DrawOpaque
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawOpaque(vert_in);
 	}
 }

--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -1039,17 +1039,12 @@ static void syphon_video_render(void *data, gs_effect_t *effect)
 	if (!s->tex)
 		return;
 
-	bool disable_blending = !s->allow_transparency;
-	if (disable_blending) {
-		gs_enable_blending(false);
-		gs_enable_color(true, true, true, false);
-	}
-
 	gs_vertexbuffer_flush(s->vertbuffer);
 	gs_load_vertexbuffer(s->vertbuffer);
 	gs_load_indexbuffer(NULL);
 	gs_load_samplerstate(s->sampler, 0);
-	gs_technique_t *tech = gs_effect_get_technique(s->effect, "Draw");
+	const char *tech_name = s->allow_transparency ? "Draw" : "DrawOpaque";
+	gs_technique_t *tech = gs_effect_get_technique(s->effect, tech_name);
 	gs_effect_set_texture(gs_effect_get_param_by_name(s->effect, "image"),
 			      s->tex);
 	gs_technique_begin(tech);
@@ -1059,11 +1054,6 @@ static void syphon_video_render(void *data, gs_effect_t *effect)
 
 	gs_technique_end_pass(tech);
 	gs_technique_end(tech);
-
-	if (disable_blending) {
-		gs_enable_color(true, true, true, true);
-		gs_enable_blending(true);
-	}
 }
 
 static uint32_t syphon_get_width(void *data)


### PR DESCRIPTION
### Description
Fix issue where Syphon Client image was disappearing when outputting RGBA.

Skipping alpha writes is not the same as writing 1.0 to alpha. We want to draw as opaque if transparency is disallowed. This matches the behavior of Game Capture on Windows.

Fixes #4873.

### Motivation and Context
Syphon Client sources were invisible in some contexts.

### How Has This Been Tested?
Verified DrawOpaque is now being called if "Allow Transparency" is false, and checked recorded videos both ways.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.