### PR TITLE
deps/media-playback: Handle discontinuities to fix video stalls

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -301,9 +301,13 @@ static inline int64_t mp_media_get_base_pts(mp_media_t *m)
 	return base_ts;
 }
 
+/* maximum timestamp variance in nanoseconds */
+#define MAX_TS_VAR 2000000000LL
+
 static inline bool mp_media_can_play_frame(mp_media_t *m, struct mp_decode *d)
 {
-	return d->frame_ready && d->frame_pts <= m->next_pts_ns;
+	return d->frame_ready && (d->frame_pts <= m->next_pts_ns ||
+				  (d->frame_pts - m->next_pts_ns > MAX_TS_VAR));
 }
 
 static void mp_media_next_audio(mp_media_t *m)


### PR DESCRIPTION
### Description

If there is a PTS discontinuity in the playback stream that causes the PTS to
reset, it is likely that new audio frames will come in while there are still
video frames waiting to be dequeued. This will cause the audio frames to be
played while the video frames wait for the PTS to get back up to where they
were before the discontinuity.

This change checks to see if the PTS is more than `MAX_TS_VAR` higher than the `next_pts_ns` and if it is, just assumes that it is time to render it.

Fixes #4887

### Motivation and Context

The issue is that [`deps/media-playback/media-playback/media.c`](https://github.com/obsproject/obs-studio/blob/master/deps/media-playback/media-playback/media.c) does not understand PTS discontinuities.

In the calculation of the next PTS that should be handled, it assumes that the audio and video frames that are up next are not crossing a discontinuity and picks the lowest one:

https://github.com/obsproject/obs-studio/blob/3cc4feb8dd0b57137272157836002c350f7a2d54/deps/media-playback/media-playback/media.c#L276-L290

When `mp_media_next_video()` checks to see if the next video frame is available:

https://github.com/obsproject/obs-studio/blob/3cc4feb8dd0b57137272157836002c350f7a2d54/deps/media-playback/media-playback/media.c#L339-L350

It only checks to see if the next video PTS is before the next PTS we are able to handle:

https://github.com/obsproject/obs-studio/blob/3cc4feb8dd0b57137272157836002c350f7a2d54/deps/media-playback/media-playback/media.c#L304-L307

The issue is that when you have a discontinuity in the stream, you can have new audio come in with much smaller PTS when there are still more video frames waiting to be decoded.

The easiest solution I can see to this is to add a check to `mp_media_can_play_frame()` where if the timestamp is more than [`MAX_TS_VAR`](https://github.com/obsproject/obs-studio/blob/3cc4feb8dd0b57137272157836002c350f7a2d54/libobs/obs-internal.h#L823) away from `m->next_pts_ns` it just considers the frame playable.


### How Has This Been Tested?

I created an intentionally broken MPEG-TS stream and fed it into the Media Source via the `tcp://` format.

Details and a video are available in #4887.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
