### PR TITLE
UI: Fix displayed autoremux file name

### DIFF
--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -865,7 +865,7 @@ void OBSRemux::AutoRemux(QString inFile, QString outFile)
 {
 	if (inFile != "" && outFile != "" && autoRemux) {
 		emit remux(inFile, outFile);
-		autoRemuxFile = inFile;
+		autoRemuxFile = outFile;
 	}
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When a recording is automatically remuxed, the text on the status bar would wrongly show the name of the file being remuxed, not the file being remuxed to.
![image](https://user-images.githubusercontent.com/59806498/122684371-4dfc9380-d205-11eb-82fc-38d982454e1a.png)
Fixes this bug, now the name/path of the new file is being shown:
<img width="643" alt="Bildschirmfoto 2021-06-20 um 20 18 32" src="https://user-images.githubusercontent.com/59806498/122684407-856b4000-d205-11eb-950d-e0cbfe34fb09.png">

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Got noticed on the Discord server

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12, compiled and issue was fixed.

For those worried, a quick project-level search shows that `autoRemuxFile`, which is being changed by this fix, is only intended for and used by the statusbar, and not by anything else, so nothing else should break.
<img width="266" alt="Bildschirmfoto 2021-06-20 um 20 11 35" src="https://user-images.githubusercontent.com/59806498/122684486-e7c44080-d205-11eb-9aa4-4f37a28bd10f.png">

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
