### PR TITLE
WIP: use the obs samplingRate

### DIFF
--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -1019,6 +1019,13 @@ bool DShowInput::UpdateAudioConfig(obs_data_t *settings)
 	audioConfig.mode =
 		(AudioMode)obs_data_get_int(settings, AUDIO_OUTPUT_MODE);
 
+	// get the obs sample_rate
+	uint32_t sampleRate = audio_output_get_sample_rate(obs_get_audio());
+
+	audioConfig.sampleRate =
+		sampleRate; // try to set the desired samplerate
+	blog(LOG_INFO, "\tobs samplerate: %d", audioConfig.sampleRate);
+
 	bool success = device.SetAudioConfig(&audioConfig);
 	if (!success)
 		return false;


### PR DESCRIPTION
dependency: https://github.com/obsproject/libdshowcapture/pull/33
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
set the desired sampling rate for the audio capture device using `audio_output_get_sample_rate()`
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Please see https://github.com/obsproject/libdshowcapture/pull/33
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
https://github.com/obsproject/libdshowcapture/pull/33
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

get the desired sampling rate using `audio_output_get_sample_rate()`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
