### PR TITLE
decklink: Fix truncation warnings

### DIFF
--- a/plugins/decklink/decklink-device-mode.cpp
+++ b/plugins/decklink/decklink-device-mode.cpp
@@ -68,20 +68,16 @@ const std::string &DeckLinkDeviceMode::GetName(void) const
 
 bool DeckLinkDeviceMode::IsEqualFrameRate(int64_t num, int64_t den)
 {
-	if (!mode)
-		return false;
+	bool equal = false;
 
-	BMDTimeValue timeValue;
-	BMDTimeScale timeScale;
-	if (mode->GetFrameRate(&timeValue, &timeScale) != S_OK)
-		return false;
+	if (mode) {
+		BMDTimeValue frameDuration;
+		BMDTimeScale timeScale;
+		if (SUCCEEDED(mode->GetFrameRate(&frameDuration, &timeScale)))
+			equal = timeScale * den == frameDuration * num;
+	}
 
-	// Calculate greatest common divisor of both values to properly compare framerates
-	int decklinkGcd = std::gcd(timeScale, timeValue);
-	int inputGcd = std::gcd(num, den);
-
-	return ((timeScale / decklinkGcd) == (num / inputGcd) &&
-		(timeValue / decklinkGcd) == (den / inputGcd));
+	return equal;
 }
 
 void DeckLinkDeviceMode::SetMode(IDeckLinkDisplayMode *mode_)

--- a/plugins/decklink/decklink-device-mode.hpp
+++ b/plugins/decklink/decklink-device-mode.hpp
@@ -3,7 +3,6 @@
 #include "platform.hpp"
 
 #include <string>
-#include <numeric>
 
 #define MODE_ID_AUTO -1
 


### PR DESCRIPTION
### Description
Also simplify DeckLinkDeviceMode::IsEqualFrameRate using cross-multiply.

### Motivation and Context
Don't like compiler warnings.

### How Has This Been Tested?
Breakpoint inspection, Filtered mode list is the same before and after change.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.