### PR TITLE
pipewire: Properly account for cursor hotspot

### DIFF
--- a/plugins/linux-capture/pipewire.c
+++ b/plugins/linux-capture/pipewire.c
@@ -1234,9 +1234,11 @@ void obs_pipewire_video_render(obs_pipewire_data *obs_pw, gs_effect_t *effect)
 
 	if (obs_pw->cursor.visible && obs_pw->cursor.valid &&
 	    obs_pw->cursor.texture) {
+		float cursor_x = obs_pw->cursor.x - obs_pw->cursor.hotspot_x;
+		float cursor_y = obs_pw->cursor.y - obs_pw->cursor.hotspot_y;
+
 		gs_matrix_push();
-		gs_matrix_translate3f((float)obs_pw->cursor.x,
-				      (float)obs_pw->cursor.y, 0.0f);
+		gs_matrix_translate3f(cursor_x, cursor_y, 0.0f);
 
 		gs_effect_set_texture(image, obs_pw->cursor.texture);
 		gs_draw_sprite(obs_pw->texture, 0, obs_pw->cursor.width,


### PR DESCRIPTION
### Description

Properly account for the hotspot by subtracting it from the cursor position.

### Motivation and Context

The cursor bitmap is centered on the hotspot, so not accounting for it means PipeWire captures were positioning the cursor sprite slightly off.

Notice that this is effectively untestable on GNOME without this PR's sibling request: https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1901

### How Has This Been Tested?

 - Add a PipeWire capture (window or monitor)
 - Notice that the cursor is positioned *exactly* where it should be

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
