### PR TITLE
pipewire: Properly pass sizes to gs_draw_sprite_subregion

### DIFF
--- a/plugins/linux-capture/pipewire.c
+++ b/plugins/linux-capture/pipewire.c
@@ -1200,9 +1200,8 @@ void obs_pipewire_video_render(obs_pipewire_data *obs_pw, gs_effect_t *effect)
 
 	if (has_effective_crop(obs_pw)) {
 		gs_draw_sprite_subregion(obs_pw->texture, 0, obs_pw->crop.x,
-					 obs_pw->crop.y,
-					 obs_pw->crop.x + obs_pw->crop.width,
-					 obs_pw->crop.y + obs_pw->crop.height);
+					 obs_pw->crop.y, obs_pw->crop.width,
+					 obs_pw->crop.height);
 	} else {
 		gs_draw_sprite(obs_pw->texture, 0, 0, 0);
 	}


### PR DESCRIPTION
### Description

Pass only width and height to `gs_draw_sprite_subregion()`, instead of adding x and y to them. 

### Motivation and Context

The `gs_draw_sprite_subregion()` function is used when a cropping rectangle is received from PipeWire. It is usually used by compositors to implement window screencast - where a large and mostly empty frame is sent, the window contents are only a small part of it, and the crop rectangle tells us that.

Recently the wlroots implementation of portals started to use it to implement cropping, and it exposed a bug in the PipeWire code in OBS Studio. The gs_draw_sprite_subregion() function takes a pair of integers representing position (x, y) and a pair of integers representing size (width, height). The PipeWire code, however, passes a second pair of positions (x2, y2) instead of sizes, and it causes overrendering the crop area.

This bug wasn't hit yet because both GNOME and KDE implementations always send (0, 0) as position, which practically never trigger this condition.

### How Has This Been Tested?

You can follow the steps described at https://github.com/obsproject/obs-studio/issues/4982, and notice that with this PR, the issue is no more.

### Types of changes

 - Bug fix (non-breaking change which fixes an issue) 

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
