### PR TITLE
obs-filters: Use linear value of secondary texture

### DIFF
--- a/plugins/obs-filters/mask-filter.c
+++ b/plugins/obs-filters/mask-filter.c
@@ -310,7 +310,7 @@ static void mask_filter_render(void *data, gs_effect_t *effect)
 		return;
 
 	param = gs_effect_get_param_by_name(filter->effect, "target");
-	gs_effect_set_texture(param, filter->target);
+	gs_effect_set_texture_srgb(param, filter->target);
 
 	param = gs_effect_get_param_by_name(filter->effect, "color");
 	gs_effect_set_vec4(param, &filter->color);


### PR DESCRIPTION
### Description
Makes behavior of blend addition more reasonable.

Fixes #5048

### Motivation and Context
0 + x should equal x.

### How Has This Been Tested?
Tested 16/16/16 on 0/0/0 is now 16/16/16 instead of 71/71/71.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.