### PR TITLE
Fix argument type mismatches on the macro da_push_back

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -117,8 +117,8 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		struct obs_frontend_source_list *sources) override
 	{
 		for (int i = 0; i < main->ui->transitions->count(); i++) {
-			OBSSource tr = main->ui->transitions->itemData(i)
-					       .value<OBSSource>();
+			obs_source_t *tr = main->ui->transitions->itemData(i)
+						   .value<OBSSource>();
 
 			if (!tr)
 				continue;

--- a/libobs/util/cf-lexer.h
+++ b/libobs/util/cf-lexer.h
@@ -187,8 +187,9 @@ static inline void
 cf_preprocessor_add_sys_include_dir(struct cf_preprocessor *pp,
 				    const char *include_dir)
 {
+	char *str = bstrdup(include_dir);
 	if (include_dir)
-		da_push_back(pp->sys_include_dirs, bstrdup(include_dir));
+		da_push_back(pp->sys_include_dirs, &str);
 }
 
 EXPORT void cf_preprocessor_add_def(struct cf_preprocessor *pp,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Inspired by the issue #5009, I checked all the argument types for `da_find`, `da_push_back`, `da_push_back_da`, `da_insert`, `da_insert_array`, `da_insert_da`, and `da_erase_item` by using [this test](https://github.com/norihiro/obs-studio/tree/test-darray-type) on Linux. The idea was inspired by [this article](https://stackoverflow.com/questions/4712720/typechecking-macro-arguments-in-c) and modified a little to make the message more readable.
Two similar issues are found and this PR fix them.

If these two changes are put in one commit, please let me know so that I will modify the commit.
Currently the test mentioned in above shows some false warning regarding `char**` and `const char**` so that I think it is not worth to merge into master branch.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The macro `da_push_back` has to receive correct type of argument.

Since the current implementation of a class `OBSSource` has a member `obs_source_t *obj` at first and the class does not have any virtual member functions, most implementation should work correctly. However, if `OBSSource` were modified in future, there is a risk that a wrong data could go to `da_push_back`.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: CentOS 8
The function `obs_frontend_get_transitions` is tested by calling `GetTransitionList` through `obs-websocket`.
The function `cf_preprocessor_add_sys_include_dir` is not tested since I cannot find any usage of the function. Maybe it's ok to remove the entire function. Though the function is exported as libobs, the function is not listed in the [document](https://obsproject.com/docs/index.html).
Both functions are tested with the macro modified as [this tree](https://github.com/norihiro/obs-studio/tree/test-darray-type).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
  - `obs_frontend_get_transitions` is tested.
  - `cf_preprocessor_add_sys_include_dir` is not tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
