### PR TITLE
UI: Fix undo delete scene that is used as source

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3733,6 +3733,24 @@ void OBSBasic::RemoveSelectedScene()
 	obs_data_array_push_back(array, scene_data);
 	obs_data_release(scene_data);
 
+	/* ----------------------------------------------- */
+	/* save all scenes and groups the scene is used in */
+
+	for (int i = 0; i < ui->scenes->count(); i++) {
+		QListWidgetItem *widget_item = ui->scenes->item(i);
+		auto item_scene = GetOBSRef<OBSScene>(widget_item);
+		if (scene == item_scene)
+			continue;
+		auto *item = obs_scene_find_source_recursive(
+			item_scene, obs_source_get_name(source));
+		if (item) {
+			scene_data = obs_save_source(obs_scene_get_source(
+				obs_sceneitem_get_scene(item)));
+			obs_data_array_push_back(array, scene_data);
+			obs_data_release(scene_data);
+		}
+	}
+
 	/* --------------------------- */
 	/* undo/redo                   */
 


### PR DESCRIPTION
### Description
Fix undo delete scene that is used as source

### Motivation and Context
When deleting a scene that is used in other scenes it was not restored correctly in the other scenes.

### How Has This Been Tested?
On windows 64 bit by deleting scenes and using the undo and redo.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
