### PR TITLE
deps/media-playback: Fix potential crash when doing swscale in media.c

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -206,18 +206,17 @@ static inline int get_sws_range(enum AVColorRange r)
 
 #define FIXED_1_0 (1 << 16)
 
-static bool mp_media_init_scaling(mp_media_t *m)
+static bool mp_media_init_scaling(mp_media_t *m, const AVFrame *frame,
+				  enum AVPixelFormat dst_fmt)
 {
-	int space = get_sws_colorspace(m->v.decoder->colorspace);
-	int range = get_sws_range(m->v.decoder->color_range);
+	int space = get_sws_colorspace(frame->colorspace);
+	int range = get_sws_range(frame->color_range);
 	const int *coeff = sws_getCoefficients(space);
 
-	m->swscale = sws_getCachedContext(NULL, m->v.decoder->width,
-					  m->v.decoder->height,
-					  m->v.decoder->pix_fmt,
-					  m->v.decoder->width,
-					  m->v.decoder->height, m->scale_format,
-					  SWS_POINT, NULL, NULL, NULL);
+	m->swscale = sws_getCachedContext(NULL, frame->width, frame->height,
+					  frame->format, frame->width,
+					  frame->height, dst_fmt,
+					  SWS_FAST_BILINEAR, NULL, NULL, NULL);
 	if (!m->swscale) {
 		blog(LOG_WARNING, "MP: Failed to initialize scaler");
 		return false;
@@ -226,15 +225,66 @@ static bool mp_media_init_scaling(mp_media_t *m)
 	sws_setColorspaceDetails(m->swscale, coeff, range, coeff, range, 0,
 				 FIXED_1_0, FIXED_1_0);
 
-	int ret = av_image_alloc(m->scale_pic, m->scale_linesizes,
-				 m->v.decoder->width, m->v.decoder->height,
-				 m->scale_format, 32);
+	int ret = av_image_alloc(m->scale_pic, m->scale_linesizes, frame->width,
+				 frame->height, dst_fmt, 32);
 	if (ret < 0) {
 		blog(LOG_WARNING, "MP: Failed to create scale pic data");
 		return false;
 	}
 
+	m->scale_format = dst_fmt;
+	m->scale_range = range;
+	m->scale_space = space;
+	m->scale_src_format = frame->format;
+	m->scale_src_width = frame->width;
+	m->scale_src_height = frame->height;
+
 	return true;
+}
+
+static bool mp_media_check_scaling(mp_media_t *m)
+{
+	bool new_scaling_needed = false;
+	enum AVPixelFormat scale_fmt = closest_format(m->v.frame->format);
+	int space = get_sws_colorspace(m->v.frame->colorspace);
+	int range = get_sws_range(m->v.frame->color_range);
+
+	if (scale_fmt == m->v.frame->format) {
+		sws_freeContext(m->swscale);
+		m->swscale = NULL;
+		av_freep(&m->scale_pic[0]);
+		m->scale_format = AV_PIX_FMT_NONE;
+		m->scale_src_format = AV_PIX_FMT_NONE;
+		m->scale_src_width = 0;
+		m->scale_src_height = 0;
+		m->scale_range = 0;
+		m->scale_space = 0;
+		return true;
+	}
+
+	if (!m->swscale || scale_fmt != m->scale_format ||
+	    m->v.frame->format != m->scale_src_format ||
+	    m->v.frame->width != m->scale_src_width ||
+	    m->v.frame->height != m->scale_src_height) {
+		new_scaling_needed = true;
+	} else if (m->swscale &&
+		   (range != m->scale_range || space != m->scale_space)) {
+		const int *coeff = sws_getCoefficients(space);
+		sws_setColorspaceDetails(m->swscale, coeff, range, coeff, range,
+					 0, FIXED_1_0, FIXED_1_0);
+		m->scale_range = range;
+		m->scale_space = space;
+		return true;
+	}
+
+	if (!new_scaling_needed)
+		return true;
+
+	sws_freeContext(m->swscale);
+	m->swscale = NULL;
+	av_freep(&m->scale_pic[0]);
+
+	return mp_media_init_scaling(m, m->v.frame, scale_fmt);
 }
 
 static bool mp_media_prepare_frames(mp_media_t *m)
@@ -261,14 +311,9 @@ static bool mp_media_prepare_frames(mp_media_t *m)
 			return false;
 	}
 
-	if (m->has_video && m->v.frame_ready && !m->swscale) {
-		m->scale_format = closest_format(m->v.frame->format);
-		if (m->scale_format != m->v.frame->format) {
-			if (!mp_media_init_scaling(m)) {
-				return false;
-			}
-		}
-	}
+	if (m->has_video && m->v.frame_ready)
+		if (!mp_media_check_scaling(m))
+			return false;
 
 	return true;
 }
@@ -383,7 +428,7 @@ static void mp_media_next_video(mp_media_t *m, bool preload)
 	if (flip)
 		frame->data[0] -= frame->linesize[0] * (f->height - 1);
 
-	new_format = convert_pixel_format(m->scale_format);
+	new_format = convert_pixel_format(closest_format(f->format));
 	new_space = convert_color_space(f->colorspace, f->color_trc);
 	new_range = m->force_range == VIDEO_RANGE_DEFAULT
 			    ? convert_color_range(f->color_range)

--- a/deps/media-playback/media-playback/media.h
+++ b/deps/media-playback/media-playback/media.h
@@ -61,6 +61,11 @@ struct mp_media {
 	struct SwsContext *swscale;
 	int scale_linesizes[4];
 	uint8_t *scale_pic[4];
+	enum AVPixelFormat scale_src_format;
+	int32_t scale_src_width;
+	int32_t scale_src_height;
+	int scale_range;
+	int scale_space;
 
 	struct mp_decode v;
 	struct mp_decode a;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
There is a potential crash when doing swscale in media.c:
If frames decoded from a media file have different pixel format/width/height..(such as a video file which is remuxed from a series pictures with different format), it will always crash inside swscaler because we have no logic to recreate/update the swscaler now.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We should check swscale with every frames to make sure the swscaler works correctly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on 64bit Windows 10

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
