### PR TITLE
Reenable drag/drop on Linux scenes/sources

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -883,11 +883,8 @@ Qt::ItemFlags SourceTreeModel::flags(const QModelIndex &index) const
 	obs_sceneitem_t *item = items[index.row()];
 	bool is_group = obs_sceneitem_is_group(item);
 
-	/* XXX: Disable drag/drop on Linux until Qt issues are fixed */
 	return QAbstractListModel::flags(index) | Qt::ItemIsEditable |
-#if defined(_WIN32) || defined(__APPLE__)
 	       Qt::ItemIsDragEnabled |
-#endif
 	       (is_group ? Qt::ItemIsDropEnabled : Qt::NoItemFlags);
 }
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -233,11 +233,6 @@ OBSBasic::OBSBasic(QWidget *parent)
 	ui->previewDisabledWidget->setVisible(false);
 	ui->contextContainer->setStyle(new OBSProxyStyle);
 
-	/* XXX: Disable drag/drop on Linux until Qt issues are fixed */
-#if !defined(_WIN32) && !defined(__APPLE__)
-	ui->scenes->setDragDropMode(QAbstractItemView::NoDragDrop);
-#endif
-
 	startingDockLayout = saveState();
 
 	statsDock = new OBSDock();


### PR DESCRIPTION
### Description

This reverts commit 457adcedd319ca2317d7cd5300694d486e88af90. Requires https://github.com/obsproject/obs-browser/pull/304

### Motivation and Context

Drag n' Drop was temporarily reverted due to https://github.com/obsproject/obs-studio/issues/4488, but https://github.com/obsproject/obs-browser/pull/304 supposedly fixes it.

### How Has This Been Tested?

 - Try and reproduce https://github.com/obsproject/obs-studio/issues/4488 - it shouldn't be reproducible anymore with this PR, and https://github.com/obsproject/obs-browser/pull/304

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
