### PR TITLE
Service:  Updated Vimm.TV RTMP Server Path

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -307,14 +307,10 @@
         {
             "name": "VIMM",
             "servers": [
-                {
-                    "name": "Europe: Frankfurt",
-                    "url": "rtmp://eu.vimm.tv/live"
-                },
-                {
-                    "name": "North America: Montreal",
-                    "url": "rtmp://us.vimm.tv/live"
-                }
+		{
+	            "name": "Autodetect",
+                    "url": "rtmp://ingest.vimm.tv/live"
+		}
             ],
             "recommended": {
                 "keyint": 2,

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -307,10 +307,10 @@
         {
             "name": "VIMM",
             "servers": [
-		{
+                {
 	            "name": "Autodetect",
                     "url": "rtmp://ingest.vimm.tv/live"
-		}
+                }
             ],
             "recommended": {
                 "keyint": 2,

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -308,7 +308,7 @@
             "name": "VIMM",
             "servers": [
                 {
-	            "name": "Autodetect",
+                    "name": "Autodetect",
                     "url": "rtmp://ingest.vimm.tv/live"
                 }
             ],


### PR DESCRIPTION
### Description

   Removed us.vimm.tv & eu.vimm.tv

  Added new Server Ingest to ingest.vimm.tv/live Tag Autodetect
  
  Screenshots 
  
  ![obs64_Rt5MiYPAaQ](https://user-images.githubusercontent.com/18028479/124433633-dc772600-dd6a-11eb-95a7-e45b6af6a79f.png)

![tAovJQO7Q3](https://user-images.githubusercontent.com/18028479/124433649-e39e3400-dd6a-11eb-8f07-f989a6e12691.png)

### Motivation and Context

Old eu.vimm.tv and us.vimm.tv no longer operate anymore, them servers got shutdown and Chiren and DDRFR33K told me Deploy this update to they new VIMM RTMP Server Update.

there is more Regions on this lists but Default is Auto at moment till they sort out rest domains 

I like you pull this data or people will not be able stream on VimmTV at all without this Ingest update since they moving away from old Servers and go full end livepeer servers.



### How Has This Been Tested?

    we been using same way but as Custom Ingest. only we changed RTMP Path and all data still same.
    
    Ingest File i changed worked with no issues as screenshot above

### Types of changes

   - Change RTMP Paths from old Server to new Ingest server for https://vimm.tv/

### Checklist:

- [x] New RTMP Server is Working as normal
- [ ] Haven't fully check if max bitrate can go higher then 8000 yet (Only i havent tested it because my ISP cant go higher then 3000)
- [x] Audio Bitrate works
- [x] `"x264opts": "scenecut=0"` im unsure needed this code still but i left it there as default.
