### PR TITLE
graphics-hook: Fix D3D12 third party overlay capture setting

### DIFF
--- a/plugins/win-capture/graphics-hook/d3d10-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d10-capture.cpp
@@ -330,7 +330,7 @@ static inline void d3d10_shmem_capture(ID3D10Resource *backbuffer)
 	data.cur_tex = next_tex;
 }
 
-void d3d10_capture(void *swap_ptr, void *backbuffer_ptr, bool)
+void d3d10_capture(void *swap_ptr, void *backbuffer_ptr)
 {
 	IDXGIResource *dxgi_backbuffer = (IDXGIResource *)backbuffer_ptr;
 	IDXGISwapChain *swap = (IDXGISwapChain *)swap_ptr;

--- a/plugins/win-capture/graphics-hook/d3d11-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d11-capture.cpp
@@ -337,7 +337,7 @@ static inline void d3d11_shmem_capture(ID3D11Resource *backbuffer)
 	data.cur_tex = next_tex;
 }
 
-void d3d11_capture(void *swap_ptr, void *backbuffer_ptr, bool)
+void d3d11_capture(void *swap_ptr, void *backbuffer_ptr)
 {
 	IDXGIResource *dxgi_backbuffer = (IDXGIResource *)backbuffer_ptr;
 	IDXGISwapChain *swap = (IDXGISwapChain *)swap_ptr;

--- a/plugins/win-capture/graphics-hook/d3d12-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d12-capture.cpp
@@ -321,8 +321,7 @@ static inline void d3d12_copy_texture(ID3D11Resource *dst, ID3D11Resource *src)
 	}
 }
 
-static inline void d3d12_shtex_capture(IDXGISwapChain *swap,
-				       bool capture_overlay)
+static inline void d3d12_shtex_capture(IDXGISwapChain *swap)
 {
 	bool dxgi_1_4 = data.dxgi_1_4;
 	UINT cur_idx;
@@ -331,10 +330,6 @@ static inline void d3d12_shtex_capture(IDXGISwapChain *swap,
 		IDXGISwapChain3 *swap3 =
 			reinterpret_cast<IDXGISwapChain3 *>(swap);
 		cur_idx = swap3->GetCurrentBackBufferIndex();
-		if (!capture_overlay) {
-			if (++cur_idx >= data.backbuffer_count)
-				cur_idx = 0;
-		}
 	} else {
 		cur_idx = data.cur_backbuffer;
 	}
@@ -352,7 +347,7 @@ static inline void d3d12_shtex_capture(IDXGISwapChain *swap,
 	}
 }
 
-void d3d12_capture(void *swap_ptr, void *, bool capture_overlay)
+void d3d12_capture(void *swap_ptr, void *)
 {
 	IDXGISwapChain *swap = (IDXGISwapChain *)swap_ptr;
 
@@ -363,7 +358,7 @@ void d3d12_capture(void *swap_ptr, void *, bool capture_overlay)
 		d3d12_init(swap);
 	}
 	if (capture_ready()) {
-		d3d12_shtex_capture(swap, capture_overlay);
+		d3d12_shtex_capture(swap);
 	}
 }
 

--- a/plugins/win-capture/graphics-hook/dxgi-capture.cpp
+++ b/plugins/win-capture/graphics-hook/dxgi-capture.cpp
@@ -31,7 +31,7 @@ bool dxgi_present_attempted = false;
 
 struct dxgi_swap_data {
 	IDXGISwapChain *swap;
-	void (*capture)(void *, void *, bool);
+	void (*capture)(void *, void *);
 	void (*free)(void);
 };
 
@@ -223,7 +223,7 @@ static HRESULT STDMETHODCALLTYPE hook_present(IDXGISwapChain *swap,
 		IUnknown *backbuffer = get_dxgi_backbuffer(swap);
 
 		if (backbuffer) {
-			data.capture(swap, backbuffer, capture_overlay);
+			data.capture(swap, backbuffer);
 			backbuffer->Release();
 		}
 	}
@@ -250,7 +250,7 @@ static HRESULT STDMETHODCALLTYPE hook_present(IDXGISwapChain *swap,
 			IUnknown *backbuffer = get_dxgi_backbuffer(swap);
 
 			if (backbuffer) {
-				data.capture(swap, backbuffer, capture_overlay);
+				data.capture(swap, backbuffer);
 				backbuffer->Release();
 			}
 		}
@@ -285,7 +285,7 @@ hook_present1(IDXGISwapChain1 *swap, UINT sync_interval, UINT flags,
 		if (backbuffer) {
 			DXGI_SWAP_CHAIN_DESC1 desc;
 			swap->GetDesc1(&desc);
-			data.capture(swap, backbuffer, capture_overlay);
+			data.capture(swap, backbuffer);
 			backbuffer->Release();
 		}
 	}
@@ -305,7 +305,7 @@ hook_present1(IDXGISwapChain1 *swap, UINT sync_interval, UINT flags,
 			IUnknown *backbuffer = get_dxgi_backbuffer(swap);
 
 			if (backbuffer) {
-				data.capture(swap, backbuffer, capture_overlay);
+				data.capture(swap, backbuffer);
 				backbuffer->Release();
 			}
 		}

--- a/plugins/win-capture/graphics-hook/graphics-hook.h
+++ b/plugins/win-capture/graphics-hook/graphics-hook.h
@@ -57,13 +57,13 @@ extern bool hook_gl(void);
 extern bool hook_vulkan(void);
 #endif
 
-extern void d3d10_capture(void *swap, void *backbuffer, bool capture_overlay);
+extern void d3d10_capture(void *swap, void *backbuffer);
 extern void d3d10_free(void);
-extern void d3d11_capture(void *swap, void *backbuffer, bool capture_overlay);
+extern void d3d11_capture(void *swap, void *backbuffer);
 extern void d3d11_free(void);
 
 #if COMPILE_D3D12_HOOK
-extern void d3d12_capture(void *swap, void *backbuffer, bool capture_overlay);
+extern void d3d12_capture(void *swap, void *backbuffer);
 extern void d3d12_free(void);
 #endif
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Doesn't make sense to grab the oldest frame when not capturing overlays, because the overlay was already rendered in it.
This will grab the latest frame.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
The "Capture third-party overlays (such as steam)" option in Game Capture wasn't working properly, it would capture overlays at all times if the game uses DirectX 12, regardless of this setting.
Fixes #3946
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Tested in Modern Warfare (2019) and Civilization 6 in DX12 mode (with discord and steam overlays).
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
Bug fix.
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
