### PR TITLE
UI: Fix support for QPalette in Qt Stylesheets

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -15,7 +15,7 @@ OBSTheme {
     shadow: rgb(0,0,0);
 
     highlight: rgb(37,36,88);
-    highlightText: rgb(255,255,255);
+    highlightedText: rgb(255,255,255);
 
     link: rgb(96,94,230);
     linkVisited: rgb(96,94,230);
@@ -29,7 +29,7 @@ OBSTheme::disabled {
 
 OBSTheme::inactive {
     highlight: rgb(48,47,48);
-    highlightText: rgb(255,255,255);
+    highlightedText: rgb(255,255,255);
 }
 
 /* General style, we override only what is needed. */

--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -1,44 +1,44 @@
 /* OBSTheme, main QApplication palette and QML values */
 OBSTheme {
-    window: #181819;
+    window: rgb(24,24,25);
     windowText: rgb(225,224,225);
     base: rgb(18,18,21);
     alternateBase: rgb(0,0,0);
     text: rgb(225,224,225);
-    button: #162458;
+    button: rgb(22,36,88);
     buttonText: rgb(225,224,225);
-    brightText: #484848;
+    brightText: rgb(72,72,72);
 
-    light: #162458;
-    mid: #181819;
+    light: rgb(22,36,88);
+    mid: rgb(24,24,25);
     dark: rgb(18,18,21);
     shadow: rgb(0,0,0);
 
-    highlight: #252458;
-    highlightText: #FFFFFF;
+    highlight: rgb(37,36,88);
+    highlightText: rgb(255,255,255);
 
-    link: #605ee6;
-    linkVisited: #605ee6;
+    link: rgb(96,94,230);
+    linkVisited: rgb(96,94,230);
 }
 
 OBSTheme::disabled {
-    text: #484848;
-    buttonText: #484848;
-    brightText: #484848;
+    text: rgb(72,72,72);
+    buttonText: rgb(72,72,72);
+    brightText: rgb(72,72,72);
 }
 
 OBSTheme::inactive {
     highlight: rgb(48,47,48);
-    highlightText: rgb(255, 255, 255);
+    highlightText: rgb(255,255,255);
 }
 
 /* General style, we override only what is needed. */
 QWidget {
-	background-color: #181819;
-	alternate-background-color: rgb(18,18,21);
-	color: rgb(225,224,225);
-	selection-background-color: #252458;
-	selection-color: white;
+	background-color: palette(window);
+	alternate-background-color: palette(base);
+	color: palette(text);
+	selection-background-color: palette(highlight);
+	selection-color: palette(highlighted-text);
 	outline: none;
 	font-family: "Open Sans", "Tahoma", "Arial", sans-serif;
 	font-size: 12px;
@@ -49,11 +49,11 @@ QWidget {
 }
 
 QLabel:link {
-	color: #2a3a75;
+	color: rgb(42,58,117);
 }
 
 QMenu {
-	border: 1px solid #333336;
+	border: 1px solid rgb(51,51,54);
 	padding: 4px;
 }
 
@@ -64,7 +64,7 @@ QMenu {
 
 * [frameShape="2"],
 * [frameShape="4"] {
-	border: 1px solid #333336;
+	border: 1px solid rgb(51,51,54);
 }
 
 
@@ -76,27 +76,27 @@ QSizeGrip {
 /* Misc */
 
 QWidget::disabled {
-	color: #484848;
+	color: palette(bright-text);
 }
 
 * [themeID="error"] {
-	color: #d91740;
+	color: rgb(217,23,64);
 }
 
 * [themeID="warning"] {
-	color: #d9af17;
+	color: rgb(217,175,23);
 }
 
 /* Dropdown menus, Scenes box, Sources box */
 QAbstractItemView {
-	background-color: #181819;
-	border: 1px solid #333336;
+	background-color: palette(window);
+	border: 1px solid rgb(51,51,54);
 }
 
 /* Group Box */
 
 QGroupBox {
-	border: 2px solid #2f2f2f;
+	border: 2px solid rgb(47,47,47);
 	margin-bottom: 8px;
 	padding-top: 32px;
 	font-weight: bold;
@@ -119,20 +119,20 @@ QGroupBox::title {
 
 /* Tooltips */
 QToolTip {
-	background-color: #212121;
+	background-color: rgb(33,33,33);
 	color: rgb(205,205,205);
-	border: 1px solid #343335;
+	border: 1px solid rgb(52,51,53);
 	border-radius: 4px;
 }
 
 /* Top Menu Bar Items */
 QMenuBar::item {
-	background-color: rgb(24,24,25);
+	background-color: palette(window);
 	padding: 6px;
 }
 
 QMenuBar::item:selected {
-	background: #2a3a75;
+	background: rgb(42,58,117);
 }
 
 /* Listbox item */
@@ -160,15 +160,15 @@ QDockWidget {
 }
 
 QDockWidget {
-	background: #181819;
+	background: palette(window);
 	border: none;
 	font-size: 14px;
 	font-weight: bold;
-	border-bottom: 2px solid #2f2f2f;
+	border-bottom: 2px solid rgb(47,47,47);
 }
 
 QDockWidget::title {
-	border-bottom: 2px solid #2f2f2f;
+	border-bottom: 2px solid rgb(47,47,47);
 	margin-left: 5px;
 	margin-right: 5px;
 	padding-top: 0px;
@@ -198,16 +198,16 @@ QDockWidget::float-button {
 QListWidget#scenes,
 SourceListWidget {
 	border: none;
-	border-bottom: 2px solid #2f2f2f;
+	border-bottom: 2px solid rgb(47,47,47);
 }
 
 SourceTree {
 	border: none;
-	border-bottom: 1px solid #2f2f2f;
+	border-bottom: 1px solid rgb(47,47,47);
 }
 
 SourceTree QLineEdit {
-	background-color: #0c101e;
+	background-color: rgb(12,16,30);
 	padding: 2px;
 	margin: -2px 6px -2px 3px;
 	font-size: 12px;
@@ -237,15 +237,15 @@ SourceTree QLineEdit {
 /* Listbox item selected, unfocused */
 QListWidget::item:hover,
 SourceTree::item:hover {
-	background-color: #212121;
-	border: 1px solid #333336;
+	background-color: rgb(33,33,33);
+	border: 1px solid rgb(51,51,54);
 }
 
 /* Listbox item selected */
 QListWidget::item:selected,
 SourceTree::item:selected {
-	background-color: #131a30;
-	border: 1px solid #252a45;
+	background-color: rgb(19,26,48);
+	border: 1px solid rgb(37,42,69);
 }
 
 /* ScrollBars */
@@ -264,7 +264,7 @@ QScrollBar:vertical {
 }
 
 QScrollBar::handle:vertical {
-	background-color: #2f2f2f;
+	background-color: rgb(47,47,47);
 	min-height: 20px;
 	margin: 0px 3px;
 	border-radius: 0px;
@@ -292,7 +292,7 @@ QScrollBar:horizontal {
 }
 
 QScrollBar::handle:horizontal {
-	background-color: #2f2f2f;
+	background-color: rgb(47,47,47);
 	min-width: 20px;
 	margin: 3px 0px;
 	border-radius: 0px;
@@ -332,18 +332,18 @@ QPushButton#sourceFiltersButton {
 /* Scenes and Sources toolbar */
 
 QToolBar {
-	background-color: rgb(24,24,25);
+	background-color: palette(window);
 	margin-top: 4px;
 }
 
 QToolButton:hover {
-	background-color: #2a3a75;
-	border: 1px solid #233166;
+	background-color: rgb(42,58,117);
+	border: 1px solid rgb(35,49,102);
 	border-radius: none;
 }
 
 QToolButton:pressed {
-	background-color: #161f41;
+	background-color: rgb(22,31,65);
 	border-radius: none;
 }
 
@@ -382,7 +382,7 @@ QToolButton:pressed {
 /* Tab Widget */
 
 QTabWidget::pane { /* The tab widget frame */
-	border-top: 1px solid #2f2f2f;
+	border-top: 1px solid rgb(47,47,47);
 }
 
 QTabWidget::tab-bar {
@@ -390,8 +390,8 @@ QTabWidget::tab-bar {
 }
 
 QTabBar::tab {
-	background-color: #212121;
-	border: 1px solid #333336;
+	background-color: rgb(33,33,33);
+	border: 1px solid rgb(51,51,54);
 	min-width: 8ex;
 	padding-top: 4px;
 	padding-bottom: 4px;
@@ -403,17 +403,17 @@ QTabBar::tab {
 }
 
 QTabBar::tab:selected {
-	background-color: #131a30;
-	border-color: #252a45;
+	background-color: rgb(19,26,48);
+	border-color: rgb(37,42,69);
 }
 
 QTabBar::tab:hover {
-	background-color: #233166;
-	border-color: #364683;
+	background-color: rgb(35,49,102);
+	border-color: rgb(54,70,131);
 }
 
 QTabBar::tab:pressed {
-	background-color: #161f41;
+	background-color: rgb(22,31,65);
 }
 
 /* ComboBox */
@@ -440,7 +440,7 @@ QComboBox::down-arrow {
 }
 
 QComboBox:on {
-	background-color: #2a3a75;
+	background-color: rgb(42,58,117);
 }
 
 QComboBox:editable {
@@ -509,15 +509,15 @@ QSpinBox::up-button:hover, QSpinBox::down-button:hover, QDoubleSpinBox::up-butto
 }
 
 QSpinBox::up-button:pressed, QSpinBox::down-button:pressed, QDoubleSpinBox::up-button:pressed, QDoubleSpinBox::down-button:pressed {
-	background-color: rgb(24,24,25);
+	background-color: palette(window);
 }
 
 QSpinBox::up-button:disabled, QSpinBox::up-button:off, QSpinBox::down-button:disabled, QSpinBox::down-button:off {
-	background-color: rgb(24,24,25);
+	background-color: palette(window);
 }
 
 QDoubleSpinBox::up-button:disabled, QDoubleSpinBox::up-button:off, QDoubleSpinBox::down-button:disabled, QDoubleSpinBox::down-button:off {
-	background-color: rgb(24,24,25);
+	background-color: palette(window);
 }
 
 QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {
@@ -534,35 +534,35 @@ QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
 /* Buttons */
 
 QPushButton {
-	color: rgb(225,224,225);
-	background-color: #162458;
-	border: 1px solid #233166;
+	color: palette(text);
+	background-color: palette(button);
+	border: 1px solid rgb(35,49,102);
 	padding: 6px 20px;
 	margin: 1px;
 }
 
 QPushButton::flat {
-	background-color: rgb(24,24,25);
+	background-color: palette(window);
 	border: none;
 }
 
 QPushButton:checked {
-	background-color: #581624;
-	border-color: #84162d;
+	background-color: rgb(88,22,36);
+	border-color: rgb(132,22,45);
 }
 
 QPushButton:hover {
-	background-color: #2a3a75;
-	border: 1px solid #364683;
+	background-color: rgb(42,58,117);
+	border: 1px solid rgb(54,70,131);
 }
 
 QPushButton:pressed {
-	background-color: #161f41;
+	background-color: rgb(22,31,65);
 }
 
 QPushButton:disabled {
-	border: 1px solid #232426;
-	background-color: #1a1a1b;
+	border: 1px solid rgb(35,36,38);
+	background-color: rgb(26,26,27);
 }
 
 QPushButton::flat:hover,
@@ -573,14 +573,14 @@ QPushButton::flat:disabled {
 /* Progress Bar */
 
 QProgressBar {
-	background: #101010;
-	border: 2px solid #363636;
+	background: rgb(16,16,16);
+	border: 2px solid rgb(54,54,54);
 	border-radius: 0px;
 	text-align: center;
 }
 
 QProgressBar::chunk {
-	background-color: #2a3a75;
+	background-color: rgb(42,58,117);
 }
 
 /* Sliders */
@@ -588,7 +588,7 @@ QProgressBar::chunk {
 QSlider::groove:horizontal {
 	background-color: QLinearGradient(x1: 0, y1: 0, x2: 0, y2: 1,
 		stop: 0 rgb(31,30,31),
-		stop: 0.75 rgb(50, 49, 50));
+		stop: 0.75 rgb(50,49,50));
 	height: 4px;
 	border: none;
 	border-radius: 2px;
@@ -599,7 +599,7 @@ QSlider::handle:horizontal {
 		stop: 0 rgb(240,239,240),
 		stop: 0.25 rgb(200,199,200),
 		stop: 1 rgb(162,161,162));
-	border: 1px solid rgb(24,24,25);
+	border: 1px solid palette(window);
 	border-radius: 3px;
 	height: 10px;
 	width: 18px;
@@ -614,20 +614,20 @@ QSlider::handle:horizontal:pressed {
 }
 
 QSlider::sub-page:horizontal {
-	background-color: #2a3a75;
+	background-color: rgb(42,58,117);
 }
 
 QSlider::sub-page:horizontal:disabled {
 	background-color: QLinearGradient(x1: 0, y1: 1, x2: 0, y2: 0,
 		stop: 0 rgb(26,25,26),
-		stop: 0.75 rgb(10, 10, 10));
+		stop: 0.75 rgb(10,10,10));
 	border-radius: 2px;
 }
 
 QSlider::groove:vertical {
 	background-color: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0,
 		stop: 0 rgb(31,30,31),
-		stop: 0.75 rgb(50, 49, 50));
+		stop: 0.75 rgb(50,49,50));
 	width: 4px;
 	border: none;
 	border-radius: 2px;
@@ -638,7 +638,7 @@ QSlider::handle:vertical {
 		stop: 0 rgb(240,239,240),
 		stop: 0.25 rgb(200,199,200),
 		stop: 1 rgb(162,161,162));
-	border: 1px solid rgb(24,24,25);
+	border: 1px solid palette(window);
 	border-radius: 3px;
 	width: 10px;
 	height: 18px;
@@ -653,13 +653,13 @@ QSlider::handle:vertical:pressed {
 }
 
 QSlider::add-page:vertical {
-	background-color: #2a3a75;
+	background-color: rgb(42,58,117);
 }
 
 QSlider::add-page:vertical:disabled {
 	background-color: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0,
 		stop: 0 rgb(26,25,26),
-		stop: 0.75 rgb(10, 10, 10));
+		stop: 0.75 rgb(10,10,10));
 	border-radius: 2px;
 }
 
@@ -675,15 +675,15 @@ QSlider::handle:disabled {
 
 VolumeMeter {
 
-	qproperty-backgroundNominalColor: #42740c;
-	qproperty-backgroundWarningColor: #988F0F;
-	qproperty-backgroundErrorColor: #802004;
-	qproperty-foregroundNominalColor: #84D82B;
-	qproperty-foregroundWarningColor: #E4D717;
-	qproperty-foregroundErrorColor: #D74116;
-	qproperty-magnitudeColor: rgb(49, 54, 59); /* Blue-gray */
-	qproperty-majorTickColor: rgb(239, 240, 241); /* White */
-	qproperty-minorTickColor: rgb(118, 121, 124); /* Light Gray */
+	qproperty-backgroundNominalColor: rgb(66,116,12);
+	qproperty-backgroundWarningColor: rgb(152,143,15);
+	qproperty-backgroundErrorColor: rgb(128,32,4);
+	qproperty-foregroundNominalColor: rgb(132,216,43);
+	qproperty-foregroundWarningColor: rgb(228,215,23);
+	qproperty-foregroundErrorColor: rgb(215,65,22);
+	qproperty-magnitudeColor: rgb(49,54,59); /* Blue-gray */
+	qproperty-majorTickColor: rgb(239,240,241); /* White */
+	qproperty-minorTickColor: rgb(118,121,124); /* Light Gray */
 	qproperty-peakDecayRate: 23.4; /* Override of the standard PPM Type I rate. */
 }
 
@@ -852,12 +852,12 @@ SourceTreeSubItemCheckBox::indicator:unchecked:hover {
 /* Label warning/error */
 
 QLabel#warningLabel {
-	color: rgb(192, 128, 0);
+	color: rgb(192,128,0);
 	font-weight: bold;
 }
 
 QLabel#errorLabel {
-	color: rgb(192, 0, 0);
+	color: rgb(192,0,0);
 	font-weight: bold;
 }
 
@@ -872,7 +872,7 @@ QLabel#errorLabel {
 OBSBasicProperties,
 #OBSBasicSettings,
 #OBSBasicFilters {
-	background: #101010;
+	background: rgb(16,16,16);
 }
 
 FocusList::item {
@@ -917,13 +917,13 @@ FocusList::item {
 }
 
 * [themeID="aboutHLayout"] {
-	background-color: rgb(8, 8, 11);
+	background-color: rgb(8,8,11);
 }
 
 /* Preview background color */
 
 OBSQTDisplay {
-	qproperty-displayBackgroundColor: #28282A;
+	qproperty-displayBackgroundColor: rgb(40,40,42);
 }
 
 /* Preview/Program labels */
@@ -954,15 +954,15 @@ OBSBasicSettings QListWidget::item {
 /* Table */
 
 QTableView {
-    gridline-color: #333336;
+    gridline-color: rgb(51,51,54);
 }
 
 QHeaderView {
     border: none;
 }
 QHeaderView::section {
-    background-color: #101010;
-    border: 1px solid #333336;
+    background-color: rgb(16,16,16);
+    border: 1px solid rgb(51,51,54);
     border-left: none;
 }
 *[themeID="trashIcon"] {
@@ -1041,11 +1041,11 @@ QPushButton#extraPanelDelete {
 }
 
 QPushButton#extraPanelDelete:hover {
-     background-color: #2a3a75;
+     background-color: rgb(42,58,117);
 }
 
 QPushButton#extraPanelDelete:pressed {
-    background-color: #161f41;
+    background-color: rgb(22,31,65);
 }
 
 OBSMissingFiles {
@@ -1084,7 +1084,7 @@ SceneTree#scenes {
 }
 
 *[gridMode="false"] SceneTree#scenes {
-	border-bottom: 2px solid #2f2f2f;
+	border-bottom: 2px solid rgb(47,47,47);
 }
 
 *[gridMode="true"] SceneTree::item {
@@ -1110,7 +1110,7 @@ QSlider::groove:horizontal[themeID="tBarSlider"] {
 	height: 5px;
 	background-color: QLinearGradient(x1: 0, y1: 0, x2: 0, y2: 1,
 		stop: 0 rgb(31,30,31),
-		stop: 0.75 rgb(50, 49, 50));
+		stop: 0.75 rgb(50,49,50));
 	border: none;
 	border-radius: 2px;
 }
@@ -1119,13 +1119,13 @@ QSlider::sub-page:horizontal[themeID="tBarSlider"] {
 	height: 5px;
 	background-color: QLinearGradient(x1: 0, y1: 0, x2: 0, y2: 1,
 		stop: 0 rgb(31,30,31),
-		stop: 0.75 rgb(50, 49, 50));
+		stop: 0.75 rgb(50,49,50));
 	border: none;
 	border-radius: 2px;
 }
 
 QSlider::handle:horizontal[themeID="tBarSlider"] {
-	background-color: #d2d2d2;
+	background-color: rgb(210,210,210);
 	width: 14px;
 	height: 28px;
 	margin: -28px 0px;

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -49,7 +49,7 @@ OBSTheme {
     shadow: rgb(11,10,11); /* veryVeryDark */
 
     highlight: rgb(42,130,218); /* blue */
-    highlightText: rgb(0,0,0);
+    highlightedText: rgb(0,0,0);
 
     link: rgb(114,162,255); /* OBS blue */
     linkVisited: rgb(114,162,255); /* OBS blue */
@@ -63,7 +63,7 @@ OBSTheme::disabled {
 
 OBSTheme::inactive {
     highlight: rgb(48,47,48);
-    highlightText: rgb(255,255,255);
+    highlightedText: rgb(255,255,255);
 }
 
 

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -51,8 +51,8 @@ OBSTheme {
     highlight: rgb(42,130,218); /* blue */
     highlightText: rgb(0,0,0);
 
-    link: rgb(114, 162, 255); /* OBS blue */
-    linkVisited: rgb(114, 162, 255); /* OBS blue */
+    link: rgb(114,162,255); /* OBS blue */
+    linkVisited: rgb(114,162,255); /* OBS blue */
 }
 
 OBSTheme::disabled {
@@ -63,47 +63,47 @@ OBSTheme::disabled {
 
 OBSTheme::inactive {
     highlight: rgb(48,47,48);
-    highlightText: rgb(255, 255, 255);
+    highlightText: rgb(255,255,255);
 }
 
 
 /* General style, we override only what is needed. */
 QWidget {
-    background-color: rgb(58,57,58); /* dark */
-    alternate-background-color: rgb(31,30,31); /* veryDark */
-    color: rgb(225,224,225); /* veryLight */
-    selection-background-color: rgb(42,130,218); /* blue */
-    selection-color: black;
+    background-color: palette(window);
+    alternate-background-color: palette(base);
+    color: palette(window-text);
+    selection-background-color: palette(highlight);
+    selection-color: palette(highlighted-text);
 }
 
 * [frameShape="1"], * [frameShape="2"], * [frameShape="3"], * [frameShape="4"], * [frameShape="5"], * [frameShape="6"] {
-    border: 1px solid rgb(31,30,31);
+    border: 1px solid palette(base);
 }
 
 
 /* Misc */
 
 QWidget::disabled {
-    color: 2px solid rgb(200,199,200); /* lighter */
+    color: 2px solid palette(bright-text);
 }
 
 QAbstractItemView, QStackedWidget#stackedMixerArea QWidget {
-    background-color: rgb(31,30,31); /* veryDark */
+    background-color: palette(base);
 }
 
 QToolTip {
-    background-color: rgb(31,30,31); /* veryDark */
+    background-color: palette(base);
     color: rgb(205,205,205);
     border: none;
 }
 
 QMenuBar::item {
-    background-color: rgb(58,57,58); /* dark */
+    background-color: palette(window);
 }
 
 QListWidget::item:selected:!active,
 SourceTree::item:selected:!active {
-    color: rgb(255, 255, 255);
+    color: rgb(255,255,255);
     background-color: rgb(48,47,48);
 }
 
@@ -146,7 +146,7 @@ QDockWidget::close-button:pressed, QDockWidget::float-button:pressed {
 /* Group Box */
 
 QGroupBox {
-    border: 1px solid rgb(31,30,31); /* veryDark */;
+    border: 1px solid palette(base);
     border-radius: 5px;
     padding-top: 24px;
     font-weight: bold;
@@ -162,12 +162,12 @@ QGroupBox::title {
 /* ScrollBars */
 
 ::corner {
-    background-color: rgb(58,57,58); /* dark */
+    background-color: palette(window);
     border: none;
 }
 
 QScrollBar:vertical {
-    background-color: rgb(58,57,58);
+    background-color: palette(window);
     width: 14px;
     margin: 0px;
 }
@@ -194,7 +194,7 @@ QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical, QScrollBar::add-
 }
 
 QScrollBar:horizontal {
-    background-color: rgb(58,57,58); /* dark */
+    background-color: palette(window);
     height: 14px;
     margin: 0px;
 }
@@ -241,7 +241,7 @@ QScrollBar::left-arrow:horizontal, QScrollBar::right-arrow:horizontal, QScrollBa
 /* Scenes and Sources toolbar */
 
 QToolBar {
-    background-color: rgb(58,57,58); /* dark */
+    background-color: palette(window);
     border: none;
 }
 
@@ -251,7 +251,7 @@ QToolButton:hover {
 }
 
 QToolButton:pressed {
-    background-color: rgb(31,30,31); /* veryDark */
+    background-color: palette(base);
     border-radius: none;
 }
 
@@ -291,7 +291,7 @@ QToolButton:pressed {
 /* Tab Widget */
 
 QTabWidget::pane { /* The tab widget frame */
-    border-top: 1px solid rgb(31,30,31); /* veryDark */
+    border-top: 1px solid palette(base); /* veryDark */
 }
 
 QTabWidget::tab-bar {
@@ -322,7 +322,7 @@ QTabBar::tab:bottom {
 }
 
 QTabBar::tab:selected {
-    background-color: rgb(31,30,31); /* veryDark */
+    background-color: palette(base);
 }
 
 QTabBar::tab:hover {
@@ -330,7 +330,7 @@ QTabBar::tab:hover {
 }
 
 QTabBar::tab:pressed {
-    background-color: rgb(31,30,31); /* veryDark */
+    background-color: palette(base);
 }
 
 
@@ -347,7 +347,7 @@ QComboBox {
 }
 
 QComboBox:hover {
-    background-color: rgb(88,87,88);
+    background-color: palette(button);
 }
 
 QComboBox::drop-down {
@@ -363,7 +363,7 @@ QComboBox::down-arrow {
 }
 
 QComboBox:on {
-    background-color: rgb(31,30,31); /* veryDark */
+    background-color: palette(base);
 }
 
 QComboBox:editable {
@@ -386,7 +386,7 @@ QComboBox::down-arrow:editable {
 /* Textedits etc */
 
 QLineEdit, QTextEdit, QPlainTextEdit {
-    background-color: rgb(31,30,31); /* veryDark */
+    background-color: palette(base);
     border: none;
     border-radius: 3px;
     padding: 2px 2px 3px 7px;
@@ -395,7 +395,7 @@ QLineEdit, QTextEdit, QPlainTextEdit {
 /* Spinbox and doubleSpinbox */
 
 QSpinBox, QDoubleSpinBox {
-    background-color: rgb(31,30,31); /* veryDark */
+    background-color: palette(base);
     border: none;
     border-radius: 3px;
     margin: 0px 3px 0px 0px;
@@ -407,7 +407,7 @@ QSpinBox::up-button, QDoubleSpinBox::up-button {
     subcontrol-position: top right; /* position at the top right corner */
 
     background-color: rgb(76,76,76);
-    border: 1px solid rgb(31,30,31); /* veryDark */
+    border: 1px solid palette(base);
     border-radius: 3px;
     border-width: 0;
     border-bottom-left-radius: 0;
@@ -419,7 +419,7 @@ QSpinBox::down-button, QDoubleSpinBox::down-button {
     subcontrol-origin: margin;
     subcontrol-position: bottom right; /* position at the top right corner */
     background-color: rgb(76,76,76);
-    border: 1px solid rgb(31,30,31); /* veryDark */
+    border: 1px solid palette(base);
     border-radius: 3px;
     border-width: 0;
     border-top-left-radius: 0;
@@ -432,15 +432,15 @@ QSpinBox::up-button:hover, QSpinBox::down-button:hover, QDoubleSpinBox::up-butto
 }
 
 QSpinBox::up-button:pressed, QSpinBox::down-button:pressed, QDoubleSpinBox::up-button:pressed, QDoubleSpinBox::down-button:pressed {
-    background-color: rgb(58,57,58); /* dark */
+    background-color: palette(window);
 }
 
 QSpinBox::up-button:disabled, QSpinBox::up-button:off, QSpinBox::down-button:disabled, QSpinBox::down-button:off {
-    background-color: rgb(58,57,58); /* dark */
+    background-color: palette(window);
 }
 
 QDoubleSpinBox::up-button:disabled, QDoubleSpinBox::up-button:off, QDoubleSpinBox::down-button:disabled, QDoubleSpinBox::down-button:off {
-    background-color: rgb(58,57,58); /* dark */
+    background-color: palette(window);
 }
 
 QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {
@@ -457,7 +457,7 @@ QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
 /* Buttons */
 
 QPushButton {
-    color: rgb(225,224,225); /* veryLight */
+    color: palette(window-text);
     background-color: rgb(76,76,76);
     border: none;
     border-radius: 3px;
@@ -467,7 +467,7 @@ QPushButton {
 }
 
 QPushButton::flat {
-    background-color: rgb(58,57,58); /* dark */
+    background-color: palette(window);
 }
 
 QPushButton:hover {
@@ -475,7 +475,7 @@ QPushButton:hover {
 }
 
 QPushButton:pressed {
-    background-color: rgb(31,30,31); /* veryDark */
+    background-color: palette(base);
 }
 
 QPushButton:checked {
@@ -499,8 +499,8 @@ QSlider::groove:horizontal {
 }
 
 QSlider::handle:horizontal {
-    background-color: #d2d2d2;
-    border: 1px solid rgb(58,57,58);
+    background-color: rgb(210,210,210);
+    border: 1px solid palette(window);
     border-radius: 3px;
     height: 10px;
     width: 18px;
@@ -508,16 +508,16 @@ QSlider::handle:horizontal {
 }
 
 QSlider::handle:horizontal:pressed {
-    background-color: #d2d2d2;
+    background-color: rgb(210,210,210);
 }
 
 QSlider::sub-page:horizontal {
-    background-color: rgb(42,130,218); /* blue */
+    background-color: palette(highlight);
     border-radius: 2px;
 }
 
 QSlider::sub-page:horizontal:disabled {
-    background-color: rgb(50, 49, 50); /* dark */
+    background-color: rgb(50,49,50); /* dark */
     border-radius: 2px;
 }
 
@@ -529,8 +529,8 @@ QSlider::groove:vertical {
 }
 
 QSlider::handle:vertical {
-    background-color: #d2d2d2;
-    border: 1px solid rgb(58,57,58);
+    background-color: rgb(210,210,210);
+    border: 1px solid palette(window);
     border-radius: 3px;
     width: 10px;
     height: 18px;
@@ -538,21 +538,21 @@ QSlider::handle:vertical {
 }
 
 QSlider::handle:vertical:pressed {
-    background-color: #d2d2d2;
+    background-color: rgb(210,210,210);
 }
 
 QSlider::add-page:vertical {
-    background-color: rgb(42,130,218); /* blue */
+    background-color: palette(highlight);
     border-radius: 2px;
 }
 
 QSlider::add-page:vertical:disabled {
-    background-color: rgb(50, 49, 50); /* dark */
+    background-color: rgb(50,49,50); /* dark */
     border-radius: 2px;
 }
 
 QSlider::handle:hover {
-    background-color: rgb(200,199,200); /* veryLight */
+    background-color: palette(bright-text);
 }
 
 QSlider::handle:disabled {
@@ -562,14 +562,14 @@ QSlider::handle:disabled {
 /* Volume Control */
 
 VolumeMeter {
-    qproperty-backgroundNominalColor: rgb(38, 127, 38);
-    qproperty-backgroundWarningColor: rgb(127, 127, 38);
-    qproperty-backgroundErrorColor: rgb(127, 38, 38);
-    qproperty-foregroundNominalColor: rgb(76, 255, 76);
-    qproperty-foregroundWarningColor: rgb(255, 255, 76);
-    qproperty-foregroundErrorColor: rgb(255, 76, 76);
-    qproperty-magnitudeColor: rgb(0, 0, 0);
-    qproperty-majorTickColor: rgb(225,224,225); /* veryLight */
+    qproperty-backgroundNominalColor: rgb(38,127,38);
+    qproperty-backgroundWarningColor: rgb(127,127,38);
+    qproperty-backgroundErrorColor: rgb(127,38,38);
+    qproperty-foregroundNominalColor: rgb(76,255,76);
+    qproperty-foregroundWarningColor: rgb(255,255,76);
+    qproperty-foregroundErrorColor: rgb(255,76,76);
+    qproperty-magnitudeColor: rgb(0,0,0);
+    qproperty-majorTickColor: palette(window-text);
     qproperty-minorTickColor: rgb(122,121,122); /* light */
 }
 
@@ -583,13 +583,13 @@ QStatusBar::item {
 /* Table View */
 
 QTableView {
-    gridline-color: rgb(88,87,88); /* kindaDark */
+    gridline-color: palette(light);
 }
 
 QHeaderView::section {
-    background-color: rgb(58,57,58); /* dark */
-    color: rgb(225,224,225); /* veryLight */
-    border: 1px solid rgb(31,30,31); /* veryDark */;
+    background-color: palette(window);
+    color: palette(window-text);
+    border: 1px solid palette(base);
     border-radius: 5px;
 }
 
@@ -648,27 +648,27 @@ SourceTreeSubItemCheckBox::indicator:unchecked {
 /* Label warning/error */
 
 QLabel#warningLabel {
-    color: rgb(192, 128, 0);
+    color: rgb(192,128,0);
     font-weight: bold;
 }
 
 QLabel#errorLabel {
-    color: rgb(192, 0, 0);
+    color: rgb(192,0,0);
     font-weight: bold;
 }
 
 * [themeID="warning"] {
-    color: rgb(192, 128, 0);
+    color: rgb(192,128,0);
     font-weight: bold;
 }
 
 * [themeID="error"] {
-    color: rgb(192, 0, 0);
+    color: rgb(192,0,0);
     font-weight: bold;
 }
 
 * [themeID="good"] {
-    color: rgb(0, 192, 0);
+    color: rgb(0,192,0);
     font-weight: bold;
 }
 
@@ -689,13 +689,13 @@ QLabel#errorLabel {
 }
 
 * [themeID="aboutHLayout"] {
-    background-color: rgb(31, 30, 31); /* veryDark */
+    background-color: palette(base);
 }
 
 /* Preview background color */
 
 OBSQTDisplay {
-	qproperty-displayBackgroundColor: rgb(76, 76, 76);
+	qproperty-displayBackgroundColor: rgb(76,76,76);
 }
 
 /* Preview/Program labels */
@@ -762,7 +762,7 @@ VisibilityCheckBox::indicator:unchecked {
 }
 
 QPushButton#extraPanelDelete {
-    background-color: rgb(31, 30, 31);
+    background-color: palette(base);
 }
 
 QPushButton#extraPanelDelete:hover {
@@ -770,7 +770,7 @@ QPushButton#extraPanelDelete:hover {
 }
 
 QPushButton#extraPanelDelete:pressed {
-    background-color: rgb(31,30,31);
+    background-color: palette(base);
 }
 
 OBSMissingFiles {
@@ -805,7 +805,7 @@ SceneTree {
 }
 
 *[gridMode="true"] SceneTree::item {
-    color: rgb(225,224,225); /* veryLight */
+    color: palette(window-text);
     background-color: rgb(76,76,76);
     border: none;
     border-radius: 3px;
@@ -824,7 +824,7 @@ SceneTree {
 }
 
 *[gridMode="true"] SceneTree::item:pressed {
-    background-color: rgb(31,30,31); /* veryDark */
+    background-color: palette(base);
 }
 
 *[gridMode="true"] SceneTree::item:checked {
@@ -844,18 +844,18 @@ QSlider[themeID="tBarSlider"] {
 }
 
 QSlider::groove:horizontal[themeID="tBarSlider"] {
-	border: 1px solid #4c4c4c;
+	border: 1px solid rgb(76,76,76);
 	height: 5px;
-	background: rgb(31,30,31);
+	background: palette(base);
 }
 
 QSlider::sub-page:horizontal[themeID="tBarSlider"] {
-	background: rgb(31,30,31);;
-	border: 1px solid #4c4c4c;
+	background: palette(base);;
+	border: 1px solid rgb(76,76,76);
 }
 
 QSlider::handle:horizontal[themeID="tBarSlider"] {
-	background-color: #d2d2d2;
+	background-color: rgb(210,210,210);
 	width: 12px;
 	height: 24px;
 	margin: -24px 0px;

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -83,7 +83,7 @@ OBSTheme::inactive {
 /************************/
 
 SourceTree::item:selected:!active {
-	color: rgb(239, 240, 241); /* White */
+	color: palette(window-text);
 	background-color: rgba(255, 148, 194, 0.25); /* Light Pink (Secondary Light) */
 	border: none;
 }
@@ -96,8 +96,8 @@ SourceTree::item:selected {
 SourceTree::item:hover,
 SourceTree::item:disabled:hover,
 SourceTree::item:hover:!active {
-	background-color: rgb(0, 188, 212); /* Cyan (Primary) */
-	color: rgb(239, 240, 241); /* White */
+	background-color: palette(button);
+	color: palette(window-text);
 	border: none;
 }
 
@@ -117,10 +117,10 @@ SourceTree QLineEdit {
 QMainWindow,
 QDialog,
 QWidget {
-	background-color: rgb(49, 54, 59); /* Blue-gray */
-	color: rgb(239, 240, 241); /* White */
-	selection-background-color: rgb(0, 188, 212); /* Cyan (Primary) */
-	selection-color: rgb(239, 240, 241); /* White */
+	background-color: palette(window);
+	color: palette(window-text);
+	selection-background-color: palette(button);
+	selection-color: palette(window-text);
 	outline: none;
 	font-family: Noto Sans, Tahoma;
 	font-size: 11px;
@@ -131,8 +131,8 @@ QWidget::disabled {
 }
 
 QWidget:item:hover {
-	background-color: rgb(0, 188, 212); /* Cyan (Primary) */
-	color: rgb(118, 121, 124); /* Light Gray */
+	background-color: palette(button);
+	color: palette(mid);
 }
 
 QComboBox:hover,
@@ -142,8 +142,8 @@ QTextEdit:hover,
 QPlainTextEdit:hover,
 QAbstractView:hover,
 QTreeView:hover {
-	border: 1px solid rgb(0, 188, 212); /* Cyan (Primary) */
-	color: rgb(239, 240, 241); /* White */
+	border: 1px solid palette(button);
+	color: palette(window-text);
 }
 
 QSizeGrip {
@@ -166,7 +166,7 @@ QListWidget QLineEdit {
 /***********************/
 
 QListWidget::item:selected:!active {
-	color: rgb(239, 240, 241); /* White */
+	color: palette(window-text);
 	background-color: rgba(255, 148, 194, 0.25); /* Light Pink (Secondary Light) */
 	border: none;
 }
@@ -179,8 +179,8 @@ QListWidget::item:selected {
 QListWidget::item:hover,
 QListWidget::item:disabled:hover,
 QListWidget::item:hover:!active {
-	background-color: rgb(0, 188, 212); /* Cyan (Primary) */
-	color: rgb(239, 240, 241); /* White */
+	background-color: palette(button);
+	color: palette(window-text);
 	border: none;
 }
 
@@ -194,13 +194,13 @@ QDockWidget {
 }
 
 QDockWidget {
-	background: rgb(49, 54, 59); /* Blue-gray */
+	background: palette(window);
 	border: 1px solid rgb(58, 64, 69); /* Light Blue-gray */
 }
 
 QDockWidget::title {
 	text-align: left;
-	background: rgb(35, 38, 41); /* Dark Gray */
+	background: palette(shadow);
 	padding-left: 5px;
 }
 
@@ -227,7 +227,7 @@ QDockWidget::close-button:pressed, QDockWidget::float-button:pressed {
 
 QGroupBox {
 	font-size: 13px;
-	border: 1px solid rgb(118, 121, 124); /* Light Gray */
+	border: 1px solid palette(mid);
 	border-radius: 2px;
 	padding-top: 16px;
 	margin-top: 20px;
@@ -246,8 +246,8 @@ QGroupBox::title {
 /*****************/
 
 QMenuBar {
-	background-color: rgb(49, 54, 59); /* Blue-gray */
-	color: rgb(239, 240, 241); /* White */
+	background-color: palette(window);
+	color: palette(window-text);
 }
 
 QMenuBar::item {
@@ -261,7 +261,7 @@ QMenuBar::item:selected {
 
 QMenuBar::item:pressed {
 	border: none;
-	background-color: rgb(0, 188, 212);
+	background-color: palette(button);
 	margin-bottom: -1px;
 	padding-bottom: 1px;
 }
@@ -275,11 +275,11 @@ QScrollBar:horizontal {
 	margin: 3px 15px 3px 15px;
 	border: 1px transparent;
 	border-radius: 4px;
-	background-color: rgb(35, 38, 41); /* Dark Gray */
+	background-color: palette(shadow);
 }
 
 QScrollBar::handle:horizontal {
-	background-color: rgb(118, 121, 124); /* Light Gray */
+	background-color: palette(mid);
 	min-width: 5px;
 	border-radius: 4px;
 }
@@ -331,7 +331,7 @@ QScrollBar::sub-page:horizontal {
 }
 
 QScrollBar:vertical {
-	background-color: rgb(35, 38, 41); /* Dark Gray */
+	background-color: palette(shadow);
 	width: 15px;
 	margin: 15px 3px 15px 3px;
 	border: 1px transparent;
@@ -339,7 +339,7 @@ QScrollBar:vertical {
 }
 
 QScrollBar::handle:vertical {
-	background-color: rgb(118, 121, 124); /* Light Gray */
+	background-color: palette(mid);
 	min-height: 5px;
 	border-radius: 4px;
 }
@@ -399,7 +399,7 @@ QTabWidget {
 }
 
 QTabWidget::pane {
-	border: 1px solid rgb(118, 121, 124); /* Light Gray */
+	border: 1px solid palette(mid);
 	padding: 5px;
 	margin: 0;
 }
@@ -436,8 +436,8 @@ QTabBar::close-button:pressed {
 }
 
 QTabBar::tab {
-	color: rgb(239, 240, 241); /* White */
-	border: 1px solid rgb(118, 121, 124); /* Light Gray */
+	color: palette(window-text);
+	border: 1px solid palette(mid); /* Light Gray */
 	background-color: rgba(240, 98, 146, 0.5); /* Pink (Secondary) */
 	padding: 5px;
 	min-width: 50px;
@@ -457,12 +457,12 @@ QTabBar::tab:bottom {
 }
 
 QTabBar::tab:!selected {
-	color: rgb(239, 240, 241); /* White */
-	background-color: rgb(84, 87, 91); /* Gray */
+	color: palette(window-text);
+	background-color: palette(dark);
 }
 
 QTabBar::tab:!selected:hover {
-	background-color: rgb(0, 188, 212); /* Cyan (Primary) */
+	background-color: palette(button);
 }
 
 /********************/
@@ -470,7 +470,7 @@ QTabBar::tab:!selected:hover {
 /********************/
 
 QToolBar {
-	background-color: rgb(49, 54, 59); /* Blue-gray */
+	background-color: palette(window);
 	border: none;
 }
 
@@ -521,8 +521,8 @@ QToolButton:pressed {
 /***********************/
 
 QComboBox {
-	background-color: rgb(35, 38, 41); /* Dark Gray */
-	border: 1px solid rgb(118, 121, 124); /* Light Gray */
+	background-color: palette(shadow);
+	border: 1px solid palette(mid);
 	border-radius: 2px;
 	padding: 5px;
 	min-width: 75px;
@@ -534,9 +534,9 @@ QComboBox:on {
 }
 
 QComboBox QAbstractItemView {
-	background-color: rgb(35, 38, 41); /* Dark Gray */
+	background-color: palette(shadow);
 	border-radius: 2px;
-	border: 1px solid rgb(118, 121, 124); /* Light Gray */
+	border: 1px solid palette(mid);
 }
 
 QComboBox::drop-down {
@@ -568,9 +568,9 @@ QComboBox::down-arrow:hover {
 
 QAbstractSpinBox {
 	padding: 5px;
-	border: 1px solid rgb(118, 121, 124); /* Light Gray */
-	background-color: rgb(35, 38, 41); /* Dark Gray */
-	color: rgb(239, 240, 241); /* White */
+	border: 1px solid palette(mid);
+	background-color: palette(shadow);
+	color: palette(window-text);
 	border-radius: 2px;
 	min-width: 75px;
 }
@@ -616,11 +616,11 @@ QAbstractSpinBox::down-arrow:hover {
 /**********************/
 
 QLineEdit {
-	background-color: rgb(35, 38, 41); /* Dark Gray */
+	background-color: palette(shadow);
 	padding: 5px;
-	border: 1px solid rgb(118, 121, 124); /* Light Gray */
+	border: 1px solid palette(mid);
 	border-radius: 2px;
-	color: rgb(239, 240, 241); /* White */
+	color: palette(window-text);
 }
 
 /**********************/
@@ -630,7 +630,7 @@ QLineEdit {
 QCheckBox {
 	spacing: 5px;
 	outline: none;
-	color: rgb(239, 240, 241); /* White */
+	color: palette(window-text);
 	margin-bottom: 2px;
 }
 
@@ -639,7 +639,7 @@ QCheckBox:hover, QCheckBox:focus {
 }
 
 QCheckBox:disabled {
-	color: rgb(118, 121, 124); /* Light Gray */
+	color: palette(mid);
 }
 
 QCheckBox::indicator,
@@ -689,12 +689,12 @@ QGroupBox::indicator:unchecked:disabled {
 QRadioButton {
 	spacing: 5px;
 	outline: none;
-	color: rgb(239, 240, 241); /* White */
+	color: palette(window-text);
 	margin-bottom: 2px;
 }
 
 QRadioButton:disabled {
-	color: rgb(118, 121, 124); /* Light Gray */
+	color: palette(mid);
 }
 
 QRadioButton::indicator {
@@ -808,13 +808,13 @@ SourceTreeSubItemCheckBox::indicator:unchecked:hover {
 /*************************/
 
 QProgressBar {
-	border: 2px solid rgb(118, 121, 124); /* Light Gray */
+	border: 2px solid palette(mid);
 	border-radius: 5px;
 	text-align: center;
 }
 
 QProgressBar::chunk {
-	background-color: rgb(0, 188, 212); /* Cyan (Primary) */
+	background-color: palette(button);
 }
 
 /**************************/
@@ -828,9 +828,9 @@ VolumeMeter {
 	qproperty-foregroundNominalColor: rgb(119, 255, 143);
 	qproperty-foregroundWarningColor: rgb(255, 157, 76);
 	qproperty-foregroundErrorColor: rgb(255, 89, 76);
-	qproperty-magnitudeColor: rgb(49, 54, 59); /* Blue-gray */
-	qproperty-majorTickColor: rgb(239, 240, 241); /* White */
-	qproperty-minorTickColor: rgb(118, 121, 124); /* Light Gray */
+	qproperty-magnitudeColor: palette(window);
+	qproperty-majorTickColor: palette(window-text);
+	qproperty-minorTickColor: palette(mid);
 }
 
 /*******************/
@@ -838,10 +838,10 @@ VolumeMeter {
 /*******************/
 
 QPushButton {
-	background-color: rgb(0, 188, 212);; /* Cyan (Primary) */
-	color: rgb(239, 240, 241); /* White */
+	background-color: palette(button);
+	color: palette(window-text);
 	border-radius: 2px;
-	border: 1px solid rgb(0, 188, 212); /* Cyan (Primary) */
+	border: 1px solid palette(button);
 	padding: 4px;
 	padding-left: 15px;
 	padding-right: 15px;
@@ -871,9 +871,9 @@ QPushButton:checked:hover {
 }
 
 QPushButton:disabled {
-	background-color: rgb(0, 139, 163); /* Dark Cyan (Primary Dark) */
-	border: 1px solid rgb(0, 139, 163); /* Dark Cyan (Primary Dark) */
-	color: rgb(162, 161, 162); /* Lighter Gray */
+	background-color: palette(base);
+	border: 1px solid palette(base);
+	color: palette(light);
 }
 
 QPushButton::menu-indicator {
@@ -893,7 +893,7 @@ QPushButton::menu-indicator {
 /******************************/
 
 QDialogButtonBox QPushButton {
-	background-color: rgb(0, 188, 212); /* Cyan (Primary) */
+	background-color: palette(button);
 }
 
 QDialogButtonBox QPushButton:hover {
@@ -906,9 +906,9 @@ QDialogButtonBox QPushButton:pressed {
 }
 
 QDialogButtonBox QPushButton:disabled {
-	background-color: rgb(0, 139, 163); /* Dark Cyan (Primary Dark) */
-	border: 1px solid rgb(0, 139, 163); /* Dark Cyan (Primary Dark) */
-	color: rgb(162, 161, 162); /* Lighter Gray */
+	background-color: palette(base);
+	border: 1px solid palette(base);
+	color: palette(light);
 }
 
 /*******************************/
@@ -928,7 +928,7 @@ QPushButton[themeID="replayBufferButton"],
 QPushButton#modeSwitch,
 QPushButton#settingsButton,
 QPushButton#exitButton {
-	background-color: rgb(0, 188, 212); /* Cyan (Primary) */
+	background-color: palette(button);
 }
 
 QPushButton#recordButton {
@@ -993,7 +993,7 @@ QPushButton#moveAsyncFilterUp,
 QPushButton#moveAsyncFilterDown,
 QPushButton#moveEffectFilterDown,
 QPushButton#moveEffectFilterUp {
-	background-color: rgb(49, 54, 59); /* Blue-gray */
+	background-color: palette(window);
 	border: none;
 }
 
@@ -1037,12 +1037,12 @@ QLabel#sceneTransitionsLabel {
 
 /* warning and error */
 QLabel#warningLabel {
-	color: rgb(255, 148, 194); /* Light Pink (Secondary Light) */
+	color: palette(bright-text);
 	font-weight: bold;
 }
 
 QLabel#errorLabel {
-	color: rgb(186, 45, 101); /* Dark Pink (Secondary Dark) */
+	color: palette(alternate-base);
 	font-weight: bold;
 }
 
@@ -1057,7 +1057,7 @@ QLabel#errorLabel {
 /****************************/
 
 QSplitter::handle {
-	border: 1px dashed rgb(118, 121, 124); /* Light Gray */
+	border: 1px dashed palette(mid);
 }
 
 QSplitter::handle:hover {
@@ -1083,7 +1083,7 @@ QSplitter::handle:vertical {
 
 QSlider::groove:horizontal {
 	background-color: QLinearGradient(x1: 0, y1: 0, x2: 0, y2: 1,
-	stop: 0 rgb(35, 38, 41), /* Dark Gray */
+	stop: 0 palette(shadow), /* Dark Gray */
 	stop: 0.75 rgb(50, 49, 50));
 	height: 4px;
 	border: none;
@@ -1094,7 +1094,7 @@ QSlider::handle:horizontal {
 	background-color: QLinearGradient(x1: 0, y1: 0, x2: 0, y2: 1,
 	stop: 0 rgb(240, 239, 240),
 	stop: 0.25 rgb(200, 199, 200),
-	stop: 1 rgb(162, 161, 162));
+	stop: 1 palette(light));
 	border: 1px solid rgb(58, 57, 58);
 	border-radius: 3px;
 	height: 10px;
@@ -1106,24 +1106,24 @@ QSlider::handle:horizontal:pressed {
 	background-color: QLinearGradient(x1: 0, y1: 1, x2: 0, y2: 0,
 	stop: 0 rgb(240, 239, 240),
 	stop: 0.25 rgb(200, 199, 200),
-	stop: 1 rgb(162, 161, 162));
+	stop: 1 palette(light));
 }
 
 QSlider::sub-page:horizontal {
-	background-color: rgb(0, 188, 212); /* Cyan (Primary) */
+	background-color: palette(button);
 	border-radius: 2px;
 }
 
 QSlider::sub-page:horizontal:disabled {
 	background-color: QLinearGradient(x1: 0, y1: 0, x2: 0, y2: 1,
-	stop: 0 rgb(35, 38, 41), /* Dark Gray */
-	stop: 0.75 rgb(35, 38, 41)); /* Dark Gray */
+	stop: 0 palette(shadow),
+	stop: 0.75 palette(shadow));
 	border-radius: 2px;
 }
 
 QSlider::groove:vertical {
 	background-color: QLinearGradient(x1: 1, y1: 0, x2: 0, y2: 0,
-	stop: 0 rgb(35, 38, 41), /* Dark Gray */
+	stop: 0 palette(shadow),
 	stop: 0.75 rgb(50, 49, 50));
 	width: 4px;
 	border: none;
@@ -1134,7 +1134,7 @@ QSlider::handle:vertical {
 	background-color: QLinearGradient(x1: 1, y1: 0, x2: 0, y2: 0,
 	stop: 0 rgb(240, 239, 240),
 	stop: 0.25 rgb(200, 199, 200),
-	stop: 1 rgb(162, 161, 162));
+	stop: 1 palette(light));
 	border: 1px solid rgb(58, 57, 58);
 	border-radius: 3px;
 	width: 10px;
@@ -1146,18 +1146,18 @@ QSlider::handle:vertical:pressed {
 	background-color: QLinearGradient(x1: 1, y1: 0, x2: 0, y2: 0,
 	stop: 0 rgb(240, 239, 240),
 	stop: 0.25 rgb(200, 199, 200),
-	stop: 1 rgb(162, 161, 162));
+	stop: 1 palette(light));
 }
 
 QSlider::add-page:vertical {
-	background-color: rgb(0, 188, 212); /* Cyan (Primary) */
+	background-color: palette(button);
 	border-radius: 2px;
 }
 
 QSlider::add-page:vertical:disabled {
 	background-color: QLinearGradient(x1: 1, y1: 0, x2: 0, y2: 0,
-	stop: 0 rgb(35, 38, 41), /* Dark Gray */
-	stop: 0.75 rgb(35, 38, 41)); /* Dark Gray */
+	stop: 0 palette(shadow),
+	stop: 0.75 palette(shadow));
 	border-radius: 2px;
 }
 
@@ -1173,13 +1173,13 @@ QSlider::handle:disabled {
 /**********************/
 
 QTableView {
-    gridline-color: rgb(118, 121, 124); /* Light Gray */
+    gridline-color: palette(mid);
 }
 
 QHeaderView::section {
-    background-color: rgb(35, 38, 41); /* Dark Gray */
-    color: rgb(239, 240, 241); /* "White" */
-    border: 1px solid rgb(118, 121, 124); /* Light Gray */
+    background-color: palette(shadow);
+    color: palette(window-text);
+    border: 1px solid palette(mid);
     border-radius: 2px;
     padding: 4px;
 }
@@ -1200,8 +1200,8 @@ OBSHotkeyLabel[hotkeyPairHover=true] {
 * [frameShape="4"],
 * [frameShape="5"],
 * [frameShape="6"] {
-	border: 1px solid rgb(118, 121, 124); /* Light Gray */
-	background-color: rgb(35, 38, 41); /* Dark Gray */
+	border: 1px solid palette(mid);
+	background-color: palette(shadow);
 }
 
 QFrame[frameShape="0"] {
@@ -1215,7 +1215,7 @@ QFrame[frameShape="0"] {
 }
 
 * [themeID="warning"] {
-	color: rgb(255, 148, 194); /* Light Pink (Secondary Light) */
+	color: palette(bright-text);
 }
 
 QStatusBar::item {
@@ -1223,12 +1223,12 @@ QStatusBar::item {
 }
 
 QAbstractItemView {
-	background-color: rgb(35, 38, 41); /* Dark Gray */
+	background-color: palette(shadow);
 }
 
 QToolTip {
-	border: 1px solid rgb(118, 121, 124); /* Light Gray */
-	background-color: rgb(49, 54, 59); /* Blue-gray */
+	border: 1px solid palette(mid);
+	background-color: palette(window);
 	color: rgb(240, 98, 146); /* Pink (Secondary) */
 }
 
@@ -1249,13 +1249,13 @@ QToolTip {
 }
 
 * [themeID="aboutHLayout"] {
-	background-color: rgb(35, 38, 41); /* Dark Gray */
+	background-color: palette(shadow);
 }
 
 /* Preview background color */
 
 OBSQTDisplay {
-	qproperty-displayBackgroundColor: rgb(35, 38, 41);
+	qproperty-displayBackgroundColor: palette(shadow);
 }
 
 /* Preview/Program labels */
@@ -1263,7 +1263,7 @@ OBSQTDisplay {
 * [themeID="previewProgramLabels"] {
 	font-size: 18px;
 	font-weight: bold;
-	color: rgb(122,121,122);
+	color: rgb(122, 121, 122);
 }
 
 /* Settings Icons */
@@ -1348,7 +1348,7 @@ VisibilityCheckBox::indicator:unchecked:hover {
 }
 
 QPushButton#extraPanelDelete {
-    background-color: rgb(35, 38, 41);
+    background-color: palette(shadow);
 }
 
 QPushButton#extraPanelDelete:hover {
@@ -1405,7 +1405,7 @@ QSlider[themeID="tBarSlider"] {
 QSlider::groove:horizontal[themeID="tBarSlider"] {
 	height: 5px;
 	background-color: QLinearGradient(x1: 1, y1: 0, x2: 0, y2: 0,
-		stop: 0 rgb(35, 38, 41), /* Dark Gray */
+		stop: 0 palette(shadow),
 		stop: 0.75 rgb(50, 49, 50));
 	border: none;
 	border-radius: 2px;
@@ -1414,14 +1414,14 @@ QSlider::groove:horizontal[themeID="tBarSlider"] {
 QSlider::sub-page:horizontal[themeID="tBarSlider"] {
 	height: 5px;
 	background-color: QLinearGradient(x1: 1, y1: 0, x2: 0, y2: 0,
-		stop: 0 rgb(35, 38, 41), /* Dark Gray */
+		stop: 0 palette(shadow),
 		stop: 0.75 rgb(50, 49, 50));
 	border: none;
 	border-radius: 2px;
 }
 
 QSlider::handle:horizontal[themeID="tBarSlider"] {
-	background-color: #d2d2d2;
+	background-color: rgb(210, 210, 210);
 	width: 12px;
 	height: 24px;
 	margin: -24px 0px;

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -60,7 +60,7 @@ OBSTheme {
 	shadow: rgb(35, 38, 41); /* Dark Gray */
 
 	highlight: rgb(98, 238, 255); /* Light Cyan (Primary Light) */
-	highlightText: rgb(0,0,0);
+	highlightedText: rgb(0,0,0);
 
 	link: rgb(98, 238, 255); /* Light Cyan (Primary Light) */
 	linkVisited: rgb(98, 238, 255); /* Light Cyan (Primary Light) */
@@ -74,7 +74,7 @@ OBSTheme::disabled {
 
 OBSTheme::inactive {
 	highlight: rgb(0, 188, 212); /* Cyan (Primary) */
-	highlightText: rgb(239, 240, 241); /* White */
+	highlightedText: rgb(239, 240, 241); /* White */
 }
 
 

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1099,8 +1099,8 @@ bool OBSApp::SetTheme(std::string name, std::string path)
 
 	QString mpath = QString("file:///") + path.c_str();
 	setPalette(defaultPalette);
-	setStyleSheet(mpath);
 	ParseExtraThemeData(path.c_str());
+	setStyleSheet(mpath);
 
 	emit StyleChanged();
 	return true;


### PR DESCRIPTION
### Description

QPalette is useful for removing duplicate styling definitions. Unfortunately, due to the incorrect order of operations when loading stylesheets into OBS, the default palette would also be loaded when parsing the stylesheet, resulting in unusable macros.

Based on the above change, I've modified all built in themes to use the palette where possible, making colour definitions clearer. Documentation on this capability can be found [here](https://doc.qt.io/qt-5/stylesheet-reference.html#paletterole).

Additionally, while consolidating variables in the themes, I noticed that `highlightedText` was defined incorrectly in theme files, so it was being ignored:
https://github.com/obsproject/obs-studio/blob/5d54cc36a7b4d4fa384de015e55c3249b5b7eaca/UI/obs-app.cpp#L910-L911

I've also gone through and replaced usages of hex colours to rgb to make everything more consistent & easier to read. This helped when replacing rgb codes with the palette.

### Motivation and Context

Making styling themes easier benefits everyone. The bug that the first commit fixes was noticed by a developer on [the Discord server](https://canary.discord.com/channels/348973006581923840/374637102551400468/871196464683036753).

### How Has This Been Tested?

Load each theme in this PR, ensure colours appear correctly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
