### PR TITLE
UI: Move saving of UI element states

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -867,14 +867,25 @@ void OBSBasic::CreateProgramOptions()
 			OBSSource actualScene = OBSGetStrongRef(programScene);
 			if (actualScene)
 				TransitionToScene(actualScene, true);
+
+			config_set_bool(App()->GlobalConfig(), "BasicWindow",
+					"EditPropertiesMode",
+					editPropertiesMode);
 		};
 
 		auto toggleSwapScenesMode = [this]() {
 			swapScenesMode = !swapScenesMode;
+
+			config_set_bool(App()->GlobalConfig(), "BasicWindow",
+					"SwapScenesMode", swapScenesMode);
 		};
 
 		auto toggleSceneDuplication = [this]() {
 			sceneDuplicationMode = !sceneDuplicationMode;
+
+			config_set_bool(App()->GlobalConfig(), "BasicWindow",
+					"SceneDuplicationMode",
+					sceneDuplicationMode);
 
 			OBSSource actualScene = OBSGetStrongRef(programScene);
 			if (actualScene)
@@ -1712,6 +1723,9 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 	ResetUI();
 	UpdateTitleBar();
+
+	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+			"PreviewProgramMode", enabled);
 }
 
 void OBSBasic::RenderProgram(void *data, uint32_t cx, uint32_t cy)

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2650,22 +2650,6 @@ OBSBasic::~OBSBasic()
 		       OBS_RELEASE_CANDIDATE_VER);
 #endif
 
-	bool alwaysOnTop = IsAlwaysOnTop(this);
-
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "PreviewEnabled",
-			previewEnabled);
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "AlwaysOnTop",
-			alwaysOnTop);
-	config_set_bool(App()->GlobalConfig(), "BasicWindow",
-			"SceneDuplicationMode", sceneDuplicationMode);
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "SwapScenesMode",
-			swapScenesMode);
-	config_set_bool(App()->GlobalConfig(), "BasicWindow",
-			"EditPropertiesMode", editPropertiesMode);
-	config_set_bool(App()->GlobalConfig(), "BasicWindow",
-			"PreviewProgramMode", IsPreviewProgramMode());
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "DocksLocked",
-			ui->lockUI->isChecked());
 	config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
 
 #ifdef _WIN32
@@ -7076,6 +7060,9 @@ void OBSBasic::ToggleAlwaysOnTop()
 	ui->actionAlwaysOnTop->setChecked(!isAlwaysOnTop);
 	SetAlwaysOnTop(this, !isAlwaysOnTop);
 
+	config_set_bool(App()->GlobalConfig(), "BasicWindow", "AlwaysOnTop",
+			isAlwaysOnTop);
+
 	show();
 }
 
@@ -7687,6 +7674,9 @@ void OBSBasic::EnablePreviewDisplay(bool enable)
 	obs_display_set_enabled(ui->preview->GetDisplay(), enable);
 	ui->preview->setVisible(enable);
 	ui->previewDisabledWidget->setVisible(!enable);
+
+	config_set_bool(App()->GlobalConfig(), "BasicWindow", "PreviewEnabled",
+			enable);
 }
 
 void OBSBasic::TogglePreview()
@@ -8128,6 +8118,9 @@ void OBSBasic::on_lockUI_toggled(bool lock)
 			extraDocks[i]->setFeatures(features);
 		}
 	}
+
+	config_set_bool(App()->GlobalConfig(), "BasicWindow", "DocksLocked",
+			lock);
 }
 
 void OBSBasic::on_toggleListboxToolbars_toggled(bool visible)


### PR DESCRIPTION
### Description
This moves saving of states of UI elements from the destructor to where they
are actually toggled.

### Motivation and Context
For clearer code, I feel like these should be saved in the function where they are toggled.

### How Has This Been Tested?
Toggled these UI elements to make sure they were saved properly.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
