### PR TITLE
obs-ffmpeg: Add ability to set FFmpeg options

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -680,6 +680,19 @@ static bool init_avformat(mp_media_t *m)
 	if (m->buffering && !m->is_local_file && !is_rist)
 		av_dict_set_int(&opts, "buffer_size", m->buffering, 0);
 
+	if (m->ffmpeg_options) {
+		int ret = av_dict_parse_string(&opts, m->ffmpeg_options, "=",
+					       " ", 0);
+		if (ret) {
+			blog(LOG_WARNING,
+			     "Failed to parse FFmpeg options: %s\n%s",
+			     av_err2str(ret), m->ffmpeg_options);
+		} else {
+			blog(LOG_INFO, "Set FFmpeg options: %s",
+			     m->ffmpeg_options);
+		}
+	}
+
 	m->fmt = avformat_alloc_context();
 	if (m->buffering == 0) {
 		m->fmt->flags |= AVFMT_FLAG_NOBUFFER;
@@ -863,6 +876,7 @@ bool mp_media_init(mp_media_t *media, const struct mp_media_info *info)
 	media->v_cb = info->v_cb;
 	media->a_cb = info->a_cb;
 	media->stop_cb = info->stop_cb;
+	media->ffmpeg_options = info->ffmpeg_options;
 	media->v_seek_cb = info->v_seek_cb;
 	media->v_preload_cb = info->v_preload_cb;
 	media->force_range = info->force_range;

--- a/deps/media-playback/media-playback/media.h
+++ b/deps/media-playback/media-playback/media.h
@@ -54,6 +54,7 @@ struct mp_media {
 
 	char *path;
 	char *format_name;
+	char *ffmpeg_options;
 	int buffering;
 	int speed;
 
@@ -118,6 +119,7 @@ struct mp_media_info {
 
 	const char *path;
 	const char *format;
+	char *ffmpeg_options;
 	int buffering;
 	int speed;
 	enum video_range_type force_range;

--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -62,6 +62,9 @@ MediaFileFilter.AllFiles="All Files"
 ReplayBuffer="Replay Buffer"
 ReplayBuffer.Save="Save Replay"
 
+FFmpeg.Options="FFmpeg Options"
+FFmpeg.Options.Tooltip="Allows you to set FFmpeg options. This only accepts options in the option=value format.\nMultiple options can be set by separating them with a space.\nExample: rtsp_transport=tcp rtsp_flags=prefer_tcp"
+
 HelperProcessFailed="Unable to start the recording helper process. Check that OBS files have not been blocked or removed by any 3rd party antivirus / security software."
 UnableToWritePath="Unable to write to %1. Make sure you're using a recording path which your user account is allowed to write to and that there is sufficient disk space."
 WarnWindowsDefender="If Windows 10 Ransomware Protection is enabled it can also cause this error. Try turning off controlled folder access in Windows Security / Virus & threat protection settings."


### PR DESCRIPTION
### Description
Added the ability to pass options to the media source to provide ffmpeg which options, such as forcing the RTSP transport protocol 

**This is a feature for the Media Source but does require code change in the obs-ffmpeg plugin.**

This adds one additional free text entry field at bottom of the media source dialogue

![rtsp2](https://user-images.githubusercontent.com/44541549/129675219-4c7c0dc4-f724-41f3-9cc8-536a5eaa7399.png)

### Motivation and Context
This was added so that obs can be configured to stream from rtsp devices using TCP, devices that often experience random video corruption when streaming over UDP.  This corruption usually presents as near the bottom of a video frame, as shown and discussed below

https://github.com/obsproject/obs-studio/issues/3684

### How Has This Been Tested?
I've tested this heavily on 64bit Windows 10, and on Ubuntu Focal x64.

### Types of changes
New feature (non-breaking change which adds functionality)
Performance enhancement (non-breaking change which improves efficiency) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
