### PR TITLE
UI: Log Show/Hide transitions on scene collection load

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -900,6 +900,16 @@ static bool LogSceneItem(obs_scene_t *, obs_sceneitem_t *item, void *v_val)
 	int child_indent = 1 + indent_count;
 	obs_source_enum_filters(source, LogFilter,
 				(void *)(intptr_t)child_indent);
+
+	obs_source_t *show_tn = obs_sceneitem_get_show_transition(item);
+	obs_source_t *hide_tn = obs_sceneitem_get_hide_transition(item);
+	if (show_tn)
+		blog(LOG_INFO, "    %s- show: '%s' (%s)", indent.c_str(),
+		     obs_source_get_name(show_tn), obs_source_get_id(show_tn));
+	if (hide_tn)
+		blog(LOG_INFO, "    %s- hide: '%s' (%s)", indent.c_str(),
+		     obs_source_get_name(hide_tn), obs_source_get_id(hide_tn));
+
 	if (obs_sceneitem_is_group(item))
 		obs_sceneitem_group_enum_items(item, LogSceneItem,
 					       (void *)(intptr_t)child_indent);


### PR DESCRIPTION
### Description

Logs visibility transitions alongside scenes, sources, filters & monitoring.

```
15:21:20.195: - scene 'Scene 3':
15:21:20.195:     - source: 'Color Source 3' (color_source_v3)
15:21:20.195:         - filter: 'Color Correction' (color_filter)
15:21:20.195:         - filter: 'Color Correction 2' (color_filter)
15:21:20.196:         - show: 'Color Source 3 Show Transition' (fade_to_color_transition)
15:21:20.196:     - source: 'Window Capture' (window_capture)
15:21:20.196:         - show: 'Window Capture Show Transition' (swipe_transition)
15:21:20.196:         - hide: 'Window Capture Hide Transition' (swipe_transition)
15:21:20.196:     - source: 'Test Nesting' (group)
15:21:20.196:         - source: 'Browser' (browser_source)
15:21:20.196:             - show: 'Browser Pokaż efekt przejścia' (fade_transition)
15:21:20.196:             - hide: 'Browser Ukryj efekt przejścia' (fade_transition)
```

### Motivation and Context

Was requested based on feedback in support channels - users can easily get terminology wrong when OBS doesn't behave the way they expect, so having detailed info about their setup helps speed up the conversation.

### How Has This Been Tested?

Apply show/hide transitions then switch scene collections or restart OBS.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
