### PR TITLE
Direct ARGB encoding, texture and non-texture (RGB)

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -192,8 +192,10 @@ static inline bool has_scaling(const struct obs_encoder *encoder)
 
 static inline bool gpu_encode_available(const struct obs_encoder *encoder)
 {
-	return (encoder->info.caps & OBS_ENCODER_CAP_PASS_TEXTURE) != 0 &&
-	       obs->video.using_nv12_tex;
+	return ((encoder->info.caps & OBS_ENCODER_CAP_PASS_TEXTURE) != 0 &&
+		obs->video.using_nv12_tex) ||
+	       ((encoder->info.caps & OBS_ENCODER_CAP_PASS_TEXTURE_ARGB) != 0 &&
+		obs->video.using_argb_tex);
 }
 
 static void add_connection(struct obs_encoder *encoder)

--- a/libobs/obs-encoder.h
+++ b/libobs/obs-encoder.h
@@ -33,6 +33,7 @@ extern "C" {
 #define OBS_ENCODER_CAP_PASS_TEXTURE (1 << 1)
 #define OBS_ENCODER_CAP_DYN_BITRATE (1 << 2)
 #define OBS_ENCODER_CAP_INTERNAL (1 << 3)
+#define OBS_ENCODER_CAP_PASS_TEXTURE_ARGB (1 << 4)
 
 /** Specifies the encoder type */
 enum obs_encoder_type {

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -253,6 +253,7 @@ struct obs_core_video {
 	bool textures_copied[NUM_TEXTURES];
 	bool texture_converted;
 	bool using_nv12_tex;
+	bool using_argb_tex;
 	struct circlebuf vframe_info_buffer;
 	struct circlebuf vframe_info_buffer_gpu;
 	gs_effect_t *default_effect;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -53,6 +53,7 @@ static inline void calc_gpu_conversion_sizes(const struct obs_video_info *ovi)
 	video->conversion_width_i = 0.f;
 
 	switch ((uint32_t)ovi->output_format) {
+
 	case VIDEO_FORMAT_I420:
 		video->conversion_needed = true;
 		video->conversion_techs[0] = "Planar_Y";
@@ -85,9 +86,12 @@ static bool obs_init_gpu_conversion(struct obs_video_info *ovi)
 					? gs_nv12_available()
 					: false;
 
+	video->using_argb_tex = ovi->output_format == VIDEO_FORMAT_RGBA;
+
 	if (!video->conversion_needed) {
 		blog(LOG_INFO, "GPU conversion not available for format: %u",
 		     (unsigned int)ovi->output_format);
+
 		video->gpu_conversion = false;
 		video->using_nv12_tex = false;
 		blog(LOG_INFO, "NV12 texture support not available");
@@ -237,9 +241,9 @@ static bool obs_init_textures(struct obs_video_info *ovi)
 	if (!video->render_texture)
 		return false;
 
-	video->output_texture = gs_texture_create(ovi->output_width,
-						  ovi->output_height, GS_RGBA,
-						  1, NULL, GS_RENDER_TARGET);
+	video->output_texture = gs_texture_create(
+		ovi->output_width, ovi->output_height, GS_RGBA, 1, NULL,
+		GS_RENDER_TARGET | GS_SHARED_KM_TEX);
 
 	if (!video->output_texture)
 		return false;
@@ -2483,6 +2487,12 @@ bool obs_nv12_tex_active(void)
 {
 	struct obs_core_video *video = &obs->video;
 	return video->using_nv12_tex;
+}
+
+bool obs_argb_tex_active(void)
+{
+	struct obs_core_video *video = &obs->video;
+	return video->using_argb_tex;
 }
 
 /* ------------------------------------------------------------------------- */

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -773,6 +773,7 @@ EXPORT uint32_t obs_get_total_frames(void);
 EXPORT uint32_t obs_get_lagged_frames(void);
 
 EXPORT bool obs_nv12_tex_active(void);
+EXPORT bool obs_argb_tex_active(void);
 
 EXPORT void obs_apply_private_data(obs_data_t *settings);
 EXPORT void obs_set_private_data(obs_data_t *settings);

--- a/plugins/obs-qsv11/QSV_Encoder.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder.cpp
@@ -158,6 +158,15 @@ qsv_t *qsv_encoder_open(qsv_param_t *pParams)
 
 	QSV_Encoder_Internal *pEncoder = new QSV_Encoder_Internal(impl, ver);
 	mfxStatus sts = pEncoder->Open(pParams);
+
+	// Fall back to NV12 from ARGB, if needed
+	if ((sts == MFX_ERR_UNSUPPORTED) &&
+	    (pParams->nFourCC == MFX_FOURCC_BGR4)) {
+		pParams->nFourCC == MFX_FOURCC_NV12;
+		pParams->nChromaFormat == MFX_CHROMAFORMAT_YUV420;
+		sts = pEncoder->Reset(pParams);
+	}
+
 	if (sts != MFX_ERR_NONE) {
 
 #define WARN_ERR_IMPL(err, str, err_name)                   \
@@ -261,9 +270,11 @@ int qsv_encoder_encode(qsv_t *pContext, uint64_t ts, uint8_t *pDataY,
 	QSV_Encoder_Internal *pEncoder = (QSV_Encoder_Internal *)pContext;
 	mfxStatus sts = MFX_ERR_NONE;
 
-	if (pDataY != NULL && pDataUV != NULL)
+	// Changed as ARGB direct encoding texture will have pDataUV == NULL
+	if (pDataY != NULL) {
 		sts = pEncoder->Encode(ts, pDataY, pDataUV, strideY, strideUV,
 				       pBS);
+	}
 
 	if (sts == MFX_ERR_NONE)
 		return 0;
@@ -410,4 +421,25 @@ enum qsv_cpu_platform qsv_get_cpu_platform()
 
 	//assume newer revisions are at least as capable as Haswell
 	return QSV_CPU_PLATFORM_INTEL;
+}
+
+// Added to get video format for QSV encoding and support ARGB direct encoding
+unsigned int qsv_encoder_get_video_format(qsv_t *pContext)
+{
+	QSV_Encoder_Internal *pEncoder = (QSV_Encoder_Internal *)pContext;
+
+	mfxU32 fourCC;
+	mfxStatus sts = MFX_ERR_NONE;
+
+	sts = pEncoder->GetCurrentFourCC(fourCC);
+
+	if (sts == MFX_ERR_NONE) {
+		if (fourCC == MFX_FOURCC_NV12) {
+			return VIDEO_FORMAT_NV12;
+		} else if (fourCC == MFX_FOURCC_BGR4) {
+			return VIDEO_FORMAT_RGBA;
+		}
+	}
+
+	return VIDEO_FORMAT_NONE;
 }

--- a/plugins/obs-qsv11/QSV_Encoder.h
+++ b/plugins/obs-qsv11/QSV_Encoder.h
@@ -105,6 +105,8 @@ typedef struct {
 	mfxU16 nICQQuality;
 	bool bMBBRC;
 	bool bCQM;
+	mfxU32 nFourCC;       // Added to support ARGB direct encoding
+	mfxU16 nChromaFormat; // Added to support ARGB direct encoding
 } qsv_param_t;
 
 enum qsv_cpu_platform {
@@ -140,6 +142,8 @@ int qsv_encoder_encode_tex(qsv_t *, uint64_t, uint32_t, uint64_t, uint64_t *,
 int qsv_encoder_headers(qsv_t *, uint8_t **pSPS, uint8_t **pPPS,
 			uint16_t *pnSPS, uint16_t *pnPPS);
 enum qsv_cpu_platform qsv_get_cpu_platform();
+unsigned int qsv_encoder_get_video_format(
+	qsv_t *pContext); // Added to get video format for direct ARGB encoding
 bool prefer_igpu_enc(int *iGPUIndex);
 
 #ifdef __cplusplus

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.h
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.h
@@ -75,6 +75,8 @@ public:
 			     mfxBitstream **pBS);
 	mfxStatus ClearData();
 	mfxStatus Reset(qsv_param_t *pParams);
+	mfxStatus GetCurrentFourCC(
+		mfxU32 &fourCC); // Added to support direct ARGB encoding
 
 protected:
 	bool InitParams(qsv_param_t *pParams);

--- a/plugins/obs-qsv11/common_directx11.cpp
+++ b/plugins/obs-qsv11/common_directx11.cpp
@@ -173,6 +173,8 @@ mfxStatus _simple_alloc(mfxFrameAllocRequest *request,
 		format = DXGI_FORMAT_NV12;
 	else if (MFX_FOURCC_RGB4 == request->Info.FourCC)
 		format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	else if (MFX_FOURCC_BGR4 == request->Info.FourCC)
+		format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	else if (MFX_FOURCC_YUY2 == request->Info.FourCC)
 		format = DXGI_FORMAT_YUY2;
 	else if (MFX_FOURCC_P8 ==
@@ -236,10 +238,12 @@ mfxStatus _simple_alloc(mfxFrameAllocRequest *request,
 		desc.Usage = D3D11_USAGE_DEFAULT;
 		desc.BindFlags = D3D11_BIND_DECODER;
 		desc.MiscFlags = 0;
-		//desc.MiscFlags            = D3D11_RESOURCE_MISC_SHARED;
 
 		if ((MFX_MEMTYPE_FROM_VPPIN & request->Type) &&
-		    (DXGI_FORMAT_B8G8R8A8_UNORM == desc.Format)) {
+		    // Changed to include both BGRA to RGBA for texture sharing
+		    ((DXGI_FORMAT_B8G8R8A8_UNORM == desc.Format) ||
+		     DXGI_FORMAT_R8G8B8A8_UNORM == desc.Format)) {
+
 			desc.BindFlags = D3D11_BIND_RENDER_TARGET;
 			if (desc.ArraySize > 2)
 				return MFX_ERR_MEMORY_ALLOC;
@@ -386,6 +390,14 @@ mfxStatus simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
 		ptr->G = ptr->B + 1;
 		ptr->R = ptr->B + 2;
 		ptr->A = ptr->B + 3;
+		break;
+	// Added to support RGBA for texture sharing
+	case DXGI_FORMAT_R8G8B8A8_UNORM:
+		ptr->Pitch = (mfxU16)lockedRect.RowPitch;
+		ptr->R = (mfxU8 *)lockedRect.pData;
+		ptr->G = ptr->R + 1;
+		ptr->B = ptr->R + 2;
+		ptr->A = ptr->R + 3;
 		break;
 	case DXGI_FORMAT_YUY2:
 		ptr->Pitch = (mfxU16)lockedRect.RowPitch;

--- a/plugins/obs-qsv11/common_directx9.cpp
+++ b/plugins/obs-qsv11/common_directx9.cpp
@@ -145,6 +145,8 @@ D3DFORMAT ConvertMfxFourccToD3dFormat(mfxU32 fourcc)
 		return D3DFMT_R8G8B8;
 	case MFX_FOURCC_RGB4:
 		return D3DFMT_A8R8G8B8;
+	case MFX_FOURCC_BGR4:
+		return D3DFMT_A8B8G8R8;
 	case MFX_FOURCC_P8:
 		return D3DFMT_P8;
 	case MFX_FOURCC_P010:
@@ -177,7 +179,8 @@ mfxStatus dx9_simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
 	if (desc.Format != D3DFMT_NV12 && desc.Format != D3DFMT_YV12 &&
 	    desc.Format != D3DFMT_YUY2 && desc.Format != D3DFMT_R8G8B8 &&
 	    desc.Format != D3DFMT_A8R8G8B8 && desc.Format != D3DFMT_P8 &&
-	    desc.Format != D3DFMT_P010 && desc.Format != D3DFMT_A2R10G10B10)
+	    desc.Format != D3DFMT_P010 && desc.Format != D3DFMT_A2R10G10B10 &&
+	    desc.Format != D3DFMT_A8B8G8R8)
 		return MFX_ERR_LOCK_MEMORY;
 
 	D3DLOCKED_RECT locked;
@@ -218,6 +221,13 @@ mfxStatus dx9_simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
 		ptr->G = ptr->B + 1;
 		ptr->R = ptr->B + 2;
 		ptr->A = ptr->B + 3;
+		break;
+	case D3DFMT_A8B8G8R8:
+		ptr->Pitch = (mfxU16)locked.Pitch;
+		ptr->R = (mfxU8 *)locked.pBits;
+		ptr->G = ptr->R + 1;
+		ptr->B = ptr->R + 2;
+		ptr->A = ptr->R + 3;
 		break;
 	case D3DFMT_P8:
 		ptr->Pitch = (mfxU16)locked.Pitch;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Allow for direct ARGB (RGB) non-texture and texture encoding, bypassing unneeded NV12 conversion

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
QSV from ICL+ allows for direct ARGB HW conversion so it improves CPU performance to use it (as unneeded RGB->NV12 conversion is done on CPU)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on CFL machine with NVIDIA card and TGL machine on Windows, making RGB (non-texture and texture) selections and using Windows->Graphics Settings to change if the renderer and encoder are on the same GPU by selecting Power Saving or Let Windows Decide/High Performance. Results on both CFL and TGL (so machines that are ICL- and ICL+) show CPU improvement and demonstrate functionality with and without discrete graphics. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
