### PR TITLE
Integrate services on Flatpak builds

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -8,6 +8,16 @@ on:
     paths-ignore: ['**.md']
     branches: [master]
 
+env:
+  TWITCH_CLIENTID: ${{ secrets.TWITCH_CLIENT_ID }}
+  TWITCH_HASH: ${{ secrets.TWITCH_HASH }}
+  RESTREAM_CLIENTID: ${{ secrets.RESTREAM_CLIENTID }}
+  RESTREAM_HASH: ${{ secrets.RESTREAM_HASH }}
+  YOUTUBE_CLIENTID: ${{ secrets.YOUTUBE_CLIENTID }}
+  YOUTUBE_CLIENTID_HASH: ${{ secrets.YOUTUBE_CLIENTID_HASH }}
+  YOUTUBE_SECRET: ${{ secrets.YOUTUBE_SECRET }}
+  YOUTUBE_SECRET_HASH: ${{ secrets.YOUTUBE_SECRET_HASH }}
+
 jobs:
   flatpak_builder:
     name: Bundle

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -259,6 +259,16 @@
         "-DENABLE_PULSEAUDIO=ON",
         "-DWITH_RTMPS=ON"
       ],
+      "secret-opts": [
+        "-DRESTREAM_CLIENTID=$RESTREAM_CLIENTID",
+        "-DRESTREAM_HASH=$RESTREAM_HASH",
+        "-DTWITCH_CLIENTID=$TWITCH_CLIENTID",
+        "-DTWITCH_HASH=$TWITCH_HASH",
+        "-DYOUTUBE_CLIENTID=$YOUTUBE_CLIENTID",
+        "-DYOUTUBE_CLIENTID_HASH=$YOUTUBE_CLIENTID_HASH",
+        "-DYOUTUBE_SECRET=$YOUTUBE_SECRET",
+        "-DYOUTUBE_SECRET_HASH=$YOUTUBE_SECRET_HASH"
+      ],
       "sources": [
         {
           "type": "dir",


### PR DESCRIPTION
### Description

Pass Twitch, Restream, and YouTube client ids and hashes to the Flatpak build, and enable services integration.

### Motivation and Context

The flatpak-builder tool now supports passing secrets options to the build system. These options are not printed during the build, nor added to the resolved manifest after build, so they don't leak env vars from CI.

Pass the various services hashes and clientids to the build system using the new "secret-opts" key.

Related: https://github.com/flathub/com.obsproject.Studio/issues/139

### How Has This Been Tested?

 - Let this CI workflow run on a commit of the master branch
 - Download the Flatpak artifact and observe that services are enabled

### Types of changes

 - New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
