### PR TITLE
obs-ffmpeg: Translate VAAPI property names

### DIFF
--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -8,8 +8,12 @@ Profile="Profile"
 RateControl="Rate Control"
 KeyframeIntervalSec="Keyframe Interval (seconds, 0=auto)"
 Lossless="Lossless"
+Level="Level"
 
 BFrames="Max B-frames"
+
+VAAPI.Codec="VAAPI Codec"
+VAAPI.Device="VAAPI Device"
 
 NVENC.Use2Pass="Use Two-Pass Encoding"
 NVENC.Preset.default="Performance"

--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -545,7 +545,8 @@ static obs_properties_t *vaapi_properties(void *unused)
 	obs_properties_t *props = obs_properties_create();
 	obs_property_t *list;
 
-	list = obs_properties_add_list(props, "vaapi_device", "VAAPI Device",
+	list = obs_properties_add_list(props, "vaapi_device",
+				       obs_module_text("VAAPI.Device"),
 				       OBS_COMBO_TYPE_LIST,
 				       OBS_COMBO_FORMAT_STRING);
 	char path[32] = "/dev/dri/renderD1";
@@ -560,13 +561,15 @@ static obs_properties_t *vaapi_properties(void *unused)
 		}
 	}
 
-	list = obs_properties_add_list(props, "vaapi_codec", "VAAPI Codec",
+	list = obs_properties_add_list(props, "vaapi_codec",
+				       obs_module_text("VAAPI.Codec"),
 				       OBS_COMBO_TYPE_LIST,
 				       OBS_COMBO_FORMAT_INT);
 
 	obs_property_list_add_int(list, "H.264 (default)", AV_CODEC_ID_H264);
 
-	list = obs_properties_add_list(props, "profile", "Profile",
+	list = obs_properties_add_list(props, "profile",
+				       obs_module_text("Profile"),
 				       OBS_COMBO_TYPE_LIST,
 				       OBS_COMBO_FORMAT_INT);
 	obs_property_list_add_int(list, "Constrained Baseline (default)",
@@ -574,7 +577,7 @@ static obs_properties_t *vaapi_properties(void *unused)
 	obs_property_list_add_int(list, "Main", FF_PROFILE_H264_MAIN);
 	obs_property_list_add_int(list, "High", FF_PROFILE_H264_HIGH);
 
-	list = obs_properties_add_list(props, "level", "Level",
+	list = obs_properties_add_list(props, "level", obs_module_text("Level"),
 				       OBS_COMBO_TYPE_LIST,
 				       OBS_COMBO_FORMAT_INT);
 	obs_property_list_add_int(list, "Auto", FF_LEVEL_UNKNOWN);


### PR DESCRIPTION
### Description

VAAPI properties were not all being run through translation, which was incredibly obvious in non-English. This ensures they are.

I do wonder if some of the dropdown options should also have translation keys - I'm open to feedback here.

Before:
![image](https://user-images.githubusercontent.com/941350/127732026-538c2f64-f068-4ea5-990d-e1ae18160b30.png)

After:
![image](https://user-images.githubusercontent.com/941350/127732051-46a61a6a-1acf-423d-8911-a4a4ef4c082a.png)

(notice "Profile" is now correctly translated)

### Motivation and Context

User-facing strings should always be translated.

### How Has This Been Tested?

Loaded a FFMPEG VAAPI encoder on Ubuntu & verified strings were translated.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
