### PR TITLE
[WIP] obs-nvenc on Linux

### DIFF
--- a/docs/sphinx/reference-encoders.rst
+++ b/docs/sphinx/reference-encoders.rst
@@ -144,6 +144,17 @@ Encoder Definition Structure (obs_encoder_info)
 
    :param  info: Video format information
 
+.. member:: bool (*obs_encoder_info.encode_texture_available)(void *data, const struct video_scale_info *info)
+
+   Returns whether texture encoding is available for this video format.
+   Has no effect if caps does not contain OBS_ENCODER_CAP_PASS_TEXTURE.
+   If this function is not defined, it is assumed that only textures in
+   NV12 format are supported.
+
+   :param  info: Video format information
+   :return:      Whether the encoder supports texture encoding with
+                 this video format
+
 .. member:: void *obs_encoder_info.type_data
             void (*obs_encoder_info.free_type_data)(void *type_data)
 

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -221,7 +221,7 @@ static void remove_connection(struct obs_encoder *encoder, bool shutdown)
 		audio_output_disconnect(encoder->media, encoder->mixer_idx,
 					receive_audio, encoder);
 	} else {
-		if (gpu_encode_available(encoder)) {
+		if (os_atomic_load_long(&obs->video.gpu_encoder_active)) {
 			stop_gpu_encode(encoder);
 		} else {
 			stop_raw_video(encoder->media, receive_video, encoder);

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -213,9 +213,21 @@ static bool add_connection(struct obs_encoder *encoder)
 
 		if (gpu_encode_available(encoder, &info)) {
 			start_gpu_encode(encoder);
-		} else {
+		} else if (encoder->info.encode) {
 			start_raw_video(encoder->media, &info, receive_video,
 					encoder);
+		} else {
+			const char *name =
+				obs_encoder_get_display_name(encoder->info.id);
+			struct dstr error_message = {0};
+			dstr_printf(
+				&error_message,
+				"Texture-only encoder %s not supported on this device",
+				name ? name : encoder->info.id);
+			obs_encoder_set_last_error(encoder,
+						   error_message.array);
+			dstr_free(&error_message);
+			return false;
 		}
 	}
 

--- a/libobs/obs-encoder.h
+++ b/libobs/obs-encoder.h
@@ -262,6 +262,21 @@ struct obs_encoder_info {
 			       uint64_t lock_key, uint64_t *next_key,
 			       struct encoder_packet *packet,
 			       bool *received_packet);
+
+	/**
+	 * Returns whether texture encoding is available for this video format
+	 *
+	 * Has no effect if caps does not contain OBS_ENCODER_CAP_PASS_TEXTURE.
+	 * If this function is not defined, it is assumed that only textures in
+	 * NV12 format are supported.
+	 *
+	 * @param          data  Data associated with this encoder context
+	 * @param[in]      info  Video format information
+	 * @return               Whether the encoder supports texture encoding
+	 *                       with this video format
+	 */
+	bool (*encode_texture_available)(void *data,
+					 const struct video_scale_info *info);
 };
 
 EXPORT void obs_register_encoder_s(const struct obs_encoder_info *info,

--- a/libobs/obs-encoder.h
+++ b/libobs/obs-encoder.h
@@ -102,6 +102,18 @@ struct encoder_frame {
 	int64_t pts;
 };
 
+struct gs_texture;
+
+/** Encoder input texture */
+struct encoder_texture {
+	/** Texture format and size */
+	struct video_scale_info info;
+	/** Shared texture handle, only set on Windows */
+	uint32_t handle;
+	/** Textures, NULL-terminated */
+	struct gs_texture *tex[];
+};
+
 /**
  * Encoder interface
  *
@@ -277,6 +289,12 @@ struct obs_encoder_info {
 	 */
 	bool (*encode_texture_available)(void *data,
 					 const struct video_scale_info *info);
+
+	bool (*encode_texture2)(void *data, struct encoder_texture *texture,
+				int64_t pts, uint64_t lock_key,
+				uint64_t *next_key,
+				struct encoder_packet *packet,
+				bool *received_packet);
 };
 
 EXPORT void obs_register_encoder_s(const struct obs_encoder_info *info,

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -250,10 +250,8 @@ struct obs_core_video {
 	gs_stagesurf_t *active_copy_surfaces[NUM_TEXTURES][NUM_CHANNELS];
 	gs_stagesurf_t *copy_surfaces[NUM_TEXTURES][NUM_CHANNELS];
 	gs_texture_t *convert_textures[NUM_CHANNELS];
-#ifdef _WIN32
 	gs_stagesurf_t *copy_surfaces_encode[NUM_TEXTURES];
 	gs_texture_t *convert_textures_encode[NUM_CHANNELS];
-#endif
 	gs_texture_t *render_texture;
 	gs_texture_t *output_texture;
 	enum gs_color_space render_space;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1204,7 +1204,7 @@ extern struct obs_encoder_info *find_encoder(const char *id);
 extern bool obs_encoder_initialize(obs_encoder_t *encoder);
 extern void obs_encoder_shutdown(obs_encoder_t *encoder);
 
-extern void obs_encoder_start(obs_encoder_t *encoder,
+extern bool obs_encoder_start(obs_encoder_t *encoder,
 			      void (*new_packet)(void *param,
 						 struct encoder_packet *packet),
 			      void *param);

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1204,6 +1204,9 @@ extern struct obs_encoder_info *find_encoder(const char *id);
 extern bool obs_encoder_initialize(obs_encoder_t *encoder);
 extern void obs_encoder_shutdown(obs_encoder_t *encoder);
 
+extern void obs_encoder_get_video_info(struct obs_encoder *encoder,
+				       struct video_scale_info *info);
+
 extern bool obs_encoder_start(obs_encoder_t *encoder,
 			      void (*new_packet)(void *param,
 						 struct encoder_packet *packet),

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -594,16 +594,30 @@ cleanup:
 		da_push_back(dest, &data);                              \
 	} while (false)
 
-#define CHECK_REQUIRED_VAL(type, info, val, func)                       \
-	do {                                                            \
-		if ((offsetof(type, val) + sizeof(info->val) > size) || \
-		    !info->val) {                                       \
-			blog(LOG_ERROR,                                 \
-			     "Required value '" #val "' for "           \
-			     "'%s' not found.  " #func " failed.",      \
-			     info->id);                                 \
-			goto error;                                     \
-		}                                                       \
+#define HAS_VAL(type, info, val) \
+	((offsetof(type, val) + sizeof(info->val) <= size) && info->val)
+
+#define CHECK_REQUIRED_VAL(type, info, val, func)                  \
+	do {                                                       \
+		if (!HAS_VAL(type, info, val)) {                   \
+			blog(LOG_ERROR,                            \
+			     "Required value '" #val "' for "      \
+			     "'%s' not found.  " #func " failed.", \
+			     info->id);                            \
+			goto error;                                \
+		}                                                  \
+	} while (false)
+
+#define CHECK_REQUIRED_VAL_EITHER(type, info, val1, val2, func)     \
+	do {                                                        \
+		if (!HAS_VAL(type, info, val1) &&                   \
+		    !HAS_VAL(type, info, val2)) {                   \
+			blog(LOG_ERROR,                             \
+			     "Neither '" #val1 "' nor '" #val2 "' " \
+			     "for '%s' found.  " #func " failed.",  \
+			     info->id);                             \
+			goto error;                                 \
+		}                                                   \
 	} while (false)
 
 #define HANDLE_ERROR(size_var, structure, info)                            \
@@ -793,7 +807,9 @@ void obs_register_encoder_s(const struct obs_encoder_info *info, size_t size)
 	CHECK_REQUIRED_VAL_(info, destroy, obs_register_encoder);
 
 	if ((info->caps & OBS_ENCODER_CAP_PASS_TEXTURE) != 0)
-		CHECK_REQUIRED_VAL_(info, encode_texture, obs_register_encoder);
+		CHECK_REQUIRED_VAL_EITHER(struct obs_encoder_info, info,
+					  encode_texture, encode_texture2,
+					  obs_register_encoder);
 	else
 		CHECK_REQUIRED_VAL_(info, encode, obs_register_encoder);
 

--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -71,7 +71,7 @@ static void *gpu_encode_thread(void *unused)
 		for (size_t i = 0; i < encoders.num; i++) {
 			struct encoder_packet pkt = {0};
 			bool received = false;
-			bool success;
+			bool success = false;
 
 			obs_encoder_t *encoder = encoders.array[i];
 			struct obs_encoder *pair = encoder->paired_encoder;
@@ -104,10 +104,33 @@ static void *gpu_encode_thread(void *unused)
 			else
 				next_key++;
 
-			success = encoder->info.encode_texture(
-				encoder->context.data, tf.handle,
-				encoder->cur_pts, lock_key, &next_key, &pkt,
-				&received);
+			if (encoder->info.encode_texture2) {
+				union {
+					struct encoder_texture tex;
+					/* MSVC complains about
+					   offsetof(..., tex[3]) */
+					char dummy[offsetof(struct encoder_texture,
+							    tex) +
+						   sizeof(struct gs_texture *) *
+							   3];
+				} u = {0};
+
+				obs_encoder_get_video_info(encoder,
+							   &u.tex.info);
+				u.tex.handle = tf.handle;
+				u.tex.tex[0] = tf.tex;
+				u.tex.tex[1] = tf.tex_uv;
+				u.tex.tex[2] = NULL;
+				success = encoder->info.encode_texture2(
+					encoder->context.data, &u.tex,
+					encoder->cur_pts, lock_key, &next_key,
+					&pkt, &received);
+			} else {
+				success = encoder->info.encode_texture(
+					encoder->context.data, tf.handle,
+					encoder->cur_pts, lock_key, &next_key,
+					&pkt, &received);
+			}
 			send_off_encoder_packet(encoder, success, received,
 						&pkt);
 

--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -174,7 +174,7 @@ static void *gpu_encode_thread(void *unused)
 
 bool init_gpu_encoding(struct obs_core_video *video)
 {
-#ifdef _WIN32
+#ifndef __APPLE__
 	struct obs_video_info *ovi = &video->ovi;
 
 	video->gpu_encode_stop = false;
@@ -184,6 +184,7 @@ bool init_gpu_encoding(struct obs_core_video *video)
 		gs_texture_t *tex;
 		gs_texture_t *tex_uv = NULL;
 
+#ifdef _WIN32
 		if (ovi->output_format == VIDEO_FORMAT_P010) {
 			gs_texture_create_p010(&tex, &tex_uv, ovi->output_width,
 					       ovi->output_height,
@@ -195,6 +196,9 @@ bool init_gpu_encoding(struct obs_core_video *video)
 					       GS_RENDER_TARGET |
 						       GS_SHARED_KM_TEX);
 		} else {
+#else
+		if (true) {
+#endif
 			/* Keep in sync with obs.c:obs_init_textures */
 			enum gs_color_format format = GS_RGBA;
 			switch (ovi->output_format) {
@@ -214,7 +218,11 @@ bool init_gpu_encoding(struct obs_core_video *video)
 			return false;
 		}
 
+#ifdef _WIN32
 		uint32_t handle = gs_texture_get_shared_handle(tex);
+#else
+		uint32_t handle = (uint32_t)-1;
+#endif
 
 		struct obs_tex_frame frame = {
 			.tex = tex, .tex_uv = tex_uv, .handle = handle};

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -375,6 +375,7 @@ static bool obs_init_textures(struct obs_video_info *ovi)
 		}
 	}
 
+	/* Keep in sync with obs-video-gpu-encode.c:init_gpu_encoding */
 	enum gs_color_format format = GS_RGBA;
 	switch (ovi->output_format) {
 	case VIDEO_FORMAT_I010:
@@ -399,15 +400,15 @@ static bool obs_init_textures(struct obs_video_info *ovi)
 		}
 	}
 
-	video->render_texture = gs_texture_create(ovi->base_width,
-						  ovi->base_height, format, 1,
-						  NULL, GS_RENDER_TARGET);
+	video->render_texture =
+		gs_texture_create(ovi->base_width, ovi->base_height, format, 1,
+				  NULL, GS_RENDER_TARGET | GS_SHARED_KM_TEX);
 	if (!video->render_texture)
 		success = false;
 
-	video->output_texture = gs_texture_create(ovi->output_width,
-						  ovi->output_height, format, 1,
-						  NULL, GS_RENDER_TARGET);
+	video->output_texture =
+		gs_texture_create(ovi->output_width, ovi->output_height, format,
+				  1, NULL, GS_RENDER_TARGET | GS_SHARED_KM_TEX);
 	if (!video->output_texture)
 		success = false;
 

--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -163,7 +163,8 @@ static bool try_connect(void *data, const char *device)
 	obs_output_set_video_conversion(vcam->output, &vsi);
 
 	blog(LOG_INFO, "Virtual camera started");
-	obs_output_begin_data_capture(vcam->output, 0);
+	if (!obs_output_begin_data_capture(vcam->output, 0))
+		return false;
 
 	return true;
 }

--- a/plugins/obs-ffmpeg/CMakeLists.txt
+++ b/plugins/obs-ffmpeg/CMakeLists.txt
@@ -57,22 +57,30 @@ endif()
 set_target_properties(obs-ffmpeg PROPERTIES FOLDER "plugins/obs-ffmpeg" PREFIX
                                                                         "")
 
-if(OS_WINDOWS)
+if(OS_WINDOWS OR OS_POSIX)
   if(MSVC)
     target_link_libraries(obs-ffmpeg PRIVATE OBS::w32-pthreads)
   endif()
 
-  set(MODULE_DESCRIPTION "OBS FFmpeg module")
-  configure_file(${CMAKE_SOURCE_DIR}/cmake/bundle/windows/obs-module.rc.in
-                 obs-ffmpeg.rc)
+  if(OS_WINDOWS)
+    set(MODULE_DESCRIPTION "OBS FFmpeg module")
+    configure_file(${CMAKE_SOURCE_DIR}/cmake/bundle/windows/obs-module.rc.in
+                   obs-ffmpeg.rc)
+  endif()
 
-  target_sources(obs-ffmpeg PRIVATE jim-nvenc.c jim-nvenc.h jim-nvenc-helpers.c
-                                    obs-ffmpeg.rc)
+  if(NOT OS_MACOS)
+    target_sources(obs-ffmpeg PRIVATE jim-nvenc.c jim-nvenc.h
+                                      jim-nvenc-helpers.c)
+    if(OS_WINDOWS)
+      target_sources(obs-ffmpeg PRIVATE obs-ffmpeg.rc)
+    endif()
+  endif()
 
-elseif(OS_POSIX AND NOT OS_MACOS)
-  find_package(Libpci REQUIRED)
-  target_sources(obs-ffmpeg PRIVATE obs-ffmpeg-vaapi.c)
-  target_link_libraries(obs-ffmpeg PRIVATE LIBPCI::LIBPCI)
+  if(OS_POSIX AND NOT OS_MACOS)
+    find_package(Libpci REQUIRED)
+    target_sources(obs-ffmpeg PRIVATE obs-ffmpeg-vaapi.c)
+    target_link_libraries(obs-ffmpeg PRIVATE LIBPCI::LIBPCI)
+  endif()
 endif()
 
 setup_plugin_target(obs-ffmpeg)

--- a/plugins/obs-ffmpeg/jim-nvenc-helpers.c
+++ b/plugins/obs-ffmpeg/jim-nvenc-helpers.c
@@ -72,10 +72,18 @@ bool nv_failed(obs_encoder_t *encoder, NVENCSTATUS err, const char *func,
 
 bool load_nvenc_lib(void)
 {
+#if !defined(__APPLE__)
+#ifdef _WIN32
 	const char *const file = (sizeof(void *) == 8) ? "nvEncodeAPI64.dll"
 						       : "nvEncodeAPI.dll";
+#else
+	const char *const file = "libnvidia-encode.so.1";
+#endif
 	nvenc_lib = os_dlopen(file);
 	return nvenc_lib != NULL;
+#else
+	return false;
+#endif
 }
 
 static void *load_nv_func(const char *func)

--- a/plugins/obs-ffmpeg/jim-nvenc-helpers.c
+++ b/plugins/obs-ffmpeg/jim-nvenc-helpers.c
@@ -79,6 +79,8 @@ bool load_nvenc_lib(void)
 #else
 	const char *const file = "libnvidia-encode.so.1";
 #endif
+	if (nvenc_lib)
+		return true;
 	nvenc_lib = os_dlopen(file);
 	return nvenc_lib != NULL;
 #else

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -1389,6 +1389,13 @@ static bool nvenc_encode_tex(void *data, uint32_t handle, int64_t pts,
 	return true;
 }
 
+static bool nvenc_encode_texture_available(void *data,
+					   const struct video_scale_info *info)
+{
+	UNUSED_PARAMETER(data);
+	return info->format == VIDEO_FORMAT_NV12;
+}
+
 extern void h264_nvenc_defaults(obs_data_t *settings);
 extern obs_properties_t *h264_nvenc_properties(void *unused);
 #ifdef ENABLE_HEVC
@@ -1432,6 +1439,7 @@ struct obs_encoder_info h264_nvenc_info = {
 	.destroy = nvenc_destroy,
 	.update = nvenc_update,
 	.encode_texture = nvenc_encode_tex,
+	.encode_texture_available = nvenc_encode_texture_available,
 	.get_defaults = h264_nvenc_defaults,
 	.get_properties = h264_nvenc_properties,
 	.get_extra_data = nvenc_extra_data,
@@ -1449,6 +1457,7 @@ struct obs_encoder_info hevc_nvenc_info = {
 	.destroy = nvenc_destroy,
 	.update = nvenc_update,
 	.encode_texture = nvenc_encode_tex,
+	.encode_texture_available = nvenc_encode_texture_available,
 	.get_defaults = hevc_nvenc_defaults,
 	.get_properties = hevc_nvenc_properties,
 	.get_extra_data = nvenc_extra_data,

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -89,7 +89,7 @@ struct nv_bitstream {
 	HANDLE event;
 };
 
-#define NV_FAIL(format, ...) nv_fail(enc->encoder, format, __VA_ARGS__)
+#define NV_FAIL(...) nv_fail(enc->encoder, __VA_ARGS__)
 #define NV_FAILED(x) nv_failed(enc->encoder, x, __FUNCTION__, #x)
 
 static bool nv_bitstream_init(struct nvenc_data *enc, struct nv_bitstream *bs)

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -1117,7 +1117,7 @@ static void *nvenc_create_h264_hevc(bool hevc, obs_data_t *settings,
 		return enc;
 	}
 
-reroute:
+reroute:;
 	const char *fallback_name = "ffmpeg_nvenc";
 #ifdef ENABLE_HEVC
 	if (hevc)

--- a/plugins/obs-ffmpeg/jim-nvenc.h
+++ b/plugins/obs-ffmpeg/jim-nvenc.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#endif
 
 #include <obs-module.h>
 #include "external/nvEncodeAPI.h"

--- a/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
@@ -164,7 +164,8 @@ bool ffmpeg_hls_mux_start(void *data)
 	stream->dropped_frames = 0;
 	stream->min_priority = 0;
 
-	obs_output_begin_data_capture(stream->output, 0);
+	if (!obs_output_begin_data_capture(stream->output, 0))
+		return false;
 
 	dstr_copy(&stream->printable_path, path_str);
 	info("Writing to path '%s'...", stream->printable_path.array);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -427,7 +427,12 @@ static bool ffmpeg_mux_start(void *data)
 	os_atomic_set_bool(&stream->active, true);
 	os_atomic_set_bool(&stream->capturing, true);
 	stream->total_bytes = 0;
-	obs_output_begin_data_capture(stream->output, 0);
+	if (!obs_output_begin_data_capture(stream->output, 0)) {
+		warn("Failed to begin data capture");
+		os_atomic_set_bool(&stream->capturing, false);
+		os_atomic_set_bool(&stream->active, false);
+		return false;
+	}
 
 	info("Writing file '%s'...", stream->path.array);
 	return true;
@@ -994,7 +999,12 @@ static bool replay_buffer_start(void *data)
 	os_atomic_set_bool(&stream->active, true);
 	os_atomic_set_bool(&stream->capturing, true);
 	stream->total_bytes = 0;
-	obs_output_begin_data_capture(stream->output, 0);
+	if (!obs_output_begin_data_capture(stream->output, 0)) {
+		warn("Failed to begin data capture");
+		os_atomic_set_bool(&stream->capturing, false);
+		os_atomic_set_bool(&stream->active, false);
+		return false;
+	}
 
 	return true;
 }

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -552,7 +552,7 @@ struct obs_encoder_info h264_nvenc_encoder_info = {
 	.get_extra_data = nvenc_extra_data,
 	.get_sei_data = nvenc_sei_data,
 	.get_video_info = nvenc_video_info,
-#ifdef _WIN32
+#ifndef __APPLE__
 	.caps = OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_INTERNAL,
 #else
 	.caps = OBS_ENCODER_CAP_DYN_BITRATE,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -1228,7 +1228,13 @@ static bool try_connect(struct ffmpeg_output *output)
 
 	obs_output_set_video_conversion(output->output, NULL);
 	obs_output_set_audio_conversion(output->output, &aci);
-	obs_output_begin_data_capture(output->output, 0);
+	if (!obs_output_begin_data_capture(output->output, 0)) {
+		ffmpeg_log_error(LOG_WARNING, &output->ff_data,
+				 "ffmpeg_output_start: Failed to begin data "
+				 "capture.");
+		ffmpeg_output_full_stop(output);
+		return false;
+	}
 	output->write_thread_active = true;
 	return true;
 }

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -224,16 +224,6 @@ static bool nvenc_device_available(void)
 
 extern bool load_nvenc_lib(void);
 
-#ifndef _WIN32
-bool load_nvenc_lib(void)
-{
-	void *lib = os_dlopen("libnvidia-encode.so.1");
-	if (lib)
-		os_dlclose(lib);
-	return !!lib;
-}
-#endif
-
 static bool nvenc_codec_exists(const char *name, const char *fallback)
 {
 	AVCodec *nvenc = avcodec_find_encoder_by_name(name);
@@ -288,11 +278,6 @@ static bool vaapi_supported(void)
 
 extern void jim_nvenc_load(bool h264, bool hevc);
 extern void jim_nvenc_unload(void);
-
-#ifndef _WIN32
-void jim_nvenc_load(bool h264, bool hevc) {}
-void jim_nvenc_unload(void) {}
-#endif
 
 #if ENABLE_FFMPEG_LOGGING
 extern void obs_ffmpeg_load_logging(void);

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -289,9 +289,12 @@ static bool vaapi_supported(void)
 }
 #endif
 
-#ifdef _WIN32
 extern void jim_nvenc_load(bool h264, bool hevc);
 extern void jim_nvenc_unload(void);
+
+#ifndef _WIN32
+void jim_nvenc_load(bool h264, bool hevc) {}
+void jim_nvenc_unload(void) {}
 #endif
 
 #if ENABLE_FFMPEG_LOGGING
@@ -343,6 +346,8 @@ bool obs_module_load(void)
 			}
 #endif
 		}
+#else
+		jim_nvenc_load(h264, hevc);
 #endif
 		if (h264)
 			obs_register_encoder(&h264_nvenc_encoder_info);
@@ -371,7 +376,7 @@ void obs_module_unload(void)
 	obs_ffmpeg_unload_logging();
 #endif
 
-#ifdef _WIN32
+#ifndef __APPLE__
 	jim_nvenc_unload();
 #endif
 }

--- a/plugins/obs-outputs/flv-output.c
+++ b/plugins/obs-outputs/flv-output.c
@@ -175,7 +175,13 @@ static bool flv_output_start(void *data)
 
 	/* write headers and start capture */
 	os_atomic_set_bool(&stream->active, true);
-	obs_output_begin_data_capture(stream->output, 0);
+	if (!obs_output_begin_data_capture(stream->output, 0)) {
+		warn("Failed to begin data capture");
+		os_atomic_set_bool(&stream->active, false);
+		fclose(stream->file);
+		stream->file = NULL;
+		return false;
+	}
 
 	info("Writing FLV file '%s'...", stream->path.array);
 	return true;

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -592,7 +592,11 @@ static int init_send(struct ftl_stream *stream)
 
 	os_atomic_set_bool(&stream->active, true);
 
-	obs_output_begin_data_capture(stream->output, 0);
+	if (!obs_output_begin_data_capture(stream->output, 0)) {
+		warn("Failed to begin data capture");
+		os_atomic_set_bool(&stream->active, false);
+		return OBS_OUTPUT_ERROR;
+	}
 
 	return OBS_OUTPUT_SUCCESS;
 }

--- a/plugins/obs-outputs/null-output.c
+++ b/plugins/obs-outputs/null-output.c
@@ -59,7 +59,8 @@ static bool null_output_start(void *data)
 	if (context->stop_thread_active)
 		pthread_join(context->stop_thread, NULL);
 
-	obs_output_begin_data_capture(context->output, 0);
+	if (!obs_output_begin_data_capture(context->output, 0))
+		return false;
 	return true;
 }
 

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -961,8 +961,12 @@ static int init_send(struct rtmp_stream *stream)
 		return OBS_OUTPUT_DISCONNECTED;
 	}
 
-	if (!silently_reconnecting(stream))
-		obs_output_begin_data_capture(stream->output, 0);
+	if (!silently_reconnecting(stream)) {
+		if (!obs_output_begin_data_capture(stream->output, 0)) {
+			warn("Failed to begin data capture");
+			return OBS_OUTPUT_DISCONNECTED;
+		}
+	}
 
 	return OBS_OUTPUT_SUCCESS;
 }

--- a/plugins/obs-qsv11/QSV_Encoder.h
+++ b/plugins/obs-qsv11/QSV_Encoder.h
@@ -105,6 +105,8 @@ typedef struct {
 	mfxU16 nICQQuality;
 	bool bMBBRC;
 	bool bCQM;
+	mfxU32 nFourCC;
+	mfxU16 nChromaFormat;
 } qsv_param_t;
 
 enum qsv_cpu_platform {
@@ -140,6 +142,7 @@ int qsv_encoder_encode_tex(qsv_t *, uint64_t, uint32_t, uint64_t, uint64_t *,
 int qsv_encoder_headers(qsv_t *, uint8_t **pSPS, uint8_t **pPPS,
 			uint16_t *pnSPS, uint16_t *pnPPS);
 enum qsv_cpu_platform qsv_get_cpu_platform();
+enum video_format qsv_encoder_get_video_format(qsv_t *);
 bool prefer_igpu_enc(int *iGPUIndex);
 
 #ifdef __cplusplus

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -202,8 +202,8 @@ bool QSV_Encoder_Internal::InitParams(qsv_param_t *pParams)
 	m_mfxEncParams.mfx.CodecProfile = pParams->nCodecProfile;
 	m_mfxEncParams.mfx.FrameInfo.FrameRateExtN = pParams->nFpsNum;
 	m_mfxEncParams.mfx.FrameInfo.FrameRateExtD = pParams->nFpsDen;
-	m_mfxEncParams.mfx.FrameInfo.FourCC = MFX_FOURCC_NV12;
-	m_mfxEncParams.mfx.FrameInfo.ChromaFormat = MFX_CHROMAFORMAT_YUV420;
+	m_mfxEncParams.mfx.FrameInfo.FourCC = pParams->nFourCC;
+	m_mfxEncParams.mfx.FrameInfo.ChromaFormat = pParams->nChromaFormat;
 	m_mfxEncParams.mfx.FrameInfo.PicStruct = MFX_PICSTRUCT_PROGRESSIVE;
 	m_mfxEncParams.mfx.FrameInfo.CropX = 0;
 	m_mfxEncParams.mfx.FrameInfo.CropY = 0;
@@ -216,10 +216,13 @@ bool QSV_Encoder_Internal::InitParams(qsv_param_t *pParams)
 	    (pParams->nbFrames == 0) &&
 	    (m_ver.Major == 1 && m_ver.Minor >= 31)) {
 		m_mfxEncParams.mfx.LowPower = MFX_CODINGOPTION_ON;
+		blog(LOG_DEBUG, "\t>>> QSV VDENC");
 		if (pParams->nRateControl == MFX_RATECONTROL_LA_ICQ ||
 		    pParams->nRateControl == MFX_RATECONTROL_LA_HRD ||
 		    pParams->nRateControl == MFX_RATECONTROL_LA)
 			pParams->nRateControl = MFX_RATECONTROL_VBR;
+	} else {
+		blog(LOG_DEBUG, "\t>>> QSV VME");
 	}
 
 	m_mfxEncParams.mfx.RateControlMethod = pParams->nRateControl;
@@ -289,6 +292,8 @@ bool QSV_Encoder_Internal::InitParams(qsv_param_t *pParams)
 		extendedBuffers[iBuffers++] = (mfxExtBuffer *)&m_co2;
 	}
 
+	blog(LOG_DEBUG, "\t>>> QSV lookahead = %d", pParams->nLADEPTH);
+
 	if (m_mfxEncParams.mfx.LowPower == MFX_CODINGOPTION_ON) {
 		memset(&m_co3, 0, sizeof(mfxExtCodingOption3));
 		m_co3.Header.BufferId = MFX_EXTBUFF_CODING_OPTION3;
@@ -340,7 +345,7 @@ mfxStatus QSV_Encoder_Internal::AllocateSurfaces()
 	mfxStatus sts = m_pmfxENC->QueryIOSurf(&m_mfxEncParams, &EncRequest);
 	MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
-	EncRequest.Type |= WILL_WRITE;
+	EncRequest.Type |= WILL_WRITE | MFX_MEMTYPE_FROM_VPPIN;
 
 	// SNB hack. On some SNB, it seems to require more surfaces
 	EncRequest.NumFrameSuggested += m_mfxEncParams.AsyncDepth;
@@ -367,7 +372,9 @@ mfxStatus QSV_Encoder_Internal::AllocateSurfaces()
 	} else {
 		mfxU16 width = (mfxU16)MSDK_ALIGN32(EncRequest.Info.Width);
 		mfxU16 height = (mfxU16)MSDK_ALIGN32(EncRequest.Info.Height);
-		mfxU8 bitsPerPixel = 12;
+		mfxU8 bitsPerPixel =
+			EncRequest.Info.FourCC == MFX_FOURCC_NV12 ? 12 : 8 * 4;
+
 		mfxU32 surfaceSize = width * height * bitsPerPixel / 8;
 		m_nSurfNum = EncRequest.NumFrameSuggested;
 
@@ -380,11 +387,21 @@ mfxStatus QSV_Encoder_Internal::AllocateSurfaces()
 			       sizeof(mfxFrameInfo));
 
 			mfxU8 *pSurface = (mfxU8 *)new mfxU8[surfaceSize];
-			m_pmfxSurfaces[i]->Data.Y = pSurface;
-			m_pmfxSurfaces[i]->Data.U = pSurface + width * height;
-			m_pmfxSurfaces[i]->Data.V =
-				pSurface + width * height + 1;
-			m_pmfxSurfaces[i]->Data.Pitch = width;
+
+			// Changing this to allow for direct ARGB encoding
+			if (EncRequest.Info.FourCC == MFX_FOURCC_NV12) {
+				m_pmfxSurfaces[i]->Data.Y = pSurface;
+				m_pmfxSurfaces[i]->Data.U =
+					pSurface + width * height;
+				m_pmfxSurfaces[i]->Data.V =
+					pSurface + width * height + 1;
+				m_pmfxSurfaces[i]->Data.Pitch = width;
+			} else if (EncRequest.Info.FourCC == MFX_FOURCC_BGR4) {
+				m_pmfxSurfaces[i]->Data.R = pSurface;
+				m_pmfxSurfaces[i]->Data.Pitch = width * 4;
+			} else {
+				return MFX_ERR_INVALID_VIDEO_PARAM;
+			}
 		}
 	}
 
@@ -478,18 +495,36 @@ mfxStatus QSV_Encoder_Internal::LoadNV12(mfxFrameSurface1 *pSurface,
 	}
 
 	pitch = pData->Pitch;
-	ptr = pData->Y + pInfo->CropX + pInfo->CropY * pData->Pitch;
 
-	// load Y plane
-	for (i = 0; i < h; i++)
-		memcpy(ptr + i * pitch, pDataY + i * strideY, w);
+	// Changed to allow for direct ARGB encoding
+	if (pInfo->FourCC == MFX_FOURCC_NV12) {
+		if ((pData->Y == NULL) || (pData->UV == NULL)) {
+			return MFX_ERR_NULL_PTR;
+		}
 
-	// load UV plane
-	h /= 2;
-	ptr = pData->UV + pInfo->CropX + (pInfo->CropY / 2) * pitch;
+		// load Y plane
+		ptr = pData->Y + pInfo->CropX + pInfo->CropY * pData->Pitch;
 
-	for (i = 0; i < h; i++)
-		memcpy(ptr + i * pitch, pDataUV + i * strideUV, w);
+		for (i = 0; i < h; i++) {
+			memcpy(ptr + i * pitch, pDataY + i * strideY, w);
+		}
+
+		// load UV plane
+		h /= 2;
+		ptr = pData->UV + pInfo->CropX + (pInfo->CropY / 2) * pitch;
+
+		for (i = 0; i < h; i++) {
+			memcpy(ptr + i * pitch, pDataUV + i * strideUV, w);
+		}
+	} else if (pInfo->FourCC == MFX_FOURCC_BGR4) {
+		ptr = pData->R + pInfo->CropX + pInfo->CropY * pData->Pitch;
+
+		for (i = 0; i < h; i++) {
+			memcpy(ptr + i * pitch, pDataY + i * strideY, 4 * w);
+		}
+	} else {
+		return MFX_ERR_UNDEFINED_BEHAVIOR;
+	}
 
 	return MFX_ERR_NONE;
 }
@@ -737,4 +772,14 @@ mfxStatus QSV_Encoder_Internal::Reset(qsv_param_t *pParams)
 	MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
 	return sts;
+}
+
+mfxStatus QSV_Encoder_Internal::GetCurrentFourCC(mfxU32 &fourCC)
+{
+	if (m_pmfxENC != nullptr) {
+		fourCC = m_mfxEncParams.mfx.FrameInfo.FourCC;
+		return MFX_ERR_NONE;
+	} else {
+		return MFX_ERR_NOT_INITIALIZED;
+	}
 }

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.h
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.h
@@ -75,6 +75,7 @@ public:
 			     mfxBitstream **pBS);
 	mfxStatus ClearData();
 	mfxStatus Reset(qsv_param_t *pParams);
+	mfxStatus GetCurrentFourCC(mfxU32 &fourCC);
 
 protected:
 	bool InitParams(qsv_param_t *pParams);

--- a/plugins/obs-qsv11/common_directx11.cpp
+++ b/plugins/obs-qsv11/common_directx11.cpp
@@ -163,6 +163,8 @@ mfxStatus _simple_alloc(mfxFrameAllocRequest *request,
 		format = DXGI_FORMAT_NV12;
 	else if (MFX_FOURCC_RGB4 == request->Info.FourCC)
 		format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	else if (MFX_FOURCC_BGR4 == request->Info.FourCC)
+		format = DXGI_FORMAT_R8G8B8A8_UNORM;
 	else if (MFX_FOURCC_YUY2 == request->Info.FourCC)
 		format = DXGI_FORMAT_YUY2;
 	else if (MFX_FOURCC_P8 ==
@@ -226,10 +228,11 @@ mfxStatus _simple_alloc(mfxFrameAllocRequest *request,
 		desc.Usage = D3D11_USAGE_DEFAULT;
 		desc.BindFlags = D3D11_BIND_DECODER;
 		desc.MiscFlags = 0;
-		//desc.MiscFlags            = D3D11_RESOURCE_MISC_SHARED;
 
 		if ((MFX_MEMTYPE_FROM_VPPIN & request->Type) &&
-		    (DXGI_FORMAT_B8G8R8A8_UNORM == desc.Format)) {
+		    ((DXGI_FORMAT_B8G8R8A8_UNORM == desc.Format) ||
+		     (DXGI_FORMAT_R8G8B8A8_UNORM == desc.Format))) {
+
 			desc.BindFlags = D3D11_BIND_RENDER_TARGET;
 			if (desc.ArraySize > 2)
 				return MFX_ERR_MEMORY_ALLOC;
@@ -376,6 +379,14 @@ mfxStatus simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
 		ptr->G = ptr->B + 1;
 		ptr->R = ptr->B + 2;
 		ptr->A = ptr->B + 3;
+		break;
+	// Added to support RGBA for texture sharing
+	case DXGI_FORMAT_R8G8B8A8_UNORM:
+		ptr->Pitch = (mfxU16)lockedRect.RowPitch;
+		ptr->R = (mfxU8 *)lockedRect.pData;
+		ptr->G = ptr->R + 1;
+		ptr->B = ptr->R + 2;
+		ptr->A = ptr->R + 3;
 		break;
 	case DXGI_FORMAT_YUY2:
 		ptr->Pitch = (mfxU16)lockedRect.RowPitch;

--- a/plugins/obs-qsv11/common_directx9.cpp
+++ b/plugins/obs-qsv11/common_directx9.cpp
@@ -145,6 +145,8 @@ D3DFORMAT ConvertMfxFourccToD3dFormat(mfxU32 fourcc)
 		return D3DFMT_R8G8B8;
 	case MFX_FOURCC_RGB4:
 		return D3DFMT_A8R8G8B8;
+	case MFX_FOURCC_BGR4:
+		return D3DFMT_A8B8G8R8;
 	case MFX_FOURCC_P8:
 		return D3DFMT_P8;
 	case MFX_FOURCC_P010:
@@ -177,7 +179,8 @@ mfxStatus dx9_simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
 	if (desc.Format != D3DFMT_NV12 && desc.Format != D3DFMT_YV12 &&
 	    desc.Format != D3DFMT_YUY2 && desc.Format != D3DFMT_R8G8B8 &&
 	    desc.Format != D3DFMT_A8R8G8B8 && desc.Format != D3DFMT_P8 &&
-	    desc.Format != D3DFMT_P010 && desc.Format != D3DFMT_A2R10G10B10)
+	    desc.Format != D3DFMT_P010 && desc.Format != D3DFMT_A2R10G10B10 &&
+	    desc.Format != D3DFMT_A8B8G8R8)
 		return MFX_ERR_LOCK_MEMORY;
 
 	D3DLOCKED_RECT locked;
@@ -218,6 +221,13 @@ mfxStatus dx9_simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
 		ptr->G = ptr->B + 1;
 		ptr->R = ptr->B + 2;
 		ptr->A = ptr->B + 3;
+		break;
+	case D3DFMT_A8B8G8R8:
+		ptr->Pitch = (mfxU16)locked.Pitch;
+		ptr->R = (mfxU8 *)locked.pBits;
+		ptr->G = ptr->R + 1;
+		ptr->B = ptr->R + 2;
+		ptr->A = ptr->R + 3;
 		break;
 	case D3DFMT_P8:
 		ptr->Pitch = (mfxU16)locked.Pitch;

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -1009,6 +1009,13 @@ static bool obs_qsv_encode_tex(void *data, uint32_t handle, int64_t pts,
 	return true;
 }
 
+static bool obs_qsv_encode_texture_available(void *data,
+					     struct video_scale_info *info)
+{
+	UNUSED_PARAMETER(data);
+	return valid_format(info->format);
+}
+
 struct obs_encoder_info obs_qsv_encoder = {
 	.id = "obs_qsv11_soft",
 	.type = OBS_ENCODER_VIDEO,
@@ -1035,6 +1042,7 @@ struct obs_encoder_info obs_qsv_encoder_tex = {
 	.destroy = obs_qsv_destroy,
 	.caps = OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_PASS_TEXTURE,
 	.encode_texture = obs_qsv_encode_tex,
+	.encode_texture_available = obs_qsv_encode_texture_available,
 	.update = obs_qsv_update,
 	.get_properties = obs_qsv_props,
 	.get_defaults = obs_qsv_defaults,

--- a/plugins/win-dshow/virtualcam.c
+++ b/plugins/win-dshow/virtualcam.c
@@ -68,7 +68,11 @@ static bool virtualcam_start(void *data)
 	os_atomic_set_bool(&vcam->active, true);
 	os_atomic_set_bool(&vcam->stopping, false);
 	blog(LOG_INFO, "Virtual output started");
-	obs_output_begin_data_capture(vcam->output, 0);
+	if (!obs_output_begin_data_capture(vcam->output, 0)) {
+		blog(LOG_WARNING, "Failed to begin data capture");
+		os_atomic_set_bool(&vcam->active, false);
+		return false;
+	}
 	return true;
 }
 


### PR DESCRIPTION
### Description
Adds an OpenGL version of jim-nvenc to obs-ffmpeg.

### Motivation and Context
#### Why is this change required?
The fallback NVENC encoder that is used on Linux copies rendered frames back to the system RAM, copies them again into an FFMPEG `AVFrame`, and makes FFMPEG upload them back to the GPU. This takes a lot of CPU time especially on older or lower-end CPUs, like my Intel i3-4370. Encoding the textures directly without copying them to system RAM solves this issue.
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
[WIP] I'm testing on Arch Linux using my Intel i3-4370 + Nvidia GTX 1060 6GB. CPU usage is decreased from around 25-30% to around 11%. The resulting video file looks correct.
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
