### PR TITLE
win-capture: Add option to allow transparency

### DIFF
--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -426,14 +426,14 @@ static obs_properties_t *wc_properties(void *data)
 	obs_property_list_add_int(p, TEXT_MATCH_CLASS, WINDOW_PRIORITY_CLASS);
 	obs_property_list_add_int(p, TEXT_MATCH_EXE, WINDOW_PRIORITY_EXE);
 
+	obs_properties_add_bool(ppts, "allow_transparency",
+				TEXT_ALLOW_TRANSPARENCY);
+
 	obs_properties_add_bool(ppts, "cursor", TEXT_CAPTURE_CURSOR);
 
 	obs_properties_add_bool(ppts, "compatibility", TEXT_COMPATIBILITY);
 
 	obs_properties_add_bool(ppts, "client_area", TEXT_CLIENT_AREA);
-
-	obs_properties_add_bool(ppts, "allow_transparency",
-				TEXT_ALLOW_TRANSPARENCY);
 
 	return ppts;
 }


### PR DESCRIPTION
### Description
Adds an "Allow transparency" checkbox to Window Capture on Windows to preserve transparency of captured windows.

### Motivation and Context
Both currently supported methods of capturing windows in OBS preserve transparency at their source, however OBS explicitly disables this by rendering as opaque. This means in situations where you'd want to capture a window without it's background (e.g. LiveSplit), you'd have to do hacky workarounds like keying a colour, destroying text antialiasing & shadows, and creating awful artefacts if not done properly.

This PR allows users to preserve the transparency of their source window into OBS, with no keying nonsense and perfect quality, and also allows the correct capture of non-square windows (e.g. Windows 11)

It's important to note BitBlt and WCG both preserve transparency in slightly different ways. BitBlt works on the window's DC level, so has some odd behaviours with transparency on some windows (some colours appearing fully transparent even though they aren't), meanwhile WGC works on the compositor level and generally provides results more accurate to how the window appears on the desktop.

### How Has This Been Tested?
Tested on LiveSplit, Chrome, Windows Explorer, Task Manager, Electron and iTunes on Windows 10 21H1


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
