### PR TITLE
win-capture: Render nothing if window is iconic

### DIFF
--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -307,9 +307,18 @@ static void wc_update(void *data, obs_data_t *settings)
 	force_reset(wc);
 }
 
+static bool window_normal(struct window_capture *wc)
+{
+	return (IsWindow(wc->window) && !IsIconic(wc->window));
+}
+
 static uint32_t wc_width(void *data)
 {
 	struct window_capture *wc = data;
+
+	if (!window_normal(wc))
+		return 0;
+
 	return (wc->method == METHOD_WGC)
 		       ? wc->exports.winrt_capture_width(wc->capture_winrt)
 		       : wc->capture.width;
@@ -318,6 +327,10 @@ static uint32_t wc_width(void *data)
 static uint32_t wc_height(void *data)
 {
 	struct window_capture *wc = data;
+
+	if (!window_normal(wc))
+		return 0;
+
 	return (wc->method == METHOD_WGC)
 		       ? wc->exports.winrt_capture_height(wc->capture_winrt)
 		       : wc->capture.height;
@@ -573,6 +586,10 @@ static void wc_tick(void *data, float seconds)
 static void wc_render(void *data, gs_effect_t *effect)
 {
 	struct window_capture *wc = data;
+
+	if (!window_normal(wc))
+		return;
+
 	if (wc->method == METHOD_WGC) {
 		if (wc->capture_winrt) {
 			if (wc->exports.winrt_capture_active(


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Render nothing if window is iconic.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
to fix #5034

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
tested on window10

### Types of changes
Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
