### PR TITLE
rtmp-services: Add "Lovecast"

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 177,
+	"version": 178,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 177
+			"version": 178
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -285,6 +285,26 @@
             }
         },
         {
+            "name": "Lovecast",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://live-a.lovecastapp.com:5222/app"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "profile": "main",
+                "max video bitrate": 8000,
+                "max audio bitrate": 192,
+                "supported resolutions": [
+                    "1920x1080",
+                    "1280x720"
+                ],
+                "max fps": 30
+            }
+        },
+        {
             "name": "Luzento.com - RTMP",
             "servers": [
                 {


### PR DESCRIPTION
### Description
Adds [Lovecast](https://www.lovecastapp.com/) to rtmp services list.
A live wedding/event streaming platform.

### Motivation and Context
Add support for "Lovecast" in rtmp services.

### How Has This Been Tested?
Local Build & CI Build

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.