### PR TITLE
libobs: Add DrawSrgbDecompressPremultiplied technique to default effects

### DIFF
--- a/libobs/data/default.effect
+++ b/libobs/data/default.effect
@@ -62,6 +62,14 @@ float4 PSDrawNonlinearAlpha(VertInOut vert_in) : TARGET
 	return rgba;
 }
 
+float4 PSDrawSrgbDecompressPremultiplied(VertInOut vert_in) : TARGET
+{
+	float4 rgba = image.Sample(def_sampler, vert_in.uv);
+	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
+	return rgba;
+}
+
 technique Draw
 {
 	pass
@@ -86,5 +94,14 @@ technique DrawNonlinearAlpha
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawNonlinearAlpha(vert_in);
+	}
+}
+
+technique DrawSrgbDecompressPremultiplied
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawSrgbDecompressPremultiplied(vert_in);
 	}
 }

--- a/libobs/data/default_rect.effect
+++ b/libobs/data/default_rect.effect
@@ -30,6 +30,24 @@ float4 PSDrawOpaque(VertInOut vert_in) : TARGET
 	return float4(image.Sample(def_sampler, vert_in.uv).rgb, 1.0);
 }
 
+float srgb_nonlinear_to_linear_channel(float u)
+{
+	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
+}
+
+float3 srgb_nonlinear_to_linear(float3 v)
+{
+	return float3(srgb_nonlinear_to_linear_channel(v.r), srgb_nonlinear_to_linear_channel(v.g), srgb_nonlinear_to_linear_channel(v.b));
+}
+
+float4 PSDrawSrgbDecompressPremultiplied(VertInOut vert_in) : TARGET
+{
+	float4 rgba = image.Sample(def_sampler, vert_in.uv);
+	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
+	return rgba;
+}
+
 technique Draw
 {
 	pass
@@ -45,5 +63,14 @@ technique DrawOpaque
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawOpaque(vert_in);
+	}
+}
+
+technique DrawSrgbDecompressPremultiplied
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawSrgbDecompressPremultiplied(vert_in);
 	}
 }


### PR DESCRIPTION
### Description
Necessary for an upcoming fix to browser source, obsproject/obs-browser#300.

### Motivation and Context
Need browser source alpha to behave like the rest of OBS.

### How Has This Been Tested?
Windows and Mac return the correct colors.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.