### PR TITLE
Themes: Specify QListView instead of QListWidget

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -136,7 +136,7 @@ QMenuBar::item:selected {
 }
 
 /* Listbox item */
-QListWidget::item,
+QListView::item,
 SourceTree::item {
 	padding: 4px 2px;
 	margin-bottom: 2px;
@@ -144,7 +144,7 @@ SourceTree::item {
 	border: 1px solid transparent;
 }
 
-QListWidget QLineEdit {
+QListView QLineEdit {
 	 padding-top: 0px;
 	 padding-bottom: 0px;
 	 padding-right: 0;
@@ -195,7 +195,7 @@ QDockWidget::float-button {
 }
 
 
-QListWidget#scenes,
+QListView#scenes,
 SourceListWidget {
 	border: none;
 	border-bottom: 2px solid #2f2f2f;
@@ -235,14 +235,14 @@ SourceTree QLineEdit {
 }
 
 /* Listbox item selected, unfocused */
-QListWidget::item:hover,
+QListView::item:hover,
 SourceTree::item:hover {
 	background-color: #212121;
 	border: 1px solid #333336;
 }
 
 /* Listbox item selected */
-QListWidget::item:selected,
+QListView::item:selected,
 SourceTree::item:selected {
 	background-color: #131a30;
 	border: 1px solid #252a45;
@@ -946,7 +946,7 @@ OBSBasicSettings {
     qproperty-advancedIcon: url(./Dark/settings/advanced.svg);
 }
 
-OBSBasicSettings QListWidget::item {
+OBSBasicSettings QListView::item {
     padding-top: 5px;
     padding-bottom: 5px;
 }

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -101,13 +101,13 @@ QMenuBar::item {
     background-color: rgb(58,57,58); /* dark */
 }
 
-QListWidget::item:selected:!active,
+QListView::item:selected:!active,
 SourceTree::item:selected:!active {
     color: rgb(255, 255, 255);
     background-color: rgb(48,47,48);
 }
 
-QListWidget QLineEdit,
+QListView QLineEdit,
 SourceTree QLineEdit {
     padding-top: 0px;
     padding-bottom: 0px;
@@ -718,7 +718,7 @@ OBSBasicSettings {
     qproperty-advancedIcon: url(./Dark/settings/advanced.svg);
 }
 
-OBSBasicSettings QListWidget::item {
+OBSBasicSettings QListView::item {
     padding-top: 5px;
     padding-bottom: 5px;
 }

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -152,7 +152,7 @@ QSizeGrip {
 	height: 12px;
 }
 
-QListWidget QLineEdit {
+QListView QLineEdit {
     padding-top: 0;
     padding-bottom: 0;
     padding-right: 0;
@@ -165,20 +165,20 @@ QListWidget QLineEdit {
 /* --- List widget --- */
 /***********************/
 
-QListWidget::item:selected:!active {
+QListView::item:selected:!active {
 	color: rgb(239, 240, 241); /* White */
 	background-color: rgba(255, 148, 194, 0.25); /* Light Pink (Secondary Light) */
 	border: none;
 }
 
-QListWidget::item:selected {
+QListView::item:selected {
 	background-color: rgba(240, 98, 146, 0.5); /* Pink (Secondary) */
 	border: none;
 }
 
-QListWidget::item:hover,
-QListWidget::item:disabled:hover,
-QListWidget::item:hover:!active {
+QListView::item:hover,
+QListView::item:disabled:hover,
+QListView::item:hover:!active {
 	background-color: rgb(0, 188, 212); /* Cyan (Primary) */
 	color: rgb(239, 240, 241); /* White */
 	border: none;
@@ -1278,7 +1278,7 @@ OBSBasicSettings {
     qproperty-advancedIcon: url(./Dark/settings/advanced.svg);
 }
 
-OBSBasicSettings QListWidget::item {
+OBSBasicSettings QListView::item {
     padding-top: 5px;
     padding-bottom: 5px;
 }

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -166,7 +166,7 @@ OBSBasicSettings {
     qproperty-advancedIcon: url(:settings/images/settings/advanced.svg);
 }
 
-OBSBasicSettings QListWidget::item {
+OBSBasicSettings QListView::item {
     padding-top: 5px;
     padding-bottom: 5px;
 }


### PR DESCRIPTION
### Description
Plugins using a QListView widget (e.g. obs-ptz) do not get the theme settings
that are applied to QListWidget. However, QListWidget directly inherits
from QListView, so a theme specifying the QListView will also get
applied to QListWidget. Change the themes to all specify QListView so
that theming is consistent.

### How Has This Been Tested?
Tested on Windows 10 by comparing view both with and without patch applied.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [N/A] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [N/A] I have included updates to all appropriate documentation.
