### PR TITLE
pulse: fill audio monitor buffer more aggressively

### DIFF
--- a/libobs/audio-monitoring/pulse/pulseaudio-output.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-output.c
@@ -20,7 +20,6 @@ struct audio_monitor {
 
 	struct circlebuf new_data;
 	audio_resampler_t *resampler;
-	size_t buffer_size;
 	size_t bytesRemaining;
 	size_t bytes_per_channel;
 
@@ -176,21 +175,20 @@ static void do_stream_write(void *param)
 	PULSE_DATA(param);
 	uint8_t *buffer = NULL;
 
-	while (data->new_data.size >= data->buffer_size &&
-	       data->bytesRemaining > 0) {
-		size_t bytesToFill = data->buffer_size;
-
-		if (bytesToFill > data->bytesRemaining)
+	while (data->new_data.size > 0 && data->bytesRemaining > 0) {
+		size_t bytesToFill = data->new_data.size;
+		if (data->bytesRemaining < bytesToFill)
 			bytesToFill = data->bytesRemaining;
 
 		pulseaudio_lock();
-		pa_stream_begin_write(data->stream, (void **)&buffer,
-				      &bytesToFill);
-		pulseaudio_unlock();
+		if (pa_stream_begin_write(data->stream, (void **)&buffer,
+					  &bytesToFill)) {
+			pulseaudio_unlock();
+			return;
+		}
 
 		circlebuf_pop_front(&data->new_data, buffer, bytesToFill);
 
-		pulseaudio_lock();
 		pa_stream_write(data->stream, buffer, bytesToFill, NULL, 0LL,
 				PA_SEEK_RELATIVE);
 		pulseaudio_unlock();
@@ -262,12 +260,29 @@ static void pulseaudio_underflow(pa_stream *p, void *userdata)
 	UNUSED_PARAMETER(p);
 	PULSE_DATA(userdata);
 
-	pthread_mutex_lock(&data->playback_mutex);
-	if (obs_source_active(data->source))
-		data->attr.tlength = (data->attr.tlength * 3) / 2;
+	pa_sample_spec spec = {0};
+	spec.format = data->format;
+	spec.rate = (uint32_t)data->samples_per_sec;
+	spec.channels = data->channels;
+	uint64_t latency = pa_bytes_to_usec(data->attr.tlength, &spec);
 
-	pa_stream_set_buffer_attr(data->stream, &data->attr, NULL, NULL);
+	pthread_mutex_lock(&data->playback_mutex);
+	if (obs_source_active(data->source) && latency < 1000000) {
+		data->attr.fragsize = (uint32_t)-1;
+		data->attr.maxlength = (uint32_t)-1;
+		data->attr.prebuf = (uint32_t)-1;
+		data->attr.minreq = (uint32_t)-1;
+		data->attr.tlength = (data->attr.tlength * 3) / 2;
+		pa_stream_set_buffer_attr(data->stream, &data->attr, NULL,
+					  NULL);
+		data->bytesRemaining = data->attr.maxlength;
+	}
 	pthread_mutex_unlock(&data->playback_mutex);
+
+	if (latency >= 1000000) {
+		blog(LOG_WARNING, "source monitor reached max latency %ldms",
+		     latency / 1000);
+	}
 
 	pulseaudio_signal(0);
 }
@@ -460,9 +475,6 @@ static bool audio_monitor_init(struct audio_monitor *monitor,
 	monitor->attr.prebuf = (uint32_t)-1;
 	monitor->attr.tlength = pa_usec_to_bytes(25000, &spec);
 
-	monitor->buffer_size =
-		monitor->bytes_per_frame * pa_usec_to_bytes(5000, &spec);
-
 	pa_stream_flags_t flags = PA_STREAM_INTERPOLATE_TIMING |
 				  PA_STREAM_AUTO_TIMING_UPDATE;
 
@@ -479,6 +491,8 @@ static bool audio_monitor_init(struct audio_monitor *monitor,
 		blog(LOG_ERROR, "Unable to connect to stream");
 		return false;
 	}
+
+	monitor->bytesRemaining = monitor->attr.maxlength;
 
 	blog(LOG_INFO, "Started Monitoring in '%s'", monitor->device);
 	return true;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Previously we would wait for pulse to attempt to read from the monitor
source and obs buffered at least 5ms of audio data before we tried to
fill the buffer. In some cases this resulted in consistently triggering
underruns in pulse.

Instead we try to fill the buffer immediately as obs outputs audio data
and while the pa buffer is not full. We also stop trying to grow the
buffer to prevent underruns after we reach 1s of latency.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Attempting to fix #3525

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Adding a media source with an mp3 gave consistent underrun's with the old code. After these changes there are no more under runs reported from the pulse log or obs.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
