### PR TITLE
Portal-based Inhibitor

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -15,11 +15,7 @@
     "--filesystem=host",
     "--talk-name=org.kde.StatusNotifierWatcher",
     "--talk-name=org.freedesktop.Flatpak",
-    "--talk-name=org.freedesktop.ScreenSaver",
-    "--talk-name=org.freedesktop.PowerManagement.Inhibit",
     "--talk-name=org.freedesktop.Notifications",
-    "--talk-name=org.mate.SessionManager",
-    "--talk-name=org.gnome.SessionManager",
     "--own-name=org.kde.StatusNotifierItem-2-2",
     "--system-talk-name=org.freedesktop.Avahi"
   ],

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -226,7 +226,8 @@ elseif(UNIX)
 	endif()
 	if(GIO_FOUND)
 		set(libobs_PLATFORM_SOURCES ${libobs_PLATFORM_SOURCES}
-			util/platform-nix-dbus.c)
+			util/platform-nix-dbus.c
+			util/platform-nix-portal.c)
 		include_directories(${GIO_INCLUDE_DIRS})
 		add_definitions(
 			${GIO_DEFINITIONS})

--- a/libobs/util/platform-nix-portal.c
+++ b/libobs/util/platform-nix-portal.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2015 Hugh Bailey <obs.jim@gmail.com>
+ *               2021 Georges Basile Stavracas Neto <georges.stavracas@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <assert.h>
+#include <gio/gio.h>
+#include "bmem.h"
+#include "dstr.h"
+
+#define PORTAL_NAME "org.freedesktop.portal.Desktop"
+
+struct portal_inhibit_info {
+	GDBusConnection *c;
+	unsigned int signal_id;
+	char *sender_name;
+	char *request_path;
+	bool active;
+};
+
+static void new_request(struct portal_inhibit_info *info, char **out_token,
+			char **out_path)
+{
+	struct dstr token;
+	struct dstr path;
+	uint32_t id;
+
+	id = rand();
+
+	dstr_init(&token);
+	dstr_printf(&token, "obs_inhibit_portal%u", id);
+	*out_token = token.array;
+
+	dstr_init(&path);
+	dstr_printf(&path, "/org/freedesktop/portal/desktop/request/%s/%s",
+		    info->sender_name, token.array);
+	*out_path = path.array;
+}
+
+static inline void unsubscribe_from_request(struct portal_inhibit_info *info)
+{
+	if (info->signal_id > 0) {
+		g_dbus_connection_signal_unsubscribe(info->c, info->signal_id);
+		info->signal_id = 0;
+	}
+}
+
+static inline void remove_inhibit_data(struct portal_inhibit_info *info)
+{
+	g_clear_pointer(&info->request_path, bfree);
+	info->active = false;
+}
+
+static void response_received(GDBusConnection *bus, const char *sender_name,
+			      const char *object_path,
+			      const char *interface_name,
+			      const char *signal_name, GVariant *parameters,
+			      gpointer data)
+{
+	UNUSED_PARAMETER(bus);
+	UNUSED_PARAMETER(sender_name);
+	UNUSED_PARAMETER(object_path);
+	UNUSED_PARAMETER(interface_name);
+	UNUSED_PARAMETER(signal_name);
+
+	struct portal_inhibit_info *info = data;
+	g_autoptr(GVariant) ret = NULL;
+	uint32_t response;
+
+	g_variant_get(parameters, "(u@a{sv})", &response, &ret);
+
+	if (response != 0) {
+		if (response == 1)
+			blog(LOG_WARNING, "Inhibit denied by user");
+
+		remove_inhibit_data(info);
+	}
+
+	unsubscribe_from_request(info);
+}
+
+static void do_inhibit(struct portal_inhibit_info *info, const char *reason)
+{
+	g_autoptr(GVariant) reply = NULL;
+	g_autoptr(GError) error = NULL;
+	GVariantBuilder options;
+	uint32_t flags = 0xC;
+	char *token;
+
+	info->active = true;
+
+	new_request(info, &token, &info->request_path);
+
+	info->signal_id = g_dbus_connection_signal_subscribe(
+		info->c, PORTAL_NAME, "org.freedesktop.portal.Request",
+		"Response", info->request_path, NULL,
+		G_DBUS_SIGNAL_FLAGS_NO_MATCH_RULE, response_received, info,
+		NULL);
+
+	g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
+	g_variant_builder_add(&options, "{sv}", "handle_token",
+			      g_variant_new_string(token));
+	g_variant_builder_add(&options, "{sv}", "reason",
+			      g_variant_new_string(reason));
+
+	bfree(token);
+
+	reply = g_dbus_connection_call_sync(
+		info->c, PORTAL_NAME, "/org/freedesktop/portal/desktop",
+		"org.freedesktop.portal.Inhibit", "Inhibit",
+		g_variant_new("(sua{sv})", "", flags, &options), NULL,
+		G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
+
+	if (error != NULL) {
+		blog(LOG_ERROR, "Failed to inhibit: %s", error->message);
+		unsubscribe_from_request(info);
+		remove_inhibit_data(info);
+		return;
+	}
+}
+
+static void do_uninhibit(struct portal_inhibit_info *info)
+{
+	g_autoptr(GError) error = NULL;
+
+	g_dbus_connection_call_sync(info->c, PORTAL_NAME, info->request_path,
+				    "org.freedesktop.portal.Request", "Close",
+				    g_variant_new("()"), G_VARIANT_TYPE_UNIT,
+				    G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
+
+	remove_inhibit_data(info);
+
+	if (error)
+		blog(LOG_WARNING, "Error uninhibiting: %s", error->message);
+}
+
+void portal_inhibit_info_destroy(struct portal_inhibit_info *info)
+{
+	if (info) {
+		unsubscribe_from_request(info);
+		remove_inhibit_data(info);
+		g_clear_pointer(&info->sender_name, bfree);
+		g_clear_object(&info->c);
+		bfree(info);
+	}
+}
+
+struct portal_inhibit_info *portal_inhibit_info_create(void)
+{
+	struct portal_inhibit_info *info = bzalloc(sizeof(*info));
+	g_autoptr(GVariant) reply = NULL;
+	g_autoptr(GError) error = NULL;
+	char *aux;
+
+	info->c = g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, &error);
+	if (!info->c) {
+		blog(LOG_ERROR, "Could not create dbus connection: %s",
+		     error->message);
+		bfree(info);
+		return NULL;
+	}
+
+	info->sender_name =
+		bstrdup(g_dbus_connection_get_unique_name(info->c) + 1);
+	while ((aux = strstr(info->sender_name, ".")) != NULL)
+		*aux = '_';
+
+	reply = g_dbus_connection_call_sync(
+		info->c, "org.freedesktop.DBus", "/org/freedesktop/DBus",
+		"org.freedesktop.DBus", "GetNameOwner",
+		g_variant_new("(s)", PORTAL_NAME), NULL,
+		G_DBUS_CALL_FLAGS_NO_AUTO_START, -1, NULL, NULL);
+
+	if (reply != NULL) {
+		blog(LOG_DEBUG, "Found portal inhibitor");
+		return info;
+	}
+
+	portal_inhibit_info_destroy(info);
+	return NULL;
+}
+
+void portal_inhibit(struct portal_inhibit_info *info, const char *reason,
+		    bool active)
+{
+	if (active == info->active)
+		return;
+
+	if (active)
+		do_inhibit(info, reason);
+	else
+		do_uninhibit(info);
+}


### PR DESCRIPTION
### Description

Add a new portal-based inhibitor. This inhibitor is only used when the Desktop portal is available and running; the previous D-Bus implementation is used in the absence of the portal.

### Motivation and Context

XDG Portals provide a plethora of features meant to be used inside and outside sandboxed environments. OBS Studio currently uses portals to implement Wayland-compatible monitor and window captures.

However, OBS Studio performs another action that can be done through portals: inhibit the screensaver. Under the Desktop portal (the same used by the captures mentioned above), there is an "Inhibit" portal that provides session inhibition.

Using portals is desired because they allow tightening the sandbox, and are well-defined integration points to modern platforms.

### How Has This Been Tested?

 - Perform any regular action that inhibits the screensaver (streaming, recording, etc)
 - Notice that the session is inhibited

This new behavior can also be observed using `dbus-monitor`, running OBS Studio in an environment that provides the Desktop portal now gives:

```
method call time=1626396267.088096 sender=:1.1125 -> destination=org.freedesktop.portal.Desktop serial=40 path=/org/freedesktop/portal/desktop; interface=org.freedesktop.portal.Inhibit; member=Inhibit
   string ""
   uint32 12
   array [
      dict entry(
         string "handle_token"
         variant             string "obs_inhibit_portal1365493956"
      )
      dict entry(
         string "reason"
         variant             string "OBS Video/audio"
      )
   ]
```

### Types of changes

 - New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
