### PR TITLE
libobs/callback: Fix signal_handler_disconnect_global

### DIFF
--- a/libobs/callback/signal.c
+++ b/libobs/callback/signal.c
@@ -403,7 +403,7 @@ void signal_handler_disconnect_global(signal_handler_t *handler,
 				      global_signal_callback_t callback,
 				      void *data)
 {
-	struct global_callback_info cb_data = {callback, data, false};
+	struct global_callback_info cb_data = {callback, data, 0, false};
 	size_t idx;
 
 	if (!handler || !callback)


### PR DESCRIPTION

### Description
signal_handler_disconnect_global was not disconnecting, because the struct used to compare was not initialized correctly

### Motivation and Context
I use this function in my plugins, but it was not working, causing OBS to crash when signals where handled on deleted objects.

### How Has This Been Tested?
Using my audio monitor plugin on windows 64 bits

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
