### PR TITLE
CI: Add OBS browser + Apple silicon support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: [macos-latest]
     env:
       MIN_MACOS_VERSION: '10.13'
-      MACOS_DEPS_VERSION: '2021-06-20'
+      MACOS_DEPS_VERSION: '2021-08-17'
       VLC_VERSION: '3.0.8'
       SPARKLE_VERSION: '1.26.0'
       QT_VERSION: '5.15.2'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
       - master
 
 env:
-  MACOS_CEF_BUILD_VERSION: '4183'
+  MACOS_CEF_BUILD_VERSION: '4430'
   LINUX_CEF_BUILD_VERSION: '4280'
   CEF_VERSION: '75.1.16+g16a67c4+chromium-75.0.3770.100'
   TWITCH_CLIENTID: ${{ secrets.TWITCH_CLIENT_ID }}
@@ -29,9 +29,9 @@ jobs:
     runs-on: [macos-latest]
     env:
       MIN_MACOS_VERSION: '10.13'
-      MACOS_DEPS_VERSION: '2021-03-25'
+      MACOS_DEPS_VERSION: '2021-06-20'
       VLC_VERSION: '3.0.8'
-      SPARKLE_VERSION: '1.23.0'
+      SPARKLE_VERSION: '1.26.0'
       QT_VERSION: '5.15.2'
       SIGN_IDENTITY: ''
       HAVE_CODESIGN_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY != '' && secrets.MACOS_SIGNING_CERT != '' }}
@@ -85,7 +85,7 @@ jobs:
         env:
           CACHE_NAME: 'cef-cache'
         with:
-          path: ${{ github.workspace }}/cmbuild/cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macosx64
+          path: ${{ github.workspace }}/cmbuild/cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macos${{ env.CURRENT_ARCH }}
           key: ${{ runner.os }}-pr-${{ env.CACHE_NAME }}-${{ env.MACOS_CEF_BUILD_VERSION }}
       - name: 'Restore VLC dependency from cache'
         id: vlc-cache
@@ -107,12 +107,22 @@ jobs:
         if: steps.deps-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          curl -L -O https://github.com/obsproject/obs-deps/releases/download/${{ env.MACOS_DEPS_VERSION }}/macos-deps-${{ env.CURRENT_ARCH }}-${{ env.MACOS_DEPS_VERSION }}.tar.gz
-          tar -xf ./macos-deps-${{ env.CURRENT_ARCH }}-${{ env.MACOS_DEPS_VERSION }}.tar.gz -C "/tmp"
+          DEPS_ARCHIVE="./macos-deps-${{ env.CURRENT_ARCH }}-${{ env.MACOS_DEPS_VERSION }}.tar.xz"
+          if [ -f $DEPS_ARCHIVE ]; then
+            info "Warning - ${DEPS_ARCHIVE} already downloaded so assuming previously installed and skipping"
+            return
+          fi
+          curl -L -O https://github.com/obsproject/obs-deps/releases/download/${{ env.MACOS_DEPS_VERSION }}/macos-deps-${{ env.CURRENT_ARCH }}-${{ env.MACOS_DEPS_VERSION }}.tar.xz
+          tar -xf ./macos-deps-${{ env.CURRENT_ARCH }}-${{ env.MACOS_DEPS_VERSION }}.tar.xz -C "/tmp"
       - name: 'Install prerequisite: Pre-built dependency Qt'
         if: steps.deps-qt-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
+          QT_DEPS_ARCHIVE="./macos-qt-${{ env.QT_VERSION }}-${{ env.CURRENT_ARCH }}-${{ env.MACOS_DEPS_VERSION }}.tar.gz"
+          if [ -f $QT_DEPS_ARCHIVE ]; then
+            info "Warning - ${QT_DEPS_ARCHIVE} already downloaded so assuming previously installed and skipping"
+            return
+          fi
           curl -L -O https://github.com/obsproject/obs-deps/releases/download/${{ env.MACOS_DEPS_VERSION }}/macos-qt-${{ env.QT_VERSION }}-${{ env.CURRENT_ARCH }}-${{ env.MACOS_DEPS_VERSION }}.tar.gz
           tar -xf ./macos-qt-${{ env.QT_VERSION }}-${{ env.CURRENT_ARCH }}-${{ env.MACOS_DEPS_VERSION }}.tar.gz -C "/tmp"
           xattr -r -d com.apple.quarantine /tmp/obsdeps
@@ -127,9 +137,9 @@ jobs:
         if: steps.sparkle-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          curl -L -o sparkle.tar.bz2 https://github.com/sparkle-project/Sparkle/releases/download/${{ env.SPARKLE_VERSION }}/Sparkle-${{ env.SPARKLE_VERSION }}.tar.bz2
+          curl -L -o sparkle.tar.xz https://github.com/sparkle-project/Sparkle/releases/download/${{ env.SPARKLE_VERSION }}/Sparkle-${{ env.SPARKLE_VERSION }}.tar.xz
           mkdir ${{ github.workspace }}/cmbuild/sparkle
-          tar -xf ./sparkle.tar.bz2 -C ${{ github.workspace }}/cmbuild/sparkle
+          tar -xf ./sparkle.tar.xz -C ${{ github.workspace }}/cmbuild/sparkle
       - name: 'Setup prerequisite: Sparkle'
         shell: bash
         run: sudo cp -R ${{ github.workspace }}/cmbuild/sparkle/Sparkle.framework /Library/Frameworks/Sparkle.framework
@@ -137,9 +147,9 @@ jobs:
         if: steps.cef-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          curl -L -O https://cdn-fastly.obsproject.com/downloads/cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macosx64.tar.bz2
-          tar -xf ./cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macosx64.tar.bz2 -C ${{ github.workspace }}/cmbuild/
-          cd ${{ github.workspace }}/cmbuild/cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macosx64
+          curl -L -O https://cdn-fastly.obsproject.com/downloads/cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macos${{ env.CURRENT_ARCH }}.tar.bz2
+          tar -xf ./cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macos${{ env.CURRENT_ARCH }}.tar.bz2 -C ${{ github.workspace }}/cmbuild/
+          cd ${{ github.workspace }}/cmbuild/cef_binary_${{ env.MACOS_CEF_BUILD_VERSION }}_macos${{ env.CURRENT_ARCH }}
           /usr/bin/sed -i '.orig' '/add_subdirectory(tests\/ceftests)/d' ./CMakeLists.txt
           /usr/bin/sed -i '.orig' s/\"10.9\"/\"${{ env.MIN_MACOS_VERSION }}\"/ ./cmake/cef_variables.cmake
           mkdir build && cd build

--- a/CI/full-build-macos.sh
+++ b/CI/full-build-macos.sh
@@ -243,8 +243,6 @@ install_cef() {
     step "Unpack..."
     /usr/bin/tar -xf ./${CEF_ARCHIVE}
     cd ${CEF_DIR}
-    step "Apply patches..."
-    patch -p1 < ${CI_SCRIPTS}/cef.patch
     # step "Fix tests..."
     # /usr/bin/sed -i '.orig' '/add_subdirectory(tests\/ceftests)/d' ./CMakeLists.txt
     # /usr/bin/sed -i '.orig' 's/"'$(test "${MACOS_CEF_BUILD_VERSION:-${CI_MACOS_CEF_VERSION}}" -le 3770 && echo "10.9" || echo "10.10")'"/"'${MIN_MACOS_VERSION:-${CI_MIN_MACOS_VERSION}}'"/' ./cmake/cef_variables.cmake


### PR DESCRIPTION
Complete build including OBS Browser native support on Apple silicon 

Download artifacts from here: https://github.com/obsproject/obs-deps/pull/60/checks?check_run_id=2869389632

Unzip them and put them in the obs-build-dependencies dir (which lives next to the obs-studio checkout will need creating if never built before i.e. mkdir ../obs-build-dependencies)

Rename so they're in expected format:
```
     macos-qt-5.15.2-arm64-2021-06-20.tar.xz
     macos-deps-arm64-2021-06-20.tar.xz

```
Then extract them so they're in /tmp/obsdeps:

```
mkdir -p /tmp/obsdeps
/usr/bin/tar -xf ../obs-build-dependencies/macos-deps-arm64-2021-06-20.tar.xz -C /tmp/obsdeps
/usr/bin/tar -xf ../obs-build-dependencies/macos-qt-5.15.2-arm64-2021-06-20.tar.xz -C /tmp/obsdeps
/usr/bin/xattr -r -d com.apple.quarantine /tmp/obsdeps
```

Copy cef_binary_90.6.7+g19ba721+chromium-90.0.4430.212_macosarm64_minimal.zip to obs-build-dependencies 
Instructions here https://github.com/obsproject/obs-browser/pull/310

Extract it and name extracted dir cef_binary_4430_macosarm64

```
cd ../obs-build-dependencies/cef_binary_4430_macosarm64
mkdir build
cd build
cmake -DCMAKE_CXX_FLAGS="-std=c++11 -stdlib=libc++ -Wno-deprecated-declarations" -DCMAKE_EXE_LINKER_FLAGS="-std=c++11 -stdlib=libc++" -DPROJECT_ARCH=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 ..
/usr/bin/make -j8
mkdir libcef_dll
cd ../../../obs-studio
./CI/full-build-macos.sh -b
```

Iterative builds for local testing can then by done by doing:

`rm -rf build/OBS.app && ./CI/full-build-macos.sh -b && codesign --deep -f -s - build/OBS.app
`

### Description
Update build scripts to include CEF 

### Motivation and Context
The other part of https://github.com/obsproject/obs-browser/pull/310 to bring in OBS Browser support natively on Apple silicon 

### How Has This Been Tested?
M1 iMac and M1 MBP
11.5.1
Setup a session recording video + playing WebGL in OBS Browser

### Types of changes
 - Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
