### PR TITLE
libobs: update `simde`

### DIFF
--- a/libobs/util/simde/.clang-format
+++ b/libobs/util/simde/.clang-format
@@ -1,0 +1,3 @@
+Language: Cpp
+SortIncludes: false
+DisableFormat: true

--- a/libobs/util/simde/hedley.h
+++ b/libobs/util/simde/hedley.h
@@ -2099,12 +2099,12 @@ HEDLEY_DIAGNOSTIC_POP
 	HEDLEY_DIAGNOSTIC_PUSH                                        \
 	_Pragma("clang diagnostic ignored \"-Wgcc-compat\"")          \
 		__attribute__((diagnose_if(!(expr), #expr, "error"))) \
-		HEDLEY_DIAGNOSTIC_POP
+			HEDLEY_DIAGNOSTIC_POP
 #define HEDLEY_REQUIRE_MSG(expr, msg)                               \
 	HEDLEY_DIAGNOSTIC_PUSH                                      \
 	_Pragma("clang diagnostic ignored \"-Wgcc-compat\"")        \
 		__attribute__((diagnose_if(!(expr), msg, "error"))) \
-		HEDLEY_DIAGNOSTIC_POP
+			HEDLEY_DIAGNOSTIC_POP
 #else
 #define HEDLEY_REQUIRE(expr) \
 	__attribute__((diagnose_if(!(expr), #expr, "error")))

--- a/libobs/util/simde/hedley.h
+++ b/libobs/util/simde/hedley.h
@@ -10,11 +10,11 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-#if !defined(HEDLEY_VERSION) || (HEDLEY_VERSION < 14)
+#if !defined(HEDLEY_VERSION) || (HEDLEY_VERSION < 16)
 #if defined(HEDLEY_VERSION)
 #undef HEDLEY_VERSION
 #endif
-#define HEDLEY_VERSION 14
+#define HEDLEY_VERSION 16
 
 #if defined(HEDLEY_STRINGIFY_EX)
 #undef HEDLEY_STRINGIFY_EX
@@ -468,7 +468,8 @@
 	HEDLEY_VERSION_ENCODE((__VER__ / 1000000), ((__VER__ / 1000) % 1000), \
 			      (__VER__ % 1000))
 #else
-#define HEDLEY_IAR_VERSION HEDLEY_VERSION_ENCODE(VER / 100, __VER__ % 100, 0)
+#define HEDLEY_IAR_VERSION \
+	HEDLEY_VERSION_ENCODE(__VER__ / 100, __VER__ % 100, 0)
 #endif
 #endif
 
@@ -557,18 +558,37 @@
 #define HEDLEY_PELLES_VERSION_CHECK(major, minor, patch) (0)
 #endif
 
+#if defined(HEDLEY_MCST_LCC_VERSION)
+#undef HEDLEY_MCST_LCC_VERSION
+#endif
+#if defined(__LCC__) && defined(__LCC_MINOR__)
+#define HEDLEY_MCST_LCC_VERSION \
+	HEDLEY_VERSION_ENCODE(__LCC__ / 100, __LCC__ % 100, __LCC_MINOR__)
+#endif
+
+#if defined(HEDLEY_MCST_LCC_VERSION_CHECK)
+#undef HEDLEY_MCST_LCC_VERSION_CHECK
+#endif
+#if defined(HEDLEY_MCST_LCC_VERSION)
+#define HEDLEY_MCST_LCC_VERSION_CHECK(major, minor, patch) \
+	(HEDLEY_MCST_LCC_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#define HEDLEY_MCST_LCC_VERSION_CHECK(major, minor, patch) (0)
+#endif
+
 #if defined(HEDLEY_GCC_VERSION)
 #undef HEDLEY_GCC_VERSION
 #endif
-#if defined(HEDLEY_GNUC_VERSION) && !defined(__clang__) &&                \
-	!defined(HEDLEY_INTEL_VERSION) && !defined(HEDLEY_PGI_VERSION) && \
-	!defined(HEDLEY_ARM_VERSION) && !defined(HEDLEY_TI_VERSION) &&    \
-	!defined(HEDLEY_TI_ARMCL_VERSION) &&                              \
-	!defined(HEDLEY_TI_CL430_VERSION) &&                              \
-	!defined(HEDLEY_TI_CL2000_VERSION) &&                             \
-	!defined(HEDLEY_TI_CL6X_VERSION) &&                               \
-	!defined(HEDLEY_TI_CL7X_VERSION) &&                               \
-	!defined(HEDLEY_TI_CLPRU_VERSION) && !defined(__COMPCERT__)
+#if defined(HEDLEY_GNUC_VERSION) && !defined(__clang__) &&                  \
+	!defined(HEDLEY_INTEL_VERSION) && !defined(HEDLEY_PGI_VERSION) &&   \
+	!defined(HEDLEY_ARM_VERSION) && !defined(HEDLEY_CRAY_VERSION) &&    \
+	!defined(HEDLEY_TI_VERSION) && !defined(HEDLEY_TI_ARMCL_VERSION) && \
+	!defined(HEDLEY_TI_CL430_VERSION) &&                                \
+	!defined(HEDLEY_TI_CL2000_VERSION) &&                               \
+	!defined(HEDLEY_TI_CL6X_VERSION) &&                                 \
+	!defined(HEDLEY_TI_CL7X_VERSION) &&                                 \
+	!defined(HEDLEY_TI_CLPRU_VERSION) && !defined(__COMPCERT__) &&      \
+	!defined(HEDLEY_MCST_LCC_VERSION)
 #define HEDLEY_GCC_VERSION HEDLEY_GNUC_VERSION
 #endif
 
@@ -585,7 +605,8 @@
 #if defined(HEDLEY_HAS_ATTRIBUTE)
 #undef HEDLEY_HAS_ATTRIBUTE
 #endif
-#if defined(__has_attribute)
+#if defined(__has_attribute) && \
+	((!defined(HEDLEY_IAR_VERSION) || HEDLEY_IAR_VERSION_CHECK(8, 5, 9)))
 #define HEDLEY_HAS_ATTRIBUTE(attribute) __has_attribute(attribute)
 #else
 #define HEDLEY_HAS_ATTRIBUTE(attribute) (0)
@@ -596,7 +617,7 @@
 #endif
 #if defined(__has_attribute)
 #define HEDLEY_GNUC_HAS_ATTRIBUTE(attribute, major, minor, patch) \
-	__has_attribute(attribute)
+	HEDLEY_HAS_ATTRIBUTE(attribute)
 #else
 #define HEDLEY_GNUC_HAS_ATTRIBUTE(attribute, major, minor, patch) \
 	HEDLEY_GNUC_VERSION_CHECK(major, minor, patch)
@@ -607,7 +628,7 @@
 #endif
 #if defined(__has_attribute)
 #define HEDLEY_GCC_HAS_ATTRIBUTE(attribute, major, minor, patch) \
-	__has_attribute(attribute)
+	HEDLEY_HAS_ATTRIBUTE(attribute)
 #else
 #define HEDLEY_GCC_HAS_ATTRIBUTE(attribute, major, minor, patch) \
 	HEDLEY_GCC_VERSION_CHECK(major, minor, patch)
@@ -992,6 +1013,8 @@
 	_Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
 #elif HEDLEY_MSVC_VERSION_CHECK(15, 0, 0)
 #define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED __pragma(warning(disable : 4996))
+#elif HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
+#define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("diag_suppress 1215,1444")
 #elif HEDLEY_TI_VERSION_CHECK(15, 12, 0) ||         \
 	(HEDLEY_TI_ARMCL_VERSION_CHECK(4, 8, 0) &&  \
 	 defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) ||  \
@@ -1052,6 +1075,8 @@
 #define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress 163")
 #elif HEDLEY_IAR_VERSION_CHECK(8, 0, 0)
 #define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress=Pe161")
+#elif HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
+#define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress 161")
 #else
 #define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS
 #endif
@@ -1091,6 +1116,9 @@
 #elif HEDLEY_IAR_VERSION_CHECK(8, 0, 0)
 #define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES \
 	_Pragma("diag_suppress=Pe1097")
+#elif HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
+#define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES \
+	_Pragma("diag_suppress 1097")
 #else
 #define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES
 #endif
@@ -1111,6 +1139,24 @@
 #define HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL
 #endif
 
+#if defined(HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION)
+#undef HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION
+#endif
+#if HEDLEY_HAS_WARNING("-Wunused-function")
+#define HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION \
+	_Pragma("clang diagnostic ignored \"-Wunused-function\"")
+#elif HEDLEY_GCC_VERSION_CHECK(3, 4, 0)
+#define HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION \
+	_Pragma("GCC diagnostic ignored \"-Wunused-function\"")
+#elif HEDLEY_MSVC_VERSION_CHECK(1, 0, 0)
+#define HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION \
+	__pragma(warning(disable : 4505))
+#elif HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
+#define HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION _Pragma("diag_suppress 3142")
+#else
+#define HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION
+#endif
+
 #if defined(HEDLEY_DEPRECATED)
 #undef HEDLEY_DEPRECATED
 #endif
@@ -1122,17 +1168,19 @@
 #define HEDLEY_DEPRECATED(since) __declspec(deprecated("Since " #since))
 #define HEDLEY_DEPRECATED_FOR(since, replacement) \
 	__declspec(deprecated("Since " #since "; use " #replacement))
-#elif HEDLEY_HAS_EXTENSION(attribute_deprecated_with_message) || \
-	HEDLEY_GCC_VERSION_CHECK(4, 5, 0) ||                     \
-	HEDLEY_INTEL_VERSION_CHECK(13, 0, 0) ||                  \
-	HEDLEY_ARM_VERSION_CHECK(5, 6, 0) ||                     \
-	HEDLEY_SUNPRO_VERSION_CHECK(5, 13, 0) ||                 \
-	HEDLEY_PGI_VERSION_CHECK(17, 10, 0) ||                   \
-	HEDLEY_TI_VERSION_CHECK(18, 1, 0) ||                     \
-	HEDLEY_TI_ARMCL_VERSION_CHECK(18, 1, 0) ||               \
-	HEDLEY_TI_CL6X_VERSION_CHECK(8, 3, 0) ||                 \
-	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||                 \
-	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 3, 0)
+#elif (HEDLEY_HAS_EXTENSION(attribute_deprecated_with_message) && \
+       !defined(HEDLEY_IAR_VERSION)) ||                           \
+	HEDLEY_GCC_VERSION_CHECK(4, 5, 0) ||                      \
+	HEDLEY_INTEL_VERSION_CHECK(13, 0, 0) ||                   \
+	HEDLEY_ARM_VERSION_CHECK(5, 6, 0) ||                      \
+	HEDLEY_SUNPRO_VERSION_CHECK(5, 13, 0) ||                  \
+	HEDLEY_PGI_VERSION_CHECK(17, 10, 0) ||                    \
+	HEDLEY_TI_VERSION_CHECK(18, 1, 0) ||                      \
+	HEDLEY_TI_ARMCL_VERSION_CHECK(18, 1, 0) ||                \
+	HEDLEY_TI_CL6X_VERSION_CHECK(8, 3, 0) ||                  \
+	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||                  \
+	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 3, 0) ||                 \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_DEPRECATED(since) \
 	__attribute__((__deprecated__("Since " #since)))
 #define HEDLEY_DEPRECATED_FOR(since, replacement) \
@@ -1160,7 +1208,9 @@
 	 defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) ||                             \
 	HEDLEY_TI_CL6X_VERSION_CHECK(7, 5, 0) ||                               \
 	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||                               \
-	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0)
+	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0) ||                              \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10) ||                            \
+	HEDLEY_IAR_VERSION_CHECK(8, 10, 0)
 #define HEDLEY_DEPRECATED(since) __attribute__((__deprecated__))
 #define HEDLEY_DEPRECATED_FOR(since, replacement) \
 	__attribute__((__deprecated__))
@@ -1181,7 +1231,8 @@
 #undef HEDLEY_UNAVAILABLE
 #endif
 #if HEDLEY_HAS_ATTRIBUTE(warning) || HEDLEY_GCC_VERSION_CHECK(4, 3, 0) || \
-	HEDLEY_INTEL_VERSION_CHECK(13, 0, 0)
+	HEDLEY_INTEL_VERSION_CHECK(13, 0, 0) ||                           \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_UNAVAILABLE(available_since) \
 	__attribute__((__warning__("Not available until " #available_since)))
 #else
@@ -1213,7 +1264,8 @@
 	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||                           \
 	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0) ||                          \
 	(HEDLEY_SUNPRO_VERSION_CHECK(5, 15, 0) && defined(__cplusplus)) || \
-	HEDLEY_PGI_VERSION_CHECK(17, 10, 0)
+	HEDLEY_PGI_VERSION_CHECK(17, 10, 0) ||                             \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_WARN_UNUSED_RESULT __attribute__((__warn_unused_result__))
 #define HEDLEY_WARN_UNUSED_RESULT_MSG(msg) \
 	__attribute__((__warn_unused_result__))
@@ -1240,7 +1292,8 @@
 #endif
 #if HEDLEY_HAS_ATTRIBUTE(sentinel) || HEDLEY_GCC_VERSION_CHECK(4, 0, 0) || \
 	HEDLEY_INTEL_VERSION_CHECK(13, 0, 0) ||                            \
-	HEDLEY_ARM_VERSION_CHECK(5, 4, 0)
+	HEDLEY_ARM_VERSION_CHECK(5, 4, 0) ||                               \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_SENTINEL(position) __attribute__((__sentinel__(position)))
 #else
 #define HEDLEY_SENTINEL(position)
@@ -1251,7 +1304,8 @@
 #endif
 #if HEDLEY_IAR_VERSION_CHECK(8, 0, 0)
 #define HEDLEY_NO_RETURN __noreturn
-#elif HEDLEY_INTEL_VERSION_CHECK(13, 0, 0)
+#elif HEDLEY_INTEL_VERSION_CHECK(13, 0, 0) || \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_NO_RETURN __attribute__((__noreturn__))
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #define HEDLEY_NO_RETURN _Noreturn
@@ -1276,7 +1330,8 @@
 	 defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) ||                           \
 	HEDLEY_TI_CL6X_VERSION_CHECK(7, 5, 0) ||                             \
 	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||                             \
-	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0)
+	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0) ||                            \
+	HEDLEY_IAR_VERSION_CHECK(8, 10, 0)
 #define HEDLEY_NO_RETURN __attribute__((__noreturn__))
 #elif HEDLEY_SUNPRO_VERSION_CHECK(5, 10, 0)
 #define HEDLEY_NO_RETURN _Pragma("does_not_return")
@@ -1330,7 +1385,9 @@
 	HEDLEY_GCC_VERSION_CHECK(4, 5, 0) ||      \
 	HEDLEY_PGI_VERSION_CHECK(18, 10, 0) ||    \
 	HEDLEY_INTEL_VERSION_CHECK(13, 0, 0) ||   \
-	HEDLEY_IBM_VERSION_CHECK(13, 1, 5)
+	HEDLEY_IBM_VERSION_CHECK(13, 1, 5) ||     \
+	HEDLEY_CRAY_VERSION_CHECK(10, 0, 0) ||    \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_UNREACHABLE() __builtin_unreachable()
 #elif defined(HEDLEY_ASSUME)
 #define HEDLEY_UNREACHABLE() HEDLEY_ASSUME(0)
@@ -1413,7 +1470,8 @@ HEDLEY_DIAGNOSTIC_POP
 	 defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) ||                         \
 	HEDLEY_TI_CL6X_VERSION_CHECK(7, 5, 0) ||                           \
 	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||                           \
-	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0)
+	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0) ||                          \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_PRINTF_FORMAT(string_idx, first_to_check) \
 	__attribute__((__format__(__printf__, string_idx, first_to_check)))
 #elif HEDLEY_PELLES_VERSION_CHECK(6, 0, 0)
@@ -1450,9 +1508,10 @@ HEDLEY_DIAGNOSTIC_POP
 #if HEDLEY_HAS_BUILTIN(__builtin_unpredictable)
 #define HEDLEY_UNPREDICTABLE(expr) __builtin_unpredictable((expr))
 #endif
-#if (HEDLEY_HAS_BUILTIN(__builtin_expect_with_probability) && \
-     !defined(HEDLEY_PGI_VERSION)) ||                         \
-	HEDLEY_GCC_VERSION_CHECK(9, 0, 0)
+#if (HEDLEY_HAS_BUILTIN(__builtin_expect_with_probability) &&           \
+     !defined(HEDLEY_PGI_VERSION) && !defined(HEDLEY_INTEL_VERSION)) || \
+	HEDLEY_GCC_VERSION_CHECK(9, 0, 0) ||                            \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_PREDICT(expr, value, probability) \
 	__builtin_expect_with_probability((expr), (value), (probability))
 #define HEDLEY_PREDICT_TRUE(expr, probability) \
@@ -1476,7 +1535,8 @@ HEDLEY_DIAGNOSTIC_POP
 	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||                           \
 	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0) ||                          \
 	HEDLEY_TINYC_VERSION_CHECK(0, 9, 27) ||                            \
-	HEDLEY_CRAY_VERSION_CHECK(8, 1, 0)
+	HEDLEY_CRAY_VERSION_CHECK(8, 1, 0) ||                              \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_PREDICT(expr, expected, probability)     \
 	(((probability) >= 0.9)                         \
 		 ? __builtin_expect((expr), (expected)) \
@@ -1535,7 +1595,8 @@ HEDLEY_DIAGNOSTIC_POP
 	 defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) ||                       \
 	HEDLEY_TI_CL6X_VERSION_CHECK(7, 5, 0) ||                         \
 	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||                         \
-	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0)
+	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0) ||                        \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_MALLOC __attribute__((__malloc__))
 #elif HEDLEY_SUNPRO_VERSION_CHECK(5, 10, 0)
 #define HEDLEY_MALLOC _Pragma("returns_new_memory")
@@ -1569,7 +1630,8 @@ HEDLEY_DIAGNOSTIC_POP
 	HEDLEY_TI_CL6X_VERSION_CHECK(7, 5, 0) ||                        \
 	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||                        \
 	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0) ||                       \
-	HEDLEY_PGI_VERSION_CHECK(17, 10, 0)
+	HEDLEY_PGI_VERSION_CHECK(17, 10, 0) ||                          \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_PURE __attribute__((__pure__))
 #elif HEDLEY_SUNPRO_VERSION_CHECK(5, 10, 0)
 #define HEDLEY_PURE _Pragma("does_not_write_global_data")
@@ -1604,7 +1666,8 @@ HEDLEY_DIAGNOSTIC_POP
 	HEDLEY_TI_CL6X_VERSION_CHECK(7, 5, 0) ||                        \
 	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||                        \
 	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0) ||                       \
-	HEDLEY_PGI_VERSION_CHECK(17, 10, 0)
+	HEDLEY_PGI_VERSION_CHECK(17, 10, 0) ||                          \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_CONST __attribute__((__const__))
 #elif HEDLEY_SUNPRO_VERSION_CHECK(5, 10, 0)
 #define HEDLEY_CONST _Pragma("no_side_effect")
@@ -1630,7 +1693,8 @@ HEDLEY_DIAGNOSTIC_POP
 	HEDLEY_TI_CL6X_VERSION_CHECK(8, 1, 0) ||                           \
 	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||                           \
 	(HEDLEY_SUNPRO_VERSION_CHECK(5, 14, 0) && defined(__cplusplus)) || \
-	HEDLEY_IAR_VERSION_CHECK(8, 0, 0) || defined(__clang__)
+	HEDLEY_IAR_VERSION_CHECK(8, 0, 0) || defined(__clang__) ||         \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_RESTRICT __restrict
 #elif HEDLEY_SUNPRO_VERSION_CHECK(5, 3, 0) && !defined(__cplusplus)
 #define HEDLEY_RESTRICT _Restrict
@@ -1654,7 +1718,8 @@ HEDLEY_DIAGNOSTIC_POP
 	HEDLEY_TI_CL2000_VERSION_CHECK(6, 2, 0) ||   \
 	HEDLEY_TI_CL6X_VERSION_CHECK(8, 0, 0) ||     \
 	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||     \
-	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0)
+	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0) ||    \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_INLINE __inline
 #else
 #define HEDLEY_INLINE
@@ -1683,7 +1748,9 @@ HEDLEY_DIAGNOSTIC_POP
 	 defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) ||  \
 	HEDLEY_TI_CL6X_VERSION_CHECK(7, 5, 0) ||    \
 	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||    \
-	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0)
+	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0) ||   \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10) || \
+	HEDLEY_IAR_VERSION_CHECK(8, 10, 0)
 #define HEDLEY_ALWAYS_INLINE __attribute__((__always_inline__)) HEDLEY_INLINE
 #elif HEDLEY_MSVC_VERSION_CHECK(12, 0, 0) || \
 	HEDLEY_INTEL_CL_VERSION_CHECK(2021, 1, 0)
@@ -1723,7 +1790,9 @@ HEDLEY_DIAGNOSTIC_POP
 	 defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) ||                         \
 	HEDLEY_TI_CL6X_VERSION_CHECK(7, 5, 0) ||                           \
 	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||                           \
-	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0)
+	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 1, 0) ||                          \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10) ||                        \
+	HEDLEY_IAR_VERSION_CHECK(8, 10, 0)
 #define HEDLEY_NEVER_INLINE __attribute__((__noinline__))
 #elif HEDLEY_MSVC_VERSION_CHECK(13, 10, 0) || \
 	HEDLEY_INTEL_CL_VERSION_CHECK(2021, 1, 0)
@@ -1763,7 +1832,8 @@ HEDLEY_DIAGNOSTIC_POP
 	HEDLEY_IBM_VERSION_CHECK(13, 1, 0) ||                                \
 	(defined(__TI_EABI__) && ((HEDLEY_TI_CL6X_VERSION_CHECK(7, 2, 0) &&  \
 				   defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
-				  HEDLEY_TI_CL6X_VERSION_CHECK(7, 5, 0)))
+				  HEDLEY_TI_CL6X_VERSION_CHECK(7, 5, 0))) || \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_PRIVATE __attribute__((__visibility__("hidden")))
 #define HEDLEY_PUBLIC __attribute__((__visibility__("default")))
 #else
@@ -1777,7 +1847,8 @@ HEDLEY_DIAGNOSTIC_POP
 #undef HEDLEY_NO_THROW
 #endif
 #if HEDLEY_HAS_ATTRIBUTE(nothrow) || HEDLEY_GCC_VERSION_CHECK(3, 3, 0) || \
-	HEDLEY_INTEL_VERSION_CHECK(13, 0, 0)
+	HEDLEY_INTEL_VERSION_CHECK(13, 0, 0) ||                           \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_NO_THROW __attribute__((__nothrow__))
 #elif HEDLEY_MSVC_VERSION_CHECK(13, 1, 0) ||         \
 	HEDLEY_INTEL_CL_VERSION_CHECK(2021, 1, 0) || \
@@ -1790,7 +1861,11 @@ HEDLEY_DIAGNOSTIC_POP
 #if defined(HEDLEY_FALL_THROUGH)
 #undef HEDLEY_FALL_THROUGH
 #endif
-#if HEDLEY_HAS_ATTRIBUTE(fallthrough) || HEDLEY_GCC_VERSION_CHECK(7, 0, 0)
+#if defined(HEDLEY_INTEL_VERSION)
+#define HEDLEY_FALL_THROUGH
+#elif HEDLEY_HAS_ATTRIBUTE(fallthrough) ||   \
+	HEDLEY_GCC_VERSION_CHECK(7, 0, 0) || \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_FALL_THROUGH __attribute__((__fallthrough__))
 #elif HEDLEY_HAS_CPP_ATTRIBUTE_NS(clang, fallthrough)
 #define HEDLEY_FALL_THROUGH \
@@ -1807,7 +1882,9 @@ HEDLEY_DIAGNOSTIC_POP
 #if defined(HEDLEY_RETURNS_NON_NULL)
 #undef HEDLEY_RETURNS_NON_NULL
 #endif
-#if HEDLEY_HAS_ATTRIBUTE(returns_nonnull) || HEDLEY_GCC_VERSION_CHECK(4, 9, 0)
+#if HEDLEY_HAS_ATTRIBUTE(returns_nonnull) || \
+	HEDLEY_GCC_VERSION_CHECK(4, 9, 0) || \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_RETURNS_NON_NULL __attribute__((__returns_nonnull__))
 #elif defined(_Ret_notnull_) /* SAL */
 #define HEDLEY_RETURNS_NON_NULL _Ret_notnull_
@@ -1845,7 +1922,8 @@ HEDLEY_DIAGNOSTIC_POP
 	HEDLEY_IBM_VERSION_CHECK(13, 1, 0) ||                               \
 	HEDLEY_TI_CL6X_VERSION_CHECK(6, 1, 0) ||                            \
 	(HEDLEY_SUNPRO_VERSION_CHECK(5, 10, 0) && !defined(__cplusplus)) || \
-	HEDLEY_CRAY_VERSION_CHECK(8, 1, 0)
+	HEDLEY_CRAY_VERSION_CHECK(8, 1, 0) ||                               \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define HEDLEY_IS_CONSTANT(expr) __builtin_constant_p(expr)
 #endif
 #if !defined(__cplusplus)
@@ -1872,7 +1950,8 @@ HEDLEY_DIAGNOSTIC_POP
 #elif (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) &&      \
        !defined(HEDLEY_SUNPRO_VERSION) && !defined(HEDLEY_PGI_VERSION) && \
        !defined(HEDLEY_IAR_VERSION)) ||                                   \
-	HEDLEY_HAS_EXTENSION(c_generic_selections) ||                     \
+	(HEDLEY_HAS_EXTENSION(c_generic_selections) &&                    \
+	 !defined(HEDLEY_IAR_VERSION)) ||                                 \
 	HEDLEY_GCC_VERSION_CHECK(4, 9, 0) ||                              \
 	HEDLEY_INTEL_VERSION_CHECK(17, 0, 0) ||                           \
 	HEDLEY_IBM_VERSION_CHECK(12, 1, 0) ||                             \
@@ -2020,12 +2099,12 @@ HEDLEY_DIAGNOSTIC_POP
 	HEDLEY_DIAGNOSTIC_PUSH                                        \
 	_Pragma("clang diagnostic ignored \"-Wgcc-compat\"")          \
 		__attribute__((diagnose_if(!(expr), #expr, "error"))) \
-			HEDLEY_DIAGNOSTIC_POP
+		HEDLEY_DIAGNOSTIC_POP
 #define HEDLEY_REQUIRE_MSG(expr, msg)                               \
 	HEDLEY_DIAGNOSTIC_PUSH                                      \
 	_Pragma("clang diagnostic ignored \"-Wgcc-compat\"")        \
 		__attribute__((diagnose_if(!(expr), msg, "error"))) \
-			HEDLEY_DIAGNOSTIC_POP
+		HEDLEY_DIAGNOSTIC_POP
 #else
 #define HEDLEY_REQUIRE(expr) \
 	__attribute__((diagnose_if(!(expr), #expr, "error")))
@@ -2040,7 +2119,9 @@ HEDLEY_DIAGNOSTIC_POP
 #if defined(HEDLEY_FLAGS)
 #undef HEDLEY_FLAGS
 #endif
-#if HEDLEY_HAS_ATTRIBUTE(flag_enum)
+#if HEDLEY_HAS_ATTRIBUTE(flag_enum) && \
+	(!defined(__cplusplus) ||      \
+	 HEDLEY_HAS_WARNING("-Wbitfield-enum-conversion"))
 #define HEDLEY_FLAGS __attribute__((__flag_enum__))
 #else
 #define HEDLEY_FLAGS

--- a/libobs/util/simde/simde-align.h
+++ b/libobs/util/simde/simde-align.h
@@ -112,20 +112,21 @@
 #elif (defined(__cplusplus) && (__cplusplus >= 201103L)) || \
 	(0 && HEDLEY_HAS_FEATURE(cxx_alignof))
 #define SIMDE_ALIGN_OF(Type) alignof(Type)
-#elif HEDLEY_GCC_VERSION_CHECK(2, 95, 0) ||                                    \
-	HEDLEY_ARM_VERSION_CHECK(4, 1, 0) ||                                   \
-	HEDLEY_INTEL_VERSION_CHECK(13, 0, 0) ||                                \
-	HEDLEY_SUNPRO_VERSION_CHECK(5, 13, 0) ||                               \
-	HEDLEY_TINYC_VERSION_CHECK(0, 9, 24) ||                                \
-	HEDLEY_PGI_VERSION_CHECK(19, 10, 0) ||                                 \
-	HEDLEY_CRAY_VERSION_CHECK(10, 0, 0) ||                                 \
-	HEDLEY_TI_ARMCL_VERSION_CHECK(16, 9, 0) ||                             \
-	HEDLEY_TI_CL2000_VERSION_CHECK(16, 9, 0) ||                            \
-	HEDLEY_TI_CL6X_VERSION_CHECK(8, 0, 0) ||                               \
-	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||                               \
-	HEDLEY_TI_CL430_VERSION_CHECK(16, 9, 0) ||                             \
-	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 3, 2) || defined(__IBM__ALIGNOF__) || \
-	defined(__clang__)
+#elif HEDLEY_GCC_VERSION_CHECK(2, 95, 0) ||         \
+	HEDLEY_ARM_VERSION_CHECK(4, 1, 0) ||        \
+	HEDLEY_INTEL_VERSION_CHECK(13, 0, 0) ||     \
+	HEDLEY_SUNPRO_VERSION_CHECK(5, 13, 0) ||    \
+	HEDLEY_TINYC_VERSION_CHECK(0, 9, 24) ||     \
+	HEDLEY_PGI_VERSION_CHECK(19, 10, 0) ||      \
+	HEDLEY_CRAY_VERSION_CHECK(10, 0, 0) ||      \
+	HEDLEY_TI_ARMCL_VERSION_CHECK(16, 9, 0) ||  \
+	HEDLEY_TI_CL2000_VERSION_CHECK(16, 9, 0) || \
+	HEDLEY_TI_CL6X_VERSION_CHECK(8, 0, 0) ||    \
+	HEDLEY_TI_CL7X_VERSION_CHECK(1, 2, 0) ||    \
+	HEDLEY_TI_CL430_VERSION_CHECK(16, 9, 0) ||  \
+	HEDLEY_TI_CLPRU_VERSION_CHECK(2, 3, 2) ||   \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10) || \
+	defined(__IBM__ALIGNOF__) || defined(__clang__)
 #define SIMDE_ALIGN_OF(Type) __alignof__(Type)
 #elif HEDLEY_IAR_VERSION_CHECK(8, 40, 0)
 #define SIMDE_ALIGN_OF(Type) __ALIGNOF__(Type)
@@ -145,8 +146,8 @@
  *
  * Most compilers are okay with types which are aligned beyond what
  * they think is the maximum, as long as the alignment is a power
- * of two.  MSVC is the exception (of course), so we need to cap the
- * alignment requests at values that the implementation supports.
+ * of two.  Older versions of MSVC is the exception, so we need to cap
+ * the alignment requests at values that the implementation supports.
  *
  * XL C/C++ will accept values larger than 16 (which is the alignment
  * of an AltiVec vector), but will not reliably align to the larger
@@ -157,18 +158,22 @@
  * macro will just return the value passed to it. */
 #if !defined(SIMDE_ALIGN_MAXIMUM)
 #if defined(HEDLEY_MSVC_VERSION)
+#if HEDLEY_MSVC_VERSION_CHECK(19, 16, 0)
+// Visual studio 2017 and newer does not need a max
+#else
 #if defined(_M_IX86) || defined(_M_AMD64)
 #if HEDLEY_MSVC_VERSION_CHECK(19, 14, 0)
 #define SIMDE_ALIGN_PLATFORM_MAXIMUM 64
 #elif HEDLEY_MSVC_VERSION_CHECK(16, 0, 0)
 /* VS 2010 is really a guess based on Wikipedia; if anyone can
-         * test with old VS versions I'd really appreciate it. */
+           * test with old VS versions I'd really appreciate it. */
 #define SIMDE_ALIGN_PLATFORM_MAXIMUM 32
 #else
 #define SIMDE_ALIGN_PLATFORM_MAXIMUM 16
 #endif
 #elif defined(_M_ARM) || defined(_M_ARM64)
 #define SIMDE_ALIGN_PLATFORM_MAXIMUM 8
+#endif
 #endif
 #elif defined(HEDLEY_IBM_VERSION)
 #define SIMDE_ALIGN_PLATFORM_MAXIMUM 16

--- a/libobs/util/simde/simde-arch.h
+++ b/libobs/util/simde/simde-arch.h
@@ -71,44 +71,41 @@
    <https://en.wikipedia.org/wiki/X86-64> */
 #if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || \
 	defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64)
+#if !defined(_M_ARM64EC)
 #define SIMDE_ARCH_AMD64 1000
+#endif
 #endif
 
 /* ARM
    <https://en.wikipedia.org/wiki/ARM_architecture> */
-#if defined(__ARM_ARCH_8A__)
-#define SIMDE_ARCH_ARM 82
-#elif defined(__ARM_ARCH_8R__)
-#define SIMDE_ARCH_ARM 81
-#elif defined(__ARM_ARCH_8__)
-#define SIMDE_ARCH_ARM 80
-#elif defined(__ARM_ARCH_7S__)
-#define SIMDE_ARCH_ARM 74
-#elif defined(__ARM_ARCH_7M__)
-#define SIMDE_ARCH_ARM 73
-#elif defined(__ARM_ARCH_7R__)
-#define SIMDE_ARCH_ARM 72
-#elif defined(__ARM_ARCH_7A__)
-#define SIMDE_ARCH_ARM 71
-#elif defined(__ARM_ARCH_7__)
-#define SIMDE_ARCH_ARM 70
-#elif defined(__ARM_ARCH)
-#define SIMDE_ARCH_ARM (__ARM_ARCH * 10)
+#if defined(__ARM_ARCH)
+#if __ARM_ARCH > 100
+#define SIMDE_ARCH_ARM (__ARM_ARCH)
+#else
+#define SIMDE_ARCH_ARM (__ARM_ARCH * 100)
+#endif
 #elif defined(_M_ARM)
-#define SIMDE_ARCH_ARM (_M_ARM * 10)
+#if _M_ARM > 100
+#define SIMDE_ARCH_ARM (_M_ARM)
+#else
+#define SIMDE_ARCH_ARM (_M_ARM * 100)
+#endif
+#elif defined(_M_ARM64) || defined(_M_ARM64EC)
+#define SIMDE_ARCH_ARM 800
 #elif defined(__arm__) || defined(__thumb__) || defined(__TARGET_ARCH_ARM) || \
 	defined(_ARM) || defined(_M_ARM) || defined(_M_ARM)
 #define SIMDE_ARCH_ARM 1
 #endif
 #if defined(SIMDE_ARCH_ARM)
-#define SIMDE_ARCH_ARM_CHECK(version) ((version) <= SIMDE_ARCH_ARM)
+#define SIMDE_ARCH_ARM_CHECK(major, minor) \
+	(((major * 100) + (minor)) <= SIMDE_ARCH_ARM)
 #else
-#define SIMDE_ARCH_ARM_CHECK(version) (0)
+#define SIMDE_ARCH_ARM_CHECK(major, minor) (0)
 #endif
 
 /* AArch64
    <https://en.wikipedia.org/wiki/ARM_architecture> */
-#if defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define SIMDE_ARCH_AARCH64 1000
 #endif
 #if defined(SIMDE_ARCH_AARCH64)
@@ -118,7 +115,7 @@
 #endif
 
 /* ARM SIMD ISA extensions */
-#if defined(__ARM_NEON)
+#if defined(__ARM_NEON) || defined(SIMDE_ARCH_AARCH64)
 #if defined(SIMDE_ARCH_AARCH64)
 #define SIMDE_ARCH_ARM_NEON SIMDE_ARCH_AARCH64
 #elif defined(SIMDE_ARCH_ARM)
@@ -181,6 +178,12 @@
 #define SIMDE_ARCH_H8300
 #endif
 
+/* Elbrus (8S, 8SV and successors)
+   <https://en.wikipedia.org/wiki/Elbrus-8S> */
+#if defined(__e2k__)
+#define SIMDE_ARCH_E2K
+#endif
+
 /* HP/PA / PA-RISC
    <https://en.wikipedia.org/wiki/PA-RISC> */
 #if defined(__PA8000__) || defined(__HPPA20__) || defined(__RISC2_0__) || \
@@ -222,8 +225,9 @@
 #define SIMDE_ARCH_X86_CHECK(version) (0)
 #endif
 
-/* SIMD ISA extensions for x86/x86_64 */
-#if defined(SIMDE_ARCH_X86) || defined(SIMDE_ARCH_AMD64)
+/* SIMD ISA extensions for x86/x86_64 and Elbrus */
+#if defined(SIMDE_ARCH_X86) || defined(SIMDE_ARCH_AMD64) || \
+	defined(SIMDE_ARCH_E2K)
 #if defined(_M_IX86_FP)
 #define SIMDE_ARCH_X86_MMX
 #if (_M_IX86_FP >= 1)
@@ -258,6 +262,9 @@
 #if defined(__SSE4_2__)
 #define SIMDE_ARCH_X86_SSE4_2 1
 #endif
+#if defined(__XOP__)
+#define SIMDE_ARCH_X86_XOP 1
+#endif
 #if defined(__AVX__)
 #define SIMDE_ARCH_X86_AVX 1
 #if !defined(SIMDE_ARCH_X86_SSE3)
@@ -282,11 +289,29 @@
 #if defined(__AVX512VP2INTERSECT__)
 #define SIMDE_ARCH_X86_AVX512VP2INTERSECT 1
 #endif
+#if defined(__AVX512BITALG__)
+#define SIMDE_ARCH_X86_AVX512BITALG 1
+#endif
+#if defined(__AVX512VPOPCNTDQ__)
+#define SIMDE_ARCH_X86_AVX512VPOPCNTDQ 1
+#endif
 #if defined(__AVX512VBMI__)
 #define SIMDE_ARCH_X86_AVX512VBMI 1
 #endif
+#if defined(__AVX512VBMI2__)
+#define SIMDE_ARCH_X86_AVX512VBMI2 1
+#endif
+#if defined(__AVX512VNNI__)
+#define SIMDE_ARCH_X86_AVX512VNNI 1
+#endif
+#if defined(__AVX5124VNNIW__)
+#define SIMDE_ARCH_X86_AVX5124VNNIW 1
+#endif
 #if defined(__AVX512BW__)
 #define SIMDE_ARCH_X86_AVX512BW 1
+#endif
+#if defined(__AVX512BF16__)
+#define SIMDE_ARCH_X86_AVX512BF16 1
 #endif
 #if defined(__AVX512CD__)
 #define SIMDE_ARCH_X86_AVX512CD 1
@@ -308,6 +333,9 @@
 #endif
 #if defined(__VPCLMULQDQ__)
 #define SIMDE_ARCH_X86_VPCLMULQDQ 1
+#endif
+#if defined(__F16C__)
+#define SIMDE_ARCH_X86_F16C 1
 #endif
 #endif
 
@@ -382,6 +410,10 @@
 #define SIMDE_ARCH_MIPS_LOONGSON_MMI 1
 #endif
 
+#if defined(__mips_msa)
+#define SIMDE_ARCH_MIPS_MSA 1
+#endif
+
 /* Matsushita MN10300
    <https://en.wikipedia.org/wiki/MN103> */
 #if defined(__MN10300__) || defined(__mn10300__)
@@ -431,8 +463,6 @@
 
 #if defined(__ALTIVEC__)
 #define SIMDE_ARCH_POWER_ALTIVEC SIMDE_ARCH_POWER
-#endif
-#if defined(SIMDE_ARCH_POWER)
 #define SIMDE_ARCH_POWER_ALTIVEC_CHECK(version) ((version) <= SIMDE_ARCH_POWER)
 #else
 #define SIMDE_ARCH_POWER_ALTIVEC_CHECK(version) (0)
@@ -487,7 +517,16 @@
    <https://en.wikipedia.org/wiki/IBM_System_z> */
 #if defined(__370__) || defined(__THW_370__) || defined(__s390__) || \
 	defined(__s390x__) || defined(__zarch__) || defined(__SYSC_ZARCH__)
-#define SIMDE_ARCH_SYSTEMZ
+#define SIMDE_ARCH_ZARCH __ARCH__
+#endif
+#if defined(SIMDE_ARCH_ZARCH)
+#define SIMDE_ARCH_ZARCH_CHECK(version) ((version) <= SIMDE_ARCH_ZARCH)
+#else
+#define SIMDE_ARCH_ZARCH_CHECK(version) (0)
+#endif
+
+#if defined(SIMDE_ARCH_ZARCH) && defined(__VEC__)
+#define SIMDE_ARCH_ZARCH_ZVECTOR SIMDE_ARCH_ZARCH
 #endif
 
 /* TMS320 DSP

--- a/libobs/util/simde/simde-common.h
+++ b/libobs/util/simde/simde-common.h
@@ -1084,14 +1084,14 @@ SIMDE_DIAGNOSTIC_DISABLE_CPP98_COMPAT_PEDANTIC_
 #if (HEDLEY_HAS_WARNING("-Wsign-conversion") &&   \
      SIMDE_DETECT_CLANG_VERSION_NOT(11, 0, 0)) || \
 	HEDLEY_GCC_VERSION_CHECK(4, 3, 0)
-#define SIMDE_BUG_IGNORE_SIGN_CONVERSION(expr)                                           \
-	(__extension__({                                                                 \
-		HEDLEY_DIAGNOSTIC_PUSH                                                   \
-		HEDLEY_DIAGNOSTIC_POP                                                    \
-		_Pragma("GCC diagnostic ignored \"-Wsign-conversion\"") __typeof__(expr) \
-			simde_bug_ignore_sign_conversion_v_ = (expr);                    \
-		HEDLEY_DIAGNOSTIC_PUSH                                                   \
-		simde_bug_ignore_sign_conversion_v_;                                     \
+#define SIMDE_BUG_IGNORE_SIGN_CONVERSION(expr)                                      \
+	(__extension__({                                                            \
+		HEDLEY_DIAGNOSTIC_PUSH                                              \
+		HEDLEY_DIAGNOSTIC_POP                                               \
+		_Pragma("GCC diagnostic ignored \"-Wsign-conversion\"") __typeof__( \
+			expr) simde_bug_ignore_sign_conversion_v_ = (expr);         \
+		HEDLEY_DIAGNOSTIC_PUSH                                              \
+		simde_bug_ignore_sign_conversion_v_;                                \
 	}))
 #else
 #define SIMDE_BUG_IGNORE_SIGN_CONVERSION(expr) (expr)

--- a/libobs/util/simde/simde-common.h
+++ b/libobs/util/simde/simde-common.h
@@ -31,10 +31,11 @@
 
 #define SIMDE_VERSION_MAJOR 0
 #define SIMDE_VERSION_MINOR 7
-#define SIMDE_VERSION_MICRO 1
+#define SIMDE_VERSION_MICRO 3
 #define SIMDE_VERSION                                                   \
 	HEDLEY_VERSION_ENCODE(SIMDE_VERSION_MAJOR, SIMDE_VERSION_MINOR, \
 			      SIMDE_VERSION_MICRO)
+// Also update meson.build in the root directory of the repository
 
 #include <stddef.h>
 #include <stdint.h>
@@ -128,6 +129,14 @@
 #define SIMDE_FAST_CONVERSION_RANGE
 #endif
 
+/* Due to differences across platforms, sometimes it can be much
+ * faster for us to allow spurious floating point exceptions,
+ * or to no generate them when we should. */
+#if !defined(SIMDE_FAST_EXCEPTIONS) && !defined(SIMDE_NO_FAST_EXCEPTIONS) && \
+	defined(SIMDE_FAST_MATH)
+#define SIMDE_FAST_EXCEPTIONS
+#endif
+
 #if HEDLEY_HAS_BUILTIN(__builtin_constant_p) ||                             \
 	HEDLEY_GCC_VERSION_CHECK(3, 4, 0) ||                                \
 	HEDLEY_INTEL_VERSION_CHECK(13, 0, 0) ||                             \
@@ -136,7 +145,8 @@
 	HEDLEY_IBM_VERSION_CHECK(13, 1, 0) ||                               \
 	HEDLEY_TI_CL6X_VERSION_CHECK(6, 1, 0) ||                            \
 	(HEDLEY_SUNPRO_VERSION_CHECK(5, 10, 0) && !defined(__cplusplus)) || \
-	HEDLEY_CRAY_VERSION_CHECK(8, 1, 0)
+	HEDLEY_CRAY_VERSION_CHECK(8, 1, 0) ||                               \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define SIMDE_CHECK_CONSTANT_(expr) (__builtin_constant_p(expr))
 #elif defined(__cplusplus) && (__cplusplus > 201703L)
 #include <type_traits>
@@ -183,6 +193,33 @@
 		static_assert(expr, message))
 #endif
 
+/* Statement exprs */
+#if HEDLEY_GNUC_VERSION_CHECK(2, 95, 0) ||       \
+	HEDLEY_TINYC_VERSION_CHECK(0, 9, 26) ||  \
+	HEDLEY_INTEL_VERSION_CHECK(9, 0, 0) ||   \
+	HEDLEY_PGI_VERSION_CHECK(18, 10, 0) ||   \
+	HEDLEY_SUNPRO_VERSION_CHECK(5, 12, 0) || \
+	HEDLEY_IBM_VERSION_CHECK(11, 1, 0) ||    \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
+#define SIMDE_STATEMENT_EXPR_(expr) (__extension__ expr)
+#endif
+
+/* This is just a convenience macro to make it easy to call a single
+ * function with a specific diagnostic disabled. */
+#if defined(SIMDE_STATEMENT_EXPR_)
+#define SIMDE_DISABLE_DIAGNOSTIC_EXPR_(diagnostic, expr) \
+	SIMDE_STATEMENT_EXPR_(({                         \
+		HEDLEY_DIAGNOSTIC_PUSH                   \
+		diagnostic(expr);                        \
+		HEDLEY_DIAGNOSTIC_POP                    \
+	}))
+#endif
+
+#if defined(SIMDE_CHECK_CONSTANT_) && defined(SIMDE_STATIC_ASSERT)
+#define SIMDE_ASSERT_CONSTANT_(v) \
+	SIMDE_STATIC_ASSERT(SIMDE_CHECK_CONSTANT_(v), #v " must be constant.")
+#endif
+
 #if (HEDLEY_HAS_ATTRIBUTE(may_alias) && !defined(HEDLEY_SUNPRO_VERSION)) || \
 	HEDLEY_GCC_VERSION_CHECK(3, 3, 0) ||                                \
 	HEDLEY_INTEL_VERSION_CHECK(13, 0, 0) ||                             \
@@ -220,7 +257,9 @@
 #define SIMDE_VECTOR_NEGATE
 /* ICC only supports SIMDE_VECTOR_SCALAR for constants */
 #define SIMDE_VECTOR_SUBSCRIPT
-#elif HEDLEY_GCC_VERSION_CHECK(4, 1, 0) || HEDLEY_INTEL_VERSION_CHECK(13, 0, 0)
+#elif HEDLEY_GCC_VERSION_CHECK(4, 1, 0) ||      \
+	HEDLEY_INTEL_VERSION_CHECK(13, 0, 0) || \
+	HEDLEY_MCST_LCC_VERSION_CHECK(1, 25, 10)
 #define SIMDE_VECTOR(size) __attribute__((__vector_size__(size)))
 #define SIMDE_VECTOR_OPS
 #elif HEDLEY_SUNPRO_VERSION_CHECK(5, 12, 0)
@@ -301,10 +340,13 @@ HEDLEY_DIAGNOSTIC_POP
 #endif
 #endif
 
-#if !defined(SIMDE_ENABLE_OPENMP) &&                   \
-	((defined(_OPENMP) && (_OPENMP >= 201307L)) || \
-	 (defined(_OPENMP_SIMD) && (_OPENMP_SIMD >= 201307L)))
+#if !defined(SIMDE_DISABLE_OPENMP)
+#if !defined(SIMDE_ENABLE_OPENMP) &&                                      \
+		((defined(_OPENMP) && (_OPENMP >= 201307L)) ||            \
+		 (defined(_OPENMP_SIMD) && (_OPENMP_SIMD >= 201307L))) || \
+	defined(HEDLEY_MCST_LCC_VERSION)
 #define SIMDE_ENABLE_OPENMP
+#endif
 #endif
 
 #if !defined(SIMDE_ENABLE_CILKPLUS) && \
@@ -323,7 +365,11 @@ HEDLEY_DIAGNOSTIC_POP
 #else
 #define SIMDE_VECTORIZE_REDUCTION(r) HEDLEY_PRAGMA(omp simd reduction(r))
 #endif
+#if !defined(HEDLEY_MCST_LCC_VERSION)
 #define SIMDE_VECTORIZE_ALIGNED(a) HEDLEY_PRAGMA(omp simd aligned(a))
+#else
+#define SIMDE_VECTORIZE_ALIGNED(a) HEDLEY_PRAGMA(omp simd)
+#endif
 #elif defined(SIMDE_ENABLE_CILKPLUS)
 #define SIMDE_VECTORIZE HEDLEY_PRAGMA(simd)
 #define SIMDE_VECTORIZE_SAFELEN(l) HEDLEY_PRAGMA(simd vectorlength(l))
@@ -361,18 +407,22 @@ HEDLEY_DIAGNOSTIC_POP
 #define SIMDE_FUNCTION_ATTRIBUTES HEDLEY_ALWAYS_INLINE static
 #endif
 
+#if defined(SIMDE_NO_INLINE)
+#define SIMDE_HUGE_FUNCTION_ATTRIBUTES HEDLEY_NEVER_INLINE static
+#elif defined(SIMDE_CONSTRAINED_COMPILATION)
+#define SIMDE_HUGE_FUNCTION_ATTRIBUTES static
+#else
+#define SIMDE_HUGE_FUNCTION_ATTRIBUTES HEDLEY_ALWAYS_INLINE static
+#endif
+
 #if HEDLEY_HAS_ATTRIBUTE(unused) || HEDLEY_GCC_VERSION_CHECK(2, 95, 0)
 #define SIMDE_FUNCTION_POSSIBLY_UNUSED_ __attribute__((__unused__))
 #else
 #define SIMDE_FUNCTION_POSSIBLY_UNUSED_
 #endif
 
-#if HEDLEY_HAS_WARNING("-Wused-but-marked-unused")
-#define SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED \
-	_Pragma("clang diagnostic ignored \"-Wused-but-marked-unused\"")
-#else
-#define SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED
-#endif
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED_
 
 #if defined(_MSC_VER)
 #define SIMDE_BEGIN_DECLS_                                            \
@@ -380,9 +430,9 @@ HEDLEY_DIAGNOSTIC_POP
 		HEDLEY_BEGIN_C_DECLS
 #define SIMDE_END_DECLS_ HEDLEY_DIAGNOSTIC_POP HEDLEY_END_C_DECLS
 #else
-#define SIMDE_BEGIN_DECLS_                              \
-	HEDLEY_DIAGNOSTIC_PUSH                          \
-	SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED \
+#define SIMDE_BEGIN_DECLS_                               \
+	HEDLEY_DIAGNOSTIC_PUSH                           \
+	SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED_ \
 	HEDLEY_BEGIN_C_DECLS
 #define SIMDE_END_DECLS_   \
 	HEDLEY_END_C_DECLS \
@@ -513,9 +563,20 @@ typedef SIMDE_FLOAT32_TYPE simde_float32;
 #define SIMDE_FLOAT64_TYPE double
 #define SIMDE_FLOAT64_C(value) value
 #else
-#define SIMDE_FLOAT32_C(value) ((SIMDE_FLOAT64_TYPE)value)
+#define SIMDE_FLOAT64_C(value) ((SIMDE_FLOAT64_TYPE)value)
 #endif
 typedef SIMDE_FLOAT64_TYPE simde_float64;
+
+#if defined(__cplusplus)
+typedef bool simde_bool;
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+typedef _Bool simde_bool;
+#elif defined(bool)
+typedef bool simde_bool;
+#else
+#include <stdbool.h>
+typedef bool simde_bool;
+#endif
 
 #if HEDLEY_HAS_WARNING("-Wbad-function-cast")
 #define SIMDE_CONVERT_FTOI(T, v)                                    \
@@ -702,6 +763,25 @@ int simde_memcmp_(const void *s1, const void *s2, size_t n)
 #include <fenv.h>
 #endif
 
+#define SIMDE_DEFINE_CONVERSION_FUNCTION_(Name, T_To, T_From) \
+	static HEDLEY_ALWAYS_INLINE HEDLEY_CONST              \
+		SIMDE_FUNCTION_POSSIBLY_UNUSED_ T_To          \
+		Name(T_From value)                            \
+	{                                                     \
+		T_To r;                                       \
+		simde_memcpy(&r, &value, sizeof(r));          \
+		return r;                                     \
+	}
+
+SIMDE_DEFINE_CONVERSION_FUNCTION_(simde_float32_as_uint32, uint32_t,
+				  simde_float32)
+SIMDE_DEFINE_CONVERSION_FUNCTION_(simde_uint32_as_float32, simde_float32,
+				  uint32_t)
+SIMDE_DEFINE_CONVERSION_FUNCTION_(simde_float64_as_uint64, uint64_t,
+				  simde_float64)
+SIMDE_DEFINE_CONVERSION_FUNCTION_(simde_uint64_as_float64, simde_float64,
+				  uint64_t)
+
 #include "check.h"
 
 /* GCC/clang have a bunch of functionality in builtins which we would
@@ -801,7 +881,34 @@ SIMDE_DIAGNOSTIC_DISABLE_CPP98_COMPAT_PEDANTIC_
 #define SIMDE_BUILTIN_HAS_64_(name) 0
 #endif
 
-HEDLEY_DIAGNOSTIC_POP
+#if !defined(__cplusplus)
+#if defined(__clang__)
+#if HEDLEY_HAS_WARNING("-Wc11-extensions")
+#define SIMDE_GENERIC_(...)                                                        \
+	(__extension__({                                                           \
+		HEDLEY_DIAGNOSTIC_PUSH                                             \
+		_Pragma("clang diagnostic ignored \"-Wc11-extensions\"") _Generic( \
+			__VA_ARGS__);                                              \
+		HEDLEY_DIAGNOSTIC_POP                                              \
+	}))
+#elif HEDLEY_HAS_WARNING("-Wc1x-extensions")
+#define SIMDE_GENERIC_(...)                                                        \
+	(__extension__({                                                           \
+		HEDLEY_DIAGNOSTIC_PUSH                                             \
+		_Pragma("clang diagnostic ignored \"-Wc1x-extensions\"") _Generic( \
+			__VA_ARGS__);                                              \
+		HEDLEY_DIAGNOSTIC_POP                                              \
+	}))
+#endif
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) || \
+	HEDLEY_HAS_EXTENSION(c_generic_selections) ||               \
+	HEDLEY_GCC_VERSION_CHECK(4, 9, 0) ||                        \
+	HEDLEY_INTEL_VERSION_CHECK(17, 0, 0) ||                     \
+	HEDLEY_IBM_VERSION_CHECK(12, 1, 0) ||                       \
+	HEDLEY_ARM_VERSION_CHECK(5, 3, 0)
+#define SIMDE_GENERIC_(...) _Generic(__VA_ARGS__)
+#endif
+#endif
 
 /* Sometimes we run into problems with specific versions of compilers
    which make the native versions unusable for us.  Often this is due
@@ -817,6 +924,9 @@ HEDLEY_DIAGNOSTIC_POP
 #if !HEDLEY_GCC_VERSION_CHECK(5, 0, 0)
 #define SIMDE_BUG_GCC_BAD_MM_SRA_EPI32 /* TODO: find relevant bug or commit */
 #endif
+#if !HEDLEY_GCC_VERSION_CHECK(6, 0, 0)
+#define SIMDE_BUG_GCC_SIZEOF_IMMEDIATE
+#endif
 #if !HEDLEY_GCC_VERSION_CHECK(4, 6, 0)
 #define SIMDE_BUG_GCC_BAD_MM_EXTRACT_EPI8 /* TODO: find relevant bug or commit */
 #endif
@@ -826,24 +936,38 @@ HEDLEY_DIAGNOSTIC_POP
 #if !HEDLEY_GCC_VERSION_CHECK(10, 0, 0)
 #define SIMDE_BUG_GCC_REV_274313
 #define SIMDE_BUG_GCC_91341
+#define SIMDE_BUG_GCC_92035
 #endif
 #if !HEDLEY_GCC_VERSION_CHECK(9, 0, 0) && defined(SIMDE_ARCH_AARCH64)
 #define SIMDE_BUG_GCC_ARM_SHIFT_SCALAR
+#endif
+#if !HEDLEY_GCC_VERSION_CHECK(9, 0, 0) && defined(SIMDE_ARCH_AARCH64)
+#define SIMDE_BUG_GCC_BAD_VEXT_REV32
 #endif
 #if defined(SIMDE_ARCH_X86) && !defined(SIMDE_ARCH_AMD64)
 #define SIMDE_BUG_GCC_94482
 #endif
 #if (defined(SIMDE_ARCH_X86) && !defined(SIMDE_ARCH_AMD64)) || \
-	defined(SIMDE_ARCH_SYSTEMZ)
+	defined(SIMDE_ARCH_ZARCH)
 #define SIMDE_BUG_GCC_53784
 #endif
 #if defined(SIMDE_ARCH_X86) || defined(SIMDE_ARCH_AMD64)
 #if HEDLEY_GCC_VERSION_CHECK(4, 3, 0) /* -Wsign-conversion */
 #define SIMDE_BUG_GCC_95144
 #endif
+#if !HEDLEY_GCC_VERSION_CHECK(11, 0, 0)
+#define SIMDE_BUG_GCC_95483
+#endif
+#if defined(__OPTIMIZE__)
+#define SIMDE_BUG_GCC_100927
+#endif
+#define SIMDE_BUG_GCC_98521
 #endif
 #if !HEDLEY_GCC_VERSION_CHECK(9, 4, 0) && defined(SIMDE_ARCH_AARCH64)
 #define SIMDE_BUG_GCC_94488
+#endif
+#if !HEDLEY_GCC_VERSION_CHECK(9, 1, 0) && defined(SIMDE_ARCH_AARCH64)
+#define SIMDE_BUG_GCC_REV_264019
 #endif
 #if defined(SIMDE_ARCH_ARM)
 #define SIMDE_BUG_GCC_95399
@@ -851,10 +975,22 @@ HEDLEY_DIAGNOSTIC_POP
 #elif defined(SIMDE_ARCH_POWER)
 #define SIMDE_BUG_GCC_95227
 #define SIMDE_BUG_GCC_95782
+#define SIMDE_BUG_VEC_CPSGN_REVERSED_ARGS
 #elif defined(SIMDE_ARCH_X86) || defined(SIMDE_ARCH_AMD64)
 #if !HEDLEY_GCC_VERSION_CHECK(10, 2, 0) && !defined(__OPTIMIZE__)
 #define SIMDE_BUG_GCC_96174
 #endif
+#elif defined(SIMDE_ARCH_ZARCH)
+#define SIMDE_BUG_GCC_95782
+#if HEDLEY_GCC_VERSION_CHECK(10, 0, 0)
+#define SIMDE_BUG_GCC_101614
+#endif
+#endif
+#if defined(SIMDE_ARCH_MIPS_MSA)
+#define SIMDE_BUG_GCC_97248
+#define SIMDE_BUG_GCC_100760
+#define SIMDE_BUG_GCC_100761
+#define SIMDE_BUG_GCC_100762
 #endif
 #define SIMDE_BUG_GCC_95399
 #elif defined(__clang__)
@@ -866,15 +1002,52 @@ HEDLEY_DIAGNOSTIC_POP
 	SIMDE_DETECT_CLANG_VERSION_NOT(11, 0, 0)
 #define SIMDE_BUG_CLANG_BAD_VI64_OPS
 #endif
+#if SIMDE_DETECT_CLANG_VERSION_NOT(9, 0, 0)
+#define SIMDE_BUG_CLANG_GIT_4EC445B8
+#define SIMDE_BUG_CLANG_REV_365298 /* 0464e07c8f6e3310c28eb210a4513bc2243c2a7e */
 #endif
-#if defined(SIMDE_ARCH_POWER)
+#endif
+#if defined(SIMDE_ARCH_ARM)
+#if !SIMDE_DETECT_CLANG_VERSION_CHECK(11, 0, 0)
+#define SIMDE_BUG_CLANG_BAD_VGET_SET_LANE_TYPES
+#endif
+#endif
+#if defined(SIMDE_ARCH_POWER) && !SIMDE_DETECT_CLANG_VERSION_CHECK(12, 0, 0)
 #define SIMDE_BUG_CLANG_46770
+#endif
+#if defined(SIMDE_ARCH_POWER) && (SIMDE_ARCH_POWER == 700) && \
+	(SIMDE_DETECT_CLANG_VERSION_CHECK(11, 0, 0))
+#define SIMDE_BUG_CLANG_50893
+#define SIMDE_BUG_CLANG_50901
 #endif
 #if defined(_ARCH_PWR9) && !SIMDE_DETECT_CLANG_VERSION_CHECK(12, 0, 0) && \
 	!defined(__OPTIMIZE__)
 #define SIMDE_BUG_CLANG_POWER9_16x4_BAD_SHIFT
 #endif
+#if defined(SIMDE_ARCH_POWER)
+#define SIMDE_BUG_CLANG_50932
+#if !SIMDE_DETECT_CLANG_VERSION_CHECK(12, 0, 0)
+#define SIMDE_BUG_VEC_CPSGN_REVERSED_ARGS
+#endif
+#endif
 #if defined(SIMDE_ARCH_X86) || defined(SIMDE_ARCH_AMD64)
+#if SIMDE_DETECT_CLANG_VERSION_NOT(5, 0, 0)
+#define SIMDE_BUG_CLANG_REV_298042 /* 6afc436a7817a52e78ae7bcdc3faafd460124cac */
+#endif
+#if SIMDE_DETECT_CLANG_VERSION_NOT(3, 7, 0)
+#define SIMDE_BUG_CLANG_REV_234560 /* b929ad7b1726a32650a8051f69a747fb6836c540 */
+#endif
+#if SIMDE_DETECT_CLANG_VERSION_CHECK(3, 8, 0) && \
+	SIMDE_DETECT_CLANG_VERSION_NOT(5, 0, 0)
+#define SIMDE_BUG_CLANG_BAD_MADD
+#endif
+#if SIMDE_DETECT_CLANG_VERSION_CHECK(4, 0, 0) && \
+	SIMDE_DETECT_CLANG_VERSION_NOT(5, 0, 0)
+#define SIMDE_BUG_CLANG_REV_299346 /* ac9959eb533a58482ea4da6c4db1e635a98de384 */
+#endif
+#if SIMDE_DETECT_CLANG_VERSION_NOT(8, 0, 0)
+#define SIMDE_BUG_CLANG_REV_344862 /* eae26bf73715994c2bd145f9b6dc3836aa4ffd4f */
+#endif
 #if HEDLEY_HAS_WARNING("-Wsign-conversion") && \
 	SIMDE_DETECT_CLANG_VERSION_NOT(11, 0, 0)
 #define SIMDE_BUG_CLANG_45931
@@ -883,6 +1056,7 @@ HEDLEY_DIAGNOSTIC_POP
 	SIMDE_DETECT_CLANG_VERSION_NOT(11, 0, 0)
 #define SIMDE_BUG_CLANG_44589
 #endif
+#define SIMDE_BUG_CLANG_48673
 #endif
 #define SIMDE_BUG_CLANG_45959
 #elif defined(HEDLEY_MSVC_VERSION)
@@ -891,6 +1065,14 @@ HEDLEY_DIAGNOSTIC_POP
 #endif
 #elif defined(HEDLEY_INTEL_VERSION)
 #define SIMDE_BUG_INTEL_857088
+#elif defined(HEDLEY_MCST_LCC_VERSION)
+#define SIMDE_BUG_MCST_LCC_MISSING_AVX_LOAD_STORE_M128_FUNCS
+#define SIMDE_BUG_MCST_LCC_MISSING_CMOV_M256
+#define SIMDE_BUG_MCST_LCC_FMA_WRONG_RESULT
+#elif defined(HEDLEY_PGI_VERSION)
+#define SIMDE_BUG_PGI_30104
+#define SIMDE_BUG_PGI_30107
+#define SIMDE_BUG_PGI_30106
 #endif
 #endif
 
@@ -902,17 +1084,32 @@ HEDLEY_DIAGNOSTIC_POP
 #if (HEDLEY_HAS_WARNING("-Wsign-conversion") &&   \
      SIMDE_DETECT_CLANG_VERSION_NOT(11, 0, 0)) || \
 	HEDLEY_GCC_VERSION_CHECK(4, 3, 0)
-#define SIMDE_BUG_IGNORE_SIGN_CONVERSION(expr)                                      \
-	(__extension__({                                                            \
-		HEDLEY_DIAGNOSTIC_PUSH                                              \
-		HEDLEY_DIAGNOSTIC_POP                                               \
-		_Pragma("GCC diagnostic ignored \"-Wsign-conversion\"") __typeof__( \
-			expr) simde_bug_ignore_sign_conversion_v_ = (expr);         \
-		HEDLEY_DIAGNOSTIC_PUSH                                              \
-		simde_bug_ignore_sign_conversion_v_;                                \
+#define SIMDE_BUG_IGNORE_SIGN_CONVERSION(expr)                                           \
+	(__extension__({                                                                 \
+		HEDLEY_DIAGNOSTIC_PUSH                                                   \
+		HEDLEY_DIAGNOSTIC_POP                                                    \
+		_Pragma("GCC diagnostic ignored \"-Wsign-conversion\"") __typeof__(expr) \
+			simde_bug_ignore_sign_conversion_v_ = (expr);                    \
+		HEDLEY_DIAGNOSTIC_PUSH                                                   \
+		simde_bug_ignore_sign_conversion_v_;                                     \
 	}))
 #else
 #define SIMDE_BUG_IGNORE_SIGN_CONVERSION(expr) (expr)
 #endif
+
+/* Usually the shift count is signed (for example, NEON or SSE).
+ * OTOH, unsigned is good for PPC (vec_srl uses unsigned), and the only option for E2K.
+ * Further info: https://github.com/simd-everywhere/simde/pull/700
+ */
+#if defined(SIMDE_ARCH_E2K) || defined(SIMDE_ARCH_POWER)
+#define SIMDE_CAST_VECTOR_SHIFT_COUNT(width, value) \
+	HEDLEY_STATIC_CAST(uint##width##_t, (value))
+#else
+#define SIMDE_CAST_VECTOR_SHIFT_COUNT(width, value) \
+	HEDLEY_STATIC_CAST(int##width##_t, (value))
+#endif
+
+/* SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED_ */
+HEDLEY_DIAGNOSTIC_POP
 
 #endif /* !defined(SIMDE_COMMON_H) */

--- a/libobs/util/simde/simde-detect-clang.h
+++ b/libobs/util/simde/simde-detect-clang.h
@@ -76,14 +76,14 @@
 #define SIMDE_DETECT_CLANG_VERSION 50000
 #elif __has_attribute(diagnose_if)
 #define SIMDE_DETECT_CLANG_VERSION 40000
-#elif __has_warning("-Wcast-calling-convention")
-#define SIMDE_DETECT_CLANG_VERSION 30900
-#elif __has_warning("-WCL4")
-#define SIMDE_DETECT_CLANG_VERSION 30800
-#elif __has_warning("-WIndependentClass-attribute")
-#define SIMDE_DETECT_CLANG_VERSION 30700
+#elif __has_warning("-Wcomma")
+#define SIMDE_DETECT_CLANG_VERSION 39000
+#elif __has_warning("-Wdouble-promotion")
+#define SIMDE_DETECT_CLANG_VERSION 38000
+#elif __has_warning("-Wshift-negative-value")
+#define SIMDE_DETECT_CLANG_VERSION 37000
 #elif __has_warning("-Wambiguous-ellipsis")
-#define SIMDE_DETECT_CLANG_VERSION 30600
+#define SIMDE_DETECT_CLANG_VERSION 36000
 #else
 #define SIMDE_DETECT_CLANG_VERSION 1
 #endif
@@ -108,7 +108,7 @@
 	 ((major * 10000) + (minor * 1000) + (revision)))
 #else
 #define SIMDE_DETECT_CLANG_VERSION_CHECK(major, minor, revision) (0)
-#define SIMDE_DETECT_CLANG_VERSION_NOT(major, minor, revision) (1)
+#define SIMDE_DETECT_CLANG_VERSION_NOT(major, minor, revision) (0)
 #endif
 
 #endif /* !defined(SIMDE_DETECT_CLANG_H) */

--- a/libobs/util/simde/simde-diagnostic.h
+++ b/libobs/util/simde/simde-diagnostic.h
@@ -49,6 +49,7 @@
 
 #include "hedley.h"
 #include "simde-detect-clang.h"
+#include "simde-arch.h"
 
 /* This is only to help us implement functions like _mm_undefined_ps. */
 #if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
@@ -196,11 +197,20 @@
  *
  * This is also used when enabling native aliases since we don't get to
  * choose the macro names. */
-#if HEDLEY_HAS_WARNING("-Wdouble-promotion")
+#if HEDLEY_HAS_WARNING("-Wreserved-id-macro")
 #define SIMDE_DIAGNOSTIC_DISABLE_RESERVED_ID_MACRO_ \
 	_Pragma("clang diagnostic ignored \"-Wreserved-id-macro\"")
 #else
 #define SIMDE_DIAGNOSTIC_DISABLE_RESERVED_ID_MACRO_
+#endif
+
+/* Similar to above; types like simde__m128i are reserved due to the
+ * double underscore, but we didn't choose them, Intel did. */
+#if HEDLEY_HAS_WARNING("-Wreserved-identifier")
+#define SIMDE_DIAGNOSTIC_DISABLE_RESERVED_ID_ \
+	_Pragma("clang diagnostic ignored \"-Wreserved-identifier\"")
+#else
+#define SIMDE_DIAGNOSTIC_DISABLE_RESERVED_ID_
 #endif
 
 /* clang 3.8 warns about the packed attribute being unnecessary when
@@ -239,24 +249,13 @@
 #define SIMDE_DIAGNOSTIC_DISABLE_VLA_
 #endif
 
+/* If you add an unused attribute to a function and don't use it, clang
+ * may emit this. */
 #if HEDLEY_HAS_WARNING("-Wused-but-marked-unused")
 #define SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED_ \
 	_Pragma("clang diagnostic ignored \"-Wused-but-marked-unused\"")
 #else
 #define SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED_
-#endif
-
-#if HEDLEY_HAS_WARNING("-Wunused-function")
-#define SIMDE_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION_ \
-	_Pragma("clang diagnostic ignored \"-Wunused-function\"")
-#elif HEDLEY_GCC_VERSION_CHECK(3, 4, 0)
-#define SIMDE_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION_ \
-	_Pragma("GCC diagnostic ignored \"-Wunused-function\"")
-#elif HEDLEY_MSVC_VERSION_CHECK(19, 0, 0) /* Likely goes back further */
-#define SIMDE_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION_ \
-	__pragma(warning(disable : 4505))
-#else
-#define SIMDE_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION_
 #endif
 
 #if HEDLEY_HAS_WARNING("-Wpass-failed")
@@ -330,8 +329,14 @@
  * -Wc++98-compat-pedantic which says 'long long' is incompatible with
  * C++98. */
 #if HEDLEY_HAS_WARNING("-Wc++98-compat-pedantic")
+#if HEDLEY_HAS_WARNING("-Wc++11-long-long")
+#define SIMDE_DIAGNOSTIC_DISABLE_CPP98_COMPAT_PEDANTIC_                 \
+	_Pragma("clang diagnostic ignored \"-Wc++98-compat-pedantic\"") \
+		_Pragma("clang diagnostic ignored \"-Wc++11-long-long\"")
+#else
 #define SIMDE_DIAGNOSTIC_DISABLE_CPP98_COMPAT_PEDANTIC_ \
 	_Pragma("clang diagnostic ignored \"-Wc++98-compat-pedantic\"")
+#endif
 #else
 #define SIMDE_DIAGNOSTIC_DISABLE_CPP98_COMPAT_PEDANTIC_
 #endif
@@ -369,8 +374,10 @@
 #define SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_ \
 	_Pragma("clang diagnostic ignored \"-Wvector-conversion\"")
 /* For NEON, the situation with -Wvector-conversion in clang < 10 is
-   * bad enough that we just disable the warning altogether. */
-#if defined(SIMDE_ARCH_ARM) && SIMDE_DETECT_CLANG_VERSION_NOT(10, 0, 0)
+   * bad enough that we just disable the warning altogether.  On x86,
+   * clang has similar issues on several sse4.2+ intrinsics before 3.8. */
+#if (defined(SIMDE_ARCH_ARM) && SIMDE_DETECT_CLANG_VERSION_NOT(10, 0, 0)) || \
+	SIMDE_DETECT_CLANG_VERSION_NOT(3, 8, 0)
 #define SIMDE_DIAGNOSTIC_DISABLE_BUGGY_VECTOR_CONVERSION_ \
 	SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
 #endif
@@ -379,6 +386,27 @@
 #endif
 #if !defined(SIMDE_DIAGNOSTIC_DISABLE_BUGGY_VECTOR_CONVERSION_)
 #define SIMDE_DIAGNOSTIC_DISABLE_BUGGY_VECTOR_CONVERSION_
+#endif
+
+/* Prior to 5.0, clang didn't support disabling diagnostics in
+ * statement exprs.  As a result, some macros we use don't
+ * properly silence warnings. */
+#if SIMDE_DETECT_CLANG_VERSION_NOT(5, 0, 0) && \
+	HEDLEY_HAS_WARNING("-Wcast-qual") &&   \
+	HEDLEY_HAS_WARNING("-Wcast-align")
+#define SIMDE_DIAGNOSTIC_DISABLE_BUGGY_CASTS_               \
+	_Pragma("clang diagnostic ignored \"-Wcast-qual\"") \
+		_Pragma("clang diagnostic ignored \"-Wcast-align\"")
+#elif SIMDE_DETECT_CLANG_VERSION_NOT(5, 0, 0) && \
+	HEDLEY_HAS_WARNING("-Wcast-qual")
+#define SIMDE_DIAGNOSTIC_DISABLE_BUGGY_CASTS_ \
+	_Pragma("clang diagnostic ignored \"-Wcast-qual\"")
+#elif SIMDE_DETECT_CLANG_VERSION_NOT(5, 0, 0) && \
+	HEDLEY_HAS_WARNING("-Wcast-align")
+#define SIMDE_DIAGNOSTIC_DISABLE_BUGGY_CASTS_ \
+	_Pragma("clang diagnostic ignored \"-Wcast-align\"")
+#else
+#define SIMDE_DIAGNOSTIC_DISABLE_BUGGY_CASTS_
 #endif
 
 /* SLEEF triggers this a *lot* in their headers */
@@ -426,7 +454,20 @@
 #define SIMDE_DISABLE_UNWANTED_DIAGNOSTICS_NATIVE_ALIASES_
 #endif
 
+/* Some native functions on E2K with instruction set < v6 are declared
+ * as deprecated due to inefficiency. Still they are more efficient
+ * than SIMDe implementation. So we're using them, and switching off
+ * these deprecation warnings. */
+#if defined(HEDLEY_MCST_LCC_VERSION)
+#define SIMDE_LCC_DISABLE_DEPRECATED_WARNINGS _Pragma("diag_suppress 1215,1444")
+#define SIMDE_LCC_REVERT_DEPRECATED_WARNINGS _Pragma("diag_default 1215,1444")
+#else
+#define SIMDE_LCC_DISABLE_DEPRECATED_WARNINGS
+#define SIMDE_LCC_REVERT_DEPRECATED_WARNINGS
+#endif
+
 #define SIMDE_DISABLE_UNWANTED_DIAGNOSTICS                           \
+	HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION                    \
 	SIMDE_DISABLE_UNWANTED_DIAGNOSTICS_NATIVE_ALIASES_           \
 	SIMDE_DIAGNOSTIC_DISABLE_PSABI_                              \
 	SIMDE_DIAGNOSTIC_DISABLE_NO_EMMS_INSTRUCTION_                \
@@ -437,11 +478,12 @@
 	SIMDE_DIAGNOSTIC_DISABLE_EXTRA_SEMI_                         \
 	SIMDE_DIAGNOSTIC_DISABLE_VLA_                                \
 	SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED_             \
-	SIMDE_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION_                    \
 	SIMDE_DIAGNOSTIC_DISABLE_PASS_FAILED_                        \
 	SIMDE_DIAGNOSTIC_DISABLE_CPP98_COMPAT_PEDANTIC_              \
 	SIMDE_DIAGNOSTIC_DISABLE_CPP11_LONG_LONG_                    \
 	SIMDE_DIAGNOSTIC_DISABLE_BUGGY_UNUSED_BUT_SET_VARIBALE_      \
-	SIMDE_DIAGNOSTIC_DISABLE_BUGGY_VECTOR_CONVERSION_
+	SIMDE_DIAGNOSTIC_DISABLE_BUGGY_CASTS_                        \
+	SIMDE_DIAGNOSTIC_DISABLE_BUGGY_VECTOR_CONVERSION_            \
+	SIMDE_DIAGNOSTIC_DISABLE_RESERVED_ID_
 
 #endif /* !defined(SIMDE_DIAGNOSTIC_H) */

--- a/libobs/util/simde/simde-features.h
+++ b/libobs/util/simde/simde-features.h
@@ -56,6 +56,29 @@
 #define SIMDE_X86_AVX512F_NATIVE
 #endif
 
+#if !defined(SIMDE_X86_AVX512VPOPCNTDQ_NATIVE) &&        \
+	!defined(SIMDE_X86_AVX512VPOPCNTDQ_NO_NATIVE) && \
+	!defined(SIMDE_NO_NATIVE)
+#if defined(SIMDE_ARCH_X86_AVX512VPOPCNTDQ)
+#define SIMDE_X86_AVX512VPOPCNTDQ_NATIVE
+#endif
+#endif
+#if defined(SIMDE_X86_AVX512VPOPCNTDQ_NATIVE) && \
+	!defined(SIMDE_X86_AVX512F_NATIVE)
+#define SIMDE_X86_AVX512F_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_AVX512BITALG_NATIVE) &&        \
+	!defined(SIMDE_X86_AVX512BITALG_NO_NATIVE) && \
+	!defined(SIMDE_NO_NATIVE)
+#if defined(SIMDE_ARCH_X86_AVX512BITALG)
+#define SIMDE_X86_AVX512BITALG_NATIVE
+#endif
+#endif
+#if defined(SIMDE_X86_AVX512BITALG_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)
+#define SIMDE_X86_AVX512F_NATIVE
+#endif
+
 #if !defined(SIMDE_X86_AVX512VBMI_NATIVE) && \
 	!defined(SIMDE_X86_AVX512VBMI_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
 #if defined(SIMDE_ARCH_X86_AVX512VBMI)
@@ -63,6 +86,37 @@
 #endif
 #endif
 #if defined(SIMDE_X86_AVX512VBMI_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)
+#define SIMDE_X86_AVX512F_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_AVX512VBMI2_NATIVE) && \
+	!defined(SIMDE_X86_AVX512VBMI2_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+#if defined(SIMDE_ARCH_X86_AVX512VBMI2)
+#define SIMDE_X86_AVX512VBMI2_NATIVE
+#endif
+#endif
+#if defined(SIMDE_X86_AVX512VBMI2_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)
+#define SIMDE_X86_AVX512F_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_AVX512VNNI_NATIVE) && \
+	!defined(SIMDE_X86_AVX512VNNI_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+#if defined(SIMDE_ARCH_X86_AVX512VNNI)
+#define SIMDE_X86_AVX512VNNI_NATIVE
+#endif
+#endif
+#if defined(SIMDE_X86_AVX512VNNI_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)
+#define SIMDE_X86_AVX512F_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_AVX5124VNNIW_NATIVE) &&        \
+	!defined(SIMDE_X86_AVX5124VNNIW_NO_NATIVE) && \
+	!defined(SIMDE_NO_NATIVE)
+#if defined(SIMDE_ARCH_X86_AVX5124VNNIW)
+#define SIMDE_X86_AVX5124VNNIW_NATIVE
+#endif
+#endif
+#if defined(SIMDE_X86_AVX5124VNNIW_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)
 #define SIMDE_X86_AVX512F_NATIVE
 #endif
 
@@ -106,6 +160,16 @@
 #define SIMDE_X86_AVX512F_NATIVE
 #endif
 
+#if !defined(SIMDE_X86_AVX512BF16_NATIVE) && \
+	!defined(SIMDE_X86_AVX512BF16_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+#if defined(SIMDE_ARCH_X86_AVX512BF16)
+#define SIMDE_X86_AVX512BF16_NATIVE
+#endif
+#endif
+#if defined(SIMDE_X86_AVX512BF16_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)
+#define SIMDE_X86_AVX512F_NATIVE
+#endif
+
 #if !defined(SIMDE_X86_AVX512F_NATIVE) && \
 	!defined(SIMDE_X86_AVX512F_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
 #if defined(SIMDE_ARCH_X86_AVX512F)
@@ -143,6 +207,16 @@
 #endif
 #endif
 #if defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_X86_SSE4_1_NATIVE)
+#define SIMDE_X86_SSE4_2_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_XOP_NATIVE) && !defined(SIMDE_X86_XOP_NO_NATIVE) && \
+	!defined(SIMDE_NO_NATIVE)
+#if defined(SIMDE_ARCH_X86_XOP)
+#define SIMDE_X86_XOP_NATIVE
+#endif
+#endif
+#if defined(SIMDE_X86_XOP_NATIVE) && !defined(SIMDE_X86_SSE4_2_NATIVE)
 #define SIMDE_X86_SSE4_2_NATIVE
 #endif
 
@@ -231,6 +305,13 @@
 #endif
 #endif
 
+#if !defined(SIMDE_X86_F16C_NATIVE) && !defined(SIMDE_X86_F16C_NO_NATIVE) && \
+	!defined(SIMDE_NO_NATIVE)
+#if defined(SIMDE_ARCH_X86_F16C)
+#define SIMDE_X86_F16C_NATIVE
+#endif
+#endif
+
 #if !defined(SIMDE_X86_SVML_NATIVE) && !defined(SIMDE_X86_SVML_NO_NATIVE) && \
 	!defined(SIMDE_NO_NATIVE)
 #if defined(__INTEL_COMPILER)
@@ -261,6 +342,14 @@
 #include <mmintrin.h>
 #endif
 
+#if defined(SIMDE_X86_XOP_NATIVE)
+#if defined(_MSC_VER)
+#include <intrin.h>
+#else
+#include <x86intrin.h>
+#endif
+#endif
+
 #if defined(HEDLEY_MSVC_VERSION)
 #pragma warning(pop)
 #endif
@@ -268,7 +357,7 @@
 #if !defined(SIMDE_ARM_NEON_A64V8_NATIVE) && \
 	!defined(SIMDE_ARM_NEON_A64V8_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
 #if defined(SIMDE_ARCH_ARM_NEON) && defined(SIMDE_ARCH_AARCH64) && \
-	SIMDE_ARCH_ARM_CHECK(80)
+	SIMDE_ARCH_ARM_CHECK(8, 0)
 #define SIMDE_ARM_NEON_A64V8_NATIVE
 #endif
 #endif
@@ -279,7 +368,7 @@
 
 #if !defined(SIMDE_ARM_NEON_A32V8_NATIVE) && \
 	!defined(SIMDE_ARM_NEON_A32V8_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
-#if defined(SIMDE_ARCH_ARM_NEON) && SIMDE_ARCH_ARM_CHECK(80) && \
+#if defined(SIMDE_ARCH_ARM_NEON) && SIMDE_ARCH_ARM_CHECK(8, 0) && \
 	(__ARM_NEON_FP & 0x02)
 #define SIMDE_ARM_NEON_A32V8_NATIVE
 #endif
@@ -291,12 +380,15 @@
 
 #if !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && \
 	!defined(SIMDE_ARM_NEON_A32V7_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
-#if defined(SIMDE_ARCH_ARM_NEON) && SIMDE_ARCH_ARM_CHECK(70)
+#if defined(SIMDE_ARCH_ARM_NEON) && SIMDE_ARCH_ARM_CHECK(7, 0)
 #define SIMDE_ARM_NEON_A32V7_NATIVE
 #endif
 #endif
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
 #include <arm_neon.h>
+#if defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
+#include <arm_fp16.h>
+#endif
 #endif
 
 #if !defined(SIMDE_ARM_SVE_NATIVE) && !defined(SIMDE_ARM_SVE_NO_NATIVE) && \
@@ -314,12 +406,6 @@
 #endif
 #endif
 #if defined(SIMDE_WASM_SIMD128_NATIVE)
-#if !defined(__wasm_unimplemented_simd128__)
-HEDLEY_DIAGNOSTIC_PUSH
-SIMDE_DIAGNOSTIC_DISABLE_RESERVED_ID_MACRO_
-#define __wasm_unimplemented_simd128__
-HEDLEY_DIAGNOSTIC_POP
-#endif
 #include <wasm_simd128.h>
 #endif
 
@@ -375,7 +461,32 @@ HEDLEY_DIAGNOSTIC_POP
 #endif
 #endif
 
-#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#if !defined(SIMDE_ZARCH_ZVECTOR_15_NATIVE) &&        \
+	!defined(SIMDE_ZARCH_ZVECTOR_15_NO_NATIVE) && \
+	!defined(SIMDE_NO_NATIVE)
+#if SIMDE_ARCH_ZARCH_CHECK(13) && defined(SIMDE_ARCH_ZARCH_ZVECTOR)
+#define SIMDE_ZARCH_ZVECTOR_15_NATIVE
+#endif
+#endif
+
+#if !defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE) &&        \
+	!defined(SIMDE_ZARCH_ZVECTOR_14_NO_NATIVE) && \
+	!defined(SIMDE_NO_NATIVE)
+#if SIMDE_ARCH_ZARCH_CHECK(12) && defined(SIMDE_ARCH_ZARCH_ZVECTOR)
+#define SIMDE_ZARCH_ZVECTOR_14_NATIVE
+#endif
+#endif
+
+#if !defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE) &&        \
+	!defined(SIMDE_ZARCH_ZVECTOR_13_NO_NATIVE) && \
+	!defined(SIMDE_NO_NATIVE)
+#if SIMDE_ARCH_ZARCH_CHECK(11) && defined(SIMDE_ARCH_ZARCH_ZVECTOR)
+#define SIMDE_ZARCH_ZVECTOR_13_NATIVE
+#endif
+#endif
+
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
 /* AltiVec conflicts with lots of stuff.  The bool keyword conflicts
    * with the bool keyword in C++ and the bool macro in C99+ (defined
    * in stdbool.h).  The vector keyword conflicts with std::vector in
@@ -393,6 +504,7 @@ HEDLEY_DIAGNOSTIC_POP
 #undef bool
 #endif
 
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
 #include <altivec.h>
 
 #if !defined(SIMDE_POWER_ALTIVEC_NO_UNDEF)
@@ -406,6 +518,9 @@ HEDLEY_DIAGNOSTIC_POP
 #undef bool
 #endif
 #endif /* !defined(SIMDE_POWER_ALTIVEC_NO_UNDEF) */
+#elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+#include <vecintrin.h>
+#endif
 
 /* Use these intsead of vector/pixel/bool in SIMDe. */
 #define SIMDE_POWER_ALTIVEC_VECTOR(T) __vector T
@@ -430,6 +545,16 @@ HEDLEY_DIAGNOSTIC_POP
 #include <loongson-mmiintrin.h>
 #endif
 
+#if !defined(SIMDE_MIPS_MSA_NATIVE) && !defined(SIMDE_MIPS_MSA_NO_NATIVE) && \
+	!defined(SIMDE_NO_NATIVE)
+#if defined(SIMDE_ARCH_MIPS_MSA)
+#define SIMDE_MIPS_MSA_NATIVE 1
+#endif
+#endif
+#if defined(SIMDE_MIPS_MSA_NATIVE)
+#include <msa.h>
+#endif
+
 /* This is used to determine whether or not to fall back on a vector
  * function in an earlier ISA extensions, as well as whether
  * we expected any attempts at vectorization to be fruitful or if we
@@ -442,7 +567,9 @@ HEDLEY_DIAGNOSTIC_POP
 #define SIMDE_NATURAL_VECTOR_SIZE (256)
 #elif defined(SIMDE_X86_SSE_NATIVE) || defined(SIMDE_ARM_NEON_A32V7_NATIVE) || \
 	defined(SIMDE_WASM_SIMD128_NATIVE) ||                                  \
-	defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+	defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) ||                              \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE) ||                              \
+	defined(SIMDE_MIPS_MSA_NATIVE)
 #define SIMDE_NATURAL_VECTOR_SIZE (128)
 #endif
 
@@ -494,8 +621,29 @@ HEDLEY_DIAGNOSTIC_POP
 #if !defined(SIMDE_X86_AVX512VL_NATIVE)
 #define SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES
 #endif
+#if !defined(SIMDE_X86_AVX512VBMI_NATIVE)
+#define SIMDE_X86_AVX512VBMI_ENABLE_NATIVE_ALIASES
+#endif
+#if !defined(SIMDE_X86_AVX512VBMI2_NATIVE)
+#define SIMDE_X86_AVX512VBMI2_ENABLE_NATIVE_ALIASES
+#endif
 #if !defined(SIMDE_X86_AVX512BW_NATIVE)
 #define SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES
+#endif
+#if !defined(SIMDE_X86_AVX512VNNI_NATIVE)
+#define SIMDE_X86_AVX512VNNI_ENABLE_NATIVE_ALIASES
+#endif
+#if !defined(SIMDE_X86_AVX5124VNNIW_NATIVE)
+#define SIMDE_X86_AVX5124VNNIW_ENABLE_NATIVE_ALIASES
+#endif
+#if !defined(SIMDE_X86_AVX512BF16_NATIVE)
+#define SIMDE_X86_AVX512BF16_ENABLE_NATIVE_ALIASES
+#endif
+#if !defined(SIMDE_X86_AVX512BITALG_NATIVE)
+#define SIMDE_X86_AVX512BITALG_ENABLE_NATIVE_ALIASES
+#endif
+#if !defined(SIMDE_X86_AVX512VPOPCNTDQ_NATIVE)
+#define SIMDE_X86_AVX512VPOPCNTDQ_ENABLE_NATIVE_ALIASES
 #endif
 #if !defined(SIMDE_X86_AVX512DQ_NATIVE)
 #define SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES
@@ -512,6 +660,9 @@ HEDLEY_DIAGNOSTIC_POP
 #if !defined(SIMDE_X86_VPCLMULQDQ_NATIVE)
 #define SIMDE_X86_VPCLMULQDQ_ENABLE_NATIVE_ALIASES
 #endif
+#if !defined(SIMDE_X86_F16C_NATIVE)
+#define SIMDE_X86_F16C_ENABLE_NATIVE_ALIASES
+#endif
 
 #if !defined(SIMDE_ARM_NEON_A32V7_NATIVE)
 #define SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES
@@ -521,6 +672,14 @@ HEDLEY_DIAGNOSTIC_POP
 #endif
 #if !defined(SIMDE_ARM_NEON_A64V8_NATIVE)
 #define SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES
+#endif
+
+#if !defined(SIMDE_ARM_SVE_NATIVE)
+#define SIMDE_ARM_SVE_ENABLE_NATIVE_ALIASES
+#endif
+
+#if !defined(SIMDE_WASM_SIMD128_NATIVE)
+#define SIMDE_WASM_SIMD128_ENABLE_NATIVE_ALIASES
 #endif
 #endif
 

--- a/libobs/util/simde/x86/mmx.h
+++ b/libobs/util/simde/x86/mmx.h
@@ -690,7 +690,8 @@ int64_t simde_mm_cvtm64_si64(simde__m64 a)
 #endif
 }
 #define simde_m_to_int64(a) simde_mm_cvtm64_si64(a)
-#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
 #define _mm_cvtm64_si64(a) simde_mm_cvtm64_si64(a)
 #define _m_to_int64(a) simde_mm_cvtm64_si64(a)
 #endif
@@ -704,7 +705,7 @@ simde__m64 simde_mm_cvtsi32_si64(int32_t a)
 	simde__m64_private r_;
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	const int32_t av[sizeof(r_.neon_i32) / sizeof(r_.neon_i32[0])] = {a, 0};
+	const int32_t av[2] = {a, 0};
 	r_.neon_i32 = vld1_s32(av);
 #else
 	r_.i32[0] = a;
@@ -739,7 +740,8 @@ simde__m64 simde_mm_cvtsi64_m64(int64_t a)
 #endif
 }
 #define simde_m_from_int64(a) simde_mm_cvtsi64_m64(a)
-#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
 #define _mm_cvtsi64_m64(a) simde_mm_cvtsi64_m64(a)
 #define _m_from_int64(a) simde_mm_cvtsi64_m64(a)
 #endif
@@ -1634,7 +1636,7 @@ simde__m64 simde_mm_srl_pi16(simde__m64 a, simde__m64 count)
 	if (HEDLEY_UNLIKELY(count_.u64[0] > 15))
 		return simde_mm_setzero_si64();
 
-	r_.i16 = a_.i16 >> HEDLEY_STATIC_CAST(int16_t, count_.u64[0]);
+	r_.u16 = a_.u16 >> HEDLEY_STATIC_CAST(uint16_t, count_.u64[0]);
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
 	r_.u16 = a_.u16 >> count_.u64[0];
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)

--- a/libobs/util/simde/x86/sse.h
+++ b/libobs/util/simde/x86/sse.h
@@ -93,9 +93,19 @@ typedef union {
 #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
 	SIMDE_ALIGN_TO_16 float64x2_t neon_f64;
 #endif
+#elif defined(SIMDE_MIPS_MSA_NATIVE)
+	v16i8 msa_i8;
+	v8i16 msa_i16;
+	v4i32 msa_i32;
+	v2i64 msa_i64;
+	v16u8 msa_u8;
+	v8u16 msa_u16;
+	v4u32 msa_u32;
+	v2u64 msa_u64;
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
 	SIMDE_ALIGN_TO_16 v128_t wasm_v128;
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
 	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) altivec_u8;
 	SIMDE_ALIGN_TO_16
 	SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) altivec_u16;
@@ -104,7 +114,8 @@ typedef union {
 	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed short) altivec_i16;
 	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int) altivec_i32;
 	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(float) altivec_f32;
-#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
 	SIMDE_ALIGN_TO_16
 	SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64;
 	SIMDE_ALIGN_TO_16
@@ -120,7 +131,8 @@ typedef __m128 simde__m128;
 typedef float32x4_t simde__m128;
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
 typedef v128_t simde__m128;
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
 typedef SIMDE_POWER_ALTIVEC_VECTOR(float) simde__m128;
 #elif defined(SIMDE_VECTOR_SUBSCRIPT)
 typedef simde_float32
@@ -174,7 +186,8 @@ SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, float64x2_t, neon, f64)
 #endif
 #endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
 
-#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
 SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128,
 				       SIMDE_POWER_ALTIVEC_VECTOR(signed char),
 				       altivec, i8)
@@ -214,7 +227,8 @@ SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(float),
 				       altivec, f32)
 #endif
 
-#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
 SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
 	m128, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
 SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
@@ -285,6 +299,123 @@ enum {
 #define _MM_FROUND_TRUNC SIMDE_MM_FROUND_TRUNC
 #define _MM_FROUND_RINT SIMDE_MM_FROUND_RINT
 #define _MM_FROUND_NEARBYINT SIMDE_MM_FROUND_NEARBYINT
+#endif
+
+#if defined(_MM_EXCEPT_INVALID)
+#define SIMDE_MM_EXCEPT_INVALID _MM_EXCEPT_INVALID
+#else
+#define SIMDE_MM_EXCEPT_INVALID (0x0001)
+#endif
+#if defined(_MM_EXCEPT_DENORM)
+#define SIMDE_MM_EXCEPT_DENORM _MM_EXCEPT_DENORM
+#else
+#define SIMDE_MM_EXCEPT_DENORM (0x0002)
+#endif
+#if defined(_MM_EXCEPT_DIV_ZERO)
+#define SIMDE_MM_EXCEPT_DIV_ZERO _MM_EXCEPT_DIV_ZERO
+#else
+#define SIMDE_MM_EXCEPT_DIV_ZERO (0x0004)
+#endif
+#if defined(_MM_EXCEPT_OVERFLOW)
+#define SIMDE_MM_EXCEPT_OVERFLOW _MM_EXCEPT_OVERFLOW
+#else
+#define SIMDE_MM_EXCEPT_OVERFLOW (0x0008)
+#endif
+#if defined(_MM_EXCEPT_UNDERFLOW)
+#define SIMDE_MM_EXCEPT_UNDERFLOW _MM_EXCEPT_UNDERFLOW
+#else
+#define SIMDE_MM_EXCEPT_UNDERFLOW (0x0010)
+#endif
+#if defined(_MM_EXCEPT_INEXACT)
+#define SIMDE_MM_EXCEPT_INEXACT _MM_EXCEPT_INEXACT
+#else
+#define SIMDE_MM_EXCEPT_INEXACT (0x0020)
+#endif
+#if defined(_MM_EXCEPT_MASK)
+#define SIMDE_MM_EXCEPT_MASK _MM_EXCEPT_MASK
+#else
+#define SIMDE_MM_EXCEPT_MASK                                   \
+	(SIMDE_MM_EXCEPT_INVALID | SIMDE_MM_EXCEPT_DENORM |    \
+	 SIMDE_MM_EXCEPT_DIV_ZERO | SIMDE_MM_EXCEPT_OVERFLOW | \
+	 SIMDE_MM_EXCEPT_UNDERFLOW | SIMDE_MM_EXCEPT_INEXACT)
+#endif
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#define _MM_EXCEPT_INVALID SIMDE_MM_EXCEPT_INVALID
+#define _MM_EXCEPT_DENORM SIMDE_MM_EXCEPT_DENORM
+#define _MM_EXCEPT_DIV_ZERO SIMDE_MM_EXCEPT_DIV_ZERO
+#define _MM_EXCEPT_OVERFLOW SIMDE_MM_EXCEPT_OVERFLOW
+#define _MM_EXCEPT_UNDERFLOW SIMDE_MM_EXCEPT_UNDERFLOW
+#define _MM_EXCEPT_INEXACT SIMDE_MM_EXCEPT_INEXACT
+#define _MM_EXCEPT_MASK SIMDE_MM_EXCEPT_MASK
+#endif
+
+#if defined(_MM_MASK_INVALID)
+#define SIMDE_MM_MASK_INVALID _MM_MASK_INVALID
+#else
+#define SIMDE_MM_MASK_INVALID (0x0080)
+#endif
+#if defined(_MM_MASK_DENORM)
+#define SIMDE_MM_MASK_DENORM _MM_MASK_DENORM
+#else
+#define SIMDE_MM_MASK_DENORM (0x0100)
+#endif
+#if defined(_MM_MASK_DIV_ZERO)
+#define SIMDE_MM_MASK_DIV_ZERO _MM_MASK_DIV_ZERO
+#else
+#define SIMDE_MM_MASK_DIV_ZERO (0x0200)
+#endif
+#if defined(_MM_MASK_OVERFLOW)
+#define SIMDE_MM_MASK_OVERFLOW _MM_MASK_OVERFLOW
+#else
+#define SIMDE_MM_MASK_OVERFLOW (0x0400)
+#endif
+#if defined(_MM_MASK_UNDERFLOW)
+#define SIMDE_MM_MASK_UNDERFLOW _MM_MASK_UNDERFLOW
+#else
+#define SIMDE_MM_MASK_UNDERFLOW (0x0800)
+#endif
+#if defined(_MM_MASK_INEXACT)
+#define SIMDE_MM_MASK_INEXACT _MM_MASK_INEXACT
+#else
+#define SIMDE_MM_MASK_INEXACT (0x1000)
+#endif
+#if defined(_MM_MASK_MASK)
+#define SIMDE_MM_MASK_MASK _MM_MASK_MASK
+#else
+#define SIMDE_MM_MASK_MASK                                 \
+	(SIMDE_MM_MASK_INVALID | SIMDE_MM_MASK_DENORM |    \
+	 SIMDE_MM_MASK_DIV_ZERO | SIMDE_MM_MASK_OVERFLOW | \
+	 SIMDE_MM_MASK_UNDERFLOW | SIMDE_MM_MASK_INEXACT)
+#endif
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#define _MM_MASK_INVALID SIMDE_MM_MASK_INVALID
+#define _MM_MASK_DENORM SIMDE_MM_MASK_DENORM
+#define _MM_MASK_DIV_ZERO SIMDE_MM_MASK_DIV_ZERO
+#define _MM_MASK_OVERFLOW SIMDE_MM_MASK_OVERFLOW
+#define _MM_MASK_UNDERFLOW SIMDE_MM_MASK_UNDERFLOW
+#define _MM_MASK_INEXACT SIMDE_MM_MASK_INEXACT
+#define _MM_MASK_MASK SIMDE_MM_MASK_MASK
+#endif
+
+#if defined(_MM_FLUSH_ZERO_MASK)
+#define SIMDE_MM_FLUSH_ZERO_MASK _MM_FLUSH_ZERO_MASK
+#else
+#define SIMDE_MM_FLUSH_ZERO_MASK (0x8000)
+#endif
+#if defined(_MM_FLUSH_ZERO_ON)
+#define SIMDE_MM_FLUSH_ZERO_ON _MM_FLUSH_ZERO_ON
+#else
+#define SIMDE_MM_FLUSH_ZERO_ON (0x8000)
+#endif
+#if defined(_MM_FLUSH_ZERO_OFF)
+#define SIMDE_MM_FLUSH_ZERO_OFF _MM_FLUSH_ZERO_OFF
+#else
+#define SIMDE_MM_FLUSH_ZERO_OFF (0x0000)
+#endif
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#define _MM_FLUSH_ZERO_MASK SIMDE_MM_FLUSH_ZERO_MASK
+#define _MM_FLUSH_ZERO_ON SIMDE_MM_FLUSH_ZERO_ON
+#define _MM_FLUSH_ZERO_OFF SIMDE_MM_FLUSH_ZERO_OFF
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
@@ -381,6 +512,32 @@ void SIMDE_MM_SET_ROUNDING_MODE(unsigned int a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
+uint32_t SIMDE_MM_GET_FLUSH_ZERO_MODE(void)
+{
+#if defined(SIMDE_X86_SSE_NATIVE)
+	return _mm_getcsr() & _MM_FLUSH_ZERO_MASK;
+#else
+	return SIMDE_MM_FLUSH_ZERO_OFF;
+#endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#define _MM_SET_FLUSH_ZERO_MODE(a) SIMDE_MM_SET_FLUSH_ZERO_MODE(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void SIMDE_MM_SET_FLUSH_ZERO_MODE(uint32_t a)
+{
+#if defined(SIMDE_X86_SSE_NATIVE)
+	_MM_SET_FLUSH_ZERO_MODE(a);
+#else
+	(void)a;
+#endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#define _MM_SET_FLUSH_ZERO_MODE(a) SIMDE_MM_SET_FLUSH_ZERO_MODE(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
 uint32_t simde_mm_getcsr(void)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
@@ -429,7 +586,8 @@ simde__m128 simde_x_mm_round_ps(simde__m128 a, int rounding, int lax_rounding)
 
 	switch (rounding & ~SIMDE_MM_FROUND_NO_EXC) {
 	case SIMDE_MM_FROUND_CUR_DIRECTION:
-#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 		r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(
 			SIMDE_POWER_ALTIVEC_VECTOR(float),
 			vec_round(a_.altivec_f32));
@@ -447,7 +605,8 @@ simde__m128 simde_x_mm_round_ps(simde__m128 a, int rounding, int lax_rounding)
 		break;
 
 	case SIMDE_MM_FROUND_TO_NEAREST_INT:
-#if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 		r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(
 			SIMDE_POWER_ALTIVEC_VECTOR(float),
 			vec_rint(a_.altivec_f32));
@@ -465,7 +624,8 @@ simde__m128 simde_x_mm_round_ps(simde__m128 a, int rounding, int lax_rounding)
 		break;
 
 	case SIMDE_MM_FROUND_TO_NEG_INF:
-#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 		r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(
 			SIMDE_POWER_ALTIVEC_VECTOR(float),
 			vec_floor(a_.altivec_f32));
@@ -483,7 +643,8 @@ simde__m128 simde_x_mm_round_ps(simde__m128 a, int rounding, int lax_rounding)
 		break;
 
 	case SIMDE_MM_FROUND_TO_POS_INF:
-#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 		r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(
 			SIMDE_POWER_ALTIVEC_VECTOR(float),
 			vec_ceil(a_.altivec_f32));
@@ -501,7 +662,8 @@ simde__m128 simde_x_mm_round_ps(simde__m128 a, int rounding, int lax_rounding)
 		break;
 
 	case SIMDE_MM_FROUND_TO_ZERO:
-#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 		r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(
 			SIMDE_POWER_ALTIVEC_VECTOR(float),
 			vec_trunc(a_.altivec_f32));
@@ -568,7 +730,8 @@ simde__m128 simde_mm_set_ps1(simde_float32 a)
 	return _mm_set_ps1(a);
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
 	return vdupq_n_f32(a);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 	(void)a;
 	return vec_splats(a);
 #else
@@ -590,19 +753,19 @@ simde__m128 simde_mm_move_ss(simde__m128 a, simde__m128 b)
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#if defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, b_.f32, 4, 1, 2, 3);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
 	r_.neon_f32 =
 		vsetq_lane_f32(vgetq_lane_f32(b_.neon_f32, 0), a_.neon_f32, 0);
 #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)
-	m = {16, 17, 18, 19, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-	r_.altivec_f32 = vec_perm(a_.altivec_f32, b_.altivec_f32, m);
+	static const SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)
+		m = {~0U, 0U, 0U, 0U};
+	r_.altivec_f32 = vec_sel(a_.altivec_f32, b_.altivec_f32, m);
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_v8x16_shuffle(b_.wasm_v128, a_.wasm_v128, 0, 1, 2,
+	r_.wasm_v128 = wasm_i8x16_shuffle(b_.wasm_v128, a_.wasm_v128, 0, 1, 2,
 					  3, 20, 21, 22, 23, 24, 25, 26, 27, 28,
 					  29, 30, 31);
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, b_.f32, 4, 1, 2, 3);
 #else
 	r_.f32[0] = b_.f32[0];
 	r_.f32[1] = a_.f32[1];
@@ -616,6 +779,35 @@ simde__m128 simde_mm_move_ss(simde__m128 a, simde__m128 b)
 #if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
 #define _mm_move_ss(a, b) simde_mm_move_ss((a), (b))
 #endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128 simde_x_mm_broadcastlow_ps(simde__m128 a)
+{
+	/* This function broadcasts the first element in the inpu vector to
+   * all lanes.  It is used to avoid generating spurious exceptions in
+   * *_ss functions since there may be garbage in the upper lanes. */
+
+#if defined(SIMDE_X86_SSE_NATIVE)
+	return _mm_shuffle_ps(a, a, 0);
+#else
+	simde__m128_private r_, a_ = simde__m128_to_private(a);
+
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f32 = vdupq_laneq_f32(a_.neon_f32, 0);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_f32 = vec_splat(a_.altivec_f32, 0);
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, a_.f32, 0, 0, 0, 0);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f32) / sizeof(r_.f32[0])); i++) {
+		r_.f32[i] = a_.f32[0];
+	}
+#endif
+
+	return simde__m128_from_private(r_);
+#endif
+}
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128 simde_mm_add_ps(simde__m128 a, simde__m128 b)
@@ -653,8 +845,12 @@ simde__m128 simde_mm_add_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_add_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_add_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(a,
+				simde_mm_add_ps(simde_x_mm_broadcastlow_ps(a),
+						simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
@@ -722,7 +918,8 @@ simde__m128 simde_mm_andnot_ps(simde__m128 a, simde__m128 b)
 	r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
 	r_.wasm_v128 = wasm_v128_andnot(b_.wasm_v128, a_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 	r_.altivec_f32 = vec_andc(b_.altivec_f32, a_.altivec_f32);
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
 	r_.i32 = ~a_.i32 & b_.i32;
@@ -858,7 +1055,8 @@ simde__m128 simde_x_mm_select_ps(simde__m128 a, simde__m128 b, simde__m128 mask)
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
 	r_.wasm_v128 = wasm_v128_bitselect(b_.wasm_v128, a_.wasm_v128,
 					   mask_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
 	r_.altivec_i32 =
 		vec_sel(a_.altivec_i32, b_.altivec_i32, mask_.altivec_u32);
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
@@ -888,7 +1086,7 @@ simde__m64 simde_mm_avg_pu16(simde__m64 a, simde__m64 b)
 	r_.neon_u16 = vrhadd_u16(b_.neon_u16, a_.neon_u16);
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) &&      \
 	defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && \
-	defined(SIMDE_CONVERT_VECTOR_)
+	defined(SIMDE_CONVERT_VECTOR_) && !defined(SIMDE_BUG_GCC_100761)
 	uint32_t wa SIMDE_VECTOR(16);
 	uint32_t wb SIMDE_VECTOR(16);
 	uint32_t wr SIMDE_VECTOR(16);
@@ -925,7 +1123,7 @@ simde__m64 simde_mm_avg_pu8(simde__m64 a, simde__m64 b)
 	r_.neon_u8 = vrhadd_u8(b_.neon_u8, a_.neon_u8);
 #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) &&      \
 	defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && \
-	defined(SIMDE_CONVERT_VECTOR_)
+	defined(SIMDE_CONVERT_VECTOR_) && !defined(SIMDE_BUG_GCC_100761)
 	uint16_t wa SIMDE_VECTOR(16);
 	uint16_t wb SIMDE_VECTOR(16);
 	uint16_t wr SIMDE_VECTOR(16);
@@ -952,15 +1150,18 @@ simde__m64 simde_mm_avg_pu8(simde__m64 a, simde__m64 b)
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128 simde_x_mm_abs_ps(simde__m128 a)
 {
-#if defined(SIMDE_X86_AVX512F_NATIVE) && \
-	(!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7, 1, 0))
-	return _mm512_castps512_ps128(_mm512_abs_ps(_mm512_castps128_ps512(a)));
+#if defined(SIMDE_X86_SSE_NATIVE)
+	simde_float32 mask_;
+	uint32_t u32_ = UINT32_C(0x7FFFFFFF);
+	simde_memcpy(&mask_, &u32_, sizeof(u32_));
+	return _mm_and_ps(_mm_set1_ps(mask_), a);
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a);
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
 	r_.neon_f32 = vabsq_f32(a_.neon_f32);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 	r_.altivec_f32 = vec_abs(a_.altivec_f32);
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
 	r_.wasm_v128 = wasm_f32x4_abs(a_.wasm_v128);
@@ -988,7 +1189,8 @@ simde__m128 simde_mm_cmpeq_ps(simde__m128 a, simde__m128 b)
 	r_.neon_u32 = vceqq_f32(a_.neon_f32, b_.neon_f32);
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
 	r_.wasm_v128 = wasm_f32x4_eq(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 	r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(
 		SIMDE_POWER_ALTIVEC_VECTOR(float),
 		vec_cmpeq(a_.altivec_f32, b_.altivec_f32));
@@ -1014,8 +1216,12 @@ simde__m128 simde_mm_cmpeq_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_cmpeq_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_cmpeq_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(
+		a, simde_mm_cmpeq_ps(simde_x_mm_broadcastlow_ps(a),
+				     simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
@@ -1072,8 +1278,12 @@ simde__m128 simde_mm_cmpge_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE) && !defined(__PGI)
 	return _mm_cmpge_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_cmpge_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(
+		a, simde_mm_cmpge_ps(simde_x_mm_broadcastlow_ps(a),
+				     simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
@@ -1130,8 +1340,12 @@ simde__m128 simde_mm_cmpgt_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE) && !defined(__PGI)
 	return _mm_cmpgt_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_cmpgt_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(
+		a, simde_mm_cmpgt_ps(simde_x_mm_broadcastlow_ps(a),
+				     simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
@@ -1188,8 +1402,12 @@ simde__m128 simde_mm_cmple_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_cmple_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_cmple_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(
+		a, simde_mm_cmple_ps(simde_x_mm_broadcastlow_ps(a),
+				     simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
@@ -1246,8 +1464,12 @@ simde__m128 simde_mm_cmplt_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_cmplt_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_cmplt_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(
+		a, simde_mm_cmplt_ps(simde_x_mm_broadcastlow_ps(a),
+				     simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
@@ -1278,17 +1500,8 @@ simde__m128 simde_mm_cmpneq_ps(simde__m128 a, simde__m128 b)
 	r_.neon_u32 = vmvnq_u32(vceqq_f32(a_.neon_f32, b_.neon_f32));
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
 	r_.wasm_v128 = wasm_f32x4_ne(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P9_NATIVE) && SIMDE_ARCH_POWER_CHECK(900) && \
-	!defined(HEDLEY_IBM_VERSION)
-	/* vec_cmpne(SIMDE_POWER_ALTIVEC_VECTOR(float), SIMDE_POWER_ALTIVEC_VECTOR(float))
-        is missing from XL C/C++ v16.1.1,
-        though the documentation (table 89 on page 432 of the IBM XL C/C++ for
-        Linux Compiler Reference, Version 16.1.1) shows that it should be
-        present.  Both GCC and clang support it. */
-	r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(
-		SIMDE_POWER_ALTIVEC_VECTOR(float),
-		vec_cmpne(a_.altivec_f32, b_.altivec_f32));
-#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 	r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(
 		SIMDE_POWER_ALTIVEC_VECTOR(float),
 		vec_cmpeq(a_.altivec_f32, b_.altivec_f32));
@@ -1317,8 +1530,12 @@ simde__m128 simde_mm_cmpneq_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_cmpneq_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_cmpneq_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(
+		a, simde_mm_cmpneq_ps(simde_x_mm_broadcastlow_ps(a),
+				      simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
@@ -1506,8 +1723,12 @@ simde__m128 simde_mm_cmpunord_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE) && !defined(__PGI)
 	return _mm_cmpunord_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_cmpunord_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(
+		a, simde_mm_cmpunord_ps(simde_x_mm_broadcastlow_ps(a),
+					simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
@@ -1690,13 +1911,14 @@ simde__m128 simde_x_mm_copysign_ps(simde__m128 dest, simde__m128 src)
 	const v128_t sign_pos = wasm_f32x4_splat(-0.0f);
 	r_.wasm_v128 =
 		wasm_v128_bitselect(src_.wasm_v128, dest_.wasm_v128, sign_pos);
-#elif defined(SIMDE_POWER_ALTIVEC_P9_NATIVE)
-#if !defined(HEDLEY_IBM_VERSION)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#if defined(SIMDE_BUG_VEC_CPSGN_REVERSED_ARGS)
 	r_.altivec_f32 = vec_cpsgn(dest_.altivec_f32, src_.altivec_f32);
 #else
 	r_.altivec_f32 = vec_cpsgn(src_.altivec_f32, dest_.altivec_f32);
 #endif
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 	const SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)
 		sign_pos = HEDLEY_REINTERPRET_CAST(
 			SIMDE_POWER_ALTIVEC_VECTOR(unsigned int),
@@ -1767,7 +1989,8 @@ simde__m64 simde_mm_cvt_ps2pi(simde__m128 a)
 	a_ = simde__m128_to_private(
 		simde_mm_round_ps(a, SIMDE_MM_FROUND_CUR_DIRECTION));
 	r_.neon_i32 = vcvt_s32_f32(vget_low_f32(a_.neon_f32));
-#elif defined(SIMDE_CONVERT_VECTOR_) && SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+#elif defined(SIMDE_CONVERT_VECTOR_) && SIMDE_NATURAL_VECTOR_SIZE_GE(128) && \
+	!defined(SIMDE_BUG_GCC_100761)
 	a_ = simde__m128_to_private(
 		simde_mm_round_ps(a, SIMDE_MM_FROUND_CUR_DIRECTION));
 	SIMDE_CONVERT_VECTOR_(r_.i32, a_.m64_private[0].f32);
@@ -1818,12 +2041,20 @@ int32_t simde_mm_cvt_ss2si(simde__m128 a)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_cvt_ss2si(a);
-#elif defined(SIMDE_ARM_NEON_A32V8_NATIVE) && !defined(SIMDE_BUG_GCC_95399)
+#elif defined(SIMDE_ARM_NEON_A32V8_NATIVE) && \
+	defined(SIMDE_FAST_CONVERSION_RANGE) && !defined(SIMDE_BUG_GCC_95399)
 	return vgetq_lane_s32(vcvtnq_s32_f32(simde__m128_to_neon_f32(a)), 0);
 #else
 	simde__m128_private a_ = simde__m128_to_private(
 		simde_mm_round_ps(a, SIMDE_MM_FROUND_CUR_DIRECTION));
+#if !defined(SIMDE_FAST_CONVERSION_RANGE)
+	return ((a_.f32[0] > HEDLEY_STATIC_CAST(simde_float32, INT32_MIN)) &&
+		(a_.f32[0] < HEDLEY_STATIC_CAST(simde_float32, INT32_MAX)))
+		       ? SIMDE_CONVERT_FTOI(int32_t, a_.f32[0])
+		       : INT32_MIN;
+#else
 	return SIMDE_CONVERT_FTOI(int32_t, a_.f32[0]);
+#endif
 #endif
 }
 #if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
@@ -2147,7 +2378,8 @@ simde__m128 simde_mm_cvtsi64_ss(simde__m128 a, int64_t b)
 	return simde__m128_from_private(r_);
 #endif
 }
-#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
 #define _mm_cvtsi64_ss(a, b) simde_mm_cvtsi64_ss((a), b)
 #endif
 
@@ -2197,7 +2429,8 @@ int64_t simde_mm_cvtss_si64(simde__m128 a)
 #endif
 #endif
 }
-#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
 #define _mm_cvtss_si64(a) simde_mm_cvtss_si64((a))
 #endif
 
@@ -2286,7 +2519,8 @@ int64_t simde_mm_cvttss_si64(simde__m128 a)
 #endif
 #endif
 }
-#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
 #define _mm_cvttss_si64(a) simde_mm_cvttss_si64((a))
 #endif
 
@@ -2295,8 +2529,12 @@ simde__m128 simde_mm_cmpord_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_cmpord_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_cmpord_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(
+		a, simde_mm_cmpord_ps(simde_x_mm_broadcastlow_ps(a),
+				      simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a);
 
@@ -2361,8 +2599,12 @@ simde__m128 simde_mm_div_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_div_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_div_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(a,
+				simde_mm_div_ps(simde_x_mm_broadcastlow_ps(a),
+						simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
@@ -2735,9 +2977,12 @@ simde__m128 simde_mm_max_ps(simde__m128 a, simde__m128 b)
 	r_.wasm_v128 =
 		wasm_v128_bitselect(a_.wasm_v128, b_.wasm_v128,
 				    wasm_f32x4_gt(a_.wasm_v128, b_.wasm_v128));
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_FAST_NANS)
+#elif (defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) ||  \
+       defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)) && \
+	defined(SIMDE_FAST_NANS)
 	r_.altivec_f32 = vec_max(a_.altivec_f32, b_.altivec_f32);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 	r_.altivec_f32 = vec_sel(b_.altivec_f32, a_.altivec_f32,
 				 vec_cmpgt(a_.altivec_f32, b_.altivec_f32));
 #else
@@ -2786,8 +3031,12 @@ simde__m128 simde_mm_max_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_max_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_max_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(a,
+				simde_mm_max_ps(simde_x_mm_broadcastlow_ps(a),
+						simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
@@ -2841,44 +3090,35 @@ simde__m128 simde_mm_min_ps(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_min_ps(a, b);
-#elif defined(SIMDE_FAST_NANS) && defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	return simde__m128_from_neon_f32(vminq_f32(simde__m128_to_neon_f32(a),
-						   simde__m128_to_neon_f32(b)));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	simde__m128_private r_, a_ = simde__m128_to_private(a),
-				b_ = simde__m128_to_private(b);
-#if defined(SIMDE_FAST_NANS)
-	r_.wasm_v128 = wasm_f32x4_min(a_.wasm_v128, b_.wasm_v128);
 #else
-	r_.wasm_v128 =
-		wasm_v128_bitselect(a_.wasm_v128, b_.wasm_v128,
-				    wasm_f32x4_lt(a_.wasm_v128, b_.wasm_v128));
-#endif
-	return simde__m128_from_private(r_);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
 
+#if defined(SIMDE_FAST_NANS) && defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_f32 = vminq_f32(a_.neon_f32, b_.neon_f32);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f32x4_pmin(b_.wasm_v128, a_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 #if defined(SIMDE_FAST_NANS)
 	r_.altivec_f32 = vec_min(a_.altivec_f32, b_.altivec_f32);
 #else
 	r_.altivec_f32 = vec_sel(b_.altivec_f32, a_.altivec_f32,
 				 vec_cmpgt(b_.altivec_f32, a_.altivec_f32));
 #endif
-
-	return simde__m128_from_private(r_);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	simde__m128 mask = simde_mm_cmplt_ps(a, b);
-	return simde_mm_or_ps(simde_mm_and_ps(mask, a),
-			      simde_mm_andnot_ps(mask, b));
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	uint32_t SIMDE_VECTOR(16)
+		m = HEDLEY_REINTERPRET_CAST(__typeof__(m), a_.f32 < b_.f32);
+	r_.f32 = HEDLEY_REINTERPRET_CAST(
+		__typeof__(r_.f32),
+		((HEDLEY_REINTERPRET_CAST(__typeof__(m), a_.f32) & m) |
+		 (HEDLEY_REINTERPRET_CAST(__typeof__(m), b_.f32) & ~m)));
 #else
-	simde__m128_private r_, a_ = simde__m128_to_private(a),
-				b_ = simde__m128_to_private(b);
-
 	SIMDE_VECTORIZE
 	for (size_t i = 0; i < (sizeof(r_.f32) / sizeof(r_.f32[0])); i++) {
 		r_.f32[i] = (a_.f32[i] < b_.f32[i]) ? a_.f32[i] : b_.f32[i];
 	}
+#endif
 
 	return simde__m128_from_private(r_);
 #endif
@@ -2919,8 +3159,12 @@ simde__m128 simde_mm_min_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_min_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_min_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(a,
+				simde_mm_min_ps(simde_x_mm_broadcastlow_ps(a),
+						simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
@@ -2956,7 +3200,8 @@ simde__m128 simde_mm_movehl_ps(simde__m128 a, simde__m128 b)
 	float32x2_t a32 = vget_high_f32(a_.neon_f32);
 	float32x2_t b32 = vget_high_f32(b_.neon_f32);
 	r_.neon_f32 = vcombine_f32(b32, a32);
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
 	r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(
 		SIMDE_POWER_ALTIVEC_VECTOR(float),
 		vec_mergel(b_.altivec_i64, a_.altivec_i64));
@@ -2985,13 +3230,14 @@ simde__m128 simde_mm_movelh_ps(simde__m128 a, simde__m128 b)
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#if defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, b_.f32, 0, 1, 4, 5);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
 	float32x2_t a10 = vget_low_f32(a_.neon_f32);
 	float32x2_t b10 = vget_low_f32(b_.neon_f32);
 	r_.neon_f32 = vcombine_f32(a10, b10);
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, b_.f32, 0, 1, 4, 5);
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
 	r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(
 		SIMDE_POWER_ALTIVEC_VECTOR(float),
 		vec_mergeh(a_.altivec_i64, b_.altivec_i64));
@@ -3053,12 +3299,7 @@ int simde_mm_movemask_ps(simde__m128 a)
 	int r = 0;
 	simde__m128_private a_ = simde__m128_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	static const int32_t shift_amount[] = {0, 1, 2, 3};
-	const int32x4_t shift = vld1q_s32(shift_amount);
-	uint32x4_t tmp = vshrq_n_u32(a_.neon_u32, 31);
-	return HEDLEY_STATIC_CAST(int, vaddvq_u32(vshlq_u32(tmp, shift)));
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
 	// Shift out everything but the sign bits with a 32-bit unsigned shift right.
 	uint64x2_t high_bits =
 		vreinterpretq_u64_u32(vshrq_n_u32(a_.neon_u32, 31));
@@ -3067,6 +3308,48 @@ int simde_mm_movemask_ps(simde__m128 a)
 		vreinterpretq_u8_u64(vsraq_n_u64(high_bits, high_bits, 31));
 	// Extract the result.
 	return vgetq_lane_u8(paired, 0) | (vgetq_lane_u8(paired, 8) << 2);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	static const uint32_t md[4] = {1 << 0, 1 << 1, 1 << 2, 1 << 3};
+
+	uint32x4_t extended =
+		vreinterpretq_u32_s32(vshrq_n_s32(a_.neon_i32, 31));
+	uint32x4_t masked = vandq_u32(vld1q_u32(md), extended);
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return HEDLEY_STATIC_CAST(int32_t, vaddvq_u32(masked));
+#else
+	uint64x2_t t64 = vpaddlq_u32(masked);
+	return HEDLEY_STATIC_CAST(int, vgetq_lane_u64(t64, 0)) +
+	       HEDLEY_STATIC_CAST(int, vgetq_lane_u64(t64, 1));
+#endif
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && defined(SIMDE_BUG_CLANG_50932)
+	SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)
+	idx = {96,  64,  32,  0,   128, 128, 128, 128,
+	       128, 128, 128, 128, 128, 128, 128, 128};
+	SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)
+	res = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(unsigned char),
+		vec_bperm(HEDLEY_REINTERPRET_CAST(
+				  SIMDE_POWER_ALTIVEC_VECTOR(unsigned __int128),
+				  a_.altivec_u64),
+			  idx));
+	return HEDLEY_STATIC_CAST(
+		int32_t,
+		vec_extract(HEDLEY_REINTERPRET_CAST(
+				    SIMDE_POWER_ALTIVEC_VECTOR(signed int),
+				    res),
+			    2));
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+	SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)
+	idx = {96,  64,  32,  0,   128, 128, 128, 128,
+	       128, 128, 128, 128, 128, 128, 128, 128};
+	SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)
+	res = vec_bperm(a_.altivec_u8, idx);
+	return HEDLEY_STATIC_CAST(
+		int32_t,
+		vec_extract(HEDLEY_REINTERPRET_CAST(
+				    SIMDE_POWER_ALTIVEC_VECTOR(signed int),
+				    res),
+			    2));
 #else
 	SIMDE_VECTORIZE_REDUCTION(| : r)
 	for (size_t i = 0; i < sizeof(a_.u32) / sizeof(a_.u32[0]); i++) {
@@ -3117,8 +3400,12 @@ simde__m128 simde_mm_mul_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_mul_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_mul_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(a,
+				simde_mm_mul_ps(simde_x_mm_broadcastlow_ps(a),
+						simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
@@ -3249,10 +3536,7 @@ simde__m128 simde_x_mm_negate_ps(simde__m128 a)
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a);
 
-#if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
-	(!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8, 1, 0))
-	r_.altivec_f32 = vec_neg(a_.altivec_f32);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
 	r_.neon_f32 = vnegq_f32(a_.neon_f32);
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
 	r_.wasm_v128 = wasm_f32x4_neg(a_.wasm_v128);
@@ -3326,8 +3610,11 @@ simde__m128 simde_mm_rcp_ss(simde__m128 a)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_rcp_ss(a);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_rcp_ps(a));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(a,
+				simde_mm_rcp_ps(simde_x_mm_broadcastlow_ps(a)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a);
 
@@ -3406,8 +3693,11 @@ simde__m128 simde_mm_rsqrt_ss(simde__m128 a)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_rsqrt_ss(a);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_rsqrt_ps(a));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(
+		a, simde_mm_rsqrt_ps(simde_x_mm_broadcastlow_ps(a)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a);
 
@@ -3471,25 +3761,24 @@ simde__m64 simde_mm_sad_pu8(simde__m64 a, simde__m64 b)
 			       b_ = simde__m64_to_private(b);
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	uint16x4_t t = vpaddl_u8(vabd_u8(a_.neon_u8, b_.neon_u8));
-	uint16_t r0 = t[0] + t[1] + t[2] + t[3];
-	r_.neon_u16 = vset_lane_u16(r0, vdup_n_u16(0), 0);
+	uint64x1_t t = vpaddl_u32(
+		vpaddl_u16(vpaddl_u8(vabd_u8(a_.neon_u8, b_.neon_u8))));
+	r_.neon_u16 =
+		vset_lane_u16(HEDLEY_STATIC_CAST(uint64_t, vget_lane_u64(t, 0)),
+			      vdup_n_u16(0), 0);
 #else
 	uint16_t sum = 0;
 
-#if defined(SIMDE_HAVE_STDLIB_H)
 	SIMDE_VECTORIZE_REDUCTION(+ : sum)
 	for (size_t i = 0; i < (sizeof(r_.u8) / sizeof(r_.u8[0])); i++) {
-		sum += HEDLEY_STATIC_CAST(uint8_t, abs(a_.u8[i] - b_.u8[i]));
+		sum += HEDLEY_STATIC_CAST(uint8_t,
+					  simde_math_abs(a_.u8[i] - b_.u8[i]));
 	}
 
 	r_.i16[0] = HEDLEY_STATIC_CAST(int16_t, sum);
 	r_.i16[1] = 0;
 	r_.i16[2] = 0;
 	r_.i16[3] = 0;
-#else
-	HEDLEY_UNREACHABLE();
-#endif
 #endif
 
 	return simde__m64_from_private(r_);
@@ -3668,31 +3957,6 @@ simde__m64 simde_mm_shuffle_pi16(simde__m64 a, const int imm8)
 #define _m_pshufw(a, imm8) simde_mm_shuffle_pi16(a, imm8)
 #endif
 
-#if defined(SIMDE_X86_SSE_NATIVE) && !defined(__PGI)
-#define simde_mm_shuffle_ps(a, b, imm8) _mm_shuffle_ps(a, b, imm8)
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#define simde_mm_shuffle_ps(a, b, imm8)                                      \
-	__extension__({                                                      \
-		float32x4_t ret;                                             \
-		ret = vmovq_n_f32(vgetq_lane_f32(a, (imm8) & (0x3)));        \
-		ret = vsetq_lane_f32(vgetq_lane_f32(a, ((imm8) >> 2) & 0x3), \
-				     ret, 1);                                \
-		ret = vsetq_lane_f32(vgetq_lane_f32(b, ((imm8) >> 4) & 0x3), \
-				     ret, 2);                                \
-		ret = vsetq_lane_f32(vgetq_lane_f32(b, ((imm8) >> 6) & 0x3), \
-				     ret, 3);                                \
-	})
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-#define simde_mm_shuffle_ps(a, b, imm8)                                        \
-	(__extension__({                                                       \
-		simde__m128_from_private((simde__m128_private){                \
-			.f32 = SIMDE_SHUFFLE_VECTOR_(                          \
-				32, 16, simde__m128_to_private(a).f32,         \
-				simde__m128_to_private(b).f32, (((imm8)) & 3), \
-				(((imm8) >> 2) & 3), (((imm8) >> 4) & 3) + 4,  \
-				(((imm8) >> 6) & 3) + 4)});                    \
-	}))
-#else
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128 simde_mm_shuffle_ps(simde__m128 a, simde__m128 b, const int imm8)
 	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
@@ -3707,6 +3971,41 @@ simde__m128 simde_mm_shuffle_ps(simde__m128 a, simde__m128 b, const int imm8)
 
 	return simde__m128_from_private(r_);
 }
+#if defined(SIMDE_X86_SSE_NATIVE) && !defined(__PGI)
+#define simde_mm_shuffle_ps(a, b, imm8) _mm_shuffle_ps(a, b, imm8)
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+#define simde_mm_shuffle_ps(a, b, imm8)                                        \
+	(__extension__({                                                       \
+		simde__m128_from_private((simde__m128_private){                \
+			.f32 = SIMDE_SHUFFLE_VECTOR_(                          \
+				32, 16, simde__m128_to_private(a).f32,         \
+				simde__m128_to_private(b).f32, (((imm8)) & 3), \
+				(((imm8) >> 2) & 3), (((imm8) >> 4) & 3) + 4,  \
+				(((imm8) >> 6) & 3) + 4)});                    \
+	}))
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_STATEMENT_EXPR_)
+#define simde_mm_shuffle_ps(a, b, imm8)                                       \
+	(__extension__({                                                      \
+		float32x4_t simde_mm_shuffle_ps_a_ =                          \
+			simde__m128i_to_neon_f32(a);                          \
+		float32x4_t simde_mm_shuffle_ps_b_ =                          \
+			simde__m128i_to_neon_f32(b);                          \
+		float32x4_t simde_mm_shuffle_ps_r_;                           \
+                                                                              \
+		simde_mm_shuffle_ps_r_ = vmovq_n_f32(vgetq_lane_f32(          \
+			simde_mm_shuffle_ps_a_, (imm8) & (0x3)));             \
+		simde_mm_shuffle_ps_r_ =                                      \
+			vsetq_lane_f32(vgetq_lane_f32(simde_mm_shuffle_ps_a_, \
+						      ((imm8) >> 2) & 0x3),   \
+				       simde_mm_shuffle_ps_r_, 1);            \
+		simde_mm_shuffle_ps_r_ =                                      \
+			vsetq_lane_f32(vgetq_lane_f32(simde_mm_shuffle_ps_b_, \
+						      ((imm8) >> 4) & 0x3),   \
+				       simde_mm_shuffle_ps_r_, 2);            \
+		vsetq_lane_f32(vgetq_lane_f32(simde_mm_shuffle_ps_b_,         \
+					      ((imm8) >> 6) & 0x3),           \
+			       simde_mm_shuffle_ps_r_, 3);                    \
+	}))
 #endif
 #if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
 #define _mm_shuffle_ps(a, b, imm8) simde_mm_shuffle_ps((a), (b), imm8)
@@ -3731,7 +4030,8 @@ simde__m128 simde_mm_sqrt_ps(simde__m128 a)
 	r_.neon_f32 = vmulq_f32(a_.neon_f32, est);
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
 	r_.wasm_v128 = wasm_f32x4_sqrt(a_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_14_NATIVE)
 	r_.altivec_f32 = vec_sqrt(a_.altivec_f32);
 #elif defined(simde_math_sqrt)
 	SIMDE_VECTORIZE
@@ -3754,8 +4054,11 @@ simde__m128 simde_mm_sqrt_ss(simde__m128 a)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_sqrt_ss(a);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_sqrt_ps(a));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(
+		a, simde_mm_sqrt_ps(simde_x_mm_broadcastlow_ps(a)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a);
 
@@ -3820,7 +4123,7 @@ void simde_mm_store1_ps(simde_float32 mem_addr[4], simde__m128 a)
 	vst1q_f32(mem_addr_, vdupq_lane_f32(vget_low_f32(a_.neon_f32), 0));
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
 	wasm_v128_store(mem_addr_,
-			wasm_v32x4_shuffle(a_.wasm_v128, a_.wasm_v128, 0, 0, 0,
+			wasm_i32x4_shuffle(a_.wasm_v128, a_.wasm_v128, 0, 0, 0,
 					   0));
 #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
 	vec_st(vec_splat(a_.altivec_f32, 0), 0, mem_addr_);
@@ -4004,8 +4307,12 @@ simde__m128 simde_mm_sub_ss(simde__m128 a, simde__m128 b)
 {
 #if defined(SIMDE_X86_SSE_NATIVE)
 	return _mm_sub_ss(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
 	return simde_mm_move_ss(a, simde_mm_sub_ps(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_ss(a,
+				simde_mm_sub_ps(simde_x_mm_broadcastlow_ps(a),
+						simde_x_mm_broadcastlow_ps(b)));
 #else
 	simde__m128_private r_, a_ = simde__m128_to_private(a),
 				b_ = simde__m128_to_private(b);
@@ -4345,131 +4652,55 @@ void simde_mm_stream_ps(simde_float32 mem_addr[4], simde__m128 a)
 			   (a))
 #endif
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#define SIMDE_MM_TRANSPOSE4_PS(row0, row1, row2, row3)            \
-	do {                                                      \
-		float32x4x2_t ROW01 = vtrnq_f32(row0, row1);      \
-		float32x4x2_t ROW23 = vtrnq_f32(row2, row3);      \
-		row0 = vcombine_f32(vget_low_f32(ROW01.val[0]),   \
-				    vget_low_f32(ROW23.val[0]));  \
-		row1 = vcombine_f32(vget_low_f32(ROW01.val[1]),   \
-				    vget_low_f32(ROW23.val[1]));  \
-		row2 = vcombine_f32(vget_high_f32(ROW01.val[0]),  \
-				    vget_high_f32(ROW23.val[0])); \
-		row3 = vcombine_f32(vget_high_f32(ROW01.val[1]),  \
-				    vget_high_f32(ROW23.val[1])); \
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && \
+	!defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+#define SIMDE_MM_TRANSPOSE4_PS(row0, row1, row2, row3)                       \
+	do {                                                                 \
+		float32x4x2_t SIMDE_MM_TRANSPOSE4_PS_ROW01 =                 \
+			vtrnq_f32(row0, row1);                               \
+		float32x4x2_t SIMDE_MM_TRANSPOSE4_PS_ROW23 =                 \
+			vtrnq_f32(row2, row3);                               \
+		row0 = vcombine_f32(                                         \
+			vget_low_f32(SIMDE_MM_TRANSPOSE4_PS_ROW01.val[0]),   \
+			vget_low_f32(SIMDE_MM_TRANSPOSE4_PS_ROW23.val[0]));  \
+		row1 = vcombine_f32(                                         \
+			vget_low_f32(SIMDE_MM_TRANSPOSE4_PS_ROW01.val[1]),   \
+			vget_low_f32(SIMDE_MM_TRANSPOSE4_PS_ROW23.val[1]));  \
+		row2 = vcombine_f32(                                         \
+			vget_high_f32(SIMDE_MM_TRANSPOSE4_PS_ROW01.val[0]),  \
+			vget_high_f32(SIMDE_MM_TRANSPOSE4_PS_ROW23.val[0])); \
+		row3 = vcombine_f32(                                         \
+			vget_high_f32(SIMDE_MM_TRANSPOSE4_PS_ROW01.val[1]),  \
+			vget_high_f32(SIMDE_MM_TRANSPOSE4_PS_ROW23.val[1])); \
 	} while (0)
 #else
-#define SIMDE_MM_TRANSPOSE4_PS(row0, row1, row2, row3)       \
-	do {                                                 \
-		simde__m128 tmp3, tmp2, tmp1, tmp0;          \
-		tmp0 = simde_mm_unpacklo_ps((row0), (row1)); \
-		tmp2 = simde_mm_unpacklo_ps((row2), (row3)); \
-		tmp1 = simde_mm_unpackhi_ps((row0), (row1)); \
-		tmp3 = simde_mm_unpackhi_ps((row2), (row3)); \
-		row0 = simde_mm_movelh_ps(tmp0, tmp2);       \
-		row1 = simde_mm_movehl_ps(tmp2, tmp0);       \
-		row2 = simde_mm_movelh_ps(tmp1, tmp3);       \
-		row3 = simde_mm_movehl_ps(tmp3, tmp1);       \
+#define SIMDE_MM_TRANSPOSE4_PS(row0, row1, row2, row3)                  \
+	do {                                                            \
+		simde__m128 SIMDE_MM_TRANSPOSE4_PS_tmp3,                \
+			SIMDE_MM_TRANSPOSE4_PS_tmp2,                    \
+			SIMDE_MM_TRANSPOSE4_PS_tmp1,                    \
+			SIMDE_MM_TRANSPOSE4_PS_tmp0;                    \
+		SIMDE_MM_TRANSPOSE4_PS_tmp0 =                           \
+			simde_mm_unpacklo_ps((row0), (row1));           \
+		SIMDE_MM_TRANSPOSE4_PS_tmp2 =                           \
+			simde_mm_unpacklo_ps((row2), (row3));           \
+		SIMDE_MM_TRANSPOSE4_PS_tmp1 =                           \
+			simde_mm_unpackhi_ps((row0), (row1));           \
+		SIMDE_MM_TRANSPOSE4_PS_tmp3 =                           \
+			simde_mm_unpackhi_ps((row2), (row3));           \
+		row0 = simde_mm_movelh_ps(SIMDE_MM_TRANSPOSE4_PS_tmp0,  \
+					  SIMDE_MM_TRANSPOSE4_PS_tmp2); \
+		row1 = simde_mm_movehl_ps(SIMDE_MM_TRANSPOSE4_PS_tmp2,  \
+					  SIMDE_MM_TRANSPOSE4_PS_tmp0); \
+		row2 = simde_mm_movelh_ps(SIMDE_MM_TRANSPOSE4_PS_tmp1,  \
+					  SIMDE_MM_TRANSPOSE4_PS_tmp3); \
+		row3 = simde_mm_movehl_ps(SIMDE_MM_TRANSPOSE4_PS_tmp3,  \
+					  SIMDE_MM_TRANSPOSE4_PS_tmp1); \
 	} while (0)
 #endif
 #if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
 #define _MM_TRANSPOSE4_PS(row0, row1, row2, row3) \
 	SIMDE_MM_TRANSPOSE4_PS(row0, row1, row2, row3)
-#endif
-
-#if defined(_MM_EXCEPT_INVALID)
-#define SIMDE_MM_EXCEPT_INVALID _MM_EXCEPT_INVALID
-#else
-#define SIMDE_MM_EXCEPT_INVALID (0x0001)
-#endif
-#if defined(_MM_EXCEPT_DENORM)
-#define SIMDE_MM_EXCEPT_DENORM _MM_EXCEPT_DENORM
-#else
-#define SIMDE_MM_EXCEPT_DENORM (0x0002)
-#endif
-#if defined(_MM_EXCEPT_DIV_ZERO)
-#define SIMDE_MM_EXCEPT_DIV_ZERO _MM_EXCEPT_DIV_ZERO
-#else
-#define SIMDE_MM_EXCEPT_DIV_ZERO (0x0004)
-#endif
-#if defined(_MM_EXCEPT_OVERFLOW)
-#define SIMDE_MM_EXCEPT_OVERFLOW _MM_EXCEPT_OVERFLOW
-#else
-#define SIMDE_MM_EXCEPT_OVERFLOW (0x0008)
-#endif
-#if defined(_MM_EXCEPT_UNDERFLOW)
-#define SIMDE_MM_EXCEPT_UNDERFLOW _MM_EXCEPT_UNDERFLOW
-#else
-#define SIMDE_MM_EXCEPT_UNDERFLOW (0x0010)
-#endif
-#if defined(_MM_EXCEPT_INEXACT)
-#define SIMDE_MM_EXCEPT_INEXACT _MM_EXCEPT_INEXACT
-#else
-#define SIMDE_MM_EXCEPT_INEXACT (0x0020)
-#endif
-#if defined(_MM_EXCEPT_MASK)
-#define SIMDE_MM_EXCEPT_MASK _MM_EXCEPT_MASK
-#else
-#define SIMDE_MM_EXCEPT_MASK                                   \
-	(SIMDE_MM_EXCEPT_INVALID | SIMDE_MM_EXCEPT_DENORM |    \
-	 SIMDE_MM_EXCEPT_DIV_ZERO | SIMDE_MM_EXCEPT_OVERFLOW | \
-	 SIMDE_MM_EXCEPT_UNDERFLOW | SIMDE_MM_EXCEPT_INEXACT)
-#endif
-
-#if defined(_MM_MASK_INVALID)
-#define SIMDE_MM_MASK_INVALID _MM_MASK_INVALID
-#else
-#define SIMDE_MM_MASK_INVALID (0x0080)
-#endif
-#if defined(_MM_MASK_DENORM)
-#define SIMDE_MM_MASK_DENORM _MM_MASK_DENORM
-#else
-#define SIMDE_MM_MASK_DENORM (0x0100)
-#endif
-#if defined(_MM_MASK_DIV_ZERO)
-#define SIMDE_MM_MASK_DIV_ZERO _MM_MASK_DIV_ZERO
-#else
-#define SIMDE_MM_MASK_DIV_ZERO (0x0200)
-#endif
-#if defined(_MM_MASK_OVERFLOW)
-#define SIMDE_MM_MASK_OVERFLOW _MM_MASK_OVERFLOW
-#else
-#define SIMDE_MM_MASK_OVERFLOW (0x0400)
-#endif
-#if defined(_MM_MASK_UNDERFLOW)
-#define SIMDE_MM_MASK_UNDERFLOW _MM_MASK_UNDERFLOW
-#else
-#define SIMDE_MM_MASK_UNDERFLOW (0x0800)
-#endif
-#if defined(_MM_MASK_INEXACT)
-#define SIMDE_MM_MASK_INEXACT _MM_MASK_INEXACT
-#else
-#define SIMDE_MM_MASK_INEXACT (0x1000)
-#endif
-#if defined(_MM_MASK_MASK)
-#define SIMDE_MM_MASK_MASK _MM_MASK_MASK
-#else
-#define SIMDE_MM_MASK_MASK                                 \
-	(SIMDE_MM_MASK_INVALID | SIMDE_MM_MASK_DENORM |    \
-	 SIMDE_MM_MASK_DIV_ZERO | SIMDE_MM_MASK_OVERFLOW | \
-	 SIMDE_MM_MASK_UNDERFLOW | SIMDE_MM_MASK_INEXACT)
-#endif
-
-#if defined(_MM_FLUSH_ZERO_MASK)
-#define SIMDE_MM_FLUSH_ZERO_MASK _MM_FLUSH_ZERO_MASK
-#else
-#define SIMDE_MM_FLUSH_ZERO_MASK (0x8000)
-#endif
-#if defined(_MM_FLUSH_ZERO_ON)
-#define SIMDE_MM_FLUSH_ZERO_ON _MM_FLUSH_ZERO_ON
-#else
-#define SIMDE_MM_FLUSH_ZERO_ON (0x8000)
-#endif
-#if defined(_MM_FLUSH_ZERO_OFF)
-#define SIMDE_MM_FLUSH_ZERO_OFF _MM_FLUSH_ZERO_OFF
-#else
-#define SIMDE_MM_FLUSH_ZERO_OFF (0x0000)
 #endif
 
 SIMDE_END_DECLS_

--- a/libobs/util/simde/x86/sse2.h
+++ b/libobs/util/simde/x86/sse2.h
@@ -39,456 +39,517 @@ SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
 SIMDE_BEGIN_DECLS_
 
 typedef union {
-  #if defined(SIMDE_VECTOR_SUBSCRIPT)
-    SIMDE_ALIGN_TO_16 int8_t          i8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 int16_t        i16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 int32_t        i32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 int64_t        i64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 uint8_t         u8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 uint16_t       u16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 uint32_t       u32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 uint64_t       u64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    #if defined(SIMDE_HAVE_INT128_)
-    SIMDE_ALIGN_TO_16 simde_int128  i128 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 simde_uint128 u128 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    #endif
-    SIMDE_ALIGN_TO_16 simde_float32  f32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 simde_float64  f64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+#if defined(SIMDE_VECTOR_SUBSCRIPT)
+	SIMDE_ALIGN_TO_16 int8_t i8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 int16_t i16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 int32_t i32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 int64_t i64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 uint8_t u8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 uint16_t u16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 uint32_t u32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 uint64_t u64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+#if defined(SIMDE_HAVE_INT128_)
+	SIMDE_ALIGN_TO_16 simde_int128 i128 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 simde_uint128 u128 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+#endif
+	SIMDE_ALIGN_TO_16 simde_float32 f32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 simde_float64 f64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
 
-    SIMDE_ALIGN_TO_16 int_fast32_t  i32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 uint_fast32_t u32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-  #else
-    SIMDE_ALIGN_TO_16 int8_t         i8[16];
-    SIMDE_ALIGN_TO_16 int16_t        i16[8];
-    SIMDE_ALIGN_TO_16 int32_t        i32[4];
-    SIMDE_ALIGN_TO_16 int64_t        i64[2];
-    SIMDE_ALIGN_TO_16 uint8_t        u8[16];
-    SIMDE_ALIGN_TO_16 uint16_t       u16[8];
-    SIMDE_ALIGN_TO_16 uint32_t       u32[4];
-    SIMDE_ALIGN_TO_16 uint64_t       u64[2];
-    #if defined(SIMDE_HAVE_INT128_)
-    SIMDE_ALIGN_TO_16 simde_int128  i128[1];
-    SIMDE_ALIGN_TO_16 simde_uint128 u128[1];
-    #endif
-    SIMDE_ALIGN_TO_16 simde_float32  f32[4];
-    SIMDE_ALIGN_TO_16 simde_float64  f64[2];
+	SIMDE_ALIGN_TO_16 int_fast32_t i32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 uint_fast32_t u32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+#else
+	SIMDE_ALIGN_TO_16 int8_t i8[16];
+	SIMDE_ALIGN_TO_16 int16_t i16[8];
+	SIMDE_ALIGN_TO_16 int32_t i32[4];
+	SIMDE_ALIGN_TO_16 int64_t i64[2];
+	SIMDE_ALIGN_TO_16 uint8_t u8[16];
+	SIMDE_ALIGN_TO_16 uint16_t u16[8];
+	SIMDE_ALIGN_TO_16 uint32_t u32[4];
+	SIMDE_ALIGN_TO_16 uint64_t u64[2];
+#if defined(SIMDE_HAVE_INT128_)
+	SIMDE_ALIGN_TO_16 simde_int128 i128[1];
+	SIMDE_ALIGN_TO_16 simde_uint128 u128[1];
+#endif
+	SIMDE_ALIGN_TO_16 simde_float32 f32[4];
+	SIMDE_ALIGN_TO_16 simde_float64 f64[2];
 
-    SIMDE_ALIGN_TO_16 int_fast32_t  i32f[16 / sizeof(int_fast32_t)];
-    SIMDE_ALIGN_TO_16 uint_fast32_t u32f[16 / sizeof(uint_fast32_t)];
-  #endif
+	SIMDE_ALIGN_TO_16 int_fast32_t i32f[16 / sizeof(int_fast32_t)];
+	SIMDE_ALIGN_TO_16 uint_fast32_t u32f[16 / sizeof(uint_fast32_t)];
+#endif
 
-    SIMDE_ALIGN_TO_16 simde__m64_private m64_private[2];
-    SIMDE_ALIGN_TO_16 simde__m64         m64[2];
+	SIMDE_ALIGN_TO_16 simde__m64_private m64_private[2];
+	SIMDE_ALIGN_TO_16 simde__m64 m64[2];
 
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    SIMDE_ALIGN_TO_16 __m128i        n;
-  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    SIMDE_ALIGN_TO_16 int8x16_t      neon_i8;
-    SIMDE_ALIGN_TO_16 int16x8_t      neon_i16;
-    SIMDE_ALIGN_TO_16 int32x4_t      neon_i32;
-    SIMDE_ALIGN_TO_16 int64x2_t      neon_i64;
-    SIMDE_ALIGN_TO_16 uint8x16_t     neon_u8;
-    SIMDE_ALIGN_TO_16 uint16x8_t     neon_u16;
-    SIMDE_ALIGN_TO_16 uint32x4_t     neon_u32;
-    SIMDE_ALIGN_TO_16 uint64x2_t     neon_u64;
-    #if defined(__ARM_FP16_FORMAT_IEEE)
-    SIMDE_ALIGN_TO_16 float16x8_t    neon_f16;
-    #endif
-    SIMDE_ALIGN_TO_16 float32x4_t    neon_f32;
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    SIMDE_ALIGN_TO_16 float64x2_t    neon_f64;
-    #endif
-  #elif defined(SIMDE_MIPS_MSA_NATIVE)
-    v16i8 msa_i8;
-    v8i16 msa_i16;
-    v4i32 msa_i32;
-    v2i64 msa_i64;
-    v16u8 msa_u8;
-    v8u16 msa_u16;
-    v4u32 msa_u32;
-    v2u64 msa_u64;
-  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    SIMDE_ALIGN_TO_16 v128_t         wasm_v128;
-  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed char)          altivec_i8;
-    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed short)         altivec_i16;
-    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32;
-    #if defined(__UINT_FAST32_TYPE__) && (defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE))
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(__INT_FAST32_TYPE__)  altivec_i32f;
-    #else
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32f;
-    #endif
-    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)        altivec_u8;
-    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)       altivec_u16;
-    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32;
-    #if defined(__UINT_FAST32_TYPE__) && (defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE))
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(__UINT_FAST32_TYPE__) altivec_u32f;
-    #else
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32f;
-    #endif
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(float)                altivec_f32;
-    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed long long)   altivec_i64;
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64;
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(double)             altivec_f64;
-    #endif
-  #endif
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	SIMDE_ALIGN_TO_16 __m128i n;
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	SIMDE_ALIGN_TO_16 int8x16_t neon_i8;
+	SIMDE_ALIGN_TO_16 int16x8_t neon_i16;
+	SIMDE_ALIGN_TO_16 int32x4_t neon_i32;
+	SIMDE_ALIGN_TO_16 int64x2_t neon_i64;
+	SIMDE_ALIGN_TO_16 uint8x16_t neon_u8;
+	SIMDE_ALIGN_TO_16 uint16x8_t neon_u16;
+	SIMDE_ALIGN_TO_16 uint32x4_t neon_u32;
+	SIMDE_ALIGN_TO_16 uint64x2_t neon_u64;
+#if defined(__ARM_FP16_FORMAT_IEEE)
+	SIMDE_ALIGN_TO_16 float16x8_t neon_f16;
+#endif
+	SIMDE_ALIGN_TO_16 float32x4_t neon_f32;
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	SIMDE_ALIGN_TO_16 float64x2_t neon_f64;
+#endif
+#elif defined(SIMDE_MIPS_MSA_NATIVE)
+	v16i8 msa_i8;
+	v8i16 msa_i16;
+	v4i32 msa_i32;
+	v2i64 msa_i64;
+	v16u8 msa_u8;
+	v8u16 msa_u16;
+	v4u32 msa_u32;
+	v2u64 msa_u64;
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	SIMDE_ALIGN_TO_16 v128_t wasm_v128;
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed char) altivec_i8;
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed short) altivec_i16;
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int) altivec_i32;
+#if defined(__UINT_FAST32_TYPE__) &&               \
+	(defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	 defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE))
+	SIMDE_ALIGN_TO_16
+		SIMDE_POWER_ALTIVEC_VECTOR(__INT_FAST32_TYPE__) altivec_i32f;
+#else
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int) altivec_i32f;
+#endif
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) altivec_u8;
+	SIMDE_ALIGN_TO_16
+	SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) altivec_u16;
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) altivec_u32;
+#if defined(__UINT_FAST32_TYPE__) &&               \
+	(defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	 defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE))
+	SIMDE_ALIGN_TO_16
+		SIMDE_POWER_ALTIVEC_VECTOR(__UINT_FAST32_TYPE__) altivec_u32f;
+#else
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) altivec_u32f;
+#endif
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(float) altivec_f32;
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	SIMDE_ALIGN_TO_16
+	SIMDE_POWER_ALTIVEC_VECTOR(signed long long) altivec_i64;
+	SIMDE_ALIGN_TO_16
+	SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64;
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(double) altivec_f64;
+#endif
+#endif
 } simde__m128i_private;
 
 typedef union {
-  #if defined(SIMDE_VECTOR_SUBSCRIPT)
-    SIMDE_ALIGN_TO_16 int8_t          i8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 int16_t        i16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 int32_t        i32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 int64_t        i64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 uint8_t         u8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 uint16_t       u16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 uint32_t       u32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 uint64_t       u64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 simde_float32  f32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 simde_float64  f64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 int_fast32_t  i32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-    SIMDE_ALIGN_TO_16 uint_fast32_t u32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-  #else
-    SIMDE_ALIGN_TO_16 int8_t         i8[16];
-    SIMDE_ALIGN_TO_16 int16_t        i16[8];
-    SIMDE_ALIGN_TO_16 int32_t        i32[4];
-    SIMDE_ALIGN_TO_16 int64_t        i64[2];
-    SIMDE_ALIGN_TO_16 uint8_t        u8[16];
-    SIMDE_ALIGN_TO_16 uint16_t       u16[8];
-    SIMDE_ALIGN_TO_16 uint32_t       u32[4];
-    SIMDE_ALIGN_TO_16 uint64_t       u64[2];
-    SIMDE_ALIGN_TO_16 simde_float32  f32[4];
-    SIMDE_ALIGN_TO_16 simde_float64  f64[2];
-    SIMDE_ALIGN_TO_16 int_fast32_t  i32f[16 / sizeof(int_fast32_t)];
-    SIMDE_ALIGN_TO_16 uint_fast32_t u32f[16 / sizeof(uint_fast32_t)];
-  #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT)
+	SIMDE_ALIGN_TO_16 int8_t i8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 int16_t i16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 int32_t i32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 int64_t i64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 uint8_t u8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 uint16_t u16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 uint32_t u32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 uint64_t u64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 simde_float32 f32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 simde_float64 f64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 int_fast32_t i32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+	SIMDE_ALIGN_TO_16 uint_fast32_t u32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+#else
+	SIMDE_ALIGN_TO_16 int8_t i8[16];
+	SIMDE_ALIGN_TO_16 int16_t i16[8];
+	SIMDE_ALIGN_TO_16 int32_t i32[4];
+	SIMDE_ALIGN_TO_16 int64_t i64[2];
+	SIMDE_ALIGN_TO_16 uint8_t u8[16];
+	SIMDE_ALIGN_TO_16 uint16_t u16[8];
+	SIMDE_ALIGN_TO_16 uint32_t u32[4];
+	SIMDE_ALIGN_TO_16 uint64_t u64[2];
+	SIMDE_ALIGN_TO_16 simde_float32 f32[4];
+	SIMDE_ALIGN_TO_16 simde_float64 f64[2];
+	SIMDE_ALIGN_TO_16 int_fast32_t i32f[16 / sizeof(int_fast32_t)];
+	SIMDE_ALIGN_TO_16 uint_fast32_t u32f[16 / sizeof(uint_fast32_t)];
+#endif
 
-    SIMDE_ALIGN_TO_16 simde__m64_private m64_private[2];
-    SIMDE_ALIGN_TO_16 simde__m64         m64[2];
+	SIMDE_ALIGN_TO_16 simde__m64_private m64_private[2];
+	SIMDE_ALIGN_TO_16 simde__m64 m64[2];
 
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    SIMDE_ALIGN_TO_16 __m128d        n;
-  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    SIMDE_ALIGN_TO_16 int8x16_t      neon_i8;
-    SIMDE_ALIGN_TO_16 int16x8_t      neon_i16;
-    SIMDE_ALIGN_TO_16 int32x4_t      neon_i32;
-    SIMDE_ALIGN_TO_16 int64x2_t      neon_i64;
-    SIMDE_ALIGN_TO_16 uint8x16_t     neon_u8;
-    SIMDE_ALIGN_TO_16 uint16x8_t     neon_u16;
-    SIMDE_ALIGN_TO_16 uint32x4_t     neon_u32;
-    SIMDE_ALIGN_TO_16 uint64x2_t     neon_u64;
-    SIMDE_ALIGN_TO_16 float32x4_t    neon_f32;
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    SIMDE_ALIGN_TO_16 float64x2_t    neon_f64;
-    #endif
-  #elif defined(SIMDE_MIPS_MSA_NATIVE)
-    v16i8 msa_i8;
-    v8i16 msa_i16;
-    v4i32 msa_i32;
-    v2i64 msa_i64;
-    v16u8 msa_u8;
-    v8u16 msa_u16;
-    v4u32 msa_u32;
-    v2u64 msa_u64;
-  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    SIMDE_ALIGN_TO_16 v128_t         wasm_v128;
-  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed char)          altivec_i8;
-    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed short)         altivec_i16;
-    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32;
-    #if defined(__INT_FAST32_TYPE__) && (defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE))
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(__INT_FAST32_TYPE__)  altivec_i32f;
-    #else
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32f;
-    #endif
-    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)        altivec_u8;
-    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)       altivec_u16;
-    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32;
-    #if defined(__UINT_FAST32_TYPE__) && (defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE))
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(__UINT_FAST32_TYPE__) altivec_u32f;
-    #else
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32f;
-    #endif
-    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(float)                altivec_f32;
-    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed long long)   altivec_i64;
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64;
-      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(double)             altivec_f64;
-    #endif
-  #endif
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	SIMDE_ALIGN_TO_16 __m128d n;
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	SIMDE_ALIGN_TO_16 int8x16_t neon_i8;
+	SIMDE_ALIGN_TO_16 int16x8_t neon_i16;
+	SIMDE_ALIGN_TO_16 int32x4_t neon_i32;
+	SIMDE_ALIGN_TO_16 int64x2_t neon_i64;
+	SIMDE_ALIGN_TO_16 uint8x16_t neon_u8;
+	SIMDE_ALIGN_TO_16 uint16x8_t neon_u16;
+	SIMDE_ALIGN_TO_16 uint32x4_t neon_u32;
+	SIMDE_ALIGN_TO_16 uint64x2_t neon_u64;
+	SIMDE_ALIGN_TO_16 float32x4_t neon_f32;
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	SIMDE_ALIGN_TO_16 float64x2_t neon_f64;
+#endif
+#elif defined(SIMDE_MIPS_MSA_NATIVE)
+	v16i8 msa_i8;
+	v8i16 msa_i16;
+	v4i32 msa_i32;
+	v2i64 msa_i64;
+	v16u8 msa_u8;
+	v8u16 msa_u16;
+	v4u32 msa_u32;
+	v2u64 msa_u64;
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	SIMDE_ALIGN_TO_16 v128_t wasm_v128;
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed char) altivec_i8;
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed short) altivec_i16;
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int) altivec_i32;
+#if defined(__INT_FAST32_TYPE__) && (defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+				     defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE))
+	SIMDE_ALIGN_TO_16
+		SIMDE_POWER_ALTIVEC_VECTOR(__INT_FAST32_TYPE__) altivec_i32f;
+#else
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int) altivec_i32f;
+#endif
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) altivec_u8;
+	SIMDE_ALIGN_TO_16
+	SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) altivec_u16;
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) altivec_u32;
+#if defined(__UINT_FAST32_TYPE__) &&               \
+	(defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	 defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE))
+	SIMDE_ALIGN_TO_16
+		SIMDE_POWER_ALTIVEC_VECTOR(__UINT_FAST32_TYPE__) altivec_u32f;
+#else
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) altivec_u32f;
+#endif
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(float) altivec_f32;
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	SIMDE_ALIGN_TO_16
+	SIMDE_POWER_ALTIVEC_VECTOR(signed long long) altivec_i64;
+	SIMDE_ALIGN_TO_16
+	SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64;
+	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(double) altivec_f64;
+#endif
+#endif
 } simde__m128d_private;
 
 #if defined(SIMDE_X86_SSE2_NATIVE)
-  typedef __m128i simde__m128i;
-  typedef __m128d simde__m128d;
+typedef __m128i simde__m128i;
+typedef __m128d simde__m128d;
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-   typedef int64x2_t simde__m128i;
-#  if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-     typedef float64x2_t simde__m128d;
-#  elif defined(SIMDE_VECTOR_SUBSCRIPT)
-     typedef simde_float64 simde__m128d SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-#  else
-     typedef simde__m128d_private simde__m128d;
-#  endif
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-   typedef v128_t simde__m128i;
-   typedef v128_t simde__m128d;
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-  typedef SIMDE_POWER_ALTIVEC_VECTOR(float) simde__m128i;
-  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-     typedef SIMDE_POWER_ALTIVEC_VECTOR(double) simde__m128d;
-  #else
-     typedef simde__m128d_private simde__m128d;
-  #endif
+typedef int64x2_t simde__m128i;
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+typedef float64x2_t simde__m128d;
 #elif defined(SIMDE_VECTOR_SUBSCRIPT)
-  typedef int64_t simde__m128i SIMDE_ALIGN_TO_16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-  typedef simde_float64 simde__m128d SIMDE_ALIGN_TO_16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+typedef simde_float64 simde__m128d SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
 #else
-  typedef simde__m128i_private simde__m128i;
-  typedef simde__m128d_private simde__m128d;
+typedef simde__m128d_private simde__m128d;
+#endif
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+typedef v128_t simde__m128i;
+typedef v128_t simde__m128d;
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+typedef SIMDE_POWER_ALTIVEC_VECTOR(float) simde__m128i;
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+typedef SIMDE_POWER_ALTIVEC_VECTOR(double) simde__m128d;
+#else
+typedef simde__m128d_private simde__m128d;
+#endif
+#elif defined(SIMDE_VECTOR_SUBSCRIPT)
+typedef int64_t simde__m128i SIMDE_ALIGN_TO_16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+typedef simde_float64
+	simde__m128d SIMDE_ALIGN_TO_16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+#else
+typedef simde__m128i_private simde__m128i;
+typedef simde__m128d_private simde__m128d;
 #endif
 
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  typedef simde__m128i __m128i;
-  typedef simde__m128d __m128d;
+typedef simde__m128i __m128i;
+typedef simde__m128d __m128d;
 #endif
 
 HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128i), "simde__m128i size incorrect");
-HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128i_private), "simde__m128i_private size incorrect");
+HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128i_private),
+		     "simde__m128i_private size incorrect");
 HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128d), "simde__m128d size incorrect");
-HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128d_private), "simde__m128d_private size incorrect");
+HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128d_private),
+		     "simde__m128d_private size incorrect");
 #if defined(SIMDE_CHECK_ALIGNMENT) && defined(SIMDE_ALIGN_OF)
-HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128i) == 16, "simde__m128i is not 16-byte aligned");
-HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128i_private) == 16, "simde__m128i_private is not 16-byte aligned");
-HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128d) == 16, "simde__m128d is not 16-byte aligned");
-HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128d_private) == 16, "simde__m128d_private is not 16-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128i) == 16,
+		     "simde__m128i is not 16-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128i_private) == 16,
+		     "simde__m128i_private is not 16-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128d) == 16,
+		     "simde__m128d is not 16-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128d_private) == 16,
+		     "simde__m128d_private is not 16-byte aligned");
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde__m128i_from_private(simde__m128i_private v) {
-  simde__m128i r;
-  simde_memcpy(&r, &v, sizeof(r));
-  return r;
+simde__m128i simde__m128i_from_private(simde__m128i_private v)
+{
+	simde__m128i r;
+	simde_memcpy(&r, &v, sizeof(r));
+	return r;
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i_private
-simde__m128i_to_private(simde__m128i v) {
-  simde__m128i_private r;
-  simde_memcpy(&r, &v, sizeof(r));
-  return r;
+simde__m128i_private simde__m128i_to_private(simde__m128i v)
+{
+	simde__m128i_private r;
+	simde_memcpy(&r, &v, sizeof(r));
+	return r;
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde__m128d_from_private(simde__m128d_private v) {
-  simde__m128d r;
-  simde_memcpy(&r, &v, sizeof(r));
-  return r;
+simde__m128d simde__m128d_from_private(simde__m128d_private v)
+{
+	simde__m128d r;
+	simde_memcpy(&r, &v, sizeof(r));
+	return r;
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d_private
-simde__m128d_to_private(simde__m128d v) {
-  simde__m128d_private r;
-  simde_memcpy(&r, &v, sizeof(r));
-  return r;
+simde__m128d_private simde__m128d_to_private(simde__m128d v)
+{
+	simde__m128d_private r;
+	simde_memcpy(&r, &v, sizeof(r));
+	return r;
 }
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int8x16_t, neon, i8)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int16x8_t, neon, i16)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int32x4_t, neon, i32)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int64x2_t, neon, i64)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint8x16_t, neon, u8)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint16x8_t, neon, u16)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint32x4_t, neon, u32)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint64x2_t, neon, u64)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, float32x4_t, neon, f32)
-  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, float64x2_t, neon, f64)
-  #endif
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed char), altivec, i8)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed short), altivec, i16)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed int), altivec, i32)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), altivec, u8)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), altivec, u16)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), altivec, u32)
-  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
-    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
-  #endif
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int8x16_t, neon, i8)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int16x8_t, neon, i16)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int32x4_t, neon, i32)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int64x2_t, neon, i64)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint8x16_t, neon, u8)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint16x8_t, neon, u16)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint32x4_t, neon, u32)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint64x2_t, neon, u64)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, float32x4_t, neon, f32)
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, float64x2_t, neon, f64)
+#endif
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i,
+				       SIMDE_POWER_ALTIVEC_VECTOR(signed char),
+				       altivec, i8)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i,
+				       SIMDE_POWER_ALTIVEC_VECTOR(signed short),
+				       altivec, i16)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i,
+				       SIMDE_POWER_ALTIVEC_VECTOR(signed int),
+				       altivec, i32)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
+	m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), altivec, u8)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
+	m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), altivec, u16)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i,
+				       SIMDE_POWER_ALTIVEC_VECTOR(unsigned int),
+				       altivec, u32)
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
+	m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
+	m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
+#endif
 #endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int8x16_t, neon, i8)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int16x8_t, neon, i16)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int32x4_t, neon, i32)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int64x2_t, neon, i64)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint8x16_t, neon, u8)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint16x8_t, neon, u16)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint32x4_t, neon, u32)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint64x2_t, neon, u64)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, float32x4_t, neon, f32)
-  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, float64x2_t, neon, f64)
-  #endif
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed char), altivec, i8)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed short), altivec, i16)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed int), altivec, i32)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), altivec, u8)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), altivec, u16)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), altivec, u32)
-  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
-    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
-    #if defined(SIMDE_BUG_GCC_95782)
-      SIMDE_FUNCTION_ATTRIBUTES
-      SIMDE_POWER_ALTIVEC_VECTOR(double)
-      simde__m128d_to_altivec_f64(simde__m128d value) {
-        simde__m128d_private r_ = simde__m128d_to_private(value);
-        return r_.altivec_f64;
-      }
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int8x16_t, neon, i8)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int16x8_t, neon, i16)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int32x4_t, neon, i32)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int64x2_t, neon, i64)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint8x16_t, neon, u8)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint16x8_t, neon, u16)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint32x4_t, neon, u32)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint64x2_t, neon, u64)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, float32x4_t, neon, f32)
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, float64x2_t, neon, f64)
+#endif
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d,
+				       SIMDE_POWER_ALTIVEC_VECTOR(signed char),
+				       altivec, i8)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d,
+				       SIMDE_POWER_ALTIVEC_VECTOR(signed short),
+				       altivec, i16)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d,
+				       SIMDE_POWER_ALTIVEC_VECTOR(signed int),
+				       altivec, i32)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
+	m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), altivec, u8)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
+	m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), altivec, u16)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d,
+				       SIMDE_POWER_ALTIVEC_VECTOR(unsigned int),
+				       altivec, u32)
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
+	m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
+	m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
+#if defined(SIMDE_BUG_GCC_95782)
+SIMDE_FUNCTION_ATTRIBUTES
+SIMDE_POWER_ALTIVEC_VECTOR(double)
+simde__m128d_to_altivec_f64(simde__m128d value)
+{
+	simde__m128d_private r_ = simde__m128d_to_private(value);
+	return r_.altivec_f64;
+}
 
-      SIMDE_FUNCTION_ATTRIBUTES
-      simde__m128d
-      simde__m128d_from_altivec_f64(SIMDE_POWER_ALTIVEC_VECTOR(double) value) {
-        simde__m128d_private r_;
-        r_.altivec_f64 = value;
-        return simde__m128d_from_private(r_);
-      }
-    #else
-      SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(double), altivec, f64)
-    #endif
-  #endif
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d simde__m128d_from_altivec_f64(SIMDE_POWER_ALTIVEC_VECTOR(double)
+						   value)
+{
+	simde__m128d_private r_;
+	r_.altivec_f64 = value;
+	return simde__m128d_from_private(r_);
+}
+#else
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d,
+				       SIMDE_POWER_ALTIVEC_VECTOR(double),
+				       altivec, f64)
+#endif
+#endif
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, v128_t, wasm, v128);
-  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, v128_t, wasm, v128);
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, v128_t, wasm, v128);
+SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, v128_t, wasm, v128);
 #endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_set_pd (simde_float64 e1, simde_float64 e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_set_pd(e1, e0);
-  #else
-    simde__m128d_private r_;
+simde__m128d simde_mm_set_pd(simde_float64 e1, simde_float64 e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_set_pd(e1, e0);
+#else
+	simde__m128d_private r_;
 
-    #if defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_make(e0, e1);
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      SIMDE_ALIGN_TO_16 simde_float64 data[2] = { e0, e1 };
-      r_.neon_f64 = vld1q_f64(data);
-    #else
-      r_.f64[0] = e0;
-      r_.f64[1] = e1;
-    #endif
+#if defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_make(e0, e1);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	SIMDE_ALIGN_TO_16 simde_float64 data[2] = {e0, e1};
+	r_.neon_f64 = vld1q_f64(data);
+#else
+	r_.f64[0] = e0;
+	r_.f64[1] = e1;
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_set_pd(e1, e0) simde_mm_set_pd(e1, e0)
+#define _mm_set_pd(e1, e0) simde_mm_set_pd(e1, e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_set1_pd (simde_float64 a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_set1_pd(a);
-  #else
-    simde__m128d_private r_;
+simde__m128d simde_mm_set1_pd(simde_float64 a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_set1_pd(a);
+#else
+	simde__m128d_private r_;
 
-    #if defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_splat(a);
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vdupq_n_f64(a);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_f64 = vec_splats(HEDLEY_STATIC_CAST(double, a));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-        r_.f64[i] = a;
-      }
-    #endif
+#if defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_splat(a);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vdupq_n_f64(a);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_f64 = vec_splats(HEDLEY_STATIC_CAST(double, a));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
+		r_.f64[i] = a;
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #define simde_mm_set_pd1(a) simde_mm_set1_pd(a)
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_set1_pd(a) simde_mm_set1_pd(a)
-  #define _mm_set_pd1(a) simde_mm_set1_pd(a)
+#define _mm_set1_pd(a) simde_mm_set1_pd(a)
+#define _mm_set_pd1(a) simde_mm_set1_pd(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_x_mm_abs_pd(simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    simde_float64 mask_;
-    uint64_t u64_ = UINT64_C(0x7FFFFFFFFFFFFFFF);
-    simde_memcpy(&mask_, &u64_, sizeof(u64_));
-    return _mm_and_pd(_mm_set1_pd(mask_), a);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a);
+simde__m128d simde_x_mm_abs_pd(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	simde_float64 mask_;
+	uint64_t u64_ = UINT64_C(0x7FFFFFFFFFFFFFFF);
+	simde_memcpy(&mask_, &u64_, sizeof(u64_));
+	return _mm_and_pd(_mm_set1_pd(mask_), a);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vabsq_f64(a_.neon_f64);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_f64 = vec_abs(a_.altivec_f64);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.f64[i] = simde_math_fabs(a_.f64[i]);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vabsq_f64(a_.neon_f64);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_f64 = vec_abs(a_.altivec_f64);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = simde_math_fabs(a_.f64[i]);
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_x_mm_not_pd(simde__m128d a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    __m128i ai = _mm_castpd_si128(a);
-    return _mm_castsi128_pd(_mm_ternarylogic_epi64(ai, ai, ai, 0x55));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a);
+simde__m128d simde_x_mm_not_pd(simde__m128d a)
+{
+#if defined(SIMDE_X86_AVX512VL_NATIVE)
+	__m128i ai = _mm_castpd_si128(a);
+	return _mm_castsi128_pd(_mm_ternarylogic_epi64(ai, ai, ai, 0x55));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vmvnq_s32(a_.neon_i32);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-      r_.altivec_f64 = vec_nor(a_.altivec_f64, a_.altivec_f64);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_i32 = vec_nor(a_.altivec_i32, a_.altivec_i32);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_v128_not(a_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32f = ~a_.i32f;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
-        r_.i32f[i] = ~(a_.i32f[i]);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vmvnq_s32(a_.neon_i32);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+	r_.altivec_f64 = vec_nor(a_.altivec_f64, a_.altivec_f64);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_i32 = vec_nor(a_.altivec_i32, a_.altivec_i32);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_v128_not(a_.wasm_v128);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32f = ~a_.i32f;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
+		r_.i32f[i] = ~(a_.i32f[i]);
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_x_mm_select_pd(simde__m128d a, simde__m128d b, simde__m128d mask) {
-  /* This function is for when you want to blend two elements together
+simde__m128d simde_x_mm_select_pd(simde__m128d a, simde__m128d b,
+				  simde__m128d mask)
+{
+/* This function is for when you want to blend two elements together
    * according to a mask.  It is similar to _mm_blendv_pd, except that
    * it is undefined whether the blend is based on the highest bit in
    * each lane (like blendv) or just bitwise operations.  This allows
@@ -496,4706 +557,4919 @@ simde_x_mm_select_pd(simde__m128d a, simde__m128d b, simde__m128d mask) {
    *
    * Basically, you promise that all the lanes in mask are either 0 or
    * ~0. */
-  #if defined(SIMDE_X86_SSE4_1_NATIVE)
-    return _mm_blendv_pd(a, b, mask);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b),
-      mask_ = simde__m128d_to_private(mask);
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+	return _mm_blendv_pd(a, b, mask);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b),
+				 mask_ = simde__m128d_to_private(mask);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = a_.i64 ^ ((a_.i64 ^ b_.i64) & mask_.i64);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vbslq_s64(mask_.neon_u64, b_.neon_i64, a_.neon_i64);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-        r_.i64[i] = a_.i64[i] ^ ((a_.i64[i] ^ b_.i64[i]) & mask_.i64[i]);
-      }
-    #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i64 = a_.i64 ^ ((a_.i64 ^ b_.i64) & mask_.i64);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = vbslq_s64(mask_.neon_u64, b_.neon_i64, a_.neon_i64);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
+		r_.i64[i] = a_.i64[i] ^
+			    ((a_.i64[i] ^ b_.i64[i]) & mask_.i64[i]);
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_add_epi8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_add_epi8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_add_epi8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_add_epi8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i8 = vaddq_s8(a_.neon_i8, b_.neon_i8);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_i8 = vec_add(a_.altivec_i8, b_.altivec_i8);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i8x16_add(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i8 = a_.i8 + b_.i8;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-        r_.i8[i] = a_.i8[i] + b_.i8[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i8 = vaddq_s8(a_.neon_i8, b_.neon_i8);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_i8 = vec_add(a_.altivec_i8, b_.altivec_i8);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i8x16_add(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i8 = a_.i8 + b_.i8;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
+		r_.i8[i] = a_.i8[i] + b_.i8[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_add_epi8(a, b) simde_mm_add_epi8(a, b)
+#define _mm_add_epi8(a, b) simde_mm_add_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_add_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_add_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_add_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_add_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i16 = vaddq_s16(a_.neon_i16, b_.neon_i16);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_i16 = vec_add(a_.altivec_i16, b_.altivec_i16);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i16x8_add(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i16 = a_.i16 + b_.i16;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = a_.i16[i] + b_.i16[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i16 = vaddq_s16(a_.neon_i16, b_.neon_i16);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_i16 = vec_add(a_.altivec_i16, b_.altivec_i16);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i16x8_add(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i16 = a_.i16 + b_.i16;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = a_.i16[i] + b_.i16[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_add_epi16(a, b) simde_mm_add_epi16(a, b)
+#define _mm_add_epi16(a, b) simde_mm_add_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_add_epi32 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_add_epi32(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_add_epi32(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_add_epi32(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vaddq_s32(a_.neon_i32, b_.neon_i32);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_i32 = vec_add(a_.altivec_i32, b_.altivec_i32);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i32x4_add(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32 = a_.i32 + b_.i32;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        r_.i32[i] = a_.i32[i] + b_.i32[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vaddq_s32(a_.neon_i32, b_.neon_i32);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_i32 = vec_add(a_.altivec_i32, b_.altivec_i32);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i32x4_add(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32 = a_.i32 + b_.i32;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		r_.i32[i] = a_.i32[i] + b_.i32[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_add_epi32(a, b) simde_mm_add_epi32(a, b)
+#define _mm_add_epi32(a, b) simde_mm_add_epi32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_add_epi64 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_add_epi64(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_add_epi64(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_add_epi64(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vaddq_s64(a_.neon_i64, b_.neon_i64);
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-      r_.altivec_i64 = vec_add(a_.altivec_i64, b_.altivec_i64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i64x2_add(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = a_.i64 + b_.i64;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-        r_.i64[i] = a_.i64[i] + b_.i64[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = vaddq_s64(a_.neon_i64, b_.neon_i64);
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+	r_.altivec_i64 = vec_add(a_.altivec_i64, b_.altivec_i64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i64x2_add(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i64 = a_.i64 + b_.i64;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
+		r_.i64[i] = a_.i64[i] + b_.i64[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_add_epi64(a, b) simde_mm_add_epi64(a, b)
+#define _mm_add_epi64(a, b) simde_mm_add_epi64(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_add_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_add_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_add_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_add_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vaddq_f64(a_.neon_f64, b_.neon_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_add(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-      r_.altivec_f64 = vec_add(a_.altivec_f64, b_.altivec_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_add(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.f64 = a_.f64 + b_.f64;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.f64[i] = a_.f64[i] + b_.f64[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vaddq_f64(a_.neon_f64, b_.neon_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_add(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+	r_.altivec_f64 = vec_add(a_.altivec_f64, b_.altivec_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_add(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.f64 = a_.f64 + b_.f64;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = a_.f64[i] + b_.f64[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_add_pd(a, b) simde_mm_add_pd(a, b)
+#define _mm_add_pd(a, b) simde_mm_add_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_move_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_move_sd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_move_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_move_sd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vsetq_lane_f64(vgetq_lane_f64(b_.neon_f64, 0), a_.neon_f64, 0);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-      #if defined(HEDLEY_IBM_VERSION)
-        r_.altivec_f64 = vec_xxpermdi(a_.altivec_f64, b_.altivec_f64, 1);
-      #else
-        r_.altivec_f64 = vec_xxpermdi(b_.altivec_f64, a_.altivec_f64, 1);
-      #endif
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i64x2_shuffle(a_.wasm_v128, b_.wasm_v128, 2, 1);
-    #elif defined(SIMDE_SHUFFLE_VECTOR_)
-      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 2, 1);
-    #else
-      r_.f64[0] = b_.f64[0];
-      r_.f64[1] = a_.f64[1];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 =
+		vsetq_lane_f64(vgetq_lane_f64(b_.neon_f64, 0), a_.neon_f64, 0);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+#if defined(HEDLEY_IBM_VERSION)
+	r_.altivec_f64 = vec_xxpermdi(a_.altivec_f64, b_.altivec_f64, 1);
+#else
+	r_.altivec_f64 = vec_xxpermdi(b_.altivec_f64, a_.altivec_f64, 1);
+#endif
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i64x2_shuffle(a_.wasm_v128, b_.wasm_v128, 2, 1);
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 2, 1);
+#else
+	r_.f64[0] = b_.f64[0];
+	r_.f64[1] = a_.f64[1];
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_move_sd(a, b) simde_mm_move_sd(a, b)
+#define _mm_move_sd(a, b) simde_mm_move_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_x_mm_broadcastlow_pd(simde__m128d a) {
-  /* This function broadcasts the first element in the input vector to
+simde__m128d simde_x_mm_broadcastlow_pd(simde__m128d a)
+{
+	/* This function broadcasts the first element in the input vector to
    * all lanes.  It is used to avoid generating spurious exceptions in
    * *_sd functions since there may be garbage in the upper lanes. */
 
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_castsi128_pd(_mm_shuffle_epi32(_mm_castpd_si128(a), 0x44));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a);
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_castsi128_pd(_mm_shuffle_epi32(_mm_castpd_si128(a), 0x44));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vdupq_laneq_f64(a_.neon_f64, 0);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-      r_.altivec_f64 = vec_splat(a_.altivec_f64, 0);
-    #elif defined(SIMDE_SHUFFLE_VECTOR_)
-      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, a_.f64, 0, 0);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.f64[i] = a_.f64[0];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vdupq_laneq_f64(a_.neon_f64, 0);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+	r_.altivec_f64 = vec_splat(a_.altivec_f64, 0);
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, a_.f64, 0, 0);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = a_.f64[0];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_add_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_add_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_add_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_add_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_add_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_add_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_add_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(a,
+				simde_mm_add_pd(simde_x_mm_broadcastlow_pd(a),
+						simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    r_.f64[0] = a_.f64[0] + b_.f64[0];
-    r_.f64[1] = a_.f64[1];
+	r_.f64[0] = a_.f64[0] + b_.f64[0];
+	r_.f64[1] = a_.f64[1];
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_add_sd(a, b) simde_mm_add_sd(a, b)
+#define _mm_add_sd(a, b) simde_mm_add_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m64
-simde_mm_add_si64 (simde__m64 a, simde__m64 b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-    return _mm_add_si64(a, b);
-  #else
-    simde__m64_private
-      r_,
-      a_ = simde__m64_to_private(a),
-      b_ = simde__m64_to_private(b);
+simde__m64 simde_mm_add_si64(simde__m64 a, simde__m64 b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+	return _mm_add_si64(a, b);
+#else
+	simde__m64_private r_, a_ = simde__m64_to_private(a),
+			       b_ = simde__m64_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vadd_s64(a_.neon_i64, b_.neon_i64);
-    #else
-      r_.i64[0] = a_.i64[0] + b_.i64[0];
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = vadd_s64(a_.neon_i64, b_.neon_i64);
+#else
+	r_.i64[0] = a_.i64[0] + b_.i64[0];
+#endif
 
-    return simde__m64_from_private(r_);
-  #endif
+	return simde__m64_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_add_si64(a, b) simde_mm_add_si64(a, b)
+#define _mm_add_si64(a, b) simde_mm_add_si64(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_adds_epi8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_adds_epi8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_adds_epi8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_adds_epi8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i8 = vqaddq_s8(a_.neon_i8, b_.neon_i8);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i8x16_add_sat(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_i8 = vec_adds(a_.altivec_i8, b_.altivec_i8);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-        r_.i8[i] = simde_math_adds_i8(a_.i8[i], b_.i8[i]);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i8 = vqaddq_s8(a_.neon_i8, b_.neon_i8);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i8x16_add_sat(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_i8 = vec_adds(a_.altivec_i8, b_.altivec_i8);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
+		r_.i8[i] = simde_math_adds_i8(a_.i8[i], b_.i8[i]);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_adds_epi8(a, b) simde_mm_adds_epi8(a, b)
+#define _mm_adds_epi8(a, b) simde_mm_adds_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_adds_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_adds_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_adds_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_adds_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i16 = vqaddq_s16(a_.neon_i16, b_.neon_i16);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i16x8_add_sat(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_i16 = vec_adds(a_.altivec_i16, b_.altivec_i16);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = simde_math_adds_i16(a_.i16[i], b_.i16[i]);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i16 = vqaddq_s16(a_.neon_i16, b_.neon_i16);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i16x8_add_sat(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_i16 = vec_adds(a_.altivec_i16, b_.altivec_i16);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = simde_math_adds_i16(a_.i16[i], b_.i16[i]);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_adds_epi16(a, b) simde_mm_adds_epi16(a, b)
+#define _mm_adds_epi16(a, b) simde_mm_adds_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_adds_epu8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_adds_epu8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_adds_epu8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_adds_epu8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u8 = vqaddq_u8(a_.neon_u8, b_.neon_u8);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u8x16_add_sat(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-      r_.altivec_u8 = vec_adds(a_.altivec_u8, b_.altivec_u8);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
-        r_.u8[i] = simde_math_adds_u8(a_.u8[i], b_.u8[i]);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u8 = vqaddq_u8(a_.neon_u8, b_.neon_u8);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_u8x16_add_sat(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+	r_.altivec_u8 = vec_adds(a_.altivec_u8, b_.altivec_u8);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u8) / sizeof(r_.u8[0])); i++) {
+		r_.u8[i] = simde_math_adds_u8(a_.u8[i], b_.u8[i]);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_adds_epu8(a, b) simde_mm_adds_epu8(a, b)
+#define _mm_adds_epu8(a, b) simde_mm_adds_epu8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_adds_epu16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_adds_epu16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_adds_epu16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_adds_epu16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u16 = vqaddq_u16(a_.neon_u16, b_.neon_u16);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u16x8_add_sat(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_u16 = vec_adds(a_.altivec_u16, b_.altivec_u16);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
-        r_.u16[i] = simde_math_adds_u16(a_.u16[i], b_.u16[i]);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u16 = vqaddq_u16(a_.neon_u16, b_.neon_u16);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_u16x8_add_sat(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_u16 = vec_adds(a_.altivec_u16, b_.altivec_u16);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u16) / sizeof(r_.u16[0])); i++) {
+		r_.u16[i] = simde_math_adds_u16(a_.u16[i], b_.u16[i]);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_adds_epu16(a, b) simde_mm_adds_epu16(a, b)
+#define _mm_adds_epu16(a, b) simde_mm_adds_epu16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_and_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_and_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_and_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_and_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vandq_s32(a_.neon_i32, b_.neon_i32);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_v128_and(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-      r_.altivec_f64 = vec_and(a_.altivec_f64, b_.altivec_f64);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32f = a_.i32f & b_.i32f;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
-        r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vandq_s32(a_.neon_i32, b_.neon_i32);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_v128_and(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+	r_.altivec_f64 = vec_and(a_.altivec_f64, b_.altivec_f64);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32f = a_.i32f & b_.i32f;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
+		r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_and_pd(a, b) simde_mm_and_pd(a, b)
+#define _mm_and_pd(a, b) simde_mm_and_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_and_si128 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_and_si128(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_and_si128(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_and_si128(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vandq_s32(b_.neon_i32, a_.neon_i32);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_u32f = vec_and(a_.altivec_u32f, b_.altivec_u32f);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32f = a_.i32f & b_.i32f;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
-        r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vandq_s32(b_.neon_i32, a_.neon_i32);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_u32f = vec_and(a_.altivec_u32f, b_.altivec_u32f);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32f = a_.i32f & b_.i32f;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
+		r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_and_si128(a, b) simde_mm_and_si128(a, b)
+#define _mm_and_si128(a, b) simde_mm_and_si128(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_andnot_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_andnot_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_andnot_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_andnot_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_v128_andnot(b_.wasm_v128, a_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_f64 = vec_andc(b_.altivec_f64, a_.altivec_f64);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_i32f = vec_andc(b_.altivec_i32f, a_.altivec_i32f);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32f = ~a_.i32f & b_.i32f;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
-        r_.u64[i] = ~a_.u64[i] & b_.u64[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_v128_andnot(b_.wasm_v128, a_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_f64 = vec_andc(b_.altivec_f64, a_.altivec_f64);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_i32f = vec_andc(b_.altivec_i32f, a_.altivec_i32f);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32f = ~a_.i32f & b_.i32f;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u64) / sizeof(r_.u64[0])); i++) {
+		r_.u64[i] = ~a_.u64[i] & b_.u64[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_andnot_pd(a, b) simde_mm_andnot_pd(a, b)
+#define _mm_andnot_pd(a, b) simde_mm_andnot_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_andnot_si128 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_andnot_si128(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_andnot_si128(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_andnot_si128(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i32 = vec_andc(b_.altivec_i32, a_.altivec_i32);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32f = ~a_.i32f & b_.i32f;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
-        r_.i32f[i] = ~(a_.i32f[i]) & b_.i32f[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i32 = vec_andc(b_.altivec_i32, a_.altivec_i32);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32f = ~a_.i32f & b_.i32f;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
+		r_.i32f[i] = ~(a_.i32f[i]) & b_.i32f[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_andnot_si128(a, b) simde_mm_andnot_si128(a, b)
+#define _mm_andnot_si128(a, b) simde_mm_andnot_si128(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_xor_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_xor_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_xor_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_xor_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32f = a_.i32f ^ b_.i32f;
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_v128_xor(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = veorq_s64(a_.neon_i64, b_.neon_i64);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
-        r_.i32f[i] = a_.i32f[i] ^ b_.i32f[i];
-      }
-    #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32f = a_.i32f ^ b_.i32f;
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_v128_xor(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = veorq_s64(a_.neon_i64, b_.neon_i64);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
+		r_.i32f[i] = a_.i32f[i] ^ b_.i32f[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_xor_pd(a, b) simde_mm_xor_pd(a, b)
+#define _mm_xor_pd(a, b) simde_mm_xor_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_avg_epu8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_avg_epu8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_avg_epu8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_avg_epu8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u8 = vrhaddq_u8(b_.neon_u8, a_.neon_u8);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u8x16_avgr(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_u8 = vec_avg(a_.altivec_u8, b_.altivec_u8);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && defined(SIMDE_CONVERT_VECTOR_)
-      uint16_t wa SIMDE_VECTOR(32);
-      uint16_t wb SIMDE_VECTOR(32);
-      uint16_t wr SIMDE_VECTOR(32);
-      SIMDE_CONVERT_VECTOR_(wa, a_.u8);
-      SIMDE_CONVERT_VECTOR_(wb, b_.u8);
-      wr = (wa + wb + 1) >> 1;
-      SIMDE_CONVERT_VECTOR_(r_.u8, wr);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
-        r_.u8[i] = (a_.u8[i] + b_.u8[i] + 1) >> 1;
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u8 = vrhaddq_u8(b_.neon_u8, a_.neon_u8);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_u8x16_avgr(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_u8 = vec_avg(a_.altivec_u8, b_.altivec_u8);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) &&      \
+	defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && \
+	defined(SIMDE_CONVERT_VECTOR_)
+	uint16_t wa SIMDE_VECTOR(32);
+	uint16_t wb SIMDE_VECTOR(32);
+	uint16_t wr SIMDE_VECTOR(32);
+	SIMDE_CONVERT_VECTOR_(wa, a_.u8);
+	SIMDE_CONVERT_VECTOR_(wb, b_.u8);
+	wr = (wa + wb + 1) >> 1;
+	SIMDE_CONVERT_VECTOR_(r_.u8, wr);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u8) / sizeof(r_.u8[0])); i++) {
+		r_.u8[i] = (a_.u8[i] + b_.u8[i] + 1) >> 1;
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_avg_epu8(a, b) simde_mm_avg_epu8(a, b)
+#define _mm_avg_epu8(a, b) simde_mm_avg_epu8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_avg_epu16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_avg_epu16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_avg_epu16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_avg_epu16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u16 = vrhaddq_u16(b_.neon_u16, a_.neon_u16);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u16x8_avgr(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_u16 = vec_avg(a_.altivec_u16, b_.altivec_u16);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && defined(SIMDE_CONVERT_VECTOR_)
-      uint32_t wa SIMDE_VECTOR(32);
-      uint32_t wb SIMDE_VECTOR(32);
-      uint32_t wr SIMDE_VECTOR(32);
-      SIMDE_CONVERT_VECTOR_(wa, a_.u16);
-      SIMDE_CONVERT_VECTOR_(wb, b_.u16);
-      wr = (wa + wb + 1) >> 1;
-      SIMDE_CONVERT_VECTOR_(r_.u16, wr);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
-        r_.u16[i] = (a_.u16[i] + b_.u16[i] + 1) >> 1;
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u16 = vrhaddq_u16(b_.neon_u16, a_.neon_u16);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_u16x8_avgr(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_u16 = vec_avg(a_.altivec_u16, b_.altivec_u16);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) &&      \
+	defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && \
+	defined(SIMDE_CONVERT_VECTOR_)
+	uint32_t wa SIMDE_VECTOR(32);
+	uint32_t wb SIMDE_VECTOR(32);
+	uint32_t wr SIMDE_VECTOR(32);
+	SIMDE_CONVERT_VECTOR_(wa, a_.u16);
+	SIMDE_CONVERT_VECTOR_(wb, b_.u16);
+	wr = (wa + wb + 1) >> 1;
+	SIMDE_CONVERT_VECTOR_(r_.u16, wr);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u16) / sizeof(r_.u16[0])); i++) {
+		r_.u16[i] = (a_.u16[i] + b_.u16[i] + 1) >> 1;
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_avg_epu16(a, b) simde_mm_avg_epu16(a, b)
+#define _mm_avg_epu16(a, b) simde_mm_avg_epu16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_setzero_si128 (void) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_setzero_si128();
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_setzero_si128(void)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_setzero_si128();
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vdupq_n_s32(0);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, 0));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i32x4_splat(INT32_C(0));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT)
-      r_.i32 = __extension__ (__typeof__(r_.i32)) { 0, 0, 0, 0 };
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
-        r_.i32f[i] = 0;
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vdupq_n_s32(0);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, 0));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i32x4_splat(INT32_C(0));
+#elif defined(SIMDE_VECTOR_SUBSCRIPT)
+	r_.i32 = __extension__(__typeof__(r_.i32)){0, 0, 0, 0};
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
+		r_.i32f[i] = 0;
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_setzero_si128() (simde_mm_setzero_si128())
+#define _mm_setzero_si128() (simde_mm_setzero_si128())
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_bslli_si128 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a);
+simde__m128i simde_mm_bslli_si128(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+{
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
 
-  if (HEDLEY_UNLIKELY((imm8 & ~15))) {
-    return simde_mm_setzero_si128();
-  }
+	if (HEDLEY_UNLIKELY((imm8 & ~15))) {
+		return simde_mm_setzero_si128();
+	}
 
-  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
-    r_.altivec_i8 =
-      #if (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
-        vec_slo
-      #else /* SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG */
-        vec_sro
-      #endif
-        (a_.altivec_i8, vec_splats(HEDLEY_STATIC_CAST(unsigned char, imm8 * 8)));
-  #elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-    r_.altivec_i8 = vec_srb(a_.altivec_i8, vec_splats(HEDLEY_STATIC_CAST(unsigned char, (imm8 & 15) << 3)));
-  #elif defined(SIMDE_HAVE_INT128_) && (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
-    r_.u128[0] = a_.u128[0] << (imm8 * 8);
-  #else
-    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
-    for (int i = imm8 ; i < HEDLEY_STATIC_CAST(int, sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-      r_.i8[i] = a_.i8[i - imm8];
-    }
-  #endif
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
+	r_.altivec_i8 =
+#if (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
+		vec_slo
+#else /* SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG */
+		vec_sro
+#endif
+		(a_.altivec_i8,
+		 vec_splats(HEDLEY_STATIC_CAST(unsigned char, imm8 * 8)));
+#elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i8 = vec_srb(a_.altivec_i8,
+				vec_splats(HEDLEY_STATIC_CAST(
+					unsigned char, (imm8 & 15) << 3)));
+#elif defined(SIMDE_HAVE_INT128_) && (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
+	r_.u128[0] = a_.u128[0] << (imm8 * 8);
+#else
+	r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+	for (int i = imm8;
+	     i < HEDLEY_STATIC_CAST(int, sizeof(r_.i8) / sizeof(r_.i8[0]));
+	     i++) {
+		r_.i8[i] = a_.i8[i - imm8];
+	}
+#endif
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-  #define simde_mm_bslli_si128(a, imm8) _mm_slli_si128(a, imm8)
+#define simde_mm_bslli_si128(a, imm8) _mm_slli_si128(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
-  #define simde_mm_bslli_si128(a, imm8) \
-  simde__m128i_from_neon_i8(((imm8) <= 0) ? simde__m128i_to_neon_i8(a) : (((imm8) > 15) ? (vdupq_n_s8(0)) : (vextq_s8(vdupq_n_s8(0), simde__m128i_to_neon_i8(a), 16 - (imm8)))))
-#elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && !defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-  #define simde_mm_bslli_si128(a, imm8) (__extension__ ({ \
-    const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
-    const simde__m128i_private simde__tmp_z_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
-    simde__m128i_private simde__tmp_r_; \
-    if (HEDLEY_UNLIKELY(imm8 > 15)) { \
-      simde__tmp_r_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
-    } else { \
-      simde__tmp_r_.i8 = \
-        SIMDE_SHUFFLE_VECTOR_(8, 16, \
-          simde__tmp_z_.i8, \
-          (simde__tmp_a_).i8, \
-          HEDLEY_STATIC_CAST(int8_t, (16 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (17 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (18 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (19 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (20 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (21 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (22 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (23 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (24 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (25 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (26 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (27 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (28 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (29 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (30 - imm8) & 31), \
-          HEDLEY_STATIC_CAST(int8_t, (31 - imm8) & 31)); \
-    } \
-    simde__m128i_from_private(simde__tmp_r_); }))
+#define simde_mm_bslli_si128(a, imm8)                                      \
+	simde__m128i_from_neon_i8(                                         \
+		((imm8) <= 0)                                              \
+			? simde__m128i_to_neon_i8(a)                       \
+			: (((imm8) > 15)                                   \
+				   ? (vdupq_n_s8(0))                       \
+				   : (vextq_s8(vdupq_n_s8(0),              \
+					       simde__m128i_to_neon_i8(a), \
+					       16 - (imm8)))))
+#elif defined(SIMDE_SHUFFLE_VECTOR_) &&            \
+	!defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && \
+	!defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+#define simde_mm_bslli_si128(a, imm8)                                          \
+	(__extension__({                                                       \
+		const simde__m128i_private simde__tmp_a_ =                     \
+			simde__m128i_to_private(a);                            \
+		const simde__m128i_private simde__tmp_z_ =                     \
+			simde__m128i_to_private(simde_mm_setzero_si128());     \
+		simde__m128i_private simde__tmp_r_;                            \
+		if (HEDLEY_UNLIKELY(imm8 > 15)) {                              \
+			simde__tmp_r_ = simde__m128i_to_private(               \
+				simde_mm_setzero_si128());                     \
+		} else {                                                       \
+			simde__tmp_r_.i8 = SIMDE_SHUFFLE_VECTOR_(              \
+				8, 16, simde__tmp_z_.i8, (simde__tmp_a_).i8,   \
+				HEDLEY_STATIC_CAST(int8_t, (16 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (17 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (18 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (19 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (20 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (21 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (22 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (23 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (24 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (25 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (26 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (27 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (28 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (29 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (30 - imm8) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (31 - imm8) & 31)); \
+		}                                                              \
+		simde__m128i_from_private(simde__tmp_r_);                      \
+	}))
 #endif
 #define simde_mm_slli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_bslli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
-  #define _mm_slli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
+#define _mm_bslli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
+#define _mm_slli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_bsrli_si128 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a);
+simde__m128i simde_mm_bsrli_si128(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+{
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
 
-  if (HEDLEY_UNLIKELY((imm8 & ~15))) {
-    return simde_mm_setzero_si128();
-  }
+	if (HEDLEY_UNLIKELY((imm8 & ~15))) {
+		return simde_mm_setzero_si128();
+	}
 
-  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
-    r_.altivec_i8 =
-    #if (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
-      vec_sro
-    #else /* SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG */
-      vec_slo
-    #endif
-        (a_.altivec_i8, vec_splats(HEDLEY_STATIC_CAST(unsigned char, imm8 * 8)));
-  #elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-    r_.altivec_i8 = vec_slb(a_.altivec_i8, vec_splats(HEDLEY_STATIC_CAST(unsigned char, (imm8 & 15) << 3)));
-  #else
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-      const int e = HEDLEY_STATIC_CAST(int, i) + imm8;
-      r_.i8[i] = (e < 16) ? a_.i8[e] : 0;
-    }
-  #endif
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
+	r_.altivec_i8 =
+#if (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
+		vec_sro
+#else /* SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG */
+		vec_slo
+#endif
+		(a_.altivec_i8,
+		 vec_splats(HEDLEY_STATIC_CAST(unsigned char, imm8 * 8)));
+#elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i8 = vec_slb(a_.altivec_i8,
+				vec_splats(HEDLEY_STATIC_CAST(
+					unsigned char, (imm8 & 15) << 3)));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
+		const int e = HEDLEY_STATIC_CAST(int, i) + imm8;
+		r_.i8[i] = (e < 16) ? a_.i8[e] : 0;
+	}
+#endif
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-  #define simde_mm_bsrli_si128(a, imm8) _mm_srli_si128(a, imm8)
+#define simde_mm_bsrli_si128(a, imm8) _mm_srli_si128(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
-  #define simde_mm_bsrli_si128(a, imm8) \
-  simde__m128i_from_neon_i8(((imm8 < 0) || (imm8 > 15)) ? vdupq_n_s8(0) : (vextq_s8(simde__m128i_to_private(a).neon_i8, vdupq_n_s8(0), ((imm8 & 15) != 0) ? imm8 : (imm8 & 15))))
-#elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && !defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-  #define simde_mm_bsrli_si128(a, imm8) (__extension__ ({ \
-    const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
-    const simde__m128i_private simde__tmp_z_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
-    simde__m128i_private simde__tmp_r_ = simde__m128i_to_private(a); \
-    if (HEDLEY_UNLIKELY(imm8 > 15)) { \
-      simde__tmp_r_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
-    } else { \
-      simde__tmp_r_.i8 = \
-      SIMDE_SHUFFLE_VECTOR_(8, 16, \
-        simde__tmp_z_.i8, \
-        (simde__tmp_a_).i8, \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 16) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 17) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 18) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 19) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 20) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 21) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 22) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 23) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 24) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 25) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 26) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 27) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 28) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 29) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 30) & 31), \
-        HEDLEY_STATIC_CAST(int8_t, (imm8 + 31) & 31)); \
-    } \
-    simde__m128i_from_private(simde__tmp_r_); }))
+#define simde_mm_bsrli_si128(a, imm8)                                   \
+	simde__m128i_from_neon_i8(                                      \
+		((imm8 < 0) || (imm8 > 15))                             \
+			? vdupq_n_s8(0)                                 \
+			: (vextq_s8(simde__m128i_to_private(a).neon_i8, \
+				    vdupq_n_s8(0),                      \
+				    ((imm8 & 15) != 0) ? imm8 : (imm8 & 15))))
+#elif defined(SIMDE_SHUFFLE_VECTOR_) &&            \
+	!defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && \
+	!defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+#define simde_mm_bsrli_si128(a, imm8)                                          \
+	(__extension__({                                                       \
+		const simde__m128i_private simde__tmp_a_ =                     \
+			simde__m128i_to_private(a);                            \
+		const simde__m128i_private simde__tmp_z_ =                     \
+			simde__m128i_to_private(simde_mm_setzero_si128());     \
+		simde__m128i_private simde__tmp_r_ =                           \
+			simde__m128i_to_private(a);                            \
+		if (HEDLEY_UNLIKELY(imm8 > 15)) {                              \
+			simde__tmp_r_ = simde__m128i_to_private(               \
+				simde_mm_setzero_si128());                     \
+		} else {                                                       \
+			simde__tmp_r_.i8 = SIMDE_SHUFFLE_VECTOR_(              \
+				8, 16, simde__tmp_z_.i8, (simde__tmp_a_).i8,   \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 16) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 17) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 18) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 19) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 20) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 21) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 22) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 23) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 24) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 25) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 26) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 27) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 28) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 29) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 30) & 31),  \
+				HEDLEY_STATIC_CAST(int8_t, (imm8 + 31) & 31)); \
+		}                                                              \
+		simde__m128i_from_private(simde__tmp_r_);                      \
+	}))
 #endif
 #define simde_mm_srli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_bsrli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
-  #define _mm_srli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
+#define _mm_bsrli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
+#define _mm_srli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_clflush (void const* p) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_clflush(p);
-  #else
-    (void) p;
-  #endif
+void simde_mm_clflush(void const *p)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_clflush(p);
+#else
+	(void)p;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_clflush(a, b) simde_mm_clflush()
+#define _mm_clflush(a, b) simde_mm_clflush()
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int
-simde_mm_comieq_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_comieq_sd(a, b);
-  #else
-    simde__m128d_private
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      return !!vgetq_lane_u64(vceqq_f64(a_.neon_f64, b_.neon_f64), 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) == wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-    #else
-      return a_.f64[0] == b_.f64[0];
-    #endif
-  #endif
+int simde_mm_comieq_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_comieq_sd(a, b);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a),
+			     b_ = simde__m128d_to_private(b);
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return !!vgetq_lane_u64(vceqq_f64(a_.neon_f64, b_.neon_f64), 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) ==
+	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+#else
+	return a_.f64[0] == b_.f64[0];
+#endif
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_comieq_sd(a, b) simde_mm_comieq_sd(a, b)
+#define _mm_comieq_sd(a, b) simde_mm_comieq_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int
-simde_mm_comige_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_comige_sd(a, b);
-  #else
-    simde__m128d_private
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      return !!vgetq_lane_u64(vcgeq_f64(a_.neon_f64, b_.neon_f64), 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >= wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-    #else
-      return a_.f64[0] >= b_.f64[0];
-    #endif
-  #endif
+int simde_mm_comige_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_comige_sd(a, b);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a),
+			     b_ = simde__m128d_to_private(b);
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return !!vgetq_lane_u64(vcgeq_f64(a_.neon_f64, b_.neon_f64), 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >=
+	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+#else
+	return a_.f64[0] >= b_.f64[0];
+#endif
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_comige_sd(a, b) simde_mm_comige_sd(a, b)
+#define _mm_comige_sd(a, b) simde_mm_comige_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int
-simde_mm_comigt_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_comigt_sd(a, b);
-  #else
-    simde__m128d_private
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      return !!vgetq_lane_u64(vcgtq_f64(a_.neon_f64, b_.neon_f64), 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) > wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-    #else
-      return a_.f64[0] > b_.f64[0];
-    #endif
-  #endif
+int simde_mm_comigt_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_comigt_sd(a, b);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a),
+			     b_ = simde__m128d_to_private(b);
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return !!vgetq_lane_u64(vcgtq_f64(a_.neon_f64, b_.neon_f64), 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >
+	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+#else
+	return a_.f64[0] > b_.f64[0];
+#endif
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_comigt_sd(a, b) simde_mm_comigt_sd(a, b)
+#define _mm_comigt_sd(a, b) simde_mm_comigt_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int
-simde_mm_comile_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_comile_sd(a, b);
-  #else
-    simde__m128d_private
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      return !!vgetq_lane_u64(vcleq_f64(a_.neon_f64, b_.neon_f64), 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <= wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-    #else
-      return a_.f64[0] <= b_.f64[0];
-    #endif
-  #endif
+int simde_mm_comile_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_comile_sd(a, b);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a),
+			     b_ = simde__m128d_to_private(b);
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return !!vgetq_lane_u64(vcleq_f64(a_.neon_f64, b_.neon_f64), 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <=
+	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+#else
+	return a_.f64[0] <= b_.f64[0];
+#endif
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_comile_sd(a, b) simde_mm_comile_sd(a, b)
+#define _mm_comile_sd(a, b) simde_mm_comile_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int
-simde_mm_comilt_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_comilt_sd(a, b);
-  #else
-    simde__m128d_private
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      return !!vgetq_lane_u64(vcltq_f64(a_.neon_f64, b_.neon_f64), 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) < wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-    #else
-      return a_.f64[0] < b_.f64[0];
-    #endif
-  #endif
+int simde_mm_comilt_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_comilt_sd(a, b);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a),
+			     b_ = simde__m128d_to_private(b);
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return !!vgetq_lane_u64(vcltq_f64(a_.neon_f64, b_.neon_f64), 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <
+	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+#else
+	return a_.f64[0] < b_.f64[0];
+#endif
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_comilt_sd(a, b) simde_mm_comilt_sd(a, b)
+#define _mm_comilt_sd(a, b) simde_mm_comilt_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int
-simde_mm_comineq_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_comineq_sd(a, b);
-  #else
-    simde__m128d_private
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      return !vgetq_lane_u64(vceqq_f64(a_.neon_f64, b_.neon_f64), 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) != wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-    #else
-      return a_.f64[0] != b_.f64[0];
-    #endif
-  #endif
+int simde_mm_comineq_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_comineq_sd(a, b);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a),
+			     b_ = simde__m128d_to_private(b);
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return !vgetq_lane_u64(vceqq_f64(a_.neon_f64, b_.neon_f64), 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) !=
+	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+#else
+	return a_.f64[0] != b_.f64[0];
+#endif
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_comineq_sd(a, b) simde_mm_comineq_sd(a, b)
+#define _mm_comineq_sd(a, b) simde_mm_comineq_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_x_mm_copysign_pd(simde__m128d dest, simde__m128d src) {
-  simde__m128d_private
-    r_,
-    dest_ = simde__m128d_to_private(dest),
-    src_ = simde__m128d_to_private(src);
+simde__m128d simde_x_mm_copysign_pd(simde__m128d dest, simde__m128d src)
+{
+	simde__m128d_private r_, dest_ = simde__m128d_to_private(dest),
+				 src_ = simde__m128d_to_private(src);
 
-  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      uint64x2_t sign_pos = vreinterpretq_u64_f64(vdupq_n_f64(-SIMDE_FLOAT64_C(0.0)));
-    #else
-      simde_float64 dbl_nz = -SIMDE_FLOAT64_C(0.0);
-      uint64_t u64_nz;
-      simde_memcpy(&u64_nz, &dbl_nz, sizeof(u64_nz));
-      uint64x2_t sign_pos = vdupq_n_u64(u64_nz);
-    #endif
-    r_.neon_u64 = vbslq_u64(sign_pos, src_.neon_u64, dest_.neon_u64);
-  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-    #if defined(SIMDE_BUG_VEC_CPSGN_REVERSED_ARGS)
-      r_.altivec_f64 = vec_cpsgn(dest_.altivec_f64, src_.altivec_f64);
-    #else
-      r_.altivec_f64 = vec_cpsgn(src_.altivec_f64, dest_.altivec_f64);
-    #endif
-  #elif defined(simde_math_copysign)
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-      r_.f64[i] = simde_math_copysign(dest_.f64[i], src_.f64[i]);
-    }
-  #else
-    simde__m128d sgnbit = simde_mm_set1_pd(-SIMDE_FLOAT64_C(0.0));
-    return simde_mm_xor_pd(simde_mm_and_pd(sgnbit, src), simde_mm_andnot_pd(sgnbit, dest));
-  #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	uint64x2_t sign_pos =
+		vreinterpretq_u64_f64(vdupq_n_f64(-SIMDE_FLOAT64_C(0.0)));
+#else
+	simde_float64 dbl_nz = -SIMDE_FLOAT64_C(0.0);
+	uint64_t u64_nz;
+	simde_memcpy(&u64_nz, &dbl_nz, sizeof(u64_nz));
+	uint64x2_t sign_pos = vdupq_n_u64(u64_nz);
+#endif
+	r_.neon_u64 = vbslq_u64(sign_pos, src_.neon_u64, dest_.neon_u64);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+#if defined(SIMDE_BUG_VEC_CPSGN_REVERSED_ARGS)
+	r_.altivec_f64 = vec_cpsgn(dest_.altivec_f64, src_.altivec_f64);
+#else
+	r_.altivec_f64 = vec_cpsgn(src_.altivec_f64, dest_.altivec_f64);
+#endif
+#elif defined(simde_math_copysign)
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = simde_math_copysign(dest_.f64[i], src_.f64[i]);
+	}
+#else
+	simde__m128d sgnbit = simde_mm_set1_pd(-SIMDE_FLOAT64_C(0.0));
+	return simde_mm_xor_pd(simde_mm_and_pd(sgnbit, src),
+			       simde_mm_andnot_pd(sgnbit, dest));
+#endif
 
-  return simde__m128d_from_private(r_);
+	return simde__m128d_from_private(r_);
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_x_mm_xorsign_pd(simde__m128d dest, simde__m128d src) {
-  return simde_mm_xor_pd(simde_mm_and_pd(simde_mm_set1_pd(-0.0), src), dest);
+simde__m128d simde_x_mm_xorsign_pd(simde__m128d dest, simde__m128d src)
+{
+	return simde_mm_xor_pd(simde_mm_and_pd(simde_mm_set1_pd(-0.0), src),
+			       dest);
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128
-simde_mm_castpd_ps (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_castpd_ps(a);
-  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    return vreinterpretq_f32_f64(a);
-  #else
-    simde__m128 r;
-    simde_memcpy(&r, &a, sizeof(a));
-    return r;
-  #endif
+simde__m128 simde_mm_castpd_ps(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_castpd_ps(a);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return vreinterpretq_f32_f64(a);
+#else
+	simde__m128 r;
+	simde_memcpy(&r, &a, sizeof(a));
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_castpd_ps(a) simde_mm_castpd_ps(a)
+#define _mm_castpd_ps(a) simde_mm_castpd_ps(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_castpd_si128 (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_castpd_si128(a);
-  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    return vreinterpretq_s64_f64(a);
-  #else
-    simde__m128i r;
-    simde_memcpy(&r, &a, sizeof(a));
-    return r;
-  #endif
+simde__m128i simde_mm_castpd_si128(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_castpd_si128(a);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return vreinterpretq_s64_f64(a);
+#else
+	simde__m128i r;
+	simde_memcpy(&r, &a, sizeof(a));
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_castpd_si128(a) simde_mm_castpd_si128(a)
+#define _mm_castpd_si128(a) simde_mm_castpd_si128(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_castps_pd (simde__m128 a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_castps_pd(a);
-  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    return vreinterpretq_f64_f32(a);
-  #else
-    simde__m128d r;
-    simde_memcpy(&r, &a, sizeof(a));
-    return r;
-  #endif
+simde__m128d simde_mm_castps_pd(simde__m128 a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_castps_pd(a);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return vreinterpretq_f64_f32(a);
+#else
+	simde__m128d r;
+	simde_memcpy(&r, &a, sizeof(a));
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_castps_pd(a) simde_mm_castps_pd(a)
+#define _mm_castps_pd(a) simde_mm_castps_pd(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_castps_si128 (simde__m128 a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_castps_si128(a);
-  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    return simde__m128i_from_neon_i32(simde__m128_to_private(a).neon_i32);
-  #else
-    simde__m128i r;
-    simde_memcpy(&r, &a, sizeof(a));
-    return r;
-  #endif
+simde__m128i simde_mm_castps_si128(simde__m128 a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_castps_si128(a);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	return simde__m128i_from_neon_i32(simde__m128_to_private(a).neon_i32);
+#else
+	simde__m128i r;
+	simde_memcpy(&r, &a, sizeof(a));
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_castps_si128(a) simde_mm_castps_si128(a)
+#define _mm_castps_si128(a) simde_mm_castps_si128(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_castsi128_pd (simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_castsi128_pd(a);
-  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    return vreinterpretq_f64_s64(a);
-  #else
-    simde__m128d r;
-    simde_memcpy(&r, &a, sizeof(a));
-    return r;
-  #endif
+simde__m128d simde_mm_castsi128_pd(simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_castsi128_pd(a);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return vreinterpretq_f64_s64(a);
+#else
+	simde__m128d r;
+	simde_memcpy(&r, &a, sizeof(a));
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_castsi128_pd(a) simde_mm_castsi128_pd(a)
+#define _mm_castsi128_pd(a) simde_mm_castsi128_pd(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128
-simde_mm_castsi128_ps (simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_castsi128_ps(a);
-  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), a);
-  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    return simde__m128_from_neon_i32(simde__m128i_to_private(a).neon_i32);
-  #else
-    simde__m128 r;
-    simde_memcpy(&r, &a, sizeof(a));
-    return r;
-  #endif
+simde__m128 simde_mm_castsi128_ps(simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_castsi128_ps(a);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), a);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	return simde__m128_from_neon_i32(simde__m128i_to_private(a).neon_i32);
+#else
+	simde__m128 r;
+	simde_memcpy(&r, &a, sizeof(a));
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_castsi128_ps(a) simde_mm_castsi128_ps(a)
+#define _mm_castsi128_ps(a) simde_mm_castsi128_ps(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cmpeq_epi8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpeq_epi8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_cmpeq_epi8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpeq_epi8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u8 = vceqq_s8(b_.neon_i8, a_.neon_i8);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i8x16_eq(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), vec_cmpeq(a_.altivec_i8, b_.altivec_i8));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 == b_.i8));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-        r_.i8[i] = (a_.i8[i] == b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u8 = vceqq_s8(b_.neon_i8, a_.neon_i8);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i8x16_eq(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(signed char),
+		vec_cmpeq(a_.altivec_i8, b_.altivec_i8));
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 == b_.i8));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
+		r_.i8[i] = (a_.i8[i] == b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpeq_epi8(a, b) simde_mm_cmpeq_epi8(a, b)
+#define _mm_cmpeq_epi8(a, b) simde_mm_cmpeq_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cmpeq_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpeq_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_cmpeq_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpeq_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u16 = vceqq_s16(b_.neon_i16, a_.neon_i16);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i16x8_eq(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short), vec_cmpeq(a_.altivec_i16, b_.altivec_i16));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i16 = (a_.i16 == b_.i16);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = (a_.i16[i] == b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u16 = vceqq_s16(b_.neon_i16, a_.neon_i16);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i16x8_eq(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(signed short),
+		vec_cmpeq(a_.altivec_i16, b_.altivec_i16));
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i16 = (a_.i16 == b_.i16);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = (a_.i16[i] == b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpeq_epi16(a, b) simde_mm_cmpeq_epi16(a, b)
+#define _mm_cmpeq_epi16(a, b) simde_mm_cmpeq_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cmpeq_epi32 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpeq_epi32(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_cmpeq_epi32(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpeq_epi32(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u32 = vceqq_s32(b_.neon_i32, a_.neon_i32);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i32x4_eq(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), vec_cmpeq(a_.altivec_i32, b_.altivec_i32));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), a_.i32 == b_.i32);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        r_.i32[i] = (a_.i32[i] == b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u32 = vceqq_s32(b_.neon_i32, a_.neon_i32);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i32x4_eq(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(signed int),
+		vec_cmpeq(a_.altivec_i32, b_.altivec_i32));
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), a_.i32 == b_.i32);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		r_.i32[i] = (a_.i32[i] == b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpeq_epi32(a, b) simde_mm_cmpeq_epi32(a, b)
+#define _mm_cmpeq_epi32(a, b) simde_mm_cmpeq_epi32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpeq_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpeq_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmpeq_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpeq_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_u64 = vceqq_f64(b_.neon_f64, a_.neon_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_eq(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpeq(a_.altivec_f64, b_.altivec_f64));
-    #elif defined(SIMDE_MIPS_MSA_NATIVE)
-      r_.msa_i32 = __msa_addv_w(a_.msa_i32, b_.msa_i32);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.u64[i] = (a_.f64[i] == b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_u64 = vceqq_f64(b_.neon_f64, a_.neon_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_eq(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(double),
+		vec_cmpeq(a_.altivec_f64, b_.altivec_f64));
+#elif defined(SIMDE_MIPS_MSA_NATIVE)
+	r_.msa_i32 = __msa_addv_w(a_.msa_i32, b_.msa_i32);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.u64[i] = (a_.f64[i] == b_.f64[i]) ? ~UINT64_C(0)
+						     : UINT64_C(0);
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpeq_pd(a, b) simde_mm_cmpeq_pd(a, b)
+#define _mm_cmpeq_pd(a, b) simde_mm_cmpeq_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpeq_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpeq_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_cmpeq_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_cmpeq_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmpeq_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpeq_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_cmpeq_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(
+		a, simde_mm_cmpeq_pd(simde_x_mm_broadcastlow_pd(a),
+				     simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    r_.u64[0] = (a_.u64[0] == b_.u64[0]) ? ~UINT64_C(0) : 0;
-    r_.u64[1] = a_.u64[1];
+	r_.u64[0] = (a_.u64[0] == b_.u64[0]) ? ~UINT64_C(0) : 0;
+	r_.u64[1] = a_.u64[1];
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpeq_sd(a, b) simde_mm_cmpeq_sd(a, b)
+#define _mm_cmpeq_sd(a, b) simde_mm_cmpeq_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpneq_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpneq_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmpneq_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpneq_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_u32 = vmvnq_u32(vreinterpretq_u32_u64(vceqq_f64(b_.neon_f64, a_.neon_f64)));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_ne(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 != b_.f64));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.u64[i] = (a_.f64[i] != b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_u32 = vmvnq_u32(
+		vreinterpretq_u32_u64(vceqq_f64(b_.neon_f64, a_.neon_f64)));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_ne(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 != b_.f64));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.u64[i] = (a_.f64[i] != b_.f64[i]) ? ~UINT64_C(0)
+						     : UINT64_C(0);
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpneq_pd(a, b) simde_mm_cmpneq_pd(a, b)
+#define _mm_cmpneq_pd(a, b) simde_mm_cmpneq_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpneq_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpneq_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_cmpneq_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_cmpneq_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmpneq_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpneq_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_cmpneq_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(
+		a, simde_mm_cmpneq_pd(simde_x_mm_broadcastlow_pd(a),
+				      simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    r_.u64[0] = (a_.f64[0] != b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
-    r_.u64[1] = a_.u64[1];
+	r_.u64[0] = (a_.f64[0] != b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+	r_.u64[1] = a_.u64[1];
 
-
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpneq_sd(a, b) simde_mm_cmpneq_sd(a, b)
+#define _mm_cmpneq_sd(a, b) simde_mm_cmpneq_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cmplt_epi8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmplt_epi8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_cmplt_epi8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmplt_epi8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u8 = vcltq_s8(a_.neon_i8, b_.neon_i8);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char),vec_cmplt(a_.altivec_i8, b_.altivec_i8));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i8x16_lt(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 < b_.i8));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-        r_.i8[i] = (a_.i8[i] < b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u8 = vcltq_s8(a_.neon_i8, b_.neon_i8);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(signed char),
+		vec_cmplt(a_.altivec_i8, b_.altivec_i8));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i8x16_lt(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 < b_.i8));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
+		r_.i8[i] = (a_.i8[i] < b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmplt_epi8(a, b) simde_mm_cmplt_epi8(a, b)
+#define _mm_cmplt_epi8(a, b) simde_mm_cmplt_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cmplt_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmplt_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_cmplt_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmplt_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u16 = vcltq_s16(a_.neon_i16, b_.neon_i16);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short), vec_cmplt(a_.altivec_i16, b_.altivec_i16));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i16x8_lt(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i16 = HEDLEY_STATIC_CAST(__typeof__(r_.i16), (a_.i16 < b_.i16));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = (a_.i16[i] < b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u16 = vcltq_s16(a_.neon_i16, b_.neon_i16);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(signed short),
+		vec_cmplt(a_.altivec_i16, b_.altivec_i16));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i16x8_lt(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i16 = HEDLEY_STATIC_CAST(__typeof__(r_.i16), (a_.i16 < b_.i16));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = (a_.i16[i] < b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmplt_epi16(a, b) simde_mm_cmplt_epi16(a, b)
+#define _mm_cmplt_epi16(a, b) simde_mm_cmplt_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cmplt_epi32 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmplt_epi32(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_cmplt_epi32(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmplt_epi32(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u32 = vcltq_s32(a_.neon_i32, b_.neon_i32);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), vec_cmplt(a_.altivec_i32, b_.altivec_i32));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i32x4_lt(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.i32 < b_.i32));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        r_.i32[i] = (a_.i32[i] < b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u32 = vcltq_s32(a_.neon_i32, b_.neon_i32);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(signed int),
+		vec_cmplt(a_.altivec_i32, b_.altivec_i32));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i32x4_lt(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.i32 < b_.i32));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		r_.i32[i] = (a_.i32[i] < b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmplt_epi32(a, b) simde_mm_cmplt_epi32(a, b)
+#define _mm_cmplt_epi32(a, b) simde_mm_cmplt_epi32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmplt_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmplt_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmplt_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmplt_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_u64 = vcltq_f64(a_.neon_f64, b_.neon_f64);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmplt(a_.altivec_f64, b_.altivec_f64));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_lt(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 < b_.f64));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.u64[i] = (a_.f64[i] < b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_u64 = vcltq_f64(a_.neon_f64, b_.neon_f64);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(double),
+		vec_cmplt(a_.altivec_f64, b_.altivec_f64));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_lt(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 < b_.f64));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.u64[i] = (a_.f64[i] < b_.f64[i]) ? ~UINT64_C(0)
+						    : UINT64_C(0);
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmplt_pd(a, b) simde_mm_cmplt_pd(a, b)
+#define _mm_cmplt_pd(a, b) simde_mm_cmplt_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmplt_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmplt_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_cmplt_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_cmplt_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmplt_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmplt_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_cmplt_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(
+		a, simde_mm_cmplt_pd(simde_x_mm_broadcastlow_pd(a),
+				     simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    r_.u64[0] = (a_.f64[0] < b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
-    r_.u64[1] = a_.u64[1];
+	r_.u64[0] = (a_.f64[0] < b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+	r_.u64[1] = a_.u64[1];
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmplt_sd(a, b) simde_mm_cmplt_sd(a, b)
+#define _mm_cmplt_sd(a, b) simde_mm_cmplt_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmple_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmple_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmple_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmple_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_u64 = vcleq_f64(a_.neon_f64, b_.neon_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_le(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmple(a_.altivec_f64, b_.altivec_f64));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.u64[i] = (a_.f64[i] <= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
-      }
-    #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_u64 = vcleq_f64(a_.neon_f64, b_.neon_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_le(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(double),
+		vec_cmple(a_.altivec_f64, b_.altivec_f64));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.u64[i] = (a_.f64[i] <= b_.f64[i]) ? ~UINT64_C(0)
+						     : UINT64_C(0);
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmple_pd(a, b) simde_mm_cmple_pd(a, b)
+#define _mm_cmple_pd(a, b) simde_mm_cmple_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmple_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmple_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_cmple_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_cmple_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmple_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmple_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_cmple_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(
+		a, simde_mm_cmple_pd(simde_x_mm_broadcastlow_pd(a),
+				     simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    r_.u64[0] = (a_.f64[0] <= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
-    r_.u64[1] = a_.u64[1];
+	r_.u64[0] = (a_.f64[0] <= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+	r_.u64[1] = a_.u64[1];
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmple_sd(a, b) simde_mm_cmple_sd(a, b)
+#define _mm_cmple_sd(a, b) simde_mm_cmple_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cmpgt_epi8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpgt_epi8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_cmpgt_epi8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpgt_epi8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u8 = vcgtq_s8(a_.neon_i8, b_.neon_i8);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i8x16_gt(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), vec_cmpgt(a_.altivec_i8, b_.altivec_i8));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 > b_.i8));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-        r_.i8[i] = (a_.i8[i] > b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u8 = vcgtq_s8(a_.neon_i8, b_.neon_i8);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i8x16_gt(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(signed char),
+		vec_cmpgt(a_.altivec_i8, b_.altivec_i8));
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 > b_.i8));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
+		r_.i8[i] = (a_.i8[i] > b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpgt_epi8(a, b) simde_mm_cmpgt_epi8(a, b)
+#define _mm_cmpgt_epi8(a, b) simde_mm_cmpgt_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cmpgt_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpgt_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_cmpgt_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpgt_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u16 = vcgtq_s16(a_.neon_i16, b_.neon_i16);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i16x8_gt(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short), vec_cmpgt(a_.altivec_i16, b_.altivec_i16));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i16 = HEDLEY_STATIC_CAST(__typeof__(r_.i16), (a_.i16 > b_.i16));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u16 = vcgtq_s16(a_.neon_i16, b_.neon_i16);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i16x8_gt(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(signed short),
+		vec_cmpgt(a_.altivec_i16, b_.altivec_i16));
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i16 = HEDLEY_STATIC_CAST(__typeof__(r_.i16), (a_.i16 > b_.i16));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpgt_epi16(a, b) simde_mm_cmpgt_epi16(a, b)
+#define _mm_cmpgt_epi16(a, b) simde_mm_cmpgt_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cmpgt_epi32 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpgt_epi32(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_cmpgt_epi32(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpgt_epi32(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u32 = vcgtq_s32(a_.neon_i32, b_.neon_i32);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i32x4_gt(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), vec_cmpgt(a_.altivec_i32, b_.altivec_i32));
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.i32 > b_.i32));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        r_.i32[i] = (a_.i32[i] > b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u32 = vcgtq_s32(a_.neon_i32, b_.neon_i32);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i32x4_gt(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(signed int),
+		vec_cmpgt(a_.altivec_i32, b_.altivec_i32));
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.i32 > b_.i32));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		r_.i32[i] = (a_.i32[i] > b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpgt_epi32(a, b) simde_mm_cmpgt_epi32(a, b)
+#define _mm_cmpgt_epi32(a, b) simde_mm_cmpgt_epi32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpgt_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpgt_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmpgt_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpgt_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_u64 = vcgtq_f64(a_.neon_f64, b_.neon_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_gt(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_f64 = HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpgt(a_.altivec_f64, b_.altivec_f64));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.u64[i] = (a_.f64[i] > b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
-      }
-    #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_u64 = vcgtq_f64(a_.neon_f64, b_.neon_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_gt(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_f64 =
+		HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double),
+				   vec_cmpgt(a_.altivec_f64, b_.altivec_f64));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.u64[i] = (a_.f64[i] > b_.f64[i]) ? ~UINT64_C(0)
+						    : UINT64_C(0);
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpgt_pd(a, b) simde_mm_cmpgt_pd(a, b)
+#define _mm_cmpgt_pd(a, b) simde_mm_cmpgt_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpgt_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-    return _mm_cmpgt_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_cmpgt_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_cmpgt_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmpgt_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+	return _mm_cmpgt_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_cmpgt_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(
+		a, simde_mm_cmpgt_pd(simde_x_mm_broadcastlow_pd(a),
+				     simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    r_.u64[0] = (a_.f64[0] > b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
-    r_.u64[1] = a_.u64[1];
+	r_.u64[0] = (a_.f64[0] > b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+	r_.u64[1] = a_.u64[1];
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpgt_sd(a, b) simde_mm_cmpgt_sd(a, b)
+#define _mm_cmpgt_sd(a, b) simde_mm_cmpgt_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpge_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpge_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmpge_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpge_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_u64 = vcgeq_f64(a_.neon_f64, b_.neon_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_ge(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_f64 = HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpge(a_.altivec_f64, b_.altivec_f64));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.u64[i] = (a_.f64[i] >= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
-      }
-    #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_u64 = vcgeq_f64(a_.neon_f64, b_.neon_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_ge(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_f64 =
+		HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double),
+				   vec_cmpge(a_.altivec_f64, b_.altivec_f64));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.u64[i] = (a_.f64[i] >= b_.f64[i]) ? ~UINT64_C(0)
+						     : UINT64_C(0);
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpge_pd(a, b) simde_mm_cmpge_pd(a, b)
+#define _mm_cmpge_pd(a, b) simde_mm_cmpge_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpge_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-    return _mm_cmpge_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_cmpge_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_cmpge_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmpge_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+	return _mm_cmpge_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_cmpge_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(
+		a, simde_mm_cmpge_pd(simde_x_mm_broadcastlow_pd(a),
+				     simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    r_.u64[0] = (a_.f64[0] >= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
-    r_.u64[1] = a_.u64[1];
+	r_.u64[0] = (a_.f64[0] >= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+	r_.u64[1] = a_.u64[1];
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpge_sd(a, b) simde_mm_cmpge_sd(a, b)
+#define _mm_cmpge_sd(a, b) simde_mm_cmpge_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpngt_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpngt_pd(a, b);
-  #else
-    return simde_mm_cmple_pd(a, b);
-  #endif
+simde__m128d simde_mm_cmpngt_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpngt_pd(a, b);
+#else
+	return simde_mm_cmple_pd(a, b);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpngt_pd(a, b) simde_mm_cmpngt_pd(a, b)
+#define _mm_cmpngt_pd(a, b) simde_mm_cmpngt_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpngt_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-    return _mm_cmpngt_sd(a, b);
-  #else
-    return simde_mm_cmple_sd(a, b);
-  #endif
+simde__m128d simde_mm_cmpngt_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+	return _mm_cmpngt_sd(a, b);
+#else
+	return simde_mm_cmple_sd(a, b);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpngt_sd(a, b) simde_mm_cmpngt_sd(a, b)
+#define _mm_cmpngt_sd(a, b) simde_mm_cmpngt_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpnge_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpnge_pd(a, b);
-  #else
-    return simde_mm_cmplt_pd(a, b);
-  #endif
+simde__m128d simde_mm_cmpnge_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpnge_pd(a, b);
+#else
+	return simde_mm_cmplt_pd(a, b);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpnge_pd(a, b) simde_mm_cmpnge_pd(a, b)
+#define _mm_cmpnge_pd(a, b) simde_mm_cmpnge_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpnge_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-    return _mm_cmpnge_sd(a, b);
-  #else
-    return simde_mm_cmplt_sd(a, b);
-  #endif
+simde__m128d simde_mm_cmpnge_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+	return _mm_cmpnge_sd(a, b);
+#else
+	return simde_mm_cmplt_sd(a, b);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpnge_sd(a, b) simde_mm_cmpnge_sd(a, b)
+#define _mm_cmpnge_sd(a, b) simde_mm_cmpnge_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpnlt_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpnlt_pd(a, b);
-  #else
-    return simde_mm_cmpge_pd(a, b);
-  #endif
+simde__m128d simde_mm_cmpnlt_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpnlt_pd(a, b);
+#else
+	return simde_mm_cmpge_pd(a, b);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpnlt_pd(a, b) simde_mm_cmpnlt_pd(a, b)
+#define _mm_cmpnlt_pd(a, b) simde_mm_cmpnlt_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpnlt_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpnlt_sd(a, b);
-  #else
-    return simde_mm_cmpge_sd(a, b);
-  #endif
+simde__m128d simde_mm_cmpnlt_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpnlt_sd(a, b);
+#else
+	return simde_mm_cmpge_sd(a, b);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpnlt_sd(a, b) simde_mm_cmpnlt_sd(a, b)
+#define _mm_cmpnlt_sd(a, b) simde_mm_cmpnlt_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpnle_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpnle_pd(a, b);
-  #else
-    return simde_mm_cmpgt_pd(a, b);
-  #endif
+simde__m128d simde_mm_cmpnle_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpnle_pd(a, b);
+#else
+	return simde_mm_cmpgt_pd(a, b);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpnle_pd(a, b) simde_mm_cmpnle_pd(a, b)
+#define _mm_cmpnle_pd(a, b) simde_mm_cmpnle_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpnle_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpnle_sd(a, b);
-  #else
-    return simde_mm_cmpgt_sd(a, b);
-  #endif
+simde__m128d simde_mm_cmpnle_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpnle_sd(a, b);
+#else
+	return simde_mm_cmpgt_sd(a, b);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpnle_sd(a, b) simde_mm_cmpnle_sd(a, b)
+#define _mm_cmpnle_sd(a, b) simde_mm_cmpnle_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpord_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpord_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmpord_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpord_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      /* Note: NEON does not have ordered compare builtin
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	/* Note: NEON does not have ordered compare builtin
         Need to compare a eq a and b eq b to check for NaN
         Do AND of results to get final */
-      uint64x2_t ceqaa = vceqq_f64(a_.neon_f64, a_.neon_f64);
-      uint64x2_t ceqbb = vceqq_f64(b_.neon_f64, b_.neon_f64);
-      r_.neon_u64 = vandq_u64(ceqaa, ceqbb);
-    #elif defined(simde_math_isnan)
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.u64[i] = (!simde_math_isnan(a_.f64[i]) && !simde_math_isnan(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
-      }
-    #else
-      HEDLEY_UNREACHABLE();
-    #endif
+	uint64x2_t ceqaa = vceqq_f64(a_.neon_f64, a_.neon_f64);
+	uint64x2_t ceqbb = vceqq_f64(b_.neon_f64, b_.neon_f64);
+	r_.neon_u64 = vandq_u64(ceqaa, ceqbb);
+#elif defined(simde_math_isnan)
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.u64[i] = (!simde_math_isnan(a_.f64[i]) &&
+			     !simde_math_isnan(b_.f64[i]))
+				    ? ~UINT64_C(0)
+				    : UINT64_C(0);
+	}
+#else
+	HEDLEY_UNREACHABLE();
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpord_pd(a, b) simde_mm_cmpord_pd(a, b)
+#define _mm_cmpord_pd(a, b) simde_mm_cmpord_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde_float64
-simde_mm_cvtsd_f64 (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-    return _mm_cvtsd_f64(a);
-  #else
-    simde__m128d_private a_ = simde__m128d_to_private(a);
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      return HEDLEY_STATIC_CAST(simde_float64, vgetq_lane_f64(a_.neon_f64, 0));
-    #else
-      return a_.f64[0];
-    #endif
-  #endif
+simde_float64 simde_mm_cvtsd_f64(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+	return _mm_cvtsd_f64(a);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a);
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return HEDLEY_STATIC_CAST(simde_float64,
+				  vgetq_lane_f64(a_.neon_f64, 0));
+#else
+	return a_.f64[0];
+#endif
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtsd_f64(a) simde_mm_cvtsd_f64(a)
+#define _mm_cvtsd_f64(a) simde_mm_cvtsd_f64(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpord_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpord_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_cmpord_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_cmpord_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmpord_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpord_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_cmpord_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(
+		a, simde_mm_cmpord_pd(simde_x_mm_broadcastlow_pd(a),
+				      simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(simde_math_isnan)
-      r_.u64[0] = (!simde_math_isnan(a_.f64[0]) && !simde_math_isnan(b_.f64[0])) ? ~UINT64_C(0) : UINT64_C(0);
-      r_.u64[1] = a_.u64[1];
-    #else
-      HEDLEY_UNREACHABLE();
-    #endif
+#if defined(simde_math_isnan)
+	r_.u64[0] =
+		(!simde_math_isnan(a_.f64[0]) && !simde_math_isnan(b_.f64[0]))
+			? ~UINT64_C(0)
+			: UINT64_C(0);
+	r_.u64[1] = a_.u64[1];
+#else
+	HEDLEY_UNREACHABLE();
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpord_sd(a, b) simde_mm_cmpord_sd(a, b)
+#define _mm_cmpord_sd(a, b) simde_mm_cmpord_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpunord_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpunord_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmpunord_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpunord_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      uint64x2_t ceqaa = vceqq_f64(a_.neon_f64, a_.neon_f64);
-      uint64x2_t ceqbb = vceqq_f64(b_.neon_f64, b_.neon_f64);
-      r_.neon_u64 = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(ceqaa, ceqbb))));
-    #elif defined(simde_math_isnan)
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.u64[i] = (simde_math_isnan(a_.f64[i]) || simde_math_isnan(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
-      }
-    #else
-      HEDLEY_UNREACHABLE();
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	uint64x2_t ceqaa = vceqq_f64(a_.neon_f64, a_.neon_f64);
+	uint64x2_t ceqbb = vceqq_f64(b_.neon_f64, b_.neon_f64);
+	r_.neon_u64 = vreinterpretq_u64_u32(
+		vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(ceqaa, ceqbb))));
+#elif defined(simde_math_isnan)
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.u64[i] = (simde_math_isnan(a_.f64[i]) ||
+			     simde_math_isnan(b_.f64[i]))
+				    ? ~UINT64_C(0)
+				    : UINT64_C(0);
+	}
+#else
+	HEDLEY_UNREACHABLE();
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpunord_pd(a, b) simde_mm_cmpunord_pd(a, b)
+#define _mm_cmpunord_pd(a, b) simde_mm_cmpunord_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cmpunord_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cmpunord_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_cmpunord_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_cmpunord_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_cmpunord_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cmpunord_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_cmpunord_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(
+		a, simde_mm_cmpunord_pd(simde_x_mm_broadcastlow_pd(a),
+					simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(simde_math_isnan)
-      r_.u64[0] = (simde_math_isnan(a_.f64[0]) || simde_math_isnan(b_.f64[0])) ? ~UINT64_C(0) : UINT64_C(0);
-      r_.u64[1] = a_.u64[1];
-    #else
-      HEDLEY_UNREACHABLE();
-    #endif
+#if defined(simde_math_isnan)
+	r_.u64[0] = (simde_math_isnan(a_.f64[0]) || simde_math_isnan(b_.f64[0]))
+			    ? ~UINT64_C(0)
+			    : UINT64_C(0);
+	r_.u64[1] = a_.u64[1];
+#else
+	HEDLEY_UNREACHABLE();
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cmpunord_sd(a, b) simde_mm_cmpunord_sd(a, b)
+#define _mm_cmpunord_sd(a, b) simde_mm_cmpunord_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cvtepi32_pd (simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvtepi32_pd(a);
-  #else
-    simde__m128d_private r_;
-    simde__m128i_private a_ = simde__m128i_to_private(a);
+simde__m128d simde_mm_cvtepi32_pd(simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvtepi32_pd(a);
+#else
+	simde__m128d_private r_;
+	simde__m128i_private a_ = simde__m128i_to_private(a);
 
-    #if defined(SIMDE_CONVERT_VECTOR_)
-      SIMDE_CONVERT_VECTOR_(r_.f64, a_.m64_private[0].i32);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.f64[i] = (simde_float64) a_.i32[i];
-      }
-    #endif
+#if defined(SIMDE_CONVERT_VECTOR_)
+	SIMDE_CONVERT_VECTOR_(r_.f64, a_.m64_private[0].i32);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = (simde_float64)a_.i32[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtepi32_pd(a) simde_mm_cvtepi32_pd(a)
+#define _mm_cvtepi32_pd(a) simde_mm_cvtepi32_pd(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128
-simde_mm_cvtepi32_ps (simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvtepi32_ps(a);
-  #else
-    simde__m128_private r_;
-    simde__m128i_private a_ = simde__m128i_to_private(a);
+simde__m128 simde_mm_cvtepi32_ps(simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvtepi32_ps(a);
+#else
+	simde__m128_private r_;
+	simde__m128i_private a_ = simde__m128i_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_f32 = vcvtq_f32_s32(a_.neon_i32);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f32x4_convert_i32x4(a_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      HEDLEY_DIAGNOSTIC_PUSH
-      #if HEDLEY_HAS_WARNING("-Wc11-extensions")
-        #pragma clang diagnostic ignored "-Wc11-extensions"
-      #endif
-      r_.altivec_f32 = vec_ctf(a_.altivec_i32, 0);
-      HEDLEY_DIAGNOSTIC_POP
-    #elif defined(SIMDE_CONVERT_VECTOR_)
-      SIMDE_CONVERT_VECTOR_(r_.f32, a_.i32);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
-        r_.f32[i] = (simde_float32) a_.i32[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_f32 = vcvtq_f32_s32(a_.neon_i32);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f32x4_convert_i32x4(a_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	HEDLEY_DIAGNOSTIC_PUSH
+#if HEDLEY_HAS_WARNING("-Wc11-extensions")
+#pragma clang diagnostic ignored "-Wc11-extensions"
+#endif
+	r_.altivec_f32 = vec_ctf(a_.altivec_i32, 0);
+	HEDLEY_DIAGNOSTIC_POP
+#elif defined(SIMDE_CONVERT_VECTOR_)
+	SIMDE_CONVERT_VECTOR_(r_.f32, a_.i32);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f32) / sizeof(r_.f32[0])); i++) {
+		r_.f32[i] = (simde_float32)a_.i32[i];
+	}
+#endif
 
-    return simde__m128_from_private(r_);
-  #endif
+	return simde__m128_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtepi32_ps(a) simde_mm_cvtepi32_ps(a)
+#define _mm_cvtepi32_ps(a) simde_mm_cvtepi32_ps(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m64
-simde_mm_cvtpd_pi32 (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-    return _mm_cvtpd_pi32(a);
-  #else
-    simde__m64_private r_;
-    simde__m128d_private a_ = simde__m128d_to_private(a);
+simde__m64 simde_mm_cvtpd_pi32(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+	return _mm_cvtpd_pi32(a);
+#else
+	simde__m64_private r_;
+	simde__m128d_private a_ = simde__m128d_to_private(a);
 
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-      simde_float64 v = simde_math_round(a_.f64[i]);
-      #if defined(SIMDE_FAST_CONVERSION_RANGE)
-        r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
-      #else
-        r_.i32[i] = ((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) && (v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX))) ?
-          SIMDE_CONVERT_FTOI(int32_t, v) : INT32_MIN;
-      #endif
-    }
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		simde_float64 v = simde_math_round(a_.f64[i]);
+#if defined(SIMDE_FAST_CONVERSION_RANGE)
+		r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
+#else
+		r_.i32[i] =
+			((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) &&
+			 (v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX)))
+				? SIMDE_CONVERT_FTOI(int32_t, v)
+				: INT32_MIN;
+#endif
+	}
 
-    return simde__m64_from_private(r_);
-  #endif
+	return simde__m64_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtpd_pi32(a) simde_mm_cvtpd_pi32(a)
+#define _mm_cvtpd_pi32(a) simde_mm_cvtpd_pi32(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cvtpd_epi32 (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(SIMDE_BUG_PGI_30107)
-    return _mm_cvtpd_epi32(a);
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_cvtpd_epi32(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(SIMDE_BUG_PGI_30107)
+	return _mm_cvtpd_epi32(a);
+#else
+	simde__m128i_private r_;
 
-    r_.m64[0] = simde_mm_cvtpd_pi32(a);
-    r_.m64[1] = simde_mm_setzero_si64();
+	r_.m64[0] = simde_mm_cvtpd_pi32(a);
+	r_.m64[1] = simde_mm_setzero_si64();
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtpd_epi32(a) simde_mm_cvtpd_epi32(a)
+#define _mm_cvtpd_epi32(a) simde_mm_cvtpd_epi32(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128
-simde_mm_cvtpd_ps (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvtpd_ps(a);
-  #else
-    simde__m128_private r_;
-    simde__m128d_private a_ = simde__m128d_to_private(a);
+simde__m128 simde_mm_cvtpd_ps(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvtpd_ps(a);
+#else
+	simde__m128_private r_;
+	simde__m128d_private a_ = simde__m128d_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f32 = vcombine_f32(vcvt_f32_f64(a_.neon_f64), vdup_n_f32(0.0f));
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-      r_.altivec_f32 = vec_float2(a_.altivec_f64, vec_splats(0.0));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f32x4_demote_f64x2_zero(a_.wasm_v128);
-    #elif HEDLEY_HAS_BUILTIN(__builtin_shufflevector) && HEDLEY_HAS_BUILTIN(__builtin_convertvector)
-      float __attribute__((__vector_size__(8))) z = { 0.0f, 0.0f };
-      r_.f32 =
-        __builtin_shufflevector(
-          __builtin_convertvector(__builtin_shufflevector(a_.f64, a_.f64, 0, 1), __typeof__(z)), z,
-          0, 1, 2, 3
-        );
-    #else
-      r_.f32[0] = HEDLEY_STATIC_CAST(simde_float32, a_.f64[0]);
-      r_.f32[1] = HEDLEY_STATIC_CAST(simde_float32, a_.f64[1]);
-      r_.f32[2] = SIMDE_FLOAT32_C(0.0);
-      r_.f32[3] = SIMDE_FLOAT32_C(0.0);
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f32 = vcombine_f32(vcvt_f32_f64(a_.neon_f64), vdup_n_f32(0.0f));
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+	r_.altivec_f32 = vec_float2(a_.altivec_f64, vec_splats(0.0));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f32x4_demote_f64x2_zero(a_.wasm_v128);
+#elif HEDLEY_HAS_BUILTIN(__builtin_shufflevector) && \
+	HEDLEY_HAS_BUILTIN(__builtin_convertvector)
+	float __attribute__((__vector_size__(8))) z = {0.0f, 0.0f};
+	r_.f32 = __builtin_shufflevector(
+		__builtin_convertvector(__builtin_shufflevector(a_.f64, a_.f64,
+								0, 1),
+					__typeof__(z)),
+		z, 0, 1, 2, 3);
+#else
+	r_.f32[0] = HEDLEY_STATIC_CAST(simde_float32, a_.f64[0]);
+	r_.f32[1] = HEDLEY_STATIC_CAST(simde_float32, a_.f64[1]);
+	r_.f32[2] = SIMDE_FLOAT32_C(0.0);
+	r_.f32[3] = SIMDE_FLOAT32_C(0.0);
+#endif
 
-    return simde__m128_from_private(r_);
-  #endif
+	return simde__m128_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtpd_ps(a) simde_mm_cvtpd_ps(a)
+#define _mm_cvtpd_ps(a) simde_mm_cvtpd_ps(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cvtpi32_pd (simde__m64 a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-    return _mm_cvtpi32_pd(a);
-  #else
-    simde__m128d_private r_;
-    simde__m64_private a_ = simde__m64_to_private(a);
+simde__m128d simde_mm_cvtpi32_pd(simde__m64 a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+	return _mm_cvtpi32_pd(a);
+#else
+	simde__m128d_private r_;
+	simde__m64_private a_ = simde__m64_to_private(a);
 
-    #if defined(SIMDE_CONVERT_VECTOR_)
-      SIMDE_CONVERT_VECTOR_(r_.f64, a_.i32);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.f64[i] = (simde_float64) a_.i32[i];
-      }
-    #endif
+#if defined(SIMDE_CONVERT_VECTOR_)
+	SIMDE_CONVERT_VECTOR_(r_.f64, a_.i32);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = (simde_float64)a_.i32[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtpi32_pd(a) simde_mm_cvtpi32_pd(a)
+#define _mm_cvtpi32_pd(a) simde_mm_cvtpi32_pd(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cvtps_epi32 (simde__m128 a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvtps_epi32(a);
-  #else
-    simde__m128i_private r_;
-    simde__m128_private a_;
+simde__m128i simde_mm_cvtps_epi32(simde__m128 a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvtps_epi32(a);
+#else
+	simde__m128i_private r_;
+	simde__m128_private a_;
 
-    #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_ROUND_TIES) && !defined(SIMDE_BUG_GCC_95399)
-      a_ = simde__m128_to_private(a);
-      r_.neon_i32 = vcvtnq_s32_f32(a_.neon_f32);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_ROUND_TIES)
-      a_ = simde__m128_to_private(a);
-      HEDLEY_DIAGNOSTIC_PUSH
-      SIMDE_DIAGNOSTIC_DISABLE_C11_EXTENSIONS_
-      SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
-      r_.altivec_i32 = vec_cts(a_.altivec_f32, 1);
-      HEDLEY_DIAGNOSTIC_POP
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE) && defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_ROUND_TIES)
-      a_ = simde__m128_to_private(a);
-      r_.wasm_v128 = wasm_i32x4_trunc_sat_f32x4(a_.wasm_v128);
-    #else
-      a_ = simde__m128_to_private(simde_x_mm_round_ps(a, SIMDE_MM_FROUND_TO_NEAREST_INT, 1));
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        simde_float32 v = simde_math_roundf(a_.f32[i]);
-        #if defined(SIMDE_FAST_CONVERSION_RANGE)
-          r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
-        #else
-          r_.i32[i] = ((v > HEDLEY_STATIC_CAST(simde_float32, INT32_MIN)) && (v < HEDLEY_STATIC_CAST(simde_float32, INT32_MAX))) ?
-            SIMDE_CONVERT_FTOI(int32_t, v) : INT32_MIN;
-        #endif
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V8_NATIVE) &&     \
+	defined(SIMDE_FAST_CONVERSION_RANGE) && \
+	defined(SIMDE_FAST_ROUND_TIES) && !defined(SIMDE_BUG_GCC_95399)
+	a_ = simde__m128_to_private(a);
+	r_.neon_i32 = vcvtnq_s32_f32(a_.neon_f32);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && \
+	defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_ROUND_TIES)
+	a_ = simde__m128_to_private(a);
+	HEDLEY_DIAGNOSTIC_PUSH
+	SIMDE_DIAGNOSTIC_DISABLE_C11_EXTENSIONS_
+	SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
+	r_.altivec_i32 = vec_cts(a_.altivec_f32, 1);
+	HEDLEY_DIAGNOSTIC_POP
+#elif defined(SIMDE_WASM_SIMD128_NATIVE) && \
+	defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_ROUND_TIES)
+	a_ = simde__m128_to_private(a);
+	r_.wasm_v128 = wasm_i32x4_trunc_sat_f32x4(a_.wasm_v128);
+#else
+	a_ = simde__m128_to_private(
+		simde_x_mm_round_ps(a, SIMDE_MM_FROUND_TO_NEAREST_INT, 1));
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		simde_float32 v = simde_math_roundf(a_.f32[i]);
+#if defined(SIMDE_FAST_CONVERSION_RANGE)
+		r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
+#else
+		r_.i32[i] =
+			((v > HEDLEY_STATIC_CAST(simde_float32, INT32_MIN)) &&
+			 (v < HEDLEY_STATIC_CAST(simde_float32, INT32_MAX)))
+				? SIMDE_CONVERT_FTOI(int32_t, v)
+				: INT32_MIN;
+#endif
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtps_epi32(a) simde_mm_cvtps_epi32(a)
+#define _mm_cvtps_epi32(a) simde_mm_cvtps_epi32(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cvtps_pd (simde__m128 a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvtps_pd(a);
-  #else
-    simde__m128d_private r_;
-    simde__m128_private a_ = simde__m128_to_private(a);
+simde__m128d simde_mm_cvtps_pd(simde__m128 a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvtps_pd(a);
+#else
+	simde__m128d_private r_;
+	simde__m128_private a_ = simde__m128_to_private(a);
 
-    #if defined(SIMDE_CONVERT_VECTOR_)
-      SIMDE_CONVERT_VECTOR_(r_.f64, a_.m64_private[0].f32);
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vcvt_f64_f32(vget_low_f32(a_.neon_f32));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.f64[i] = a_.f32[i];
-      }
-    #endif
+#if defined(SIMDE_CONVERT_VECTOR_)
+	SIMDE_CONVERT_VECTOR_(r_.f64, a_.m64_private[0].f32);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vcvt_f64_f32(vget_low_f32(a_.neon_f32));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = a_.f32[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtps_pd(a) simde_mm_cvtps_pd(a)
+#define _mm_cvtps_pd(a) simde_mm_cvtps_pd(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int32_t
-simde_mm_cvtsd_si32 (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvtsd_si32(a);
-  #else
-    simde__m128d_private a_ = simde__m128d_to_private(a);
+int32_t simde_mm_cvtsd_si32(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvtsd_si32(a);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a);
 
-    simde_float64 v = simde_math_round(a_.f64[0]);
-    #if defined(SIMDE_FAST_CONVERSION_RANGE)
-      return SIMDE_CONVERT_FTOI(int32_t, v);
-    #else
-      return ((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) && (v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX))) ?
-        SIMDE_CONVERT_FTOI(int32_t, v) : INT32_MIN;
-    #endif
-  #endif
+	simde_float64 v = simde_math_round(a_.f64[0]);
+#if defined(SIMDE_FAST_CONVERSION_RANGE)
+	return SIMDE_CONVERT_FTOI(int32_t, v);
+#else
+	return ((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) &&
+		(v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX)))
+		       ? SIMDE_CONVERT_FTOI(int32_t, v)
+		       : INT32_MIN;
+#endif
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtsd_si32(a) simde_mm_cvtsd_si32(a)
+#define _mm_cvtsd_si32(a) simde_mm_cvtsd_si32(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int64_t
-simde_mm_cvtsd_si64 (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
-    #if defined(__PGI)
-      return _mm_cvtsd_si64x(a);
-    #else
-      return _mm_cvtsd_si64(a);
-    #endif
-  #else
-    simde__m128d_private a_ = simde__m128d_to_private(a);
-    return SIMDE_CONVERT_FTOI(int64_t, simde_math_round(a_.f64[0]));
-  #endif
+int64_t simde_mm_cvtsd_si64(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+#if defined(__PGI)
+	return _mm_cvtsd_si64x(a);
+#else
+	return _mm_cvtsd_si64(a);
+#endif
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a);
+	return SIMDE_CONVERT_FTOI(int64_t, simde_math_round(a_.f64[0]));
+#endif
 }
 #define simde_mm_cvtsd_si64x(a) simde_mm_cvtsd_si64(a)
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
-  #define _mm_cvtsd_si64(a) simde_mm_cvtsd_si64(a)
-  #define _mm_cvtsd_si64x(a) simde_mm_cvtsd_si64x(a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
+#define _mm_cvtsd_si64(a) simde_mm_cvtsd_si64(a)
+#define _mm_cvtsd_si64x(a) simde_mm_cvtsd_si64x(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128
-simde_mm_cvtsd_ss (simde__m128 a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvtsd_ss(a, b);
-  #else
-    simde__m128_private
-      r_,
-      a_ = simde__m128_to_private(a);
-    simde__m128d_private b_ = simde__m128d_to_private(b);
+simde__m128 simde_mm_cvtsd_ss(simde__m128 a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvtsd_ss(a, b);
+#else
+	simde__m128_private r_, a_ = simde__m128_to_private(a);
+	simde__m128d_private b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f32 = vsetq_lane_f32(vcvtxd_f32_f64(vgetq_lane_f64(b_.neon_f64, 0)), a_.neon_f32, 0);
-    #else
-      r_.f32[0] = HEDLEY_STATIC_CAST(simde_float32, b_.f64[0]);
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f32 = vsetq_lane_f32(
+		vcvtxd_f32_f64(vgetq_lane_f64(b_.neon_f64, 0)), a_.neon_f32, 0);
+#else
+	r_.f32[0] = HEDLEY_STATIC_CAST(simde_float32, b_.f64[0]);
 
-      SIMDE_VECTORIZE
-      for (size_t i = 1 ; i < (sizeof(r_) / sizeof(r_.i32[0])) ; i++) {
-        r_.i32[i] = a_.i32[i];
-      }
-    #endif
-    return simde__m128_from_private(r_);
-  #endif
+	SIMDE_VECTORIZE
+	for (size_t i = 1; i < (sizeof(r_) / sizeof(r_.i32[0])); i++) {
+		r_.i32[i] = a_.i32[i];
+	}
+#endif
+	return simde__m128_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtsd_ss(a, b) simde_mm_cvtsd_ss(a, b)
+#define _mm_cvtsd_ss(a, b) simde_mm_cvtsd_ss(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int16_t
-simde_x_mm_cvtsi128_si16 (simde__m128i a) {
-  simde__m128i_private
-    a_ = simde__m128i_to_private(a);
+int16_t simde_x_mm_cvtsi128_si16(simde__m128i a)
+{
+	simde__m128i_private a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    return vgetq_lane_s16(a_.neon_i16, 0);
-  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    return HEDLEY_STATIC_CAST(int16_t, wasm_i16x8_extract_lane(a_.wasm_v128, 0));
-  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-    #if defined(SIMDE_BUG_GCC_95227)
-      (void) a_;
-    #endif
-    return vec_extract(a_.altivec_i16, 0);
-  #else
-    return a_.i16[0];
-  #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	return vgetq_lane_s16(a_.neon_i16, 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return HEDLEY_STATIC_CAST(int16_t,
+				  wasm_i16x8_extract_lane(a_.wasm_v128, 0));
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#if defined(SIMDE_BUG_GCC_95227)
+	(void)a_;
+#endif
+	return vec_extract(a_.altivec_i16, 0);
+#else
+	return a_.i16[0];
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-int32_t
-simde_mm_cvtsi128_si32 (simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvtsi128_si32(a);
-  #else
-    simde__m128i_private
-      a_ = simde__m128i_to_private(a);
+int32_t simde_mm_cvtsi128_si32(simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvtsi128_si32(a);
+#else
+	simde__m128i_private a_ = simde__m128i_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      return vgetq_lane_s32(a_.neon_i32, 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      return HEDLEY_STATIC_CAST(int32_t, wasm_i32x4_extract_lane(a_.wasm_v128, 0));
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      #if defined(SIMDE_BUG_GCC_95227)
-        (void) a_;
-      #endif
-      return vec_extract(a_.altivec_i32, 0);
-    #else
-      return a_.i32[0];
-    #endif
-  #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	return vgetq_lane_s32(a_.neon_i32, 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return HEDLEY_STATIC_CAST(int32_t,
+				  wasm_i32x4_extract_lane(a_.wasm_v128, 0));
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#if defined(SIMDE_BUG_GCC_95227)
+	(void)a_;
+#endif
+	return vec_extract(a_.altivec_i32, 0);
+#else
+	return a_.i32[0];
+#endif
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtsi128_si32(a) simde_mm_cvtsi128_si32(a)
+#define _mm_cvtsi128_si32(a) simde_mm_cvtsi128_si32(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int64_t
-simde_mm_cvtsi128_si64 (simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
-    #if defined(__PGI)
-      return _mm_cvtsi128_si64x(a);
-    #else
-      return _mm_cvtsi128_si64(a);
-    #endif
-  #else
-    simde__m128i_private a_ = simde__m128i_to_private(a);
-  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) && !defined(HEDLEY_IBM_VERSION)
-    return vec_extract(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed long long), a_.i64), 0);
-  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    return vgetq_lane_s64(a_.neon_i64, 0);
-  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    return HEDLEY_STATIC_CAST(int64_t, wasm_i64x2_extract_lane(a_.wasm_v128, 0));
-  #endif
-    return a_.i64[0];
-  #endif
+int64_t simde_mm_cvtsi128_si64(simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+#if defined(__PGI)
+	return _mm_cvtsi128_si64x(a);
+#else
+	return _mm_cvtsi128_si64(a);
+#endif
+#else
+	simde__m128i_private a_ = simde__m128i_to_private(a);
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) && !defined(HEDLEY_IBM_VERSION)
+	return vec_extract(HEDLEY_REINTERPRET_CAST(
+				   SIMDE_POWER_ALTIVEC_VECTOR(signed long long),
+				   a_.i64),
+			   0);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	return vgetq_lane_s64(a_.neon_i64, 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return HEDLEY_STATIC_CAST(int64_t,
+				  wasm_i64x2_extract_lane(a_.wasm_v128, 0));
+#endif
+	return a_.i64[0];
+#endif
 }
 #define simde_mm_cvtsi128_si64x(a) simde_mm_cvtsi128_si64(a)
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
-  #define _mm_cvtsi128_si64(a) simde_mm_cvtsi128_si64(a)
-  #define _mm_cvtsi128_si64x(a) simde_mm_cvtsi128_si64x(a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
+#define _mm_cvtsi128_si64(a) simde_mm_cvtsi128_si64(a)
+#define _mm_cvtsi128_si64x(a) simde_mm_cvtsi128_si64x(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cvtsi32_sd (simde__m128d a, int32_t b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvtsi32_sd(a, b);
-  #else
-    simde__m128d_private r_;
-    simde__m128d_private a_ = simde__m128d_to_private(a);
+simde__m128d simde_mm_cvtsi32_sd(simde__m128d a, int32_t b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvtsi32_sd(a, b);
+#else
+	simde__m128d_private r_;
+	simde__m128d_private a_ = simde__m128d_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vsetq_lane_f64(HEDLEY_STATIC_CAST(float64_t, b), a_.neon_f64, 0);
-    #else
-      r_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b);
-      r_.i64[1] = a_.i64[1];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vsetq_lane_f64(HEDLEY_STATIC_CAST(float64_t, b),
+				     a_.neon_f64, 0);
+#else
+	r_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b);
+	r_.i64[1] = a_.i64[1];
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtsi32_sd(a, b) simde_mm_cvtsi32_sd(a, b)
+#define _mm_cvtsi32_sd(a, b) simde_mm_cvtsi32_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_cvtsi16_si128 (int16_t a) {
-  simde__m128i_private r_;
+simde__m128i simde_x_mm_cvtsi16_si128(int16_t a)
+{
+	simde__m128i_private r_;
 
-  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    r_.neon_i16 = vsetq_lane_s16(a, vdupq_n_s16(0), 0);
-  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    r_.wasm_v128 = wasm_i16x8_make(a, 0, 0, 0, 0, 0, 0, 0);
-  #else
-    r_.i16[0] = a;
-    r_.i16[1] = 0;
-    r_.i16[2] = 0;
-    r_.i16[3] = 0;
-    r_.i16[4] = 0;
-    r_.i16[5] = 0;
-    r_.i16[6] = 0;
-    r_.i16[7] = 0;
-  #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i16 = vsetq_lane_s16(a, vdupq_n_s16(0), 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i16x8_make(a, 0, 0, 0, 0, 0, 0, 0);
+#else
+	r_.i16[0] = a;
+	r_.i16[1] = 0;
+	r_.i16[2] = 0;
+	r_.i16[3] = 0;
+	r_.i16[4] = 0;
+	r_.i16[5] = 0;
+	r_.i16[6] = 0;
+	r_.i16[7] = 0;
+#endif
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cvtsi32_si128 (int32_t a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvtsi32_si128(a);
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_cvtsi32_si128(int32_t a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvtsi32_si128(a);
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vsetq_lane_s32(a, vdupq_n_s32(0), 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i32x4_make(a, 0, 0, 0);
-    #else
-      r_.i32[0] = a;
-      r_.i32[1] = 0;
-      r_.i32[2] = 0;
-      r_.i32[3] = 0;
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vsetq_lane_s32(a, vdupq_n_s32(0), 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i32x4_make(a, 0, 0, 0);
+#else
+	r_.i32[0] = a;
+	r_.i32[1] = 0;
+	r_.i32[2] = 0;
+	r_.i32[3] = 0;
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtsi32_si128(a) simde_mm_cvtsi32_si128(a)
+#define _mm_cvtsi32_si128(a) simde_mm_cvtsi32_si128(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cvtsi64_sd (simde__m128d a, int64_t b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
-    #if !defined(__PGI)
-      return _mm_cvtsi64_sd(a, b);
-    #else
-      return _mm_cvtsi64x_sd(a, b);
-    #endif
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a);
+simde__m128d simde_mm_cvtsi64_sd(simde__m128d a, int64_t b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+#if !defined(__PGI)
+	return _mm_cvtsi64_sd(a, b);
+#else
+	return _mm_cvtsi64x_sd(a, b);
+#endif
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vsetq_lane_f64(HEDLEY_STATIC_CAST(float64_t, b), a_.neon_f64, 0);
-    #else
-      r_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b);
-      r_.f64[1] = a_.f64[1];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vsetq_lane_f64(HEDLEY_STATIC_CAST(float64_t, b),
+				     a_.neon_f64, 0);
+#else
+	r_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b);
+	r_.f64[1] = a_.f64[1];
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #define simde_mm_cvtsi64x_sd(a, b) simde_mm_cvtsi64_sd(a, b)
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
-  #define _mm_cvtsi64_sd(a, b) simde_mm_cvtsi64_sd(a, b)
-  #define _mm_cvtsi64x_sd(a, b) simde_mm_cvtsi64x_sd(a, b)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
+#define _mm_cvtsi64_sd(a, b) simde_mm_cvtsi64_sd(a, b)
+#define _mm_cvtsi64x_sd(a, b) simde_mm_cvtsi64x_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cvtsi64_si128 (int64_t a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
-    #if !defined(__PGI)
-      return _mm_cvtsi64_si128(a);
-    #else
-      return _mm_cvtsi64x_si128(a);
-    #endif
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_cvtsi64_si128(int64_t a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+#if !defined(__PGI)
+	return _mm_cvtsi64_si128(a);
+#else
+	return _mm_cvtsi64x_si128(a);
+#endif
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vsetq_lane_s64(a, vdupq_n_s64(0), 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i64x2_make(a, 0);
-    #else
-      r_.i64[0] = a;
-      r_.i64[1] = 0;
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = vsetq_lane_s64(a, vdupq_n_s64(0), 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i64x2_make(a, 0);
+#else
+	r_.i64[0] = a;
+	r_.i64[1] = 0;
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #define simde_mm_cvtsi64x_si128(a) simde_mm_cvtsi64_si128(a)
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
-  #define _mm_cvtsi64_si128(a) simde_mm_cvtsi64_si128(a)
-  #define _mm_cvtsi64x_si128(a) simde_mm_cvtsi64x_si128(a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
+#define _mm_cvtsi64_si128(a) simde_mm_cvtsi64_si128(a)
+#define _mm_cvtsi64x_si128(a) simde_mm_cvtsi64x_si128(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_cvtss_sd (simde__m128d a, simde__m128 b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvtss_sd(a, b);
-  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    float64x2_t temp = vcvt_f64_f32(vset_lane_f32(vgetq_lane_f32(simde__m128_to_private(b).neon_f32, 0), vdup_n_f32(0), 0));
-    return vsetq_lane_f64(vgetq_lane_f64(simde__m128d_to_private(a).neon_f64, 1), temp, 1);
-  #else
-    simde__m128d_private
-      a_ = simde__m128d_to_private(a);
-    simde__m128_private b_ = simde__m128_to_private(b);
+simde__m128d simde_mm_cvtss_sd(simde__m128d a, simde__m128 b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvtss_sd(a, b);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	float64x2_t temp = vcvt_f64_f32(vset_lane_f32(
+		vgetq_lane_f32(simde__m128_to_private(b).neon_f32, 0),
+		vdup_n_f32(0), 0));
+	return vsetq_lane_f64(
+		vgetq_lane_f64(simde__m128d_to_private(a).neon_f64, 1), temp,
+		1);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a);
+	simde__m128_private b_ = simde__m128_to_private(b);
 
-    a_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b_.f32[0]);
+	a_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b_.f32[0]);
 
-    return simde__m128d_from_private(a_);
-  #endif
+	return simde__m128d_from_private(a_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvtss_sd(a, b) simde_mm_cvtss_sd(a, b)
+#define _mm_cvtss_sd(a, b) simde_mm_cvtss_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m64
-simde_mm_cvttpd_pi32 (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-    return _mm_cvttpd_pi32(a);
-  #else
-    simde__m64_private r_;
-    simde__m128d_private a_ = simde__m128d_to_private(a);
+simde__m64 simde_mm_cvttpd_pi32(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+	return _mm_cvttpd_pi32(a);
+#else
+	simde__m64_private r_;
+	simde__m128d_private a_ = simde__m128d_to_private(a);
 
-    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_FAST_CONVERSION_RANGE)
-      SIMDE_CONVERT_VECTOR_(r_.i32, a_.f64);
-    #else
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        simde_float64 v = a_.f64[i];
-        #if defined(SIMDE_FAST_CONVERSION_RANGE)
-          r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
-        #else
-          r_.i32[i] = ((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) && (v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX))) ?
-            SIMDE_CONVERT_FTOI(int32_t, v) : INT32_MIN;
-        #endif
-      }
-    #endif
+#if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_FAST_CONVERSION_RANGE)
+	SIMDE_CONVERT_VECTOR_(r_.i32, a_.f64);
+#else
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		simde_float64 v = a_.f64[i];
+#if defined(SIMDE_FAST_CONVERSION_RANGE)
+		r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
+#else
+		r_.i32[i] =
+			((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) &&
+			 (v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX)))
+				? SIMDE_CONVERT_FTOI(int32_t, v)
+				: INT32_MIN;
+#endif
+	}
+#endif
 
-    return simde__m64_from_private(r_);
-  #endif
+	return simde__m64_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvttpd_pi32(a) simde_mm_cvttpd_pi32(a)
+#define _mm_cvttpd_pi32(a) simde_mm_cvttpd_pi32(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cvttpd_epi32 (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvttpd_epi32(a);
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_cvttpd_epi32(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvttpd_epi32(a);
+#else
+	simde__m128i_private r_;
 
-    r_.m64[0] = simde_mm_cvttpd_pi32(a);
-    r_.m64[1] = simde_mm_setzero_si64();
+	r_.m64[0] = simde_mm_cvttpd_pi32(a);
+	r_.m64[1] = simde_mm_setzero_si64();
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvttpd_epi32(a) simde_mm_cvttpd_epi32(a)
+#define _mm_cvttpd_epi32(a) simde_mm_cvttpd_epi32(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_cvttps_epi32 (simde__m128 a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvttps_epi32(a);
-  #else
-    simde__m128i_private r_;
-    simde__m128_private a_ = simde__m128_to_private(a);
+simde__m128i simde_mm_cvttps_epi32(simde__m128 a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvttps_epi32(a);
+#else
+	simde__m128i_private r_;
+	simde__m128_private a_ = simde__m128_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vcvtq_s32_f32(a_.neon_f32);
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vcvtq_s32_f32(a_.neon_f32);
 
-      #if !defined(SIMDE_FAST_CONVERSION_RANGE) || !defined(SIMDE_FAST_NANS)
-        /* Values below INT32_MIN saturate anyways, so we don't need to
+#if !defined(SIMDE_FAST_CONVERSION_RANGE) || !defined(SIMDE_FAST_NANS)
+/* Values below INT32_MIN saturate anyways, so we don't need to
          * test for that. */
-        #if !defined(SIMDE_FAST_CONVERSION_RANGE) && !defined(SIMDE_FAST_NANS)
-          uint32x4_t valid_input =
-            vandq_u32(
-              vcltq_f32(a_.neon_f32, vdupq_n_f32(SIMDE_FLOAT32_C(2147483648.0))),
-              vceqq_f32(a_.neon_f32, a_.neon_f32)
-            );
-        #elif !defined(SIMDE_FAST_CONVERSION_RANGE)
-          uint32x4_t valid_input = vcltq_f32(a_.neon_f32, vdupq_n_f32(SIMDE_FLOAT32_C(2147483648.0)));
-        #elif !defined(SIMDE_FAST_NANS)
-          uint32x4_t valid_input = vceqq_f32(a_.neon_f32, a_.neon_f32);
-        #endif
+#if !defined(SIMDE_FAST_CONVERSION_RANGE) && !defined(SIMDE_FAST_NANS)
+	uint32x4_t valid_input =
+		vandq_u32(vcltq_f32(a_.neon_f32,
+				    vdupq_n_f32(SIMDE_FLOAT32_C(2147483648.0))),
+			  vceqq_f32(a_.neon_f32, a_.neon_f32));
+#elif !defined(SIMDE_FAST_CONVERSION_RANGE)
+	uint32x4_t valid_input = vcltq_f32(
+		a_.neon_f32, vdupq_n_f32(SIMDE_FLOAT32_C(2147483648.0)));
+#elif !defined(SIMDE_FAST_NANS)
+	uint32x4_t valid_input = vceqq_f32(a_.neon_f32, a_.neon_f32);
+#endif
 
-        r_.neon_i32 = vbslq_s32(valid_input, r_.neon_i32, vdupq_n_s32(INT32_MIN));
-      #endif
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i32x4_trunc_sat_f32x4(a_.wasm_v128);
+	r_.neon_i32 =
+		vbslq_s32(valid_input, r_.neon_i32, vdupq_n_s32(INT32_MIN));
+#endif
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i32x4_trunc_sat_f32x4(a_.wasm_v128);
 
-      #if !defined(SIMDE_FAST_CONVERSION_RANGE) || !defined(SIMDE_FAST_NANS)
-        #if !defined(SIMDE_FAST_CONVERSION_RANGE) && !defined(SIMDE_FAST_NANS)
-          v128_t valid_input =
-            wasm_v128_and(
-              wasm_f32x4_lt(a_.wasm_v128, wasm_f32x4_splat(SIMDE_FLOAT32_C(2147483648.0))),
-              wasm_f32x4_eq(a_.wasm_v128, a_.wasm_v128)
-            );
-        #elif !defined(SIMDE_FAST_CONVERSION_RANGE)
-          v128_t valid_input = wasm_f32x4_lt(a_.wasm_v128, wasm_f32x4_splat(SIMDE_FLOAT32_C(2147483648.0)));
-        #elif !defined(SIMDE_FAST_NANS)
-          v128_t valid_input = wasm_f32x4_eq(a_.wasm_v128, a_.wasm_v128);
-        #endif
+#if !defined(SIMDE_FAST_CONVERSION_RANGE) || !defined(SIMDE_FAST_NANS)
+#if !defined(SIMDE_FAST_CONVERSION_RANGE) && !defined(SIMDE_FAST_NANS)
+	v128_t valid_input = wasm_v128_and(
+		wasm_f32x4_lt(a_.wasm_v128,
+			      wasm_f32x4_splat(SIMDE_FLOAT32_C(2147483648.0))),
+		wasm_f32x4_eq(a_.wasm_v128, a_.wasm_v128));
+#elif !defined(SIMDE_FAST_CONVERSION_RANGE)
+	v128_t valid_input = wasm_f32x4_lt(
+		a_.wasm_v128, wasm_f32x4_splat(SIMDE_FLOAT32_C(2147483648.0)));
+#elif !defined(SIMDE_FAST_NANS)
+	v128_t valid_input = wasm_f32x4_eq(a_.wasm_v128, a_.wasm_v128);
+#endif
 
-        r_.wasm_v128 = wasm_v128_bitselect(r_.wasm_v128, wasm_i32x4_splat(INT32_MIN), valid_input);
-      #endif
-    #elif defined(SIMDE_CONVERT_VECTOR_)
-      SIMDE_CONVERT_VECTOR_(r_.i32, a_.f32);
+	r_.wasm_v128 = wasm_v128_bitselect(
+		r_.wasm_v128, wasm_i32x4_splat(INT32_MIN), valid_input);
+#endif
+#elif defined(SIMDE_CONVERT_VECTOR_)
+	SIMDE_CONVERT_VECTOR_(r_.i32, a_.f32);
 
-      #if !defined(SIMDE_FAST_CONVERSION_RANGE) || !defined(SIMDE_FAST_NANS)
-        #if !defined(SIMDE_FAST_CONVERSION_RANGE)
-          static const simde_float32 first_too_high SIMDE_VECTOR(16) = { SIMDE_FLOAT32_C(2147483648.0), SIMDE_FLOAT32_C(2147483648.0), SIMDE_FLOAT32_C(2147483648.0), SIMDE_FLOAT32_C(2147483648.0) };
+#if !defined(SIMDE_FAST_CONVERSION_RANGE) || !defined(SIMDE_FAST_NANS)
+#if !defined(SIMDE_FAST_CONVERSION_RANGE)
+	static const simde_float32 first_too_high SIMDE_VECTOR(16) = {
+		SIMDE_FLOAT32_C(2147483648.0), SIMDE_FLOAT32_C(2147483648.0),
+		SIMDE_FLOAT32_C(2147483648.0), SIMDE_FLOAT32_C(2147483648.0)};
 
-          __typeof__(r_.i32) valid_input =
-            HEDLEY_REINTERPRET_CAST(
-              __typeof__(r_.i32),
-              (a_.f32 < first_too_high) & (a_.f32 >= -first_too_high)
-            );
-        #elif !defined(SIMDE_FAST_NANS)
-          __typeof__(r_.i32) valid_input = HEDLEY_REINTERPRET_CAST( __typeof__(valid_input), a_.f32 == a_.f32);
-        #endif
+	__typeof__(r_.i32) valid_input = HEDLEY_REINTERPRET_CAST(
+		__typeof__(r_.i32),
+		(a_.f32 < first_too_high) & (a_.f32 >= -first_too_high));
+#elif !defined(SIMDE_FAST_NANS)
+	__typeof__(r_.i32) valid_input = HEDLEY_REINTERPRET_CAST(
+		__typeof__(valid_input), a_.f32 == a_.f32);
+#endif
 
-        __typeof__(r_.i32) invalid_output = { INT32_MIN, INT32_MIN, INT32_MIN, INT32_MIN };
-        r_.i32 = (r_.i32 & valid_input) | (invalid_output & ~valid_input);
-      #endif
-    #else
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        simde_float32 v = a_.f32[i];
-        #if defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_NANS)
-          r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
-        #else
-          r_.i32[i] = ((v > HEDLEY_STATIC_CAST(simde_float32, INT32_MIN)) && (v < HEDLEY_STATIC_CAST(simde_float32, INT32_MAX))) ?
-            SIMDE_CONVERT_FTOI(int32_t, v) : INT32_MIN;
-        #endif
-      }
-    #endif
+	__typeof__(r_.i32)
+		invalid_output = {INT32_MIN, INT32_MIN, INT32_MIN, INT32_MIN};
+	r_.i32 = (r_.i32 & valid_input) | (invalid_output & ~valid_input);
+#endif
+#else
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		simde_float32 v = a_.f32[i];
+#if defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_NANS)
+		r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
+#else
+		r_.i32[i] =
+			((v > HEDLEY_STATIC_CAST(simde_float32, INT32_MIN)) &&
+			 (v < HEDLEY_STATIC_CAST(simde_float32, INT32_MAX)))
+				? SIMDE_CONVERT_FTOI(int32_t, v)
+				: INT32_MIN;
+#endif
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvttps_epi32(a) simde_mm_cvttps_epi32(a)
+#define _mm_cvttps_epi32(a) simde_mm_cvttps_epi32(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int32_t
-simde_mm_cvttsd_si32 (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_cvttsd_si32(a);
-  #else
-    simde__m128d_private a_ = simde__m128d_to_private(a);
-    simde_float64 v = a_.f64[0];
-    #if defined(SIMDE_FAST_CONVERSION_RANGE)
-      return SIMDE_CONVERT_FTOI(int32_t, v);
-    #else
-      return ((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) && (v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX))) ?
-        SIMDE_CONVERT_FTOI(int32_t, v) : INT32_MIN;
-    #endif
-  #endif
+int32_t simde_mm_cvttsd_si32(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_cvttsd_si32(a);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a);
+	simde_float64 v = a_.f64[0];
+#if defined(SIMDE_FAST_CONVERSION_RANGE)
+	return SIMDE_CONVERT_FTOI(int32_t, v);
+#else
+	return ((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) &&
+		(v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX)))
+		       ? SIMDE_CONVERT_FTOI(int32_t, v)
+		       : INT32_MIN;
+#endif
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_cvttsd_si32(a) simde_mm_cvttsd_si32(a)
+#define _mm_cvttsd_si32(a) simde_mm_cvttsd_si32(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int64_t
-simde_mm_cvttsd_si64 (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
-    #if !defined(__PGI)
-      return _mm_cvttsd_si64(a);
-    #else
-      return _mm_cvttsd_si64x(a);
-    #endif
-  #else
-    simde__m128d_private a_ = simde__m128d_to_private(a);
-    return SIMDE_CONVERT_FTOI(int64_t, a_.f64[0]);
-  #endif
+int64_t simde_mm_cvttsd_si64(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+#if !defined(__PGI)
+	return _mm_cvttsd_si64(a);
+#else
+	return _mm_cvttsd_si64x(a);
+#endif
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a);
+	return SIMDE_CONVERT_FTOI(int64_t, a_.f64[0]);
+#endif
 }
 #define simde_mm_cvttsd_si64x(a) simde_mm_cvttsd_si64(a)
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
-  #define _mm_cvttsd_si64(a) simde_mm_cvttsd_si64(a)
-  #define _mm_cvttsd_si64x(a) simde_mm_cvttsd_si64x(a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
+#define _mm_cvttsd_si64(a) simde_mm_cvttsd_si64(a)
+#define _mm_cvttsd_si64x(a) simde_mm_cvttsd_si64x(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_div_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_div_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_div_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_div_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.f64 = a_.f64 / b_.f64;
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vdivq_f64(a_.neon_f64, b_.neon_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 =  wasm_f64x2_div(a_.wasm_v128, b_.wasm_v128);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.f64[i] = a_.f64[i] / b_.f64[i];
-      }
-    #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.f64 = a_.f64 / b_.f64;
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vdivq_f64(a_.neon_f64, b_.neon_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_div(a_.wasm_v128, b_.wasm_v128);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = a_.f64[i] / b_.f64[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_div_pd(a, b) simde_mm_div_pd(a, b)
+#define _mm_div_pd(a, b) simde_mm_div_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_div_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_div_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_div_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_div_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_div_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_div_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_div_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(a,
+				simde_mm_div_pd(simde_x_mm_broadcastlow_pd(a),
+						simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      float64x2_t temp = vdivq_f64(a_.neon_f64, b_.neon_f64);
-      r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
-    #else
-      r_.f64[0] = a_.f64[0] / b_.f64[0];
-      r_.f64[1] = a_.f64[1];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	float64x2_t temp = vdivq_f64(a_.neon_f64, b_.neon_f64);
+	r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
+#else
+	r_.f64[0] = a_.f64[0] / b_.f64[0];
+	r_.f64[1] = a_.f64[1];
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_div_sd(a, b) simde_mm_div_sd(a, b)
+#define _mm_div_sd(a, b) simde_mm_div_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int32_t
-simde_mm_extract_epi16 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 7)  {
-  uint16_t r;
-  simde__m128i_private a_ = simde__m128i_to_private(a);
+int32_t simde_mm_extract_epi16(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 7)
+{
+	uint16_t r;
+	simde__m128i_private a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-    #if defined(SIMDE_BUG_GCC_95227)
-      (void) a_;
-      (void) imm8;
-    #endif
-    r = HEDLEY_STATIC_CAST(uint16_t, vec_extract(a_.altivec_i16, imm8));
-  #else
-    r = a_.u16[imm8 & 7];
-  #endif
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#if defined(SIMDE_BUG_GCC_95227)
+	(void)a_;
+	(void)imm8;
+#endif
+	r = HEDLEY_STATIC_CAST(uint16_t, vec_extract(a_.altivec_i16, imm8));
+#else
+	r = a_.u16[imm8 & 7];
+#endif
 
-  return  HEDLEY_STATIC_CAST(int32_t, r);
+	return HEDLEY_STATIC_CAST(int32_t, r);
 }
-#if defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(4,6,0))
-  #define simde_mm_extract_epi16(a, imm8) _mm_extract_epi16(a, imm8)
+#if defined(SIMDE_X86_SSE2_NATIVE) && \
+	(!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(4, 6, 0))
+#define simde_mm_extract_epi16(a, imm8) _mm_extract_epi16(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-  #define simde_mm_extract_epi16(a, imm8) (HEDLEY_STATIC_CAST(int32_t, vgetq_lane_s16(simde__m128i_to_private(a).neon_i16, (imm8))) & (INT32_C(0x0000ffff)))
+#define simde_mm_extract_epi16(a, imm8)                                       \
+	(HEDLEY_STATIC_CAST(                                                  \
+		 int32_t, vgetq_lane_s16(simde__m128i_to_private(a).neon_i16, \
+					 (imm8))) &                           \
+	 (INT32_C(0x0000ffff)))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_extract_epi16(a, imm8) simde_mm_extract_epi16(a, imm8)
+#define _mm_extract_epi16(a, imm8) simde_mm_extract_epi16(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_insert_epi16 (simde__m128i a, int16_t i, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 7)  {
-  simde__m128i_private a_ = simde__m128i_to_private(a);
-  a_.i16[imm8 & 7] = i;
-  return simde__m128i_from_private(a_);
+simde__m128i simde_mm_insert_epi16(simde__m128i a, int16_t i, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 7)
+{
+	simde__m128i_private a_ = simde__m128i_to_private(a);
+	a_.i16[imm8 & 7] = i;
+	return simde__m128i_from_private(a_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-  #define simde_mm_insert_epi16(a, i, imm8) _mm_insert_epi16((a), (i), (imm8))
+#define simde_mm_insert_epi16(a, i, imm8) _mm_insert_epi16((a), (i), (imm8))
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-  #define simde_mm_insert_epi16(a, i, imm8) simde__m128i_from_neon_i16(vsetq_lane_s16((i), simde__m128i_to_neon_i16(a), (imm8)))
+#define simde_mm_insert_epi16(a, i, imm8) \
+	simde__m128i_from_neon_i16(       \
+		vsetq_lane_s16((i), simde__m128i_to_neon_i16(a), (imm8)))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_insert_epi16(a, i, imm8) simde_mm_insert_epi16(a, i, imm8)
+#define _mm_insert_epi16(a, i, imm8) simde_mm_insert_epi16(a, i, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128d
-simde_mm_load_pd (simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)]) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_load_pd(mem_addr);
-  #else
-    simde__m128d_private r_;
+simde_mm_load_pd(simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)])
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_load_pd(mem_addr);
+#else
+	simde__m128d_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vld1q_f64(mem_addr);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u32 = vld1q_u32(HEDLEY_REINTERPRET_CAST(uint32_t const*, mem_addr));
-    #else
-      simde_memcpy(&r_, SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128d), sizeof(r_));
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vld1q_f64(mem_addr);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u32 =
+		vld1q_u32(HEDLEY_REINTERPRET_CAST(uint32_t const *, mem_addr));
+#else
+	simde_memcpy(&r_, SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128d),
+		     sizeof(r_));
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_load_pd(mem_addr) simde_mm_load_pd(mem_addr)
+#define _mm_load_pd(mem_addr) simde_mm_load_pd(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_load1_pd (simde_float64 const* mem_addr) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_load1_pd(mem_addr);
-  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    return simde__m128d_from_neon_f64(vld1q_dup_f64(mem_addr));
-  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    return simde__m128d_from_wasm_v128(wasm_v128_load64_splat(mem_addr));
-  #else
-    return simde_mm_set1_pd(*mem_addr);
-  #endif
+simde__m128d simde_mm_load1_pd(simde_float64 const *mem_addr)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_load1_pd(mem_addr);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return simde__m128d_from_neon_f64(vld1q_dup_f64(mem_addr));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return simde__m128d_from_wasm_v128(wasm_v128_load64_splat(mem_addr));
+#else
+	return simde_mm_set1_pd(*mem_addr);
+#endif
 }
 #define simde_mm_load_pd1(mem_addr) simde_mm_load1_pd(mem_addr)
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_load_pd1(mem_addr) simde_mm_load1_pd(mem_addr)
-  #define _mm_load1_pd(mem_addr) simde_mm_load1_pd(mem_addr)
+#define _mm_load_pd1(mem_addr) simde_mm_load1_pd(mem_addr)
+#define _mm_load1_pd(mem_addr) simde_mm_load1_pd(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d simde_mm_load_sd(simde_float64 const *mem_addr)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_load_sd(mem_addr);
+#else
+	simde__m128d_private r_;
+
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vsetq_lane_f64(*mem_addr, vdupq_n_f64(0), 0);
+#else
+	r_.f64[0] = *mem_addr;
+	r_.u64[1] = UINT64_C(0);
+#endif
+
+	return simde__m128d_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_load_sd(mem_addr) simde_mm_load_sd(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i simde_mm_load_si128(simde__m128i const *mem_addr)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_load_si128(
+		HEDLEY_REINTERPRET_CAST(__m128i const *, mem_addr));
+#else
+	simde__m128i_private r_;
+
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_i32 = vec_ld(
+		0, HEDLEY_REINTERPRET_CAST(
+			   SIMDE_POWER_ALTIVEC_VECTOR(int) const *, mem_addr));
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 =
+		vld1q_s32(HEDLEY_REINTERPRET_CAST(int32_t const *, mem_addr));
+#else
+	simde_memcpy(&r_, SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128i),
+		     sizeof(simde__m128i));
+#endif
+
+	return simde__m128i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_load_si128(mem_addr) simde_mm_load_si128(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d simde_mm_loadh_pd(simde__m128d a, simde_float64 const *mem_addr)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_loadh_pd(a, mem_addr);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
+
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vcombine_f64(
+		vget_low_f64(a_.neon_f64),
+		vld1_f64(HEDLEY_REINTERPRET_CAST(const float64_t *, mem_addr)));
+#else
+	simde_float64 t;
+
+	simde_memcpy(&t, mem_addr, sizeof(t));
+	r_.f64[0] = a_.f64[0];
+	r_.f64[1] = t;
+#endif
+
+	return simde__m128d_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_loadh_pd(a, mem_addr) simde_mm_loadh_pd(a, mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i simde_mm_loadl_epi64(simde__m128i const *mem_addr)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_loadl_epi64(mem_addr);
+#else
+	simde__m128i_private r_;
+
+	int64_t value;
+	simde_memcpy(&value, mem_addr, sizeof(value));
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = vcombine_s64(
+		vld1_s64(HEDLEY_REINTERPRET_CAST(int64_t const *, mem_addr)),
+		vdup_n_s64(0));
+#else
+	r_.i64[0] = value;
+	r_.i64[1] = 0;
+#endif
+
+	return simde__m128i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_loadl_epi64(mem_addr) simde_mm_loadl_epi64(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d simde_mm_loadl_pd(simde__m128d a, simde_float64 const *mem_addr)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_loadl_pd(a, mem_addr);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
+
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vcombine_f64(
+		vld1_f64(HEDLEY_REINTERPRET_CAST(const float64_t *, mem_addr)),
+		vget_high_f64(a_.neon_f64));
+#else
+	r_.f64[0] = *mem_addr;
+	r_.u64[1] = a_.u64[1];
+#endif
+
+	return simde__m128d_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_loadl_pd(a, mem_addr) simde_mm_loadl_pd(a, mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128d
-simde_mm_load_sd (simde_float64 const* mem_addr) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_load_sd(mem_addr);
-  #else
-    simde__m128d_private r_;
+simde_mm_loadr_pd(simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)])
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_loadr_pd(mem_addr);
+#else
+	simde__m128d_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vsetq_lane_f64(*mem_addr, vdupq_n_f64(0), 0);
-    #else
-      r_.f64[0] = *mem_addr;
-      r_.u64[1] = UINT64_C(0);
-    #endif
-
-    return simde__m128d_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_load_sd(mem_addr) simde_mm_load_sd(mem_addr)
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vld1q_f64(mem_addr);
+	r_.neon_f64 = vextq_f64(r_.neon_f64, r_.neon_f64, 1);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 =
+		vld1q_s64(HEDLEY_REINTERPRET_CAST(int64_t const *, mem_addr));
+	r_.neon_i64 = vextq_s64(r_.neon_i64, r_.neon_i64, 1);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	v128_t tmp = wasm_v128_load(mem_addr);
+	r_.wasm_v128 = wasm_i64x2_shuffle(tmp, tmp, 1, 0);
+#else
+	r_.f64[0] = mem_addr[1];
+	r_.f64[1] = mem_addr[0];
 #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_load_si128 (simde__m128i const* mem_addr) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_load_si128(HEDLEY_REINTERPRET_CAST(__m128i const*, mem_addr));
-  #else
-    simde__m128i_private r_;
-
-    #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_i32 = vec_ld(0, HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(int) const*, mem_addr));
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vld1q_s32(HEDLEY_REINTERPRET_CAST(int32_t const*, mem_addr));
-    #else
-      simde_memcpy(&r_, SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128i), sizeof(simde__m128i));
-    #endif
-
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_load_si128(mem_addr) simde_mm_load_si128(mem_addr)
+#define _mm_loadr_pd(mem_addr) simde_mm_loadr_pd(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128d
-simde_mm_loadh_pd (simde__m128d a, simde_float64 const* mem_addr) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_loadh_pd(a, mem_addr);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a);
+simde_mm_loadu_pd(simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)])
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_loadu_pd(mem_addr);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return vld1q_f64(mem_addr);
+#else
+	simde__m128d_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vcombine_f64(vget_low_f64(a_.neon_f64), vld1_f64(HEDLEY_REINTERPRET_CAST(const float64_t*, mem_addr)));
-    #else
-      simde_float64 t;
+	simde_memcpy(&r_, mem_addr, sizeof(r_));
 
-      simde_memcpy(&t, mem_addr, sizeof(t));
-      r_.f64[0] = a_.f64[0];
-      r_.f64[1] = t;
-    #endif
-
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_loadh_pd(a, mem_addr) simde_mm_loadh_pd(a, mem_addr)
+#define _mm_loadu_pd(mem_addr) simde_mm_loadu_pd(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_loadl_epi64 (simde__m128i const* mem_addr) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_loadl_epi64(mem_addr);
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_loadu_epi8(void const *mem_addr)
+{
+#if defined(SIMDE_X86_AVX512VL_NATIVE) &&                                      \
+	defined(SIMDE_X86_AVX512BW_NATIVE) && !defined(SIMDE_BUG_GCC_95483) && \
+	!defined(SIMDE_BUG_CLANG_REV_344862)
+	return _mm_loadu_epi8(mem_addr);
+#elif defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, mem_addr));
+#else
+	simde__m128i_private r_;
 
-    int64_t value;
-    simde_memcpy(&value, mem_addr, sizeof(value));
-
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vcombine_s64(vld1_s64(HEDLEY_REINTERPRET_CAST(int64_t const *, mem_addr)), vdup_n_s64(0));
-    #else
-      r_.i64[0] = value;
-      r_.i64[1] = 0;
-    #endif
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_loadl_epi64(mem_addr) simde_mm_loadl_epi64(mem_addr)
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i8 =
+		vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const *, mem_addr));
+#else
+	simde_memcpy(&r_, mem_addr, sizeof(r_));
 #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_loadl_pd (simde__m128d a, simde_float64 const* mem_addr) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_loadl_pd(a, mem_addr);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a);
-
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vcombine_f64(vld1_f64(
-        HEDLEY_REINTERPRET_CAST(const float64_t*, mem_addr)), vget_high_f64(a_.neon_f64));
-    #else
-      r_.f64[0] = *mem_addr;
-      r_.u64[1] = a_.u64[1];
-    #endif
-
-    return simde__m128d_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_loadl_pd(a, mem_addr) simde_mm_loadl_pd(a, mem_addr)
+	return simde__m128i_from_private(r_);
 #endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_loadr_pd (simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)]) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_loadr_pd(mem_addr);
-  #else
-    simde__m128d_private
-      r_;
-
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vld1q_f64(mem_addr);
-      r_.neon_f64 = vextq_f64(r_.neon_f64, r_.neon_f64, 1);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vld1q_s64(HEDLEY_REINTERPRET_CAST(int64_t const *, mem_addr));
-      r_.neon_i64 = vextq_s64(r_.neon_i64, r_.neon_i64, 1);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      v128_t tmp = wasm_v128_load(mem_addr);
-      r_.wasm_v128 = wasm_i64x2_shuffle(tmp, tmp, 1, 0);
-    #else
-      r_.f64[0] = mem_addr[1];
-      r_.f64[1] = mem_addr[0];
-    #endif
-
-    return simde__m128d_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_loadr_pd(mem_addr) simde_mm_loadr_pd(mem_addr)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_loadu_pd (simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)]) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_loadu_pd(mem_addr);
-  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    return vld1q_f64(mem_addr);
-  #else
-    simde__m128d_private r_;
-
-    simde_memcpy(&r_, mem_addr, sizeof(r_));
-
-    return simde__m128d_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_loadu_pd(mem_addr) simde_mm_loadu_pd(mem_addr)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_loadu_epi8(void const * mem_addr) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE) && !defined(SIMDE_BUG_GCC_95483) && !defined(SIMDE_BUG_CLANG_REV_344862)
-    return _mm_loadu_epi8(mem_addr);
-  #elif defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, mem_addr));
-  #else
-    simde__m128i_private r_;
-
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i8 = vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const*, mem_addr));
-    #else
-      simde_memcpy(&r_, mem_addr, sizeof(r_));
-    #endif
-
-    return simde__m128i_from_private(r_);
-  #endif
 }
 #define simde_x_mm_loadu_epi8(mem_addr) simde_mm_loadu_epi8(mem_addr)
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && (defined(SIMDE_BUG_GCC_95483) || defined(SIMDE_BUG_CLANG_REV_344862)))
-  #undef _mm_loadu_epi8
-  #define _mm_loadu_epi8(a) simde_mm_loadu_epi8(a)
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) ||     \
+	defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) &&             \
+	 (defined(SIMDE_BUG_GCC_95483) ||                    \
+	  defined(SIMDE_BUG_CLANG_REV_344862)))
+#undef _mm_loadu_epi8
+#define _mm_loadu_epi8(a) simde_mm_loadu_epi8(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_loadu_epi16(void const * mem_addr) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE) && !defined(SIMDE_BUG_GCC_95483) && !defined(SIMDE_BUG_CLANG_REV_344862)
-    return _mm_loadu_epi16(mem_addr);
-  #elif defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, mem_addr));
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_loadu_epi16(void const *mem_addr)
+{
+#if defined(SIMDE_X86_AVX512VL_NATIVE) &&                                      \
+	defined(SIMDE_X86_AVX512BW_NATIVE) && !defined(SIMDE_BUG_GCC_95483) && \
+	!defined(SIMDE_BUG_CLANG_REV_344862)
+	return _mm_loadu_epi16(mem_addr);
+#elif defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, mem_addr));
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i16 = vreinterpretq_s16_s8(vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const*, mem_addr)));
-    #else
-      simde_memcpy(&r_, mem_addr, sizeof(r_));
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i16 = vreinterpretq_s16_s8(
+		vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const *, mem_addr)));
+#else
+	simde_memcpy(&r_, mem_addr, sizeof(r_));
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #define simde_x_mm_loadu_epi16(mem_addr) simde_mm_loadu_epi16(mem_addr)
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && (defined(SIMDE_BUG_GCC_95483) || defined(SIMDE_BUG_CLANG_REV_344862)))
-  #undef _mm_loadu_epi16
-  #define _mm_loadu_epi16(a) simde_mm_loadu_epi16(a)
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) ||     \
+	defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) &&             \
+	 (defined(SIMDE_BUG_GCC_95483) ||                    \
+	  defined(SIMDE_BUG_CLANG_REV_344862)))
+#undef _mm_loadu_epi16
+#define _mm_loadu_epi16(a) simde_mm_loadu_epi16(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_loadu_epi32(void const * mem_addr) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE) && !defined(SIMDE_BUG_GCC_95483) && !defined(SIMDE_BUG_CLANG_REV_344862)
-    return _mm_loadu_epi32(mem_addr);
-  #elif defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, mem_addr));
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_loadu_epi32(void const *mem_addr)
+{
+#if defined(SIMDE_X86_AVX512VL_NATIVE) && !defined(SIMDE_BUG_GCC_95483) && \
+	!defined(SIMDE_BUG_CLANG_REV_344862)
+	return _mm_loadu_epi32(mem_addr);
+#elif defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, mem_addr));
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vreinterpretq_s32_s8(vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const*, mem_addr)));
-    #else
-      simde_memcpy(&r_, mem_addr, sizeof(r_));
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vreinterpretq_s32_s8(
+		vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const *, mem_addr)));
+#else
+	simde_memcpy(&r_, mem_addr, sizeof(r_));
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #define simde_x_mm_loadu_epi32(mem_addr) simde_mm_loadu_epi32(mem_addr)
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && (defined(SIMDE_BUG_GCC_95483) || defined(SIMDE_BUG_CLANG_REV_344862)))
-  #undef _mm_loadu_epi32
-  #define _mm_loadu_epi32(a) simde_mm_loadu_epi32(a)
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) &&         \
+	 (defined(SIMDE_BUG_GCC_95483) ||                \
+	  defined(SIMDE_BUG_CLANG_REV_344862)))
+#undef _mm_loadu_epi32
+#define _mm_loadu_epi32(a) simde_mm_loadu_epi32(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_loadu_epi64(void const * mem_addr) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE) && !defined(SIMDE_BUG_GCC_95483) && !defined(SIMDE_BUG_CLANG_REV_344862)
-    return _mm_loadu_epi64(mem_addr);
-  #elif defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, mem_addr));
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_loadu_epi64(void const *mem_addr)
+{
+#if defined(SIMDE_X86_AVX512VL_NATIVE) && !defined(SIMDE_BUG_GCC_95483) && \
+	!defined(SIMDE_BUG_CLANG_REV_344862)
+	return _mm_loadu_epi64(mem_addr);
+#elif defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, mem_addr));
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vreinterpretq_s64_s8(vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const*, mem_addr)));
-    #else
-      simde_memcpy(&r_, mem_addr, sizeof(r_));
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = vreinterpretq_s64_s8(
+		vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const *, mem_addr)));
+#else
+	simde_memcpy(&r_, mem_addr, sizeof(r_));
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #define simde_x_mm_loadu_epi64(mem_addr) simde_mm_loadu_epi64(mem_addr)
-#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && (defined(SIMDE_BUG_GCC_95483) || defined(SIMDE_BUG_CLANG_REV_344862)))
-  #undef _mm_loadu_epi64
-  #define _mm_loadu_epi64(a) simde_mm_loadu_epi64(a)
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) &&         \
+	 (defined(SIMDE_BUG_GCC_95483) ||                \
+	  defined(SIMDE_BUG_CLANG_REV_344862)))
+#undef _mm_loadu_epi64
+#define _mm_loadu_epi64(a) simde_mm_loadu_epi64(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_loadu_si128 (void const* mem_addr) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_loadu_si128(HEDLEY_STATIC_CAST(__m128i const*, mem_addr));
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_loadu_si128(void const *mem_addr)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_loadu_si128(HEDLEY_STATIC_CAST(__m128i const *, mem_addr));
+#else
+	simde__m128i_private r_;
 
-    #if HEDLEY_GNUC_HAS_ATTRIBUTE(may_alias,3,3,0)
-      HEDLEY_DIAGNOSTIC_PUSH
-      SIMDE_DIAGNOSTIC_DISABLE_PACKED_
-      struct simde_mm_loadu_si128_s {
-        __typeof__(r_) v;
-      } __attribute__((__packed__, __may_alias__));
-      r_ = HEDLEY_REINTERPRET_CAST(const struct simde_mm_loadu_si128_s *, mem_addr)->v;
-      HEDLEY_DIAGNOSTIC_POP
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i8 = vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const*, mem_addr));
-    #else
-      simde_memcpy(&r_, mem_addr, sizeof(r_));
-    #endif
+#if HEDLEY_GNUC_HAS_ATTRIBUTE(may_alias, 3, 3, 0)
+	HEDLEY_DIAGNOSTIC_PUSH
+	SIMDE_DIAGNOSTIC_DISABLE_PACKED_
+	struct simde_mm_loadu_si128_s {
+		__typeof__(r_) v;
+	} __attribute__((__packed__, __may_alias__));
+	r_ = HEDLEY_REINTERPRET_CAST(const struct simde_mm_loadu_si128_s *,
+				     mem_addr)
+		     ->v;
+	HEDLEY_DIAGNOSTIC_POP
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i8 =
+		vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const *, mem_addr));
+#else
+	simde_memcpy(&r_, mem_addr, sizeof(r_));
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_loadu_si128(mem_addr) simde_mm_loadu_si128(mem_addr)
+#define _mm_loadu_si128(mem_addr) simde_mm_loadu_si128(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_madd_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_madd_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_madd_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_madd_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      int32x4_t pl = vmull_s16(vget_low_s16(a_.neon_i16),  vget_low_s16(b_.neon_i16));
-      int32x4_t ph = vmull_high_s16(a_.neon_i16, b_.neon_i16);
-      r_.neon_i32 = vpaddq_s32(pl, ph);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      int32x4_t pl = vmull_s16(vget_low_s16(a_.neon_i16),  vget_low_s16(b_.neon_i16));
-      int32x4_t ph = vmull_s16(vget_high_s16(a_.neon_i16), vget_high_s16(b_.neon_i16));
-      int32x2_t rl = vpadd_s32(vget_low_s32(pl), vget_high_s32(pl));
-      int32x2_t rh = vpadd_s32(vget_low_s32(ph), vget_high_s32(ph));
-      r_.neon_i32 = vcombine_s32(rl, rh);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_i32 = vec_msum(a_.altivec_i16, b_.altivec_i16, vec_splats(0));
-    #elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i32 = vec_mule(a_.altivec_i16, b_.altivec_i16) + vec_mulo(a_.altivec_i16, b_.altivec_i16);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_CONVERT_VECTOR_) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
-      int32_t SIMDE_VECTOR(32) a32, b32, p32;
-      SIMDE_CONVERT_VECTOR_(a32, a_.i16);
-      SIMDE_CONVERT_VECTOR_(b32, b_.i16);
-      p32 = a32 * b32;
-      r_.i32 =
-        __builtin_shufflevector(p32, p32, 0, 2, 4, 6) +
-        __builtin_shufflevector(p32, p32, 1, 3, 5, 7);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i16[0])) ; i += 2) {
-        r_.i32[i / 2] = (a_.i16[i] * b_.i16[i]) + (a_.i16[i + 1] * b_.i16[i + 1]);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	int32x4_t pl =
+		vmull_s16(vget_low_s16(a_.neon_i16), vget_low_s16(b_.neon_i16));
+	int32x4_t ph = vmull_high_s16(a_.neon_i16, b_.neon_i16);
+	r_.neon_i32 = vpaddq_s32(pl, ph);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	int32x4_t pl =
+		vmull_s16(vget_low_s16(a_.neon_i16), vget_low_s16(b_.neon_i16));
+	int32x4_t ph = vmull_s16(vget_high_s16(a_.neon_i16),
+				 vget_high_s16(b_.neon_i16));
+	int32x2_t rl = vpadd_s32(vget_low_s32(pl), vget_high_s32(pl));
+	int32x2_t rh = vpadd_s32(vget_low_s32(ph), vget_high_s32(ph));
+	r_.neon_i32 = vcombine_s32(rl, rh);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_i32 =
+		vec_msum(a_.altivec_i16, b_.altivec_i16, vec_splats(0));
+#elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i32 = vec_mule(a_.altivec_i16, b_.altivec_i16) +
+			 vec_mulo(a_.altivec_i16, b_.altivec_i16);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_CONVERT_VECTOR_) && \
+	HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+	int32_t SIMDE_VECTOR(32) a32, b32, p32;
+	SIMDE_CONVERT_VECTOR_(a32, a_.i16);
+	SIMDE_CONVERT_VECTOR_(b32, b_.i16);
+	p32 = a32 * b32;
+	r_.i32 = __builtin_shufflevector(p32, p32, 0, 2, 4, 6) +
+		 __builtin_shufflevector(p32, p32, 1, 3, 5, 7);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.i16[0])); i += 2) {
+		r_.i32[i / 2] = (a_.i16[i] * b_.i16[i]) +
+				(a_.i16[i + 1] * b_.i16[i + 1]);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_madd_epi16(a, b) simde_mm_madd_epi16(a, b)
+#define _mm_madd_epi16(a, b) simde_mm_madd_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_maskmoveu_si128 (simde__m128i a, simde__m128i mask, int8_t mem_addr[HEDLEY_ARRAY_PARAM(16)]) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_maskmoveu_si128(a, mask, HEDLEY_REINTERPRET_CAST(char*, mem_addr));
-  #else
-    simde__m128i_private
-      a_ = simde__m128i_to_private(a),
-      mask_ = simde__m128i_to_private(mask);
+void simde_mm_maskmoveu_si128(simde__m128i a, simde__m128i mask,
+			      int8_t mem_addr[HEDLEY_ARRAY_PARAM(16)])
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_maskmoveu_si128(a, mask, HEDLEY_REINTERPRET_CAST(char *, mem_addr));
+#else
+	simde__m128i_private a_ = simde__m128i_to_private(a),
+			     mask_ = simde__m128i_to_private(mask);
 
-    for (size_t i = 0 ; i < (sizeof(a_.i8) / sizeof(a_.i8[0])) ; i++) {
-      if (mask_.u8[i] & 0x80) {
-        mem_addr[i] = a_.i8[i];
-      }
-    }
-  #endif
+	for (size_t i = 0; i < (sizeof(a_.i8) / sizeof(a_.i8[0])); i++) {
+		if (mask_.u8[i] & 0x80) {
+			mem_addr[i] = a_.i8[i];
+		}
+	}
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_maskmoveu_si128(a, mask, mem_addr) simde_mm_maskmoveu_si128((a), (mask), SIMDE_CHECKED_REINTERPRET_CAST(int8_t*, char*, (mem_addr)))
+#define _mm_maskmoveu_si128(a, mask, mem_addr) \
+	simde_mm_maskmoveu_si128(              \
+		(a), (mask),                   \
+		SIMDE_CHECKED_REINTERPRET_CAST(int8_t *, char *, (mem_addr)))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int32_t
-simde_mm_movemask_epi8 (simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__INTEL_COMPILER)
-    /* ICC has trouble with _mm_movemask_epi8 at -O2 and above: */
-    return _mm_movemask_epi8(a);
-  #else
-    int32_t r = 0;
-    simde__m128i_private a_ = simde__m128i_to_private(a);
+int32_t simde_mm_movemask_epi8(simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__INTEL_COMPILER)
+	/* ICC has trouble with _mm_movemask_epi8 at -O2 and above: */
+	return _mm_movemask_epi8(a);
+#else
+	int32_t r = 0;
+	simde__m128i_private a_ = simde__m128i_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      /* https://github.com/WebAssembly/simd/pull/201#issue-380682845 */
-      static const uint8_t md[16] = {
-        1 << 0, 1 << 1, 1 << 2, 1 << 3,
-        1 << 4, 1 << 5, 1 << 6, 1 << 7,
-        1 << 0, 1 << 1, 1 << 2, 1 << 3,
-        1 << 4, 1 << 5, 1 << 6, 1 << 7,
-      };
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	/* https://github.com/WebAssembly/simd/pull/201#issue-380682845 */
+	static const uint8_t md[16] = {
+		1 << 0, 1 << 1, 1 << 2, 1 << 3, 1 << 4, 1 << 5, 1 << 6, 1 << 7,
+		1 << 0, 1 << 1, 1 << 2, 1 << 3, 1 << 4, 1 << 5, 1 << 6, 1 << 7,
+	};
 
-      /* Extend sign bit over entire lane */
-      uint8x16_t extended = vreinterpretq_u8_s8(vshrq_n_s8(a_.neon_i8, 7));
-      /* Clear all but the bit we're interested in. */
-      uint8x16_t masked = vandq_u8(vld1q_u8(md), extended);
-      /* Alternate bytes from low half and high half */
-      uint8x8x2_t tmp = vzip_u8(vget_low_u8(masked), vget_high_u8(masked));
-      uint16x8_t x = vreinterpretq_u16_u8(vcombine_u8(tmp.val[0], tmp.val[1]));
-      #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-        r = vaddvq_u16(x);
-      #else
-        uint64x2_t t64 = vpaddlq_u32(vpaddlq_u16(x));
-        r =
-          HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u64(t64, 0)) +
-          HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u64(t64, 1));
-      #endif
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && !defined(HEDLEY_IBM_VERSION) && (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
-      static const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) perm = { 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 0 };
-      r = HEDLEY_STATIC_CAST(int32_t, vec_extract(vec_vbpermq(a_.altivec_u8, perm), 1));
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && !defined(HEDLEY_IBM_VERSION) && (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG)
-      static const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) perm = { 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 0 };
-      r = HEDLEY_STATIC_CAST(int32_t, vec_extract(vec_vbpermq(a_.altivec_u8, perm), 14));
-    #else
-      SIMDE_VECTORIZE_REDUCTION(|:r)
-      for (size_t i = 0 ; i < (sizeof(a_.u8) / sizeof(a_.u8[0])) ; i++) {
-        r |= (a_.u8[15 - i] >> 7) << (15 - i);
-      }
-    #endif
+	/* Extend sign bit over entire lane */
+	uint8x16_t extended = vreinterpretq_u8_s8(vshrq_n_s8(a_.neon_i8, 7));
+	/* Clear all but the bit we're interested in. */
+	uint8x16_t masked = vandq_u8(vld1q_u8(md), extended);
+	/* Alternate bytes from low half and high half */
+	uint8x8x2_t tmp = vzip_u8(vget_low_u8(masked), vget_high_u8(masked));
+	uint16x8_t x =
+		vreinterpretq_u16_u8(vcombine_u8(tmp.val[0], tmp.val[1]));
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r = vaddvq_u16(x);
+#else
+	uint64x2_t t64 = vpaddlq_u32(vpaddlq_u16(x));
+	r = HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u64(t64, 0)) +
+	    HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u64(t64, 1));
+#endif
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
+	!defined(HEDLEY_IBM_VERSION) &&         \
+	(SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
+	static const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)
+		perm = {120, 112, 104, 96, 88, 80, 72, 64,
+			56,  48,  40,  32, 24, 16, 8,  0};
+	r = HEDLEY_STATIC_CAST(
+		int32_t, vec_extract(vec_vbpermq(a_.altivec_u8, perm), 1));
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
+	!defined(HEDLEY_IBM_VERSION) &&         \
+	(SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG)
+	static const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)
+		perm = {120, 112, 104, 96, 88, 80, 72, 64,
+			56,  48,  40,  32, 24, 16, 8,  0};
+	r = HEDLEY_STATIC_CAST(
+		int32_t, vec_extract(vec_vbpermq(a_.altivec_u8, perm), 14));
+#else
+	SIMDE_VECTORIZE_REDUCTION(| : r)
+	for (size_t i = 0; i < (sizeof(a_.u8) / sizeof(a_.u8[0])); i++) {
+		r |= (a_.u8[15 - i] >> 7) << (15 - i);
+	}
+#endif
 
-    return r;
-  #endif
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_movemask_epi8(a) simde_mm_movemask_epi8(a)
+#define _mm_movemask_epi8(a) simde_mm_movemask_epi8(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int32_t
-simde_mm_movemask_pd (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_movemask_pd(a);
-  #else
-    int32_t r = 0;
-    simde__m128d_private a_ = simde__m128d_to_private(a);
+int32_t simde_mm_movemask_pd(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_movemask_pd(a);
+#else
+	int32_t r = 0;
+	simde__m128d_private a_ = simde__m128d_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      HEDLEY_DIAGNOSTIC_PUSH
-      SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
-      uint64x2_t shifted = vshrq_n_u64(a_.neon_u64, 63);
-      r =
-        HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u64(shifted, 0)) +
-        (HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u64(shifted, 1)) << 1);
-      HEDLEY_DIAGNOSTIC_POP
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && defined(SIMDE_BUG_CLANG_50932)
-      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) idx = { 64, 0, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128 };
-      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) res = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_bperm(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned __int128), a_.altivec_u64), idx));
-      r = HEDLEY_STATIC_CAST(int32_t, vec_extract(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), res), 2));
-    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) idx = { 64, 0, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128 };
-      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) res = vec_bperm(a_.altivec_u8, idx);
-      r = HEDLEY_STATIC_CAST(int32_t, vec_extract(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), res), 2));
-    #else
-      SIMDE_VECTORIZE_REDUCTION(|:r)
-      for (size_t i = 0 ; i < (sizeof(a_.u64) / sizeof(a_.u64[0])) ; i++) {
-        r |= (a_.u64[i] >> 63) << i;
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	HEDLEY_DIAGNOSTIC_PUSH
+	SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
+	uint64x2_t shifted = vshrq_n_u64(a_.neon_u64, 63);
+	r = HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u64(shifted, 0)) +
+	    (HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u64(shifted, 1)) << 1);
+	HEDLEY_DIAGNOSTIC_POP
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && defined(SIMDE_BUG_CLANG_50932)
+	SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)
+	idx = {64,  0,   128, 128, 128, 128, 128, 128,
+	       128, 128, 128, 128, 128, 128, 128, 128};
+	SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)
+	res = HEDLEY_REINTERPRET_CAST(
+		SIMDE_POWER_ALTIVEC_VECTOR(unsigned char),
+		vec_bperm(HEDLEY_REINTERPRET_CAST(
+				  SIMDE_POWER_ALTIVEC_VECTOR(unsigned __int128),
+				  a_.altivec_u64),
+			  idx));
+	r = HEDLEY_STATIC_CAST(
+		int32_t,
+		vec_extract(HEDLEY_REINTERPRET_CAST(
+				    SIMDE_POWER_ALTIVEC_VECTOR(signed int),
+				    res),
+			    2));
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+	SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)
+	idx = {64,  0,   128, 128, 128, 128, 128, 128,
+	       128, 128, 128, 128, 128, 128, 128, 128};
+	SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)
+	res = vec_bperm(a_.altivec_u8, idx);
+	r = HEDLEY_STATIC_CAST(
+		int32_t,
+		vec_extract(HEDLEY_REINTERPRET_CAST(
+				    SIMDE_POWER_ALTIVEC_VECTOR(signed int),
+				    res),
+			    2));
+#else
+	SIMDE_VECTORIZE_REDUCTION(| : r)
+	for (size_t i = 0; i < (sizeof(a_.u64) / sizeof(a_.u64[0])); i++) {
+		r |= (a_.u64[i] >> 63) << i;
+	}
+#endif
 
-    return r;
-  #endif
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_movemask_pd(a) simde_mm_movemask_pd(a)
+#define _mm_movemask_pd(a) simde_mm_movemask_pd(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m64
-simde_mm_movepi64_pi64 (simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-    return _mm_movepi64_pi64(a);
-  #else
-    simde__m64_private r_;
-    simde__m128i_private a_ = simde__m128i_to_private(a);
+simde__m64 simde_mm_movepi64_pi64(simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+	return _mm_movepi64_pi64(a);
+#else
+	simde__m64_private r_;
+	simde__m128i_private a_ = simde__m128i_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_i64 = vget_low_s64(a_.neon_i64);
-    #else
-      r_.i64[0] = a_.i64[0];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_i64 = vget_low_s64(a_.neon_i64);
+#else
+	r_.i64[0] = a_.i64[0];
+#endif
 
-    return simde__m64_from_private(r_);
-  #endif
+	return simde__m64_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_movepi64_pi64(a) simde_mm_movepi64_pi64(a)
+#define _mm_movepi64_pi64(a) simde_mm_movepi64_pi64(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_movpi64_epi64 (simde__m64 a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-    return _mm_movpi64_epi64(a);
-  #else
-    simde__m128i_private r_;
-    simde__m64_private a_ = simde__m64_to_private(a);
+simde__m128i simde_mm_movpi64_epi64(simde__m64 a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+	return _mm_movpi64_epi64(a);
+#else
+	simde__m128i_private r_;
+	simde__m64_private a_ = simde__m64_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vcombine_s64(a_.neon_i64, vdup_n_s64(0));
-    #else
-      r_.i64[0] = a_.i64[0];
-      r_.i64[1] = 0;
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = vcombine_s64(a_.neon_i64, vdup_n_s64(0));
+#else
+	r_.i64[0] = a_.i64[0];
+	r_.i64[1] = 0;
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_movpi64_epi64(a) simde_mm_movpi64_epi64(a)
+#define _mm_movpi64_epi64(a) simde_mm_movpi64_epi64(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_min_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_min_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_min_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_min_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i16 = vminq_s16(a_.neon_i16, b_.neon_i16);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i16x8_min(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i16 = vec_min(a_.altivec_i16, b_.altivec_i16);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = (a_.i16[i] < b_.i16[i]) ? a_.i16[i] : b_.i16[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i16 = vminq_s16(a_.neon_i16, b_.neon_i16);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i16x8_min(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i16 = vec_min(a_.altivec_i16, b_.altivec_i16);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = (a_.i16[i] < b_.i16[i]) ? a_.i16[i] : b_.i16[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_min_epi16(a, b) simde_mm_min_epi16(a, b)
+#define _mm_min_epi16(a, b) simde_mm_min_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_min_epu8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_min_epu8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_min_epu8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_min_epu8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u8 = vminq_u8(a_.neon_u8, b_.neon_u8);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u8x16_min(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_u8 = vec_min(a_.altivec_u8, b_.altivec_u8);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
-        r_.u8[i] = (a_.u8[i] < b_.u8[i]) ? a_.u8[i] : b_.u8[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u8 = vminq_u8(a_.neon_u8, b_.neon_u8);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_u8x16_min(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_u8 = vec_min(a_.altivec_u8, b_.altivec_u8);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u8) / sizeof(r_.u8[0])); i++) {
+		r_.u8[i] = (a_.u8[i] < b_.u8[i]) ? a_.u8[i] : b_.u8[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_min_epu8(a, b) simde_mm_min_epu8(a, b)
+#define _mm_min_epu8(a, b) simde_mm_min_epu8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_min_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_min_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_min_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_min_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_f64 = vec_min(a_.altivec_f64, b_.altivec_f64);
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vminq_f64(a_.neon_f64, b_.neon_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_min(a_.wasm_v128, b_.wasm_v128);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.f64[i] = (a_.f64[i] < b_.f64[i]) ? a_.f64[i] : b_.f64[i];
-      }
-    #endif
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_f64 = vec_min(a_.altivec_f64, b_.altivec_f64);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vminq_f64(a_.neon_f64, b_.neon_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_min(a_.wasm_v128, b_.wasm_v128);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = (a_.f64[i] < b_.f64[i]) ? a_.f64[i] : b_.f64[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_min_pd(a, b) simde_mm_min_pd(a, b)
+#define _mm_min_pd(a, b) simde_mm_min_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_min_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_min_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_min_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_min_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_min_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_min_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_min_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(a,
+				simde_mm_min_pd(simde_x_mm_broadcastlow_pd(a),
+						simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      float64x2_t temp = vminq_f64(a_.neon_f64, b_.neon_f64);
-      r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
-    #else
-      r_.f64[0] = (a_.f64[0] < b_.f64[0]) ? a_.f64[0] : b_.f64[0];
-      r_.f64[1] = a_.f64[1];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	float64x2_t temp = vminq_f64(a_.neon_f64, b_.neon_f64);
+	r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
+#else
+	r_.f64[0] = (a_.f64[0] < b_.f64[0]) ? a_.f64[0] : b_.f64[0];
+	r_.f64[1] = a_.f64[1];
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_min_sd(a, b) simde_mm_min_sd(a, b)
+#define _mm_min_sd(a, b) simde_mm_min_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_max_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_max_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_max_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_max_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i16 = vmaxq_s16(a_.neon_i16, b_.neon_i16);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i16x8_max(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i16 = vec_max(a_.altivec_i16, b_.altivec_i16);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? a_.i16[i] : b_.i16[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i16 = vmaxq_s16(a_.neon_i16, b_.neon_i16);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i16x8_max(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i16 = vec_max(a_.altivec_i16, b_.altivec_i16);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? a_.i16[i] : b_.i16[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_max_epi16(a, b) simde_mm_max_epi16(a, b)
+#define _mm_max_epi16(a, b) simde_mm_max_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_max_epu8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_max_epu8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_max_epu8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_max_epu8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u8 = vmaxq_u8(a_.neon_u8, b_.neon_u8);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u8x16_max(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_u8 = vec_max(a_.altivec_u8, b_.altivec_u8);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
-        r_.u8[i] = (a_.u8[i] > b_.u8[i]) ? a_.u8[i] : b_.u8[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u8 = vmaxq_u8(a_.neon_u8, b_.neon_u8);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_u8x16_max(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_u8 = vec_max(a_.altivec_u8, b_.altivec_u8);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u8) / sizeof(r_.u8[0])); i++) {
+		r_.u8[i] = (a_.u8[i] > b_.u8[i]) ? a_.u8[i] : b_.u8[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_max_epu8(a, b) simde_mm_max_epu8(a, b)
+#define _mm_max_epu8(a, b) simde_mm_max_epu8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_max_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_max_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_max_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_max_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_f64 = vec_max(a_.altivec_f64, b_.altivec_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_max(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vmaxq_f64(a_.neon_f64, b_.neon_f64);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.f64[i] = (a_.f64[i] > b_.f64[i]) ? a_.f64[i] : b_.f64[i];
-      }
-    #endif
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_f64 = vec_max(a_.altivec_f64, b_.altivec_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_max(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vmaxq_f64(a_.neon_f64, b_.neon_f64);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = (a_.f64[i] > b_.f64[i]) ? a_.f64[i] : b_.f64[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_max_pd(a, b) simde_mm_max_pd(a, b)
+#define _mm_max_pd(a, b) simde_mm_max_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_max_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_max_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_max_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_max_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_max_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_max_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_max_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(a,
+				simde_mm_max_pd(simde_x_mm_broadcastlow_pd(a),
+						simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      float64x2_t temp = vmaxq_f64(a_.neon_f64, b_.neon_f64);
-      r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
-    #else
-      r_.f64[0] = (a_.f64[0] > b_.f64[0]) ? a_.f64[0] : b_.f64[0];
-      r_.f64[1] = a_.f64[1];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	float64x2_t temp = vmaxq_f64(a_.neon_f64, b_.neon_f64);
+	r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
+#else
+	r_.f64[0] = (a_.f64[0] > b_.f64[0]) ? a_.f64[0] : b_.f64[0];
+	r_.f64[1] = a_.f64[1];
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_max_sd(a, b) simde_mm_max_sd(a, b)
+#define _mm_max_sd(a, b) simde_mm_max_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_move_epi64 (simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_move_epi64(a);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a);
+simde__m128i simde_mm_move_epi64(simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_move_epi64(a);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vsetq_lane_s64(0, a_.neon_i64, 1);
-    #else
-      r_.i64[0] = a_.i64[0];
-      r_.i64[1] = 0;
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = vsetq_lane_s64(0, a_.neon_i64, 1);
+#else
+	r_.i64[0] = a_.i64[0];
+	r_.i64[1] = 0;
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_move_epi64(a) simde_mm_move_epi64(a)
+#define _mm_move_epi64(a) simde_mm_move_epi64(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_mul_epu32 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_mul_epu32(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_mul_epu32(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_mul_epu32(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      uint32x2_t a_lo = vmovn_u64(a_.neon_u64);
-      uint32x2_t b_lo = vmovn_u64(b_.neon_u64);
-      r_.neon_u64 = vmull_u32(a_lo, b_lo);
-    #elif defined(SIMDE_SHUFFLE_VECTOR_) && (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
-      __typeof__(a_.u32) z = { 0, };
-      a_.u32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.u32, z, 0, 4, 2, 6);
-      b_.u32 = SIMDE_SHUFFLE_VECTOR_(32, 16, b_.u32, z, 0, 4, 2, 6);
-      r_.u64 = HEDLEY_REINTERPRET_CAST(__typeof__(r_.u64), a_.u32) *
-               HEDLEY_REINTERPRET_CAST(__typeof__(r_.u64), b_.u32);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
-        r_.u64[i] = HEDLEY_STATIC_CAST(uint64_t, a_.u32[i * 2]) * HEDLEY_STATIC_CAST(uint64_t, b_.u32[i * 2]);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	uint32x2_t a_lo = vmovn_u64(a_.neon_u64);
+	uint32x2_t b_lo = vmovn_u64(b_.neon_u64);
+	r_.neon_u64 = vmull_u32(a_lo, b_lo);
+#elif defined(SIMDE_SHUFFLE_VECTOR_) && \
+	(SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
+	__typeof__(a_.u32) z = {
+		0,
+	};
+	a_.u32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.u32, z, 0, 4, 2, 6);
+	b_.u32 = SIMDE_SHUFFLE_VECTOR_(32, 16, b_.u32, z, 0, 4, 2, 6);
+	r_.u64 = HEDLEY_REINTERPRET_CAST(__typeof__(r_.u64), a_.u32) *
+		 HEDLEY_REINTERPRET_CAST(__typeof__(r_.u64), b_.u32);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u64) / sizeof(r_.u64[0])); i++) {
+		r_.u64[i] = HEDLEY_STATIC_CAST(uint64_t, a_.u32[i * 2]) *
+			    HEDLEY_STATIC_CAST(uint64_t, b_.u32[i * 2]);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_mul_epu32(a, b) simde_mm_mul_epu32(a, b)
+#define _mm_mul_epu32(a, b) simde_mm_mul_epu32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_mul_epi64 (simde__m128i a, simde__m128i b) {
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a),
-    b_ = simde__m128i_to_private(b);
+simde__m128i simde_x_mm_mul_epi64(simde__m128i a, simde__m128i b)
+{
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-    r_.i64 = a_.i64 * b_.i64;
-  #else
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-      r_.i64[i] = a_.i64[i] * b_.i64[i];
-    }
-  #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i64 = a_.i64 * b_.i64;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
+		r_.i64[i] = a_.i64[i] * b_.i64[i];
+	}
+#endif
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_mod_epi64 (simde__m128i a, simde__m128i b) {
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a),
-    b_ = simde__m128i_to_private(b);
+simde__m128i simde_x_mm_mod_epi64(simde__m128i a, simde__m128i b)
+{
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_PGI_30104)
-    r_.i64 = a_.i64 % b_.i64;
-  #else
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-      r_.i64[i] = a_.i64[i] % b_.i64[i];
-    }
-  #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_PGI_30104)
+	r_.i64 = a_.i64 % b_.i64;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
+		r_.i64[i] = a_.i64[i] % b_.i64[i];
+	}
+#endif
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_mul_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_mul_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_mul_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_mul_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.f64 = a_.f64 * b_.f64;
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vmulq_f64(a_.neon_f64, b_.neon_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_mul(a_.wasm_v128, b_.wasm_v128);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.f64[i] = a_.f64[i] * b_.f64[i];
-      }
-    #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.f64 = a_.f64 * b_.f64;
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vmulq_f64(a_.neon_f64, b_.neon_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_mul(a_.wasm_v128, b_.wasm_v128);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = a_.f64[i] * b_.f64[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_mul_pd(a, b) simde_mm_mul_pd(a, b)
+#define _mm_mul_pd(a, b) simde_mm_mul_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_mul_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_mul_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_mul_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_mul_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_mul_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_mul_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_mul_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(a,
+				simde_mm_mul_pd(simde_x_mm_broadcastlow_pd(a),
+						simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      float64x2_t temp = vmulq_f64(a_.neon_f64, b_.neon_f64);
-      r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
-    #else
-      r_.f64[0] = a_.f64[0] * b_.f64[0];
-      r_.f64[1] = a_.f64[1];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	float64x2_t temp = vmulq_f64(a_.neon_f64, b_.neon_f64);
+	r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
+#else
+	r_.f64[0] = a_.f64[0] * b_.f64[0];
+	r_.f64[1] = a_.f64[1];
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_mul_sd(a, b) simde_mm_mul_sd(a, b)
+#define _mm_mul_sd(a, b) simde_mm_mul_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m64
-simde_mm_mul_su32 (simde__m64 a, simde__m64 b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE) && !defined(__PGI)
-    return _mm_mul_su32(a, b);
-  #else
-    simde__m64_private
-      r_,
-      a_ = simde__m64_to_private(a),
-      b_ = simde__m64_to_private(b);
+simde__m64 simde_mm_mul_su32(simde__m64 a, simde__m64 b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE) && \
+	!defined(__PGI)
+	return _mm_mul_su32(a, b);
+#else
+	simde__m64_private r_, a_ = simde__m64_to_private(a),
+			       b_ = simde__m64_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.u64[0] = vget_lane_u64(vget_low_u64(vmull_u32(vreinterpret_u32_s64(a_.neon_i64), vreinterpret_u32_s64(b_.neon_i64))), 0);
-    #else
-      r_.u64[0] = HEDLEY_STATIC_CAST(uint64_t, a_.u32[0]) * HEDLEY_STATIC_CAST(uint64_t, b_.u32[0]);
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.u64[0] = vget_lane_u64(
+		vget_low_u64(vmull_u32(vreinterpret_u32_s64(a_.neon_i64),
+				       vreinterpret_u32_s64(b_.neon_i64))),
+		0);
+#else
+	r_.u64[0] = HEDLEY_STATIC_CAST(uint64_t, a_.u32[0]) *
+		    HEDLEY_STATIC_CAST(uint64_t, b_.u32[0]);
+#endif
 
-    return simde__m64_from_private(r_);
-  #endif
+	return simde__m64_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_mul_su32(a, b) simde_mm_mul_su32(a, b)
+#define _mm_mul_su32(a, b) simde_mm_mul_su32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_mulhi_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_mulhi_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_mulhi_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_mulhi_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      int16x4_t a3210 = vget_low_s16(a_.neon_i16);
-      int16x4_t b3210 = vget_low_s16(b_.neon_i16);
-      int32x4_t ab3210 = vmull_s16(a3210, b3210); /* 3333222211110000 */
-      #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-        int32x4_t ab7654 = vmull_high_s16(a_.neon_i16, b_.neon_i16);
-        r_.neon_i16 = vuzp2q_s16(vreinterpretq_s16_s32(ab3210), vreinterpretq_s16_s32(ab7654));
-      #else
-        int16x4_t a7654 = vget_high_s16(a_.neon_i16);
-        int16x4_t b7654 = vget_high_s16(b_.neon_i16);
-        int32x4_t ab7654 = vmull_s16(a7654, b7654); /* 7777666655554444 */
-        uint16x8x2_t rv = vuzpq_u16(vreinterpretq_u16_s32(ab3210), vreinterpretq_u16_s32(ab7654));
-        r_.neon_u16 = rv.val[1];
-      #endif
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, (HEDLEY_STATIC_CAST(uint32_t, HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) * HEDLEY_STATIC_CAST(int32_t, b_.i16[i])) >> 16));
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	int16x4_t a3210 = vget_low_s16(a_.neon_i16);
+	int16x4_t b3210 = vget_low_s16(b_.neon_i16);
+	int32x4_t ab3210 = vmull_s16(a3210, b3210); /* 3333222211110000 */
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	int32x4_t ab7654 = vmull_high_s16(a_.neon_i16, b_.neon_i16);
+	r_.neon_i16 = vuzp2q_s16(vreinterpretq_s16_s32(ab3210),
+				 vreinterpretq_s16_s32(ab7654));
+#else
+	int16x4_t a7654 = vget_high_s16(a_.neon_i16);
+	int16x4_t b7654 = vget_high_s16(b_.neon_i16);
+	int32x4_t ab7654 = vmull_s16(a7654, b7654); /* 7777666655554444 */
+	uint16x8x2_t rv = vuzpq_u16(vreinterpretq_u16_s32(ab3210),
+				    vreinterpretq_u16_s32(ab7654));
+	r_.neon_u16 = rv.val[1];
+#endif
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.u16[i] = HEDLEY_STATIC_CAST(
+			uint16_t,
+			(HEDLEY_STATIC_CAST(
+				 uint32_t,
+				 HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) *
+					 HEDLEY_STATIC_CAST(int32_t,
+							    b_.i16[i])) >>
+			 16));
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_mulhi_epi16(a, b) simde_mm_mulhi_epi16(a, b)
+#define _mm_mulhi_epi16(a, b) simde_mm_mulhi_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_mulhi_epu16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-    return _mm_mulhi_epu16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_mulhi_epu16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+	return _mm_mulhi_epu16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      uint16x4_t a3210 = vget_low_u16(a_.neon_u16);
-      uint16x4_t b3210 = vget_low_u16(b_.neon_u16);
-      uint32x4_t ab3210 = vmull_u16(a3210, b3210); /* 3333222211110000 */
-      #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-        uint32x4_t ab7654 = vmull_high_u16(a_.neon_u16, b_.neon_u16);
-        r_.neon_u16 = vuzp2q_u16(vreinterpretq_u16_u32(ab3210), vreinterpretq_u16_u32(ab7654));
-      #else
-        uint16x4_t a7654 = vget_high_u16(a_.neon_u16);
-        uint16x4_t b7654 = vget_high_u16(b_.neon_u16);
-        uint32x4_t ab7654 = vmull_u16(a7654, b7654); /* 7777666655554444 */
-        uint16x8x2_t neon_r = vuzpq_u16(vreinterpretq_u16_u32(ab3210), vreinterpretq_u16_u32(ab7654));
-        r_.neon_u16 = neon_r.val[1];
-      #endif
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
-        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, HEDLEY_STATIC_CAST(uint32_t, a_.u16[i]) * HEDLEY_STATIC_CAST(uint32_t, b_.u16[i]) >> 16);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	uint16x4_t a3210 = vget_low_u16(a_.neon_u16);
+	uint16x4_t b3210 = vget_low_u16(b_.neon_u16);
+	uint32x4_t ab3210 = vmull_u16(a3210, b3210); /* 3333222211110000 */
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	uint32x4_t ab7654 = vmull_high_u16(a_.neon_u16, b_.neon_u16);
+	r_.neon_u16 = vuzp2q_u16(vreinterpretq_u16_u32(ab3210),
+				 vreinterpretq_u16_u32(ab7654));
+#else
+	uint16x4_t a7654 = vget_high_u16(a_.neon_u16);
+	uint16x4_t b7654 = vget_high_u16(b_.neon_u16);
+	uint32x4_t ab7654 = vmull_u16(a7654, b7654); /* 7777666655554444 */
+	uint16x8x2_t neon_r = vuzpq_u16(vreinterpretq_u16_u32(ab3210),
+					vreinterpretq_u16_u32(ab7654));
+	r_.neon_u16 = neon_r.val[1];
+#endif
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u16) / sizeof(r_.u16[0])); i++) {
+		r_.u16[i] = HEDLEY_STATIC_CAST(
+			uint16_t,
+			HEDLEY_STATIC_CAST(uint32_t, a_.u16[i]) *
+					HEDLEY_STATIC_CAST(uint32_t,
+							   b_.u16[i]) >>
+				16);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_mulhi_epu16(a, b) simde_mm_mulhi_epu16(a, b)
+#define _mm_mulhi_epu16(a, b) simde_mm_mulhi_epu16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_mullo_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_mullo_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_mullo_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_mullo_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i16 = vmulq_s16(a_.neon_i16, b_.neon_i16);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      (void) a_;
-      (void) b_;
-      r_.altivec_i16 = vec_mul(a_.altivec_i16, b_.altivec_i16);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, HEDLEY_STATIC_CAST(uint32_t, a_.u16[i]) * HEDLEY_STATIC_CAST(uint32_t, b_.u16[i]));
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i16 = vmulq_s16(a_.neon_i16, b_.neon_i16);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	(void)a_;
+	(void)b_;
+	r_.altivec_i16 = vec_mul(a_.altivec_i16, b_.altivec_i16);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.u16[i] = HEDLEY_STATIC_CAST(
+			uint16_t,
+			HEDLEY_STATIC_CAST(uint32_t, a_.u16[i]) *
+				HEDLEY_STATIC_CAST(uint32_t, b_.u16[i]));
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_mullo_epi16(a, b) simde_mm_mullo_epi16(a, b)
+#define _mm_mullo_epi16(a, b) simde_mm_mullo_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_or_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_or_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_or_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_or_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32f = a_.i32f | b_.i32f;
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_v128_or(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vorrq_s64(a_.neon_i64, b_.neon_i64);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
-        r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
-      }
-    #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32f = a_.i32f | b_.i32f;
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_v128_or(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = vorrq_s64(a_.neon_i64, b_.neon_i64);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
+		r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_or_pd(a, b) simde_mm_or_pd(a, b)
+#define _mm_or_pd(a, b) simde_mm_or_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_or_si128 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_or_si128(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_or_si128(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_or_si128(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vorrq_s32(a_.neon_i32, b_.neon_i32);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_i32 = vec_or(a_.altivec_i32, b_.altivec_i32);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32f = a_.i32f | b_.i32f;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
-        r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vorrq_s32(a_.neon_i32, b_.neon_i32);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_i32 = vec_or(a_.altivec_i32, b_.altivec_i32);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32f = a_.i32f | b_.i32f;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
+		r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_or_si128(a, b) simde_mm_or_si128(a, b)
+#define _mm_or_si128(a, b) simde_mm_or_si128(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_packs_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_packs_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_packs_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_packs_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i8 = vcombine_s8(vqmovn_s16(a_.neon_i16), vqmovn_s16(b_.neon_i16));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i8[i]     = (a_.i16[i] > INT8_MAX) ? INT8_MAX : ((a_.i16[i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, a_.i16[i]));
-        r_.i8[i + 8] = (b_.i16[i] > INT8_MAX) ? INT8_MAX : ((b_.i16[i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, b_.i16[i]));
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i8 =
+		vcombine_s8(vqmovn_s16(a_.neon_i16), vqmovn_s16(b_.neon_i16));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i8[i] = (a_.i16[i] > INT8_MAX)
+				   ? INT8_MAX
+				   : ((a_.i16[i] < INT8_MIN)
+					      ? INT8_MIN
+					      : HEDLEY_STATIC_CAST(int8_t,
+								   a_.i16[i]));
+		r_.i8[i + 8] = (b_.i16[i] > INT8_MAX)
+				       ? INT8_MAX
+				       : ((b_.i16[i] < INT8_MIN)
+						  ? INT8_MIN
+						  : HEDLEY_STATIC_CAST(
+							    int8_t, b_.i16[i]));
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_packs_epi16(a, b) simde_mm_packs_epi16(a, b)
+#define _mm_packs_epi16(a, b) simde_mm_packs_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_packs_epi32 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_packs_epi32(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_packs_epi32(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_packs_epi32(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i16 = vcombine_s16(vqmovn_s32(a_.neon_i32), vqmovn_s32(b_.neon_i32));
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_i16 = vec_packs(a_.altivec_i32, b_.altivec_i32);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        r_.i16[i]     = (a_.i32[i] > INT16_MAX) ? INT16_MAX : ((a_.i32[i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, a_.i32[i]));
-        r_.i16[i + 4] = (b_.i32[i] > INT16_MAX) ? INT16_MAX : ((b_.i32[i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, b_.i32[i]));
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i16 =
+		vcombine_s16(vqmovn_s32(a_.neon_i32), vqmovn_s32(b_.neon_i32));
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_i16 = vec_packs(a_.altivec_i32, b_.altivec_i32);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		r_.i16[i] = (a_.i32[i] > INT16_MAX)
+				    ? INT16_MAX
+				    : ((a_.i32[i] < INT16_MIN)
+					       ? INT16_MIN
+					       : HEDLEY_STATIC_CAST(int16_t,
+								    a_.i32[i]));
+		r_.i16[i + 4] =
+			(b_.i32[i] > INT16_MAX)
+				? INT16_MAX
+				: ((b_.i32[i] < INT16_MIN)
+					   ? INT16_MIN
+					   : HEDLEY_STATIC_CAST(int16_t,
+								b_.i32[i]));
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_packs_epi32(a, b) simde_mm_packs_epi32(a, b)
+#define _mm_packs_epi32(a, b) simde_mm_packs_epi32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_packus_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_packus_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_packus_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_packus_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u8 = vcombine_u8(vqmovun_s16(a_.neon_i16), vqmovun_s16(b_.neon_i16));
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_u8 = vec_packsu(a_.altivec_i16, b_.altivec_i16);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.u8[i]     = (a_.i16[i] > UINT8_MAX) ? UINT8_MAX : ((a_.i16[i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, a_.i16[i]));
-        r_.u8[i + 8] = (b_.i16[i] > UINT8_MAX) ? UINT8_MAX : ((b_.i16[i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, b_.i16[i]));
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u8 =
+		vcombine_u8(vqmovun_s16(a_.neon_i16), vqmovun_s16(b_.neon_i16));
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_u8 = vec_packsu(a_.altivec_i16, b_.altivec_i16);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.u8[i] = (a_.i16[i] > UINT8_MAX)
+				   ? UINT8_MAX
+				   : ((a_.i16[i] < 0)
+					      ? UINT8_C(0)
+					      : HEDLEY_STATIC_CAST(uint8_t,
+								   a_.i16[i]));
+		r_.u8[i + 8] =
+			(b_.i16[i] > UINT8_MAX)
+				? UINT8_MAX
+				: ((b_.i16[i] < 0)
+					   ? UINT8_C(0)
+					   : HEDLEY_STATIC_CAST(uint8_t,
+								b_.i16[i]));
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_packus_epi16(a, b) simde_mm_packus_epi16(a, b)
+#define _mm_packus_epi16(a, b) simde_mm_packus_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_pause (void) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_pause();
-  #endif
+void simde_mm_pause(void)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_pause();
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_pause() (simde_mm_pause())
+#define _mm_pause() (simde_mm_pause())
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_sad_epu8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_sad_epu8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_sad_epu8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_sad_epu8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      const uint16x8_t t = vpaddlq_u8(vabdq_u8(a_.neon_u8, b_.neon_u8));
-      r_.neon_u64 = vcombine_u64(
-        vpaddl_u32(vpaddl_u16(vget_low_u16(t))),
-        vpaddl_u32(vpaddl_u16(vget_high_u16(t))));
-    #else
-      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-        uint16_t tmp = 0;
-        SIMDE_VECTORIZE_REDUCTION(+:tmp)
-        for (size_t j = 0 ; j < ((sizeof(r_.u8) / sizeof(r_.u8[0])) / 2) ; j++) {
-          const size_t e = j + (i * 8);
-          tmp += (a_.u8[e] > b_.u8[e]) ? (a_.u8[e] - b_.u8[e]) : (b_.u8[e] - a_.u8[e]);
-        }
-        r_.i64[i] = tmp;
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	const uint16x8_t t = vpaddlq_u8(vabdq_u8(a_.neon_u8, b_.neon_u8));
+	r_.neon_u64 = vcombine_u64(vpaddl_u32(vpaddl_u16(vget_low_u16(t))),
+				   vpaddl_u32(vpaddl_u16(vget_high_u16(t))));
+#else
+	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
+		uint16_t tmp = 0;
+		SIMDE_VECTORIZE_REDUCTION(+ : tmp)
+		for (size_t j = 0; j < ((sizeof(r_.u8) / sizeof(r_.u8[0])) / 2);
+		     j++) {
+			const size_t e = j + (i * 8);
+			tmp += (a_.u8[e] > b_.u8[e]) ? (a_.u8[e] - b_.u8[e])
+						     : (b_.u8[e] - a_.u8[e]);
+		}
+		r_.i64[i] = tmp;
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sad_epu8(a, b) simde_mm_sad_epu8(a, b)
+#define _mm_sad_epu8(a, b) simde_mm_sad_epu8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_set_epi8 (int8_t e15, int8_t e14, int8_t e13, int8_t e12,
-       int8_t e11, int8_t e10, int8_t  e9, int8_t  e8,
-       int8_t  e7, int8_t  e6, int8_t  e5, int8_t  e4,
-       int8_t  e3, int8_t  e2, int8_t  e1, int8_t  e0) {
+simde__m128i simde_mm_set_epi8(int8_t e15, int8_t e14, int8_t e13, int8_t e12,
+			       int8_t e11, int8_t e10, int8_t e9, int8_t e8,
+			       int8_t e7, int8_t e6, int8_t e5, int8_t e4,
+			       int8_t e3, int8_t e2, int8_t e1, int8_t e0)
+{
 
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_set_epi8(
-      e15, e14, e13, e12, e11, e10,  e9,  e8,
-       e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
-  #else
-    simde__m128i_private r_;
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_set_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5,
+			    e4, e3, e2, e1, e0);
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i8x16_make(
-         e0,  e1,  e2,  e3,  e4,  e5,  e6,  e7,
-         e8,  e9, e10, e11, e12, e13, e14, e15);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      SIMDE_ALIGN_LIKE_16(int8x16_t) int8_t data[16] = {
-        e0,  e1,  e2,  e3,
-        e4,  e5,  e6,  e7,
-        e8,  e9,  e10, e11,
-        e12, e13, e14, e15};
-      r_.neon_i8 = vld1q_s8(data);
-    #else
-      r_.i8[ 0] =  e0;
-      r_.i8[ 1] =  e1;
-      r_.i8[ 2] =  e2;
-      r_.i8[ 3] =  e3;
-      r_.i8[ 4] =  e4;
-      r_.i8[ 5] =  e5;
-      r_.i8[ 6] =  e6;
-      r_.i8[ 7] =  e7;
-      r_.i8[ 8] =  e8;
-      r_.i8[ 9] =  e9;
-      r_.i8[10] = e10;
-      r_.i8[11] = e11;
-      r_.i8[12] = e12;
-      r_.i8[13] = e13;
-      r_.i8[14] = e14;
-      r_.i8[15] = e15;
-    #endif
+#if defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i8x16_make(e0, e1, e2, e3, e4, e5, e6, e7, e8, e9,
+				       e10, e11, e12, e13, e14, e15);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	SIMDE_ALIGN_LIKE_16(int8x16_t)
+	int8_t data[16] = {e0, e1, e2,  e3,  e4,  e5,  e6,  e7,
+			   e8, e9, e10, e11, e12, e13, e14, e15};
+	r_.neon_i8 = vld1q_s8(data);
+#else
+	r_.i8[0] = e0;
+	r_.i8[1] = e1;
+	r_.i8[2] = e2;
+	r_.i8[3] = e3;
+	r_.i8[4] = e4;
+	r_.i8[5] = e5;
+	r_.i8[6] = e6;
+	r_.i8[7] = e7;
+	r_.i8[8] = e8;
+	r_.i8[9] = e9;
+	r_.i8[10] = e10;
+	r_.i8[11] = e11;
+	r_.i8[12] = e12;
+	r_.i8[13] = e13;
+	r_.i8[14] = e14;
+	r_.i8[15] = e15;
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_set_epi8(e15, e14, e13, e12, e11, e10,  e9,  e8,  e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0) simde_mm_set_epi8(e15, e14, e13, e12, e11, e10,  e9,  e8,  e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0)
+#define _mm_set_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, \
+		     e2, e1, e0)                                               \
+	simde_mm_set_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5,    \
+			  e4, e3, e2, e1, e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_set_epi16 (int16_t e7, int16_t e6, int16_t e5, int16_t e4,
-        int16_t e3, int16_t e2, int16_t e1, int16_t e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_set_epi16(e7, e6, e5, e4, e3, e2, e1, e0);
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_set_epi16(int16_t e7, int16_t e6, int16_t e5, int16_t e4,
+				int16_t e3, int16_t e2, int16_t e1, int16_t e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_set_epi16(e7, e6, e5, e4, e3, e2, e1, e0);
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      SIMDE_ALIGN_LIKE_16(int16x8_t) int16_t data[8] = { e0, e1, e2, e3, e4, e5, e6, e7 };
-      r_.neon_i16 = vld1q_s16(data);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i16x8_make(e0, e1, e2, e3, e4, e5, e6, e7);
-    #else
-      r_.i16[0] = e0;
-      r_.i16[1] = e1;
-      r_.i16[2] = e2;
-      r_.i16[3] = e3;
-      r_.i16[4] = e4;
-      r_.i16[5] = e5;
-      r_.i16[6] = e6;
-      r_.i16[7] = e7;
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	SIMDE_ALIGN_LIKE_16(int16x8_t)
+	int16_t data[8] = {e0, e1, e2, e3, e4, e5, e6, e7};
+	r_.neon_i16 = vld1q_s16(data);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i16x8_make(e0, e1, e2, e3, e4, e5, e6, e7);
+#else
+	r_.i16[0] = e0;
+	r_.i16[1] = e1;
+	r_.i16[2] = e2;
+	r_.i16[3] = e3;
+	r_.i16[4] = e4;
+	r_.i16[5] = e5;
+	r_.i16[6] = e6;
+	r_.i16[7] = e7;
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_set_epi16(e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0) simde_mm_set_epi16(e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0)
+#define _mm_set_epi16(e7, e6, e5, e4, e3, e2, e1, e0) \
+	simde_mm_set_epi16(e7, e6, e5, e4, e3, e2, e1, e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_loadu_si16 (void const* mem_addr) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && ( \
-      SIMDE_DETECT_CLANG_VERSION_CHECK(8,0,0) || \
-      HEDLEY_INTEL_VERSION_CHECK(20,21,1))
-    return _mm_loadu_si16(mem_addr);
-  #else
-    int16_t val;
-    simde_memcpy(&val, mem_addr, sizeof(val));
-    return simde_x_mm_cvtsi16_si128(val);
-  #endif
+simde__m128i simde_mm_loadu_si16(void const *mem_addr)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) &&                 \
+	(SIMDE_DETECT_CLANG_VERSION_CHECK(8, 0, 0) || \
+	 HEDLEY_INTEL_VERSION_CHECK(20, 21, 1))
+	return _mm_loadu_si16(mem_addr);
+#else
+	int16_t val;
+	simde_memcpy(&val, mem_addr, sizeof(val));
+	return simde_x_mm_cvtsi16_si128(val);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_loadu_si16(mem_addr) simde_mm_loadu_si16(mem_addr)
+#define _mm_loadu_si16(mem_addr) simde_mm_loadu_si16(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_set_epi32 (int32_t e3, int32_t e2, int32_t e1, int32_t e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_set_epi32(e3, e2, e1, e0);
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_set_epi32(int32_t e3, int32_t e2, int32_t e1, int32_t e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_set_epi32(e3, e2, e1, e0);
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      SIMDE_ALIGN_LIKE_16(int32x4_t) int32_t data[4] = { e0, e1, e2, e3 };
-      r_.neon_i32 = vld1q_s32(data);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i32x4_make(e0, e1, e2, e3);
-    #else
-      r_.i32[0] = e0;
-      r_.i32[1] = e1;
-      r_.i32[2] = e2;
-      r_.i32[3] = e3;
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	SIMDE_ALIGN_LIKE_16(int32x4_t) int32_t data[4] = {e0, e1, e2, e3};
+	r_.neon_i32 = vld1q_s32(data);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i32x4_make(e0, e1, e2, e3);
+#else
+	r_.i32[0] = e0;
+	r_.i32[1] = e1;
+	r_.i32[2] = e2;
+	r_.i32[3] = e3;
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_set_epi32(e3,  e2,  e1,  e0) simde_mm_set_epi32(e3,  e2,  e1,  e0)
+#define _mm_set_epi32(e3, e2, e1, e0) simde_mm_set_epi32(e3, e2, e1, e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_loadu_si32 (void const* mem_addr) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && ( \
-      SIMDE_DETECT_CLANG_VERSION_CHECK(8,0,0) || \
-      HEDLEY_INTEL_VERSION_CHECK(20,21,1))
-    return _mm_loadu_si32(mem_addr);
-  #else
-    int32_t val;
-    simde_memcpy(&val, mem_addr, sizeof(val));
-    return simde_mm_cvtsi32_si128(val);
-  #endif
+simde__m128i simde_mm_loadu_si32(void const *mem_addr)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) &&                 \
+	(SIMDE_DETECT_CLANG_VERSION_CHECK(8, 0, 0) || \
+	 HEDLEY_INTEL_VERSION_CHECK(20, 21, 1))
+	return _mm_loadu_si32(mem_addr);
+#else
+	int32_t val;
+	simde_memcpy(&val, mem_addr, sizeof(val));
+	return simde_mm_cvtsi32_si128(val);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_loadu_si32(mem_addr) simde_mm_loadu_si32(mem_addr)
+#define _mm_loadu_si32(mem_addr) simde_mm_loadu_si32(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_set_epi64 (simde__m64 e1, simde__m64 e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-    return _mm_set_epi64(e1, e0);
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_set_epi64(simde__m64 e1, simde__m64 e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+	return _mm_set_epi64(e1, e0);
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vcombine_s64(simde__m64_to_neon_i64(e0), simde__m64_to_neon_i64(e1));
-    #else
-      r_.m64[0] = e0;
-      r_.m64[1] = e1;
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = vcombine_s64(simde__m64_to_neon_i64(e0),
+				   simde__m64_to_neon_i64(e1));
+#else
+	r_.m64[0] = e0;
+	r_.m64[1] = e1;
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_set_epi64(e1, e0) (simde_mm_set_epi64((e1), (e0)))
+#define _mm_set_epi64(e1, e0) (simde_mm_set_epi64((e1), (e0)))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_set_epi64x (int64_t e1, int64_t e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,0,0))
-    return _mm_set_epi64x(e1, e0);
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_set_epi64x(int64_t e1, int64_t e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && \
+	(!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19, 0, 0))
+	return _mm_set_epi64x(e1, e0);
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      SIMDE_ALIGN_LIKE_16(int64x2_t) int64_t data[2] = {e0, e1};
-      r_.neon_i64 = vld1q_s64(data);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i64x2_make(e0, e1);
-    #else
-      r_.i64[0] = e0;
-      r_.i64[1] = e1;
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	SIMDE_ALIGN_LIKE_16(int64x2_t) int64_t data[2] = {e0, e1};
+	r_.neon_i64 = vld1q_s64(data);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i64x2_make(e0, e1);
+#else
+	r_.i64[0] = e0;
+	r_.i64[1] = e1;
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_set_epi64x(e1, e0) simde_mm_set_epi64x(e1, e0)
+#define _mm_set_epi64x(e1, e0) simde_mm_set_epi64x(e1, e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_loadu_si64 (void const* mem_addr) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && ( \
-      SIMDE_DETECT_CLANG_VERSION_CHECK(8,0,0) || \
-      HEDLEY_GCC_VERSION_CHECK(11,0,0) || \
-      HEDLEY_INTEL_VERSION_CHECK(20,21,1))
-    return _mm_loadu_si64(mem_addr);
-  #else
-  int64_t val;
-    simde_memcpy(&val, mem_addr, sizeof(val));
-    return simde_mm_cvtsi64_si128(val);
-  #endif
+simde__m128i simde_mm_loadu_si64(void const *mem_addr)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) &&                 \
+	(SIMDE_DETECT_CLANG_VERSION_CHECK(8, 0, 0) || \
+	 HEDLEY_GCC_VERSION_CHECK(11, 0, 0) ||        \
+	 HEDLEY_INTEL_VERSION_CHECK(20, 21, 1))
+	return _mm_loadu_si64(mem_addr);
+#else
+	int64_t val;
+	simde_memcpy(&val, mem_addr, sizeof(val));
+	return simde_mm_cvtsi64_si128(val);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_loadu_si64(mem_addr) simde_mm_loadu_si64(mem_addr)
+#define _mm_loadu_si64(mem_addr) simde_mm_loadu_si64(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_set_epu8 (uint8_t e15, uint8_t e14, uint8_t e13, uint8_t e12,
-         uint8_t e11, uint8_t e10, uint8_t  e9, uint8_t  e8,
-         uint8_t  e7, uint8_t  e6, uint8_t  e5, uint8_t  e4,
-         uint8_t  e3, uint8_t  e2, uint8_t  e1, uint8_t  e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_set_epi8(
-      HEDLEY_STATIC_CAST(char, e15), HEDLEY_STATIC_CAST(char, e14), HEDLEY_STATIC_CAST(char, e13), HEDLEY_STATIC_CAST(char, e12),
-      HEDLEY_STATIC_CAST(char, e11), HEDLEY_STATIC_CAST(char, e10), HEDLEY_STATIC_CAST(char,  e9), HEDLEY_STATIC_CAST(char,  e8),
-      HEDLEY_STATIC_CAST(char,  e7), HEDLEY_STATIC_CAST(char,  e6), HEDLEY_STATIC_CAST(char,  e5), HEDLEY_STATIC_CAST(char,  e4),
-      HEDLEY_STATIC_CAST(char,  e3), HEDLEY_STATIC_CAST(char,  e2), HEDLEY_STATIC_CAST(char,  e1), HEDLEY_STATIC_CAST(char,  e0));
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_x_mm_set_epu8(uint8_t e15, uint8_t e14, uint8_t e13,
+				 uint8_t e12, uint8_t e11, uint8_t e10,
+				 uint8_t e9, uint8_t e8, uint8_t e7, uint8_t e6,
+				 uint8_t e5, uint8_t e4, uint8_t e3, uint8_t e2,
+				 uint8_t e1, uint8_t e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_set_epi8(
+		HEDLEY_STATIC_CAST(char, e15), HEDLEY_STATIC_CAST(char, e14),
+		HEDLEY_STATIC_CAST(char, e13), HEDLEY_STATIC_CAST(char, e12),
+		HEDLEY_STATIC_CAST(char, e11), HEDLEY_STATIC_CAST(char, e10),
+		HEDLEY_STATIC_CAST(char, e9), HEDLEY_STATIC_CAST(char, e8),
+		HEDLEY_STATIC_CAST(char, e7), HEDLEY_STATIC_CAST(char, e6),
+		HEDLEY_STATIC_CAST(char, e5), HEDLEY_STATIC_CAST(char, e4),
+		HEDLEY_STATIC_CAST(char, e3), HEDLEY_STATIC_CAST(char, e2),
+		HEDLEY_STATIC_CAST(char, e1), HEDLEY_STATIC_CAST(char, e0));
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      SIMDE_ALIGN_LIKE_16(uint8x16_t) uint8_t data[16] = {
-        e0,  e1,  e2,  e3,
-        e4,  e5,  e6,  e7,
-        e8,  e9,  e10, e11,
-        e12, e13, e14, e15};
-      r_.neon_u8 = vld1q_u8(data);
-    #else
-      r_.u8[ 0] =  e0; r_.u8[ 1] =  e1; r_.u8[ 2] =  e2; r_.u8[ 3] =  e3;
-      r_.u8[ 4] =  e4; r_.u8[ 5] =  e5; r_.u8[ 6] =  e6; r_.u8[ 7] =  e7;
-      r_.u8[ 8] =  e8; r_.u8[ 9] =  e9; r_.u8[10] = e10; r_.u8[11] = e11;
-      r_.u8[12] = e12; r_.u8[13] = e13; r_.u8[14] = e14; r_.u8[15] = e15;
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	SIMDE_ALIGN_LIKE_16(uint8x16_t)
+	uint8_t data[16] = {e0, e1, e2,  e3,  e4,  e5,  e6,  e7,
+			    e8, e9, e10, e11, e12, e13, e14, e15};
+	r_.neon_u8 = vld1q_u8(data);
+#else
+	r_.u8[0] = e0;
+	r_.u8[1] = e1;
+	r_.u8[2] = e2;
+	r_.u8[3] = e3;
+	r_.u8[4] = e4;
+	r_.u8[5] = e5;
+	r_.u8[6] = e6;
+	r_.u8[7] = e7;
+	r_.u8[8] = e8;
+	r_.u8[9] = e9;
+	r_.u8[10] = e10;
+	r_.u8[11] = e11;
+	r_.u8[12] = e12;
+	r_.u8[13] = e13;
+	r_.u8[14] = e14;
+	r_.u8[15] = e15;
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_set_epu16 (uint16_t e7, uint16_t e6, uint16_t e5, uint16_t e4,
-          uint16_t e3, uint16_t e2, uint16_t e1, uint16_t e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_set_epi16(
-      HEDLEY_STATIC_CAST(short,  e7), HEDLEY_STATIC_CAST(short,  e6), HEDLEY_STATIC_CAST(short,  e5), HEDLEY_STATIC_CAST(short,  e4),
-      HEDLEY_STATIC_CAST(short,  e3), HEDLEY_STATIC_CAST(short,  e2), HEDLEY_STATIC_CAST(short,  e1), HEDLEY_STATIC_CAST(short,  e0));
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_x_mm_set_epu16(uint16_t e7, uint16_t e6, uint16_t e5,
+				  uint16_t e4, uint16_t e3, uint16_t e2,
+				  uint16_t e1, uint16_t e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_set_epi16(
+		HEDLEY_STATIC_CAST(short, e7), HEDLEY_STATIC_CAST(short, e6),
+		HEDLEY_STATIC_CAST(short, e5), HEDLEY_STATIC_CAST(short, e4),
+		HEDLEY_STATIC_CAST(short, e3), HEDLEY_STATIC_CAST(short, e2),
+		HEDLEY_STATIC_CAST(short, e1), HEDLEY_STATIC_CAST(short, e0));
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      SIMDE_ALIGN_LIKE_16(uint16x8_t) uint16_t data[8] = { e0, e1, e2, e3, e4, e5, e6, e7 };
-      r_.neon_u16 = vld1q_u16(data);
-    #else
-      r_.u16[0] = e0; r_.u16[1] = e1; r_.u16[2] = e2; r_.u16[3] = e3;
-      r_.u16[4] = e4; r_.u16[5] = e5; r_.u16[6] = e6; r_.u16[7] = e7;
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	SIMDE_ALIGN_LIKE_16(uint16x8_t)
+	uint16_t data[8] = {e0, e1, e2, e3, e4, e5, e6, e7};
+	r_.neon_u16 = vld1q_u16(data);
+#else
+	r_.u16[0] = e0;
+	r_.u16[1] = e1;
+	r_.u16[2] = e2;
+	r_.u16[3] = e3;
+	r_.u16[4] = e4;
+	r_.u16[5] = e5;
+	r_.u16[6] = e6;
+	r_.u16[7] = e7;
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_set_epu32 (uint32_t e3, uint32_t e2, uint32_t e1, uint32_t e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_set_epi32(
-      HEDLEY_STATIC_CAST(int,  e3), HEDLEY_STATIC_CAST(int,  e2), HEDLEY_STATIC_CAST(int,  e1), HEDLEY_STATIC_CAST(int,  e0));
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_x_mm_set_epu32(uint32_t e3, uint32_t e2, uint32_t e1,
+				  uint32_t e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_set_epi32(HEDLEY_STATIC_CAST(int, e3),
+			     HEDLEY_STATIC_CAST(int, e2),
+			     HEDLEY_STATIC_CAST(int, e1),
+			     HEDLEY_STATIC_CAST(int, e0));
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      SIMDE_ALIGN_LIKE_16(uint32x4_t) uint32_t data[4] = { e0, e1, e2, e3 };
-      r_.neon_u32 = vld1q_u32(data);
-    #else
-      r_.u32[0] = e0;
-      r_.u32[1] = e1;
-      r_.u32[2] = e2;
-      r_.u32[3] = e3;
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	SIMDE_ALIGN_LIKE_16(uint32x4_t) uint32_t data[4] = {e0, e1, e2, e3};
+	r_.neon_u32 = vld1q_u32(data);
+#else
+	r_.u32[0] = e0;
+	r_.u32[1] = e1;
+	r_.u32[2] = e2;
+	r_.u32[3] = e3;
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_set_epu64x (uint64_t e1, uint64_t e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,0,0))
-    return _mm_set_epi64x(HEDLEY_STATIC_CAST(int64_t,  e1), HEDLEY_STATIC_CAST(int64_t,  e0));
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_x_mm_set_epu64x(uint64_t e1, uint64_t e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && \
+	(!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19, 0, 0))
+	return _mm_set_epi64x(HEDLEY_STATIC_CAST(int64_t, e1),
+			      HEDLEY_STATIC_CAST(int64_t, e0));
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      SIMDE_ALIGN_LIKE_16(uint64x2_t) uint64_t data[2] = {e0, e1};
-      r_.neon_u64 = vld1q_u64(data);
-    #else
-      r_.u64[0] = e0;
-      r_.u64[1] = e1;
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	SIMDE_ALIGN_LIKE_16(uint64x2_t) uint64_t data[2] = {e0, e1};
+	r_.neon_u64 = vld1q_u64(data);
+#else
+	r_.u64[0] = e0;
+	r_.u64[1] = e1;
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_set_sd (simde_float64 a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_set_sd(a);
-  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    return vsetq_lane_f64(a, vdupq_n_f64(SIMDE_FLOAT64_C(0.0)), 0);
-  #else
-    return simde_mm_set_pd(SIMDE_FLOAT64_C(0.0), a);
-  #endif
+simde__m128d simde_mm_set_sd(simde_float64 a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_set_sd(a);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	return vsetq_lane_f64(a, vdupq_n_f64(SIMDE_FLOAT64_C(0.0)), 0);
+#else
+	return simde_mm_set_pd(SIMDE_FLOAT64_C(0.0), a);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_set_sd(a) simde_mm_set_sd(a)
+#define _mm_set_sd(a) simde_mm_set_sd(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_set1_epi8 (int8_t a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_set1_epi8(a);
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_set1_epi8(int8_t a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_set1_epi8(a);
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i8 = vdupq_n_s8(a);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i8x16_splat(a);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i8 = vec_splats(HEDLEY_STATIC_CAST(signed char, a));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-        r_.i8[i] = a;
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i8 = vdupq_n_s8(a);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i8x16_splat(a);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i8 = vec_splats(HEDLEY_STATIC_CAST(signed char, a));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
+		r_.i8[i] = a;
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_set1_epi8(a) simde_mm_set1_epi8(a)
+#define _mm_set1_epi8(a) simde_mm_set1_epi8(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_set1_epi16 (int16_t a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_set1_epi16(a);
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_set1_epi16(int16_t a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_set1_epi16(a);
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i16 = vdupq_n_s16(a);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i16x8_splat(a);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i16 = vec_splats(HEDLEY_STATIC_CAST(signed short, a));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = a;
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i16 = vdupq_n_s16(a);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i16x8_splat(a);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i16 = vec_splats(HEDLEY_STATIC_CAST(signed short, a));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = a;
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_set1_epi16(a) simde_mm_set1_epi16(a)
+#define _mm_set1_epi16(a) simde_mm_set1_epi16(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_set1_epi32 (int32_t a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_set1_epi32(a);
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_set1_epi32(int32_t a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_set1_epi32(a);
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vdupq_n_s32(a);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i32x4_splat(a);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, a));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        r_.i32[i] = a;
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vdupq_n_s32(a);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i32x4_splat(a);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, a));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		r_.i32[i] = a;
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_set1_epi32(a) simde_mm_set1_epi32(a)
+#define _mm_set1_epi32(a) simde_mm_set1_epi32(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_set1_epi64x (int64_t a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,0,0))
-    return _mm_set1_epi64x(a);
-  #else
-    simde__m128i_private r_;
+simde__m128i simde_mm_set1_epi64x(int64_t a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && \
+	(!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19, 0, 0))
+	return _mm_set1_epi64x(a);
+#else
+	simde__m128i_private r_;
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vdupq_n_s64(a);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i64x2_splat(a);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_i64 = vec_splats(HEDLEY_STATIC_CAST(signed long long, a));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-        r_.i64[i] = a;
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = vdupq_n_s64(a);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i64x2_splat(a);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_i64 = vec_splats(HEDLEY_STATIC_CAST(signed long long, a));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
+		r_.i64[i] = a;
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_set1_epi64x(a) simde_mm_set1_epi64x(a)
+#define _mm_set1_epi64x(a) simde_mm_set1_epi64x(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_set1_epi64 (simde__m64 a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-    return _mm_set1_epi64(a);
-  #else
-    simde__m64_private a_ = simde__m64_to_private(a);
-    return simde_mm_set1_epi64x(a_.i64[0]);
-  #endif
+simde__m128i simde_mm_set1_epi64(simde__m64 a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+	return _mm_set1_epi64(a);
+#else
+	simde__m64_private a_ = simde__m64_to_private(a);
+	return simde_mm_set1_epi64x(a_.i64[0]);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_set1_epi64(a) simde_mm_set1_epi64(a)
+#define _mm_set1_epi64(a) simde_mm_set1_epi64(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_set1_epu8 (uint8_t value) {
-  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-    return simde__m128i_from_altivec_u8(vec_splats(HEDLEY_STATIC_CAST(unsigned char, value)));
-  #else
-    return simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, value));
-  #endif
+simde__m128i simde_x_mm_set1_epu8(uint8_t value)
+{
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	return simde__m128i_from_altivec_u8(
+		vec_splats(HEDLEY_STATIC_CAST(unsigned char, value)));
+#else
+	return simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, value));
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_set1_epu16 (uint16_t value) {
-  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-    return simde__m128i_from_altivec_u16(vec_splats(HEDLEY_STATIC_CAST(unsigned short, value)));
-  #else
-    return simde_mm_set1_epi16(HEDLEY_STATIC_CAST(int16_t, value));
-  #endif
+simde__m128i simde_x_mm_set1_epu16(uint16_t value)
+{
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	return simde__m128i_from_altivec_u16(
+		vec_splats(HEDLEY_STATIC_CAST(unsigned short, value)));
+#else
+	return simde_mm_set1_epi16(HEDLEY_STATIC_CAST(int16_t, value));
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_set1_epu32 (uint32_t value) {
-  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-    return simde__m128i_from_altivec_u32(vec_splats(HEDLEY_STATIC_CAST(unsigned int, value)));
-  #else
-    return simde_mm_set1_epi32(HEDLEY_STATIC_CAST(int32_t, value));
-  #endif
+simde__m128i simde_x_mm_set1_epu32(uint32_t value)
+{
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	return simde__m128i_from_altivec_u32(
+		vec_splats(HEDLEY_STATIC_CAST(unsigned int, value)));
+#else
+	return simde_mm_set1_epi32(HEDLEY_STATIC_CAST(int32_t, value));
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_set1_epu64 (uint64_t value) {
-  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-    return simde__m128i_from_altivec_u64(vec_splats(HEDLEY_STATIC_CAST(unsigned long long, value)));
-  #else
-    return simde_mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, value));
-  #endif
+simde__m128i simde_x_mm_set1_epu64(uint64_t value)
+{
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+	return simde__m128i_from_altivec_u64(
+		vec_splats(HEDLEY_STATIC_CAST(unsigned long long, value)));
+#else
+	return simde_mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, value));
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_setr_epi8 (int8_t e15, int8_t e14, int8_t e13, int8_t e12,
-        int8_t e11, int8_t e10, int8_t  e9, int8_t  e8,
-        int8_t  e7, int8_t  e6, int8_t  e5, int8_t  e4,
-        int8_t  e3, int8_t  e2, int8_t  e1, int8_t  e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_setr_epi8(
-      e15, e14, e13, e12, e11, e10,  e9,    e8,
-      e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
-  #else
-    return simde_mm_set_epi8(
-      e0, e1, e2, e3, e4, e5, e6, e7,
-      e8, e9, e10, e11, e12, e13, e14, e15);
-  #endif
+simde__m128i simde_mm_setr_epi8(int8_t e15, int8_t e14, int8_t e13, int8_t e12,
+				int8_t e11, int8_t e10, int8_t e9, int8_t e8,
+				int8_t e7, int8_t e6, int8_t e5, int8_t e4,
+				int8_t e3, int8_t e2, int8_t e1, int8_t e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_setr_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5,
+			     e4, e3, e2, e1, e0);
+#else
+	return simde_mm_set_epi8(e0, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10,
+				 e11, e12, e13, e14, e15);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_setr_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0) simde_mm_setr_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0)
+#define _mm_setr_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4,  \
+		      e3, e2, e1, e0)                                        \
+	simde_mm_setr_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, \
+			   e4, e3, e2, e1, e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_setr_epi16 (int16_t e7, int16_t e6, int16_t e5, int16_t e4,
-         int16_t e3, int16_t e2, int16_t e1, int16_t e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_setr_epi16(e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
-  #else
-    return simde_mm_set_epi16(e0, e1, e2, e3, e4, e5, e6, e7);
-  #endif
+simde__m128i simde_mm_setr_epi16(int16_t e7, int16_t e6, int16_t e5, int16_t e4,
+				 int16_t e3, int16_t e2, int16_t e1, int16_t e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_setr_epi16(e7, e6, e5, e4, e3, e2, e1, e0);
+#else
+	return simde_mm_set_epi16(e0, e1, e2, e3, e4, e5, e6, e7);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_setr_epi16(e7, e6, e5, e4, e3, e2, e1, e0) simde_mm_setr_epi16(e7, e6, e5, e4, e3, e2, e1, e0)
+#define _mm_setr_epi16(e7, e6, e5, e4, e3, e2, e1, e0) \
+	simde_mm_setr_epi16(e7, e6, e5, e4, e3, e2, e1, e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_setr_epi32 (int32_t e3, int32_t e2, int32_t e1, int32_t e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_setr_epi32(e3, e2, e1, e0);
-  #else
-    return simde_mm_set_epi32(e0, e1, e2, e3);
-  #endif
+simde__m128i simde_mm_setr_epi32(int32_t e3, int32_t e2, int32_t e1, int32_t e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_setr_epi32(e3, e2, e1, e0);
+#else
+	return simde_mm_set_epi32(e0, e1, e2, e3);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_setr_epi32(e3, e2, e1, e0) simde_mm_setr_epi32(e3, e2, e1, e0)
+#define _mm_setr_epi32(e3, e2, e1, e0) simde_mm_setr_epi32(e3, e2, e1, e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_setr_epi64 (simde__m64 e1, simde__m64 e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-    return _mm_setr_epi64(e1, e0);
-  #else
-    return simde_mm_set_epi64(e0, e1);
-  #endif
+simde__m128i simde_mm_setr_epi64(simde__m64 e1, simde__m64 e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+	return _mm_setr_epi64(e1, e0);
+#else
+	return simde_mm_set_epi64(e0, e1);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_setr_epi64(e1, e0) (simde_mm_setr_epi64((e1), (e0)))
+#define _mm_setr_epi64(e1, e0) (simde_mm_setr_epi64((e1), (e0)))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_setr_pd (simde_float64 e1, simde_float64 e0) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_setr_pd(e1, e0);
-  #else
-    return simde_mm_set_pd(e0, e1);
-  #endif
+simde__m128d simde_mm_setr_pd(simde_float64 e1, simde_float64 e0)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_setr_pd(e1, e0);
+#else
+	return simde_mm_set_pd(e0, e1);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_setr_pd(e1, e0) simde_mm_setr_pd(e1, e0)
+#define _mm_setr_pd(e1, e0) simde_mm_setr_pd(e1, e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_setzero_pd (void) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_setzero_pd();
-  #else
-    return simde_mm_castsi128_pd(simde_mm_setzero_si128());
-  #endif
+simde__m128d simde_mm_setzero_pd(void)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_setzero_pd();
+#else
+	return simde_mm_castsi128_pd(simde_mm_setzero_si128());
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_setzero_pd() simde_mm_setzero_pd()
+#define _mm_setzero_pd() simde_mm_setzero_pd()
 #endif
 
 #if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
@@ -5204,37 +5478,37 @@ SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_undefined_pd (void) {
-  simde__m128d_private r_;
+simde__m128d simde_mm_undefined_pd(void)
+{
+	simde__m128d_private r_;
 
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE__HAVE_UNDEFINED128)
-    r_.n = _mm_undefined_pd();
-  #elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
-    r_ = simde__m128d_to_private(simde_mm_setzero_pd());
-  #endif
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE__HAVE_UNDEFINED128)
+	r_.n = _mm_undefined_pd();
+#elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+	r_ = simde__m128d_to_private(simde_mm_setzero_pd());
+#endif
 
-  return simde__m128d_from_private(r_);
+	return simde__m128d_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_undefined_pd() simde_mm_undefined_pd()
+#define _mm_undefined_pd() simde_mm_undefined_pd()
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_undefined_si128 (void) {
-  simde__m128i_private r_;
+simde__m128i simde_mm_undefined_si128(void)
+{
+	simde__m128i_private r_;
 
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE__HAVE_UNDEFINED128)
-    r_.n = _mm_undefined_si128();
-  #elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
-    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
-  #endif
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE__HAVE_UNDEFINED128)
+	r_.n = _mm_undefined_si128();
+#elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+	r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+#endif
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_undefined_si128() (simde_mm_undefined_si128())
+#define _mm_undefined_si128() (simde_mm_undefined_si128())
 #endif
 
 #if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
@@ -5242,2176 +5516,2251 @@ HEDLEY_DIAGNOSTIC_POP
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_x_mm_setone_pd (void) {
-  return simde_mm_castps_pd(simde_x_mm_setone_ps());
+simde__m128d simde_x_mm_setone_pd(void)
+{
+	return simde_mm_castps_pd(simde_x_mm_setone_ps());
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_setone_si128 (void) {
-  return simde_mm_castps_si128(simde_x_mm_setone_ps());
+simde__m128i simde_x_mm_setone_si128(void)
+{
+	return simde_mm_castps_si128(simde_x_mm_setone_ps());
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_shuffle_epi32 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a);
+simde__m128i simde_mm_shuffle_epi32(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+{
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
 
-  for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-    r_.i32[i] = a_.i32[(imm8 >> (i * 2)) & 3];
-  }
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		r_.i32[i] = a_.i32[(imm8 >> (i * 2)) & 3];
+	}
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-  #define simde_mm_shuffle_epi32(a, imm8) _mm_shuffle_epi32((a), (imm8))
+#define simde_mm_shuffle_epi32(a, imm8) _mm_shuffle_epi32((a), (imm8))
 #elif defined(SIMDE_SHUFFLE_VECTOR_)
-  #define simde_mm_shuffle_epi32(a, imm8) (__extension__ ({ \
-      const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
-      simde__m128i_from_private((simde__m128i_private) { .i32 = \
-        SIMDE_SHUFFLE_VECTOR_(32, 16, \
-          (simde__tmp_a_).i32, \
-          (simde__tmp_a_).i32, \
-          ((imm8)     ) & 3, \
-          ((imm8) >> 2) & 3, \
-          ((imm8) >> 4) & 3, \
-          ((imm8) >> 6) & 3) }); }))
+#define simde_mm_shuffle_epi32(a, imm8)                               \
+	(__extension__({                                              \
+		const simde__m128i_private simde__tmp_a_ =            \
+			simde__m128i_to_private(a);                   \
+		simde__m128i_from_private((simde__m128i_private){     \
+			.i32 = SIMDE_SHUFFLE_VECTOR_(                 \
+				32, 16, (simde__tmp_a_).i32,          \
+				(simde__tmp_a_).i32, ((imm8)) & 3,    \
+				((imm8) >> 2) & 3, ((imm8) >> 4) & 3, \
+				((imm8) >> 6) & 3)});                 \
+	}))
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_STATEMENT_EXPR_)
-  #define simde_mm_shuffle_epi32(a, imm8) \
-    (__extension__ ({ \
-      const int32x4_t simde_mm_shuffle_epi32_a_ = simde__m128i_to_neon_i32(a); \
-      int32x4_t simde_mm_shuffle_epi32_r_; \
-      simde_mm_shuffle_epi32_r_ = vmovq_n_s32(vgetq_lane_s32(simde_mm_shuffle_epi32_a_, (imm8) & (0x3))); \
-      simde_mm_shuffle_epi32_r_ = vsetq_lane_s32(vgetq_lane_s32(simde_mm_shuffle_epi32_a_, ((imm8) >> 2) & 0x3), simde_mm_shuffle_epi32_r_, 1); \
-      simde_mm_shuffle_epi32_r_ = vsetq_lane_s32(vgetq_lane_s32(simde_mm_shuffle_epi32_a_, ((imm8) >> 4) & 0x3), simde_mm_shuffle_epi32_r_, 2); \
-      simde_mm_shuffle_epi32_r_ = vsetq_lane_s32(vgetq_lane_s32(simde_mm_shuffle_epi32_a_, ((imm8) >> 6) & 0x3), simde_mm_shuffle_epi32_r_, 3); \
-      vreinterpretq_s64_s32(simde_mm_shuffle_epi32_r_); \
-    }))
+#define simde_mm_shuffle_epi32(a, imm8)                                 \
+	(__extension__({                                                \
+		const int32x4_t simde_mm_shuffle_epi32_a_ =             \
+			simde__m128i_to_neon_i32(a);                    \
+		int32x4_t simde_mm_shuffle_epi32_r_;                    \
+		simde_mm_shuffle_epi32_r_ = vmovq_n_s32(vgetq_lane_s32( \
+			simde_mm_shuffle_epi32_a_, (imm8) & (0x3)));    \
+		simde_mm_shuffle_epi32_r_ = vsetq_lane_s32(             \
+			vgetq_lane_s32(simde_mm_shuffle_epi32_a_,       \
+				       ((imm8) >> 2) & 0x3),            \
+			simde_mm_shuffle_epi32_r_, 1);                  \
+		simde_mm_shuffle_epi32_r_ = vsetq_lane_s32(             \
+			vgetq_lane_s32(simde_mm_shuffle_epi32_a_,       \
+				       ((imm8) >> 4) & 0x3),            \
+			simde_mm_shuffle_epi32_r_, 2);                  \
+		simde_mm_shuffle_epi32_r_ = vsetq_lane_s32(             \
+			vgetq_lane_s32(simde_mm_shuffle_epi32_a_,       \
+				       ((imm8) >> 6) & 0x3),            \
+			simde_mm_shuffle_epi32_r_, 3);                  \
+		vreinterpretq_s64_s32(simde_mm_shuffle_epi32_r_);       \
+	}))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_shuffle_epi32(a, imm8) simde_mm_shuffle_epi32(a, imm8)
+#define _mm_shuffle_epi32(a, imm8) simde_mm_shuffle_epi32(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_shuffle_pd (simde__m128d a, simde__m128d b, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 3)  {
-  simde__m128d_private
-    r_,
-    a_ = simde__m128d_to_private(a),
-    b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_shuffle_pd(simde__m128d a, simde__m128d b, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 3)
+{
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-  r_.f64[0] = ((imm8 & 1) == 0) ? a_.f64[0] : a_.f64[1];
-  r_.f64[1] = ((imm8 & 2) == 0) ? b_.f64[0] : b_.f64[1];
+	r_.f64[0] = ((imm8 & 1) == 0) ? a_.f64[0] : a_.f64[1];
+	r_.f64[1] = ((imm8 & 2) == 0) ? b_.f64[0] : b_.f64[1];
 
-  return simde__m128d_from_private(r_);
+	return simde__m128d_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-  #define simde_mm_shuffle_pd(a, b, imm8) _mm_shuffle_pd((a), (b), (imm8))
+#define simde_mm_shuffle_pd(a, b, imm8) _mm_shuffle_pd((a), (b), (imm8))
 #elif defined(SIMDE_SHUFFLE_VECTOR_)
-  #define simde_mm_shuffle_pd(a, b, imm8) (__extension__ ({ \
-      simde__m128d_from_private((simde__m128d_private) { .f64 = \
-        SIMDE_SHUFFLE_VECTOR_(64, 16, \
-          simde__m128d_to_private(a).f64, \
-          simde__m128d_to_private(b).f64, \
-          (((imm8)     ) & 1), \
-          (((imm8) >> 1) & 1) + 2) }); }))
+#define simde_mm_shuffle_pd(a, b, imm8)                                     \
+	(__extension__({                                                    \
+		simde__m128d_from_private((simde__m128d_private){           \
+			.f64 = SIMDE_SHUFFLE_VECTOR_(                       \
+				64, 16, simde__m128d_to_private(a).f64,     \
+				simde__m128d_to_private(b).f64,             \
+				(((imm8)) & 1), (((imm8) >> 1) & 1) + 2)}); \
+	}))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_shuffle_pd(a, b, imm8) simde_mm_shuffle_pd(a, b, imm8)
+#define _mm_shuffle_pd(a, b, imm8) simde_mm_shuffle_pd(a, b, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_shufflehi_epi16 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a);
+simde__m128i simde_mm_shufflehi_epi16(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+{
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
 
-  SIMDE_VECTORIZE
-  for (size_t i = 0 ; i < ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2) ; i++) {
-    r_.i16[i] = a_.i16[i];
-  }
-  for (size_t i = ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2) ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-    r_.i16[i] = a_.i16[((imm8 >> ((i - 4) * 2)) & 3) + 4];
-  }
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2);
+	     i++) {
+		r_.i16[i] = a_.i16[i];
+	}
+	for (size_t i = ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2);
+	     i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = a_.i16[((imm8 >> ((i - 4) * 2)) & 3) + 4];
+	}
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-  #define simde_mm_shufflehi_epi16(a, imm8) _mm_shufflehi_epi16((a), (imm8))
+#define simde_mm_shufflehi_epi16(a, imm8) _mm_shufflehi_epi16((a), (imm8))
 #elif defined(SIMDE_SHUFFLE_VECTOR_)
-  #define simde_mm_shufflehi_epi16(a, imm8) (__extension__ ({ \
-      const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
-      simde__m128i_from_private((simde__m128i_private) { .i16 = \
-        SIMDE_SHUFFLE_VECTOR_(16, 16, \
-          (simde__tmp_a_).i16, \
-          (simde__tmp_a_).i16, \
-          0, 1, 2, 3, \
-          (((imm8)     ) & 3) + 4, \
-          (((imm8) >> 2) & 3) + 4, \
-          (((imm8) >> 4) & 3) + 4, \
-          (((imm8) >> 6) & 3) + 4) }); }))
+#define simde_mm_shufflehi_epi16(a, imm8)                                    \
+	(__extension__({                                                     \
+		const simde__m128i_private simde__tmp_a_ =                   \
+			simde__m128i_to_private(a);                          \
+		simde__m128i_from_private((simde__m128i_private){            \
+			.i16 = SIMDE_SHUFFLE_VECTOR_(                        \
+				16, 16, (simde__tmp_a_).i16,                 \
+				(simde__tmp_a_).i16, 0, 1, 2, 3,             \
+				(((imm8)) & 3) + 4, (((imm8) >> 2) & 3) + 4, \
+				(((imm8) >> 4) & 3) + 4,                     \
+				(((imm8) >> 6) & 3) + 4)});                  \
+	}))
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_STATEMENT_EXPR_)
-  #define simde_mm_shufflehi_epi16(a, imm8) \
-    (__extension__ ({ \
-      int16x8_t simde_mm_shufflehi_epi16_a_ = simde__m128i_to_neon_i16(a); \
-      int16x8_t simde_mm_shufflehi_epi16_r_ = simde_mm_shufflehi_epi16_a_; \
-      simde_mm_shufflehi_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflehi_epi16_a_, (((imm8)     ) & 0x3) + 4), simde_mm_shufflehi_epi16_r_, 4); \
-      simde_mm_shufflehi_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflehi_epi16_a_, (((imm8) >> 2) & 0x3) + 4), simde_mm_shufflehi_epi16_r_, 5); \
-      simde_mm_shufflehi_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflehi_epi16_a_, (((imm8) >> 4) & 0x3) + 4), simde_mm_shufflehi_epi16_r_, 6); \
-      simde_mm_shufflehi_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflehi_epi16_a_, (((imm8) >> 6) & 0x3) + 4), simde_mm_shufflehi_epi16_r_, 7); \
-      simde__m128i_from_neon_i16(simde_mm_shufflehi_epi16_r_); \
-    }))
+#define simde_mm_shufflehi_epi16(a, imm8)                                \
+	(__extension__({                                                 \
+		int16x8_t simde_mm_shufflehi_epi16_a_ =                  \
+			simde__m128i_to_neon_i16(a);                     \
+		int16x8_t simde_mm_shufflehi_epi16_r_ =                  \
+			simde_mm_shufflehi_epi16_a_;                     \
+		simde_mm_shufflehi_epi16_r_ = vsetq_lane_s16(            \
+			vgetq_lane_s16(simde_mm_shufflehi_epi16_a_,      \
+				       (((imm8)) & 0x3) + 4),            \
+			simde_mm_shufflehi_epi16_r_, 4);                 \
+		simde_mm_shufflehi_epi16_r_ = vsetq_lane_s16(            \
+			vgetq_lane_s16(simde_mm_shufflehi_epi16_a_,      \
+				       (((imm8) >> 2) & 0x3) + 4),       \
+			simde_mm_shufflehi_epi16_r_, 5);                 \
+		simde_mm_shufflehi_epi16_r_ = vsetq_lane_s16(            \
+			vgetq_lane_s16(simde_mm_shufflehi_epi16_a_,      \
+				       (((imm8) >> 4) & 0x3) + 4),       \
+			simde_mm_shufflehi_epi16_r_, 6);                 \
+		simde_mm_shufflehi_epi16_r_ = vsetq_lane_s16(            \
+			vgetq_lane_s16(simde_mm_shufflehi_epi16_a_,      \
+				       (((imm8) >> 6) & 0x3) + 4),       \
+			simde_mm_shufflehi_epi16_r_, 7);                 \
+		simde__m128i_from_neon_i16(simde_mm_shufflehi_epi16_r_); \
+	}))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_shufflehi_epi16(a, imm8) simde_mm_shufflehi_epi16(a, imm8)
+#define _mm_shufflehi_epi16(a, imm8) simde_mm_shufflehi_epi16(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_shufflelo_epi16 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a);
+simde__m128i simde_mm_shufflelo_epi16(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+{
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
 
-  for (size_t i = 0 ; i < ((sizeof(r_.i16) / sizeof(r_.i16[0])) / 2) ; i++) {
-    r_.i16[i] = a_.i16[((imm8 >> (i * 2)) & 3)];
-  }
-  SIMDE_VECTORIZE
-  for (size_t i = ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2) ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-    r_.i16[i] = a_.i16[i];
-  }
+	for (size_t i = 0; i < ((sizeof(r_.i16) / sizeof(r_.i16[0])) / 2);
+	     i++) {
+		r_.i16[i] = a_.i16[((imm8 >> (i * 2)) & 3)];
+	}
+	SIMDE_VECTORIZE
+	for (size_t i = ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2);
+	     i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = a_.i16[i];
+	}
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-  #define simde_mm_shufflelo_epi16(a, imm8) _mm_shufflelo_epi16((a), (imm8))
+#define simde_mm_shufflelo_epi16(a, imm8) _mm_shufflelo_epi16((a), (imm8))
 #elif defined(SIMDE_SHUFFLE_VECTOR_)
-  #define simde_mm_shufflelo_epi16(a, imm8) (__extension__ ({ \
-      const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
-      simde__m128i_from_private((simde__m128i_private) { .i16 = \
-        SIMDE_SHUFFLE_VECTOR_(16, 16, \
-          (simde__tmp_a_).i16, \
-          (simde__tmp_a_).i16, \
-          (((imm8)     ) & 3), \
-          (((imm8) >> 2) & 3), \
-          (((imm8) >> 4) & 3), \
-          (((imm8) >> 6) & 3), \
-          4, 5, 6, 7) }); }))
+#define simde_mm_shufflelo_epi16(a, imm8)                                 \
+	(__extension__({                                                  \
+		const simde__m128i_private simde__tmp_a_ =                \
+			simde__m128i_to_private(a);                       \
+		simde__m128i_from_private((simde__m128i_private){         \
+			.i16 = SIMDE_SHUFFLE_VECTOR_(                     \
+				16, 16, (simde__tmp_a_).i16,              \
+				(simde__tmp_a_).i16, (((imm8)) & 3),      \
+				(((imm8) >> 2) & 3), (((imm8) >> 4) & 3), \
+				(((imm8) >> 6) & 3), 4, 5, 6, 7)});       \
+	}))
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_STATEMENT_EXPR_)
-  #define simde_mm_shufflelo_epi16(a, imm8) \
-    (__extension__({ \
-      int16x8_t simde_mm_shufflelo_epi16_a_ = simde__m128i_to_neon_i16(a); \
-      int16x8_t simde_mm_shufflelo_epi16_r_ = simde_mm_shufflelo_epi16_a_; \
-      simde_mm_shufflelo_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflelo_epi16_a_, (((imm8)     ) & 0x3)), simde_mm_shufflelo_epi16_r_, 0); \
-      simde_mm_shufflelo_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflelo_epi16_a_, (((imm8) >> 2) & 0x3)), simde_mm_shufflelo_epi16_r_, 1); \
-      simde_mm_shufflelo_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflelo_epi16_a_, (((imm8) >> 4) & 0x3)), simde_mm_shufflelo_epi16_r_, 2); \
-      simde_mm_shufflelo_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflelo_epi16_a_, (((imm8) >> 6) & 0x3)), simde_mm_shufflelo_epi16_r_, 3); \
-      simde__m128i_from_neon_i16(simde_mm_shufflelo_epi16_r_); \
-    }))
+#define simde_mm_shufflelo_epi16(a, imm8)                                \
+	(__extension__({                                                 \
+		int16x8_t simde_mm_shufflelo_epi16_a_ =                  \
+			simde__m128i_to_neon_i16(a);                     \
+		int16x8_t simde_mm_shufflelo_epi16_r_ =                  \
+			simde_mm_shufflelo_epi16_a_;                     \
+		simde_mm_shufflelo_epi16_r_ = vsetq_lane_s16(            \
+			vgetq_lane_s16(simde_mm_shufflelo_epi16_a_,      \
+				       (((imm8)) & 0x3)),                \
+			simde_mm_shufflelo_epi16_r_, 0);                 \
+		simde_mm_shufflelo_epi16_r_ = vsetq_lane_s16(            \
+			vgetq_lane_s16(simde_mm_shufflelo_epi16_a_,      \
+				       (((imm8) >> 2) & 0x3)),           \
+			simde_mm_shufflelo_epi16_r_, 1);                 \
+		simde_mm_shufflelo_epi16_r_ = vsetq_lane_s16(            \
+			vgetq_lane_s16(simde_mm_shufflelo_epi16_a_,      \
+				       (((imm8) >> 4) & 0x3)),           \
+			simde_mm_shufflelo_epi16_r_, 2);                 \
+		simde_mm_shufflelo_epi16_r_ = vsetq_lane_s16(            \
+			vgetq_lane_s16(simde_mm_shufflelo_epi16_a_,      \
+				       (((imm8) >> 6) & 0x3)),           \
+			simde_mm_shufflelo_epi16_r_, 3);                 \
+		simde__m128i_from_neon_i16(simde_mm_shufflelo_epi16_r_); \
+	}))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_shufflelo_epi16(a, imm8) simde_mm_shufflelo_epi16(a, imm8)
+#define _mm_shufflelo_epi16(a, imm8) simde_mm_shufflelo_epi16(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_sll_epi16 (simde__m128i a, simde__m128i count) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_sll_epi16(a, count);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      count_ = simde__m128i_to_private(count);
-
-    if (count_.u64[0] > 15)
-      return simde_mm_setzero_si128();
-
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-      r_.u16 = (a_.u16 << count_.u64[0]);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u16 = vshlq_u16(a_.neon_u16, vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, count_.u64[0])));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = ((wasm_i64x2_extract_lane(count_.wasm_v128, 0) < 16) ? wasm_i16x8_shl(a_.wasm_v128, HEDLEY_STATIC_CAST(int32_t, wasm_i64x2_extract_lane(count_.wasm_v128, 0))) : wasm_i16x8_const(0,0,0,0,0,0,0,0));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
-        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, (a_.u16[i] << count_.u64[0]));
-      }
-    #endif
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sll_epi16(a, count) simde_mm_sll_epi16((a), (count))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_sll_epi32 (simde__m128i a, simde__m128i count) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_sll_epi32(a, count);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      count_ = simde__m128i_to_private(count);
-
-    if (count_.u64[0] > 31)
-      return simde_mm_setzero_si128();
-
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-      r_.u32 = (a_.u32 << count_.u64[0]);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u32 = vshlq_u32(a_.neon_u32, vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, count_.u64[0])));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = ((wasm_i64x2_extract_lane(count_.wasm_v128, 0) < 32) ? wasm_i32x4_shl(a_.wasm_v128, HEDLEY_STATIC_CAST(int32_t, wasm_i64x2_extract_lane(count_.wasm_v128, 0))) : wasm_i32x4_const(0,0,0,0));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
-        r_.u32[i] = HEDLEY_STATIC_CAST(uint32_t, (a_.u32[i] << count_.u64[0]));
-      }
-    #endif
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sll_epi32(a, count) (simde_mm_sll_epi32(a, (count)))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_sll_epi64 (simde__m128i a, simde__m128i count) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_sll_epi64(a, count);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      count_ = simde__m128i_to_private(count);
-
-    if (count_.u64[0] > 63)
-      return simde_mm_setzero_si128();
-
-    const int_fast16_t s = HEDLEY_STATIC_CAST(int_fast16_t, count_.u64[0]);
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u64 = vshlq_u64(a_.neon_u64, vdupq_n_s64(HEDLEY_STATIC_CAST(int64_t, s)));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = (s < 64) ? wasm_i64x2_shl(a_.wasm_v128, s) : wasm_i64x2_const(0,0);
-    #else
-      #if !defined(SIMDE_BUG_GCC_94488)
-        SIMDE_VECTORIZE
-      #endif
-      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
-        r_.u64[i] = a_.u64[i] << s;
-      }
-    #endif
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sll_epi64(a, count) (simde_mm_sll_epi64(a, (count)))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_sqrt_pd (simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_sqrt_pd(a);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a);
-
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vsqrtq_f64(a_.neon_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_sqrt(a_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
-      r_.altivec_f64 = vec_sqrt(a_.altivec_f64);
-    #elif defined(simde_math_sqrt)
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.f64[i] = simde_math_sqrt(a_.f64[i]);
-      }
-    #else
-      HEDLEY_UNREACHABLE();
-    #endif
-
-    return simde__m128d_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sqrt_pd(a) simde_mm_sqrt_pd(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_sqrt_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_sqrt_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_sqrt_pd(b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_sqrt_pd(simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
-
-    #if defined(simde_math_sqrt)
-      r_.f64[0] = simde_math_sqrt(b_.f64[0]);
-      r_.f64[1] = a_.f64[1];
-    #else
-      HEDLEY_UNREACHABLE();
-    #endif
-
-    return simde__m128d_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sqrt_sd(a, b) simde_mm_sqrt_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_srl_epi16 (simde__m128i a, simde__m128i count) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_srl_epi16(a, count);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      count_ = simde__m128i_to_private(count);
-
-    const int cnt = HEDLEY_STATIC_CAST(int, (count_.i64[0] > 16 ? 16 : count_.i64[0]));
-
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u16 = vshlq_u16(a_.neon_u16, vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
-        r_.u16[i] = a_.u16[i] >> cnt;
-      }
-    #endif
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_srl_epi16(a, count) (simde_mm_srl_epi16(a, (count)))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_srl_epi32 (simde__m128i a, simde__m128i count) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_srl_epi32(a, count);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      count_ = simde__m128i_to_private(count);
-
-    const int cnt = HEDLEY_STATIC_CAST(int, (count_.i64[0] > 32 ? 32 : count_.i64[0]));
-
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u32 = vshlq_u32(a_.neon_u32, vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, -cnt)));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u32x4_shr(a_.wasm_v128, cnt);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
-        r_.u32[i] = a_.u32[i] >> cnt;
-      }
-    #endif
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_srl_epi32(a, count) (simde_mm_srl_epi32(a, (count)))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_srl_epi64 (simde__m128i a, simde__m128i count) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_srl_epi64(a, count);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      count_ = simde__m128i_to_private(count);
-
-    const int cnt = HEDLEY_STATIC_CAST(int, (count_.i64[0] > 64 ? 64 : count_.i64[0]));
-
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u64 = vshlq_u64(a_.neon_u64, vdupq_n_s64(HEDLEY_STATIC_CAST(int64_t, -cnt)));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u64x2_shr(a_.wasm_v128, cnt);
-    #else
-      #if !defined(SIMDE_BUG_GCC_94488)
-        SIMDE_VECTORIZE
-      #endif
-      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
-        r_.u64[i] = a_.u64[i] >> cnt;
-      }
-    #endif
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_srl_epi64(a, count) (simde_mm_srl_epi64(a, (count)))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_srai_epi16 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
-  /* MSVC requires a range of (0, 255). */
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a);
-
-  const int cnt = (imm8 & ~15) ? 15 : imm8;
-
-  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    r_.neon_i16 = vshlq_s16(a_.neon_i16, vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
-  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    r_.wasm_v128 = wasm_i16x8_shr(a_.wasm_v128, cnt);
-  #else
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i16[0])) ; i++) {
-      r_.i16[i] = a_.i16[i] >> cnt;
-    }
-  #endif
-
-  return simde__m128i_from_private(r_);
-}
+simde__m128i simde_mm_sll_epi16(simde__m128i a, simde__m128i count)
+{
 #if defined(SIMDE_X86_SSE2_NATIVE)
-  #define simde_mm_srai_epi16(a, imm8) _mm_srai_epi16((a), (imm8))
-#endif
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_srai_epi16(a, imm8) simde_mm_srai_epi16(a, imm8)
-#endif
+	return _mm_sll_epi16(a, count);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 count_ = simde__m128i_to_private(count);
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_srai_epi32 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
-  /* MSVC requires a range of (0, 255). */
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a);
+	if (count_.u64[0] > 15)
+		return simde_mm_setzero_si128();
 
-  const int cnt = (imm8 & ~31) ? 31 : imm8;
-
-  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    r_.neon_i32 = vshlq_s32(a_.neon_i32, vdupq_n_s32(-cnt));
-  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-    r_.wasm_v128 = wasm_i32x4_shr(a_.wasm_v128, cnt);
-  #else
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i32[0])) ; i++) {
-      r_.i32[i] = a_.i32[i] >> cnt;
-    }
-  #endif
-
-  return simde__m128i_from_private(r_);
-}
-#if defined(SIMDE_X86_SSE2_NATIVE)
-  #define simde_mm_srai_epi32(a, imm8) _mm_srai_epi32((a), (imm8))
-#endif
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_srai_epi32(a, imm8) simde_mm_srai_epi32(a, imm8)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_sra_epi16 (simde__m128i a, simde__m128i count) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_sra_epi16(a, count);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      count_ = simde__m128i_to_private(count);
-
-    const int cnt = HEDLEY_STATIC_CAST(int, (count_.i64[0] > 15 ? 15 : count_.i64[0]));
-
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i16 = vshlq_s16(a_.neon_i16, vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i16x8_shr(a_.wasm_v128, cnt);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = a_.i16[i] >> cnt;
-      }
-    #endif
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sra_epi16(a, count) (simde_mm_sra_epi16(a, count))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_sra_epi32 (simde__m128i a, simde__m128i count) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(SIMDE_BUG_GCC_BAD_MM_SRA_EPI32)
-    return _mm_sra_epi32(a, count);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      count_ = simde__m128i_to_private(count);
-
-    const int cnt = count_.u64[0] > 31 ? 31 : HEDLEY_STATIC_CAST(int, count_.u64[0]);
-
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vshlq_s32(a_.neon_i32, vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, -cnt)));
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i32x4_shr(a_.wasm_v128, cnt);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        r_.i32[i] = a_.i32[i] >> cnt;
-      }
-    #endif
-
-    return simde__m128i_from_private(r_);
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sra_epi32(a, count) (simde_mm_sra_epi32(a, (count)))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_slli_epi16 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
-  if (HEDLEY_UNLIKELY((imm8 > 15))) {
-    return simde_mm_setzero_si128();
-  }
-
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a);
-
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-    r_.i16 = a_.i16 << SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8 & 0xff);
-  #else
-    const int s = (imm8 > HEDLEY_STATIC_CAST(int, sizeof(r_.i16[0]) * CHAR_BIT) - 1) ? 0 : imm8;
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-      r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, a_.i16[i] << s);
-    }
-  #endif
-
-  return simde__m128i_from_private(r_);
-}
-#if defined(SIMDE_X86_SSE2_NATIVE)
-  #define simde_mm_slli_epi16(a, imm8) _mm_slli_epi16(a, imm8)
+#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+	r_.u16 = (a_.u16 << count_.u64[0]);
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-  #define simde_mm_slli_epi16(a, imm8) \
-    (((imm8) <= 0) ? \
-      (a) : \
-      simde__m128i_from_neon_i16( \
-        ((imm8) > 15) ? \
-          vandq_s16(simde__m128i_to_neon_i16(a), vdupq_n_s16(0)) : \
-          vshlq_n_s16(simde__m128i_to_neon_i16(a), ((imm8) & 15))))
+	r_.neon_u16 = vshlq_u16(a_.neon_u16, vdupq_n_s16(HEDLEY_STATIC_CAST(
+						     int16_t, count_.u64[0])));
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-  #define simde_mm_slli_epi16(a, imm8) \
-    ((imm8 < 16) ? wasm_i16x8_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i16x8_const(0,0,0,0,0,0,0,0))
+	r_.wasm_v128 =
+		((wasm_i64x2_extract_lane(count_.wasm_v128, 0) < 16)
+			 ? wasm_i16x8_shl(a_.wasm_v128,
+					  HEDLEY_STATIC_CAST(
+						  int32_t,
+						  wasm_i64x2_extract_lane(
+							  count_.wasm_v128, 0)))
+			 : wasm_i16x8_const(0, 0, 0, 0, 0, 0, 0, 0));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u16) / sizeof(r_.u16[0])); i++) {
+		r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t,
+					       (a_.u16[i] << count_.u64[0]));
+	}
+#endif
+
+	return simde__m128i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_sll_epi16(a, count) simde_mm_sll_epi16((a), (count))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i simde_mm_sll_epi32(simde__m128i a, simde__m128i count)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_sll_epi32(a, count);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 count_ = simde__m128i_to_private(count);
+
+	if (count_.u64[0] > 31)
+		return simde_mm_setzero_si128();
+
+#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+	r_.u32 = (a_.u32 << count_.u64[0]);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u32 = vshlq_u32(a_.neon_u32, vdupq_n_s32(HEDLEY_STATIC_CAST(
+						     int32_t, count_.u64[0])));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 =
+		((wasm_i64x2_extract_lane(count_.wasm_v128, 0) < 32)
+			 ? wasm_i32x4_shl(a_.wasm_v128,
+					  HEDLEY_STATIC_CAST(
+						  int32_t,
+						  wasm_i64x2_extract_lane(
+							  count_.wasm_v128, 0)))
+			 : wasm_i32x4_const(0, 0, 0, 0));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u32) / sizeof(r_.u32[0])); i++) {
+		r_.u32[i] = HEDLEY_STATIC_CAST(uint32_t,
+					       (a_.u32[i] << count_.u64[0]));
+	}
+#endif
+
+	return simde__m128i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_sll_epi32(a, count) (simde_mm_sll_epi32(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i simde_mm_sll_epi64(simde__m128i a, simde__m128i count)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_sll_epi64(a, count);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 count_ = simde__m128i_to_private(count);
+
+	if (count_.u64[0] > 63)
+		return simde_mm_setzero_si128();
+
+	const int_fast16_t s = HEDLEY_STATIC_CAST(int_fast16_t, count_.u64[0]);
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u64 = vshlq_u64(a_.neon_u64,
+				vdupq_n_s64(HEDLEY_STATIC_CAST(int64_t, s)));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = (s < 64) ? wasm_i64x2_shl(a_.wasm_v128, s)
+				: wasm_i64x2_const(0, 0);
+#else
+#if !defined(SIMDE_BUG_GCC_94488)
+	SIMDE_VECTORIZE
+#endif
+	for (size_t i = 0; i < (sizeof(r_.u64) / sizeof(r_.u64[0])); i++) {
+		r_.u64[i] = a_.u64[i] << s;
+	}
+#endif
+
+	return simde__m128i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_sll_epi64(a, count) (simde_mm_sll_epi64(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d simde_mm_sqrt_pd(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_sqrt_pd(a);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
+
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vsqrtq_f64(a_.neon_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_sqrt(a_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || \
+	defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+	r_.altivec_f64 = vec_sqrt(a_.altivec_f64);
+#elif defined(simde_math_sqrt)
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = simde_math_sqrt(a_.f64[i]);
+	}
+#else
+	HEDLEY_UNREACHABLE();
+#endif
+
+	return simde__m128d_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_sqrt_pd(a) simde_mm_sqrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d simde_mm_sqrt_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_sqrt_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_sqrt_pd(b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(
+		a, simde_mm_sqrt_pd(simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
+
+#if defined(simde_math_sqrt)
+	r_.f64[0] = simde_math_sqrt(b_.f64[0]);
+	r_.f64[1] = a_.f64[1];
+#else
+	HEDLEY_UNREACHABLE();
+#endif
+
+	return simde__m128d_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_sqrt_sd(a, b) simde_mm_sqrt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i simde_mm_srl_epi16(simde__m128i a, simde__m128i count)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_srl_epi16(a, count);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 count_ = simde__m128i_to_private(count);
+
+	const int cnt = HEDLEY_STATIC_CAST(
+		int, (count_.i64[0] > 16 ? 16 : count_.i64[0]));
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u16 = vshlq_u16(a_.neon_u16,
+				vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u16) / sizeof(r_.u16[0])); i++) {
+		r_.u16[i] = a_.u16[i] >> cnt;
+	}
+#endif
+
+	return simde__m128i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_srl_epi16(a, count) (simde_mm_srl_epi16(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i simde_mm_srl_epi32(simde__m128i a, simde__m128i count)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_srl_epi32(a, count);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 count_ = simde__m128i_to_private(count);
+
+	const int cnt = HEDLEY_STATIC_CAST(
+		int, (count_.i64[0] > 32 ? 32 : count_.i64[0]));
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u32 = vshlq_u32(a_.neon_u32,
+				vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, -cnt)));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_u32x4_shr(a_.wasm_v128, cnt);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u32) / sizeof(r_.u32[0])); i++) {
+		r_.u32[i] = a_.u32[i] >> cnt;
+	}
+#endif
+
+	return simde__m128i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_srl_epi32(a, count) (simde_mm_srl_epi32(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i simde_mm_srl_epi64(simde__m128i a, simde__m128i count)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_srl_epi64(a, count);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 count_ = simde__m128i_to_private(count);
+
+	const int cnt = HEDLEY_STATIC_CAST(
+		int, (count_.i64[0] > 64 ? 64 : count_.i64[0]));
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u64 = vshlq_u64(a_.neon_u64,
+				vdupq_n_s64(HEDLEY_STATIC_CAST(int64_t, -cnt)));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_u64x2_shr(a_.wasm_v128, cnt);
+#else
+#if !defined(SIMDE_BUG_GCC_94488)
+	SIMDE_VECTORIZE
+#endif
+	for (size_t i = 0; i < (sizeof(r_.u64) / sizeof(r_.u64[0])); i++) {
+		r_.u64[i] = a_.u64[i] >> cnt;
+	}
+#endif
+
+	return simde__m128i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_srl_epi64(a, count) (simde_mm_srl_epi64(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i simde_mm_srai_epi16(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_RANGE(imm8, 0, 255)
+{
+	/* MSVC requires a range of (0, 255). */
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
+
+	const int cnt = (imm8 & ~15) ? 15 : imm8;
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i16 = vshlq_s16(a_.neon_i16,
+				vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i16x8_shr(a_.wasm_v128, cnt);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = a_.i16[i] >> cnt;
+	}
+#endif
+
+	return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+#define simde_mm_srai_epi16(a, imm8) _mm_srai_epi16((a), (imm8))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_srai_epi16(a, imm8) simde_mm_srai_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i simde_mm_srai_epi32(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_RANGE(imm8, 0, 255)
+{
+	/* MSVC requires a range of (0, 255). */
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
+
+	const int cnt = (imm8 & ~31) ? 31 : imm8;
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vshlq_s32(a_.neon_i32, vdupq_n_s32(-cnt));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i32x4_shr(a_.wasm_v128, cnt);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.i32[0])); i++) {
+		r_.i32[i] = a_.i32[i] >> cnt;
+	}
+#endif
+
+	return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+#define simde_mm_srai_epi32(a, imm8) _mm_srai_epi32((a), (imm8))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_srai_epi32(a, imm8) simde_mm_srai_epi32(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i simde_mm_sra_epi16(simde__m128i a, simde__m128i count)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_sra_epi16(a, count);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 count_ = simde__m128i_to_private(count);
+
+	const int cnt = HEDLEY_STATIC_CAST(
+		int, (count_.i64[0] > 15 ? 15 : count_.i64[0]));
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i16 = vshlq_s16(a_.neon_i16,
+				vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i16x8_shr(a_.wasm_v128, cnt);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = a_.i16[i] >> cnt;
+	}
+#endif
+
+	return simde__m128i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_sra_epi16(a, count) (simde_mm_sra_epi16(a, count))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i simde_mm_sra_epi32(simde__m128i a, simde__m128i count)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(SIMDE_BUG_GCC_BAD_MM_SRA_EPI32)
+	return _mm_sra_epi32(a, count);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 count_ = simde__m128i_to_private(count);
+
+	const int cnt = count_.u64[0] > 31
+				? 31
+				: HEDLEY_STATIC_CAST(int, count_.u64[0]);
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vshlq_s32(a_.neon_i32,
+				vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, -cnt)));
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i32x4_shr(a_.wasm_v128, cnt);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		r_.i32[i] = a_.i32[i] >> cnt;
+	}
+#endif
+
+	return simde__m128i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_sra_epi32(a, count) (simde_mm_sra_epi32(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i simde_mm_slli_epi16(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+{
+	if (HEDLEY_UNLIKELY((imm8 > 15))) {
+		return simde_mm_setzero_si128();
+	}
+
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
+
+#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+	r_.i16 = a_.i16 << SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8 & 0xff);
+#else
+	const int s =
+		(imm8 >
+		 HEDLEY_STATIC_CAST(int, sizeof(r_.i16[0]) * CHAR_BIT) - 1)
+			? 0
+			: imm8;
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, a_.i16[i] << s);
+	}
+#endif
+
+	return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+#define simde_mm_slli_epi16(a, imm8) _mm_slli_epi16(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#define simde_mm_slli_epi16(a, imm8)                                          \
+	(((imm8) <= 0)                                                        \
+		 ? (a)                                                        \
+		 : simde__m128i_from_neon_i16(                                \
+			   ((imm8) > 15)                                      \
+				   ? vandq_s16(simde__m128i_to_neon_i16(a),   \
+					       vdupq_n_s16(0))                \
+				   : vshlq_n_s16(simde__m128i_to_neon_i16(a), \
+						 ((imm8)&15))))
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+#define simde_mm_slli_epi16(a, imm8)                                          \
+	((imm8 < 16)                                                          \
+		 ? wasm_i16x8_shl(simde__m128i_to_private(a).wasm_v128, imm8) \
+		 : wasm_i16x8_const(0, 0, 0, 0, 0, 0, 0, 0))
 #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-  #define simde_mm_slli_epi16(a, imm8) \
-    ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_altivec_i16(vec_sl(simde__m128i_to_altivec_i16(a), vec_splat_u16(HEDLEY_STATIC_CAST(unsigned short, imm8)))))
+#define simde_mm_slli_epi16(a, imm8)                                     \
+	((imm8 & ~15) ? simde_mm_setzero_si128()                         \
+		      : simde__m128i_from_altivec_i16(                   \
+				vec_sl(simde__m128i_to_altivec_i16(a),   \
+				       vec_splat_u16(HEDLEY_STATIC_CAST( \
+					       unsigned short, imm8)))))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_slli_epi16(a, imm8) simde_mm_slli_epi16(a, imm8)
+#define _mm_slli_epi16(a, imm8) simde_mm_slli_epi16(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_slli_epi32 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
-  if (HEDLEY_UNLIKELY((imm8 > 31))) {
-    return simde_mm_setzero_si128();
-  }
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a);
+simde__m128i simde_mm_slli_epi32(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+{
+	if (HEDLEY_UNLIKELY((imm8 > 31))) {
+		return simde_mm_setzero_si128();
+	}
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-    r_.i32 = a_.i32 << imm8;
-  #else
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-      r_.i32[i] = a_.i32[i] << (imm8 & 0xff);
-    }
-  #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+	r_.i32 = a_.i32 << imm8;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		r_.i32[i] = a_.i32[i] << (imm8 & 0xff);
+	}
+#endif
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-  #define simde_mm_slli_epi32(a, imm8) _mm_slli_epi32(a, imm8)
+#define simde_mm_slli_epi32(a, imm8) _mm_slli_epi32(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-  #define simde_mm_slli_epi32(a, imm8) \
-    (((imm8) <= 0) ? \
-      (a) : \
-      simde__m128i_from_neon_i32( \
-        ((imm8) > 31) ? \
-          vandq_s32(simde__m128i_to_neon_i32(a), vdupq_n_s32(0)) : \
-          vshlq_n_s32(simde__m128i_to_neon_i32(a), ((imm8) & 31))))
+#define simde_mm_slli_epi32(a, imm8)                                          \
+	(((imm8) <= 0)                                                        \
+		 ? (a)                                                        \
+		 : simde__m128i_from_neon_i32(                                \
+			   ((imm8) > 31)                                      \
+				   ? vandq_s32(simde__m128i_to_neon_i32(a),   \
+					       vdupq_n_s32(0))                \
+				   : vshlq_n_s32(simde__m128i_to_neon_i32(a), \
+						 ((imm8)&31))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-  #define simde_mm_slli_epi32(a, imm8) \
-    ((imm8 < 32) ? wasm_i32x4_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i32x4_const(0,0,0,0))
+#define simde_mm_slli_epi32(a, imm8)                                          \
+	((imm8 < 32)                                                          \
+		 ? wasm_i32x4_shl(simde__m128i_to_private(a).wasm_v128, imm8) \
+		 : wasm_i32x4_const(0, 0, 0, 0))
 #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-  #define simde_mm_slli_epi32(a, imm8) \
-     (__extension__ ({ \
-       simde__m128i ret; \
-       if ((imm8) <= 0) { \
-         ret = a; \
-       } else if ((imm8) > 31) { \
-         ret = simde_mm_setzero_si128(); \
-       } else { \
-         ret = simde__m128i_from_altivec_i32( \
-           vec_sl(simde__m128i_to_altivec_i32(a), \
-             vec_splats(HEDLEY_STATIC_CAST(unsigned int, (imm8) & 31)))); \
-       } \
-       ret; \
-     }))
+#define simde_mm_slli_epi32(a, imm8)                                        \
+	(__extension__({                                                    \
+		simde__m128i ret;                                           \
+		if ((imm8) <= 0) {                                          \
+			ret = a;                                            \
+		} else if ((imm8) > 31) {                                   \
+			ret = simde_mm_setzero_si128();                     \
+		} else {                                                    \
+			ret = simde__m128i_from_altivec_i32(                \
+				vec_sl(simde__m128i_to_altivec_i32(a),      \
+				       vec_splats(HEDLEY_STATIC_CAST(       \
+					       unsigned int, (imm8)&31)))); \
+		}                                                           \
+		ret;                                                        \
+	}))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_slli_epi32(a, imm8) simde_mm_slli_epi32(a, imm8)
+#define _mm_slli_epi32(a, imm8) simde_mm_slli_epi32(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_slli_epi64 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
-  if (HEDLEY_UNLIKELY((imm8 > 63))) {
-    return simde_mm_setzero_si128();
-  }
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a);
+simde__m128i simde_mm_slli_epi64(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+{
+	if (HEDLEY_UNLIKELY((imm8 > 63))) {
+		return simde_mm_setzero_si128();
+	}
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-    r_.i64 = a_.i64 << imm8;
-  #else
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-      r_.i64[i] = a_.i64[i] << (imm8 & 0xff);
-    }
-  #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+	r_.i64 = a_.i64 << imm8;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
+		r_.i64[i] = a_.i64[i] << (imm8 & 0xff);
+	}
+#endif
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-  #define simde_mm_slli_epi64(a, imm8) _mm_slli_epi64(a, imm8)
+#define simde_mm_slli_epi64(a, imm8) _mm_slli_epi64(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-  #define simde_mm_slli_epi64(a, imm8) \
-    (((imm8) <= 0) ? \
-      (a) : \
-      simde__m128i_from_neon_i64( \
-        ((imm8) > 63) ? \
-          vandq_s64(simde__m128i_to_neon_i64(a), vdupq_n_s64(0)) : \
-          vshlq_n_s64(simde__m128i_to_neon_i64(a), ((imm8) & 63))))
+#define simde_mm_slli_epi64(a, imm8)                                          \
+	(((imm8) <= 0)                                                        \
+		 ? (a)                                                        \
+		 : simde__m128i_from_neon_i64(                                \
+			   ((imm8) > 63)                                      \
+				   ? vandq_s64(simde__m128i_to_neon_i64(a),   \
+					       vdupq_n_s64(0))                \
+				   : vshlq_n_s64(simde__m128i_to_neon_i64(a), \
+						 ((imm8)&63))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-  #define simde_mm_slli_epi64(a, imm8) \
-    ((imm8 < 64) ? wasm_i64x2_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i64x2_const(0,0))
+#define simde_mm_slli_epi64(a, imm8)                                          \
+	((imm8 < 64)                                                          \
+		 ? wasm_i64x2_shl(simde__m128i_to_private(a).wasm_v128, imm8) \
+		 : wasm_i64x2_const(0, 0))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_slli_epi64(a, imm8) simde_mm_slli_epi64(a, imm8)
+#define _mm_slli_epi64(a, imm8) simde_mm_slli_epi64(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_srli_epi16 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
-  if (HEDLEY_UNLIKELY((imm8 > 15))) {
-    return simde_mm_setzero_si128();
-  }
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a);
+simde__m128i simde_mm_srli_epi16(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+{
+	if (HEDLEY_UNLIKELY((imm8 > 15))) {
+		return simde_mm_setzero_si128();
+	}
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-    r_.u16 = a_.u16 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8);
-  #else
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-      r_.u16[i] = a_.u16[i] >> (imm8 & 0xff);
-    }
-  #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+	r_.u16 = a_.u16 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.u16[i] = a_.u16[i] >> (imm8 & 0xff);
+	}
+#endif
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-  #define simde_mm_srli_epi16(a, imm8) _mm_srli_epi16(a, imm8)
+#define simde_mm_srli_epi16(a, imm8) _mm_srli_epi16(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-  #define simde_mm_srli_epi16(a, imm8) \
-    (((imm8) <= 0) ? \
-      (a) : \
-      simde__m128i_from_neon_u16( \
-        ((imm8) > 15) ? \
-          vandq_u16(simde__m128i_to_neon_u16(a), vdupq_n_u16(0)) : \
-          vshrq_n_u16(simde__m128i_to_neon_u16(a), ((imm8) & 15) | (((imm8) & 15) == 0))))
+#define simde_mm_srli_epi16(a, imm8)                                          \
+	(((imm8) <= 0)                                                        \
+		 ? (a)                                                        \
+		 : simde__m128i_from_neon_u16(                                \
+			   ((imm8) > 15)                                      \
+				   ? vandq_u16(simde__m128i_to_neon_u16(a),   \
+					       vdupq_n_u16(0))                \
+				   : vshrq_n_u16(simde__m128i_to_neon_u16(a), \
+						 ((imm8)&15) |                \
+							 (((imm8)&15) == 0))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-  #define simde_mm_srli_epi16(a, imm8) \
-    ((imm8 < 16) ? wasm_u16x8_shr(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i16x8_const(0,0,0,0,0,0,0,0))
+#define simde_mm_srli_epi16(a, imm8)                                          \
+	((imm8 < 16)                                                          \
+		 ? wasm_u16x8_shr(simde__m128i_to_private(a).wasm_v128, imm8) \
+		 : wasm_i16x8_const(0, 0, 0, 0, 0, 0, 0, 0))
 #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-  #define simde_mm_srli_epi16(a, imm8) \
-    ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_altivec_i16(vec_sr(simde__m128i_to_altivec_i16(a), vec_splat_u16(HEDLEY_STATIC_CAST(unsigned short, imm8)))))
+#define simde_mm_srli_epi16(a, imm8)                                     \
+	((imm8 & ~15) ? simde_mm_setzero_si128()                         \
+		      : simde__m128i_from_altivec_i16(                   \
+				vec_sr(simde__m128i_to_altivec_i16(a),   \
+				       vec_splat_u16(HEDLEY_STATIC_CAST( \
+					       unsigned short, imm8)))))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_srli_epi16(a, imm8) simde_mm_srli_epi16(a, imm8)
+#define _mm_srli_epi16(a, imm8) simde_mm_srli_epi16(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_srli_epi32 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
-  if (HEDLEY_UNLIKELY((imm8 > 31))) {
-    return simde_mm_setzero_si128();
-  }
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a);
+simde__m128i simde_mm_srli_epi32(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+{
+	if (HEDLEY_UNLIKELY((imm8 > 31))) {
+		return simde_mm_setzero_si128();
+	}
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-    r_.u32 = a_.u32 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8 & 0xff);
-  #else
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-      r_.u32[i] = a_.u32[i] >> (imm8 & 0xff);
-    }
-  #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+	r_.u32 = a_.u32 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8 & 0xff);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		r_.u32[i] = a_.u32[i] >> (imm8 & 0xff);
+	}
+#endif
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-  #define simde_mm_srli_epi32(a, imm8) _mm_srli_epi32(a, imm8)
+#define simde_mm_srli_epi32(a, imm8) _mm_srli_epi32(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-  #define simde_mm_srli_epi32(a, imm8) \
-    (((imm8) <= 0) ? \
-      (a) : \
-      simde__m128i_from_neon_u32( \
-        ((imm8) > 31) ? \
-          vandq_u32(simde__m128i_to_neon_u32(a), vdupq_n_u32(0)) : \
-          vshrq_n_u32(simde__m128i_to_neon_u32(a), ((imm8) & 31) | (((imm8) & 31) == 0))))
+#define simde_mm_srli_epi32(a, imm8)                                          \
+	(((imm8) <= 0)                                                        \
+		 ? (a)                                                        \
+		 : simde__m128i_from_neon_u32(                                \
+			   ((imm8) > 31)                                      \
+				   ? vandq_u32(simde__m128i_to_neon_u32(a),   \
+					       vdupq_n_u32(0))                \
+				   : vshrq_n_u32(simde__m128i_to_neon_u32(a), \
+						 ((imm8)&31) |                \
+							 (((imm8)&31) == 0))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-  #define simde_mm_srli_epi32(a, imm8) \
-    ((imm8 < 32) ? wasm_u32x4_shr(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i32x4_const(0,0,0,0))
+#define simde_mm_srli_epi32(a, imm8)                                          \
+	((imm8 < 32)                                                          \
+		 ? wasm_u32x4_shr(simde__m128i_to_private(a).wasm_v128, imm8) \
+		 : wasm_i32x4_const(0, 0, 0, 0))
 #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-  #define simde_mm_srli_epi32(a, imm8) \
-    (__extension__ ({ \
-        simde__m128i ret; \
-        if ((imm8) <= 0) { \
-            ret = a; \
-        } else if ((imm8) > 31) { \
-            ret = simde_mm_setzero_si128(); \
-        } else { \
-            ret = simde__m128i_from_altivec_i32( \
-              vec_sr(simde__m128i_to_altivec_i32(a), \
-                vec_splats(HEDLEY_STATIC_CAST(unsigned int, (imm8) & 31)))); \
-        } \
-        ret; \
-    }))
+#define simde_mm_srli_epi32(a, imm8)                                        \
+	(__extension__({                                                    \
+		simde__m128i ret;                                           \
+		if ((imm8) <= 0) {                                          \
+			ret = a;                                            \
+		} else if ((imm8) > 31) {                                   \
+			ret = simde_mm_setzero_si128();                     \
+		} else {                                                    \
+			ret = simde__m128i_from_altivec_i32(                \
+				vec_sr(simde__m128i_to_altivec_i32(a),      \
+				       vec_splats(HEDLEY_STATIC_CAST(       \
+					       unsigned int, (imm8)&31)))); \
+		}                                                           \
+		ret;                                                        \
+	}))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_srli_epi32(a, imm8) simde_mm_srli_epi32(a, imm8)
+#define _mm_srli_epi32(a, imm8) simde_mm_srli_epi32(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_srli_epi64 (simde__m128i a, const int imm8)
-    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a);
+simde__m128i simde_mm_srli_epi64(simde__m128i a, const int imm8)
+	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
+{
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
 
-  if (HEDLEY_UNLIKELY((imm8 & 63) != imm8))
-    return simde_mm_setzero_si128();
+	if (HEDLEY_UNLIKELY((imm8 & 63) != imm8))
+		return simde_mm_setzero_si128();
 
-  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    r_.neon_u64 = vshlq_u64(a_.neon_u64, vdupq_n_s64(-imm8));
-  #else
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_94488)
-      r_.u64 = a_.u64 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-        r_.u64[i] = a_.u64[i] >> imm8;
-      }
-    #endif
-  #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u64 = vshlq_u64(a_.neon_u64, vdupq_n_s64(-imm8));
+#else
+#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_94488)
+	r_.u64 = a_.u64 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
+		r_.u64[i] = a_.u64[i] >> imm8;
+	}
+#endif
+#endif
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-  #define simde_mm_srli_epi64(a, imm8) _mm_srli_epi64(a, imm8)
+#define simde_mm_srli_epi64(a, imm8) _mm_srli_epi64(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-  #define simde_mm_srli_epi64(a, imm8) \
-    (((imm8) <= 0) ? \
-      (a) : \
-      simde__m128i_from_neon_u64( \
-        ((imm8) > 63) ? \
-          vandq_u64(simde__m128i_to_neon_u64(a), vdupq_n_u64(0)) : \
-          vshrq_n_u64(simde__m128i_to_neon_u64(a), ((imm8) & 63) | (((imm8) & 63) == 0))))
+#define simde_mm_srli_epi64(a, imm8)                                          \
+	(((imm8) <= 0)                                                        \
+		 ? (a)                                                        \
+		 : simde__m128i_from_neon_u64(                                \
+			   ((imm8) > 63)                                      \
+				   ? vandq_u64(simde__m128i_to_neon_u64(a),   \
+					       vdupq_n_u64(0))                \
+				   : vshrq_n_u64(simde__m128i_to_neon_u64(a), \
+						 ((imm8)&63) |                \
+							 (((imm8)&63) == 0))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-  #define simde_mm_srli_epi64(a, imm8) \
-    ((imm8 < 64) ? wasm_u64x2_shr(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i64x2_const(0,0))
+#define simde_mm_srli_epi64(a, imm8)                                          \
+	((imm8 < 64)                                                          \
+		 ? wasm_u64x2_shr(simde__m128i_to_private(a).wasm_v128, imm8) \
+		 : wasm_i64x2_const(0, 0))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_srli_epi64(a, imm8) simde_mm_srli_epi64(a, imm8)
+#define _mm_srli_epi64(a, imm8) simde_mm_srli_epi64(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_store_pd (simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_store_pd(mem_addr, a);
-  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    vst1q_f64(mem_addr, simde__m128d_to_private(a).neon_f64);
-  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    vst1q_s64(HEDLEY_REINTERPRET_CAST(int64_t*, mem_addr), simde__m128d_to_private(a).neon_i64);
-  #else
-    simde_memcpy(SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128d), &a, sizeof(a));
-  #endif
+void simde_mm_store_pd(simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)],
+		       simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_store_pd(mem_addr, a);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	vst1q_f64(mem_addr, simde__m128d_to_private(a).neon_f64);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	vst1q_s64(HEDLEY_REINTERPRET_CAST(int64_t *, mem_addr),
+		  simde__m128d_to_private(a).neon_i64);
+#else
+	simde_memcpy(SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128d), &a,
+		     sizeof(a));
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_store_pd(mem_addr, a) simde_mm_store_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#define _mm_store_pd(mem_addr, a) \
+	simde_mm_store_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_store1_pd (simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_store1_pd(mem_addr, a);
-  #else
-    simde__m128d_private a_ = simde__m128d_to_private(a);
+void simde_mm_store1_pd(simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)],
+			simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_store1_pd(mem_addr, a);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      vst1q_f64(mem_addr, vdupq_laneq_f64(a_.neon_f64, 0));
-    #else
-      mem_addr[0] = a_.f64[0];
-      mem_addr[1] = a_.f64[0];
-    #endif
-  #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	vst1q_f64(mem_addr, vdupq_laneq_f64(a_.neon_f64, 0));
+#else
+	mem_addr[0] = a_.f64[0];
+	mem_addr[1] = a_.f64[0];
+#endif
+#endif
 }
-#define simde_mm_store_pd1(mem_addr, a) simde_mm_store1_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#define simde_mm_store_pd1(mem_addr, a) \
+	simde_mm_store1_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_store1_pd(mem_addr, a) simde_mm_store1_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
-  #define _mm_store_pd1(mem_addr, a) simde_mm_store_pd1(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#define _mm_store1_pd(mem_addr, a) \
+	simde_mm_store1_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
+#define _mm_store_pd1(mem_addr, a) \
+	simde_mm_store_pd1(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_store_sd (simde_float64* mem_addr, simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_store_sd(mem_addr, a);
-  #else
-    simde__m128d_private a_ = simde__m128d_to_private(a);
+void simde_mm_store_sd(simde_float64 *mem_addr, simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_store_sd(mem_addr, a);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      const simde_float64 v = vgetq_lane_f64(a_.neon_f64, 0);
-      simde_memcpy(mem_addr, &v, sizeof(v));
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      const int64_t v = vgetq_lane_s64(a_.neon_i64, 0);
-      simde_memcpy(HEDLEY_REINTERPRET_CAST(int64_t*, mem_addr), &v, sizeof(v));
-    #else
-      simde_float64 v = a_.f64[0];
-      simde_memcpy(mem_addr, &v, sizeof(simde_float64));
-    #endif
-  #endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_store_sd(mem_addr, a) simde_mm_store_sd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	const simde_float64 v = vgetq_lane_f64(a_.neon_f64, 0);
+	simde_memcpy(mem_addr, &v, sizeof(v));
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	const int64_t v = vgetq_lane_s64(a_.neon_i64, 0);
+	simde_memcpy(HEDLEY_REINTERPRET_CAST(int64_t *, mem_addr), &v,
+		     sizeof(v));
+#else
+	simde_float64 v = a_.f64[0];
+	simde_memcpy(mem_addr, &v, sizeof(simde_float64));
 #endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_store_si128 (simde__m128i* mem_addr, simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_store_si128(HEDLEY_STATIC_CAST(__m128i*, mem_addr), a);
-  #else
-    simde__m128i_private a_ = simde__m128i_to_private(a);
-
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      vst1q_s32(HEDLEY_REINTERPRET_CAST(int32_t*, mem_addr), a_.neon_i32);
-    #else
-      simde_memcpy(SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128i), &a_, sizeof(a_));
-    #endif
-  #endif
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_store_si128(mem_addr, a) simde_mm_store_si128(mem_addr, a)
+#define _mm_store_sd(mem_addr, a) \
+	simde_mm_store_sd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-  simde_mm_storeh_pd (simde_float64* mem_addr, simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_storeh_pd(mem_addr, a);
-  #else
-    simde__m128d_private a_ = simde__m128d_to_private(a);
+void simde_mm_store_si128(simde__m128i *mem_addr, simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_store_si128(HEDLEY_STATIC_CAST(__m128i *, mem_addr), a);
+#else
+	simde__m128i_private a_ = simde__m128i_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      *mem_addr = vgetq_lane_f64(a_.neon_f64, 1);
-    #else
-      *mem_addr = a_.f64[1];
-    #endif
-  #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	vst1q_s32(HEDLEY_REINTERPRET_CAST(int32_t *, mem_addr), a_.neon_i32);
+#else
+	simde_memcpy(SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128i), &a_,
+		     sizeof(a_));
+#endif
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_storeh_pd(mem_addr, a) simde_mm_storeh_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#define _mm_store_si128(mem_addr, a) simde_mm_store_si128(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_storel_epi64 (simde__m128i* mem_addr, simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_storel_epi64(HEDLEY_STATIC_CAST(__m128i*, mem_addr), a);
-  #else
-    simde__m128i_private a_ = simde__m128i_to_private(a);
-    int64_t tmp;
+void simde_mm_storeh_pd(simde_float64 *mem_addr, simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_storeh_pd(mem_addr, a);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a);
 
-    /* memcpy to prevent aliasing, tmp because we can't take the
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	*mem_addr = vgetq_lane_f64(a_.neon_f64, 1);
+#else
+	*mem_addr = a_.f64[1];
+#endif
+#endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+#define _mm_storeh_pd(mem_addr, a) \
+	simde_mm_storeh_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void simde_mm_storel_epi64(simde__m128i *mem_addr, simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_storel_epi64(HEDLEY_STATIC_CAST(__m128i *, mem_addr), a);
+#else
+	simde__m128i_private a_ = simde__m128i_to_private(a);
+	int64_t tmp;
+
+	/* memcpy to prevent aliasing, tmp because we can't take the
      * address of a vector element. */
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      tmp = vgetq_lane_s64(a_.neon_i64, 0);
-    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-      #if defined(SIMDE_BUG_GCC_95227)
-        (void) a_;
-      #endif
-      tmp = vec_extract(a_.altivec_i64, 0);
-    #else
-      tmp = a_.i64[0];
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	tmp = vgetq_lane_s64(a_.neon_i64, 0);
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+#if defined(SIMDE_BUG_GCC_95227)
+	(void)a_;
+#endif
+	tmp = vec_extract(a_.altivec_i64, 0);
+#else
+	tmp = a_.i64[0];
+#endif
 
-    simde_memcpy(mem_addr, &tmp, sizeof(tmp));
-  #endif
+	simde_memcpy(mem_addr, &tmp, sizeof(tmp));
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_storel_epi64(mem_addr, a) simde_mm_storel_epi64(mem_addr, a)
+#define _mm_storel_epi64(mem_addr, a) simde_mm_storel_epi64(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_storel_pd (simde_float64* mem_addr, simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_storel_pd(mem_addr, a);
-  #else
-    simde__m128d_private a_ = simde__m128d_to_private(a);
+void simde_mm_storel_pd(simde_float64 *mem_addr, simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_storel_pd(mem_addr, a);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a);
 
-    simde_float64 tmp;
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      tmp = vgetq_lane_f64(a_.neon_f64, 0);
-    #else
-      tmp = a_.f64[0];
-    #endif
-    simde_memcpy(mem_addr, &tmp, sizeof(tmp));
-  #endif
+	simde_float64 tmp;
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	tmp = vgetq_lane_f64(a_.neon_f64, 0);
+#else
+	tmp = a_.f64[0];
+#endif
+	simde_memcpy(mem_addr, &tmp, sizeof(tmp));
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_storel_pd(mem_addr, a) simde_mm_storel_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#define _mm_storel_pd(mem_addr, a) \
+	simde_mm_storel_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_storer_pd (simde_float64 mem_addr[2], simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_storer_pd(mem_addr, a);
-  #else
-    simde__m128d_private a_ = simde__m128d_to_private(a);
+void simde_mm_storer_pd(simde_float64 mem_addr[2], simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_storer_pd(mem_addr, a);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      vst1q_s64(HEDLEY_REINTERPRET_CAST(int64_t*, mem_addr), vextq_s64(a_.neon_i64, a_.neon_i64, 1));
-    #elif defined(SIMDE_SHUFFLE_VECTOR_)
-      a_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, a_.f64, 1, 0);
-      simde_mm_store_pd(mem_addr, simde__m128d_from_private(a_));
-    #else
-      mem_addr[0] = a_.f64[1];
-      mem_addr[1] = a_.f64[0];
-    #endif
-  #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	vst1q_s64(HEDLEY_REINTERPRET_CAST(int64_t *, mem_addr),
+		  vextq_s64(a_.neon_i64, a_.neon_i64, 1));
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	a_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, a_.f64, 1, 0);
+	simde_mm_store_pd(mem_addr, simde__m128d_from_private(a_));
+#else
+	mem_addr[0] = a_.f64[1];
+	mem_addr[1] = a_.f64[0];
+#endif
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_storer_pd(mem_addr, a) simde_mm_storer_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#define _mm_storer_pd(mem_addr, a) \
+	simde_mm_storer_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_storeu_pd (simde_float64* mem_addr, simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_storeu_pd(mem_addr, a);
-  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-    vst1q_f64(mem_addr, simde__m128d_to_private(a).neon_f64);
-  #else
-    simde_memcpy(mem_addr, &a, sizeof(a));
-  #endif
+void simde_mm_storeu_pd(simde_float64 *mem_addr, simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_storeu_pd(mem_addr, a);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	vst1q_f64(mem_addr, simde__m128d_to_private(a).neon_f64);
+#else
+	simde_memcpy(mem_addr, &a, sizeof(a));
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_storeu_pd(mem_addr, a) simde_mm_storeu_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#define _mm_storeu_pd(mem_addr, a) \
+	simde_mm_storeu_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_storeu_si128 (void* mem_addr, simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_storeu_si128(HEDLEY_STATIC_CAST(__m128i*, mem_addr), a);
-  #else
-    simde_memcpy(mem_addr, &a, sizeof(a));
-  #endif
+void simde_mm_storeu_si128(void *mem_addr, simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_storeu_si128(HEDLEY_STATIC_CAST(__m128i *, mem_addr), a);
+#else
+	simde_memcpy(mem_addr, &a, sizeof(a));
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_storeu_si128(mem_addr, a) simde_mm_storeu_si128(mem_addr, a)
+#define _mm_storeu_si128(mem_addr, a) simde_mm_storeu_si128(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_storeu_si16 (void* mem_addr, simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && ( \
-      SIMDE_DETECT_CLANG_VERSION_CHECK(8,0,0) || \
-      HEDLEY_GCC_VERSION_CHECK(11,0,0) || \
-      HEDLEY_INTEL_VERSION_CHECK(20,21,1))
-    _mm_storeu_si16(mem_addr, a);
-  #else
-    int16_t val = simde_x_mm_cvtsi128_si16(a);
-    simde_memcpy(mem_addr, &val, sizeof(val));
-  #endif
+void simde_mm_storeu_si16(void *mem_addr, simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) &&                 \
+	(SIMDE_DETECT_CLANG_VERSION_CHECK(8, 0, 0) || \
+	 HEDLEY_GCC_VERSION_CHECK(11, 0, 0) ||        \
+	 HEDLEY_INTEL_VERSION_CHECK(20, 21, 1))
+	_mm_storeu_si16(mem_addr, a);
+#else
+	int16_t val = simde_x_mm_cvtsi128_si16(a);
+	simde_memcpy(mem_addr, &val, sizeof(val));
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_storeu_si16(mem_addr, a) simde_mm_storeu_si16(mem_addr, a)
+#define _mm_storeu_si16(mem_addr, a) simde_mm_storeu_si16(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_storeu_si32 (void* mem_addr, simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && ( \
-      SIMDE_DETECT_CLANG_VERSION_CHECK(8,0,0) || \
-      HEDLEY_GCC_VERSION_CHECK(11,0,0) || \
-      HEDLEY_INTEL_VERSION_CHECK(20,21,1))
-    _mm_storeu_si32(mem_addr, a);
-  #else
-    int32_t val = simde_mm_cvtsi128_si32(a);
-    simde_memcpy(mem_addr, &val, sizeof(val));
-  #endif
+void simde_mm_storeu_si32(void *mem_addr, simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) &&                 \
+	(SIMDE_DETECT_CLANG_VERSION_CHECK(8, 0, 0) || \
+	 HEDLEY_GCC_VERSION_CHECK(11, 0, 0) ||        \
+	 HEDLEY_INTEL_VERSION_CHECK(20, 21, 1))
+	_mm_storeu_si32(mem_addr, a);
+#else
+	int32_t val = simde_mm_cvtsi128_si32(a);
+	simde_memcpy(mem_addr, &val, sizeof(val));
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_storeu_si32(mem_addr, a) simde_mm_storeu_si32(mem_addr, a)
+#define _mm_storeu_si32(mem_addr, a) simde_mm_storeu_si32(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_storeu_si64 (void* mem_addr, simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && ( \
-      SIMDE_DETECT_CLANG_VERSION_CHECK(8,0,0) || \
-      HEDLEY_GCC_VERSION_CHECK(11,0,0) || \
-      HEDLEY_INTEL_VERSION_CHECK(20,21,1))
-    _mm_storeu_si64(mem_addr, a);
-  #else
-    int64_t val = simde_mm_cvtsi128_si64(a);
-    simde_memcpy(mem_addr, &val, sizeof(val));
-  #endif
+void simde_mm_storeu_si64(void *mem_addr, simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) &&                 \
+	(SIMDE_DETECT_CLANG_VERSION_CHECK(8, 0, 0) || \
+	 HEDLEY_GCC_VERSION_CHECK(11, 0, 0) ||        \
+	 HEDLEY_INTEL_VERSION_CHECK(20, 21, 1))
+	_mm_storeu_si64(mem_addr, a);
+#else
+	int64_t val = simde_mm_cvtsi128_si64(a);
+	simde_memcpy(mem_addr, &val, sizeof(val));
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_storeu_si64(mem_addr, a) simde_mm_storeu_si64(mem_addr, a)
+#define _mm_storeu_si64(mem_addr, a) simde_mm_storeu_si64(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_stream_pd (simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_stream_pd(mem_addr, a);
-  #else
-    simde_memcpy(mem_addr, &a, sizeof(a));
-  #endif
+void simde_mm_stream_pd(simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)],
+			simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_stream_pd(mem_addr, a);
+#else
+	simde_memcpy(mem_addr, &a, sizeof(a));
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_stream_pd(mem_addr, a) simde_mm_stream_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#define _mm_stream_pd(mem_addr, a) \
+	simde_mm_stream_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_stream_si128 (simde__m128i* mem_addr, simde__m128i a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
-    _mm_stream_si128(HEDLEY_STATIC_CAST(__m128i*, mem_addr), a);
-  #else
-    simde_memcpy(mem_addr, &a, sizeof(a));
-  #endif
+void simde_mm_stream_si128(simde__m128i *mem_addr, simde__m128i a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+	_mm_stream_si128(HEDLEY_STATIC_CAST(__m128i *, mem_addr), a);
+#else
+	simde_memcpy(mem_addr, &a, sizeof(a));
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_stream_si128(mem_addr, a) simde_mm_stream_si128(mem_addr, a)
+#define _mm_stream_si128(mem_addr, a) simde_mm_stream_si128(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_stream_si32 (int32_t* mem_addr, int32_t a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_stream_si32(mem_addr, a);
-  #else
-    *mem_addr = a;
-  #endif
+void simde_mm_stream_si32(int32_t *mem_addr, int32_t a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_stream_si32(mem_addr, a);
+#else
+	*mem_addr = a;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_stream_si32(mem_addr, a) simde_mm_stream_si32(mem_addr, a)
+#define _mm_stream_si32(mem_addr, a) simde_mm_stream_si32(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_stream_si64 (int64_t* mem_addr, int64_t a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64) && !defined(HEDLEY_MSVC_VERSION)
-    _mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(long long int*, int64_t*, mem_addr), a);
-  #else
-    *mem_addr = a;
-  #endif
+void simde_mm_stream_si64(int64_t *mem_addr, int64_t a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64) && \
+	!defined(HEDLEY_MSVC_VERSION)
+	_mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(long long int *,
+						       int64_t *, mem_addr),
+			a);
+#else
+	*mem_addr = a;
+#endif
 }
 #define simde_mm_stream_si64x(mem_addr, a) simde_mm_stream_si64(mem_addr, a)
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
-  #define _mm_stream_si64(mem_addr, a) simde_mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(int64_t*, __int64*, mem_addr), a)
-  #define _mm_stream_si64x(mem_addr, a) simde_mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(int64_t*, __int64*, mem_addr), a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || \
+	(defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
+#define _mm_stream_si64(mem_addr, a)                                  \
+	simde_mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(          \
+				     int64_t *, __int64 *, mem_addr), \
+			     a)
+#define _mm_stream_si64x(mem_addr, a)                                 \
+	simde_mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(          \
+				     int64_t *, __int64 *, mem_addr), \
+			     a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_sub_epi8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_sub_epi8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_sub_epi8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_sub_epi8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i8 = vsubq_s8(a_.neon_i8, b_.neon_i8);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i8 = a_.i8 - b_.i8;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
-        r_.i8[i] = a_.i8[i] - b_.i8[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i8 = vsubq_s8(a_.neon_i8, b_.neon_i8);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i8 = a_.i8 - b_.i8;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
+		r_.i8[i] = a_.i8[i] - b_.i8[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sub_epi8(a, b) simde_mm_sub_epi8(a, b)
+#define _mm_sub_epi8(a, b) simde_mm_sub_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_sub_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_sub_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_sub_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_sub_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i16 = vsubq_s16(a_.neon_i16, b_.neon_i16);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i16 = a_.i16 - b_.i16;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = a_.i16[i] - b_.i16[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i16 = vsubq_s16(a_.neon_i16, b_.neon_i16);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i16 = a_.i16 - b_.i16;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = a_.i16[i] - b_.i16[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sub_epi16(a, b) simde_mm_sub_epi16(a, b)
+#define _mm_sub_epi16(a, b) simde_mm_sub_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_sub_epi32 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_sub_epi32(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_sub_epi32(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_sub_epi32(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vsubq_s32(a_.neon_i32, b_.neon_i32);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32 = a_.i32 - b_.i32;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
-        r_.i32[i] = a_.i32[i] - b_.i32[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vsubq_s32(a_.neon_i32, b_.neon_i32);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32 = a_.i32 - b_.i32;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+		r_.i32[i] = a_.i32[i] - b_.i32[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sub_epi32(a, b) simde_mm_sub_epi32(a, b)
+#define _mm_sub_epi32(a, b) simde_mm_sub_epi32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_sub_epi64 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_sub_epi64(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_sub_epi64(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_sub_epi64(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vsubq_s64(a_.neon_i64, b_.neon_i64);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = a_.i64 - b_.i64;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
-        r_.i64[i] = a_.i64[i] - b_.i64[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = vsubq_s64(a_.neon_i64, b_.neon_i64);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i64 = a_.i64 - b_.i64;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
+		r_.i64[i] = a_.i64[i] - b_.i64[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sub_epi64(a, b) simde_mm_sub_epi64(a, b)
+#define _mm_sub_epi64(a, b) simde_mm_sub_epi64(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_sub_epu32 (simde__m128i a, simde__m128i b) {
-  simde__m128i_private
-    r_,
-    a_ = simde__m128i_to_private(a),
-    b_ = simde__m128i_to_private(b);
+simde__m128i simde_x_mm_sub_epu32(simde__m128i a, simde__m128i b)
+{
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-  #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-    r_.u32 = a_.u32 - b_.u32;
-  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-    r_.neon_u32 = vsubq_u32(a_.neon_u32, b_.neon_u32);
-  #else
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
-      r_.u32[i] = a_.u32[i] - b_.u32[i];
-    }
-  #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.u32 = a_.u32 - b_.u32;
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u32 = vsubq_u32(a_.neon_u32, b_.neon_u32);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.u32) / sizeof(r_.u32[0])); i++) {
+		r_.u32[i] = a_.u32[i] - b_.u32[i];
+	}
+#endif
 
-  return simde__m128i_from_private(r_);
+	return simde__m128i_from_private(r_);
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_sub_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_sub_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_sub_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_sub_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.f64 = a_.f64 - b_.f64;
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vsubq_f64(a_.neon_f64, b_.neon_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_sub(a_.wasm_v128, b_.wasm_v128);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.f64[i] = a_.f64[i] - b_.f64[i];
-      }
-    #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.f64 = a_.f64 - b_.f64;
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vsubq_f64(a_.neon_f64, b_.neon_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_sub(a_.wasm_v128, b_.wasm_v128);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = a_.f64[i] - b_.f64[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sub_pd(a, b) simde_mm_sub_pd(a, b)
+#define _mm_sub_pd(a, b) simde_mm_sub_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_sub_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_sub_sd(a, b);
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
-    return simde_mm_move_sd(a, simde_mm_sub_pd(a, b));
-  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-    return simde_mm_move_sd(a, simde_mm_sub_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_sub_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_sub_sd(a, b);
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+	return simde_mm_move_sd(a, simde_mm_sub_pd(a, b));
+#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+	return simde_mm_move_sd(a,
+				simde_mm_sub_pd(simde_x_mm_broadcastlow_pd(a),
+						simde_x_mm_broadcastlow_pd(b)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    r_.f64[0] = a_.f64[0] - b_.f64[0];
-    r_.f64[1] = a_.f64[1];
+	r_.f64[0] = a_.f64[0] - b_.f64[0];
+	r_.f64[1] = a_.f64[1];
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sub_sd(a, b) simde_mm_sub_sd(a, b)
+#define _mm_sub_sd(a, b) simde_mm_sub_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m64
-simde_mm_sub_si64 (simde__m64 a, simde__m64 b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-    return _mm_sub_si64(a, b);
-  #else
-    simde__m64_private
-      r_,
-      a_ = simde__m64_to_private(a),
-      b_ = simde__m64_to_private(b);
+simde__m64 simde_mm_sub_si64(simde__m64 a, simde__m64 b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+	return _mm_sub_si64(a, b);
+#else
+	simde__m64_private r_, a_ = simde__m64_to_private(a),
+			       b_ = simde__m64_to_private(b);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i64 = a_.i64 - b_.i64;
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i64 = vsub_s64(a_.neon_i64, b_.neon_i64);
-    #else
-      r_.i64[0] = a_.i64[0] - b_.i64[0];
-    #endif
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i64 = a_.i64 - b_.i64;
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i64 = vsub_s64(a_.neon_i64, b_.neon_i64);
+#else
+	r_.i64[0] = a_.i64[0] - b_.i64[0];
+#endif
 
-    return simde__m64_from_private(r_);
-  #endif
+	return simde__m64_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_sub_si64(a, b) simde_mm_sub_si64(a, b)
+#define _mm_sub_si64(a, b) simde_mm_sub_si64(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_subs_epi8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_subs_epi8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_subs_epi8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_subs_epi8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i8 = vqsubq_s8(a_.neon_i8, b_.neon_i8);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i8x16_sub_sat(a_.wasm_v128, b_.wasm_v128);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i8[0])) ; i++) {
-        r_.i8[i] = simde_math_subs_i8(a_.i8[i], b_.i8[i]);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i8 = vqsubq_s8(a_.neon_i8, b_.neon_i8);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i8x16_sub_sat(a_.wasm_v128, b_.wasm_v128);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.i8[0])); i++) {
+		r_.i8[i] = simde_math_subs_i8(a_.i8[i], b_.i8[i]);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_subs_epi8(a, b) simde_mm_subs_epi8(a, b)
+#define _mm_subs_epi8(a, b) simde_mm_subs_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_subs_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_subs_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_subs_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_subs_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i16 = vqsubq_s16(a_.neon_i16, b_.neon_i16);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i16x8_sub_sat(a_.wasm_v128, b_.wasm_v128);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i16[0])) ; i++) {
-        r_.i16[i] = simde_math_subs_i16(a_.i16[i], b_.i16[i]);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i16 = vqsubq_s16(a_.neon_i16, b_.neon_i16);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i16x8_sub_sat(a_.wasm_v128, b_.wasm_v128);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.i16[0])); i++) {
+		r_.i16[i] = simde_math_subs_i16(a_.i16[i], b_.i16[i]);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_subs_epi16(a, b) simde_mm_subs_epi16(a, b)
+#define _mm_subs_epi16(a, b) simde_mm_subs_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_subs_epu8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_subs_epu8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_subs_epu8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_subs_epu8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u8 = vqsubq_u8(a_.neon_u8, b_.neon_u8);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u8x16_sub_sat(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_u8 = vec_subs(a_.altivec_u8, b_.altivec_u8);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.u8[0])) ; i++) {
-        r_.u8[i] = simde_math_subs_u8(a_.u8[i], b_.u8[i]);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u8 = vqsubq_u8(a_.neon_u8, b_.neon_u8);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_u8x16_sub_sat(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_u8 = vec_subs(a_.altivec_u8, b_.altivec_u8);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.u8[0])); i++) {
+		r_.u8[i] = simde_math_subs_u8(a_.u8[i], b_.u8[i]);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_subs_epu8(a, b) simde_mm_subs_epu8(a, b)
+#define _mm_subs_epu8(a, b) simde_mm_subs_epu8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_subs_epu16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_subs_epu16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_subs_epu16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_subs_epu16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_u16 = vqsubq_u16(a_.neon_u16, b_.neon_u16);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_u16x8_sub_sat(a_.wasm_v128, b_.wasm_v128);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_u16 = vec_subs(a_.altivec_u16, b_.altivec_u16);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.u16[0])) ; i++) {
-        r_.u16[i] = simde_math_subs_u16(a_.u16[i], b_.u16[i]);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_u16 = vqsubq_u16(a_.neon_u16, b_.neon_u16);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_u16x8_sub_sat(a_.wasm_v128, b_.wasm_v128);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_u16 = vec_subs(a_.altivec_u16, b_.altivec_u16);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.u16[0])); i++) {
+		r_.u16[i] = simde_math_subs_u16(a_.u16[i], b_.u16[i]);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_subs_epu16(a, b) simde_mm_subs_epu16(a, b)
+#define _mm_subs_epu16(a, b) simde_mm_subs_epu16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int
-simde_mm_ucomieq_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_ucomieq_sd(a, b);
-  #else
-    simde__m128d_private
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
-    int r;
+int simde_mm_ucomieq_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_ucomieq_sd(a, b);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a),
+			     b_ = simde__m128d_to_private(b);
+	int r;
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
-      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
-      uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
-      uint64x2_t a_eq_b = vceqq_f64(a_.neon_f64, b_.neon_f64);
-      r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_eq_b), 0) != 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) == wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-    #elif defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r =  a_.f64[0] == b_.f64[0];
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r =  a_.f64[0] == b_.f64[0];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+	uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+	uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(
+		vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
+	uint64x2_t a_eq_b = vceqq_f64(a_.neon_f64, b_.neon_f64);
+	r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_eq_b), 0) != 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) ==
+	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+#elif defined(SIMDE_HAVE_FENV_H)
+	fenv_t envp;
+	int x = feholdexcept(&envp);
+	r = a_.f64[0] == b_.f64[0];
+	if (HEDLEY_LIKELY(x == 0))
+		fesetenv(&envp);
+#else
+	r = a_.f64[0] == b_.f64[0];
+#endif
 
-    return r;
-  #endif
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_ucomieq_sd(a, b) simde_mm_ucomieq_sd(a, b)
+#define _mm_ucomieq_sd(a, b) simde_mm_ucomieq_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int
-simde_mm_ucomige_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_ucomige_sd(a, b);
-  #else
-    simde__m128d_private
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
-    int r;
+int simde_mm_ucomige_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_ucomige_sd(a, b);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a),
+			     b_ = simde__m128d_to_private(b);
+	int r;
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
-      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
-      uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
-      uint64x2_t a_ge_b = vcgeq_f64(a_.neon_f64, b_.neon_f64);
-      r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_ge_b), 0) != 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >= wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-    #elif defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = a_.f64[0] >= b_.f64[0];
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = a_.f64[0] >= b_.f64[0];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+	uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+	uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
+	uint64x2_t a_ge_b = vcgeq_f64(a_.neon_f64, b_.neon_f64);
+	r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_ge_b), 0) != 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >=
+	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+#elif defined(SIMDE_HAVE_FENV_H)
+	fenv_t envp;
+	int x = feholdexcept(&envp);
+	r = a_.f64[0] >= b_.f64[0];
+	if (HEDLEY_LIKELY(x == 0))
+		fesetenv(&envp);
+#else
+	r = a_.f64[0] >= b_.f64[0];
+#endif
 
-    return r;
-  #endif
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_ucomige_sd(a, b) simde_mm_ucomige_sd(a, b)
+#define _mm_ucomige_sd(a, b) simde_mm_ucomige_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int
-simde_mm_ucomigt_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_ucomigt_sd(a, b);
-  #else
-    simde__m128d_private
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
-    int r;
+int simde_mm_ucomigt_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_ucomigt_sd(a, b);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a),
+			     b_ = simde__m128d_to_private(b);
+	int r;
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
-      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
-      uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
-      uint64x2_t a_gt_b = vcgtq_f64(a_.neon_f64, b_.neon_f64);
-      r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_gt_b), 0) != 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) > wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-    #elif defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = a_.f64[0] > b_.f64[0];
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = a_.f64[0] > b_.f64[0];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+	uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+	uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
+	uint64x2_t a_gt_b = vcgtq_f64(a_.neon_f64, b_.neon_f64);
+	r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_gt_b), 0) != 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >
+	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+#elif defined(SIMDE_HAVE_FENV_H)
+	fenv_t envp;
+	int x = feholdexcept(&envp);
+	r = a_.f64[0] > b_.f64[0];
+	if (HEDLEY_LIKELY(x == 0))
+		fesetenv(&envp);
+#else
+	r = a_.f64[0] > b_.f64[0];
+#endif
 
-    return r;
-  #endif
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_ucomigt_sd(a, b) simde_mm_ucomigt_sd(a, b)
+#define _mm_ucomigt_sd(a, b) simde_mm_ucomigt_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int
-simde_mm_ucomile_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_ucomile_sd(a, b);
-  #else
-    simde__m128d_private
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
-    int r;
+int simde_mm_ucomile_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_ucomile_sd(a, b);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a),
+			     b_ = simde__m128d_to_private(b);
+	int r;
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
-      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
-      uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
-      uint64x2_t a_le_b = vcleq_f64(a_.neon_f64, b_.neon_f64);
-      r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_le_b), 0) != 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <= wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-    #elif defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = a_.f64[0] <= b_.f64[0];
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = a_.f64[0] <= b_.f64[0];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+	uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+	uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(
+		vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
+	uint64x2_t a_le_b = vcleq_f64(a_.neon_f64, b_.neon_f64);
+	r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_le_b), 0) != 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <=
+	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+#elif defined(SIMDE_HAVE_FENV_H)
+	fenv_t envp;
+	int x = feholdexcept(&envp);
+	r = a_.f64[0] <= b_.f64[0];
+	if (HEDLEY_LIKELY(x == 0))
+		fesetenv(&envp);
+#else
+	r = a_.f64[0] <= b_.f64[0];
+#endif
 
-    return r;
-  #endif
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_ucomile_sd(a, b) simde_mm_ucomile_sd(a, b)
+#define _mm_ucomile_sd(a, b) simde_mm_ucomile_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int
-simde_mm_ucomilt_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_ucomilt_sd(a, b);
-  #else
-    simde__m128d_private
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
-    int r;
+int simde_mm_ucomilt_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_ucomilt_sd(a, b);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a),
+			     b_ = simde__m128d_to_private(b);
+	int r;
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
-      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
-      uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
-      uint64x2_t a_lt_b = vcltq_f64(a_.neon_f64, b_.neon_f64);
-      r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_lt_b), 0) != 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) < wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-    #elif defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = a_.f64[0] < b_.f64[0];
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = a_.f64[0] < b_.f64[0];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+	uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+	uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(
+		vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
+	uint64x2_t a_lt_b = vcltq_f64(a_.neon_f64, b_.neon_f64);
+	r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_lt_b), 0) != 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <
+	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+#elif defined(SIMDE_HAVE_FENV_H)
+	fenv_t envp;
+	int x = feholdexcept(&envp);
+	r = a_.f64[0] < b_.f64[0];
+	if (HEDLEY_LIKELY(x == 0))
+		fesetenv(&envp);
+#else
+	r = a_.f64[0] < b_.f64[0];
+#endif
 
-    return r;
-  #endif
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_ucomilt_sd(a, b) simde_mm_ucomilt_sd(a, b)
+#define _mm_ucomilt_sd(a, b) simde_mm_ucomilt_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int
-simde_mm_ucomineq_sd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_ucomineq_sd(a, b);
-  #else
-    simde__m128d_private
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
-    int r;
+int simde_mm_ucomineq_sd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_ucomineq_sd(a, b);
+#else
+	simde__m128d_private a_ = simde__m128d_to_private(a),
+			     b_ = simde__m128d_to_private(b);
+	int r;
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
-      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
-      uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
-      uint64x2_t a_neq_b = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vceqq_f64(a_.neon_f64, b_.neon_f64))));
-      r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_neq_b), 0) != 0);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) != wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-    #elif defined(SIMDE_HAVE_FENV_H)
-      fenv_t envp;
-      int x = feholdexcept(&envp);
-      r = a_.f64[0] != b_.f64[0];
-      if (HEDLEY_LIKELY(x == 0))
-        fesetenv(&envp);
-    #else
-      r = a_.f64[0] != b_.f64[0];
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+	uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+	uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
+	uint64x2_t a_neq_b = vreinterpretq_u64_u32(vmvnq_u32(
+		vreinterpretq_u32_u64(vceqq_f64(a_.neon_f64, b_.neon_f64))));
+	r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_neq_b), 0) != 0);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) !=
+	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+#elif defined(SIMDE_HAVE_FENV_H)
+	fenv_t envp;
+	int x = feholdexcept(&envp);
+	r = a_.f64[0] != b_.f64[0];
+	if (HEDLEY_LIKELY(x == 0))
+		fesetenv(&envp);
+#else
+	r = a_.f64[0] != b_.f64[0];
+#endif
 
-    return r;
-  #endif
+	return r;
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_ucomineq_sd(a, b) simde_mm_ucomineq_sd(a, b)
+#define _mm_ucomineq_sd(a, b) simde_mm_ucomineq_sd(a, b)
 #endif
 
 #if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
-  HEDLEY_DIAGNOSTIC_PUSH
-  SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
 #endif
 
 #if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
-  HEDLEY_DIAGNOSTIC_POP
+HEDLEY_DIAGNOSTIC_POP
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_lfence (void) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_lfence();
-  #else
-    simde_mm_sfence();
-  #endif
+void simde_mm_lfence(void)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_lfence();
+#else
+	simde_mm_sfence();
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_lfence() simde_mm_lfence()
+#define _mm_lfence() simde_mm_lfence()
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void
-simde_mm_mfence (void) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    _mm_mfence();
-  #else
-    simde_mm_sfence();
-  #endif
+void simde_mm_mfence(void)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	_mm_mfence();
+#else
+	simde_mm_sfence();
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_mfence() simde_mm_mfence()
+#define _mm_mfence() simde_mm_mfence()
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_unpackhi_epi8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_unpackhi_epi8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_unpackhi_epi8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_unpackhi_epi8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_i8 = vzip2q_s8(a_.neon_i8, b_.neon_i8);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      int8x8_t a1 = vreinterpret_s8_s16(vget_high_s16(a_.neon_i16));
-      int8x8_t b1 = vreinterpret_s8_s16(vget_high_s16(b_.neon_i16));
-      int8x8x2_t result = vzip_s8(a1, b1);
-      r_.neon_i8 = vcombine_s8(result.val[0], result.val[1]);
-    #elif defined(SIMDE_SHUFFLE_VECTOR_)
-      r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.i8, b_.i8, 8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i8[0])) / 2) ; i++) {
-        r_.i8[(i * 2)]     = a_.i8[i + ((sizeof(r_) / sizeof(r_.i8[0])) / 2)];
-        r_.i8[(i * 2) + 1] = b_.i8[i + ((sizeof(r_) / sizeof(r_.i8[0])) / 2)];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_i8 = vzip2q_s8(a_.neon_i8, b_.neon_i8);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	int8x8_t a1 = vreinterpret_s8_s16(vget_high_s16(a_.neon_i16));
+	int8x8_t b1 = vreinterpret_s8_s16(vget_high_s16(b_.neon_i16));
+	int8x8x2_t result = vzip_s8(a1, b1);
+	r_.neon_i8 = vcombine_s8(result.val[0], result.val[1]);
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.i8, b_.i8, 8, 24, 9, 25, 10, 26,
+				      11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i8[0])) / 2); i++) {
+		r_.i8[(i * 2)] =
+			a_.i8[i + ((sizeof(r_) / sizeof(r_.i8[0])) / 2)];
+		r_.i8[(i * 2) + 1] =
+			b_.i8[i + ((sizeof(r_) / sizeof(r_.i8[0])) / 2)];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_unpackhi_epi8(a, b) simde_mm_unpackhi_epi8(a, b)
+#define _mm_unpackhi_epi8(a, b) simde_mm_unpackhi_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_unpackhi_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_unpackhi_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_unpackhi_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_unpackhi_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_i16 = vzip2q_s16(a_.neon_i16, b_.neon_i16);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      int16x4_t a1 = vget_high_s16(a_.neon_i16);
-      int16x4_t b1 = vget_high_s16(b_.neon_i16);
-      int16x4x2_t result = vzip_s16(a1, b1);
-      r_.neon_i16 = vcombine_s16(result.val[0], result.val[1]);
-    #elif defined(SIMDE_SHUFFLE_VECTOR_)
-      r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.i16, b_.i16, 4, 12, 5, 13, 6, 14, 7, 15);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i16[0])) / 2) ; i++) {
-        r_.i16[(i * 2)]     = a_.i16[i + ((sizeof(r_) / sizeof(r_.i16[0])) / 2)];
-        r_.i16[(i * 2) + 1] = b_.i16[i + ((sizeof(r_) / sizeof(r_.i16[0])) / 2)];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_i16 = vzip2q_s16(a_.neon_i16, b_.neon_i16);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	int16x4_t a1 = vget_high_s16(a_.neon_i16);
+	int16x4_t b1 = vget_high_s16(b_.neon_i16);
+	int16x4x2_t result = vzip_s16(a1, b1);
+	r_.neon_i16 = vcombine_s16(result.val[0], result.val[1]);
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.i16, b_.i16, 4, 12, 5, 13, 6,
+				       14, 7, 15);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i16[0])) / 2); i++) {
+		r_.i16[(i * 2)] =
+			a_.i16[i + ((sizeof(r_) / sizeof(r_.i16[0])) / 2)];
+		r_.i16[(i * 2) + 1] =
+			b_.i16[i + ((sizeof(r_) / sizeof(r_.i16[0])) / 2)];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_unpackhi_epi16(a, b) simde_mm_unpackhi_epi16(a, b)
+#define _mm_unpackhi_epi16(a, b) simde_mm_unpackhi_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_unpackhi_epi32 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_unpackhi_epi32(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_unpackhi_epi32(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_unpackhi_epi32(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_i32 = vzip2q_s32(a_.neon_i32, b_.neon_i32);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      int32x2_t a1 = vget_high_s32(a_.neon_i32);
-      int32x2_t b1 = vget_high_s32(b_.neon_i32);
-      int32x2x2_t result = vzip_s32(a1, b1);
-      r_.neon_i32 = vcombine_s32(result.val[0], result.val[1]);
-    #elif defined(SIMDE_SHUFFLE_VECTOR_)
-      r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.i32, b_.i32, 2, 6, 3, 7);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i32[0])) / 2) ; i++) {
-        r_.i32[(i * 2)]     = a_.i32[i + ((sizeof(r_) / sizeof(r_.i32[0])) / 2)];
-        r_.i32[(i * 2) + 1] = b_.i32[i + ((sizeof(r_) / sizeof(r_.i32[0])) / 2)];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_i32 = vzip2q_s32(a_.neon_i32, b_.neon_i32);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	int32x2_t a1 = vget_high_s32(a_.neon_i32);
+	int32x2_t b1 = vget_high_s32(b_.neon_i32);
+	int32x2x2_t result = vzip_s32(a1, b1);
+	r_.neon_i32 = vcombine_s32(result.val[0], result.val[1]);
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.i32, b_.i32, 2, 6, 3, 7);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i32[0])) / 2); i++) {
+		r_.i32[(i * 2)] =
+			a_.i32[i + ((sizeof(r_) / sizeof(r_.i32[0])) / 2)];
+		r_.i32[(i * 2) + 1] =
+			b_.i32[i + ((sizeof(r_) / sizeof(r_.i32[0])) / 2)];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_unpackhi_epi32(a, b) simde_mm_unpackhi_epi32(a, b)
+#define _mm_unpackhi_epi32(a, b) simde_mm_unpackhi_epi32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_unpackhi_epi64 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_unpackhi_epi64(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_unpackhi_epi64(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_unpackhi_epi64(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      int64x1_t a_h = vget_high_s64(a_.neon_i64);
-      int64x1_t b_h = vget_high_s64(b_.neon_i64);
-      r_.neon_i64 = vcombine_s64(a_h, b_h);
-    #elif defined(SIMDE_SHUFFLE_VECTOR_)
-      r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.i64, b_.i64, 1, 3);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i64[0])) / 2) ; i++) {
-        r_.i64[(i * 2)]     = a_.i64[i + ((sizeof(r_) / sizeof(r_.i64[0])) / 2)];
-        r_.i64[(i * 2) + 1] = b_.i64[i + ((sizeof(r_) / sizeof(r_.i64[0])) / 2)];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	int64x1_t a_h = vget_high_s64(a_.neon_i64);
+	int64x1_t b_h = vget_high_s64(b_.neon_i64);
+	r_.neon_i64 = vcombine_s64(a_h, b_h);
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.i64, b_.i64, 1, 3);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i64[0])) / 2); i++) {
+		r_.i64[(i * 2)] =
+			a_.i64[i + ((sizeof(r_) / sizeof(r_.i64[0])) / 2)];
+		r_.i64[(i * 2) + 1] =
+			b_.i64[i + ((sizeof(r_) / sizeof(r_.i64[0])) / 2)];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_unpackhi_epi64(a, b) simde_mm_unpackhi_epi64(a, b)
+#define _mm_unpackhi_epi64(a, b) simde_mm_unpackhi_epi64(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_unpackhi_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_unpackhi_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_unpackhi_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_unpackhi_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vzip2q_f64(a_.neon_f64, b_.neon_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_i64x2_shuffle(a_.wasm_v128, b_.wasm_v128, 1, 3);
-    #elif defined(SIMDE_SHUFFLE_VECTOR_)
-      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 1, 3);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.f64[0])) / 2) ; i++) {
-        r_.f64[(i * 2)]     = a_.f64[i + ((sizeof(r_) / sizeof(r_.f64[0])) / 2)];
-        r_.f64[(i * 2) + 1] = b_.f64[i + ((sizeof(r_) / sizeof(r_.f64[0])) / 2)];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vzip2q_f64(a_.neon_f64, b_.neon_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_i64x2_shuffle(a_.wasm_v128, b_.wasm_v128, 1, 3);
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 1, 3);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.f64[0])) / 2); i++) {
+		r_.f64[(i * 2)] =
+			a_.f64[i + ((sizeof(r_) / sizeof(r_.f64[0])) / 2)];
+		r_.f64[(i * 2) + 1] =
+			b_.f64[i + ((sizeof(r_) / sizeof(r_.f64[0])) / 2)];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_unpackhi_pd(a, b) simde_mm_unpackhi_pd(a, b)
+#define _mm_unpackhi_pd(a, b) simde_mm_unpackhi_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_unpacklo_epi8 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_unpacklo_epi8(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_unpacklo_epi8(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_unpacklo_epi8(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_i8 = vzip1q_s8(a_.neon_i8, b_.neon_i8);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      int8x8_t a1 = vreinterpret_s8_s16(vget_low_s16(a_.neon_i16));
-      int8x8_t b1 = vreinterpret_s8_s16(vget_low_s16(b_.neon_i16));
-      int8x8x2_t result = vzip_s8(a1, b1);
-      r_.neon_i8 = vcombine_s8(result.val[0], result.val[1]);
-    #elif defined(SIMDE_SHUFFLE_VECTOR_)
-      r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.i8, b_.i8, 0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i8[0])) / 2) ; i++) {
-        r_.i8[(i * 2)]     = a_.i8[i];
-        r_.i8[(i * 2) + 1] = b_.i8[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_i8 = vzip1q_s8(a_.neon_i8, b_.neon_i8);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	int8x8_t a1 = vreinterpret_s8_s16(vget_low_s16(a_.neon_i16));
+	int8x8_t b1 = vreinterpret_s8_s16(vget_low_s16(b_.neon_i16));
+	int8x8x2_t result = vzip_s8(a1, b1);
+	r_.neon_i8 = vcombine_s8(result.val[0], result.val[1]);
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.i8, b_.i8, 0, 16, 1, 17, 2, 18,
+				      3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i8[0])) / 2); i++) {
+		r_.i8[(i * 2)] = a_.i8[i];
+		r_.i8[(i * 2) + 1] = b_.i8[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_unpacklo_epi8(a, b) simde_mm_unpacklo_epi8(a, b)
+#define _mm_unpacklo_epi8(a, b) simde_mm_unpacklo_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_unpacklo_epi16 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_unpacklo_epi16(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_unpacklo_epi16(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_unpacklo_epi16(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_i16 = vzip1q_s16(a_.neon_i16, b_.neon_i16);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      int16x4_t a1 = vget_low_s16(a_.neon_i16);
-      int16x4_t b1 = vget_low_s16(b_.neon_i16);
-      int16x4x2_t result = vzip_s16(a1, b1);
-      r_.neon_i16 = vcombine_s16(result.val[0], result.val[1]);
-    #elif defined(SIMDE_SHUFFLE_VECTOR_)
-      r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.i16, b_.i16, 0, 8, 1, 9, 2, 10, 3, 11);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i16[0])) / 2) ; i++) {
-        r_.i16[(i * 2)]     = a_.i16[i];
-        r_.i16[(i * 2) + 1] = b_.i16[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_i16 = vzip1q_s16(a_.neon_i16, b_.neon_i16);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	int16x4_t a1 = vget_low_s16(a_.neon_i16);
+	int16x4_t b1 = vget_low_s16(b_.neon_i16);
+	int16x4x2_t result = vzip_s16(a1, b1);
+	r_.neon_i16 = vcombine_s16(result.val[0], result.val[1]);
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.i16, b_.i16, 0, 8, 1, 9, 2,
+				       10, 3, 11);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i16[0])) / 2); i++) {
+		r_.i16[(i * 2)] = a_.i16[i];
+		r_.i16[(i * 2) + 1] = b_.i16[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_unpacklo_epi16(a, b) simde_mm_unpacklo_epi16(a, b)
+#define _mm_unpacklo_epi16(a, b) simde_mm_unpacklo_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_unpacklo_epi32 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_unpacklo_epi32(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_unpacklo_epi32(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_unpacklo_epi32(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_i32 = vzip1q_s32(a_.neon_i32, b_.neon_i32);
-    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      int32x2_t a1 = vget_low_s32(a_.neon_i32);
-      int32x2_t b1 = vget_low_s32(b_.neon_i32);
-      int32x2x2_t result = vzip_s32(a1, b1);
-      r_.neon_i32 = vcombine_s32(result.val[0], result.val[1]);
-    #elif defined(SIMDE_SHUFFLE_VECTOR_)
-      r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.i32, b_.i32, 0, 4, 1, 5);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i32[0])) / 2) ; i++) {
-        r_.i32[(i * 2)]     = a_.i32[i];
-        r_.i32[(i * 2) + 1] = b_.i32[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_i32 = vzip1q_s32(a_.neon_i32, b_.neon_i32);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	int32x2_t a1 = vget_low_s32(a_.neon_i32);
+	int32x2_t b1 = vget_low_s32(b_.neon_i32);
+	int32x2x2_t result = vzip_s32(a1, b1);
+	r_.neon_i32 = vcombine_s32(result.val[0], result.val[1]);
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.i32, b_.i32, 0, 4, 1, 5);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i32[0])) / 2); i++) {
+		r_.i32[(i * 2)] = a_.i32[i];
+		r_.i32[(i * 2) + 1] = b_.i32[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_unpacklo_epi32(a, b) simde_mm_unpacklo_epi32(a, b)
+#define _mm_unpacklo_epi32(a, b) simde_mm_unpacklo_epi32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_unpacklo_epi64 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_unpacklo_epi64(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_unpacklo_epi64(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_unpacklo_epi64(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      int64x1_t a_l = vget_low_s64(a_.neon_i64);
-      int64x1_t b_l = vget_low_s64(b_.neon_i64);
-      r_.neon_i64 = vcombine_s64(a_l, b_l);
-    #elif defined(SIMDE_SHUFFLE_VECTOR_)
-      r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.i64, b_.i64, 0, 2);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i64[0])) / 2) ; i++) {
-        r_.i64[(i * 2)]     = a_.i64[i];
-        r_.i64[(i * 2) + 1] = b_.i64[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	int64x1_t a_l = vget_low_s64(a_.neon_i64);
+	int64x1_t b_l = vget_low_s64(b_.neon_i64);
+	r_.neon_i64 = vcombine_s64(a_l, b_l);
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.i64, b_.i64, 0, 2);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i64[0])) / 2); i++) {
+		r_.i64[(i * 2)] = a_.i64[i];
+		r_.i64[(i * 2) + 1] = b_.i64[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_unpacklo_epi64(a, b) simde_mm_unpacklo_epi64(a, b)
+#define _mm_unpacklo_epi64(a, b) simde_mm_unpacklo_epi64(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_mm_unpacklo_pd (simde__m128d a, simde__m128d b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_unpacklo_pd(a, b);
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a),
-      b_ = simde__m128d_to_private(b);
+simde__m128d simde_mm_unpacklo_pd(simde__m128d a, simde__m128d b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_unpacklo_pd(a, b);
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
+				 b_ = simde__m128d_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vzip1q_f64(a_.neon_f64, b_.neon_f64);
-    #elif defined(SIMDE_SHUFFLE_VECTOR_)
-      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 0, 2);
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.f64[0])) / 2) ; i++) {
-        r_.f64[(i * 2)]     = a_.f64[i];
-        r_.f64[(i * 2) + 1] = b_.f64[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vzip1q_f64(a_.neon_f64, b_.neon_f64);
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+	r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 0, 2);
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.f64[0])) / 2); i++) {
+		r_.f64[(i * 2)] = a_.f64[i];
+		r_.f64[(i * 2) + 1] = b_.f64[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_unpacklo_pd(a, b) simde_mm_unpacklo_pd(a, b)
+#define _mm_unpacklo_pd(a, b) simde_mm_unpacklo_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d
-simde_x_mm_negate_pd(simde__m128d a) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return simde_mm_xor_pd(a, _mm_set1_pd(SIMDE_FLOAT64_C(-0.0)));
-  #else
-    simde__m128d_private
-      r_,
-      a_ = simde__m128d_to_private(a);
+simde__m128d simde_x_mm_negate_pd(simde__m128d a)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return simde_mm_xor_pd(a, _mm_set1_pd(SIMDE_FLOAT64_C(-0.0)));
+#else
+	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
 
-    #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
-        (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,1,0))
-      r_.altivec_f64 = vec_neg(a_.altivec_f64);
-    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-      r_.neon_f64 = vnegq_f64(a_.neon_f64);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_f64x2_neg(a_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_NEGATE)
-      r_.f64 = -a_.f64;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
-        r_.f64[i] = -a_.f64[i];
-      }
-    #endif
+#if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
+	(!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8, 1, 0))
+	r_.altivec_f64 = vec_neg(a_.altivec_f64);
+#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+	r_.neon_f64 = vnegq_f64(a_.neon_f64);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_f64x2_neg(a_.wasm_v128);
+#elif defined(SIMDE_VECTOR_NEGATE)
+	r_.f64 = -a_.f64;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+		r_.f64[i] = -a_.f64[i];
+	}
+#endif
 
-    return simde__m128d_from_private(r_);
-  #endif
+	return simde__m128d_from_private(r_);
+#endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_mm_xor_si128 (simde__m128i a, simde__m128i b) {
-  #if defined(SIMDE_X86_SSE2_NATIVE)
-    return _mm_xor_si128(a, b);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a),
-      b_ = simde__m128i_to_private(b);
+simde__m128i simde_mm_xor_si128(simde__m128i a, simde__m128i b)
+{
+#if defined(SIMDE_X86_SSE2_NATIVE)
+	return _mm_xor_si128(a, b);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
+				 b_ = simde__m128i_to_private(b);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = veorq_s32(a_.neon_i32, b_.neon_i32);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_i32 = vec_xor(a_.altivec_i32, b_.altivec_i32);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32f = a_.i32f ^ b_.i32f;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
-        r_.i32f[i] = a_.i32f[i] ^ b_.i32f[i];
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = veorq_s32(a_.neon_i32, b_.neon_i32);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_i32 = vec_xor(a_.altivec_i32, b_.altivec_i32);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32f = a_.i32f ^ b_.i32f;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
+		r_.i32f[i] = a_.i32f[i] ^ b_.i32f[i];
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _mm_xor_si128(a, b) simde_mm_xor_si128(a, b)
+#define _mm_xor_si128(a, b) simde_mm_xor_si128(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i
-simde_x_mm_not_si128 (simde__m128i a) {
-  #if defined(SIMDE_X86_AVX512VL_NATIVE)
-    return _mm_ternarylogic_epi32(a, a, a, 0x55);
-  #else
-    simde__m128i_private
-      r_,
-      a_ = simde__m128i_to_private(a);
+simde__m128i simde_x_mm_not_si128(simde__m128i a)
+{
+#if defined(SIMDE_X86_AVX512VL_NATIVE)
+	return _mm_ternarylogic_epi32(a, a, a, 0x55);
+#else
+	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
 
-    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-      r_.neon_i32 = vmvnq_s32(a_.neon_i32);
-    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-      r_.altivec_i32 = vec_nor(a_.altivec_i32, a_.altivec_i32);
-    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-      r_.wasm_v128 = wasm_v128_not(a_.wasm_v128);
-    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-      r_.i32f = ~a_.i32f;
-    #else
-      SIMDE_VECTORIZE
-      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
-        r_.i32f[i] = ~(a_.i32f[i]);
-      }
-    #endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+	r_.neon_i32 = vmvnq_s32(a_.neon_i32);
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+	r_.altivec_i32 = vec_nor(a_.altivec_i32, a_.altivec_i32);
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+	r_.wasm_v128 = wasm_v128_not(a_.wasm_v128);
+#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+	r_.i32f = ~a_.i32f;
+#else
+	SIMDE_VECTORIZE
+	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
+		r_.i32f[i] = ~(a_.i32f[i]);
+	}
+#endif
 
-    return simde__m128i_from_private(r_);
-  #endif
+	return simde__m128i_from_private(r_);
+#endif
 }
 
 #define SIMDE_MM_SHUFFLE2(x, y) (((x) << 1) | (y))
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-  #define _MM_SHUFFLE2(x, y) SIMDE_MM_SHUFFLE2(x, y)
+#define _MM_SHUFFLE2(x, y) SIMDE_MM_SHUFFLE2(x, y)
 #endif
 
 SIMDE_END_DECLS_

--- a/libobs/util/simde/x86/sse2.h
+++ b/libobs/util/simde/x86/sse2.h
@@ -39,475 +39,456 @@ SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
 SIMDE_BEGIN_DECLS_
 
 typedef union {
-#if defined(SIMDE_VECTOR_SUBSCRIPT)
-	SIMDE_ALIGN_TO_16 int8_t i8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 int16_t i16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 int32_t i32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 int64_t i64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 uint8_t u8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 uint16_t u16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 uint32_t u32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 uint64_t u64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-#if defined(SIMDE_HAVE_INT128_)
-	SIMDE_ALIGN_TO_16 simde_int128 i128 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 simde_uint128 u128 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-#endif
-	SIMDE_ALIGN_TO_16 simde_float32 f32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 simde_float64 f64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+  #if defined(SIMDE_VECTOR_SUBSCRIPT)
+    SIMDE_ALIGN_TO_16 int8_t          i8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 int16_t        i16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 int32_t        i32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 int64_t        i64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 uint8_t         u8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 uint16_t       u16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 uint32_t       u32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 uint64_t       u64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_ALIGN_TO_16 simde_int128  i128 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 simde_uint128 u128 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    #endif
+    SIMDE_ALIGN_TO_16 simde_float32  f32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 simde_float64  f64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
 
-	SIMDE_ALIGN_TO_16 int_fast32_t i32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 uint_fast32_t u32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-#else
-	SIMDE_ALIGN_TO_16 int8_t i8[16];
-	SIMDE_ALIGN_TO_16 int16_t i16[8];
-	SIMDE_ALIGN_TO_16 int32_t i32[4];
-	SIMDE_ALIGN_TO_16 int64_t i64[2];
-	SIMDE_ALIGN_TO_16 uint8_t u8[16];
-	SIMDE_ALIGN_TO_16 uint16_t u16[8];
-	SIMDE_ALIGN_TO_16 uint32_t u32[4];
-	SIMDE_ALIGN_TO_16 uint64_t u64[2];
-#if defined(SIMDE_HAVE_INT128_)
-	SIMDE_ALIGN_TO_16 simde_int128 i128[1];
-	SIMDE_ALIGN_TO_16 simde_uint128 u128[1];
-#endif
-	SIMDE_ALIGN_TO_16 simde_float32 f32[4];
-	SIMDE_ALIGN_TO_16 simde_float64 f64[2];
+    SIMDE_ALIGN_TO_16 int_fast32_t  i32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 uint_fast32_t u32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+  #else
+    SIMDE_ALIGN_TO_16 int8_t         i8[16];
+    SIMDE_ALIGN_TO_16 int16_t        i16[8];
+    SIMDE_ALIGN_TO_16 int32_t        i32[4];
+    SIMDE_ALIGN_TO_16 int64_t        i64[2];
+    SIMDE_ALIGN_TO_16 uint8_t        u8[16];
+    SIMDE_ALIGN_TO_16 uint16_t       u16[8];
+    SIMDE_ALIGN_TO_16 uint32_t       u32[4];
+    SIMDE_ALIGN_TO_16 uint64_t       u64[2];
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_ALIGN_TO_16 simde_int128  i128[1];
+    SIMDE_ALIGN_TO_16 simde_uint128 u128[1];
+    #endif
+    SIMDE_ALIGN_TO_16 simde_float32  f32[4];
+    SIMDE_ALIGN_TO_16 simde_float64  f64[2];
 
-	SIMDE_ALIGN_TO_16 int_fast32_t i32f[16 / sizeof(int_fast32_t)];
-	SIMDE_ALIGN_TO_16 uint_fast32_t u32f[16 / sizeof(uint_fast32_t)];
-#endif
+    SIMDE_ALIGN_TO_16 int_fast32_t  i32f[16 / sizeof(int_fast32_t)];
+    SIMDE_ALIGN_TO_16 uint_fast32_t u32f[16 / sizeof(uint_fast32_t)];
+  #endif
 
-	SIMDE_ALIGN_TO_16 simde__m64_private m64_private[2];
-	SIMDE_ALIGN_TO_16 simde__m64 m64[2];
+    SIMDE_ALIGN_TO_16 simde__m64_private m64_private[2];
+    SIMDE_ALIGN_TO_16 simde__m64         m64[2];
 
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	SIMDE_ALIGN_TO_16 __m128i n;
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	SIMDE_ALIGN_TO_16 int8x16_t neon_i8;
-	SIMDE_ALIGN_TO_16 int16x8_t neon_i16;
-	SIMDE_ALIGN_TO_16 int32x4_t neon_i32;
-	SIMDE_ALIGN_TO_16 int64x2_t neon_i64;
-	SIMDE_ALIGN_TO_16 uint8x16_t neon_u8;
-	SIMDE_ALIGN_TO_16 uint16x8_t neon_u16;
-	SIMDE_ALIGN_TO_16 uint32x4_t neon_u32;
-	SIMDE_ALIGN_TO_16 uint64x2_t neon_u64;
-	SIMDE_ALIGN_TO_16 float32x4_t neon_f32;
-#if defined(SIMDE_ARCH_AARCH64)
-	SIMDE_ALIGN_TO_16 float64x2_t neon_f64;
-#endif
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	SIMDE_ALIGN_TO_16 v128_t wasm_v128;
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed char) altivec_i8;
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed short) altivec_i16;
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int) altivec_i32;
-#if defined(__UINT_FAST32_TYPE__) && defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	SIMDE_ALIGN_TO_16
-	SIMDE_POWER_ALTIVEC_VECTOR(__INT_FAST32_TYPE__) altivec_i32f;
-#else
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int) altivec_i32f;
-#endif
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) altivec_u8;
-	SIMDE_ALIGN_TO_16
-	SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) altivec_u16;
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) altivec_u32;
-#if defined(__UINT_FAST32_TYPE__) && defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	SIMDE_ALIGN_TO_16
-	SIMDE_POWER_ALTIVEC_VECTOR(__UINT_FAST32_TYPE__) altivec_u32f;
-#else
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) altivec_u32f;
-#endif
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(float) altivec_f32;
-#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	SIMDE_ALIGN_TO_16
-	SIMDE_POWER_ALTIVEC_VECTOR(signed long long) altivec_i64;
-	SIMDE_ALIGN_TO_16
-	SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64;
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(double) altivec_f64;
-#endif
-#endif
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    SIMDE_ALIGN_TO_16 __m128i        n;
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_ALIGN_TO_16 int8x16_t      neon_i8;
+    SIMDE_ALIGN_TO_16 int16x8_t      neon_i16;
+    SIMDE_ALIGN_TO_16 int32x4_t      neon_i32;
+    SIMDE_ALIGN_TO_16 int64x2_t      neon_i64;
+    SIMDE_ALIGN_TO_16 uint8x16_t     neon_u8;
+    SIMDE_ALIGN_TO_16 uint16x8_t     neon_u16;
+    SIMDE_ALIGN_TO_16 uint32x4_t     neon_u32;
+    SIMDE_ALIGN_TO_16 uint64x2_t     neon_u64;
+    #if defined(__ARM_FP16_FORMAT_IEEE)
+    SIMDE_ALIGN_TO_16 float16x8_t    neon_f16;
+    #endif
+    SIMDE_ALIGN_TO_16 float32x4_t    neon_f32;
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    SIMDE_ALIGN_TO_16 float64x2_t    neon_f64;
+    #endif
+  #elif defined(SIMDE_MIPS_MSA_NATIVE)
+    v16i8 msa_i8;
+    v8i16 msa_i16;
+    v4i32 msa_i32;
+    v2i64 msa_i64;
+    v16u8 msa_u8;
+    v8u16 msa_u16;
+    v4u32 msa_u32;
+    v2u64 msa_u64;
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    SIMDE_ALIGN_TO_16 v128_t         wasm_v128;
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed char)          altivec_i8;
+    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed short)         altivec_i16;
+    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32;
+    #if defined(__UINT_FAST32_TYPE__) && (defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE))
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(__INT_FAST32_TYPE__)  altivec_i32f;
+    #else
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32f;
+    #endif
+    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)        altivec_u8;
+    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)       altivec_u16;
+    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32;
+    #if defined(__UINT_FAST32_TYPE__) && (defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE))
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(__UINT_FAST32_TYPE__) altivec_u32f;
+    #else
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32f;
+    #endif
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(float)                altivec_f32;
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed long long)   altivec_i64;
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64;
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(double)             altivec_f64;
+    #endif
+  #endif
 } simde__m128i_private;
 
 typedef union {
-#if defined(SIMDE_VECTOR_SUBSCRIPT)
-	SIMDE_ALIGN_TO_16 int8_t i8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 int16_t i16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 int32_t i32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 int64_t i64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 uint8_t u8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 uint16_t u16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 uint32_t u32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 uint64_t u64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 simde_float32 f32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 simde_float64 f64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 int_fast32_t i32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-	SIMDE_ALIGN_TO_16 uint_fast32_t u32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-#else
-	SIMDE_ALIGN_TO_16 int8_t i8[16];
-	SIMDE_ALIGN_TO_16 int16_t i16[8];
-	SIMDE_ALIGN_TO_16 int32_t i32[4];
-	SIMDE_ALIGN_TO_16 int64_t i64[2];
-	SIMDE_ALIGN_TO_16 uint8_t u8[16];
-	SIMDE_ALIGN_TO_16 uint16_t u16[8];
-	SIMDE_ALIGN_TO_16 uint32_t u32[4];
-	SIMDE_ALIGN_TO_16 uint64_t u64[2];
-	SIMDE_ALIGN_TO_16 simde_float32 f32[4];
-	SIMDE_ALIGN_TO_16 simde_float64 f64[2];
-	SIMDE_ALIGN_TO_16 int_fast32_t i32f[16 / sizeof(int_fast32_t)];
-	SIMDE_ALIGN_TO_16 uint_fast32_t u32f[16 / sizeof(uint_fast32_t)];
-#endif
+  #if defined(SIMDE_VECTOR_SUBSCRIPT)
+    SIMDE_ALIGN_TO_16 int8_t          i8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 int16_t        i16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 int32_t        i32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 int64_t        i64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 uint8_t         u8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 uint16_t       u16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 uint32_t       u32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 uint64_t       u64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 simde_float32  f32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 simde_float64  f64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 int_fast32_t  i32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN_TO_16 uint_fast32_t u32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+  #else
+    SIMDE_ALIGN_TO_16 int8_t         i8[16];
+    SIMDE_ALIGN_TO_16 int16_t        i16[8];
+    SIMDE_ALIGN_TO_16 int32_t        i32[4];
+    SIMDE_ALIGN_TO_16 int64_t        i64[2];
+    SIMDE_ALIGN_TO_16 uint8_t        u8[16];
+    SIMDE_ALIGN_TO_16 uint16_t       u16[8];
+    SIMDE_ALIGN_TO_16 uint32_t       u32[4];
+    SIMDE_ALIGN_TO_16 uint64_t       u64[2];
+    SIMDE_ALIGN_TO_16 simde_float32  f32[4];
+    SIMDE_ALIGN_TO_16 simde_float64  f64[2];
+    SIMDE_ALIGN_TO_16 int_fast32_t  i32f[16 / sizeof(int_fast32_t)];
+    SIMDE_ALIGN_TO_16 uint_fast32_t u32f[16 / sizeof(uint_fast32_t)];
+  #endif
 
-	SIMDE_ALIGN_TO_16 simde__m64_private m64_private[2];
-	SIMDE_ALIGN_TO_16 simde__m64 m64[2];
+    SIMDE_ALIGN_TO_16 simde__m64_private m64_private[2];
+    SIMDE_ALIGN_TO_16 simde__m64         m64[2];
 
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	SIMDE_ALIGN_TO_16 __m128d n;
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	SIMDE_ALIGN_TO_16 int8x16_t neon_i8;
-	SIMDE_ALIGN_TO_16 int16x8_t neon_i16;
-	SIMDE_ALIGN_TO_16 int32x4_t neon_i32;
-	SIMDE_ALIGN_TO_16 int64x2_t neon_i64;
-	SIMDE_ALIGN_TO_16 uint8x16_t neon_u8;
-	SIMDE_ALIGN_TO_16 uint16x8_t neon_u16;
-	SIMDE_ALIGN_TO_16 uint32x4_t neon_u32;
-	SIMDE_ALIGN_TO_16 uint64x2_t neon_u64;
-	SIMDE_ALIGN_TO_16 float32x4_t neon_f32;
-#if defined(SIMDE_ARCH_AARCH64)
-	SIMDE_ALIGN_TO_16 float64x2_t neon_f64;
-#endif
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	SIMDE_ALIGN_TO_16 v128_t wasm_v128;
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed char) altivec_i8;
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed short) altivec_i16;
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int) altivec_i32;
-#if defined(__INT_FAST32_TYPE__) && defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	SIMDE_ALIGN_TO_16
-	SIMDE_POWER_ALTIVEC_VECTOR(__INT_FAST32_TYPE__) altivec_i32f;
-#else
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int) altivec_i32f;
-#endif
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) altivec_u8;
-	SIMDE_ALIGN_TO_16
-	SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) altivec_u16;
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) altivec_u32;
-#if defined(__UINT_FAST32_TYPE__) && defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	SIMDE_ALIGN_TO_16
-	SIMDE_POWER_ALTIVEC_VECTOR(__UINT_FAST32_TYPE__) altivec_u32f;
-#else
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) altivec_u32f;
-#endif
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(float) altivec_f32;
-#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	SIMDE_ALIGN_TO_16
-	SIMDE_POWER_ALTIVEC_VECTOR(signed long long) altivec_i64;
-	SIMDE_ALIGN_TO_16
-	SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64;
-	SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(double) altivec_f64;
-#endif
-#endif
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    SIMDE_ALIGN_TO_16 __m128d        n;
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_ALIGN_TO_16 int8x16_t      neon_i8;
+    SIMDE_ALIGN_TO_16 int16x8_t      neon_i16;
+    SIMDE_ALIGN_TO_16 int32x4_t      neon_i32;
+    SIMDE_ALIGN_TO_16 int64x2_t      neon_i64;
+    SIMDE_ALIGN_TO_16 uint8x16_t     neon_u8;
+    SIMDE_ALIGN_TO_16 uint16x8_t     neon_u16;
+    SIMDE_ALIGN_TO_16 uint32x4_t     neon_u32;
+    SIMDE_ALIGN_TO_16 uint64x2_t     neon_u64;
+    SIMDE_ALIGN_TO_16 float32x4_t    neon_f32;
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    SIMDE_ALIGN_TO_16 float64x2_t    neon_f64;
+    #endif
+  #elif defined(SIMDE_MIPS_MSA_NATIVE)
+    v16i8 msa_i8;
+    v8i16 msa_i16;
+    v4i32 msa_i32;
+    v2i64 msa_i64;
+    v16u8 msa_u8;
+    v8u16 msa_u16;
+    v4u32 msa_u32;
+    v2u64 msa_u64;
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    SIMDE_ALIGN_TO_16 v128_t         wasm_v128;
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed char)          altivec_i8;
+    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed short)         altivec_i16;
+    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32;
+    #if defined(__INT_FAST32_TYPE__) && (defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE))
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(__INT_FAST32_TYPE__)  altivec_i32f;
+    #else
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32f;
+    #endif
+    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)        altivec_u8;
+    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)       altivec_u16;
+    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32;
+    #if defined(__UINT_FAST32_TYPE__) && (defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE))
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(__UINT_FAST32_TYPE__) altivec_u32f;
+    #else
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32f;
+    #endif
+    SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(float)                altivec_f32;
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(signed long long)   altivec_i64;
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64;
+      SIMDE_ALIGN_TO_16 SIMDE_POWER_ALTIVEC_VECTOR(double)             altivec_f64;
+    #endif
+  #endif
 } simde__m128d_private;
 
 #if defined(SIMDE_X86_SSE2_NATIVE)
-typedef __m128i simde__m128i;
-typedef __m128d simde__m128d;
+  typedef __m128i simde__m128i;
+  typedef __m128d simde__m128d;
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-typedef int64x2_t simde__m128i;
-#if defined(SIMDE_ARCH_AARCH64)
-typedef float64x2_t simde__m128d;
-#elif defined(SIMDE_VECTOR_SUBSCRIPT)
-typedef simde_float64 simde__m128d SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-#else
-typedef simde__m128d_private simde__m128d;
-#endif
+   typedef int64x2_t simde__m128i;
+#  if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+     typedef float64x2_t simde__m128d;
+#  elif defined(SIMDE_VECTOR_SUBSCRIPT)
+     typedef simde_float64 simde__m128d SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+#  else
+     typedef simde__m128d_private simde__m128d;
+#  endif
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-typedef v128_t simde__m128i;
-typedef v128_t simde__m128d;
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-typedef SIMDE_POWER_ALTIVEC_VECTOR(float) simde__m128i;
-#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-typedef SIMDE_POWER_ALTIVEC_VECTOR(double) simde__m128d;
-#else
-typedef simde__m128d_private simde__m128d;
-#endif
+   typedef v128_t simde__m128i;
+   typedef v128_t simde__m128d;
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+  typedef SIMDE_POWER_ALTIVEC_VECTOR(float) simde__m128i;
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+     typedef SIMDE_POWER_ALTIVEC_VECTOR(double) simde__m128d;
+  #else
+     typedef simde__m128d_private simde__m128d;
+  #endif
 #elif defined(SIMDE_VECTOR_SUBSCRIPT)
-typedef int64_t simde__m128i SIMDE_ALIGN_TO_16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
-typedef simde_float64
-	simde__m128d SIMDE_ALIGN_TO_16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+  typedef int64_t simde__m128i SIMDE_ALIGN_TO_16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+  typedef simde_float64 simde__m128d SIMDE_ALIGN_TO_16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
 #else
-typedef simde__m128i_private simde__m128i;
-typedef simde__m128d_private simde__m128d;
+  typedef simde__m128i_private simde__m128i;
+  typedef simde__m128d_private simde__m128d;
 #endif
 
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-typedef simde__m128i __m128i;
-typedef simde__m128d __m128d;
+  typedef simde__m128i __m128i;
+  typedef simde__m128d __m128d;
 #endif
 
 HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128i), "simde__m128i size incorrect");
-HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128i_private),
-		     "simde__m128i_private size incorrect");
+HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128i_private), "simde__m128i_private size incorrect");
 HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128d), "simde__m128d size incorrect");
-HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128d_private),
-		     "simde__m128d_private size incorrect");
+HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128d_private), "simde__m128d_private size incorrect");
 #if defined(SIMDE_CHECK_ALIGNMENT) && defined(SIMDE_ALIGN_OF)
-HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128i) == 16,
-		     "simde__m128i is not 16-byte aligned");
-HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128i_private) == 16,
-		     "simde__m128i_private is not 16-byte aligned");
-HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128d) == 16,
-		     "simde__m128d is not 16-byte aligned");
-HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128d_private) == 16,
-		     "simde__m128d_private is not 16-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128i) == 16, "simde__m128i is not 16-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128i_private) == 16, "simde__m128i_private is not 16-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128d) == 16, "simde__m128d is not 16-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128d_private) == 16, "simde__m128d_private is not 16-byte aligned");
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde__m128i_from_private(simde__m128i_private v)
-{
-	simde__m128i r;
-	simde_memcpy(&r, &v, sizeof(r));
-	return r;
+simde__m128i
+simde__m128i_from_private(simde__m128i_private v) {
+  simde__m128i r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i_private simde__m128i_to_private(simde__m128i v)
-{
-	simde__m128i_private r;
-	simde_memcpy(&r, &v, sizeof(r));
-	return r;
+simde__m128i_private
+simde__m128i_to_private(simde__m128i v) {
+  simde__m128i_private r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde__m128d_from_private(simde__m128d_private v)
-{
-	simde__m128d r;
-	simde_memcpy(&r, &v, sizeof(r));
-	return r;
+simde__m128d
+simde__m128d_from_private(simde__m128d_private v) {
+  simde__m128d r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d_private simde__m128d_to_private(simde__m128d v)
-{
-	simde__m128d_private r;
-	simde_memcpy(&r, &v, sizeof(r));
-	return r;
+simde__m128d_private
+simde__m128d_to_private(simde__m128d v) {
+  simde__m128d_private r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
 }
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int8x16_t, neon, i8)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int16x8_t, neon, i16)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int32x4_t, neon, i32)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int64x2_t, neon, i64)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint8x16_t, neon, u8)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint16x8_t, neon, u16)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint32x4_t, neon, u32)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint64x2_t, neon, u64)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, float32x4_t, neon, f32)
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, float64x2_t, neon, f64)
-#endif
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i,
-				       SIMDE_POWER_ALTIVEC_VECTOR(signed char),
-				       altivec, i8)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i,
-				       SIMDE_POWER_ALTIVEC_VECTOR(signed short),
-				       altivec, i16)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i,
-				       SIMDE_POWER_ALTIVEC_VECTOR(signed int),
-				       altivec, i32)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
-	m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), altivec, u8)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
-	m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), altivec, u16)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i,
-				       SIMDE_POWER_ALTIVEC_VECTOR(unsigned int),
-				       altivec, u32)
-#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
-	m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
-	m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
-#endif
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int8x16_t, neon, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int16x8_t, neon, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int32x4_t, neon, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int64x2_t, neon, i64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint8x16_t, neon, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint16x8_t, neon, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint32x4_t, neon, u32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint64x2_t, neon, u64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, float32x4_t, neon, f32)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, float64x2_t, neon, f64)
+  #endif
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed char), altivec, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed short), altivec, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed int), altivec, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), altivec, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), altivec, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), altivec, u32)
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
+  #endif
 #endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int8x16_t, neon, i8)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int16x8_t, neon, i16)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int32x4_t, neon, i32)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int64x2_t, neon, i64)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint8x16_t, neon, u8)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint16x8_t, neon, u16)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint32x4_t, neon, u32)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint64x2_t, neon, u64)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, float32x4_t, neon, f32)
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, float64x2_t, neon, f64)
-#endif
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d,
-				       SIMDE_POWER_ALTIVEC_VECTOR(signed char),
-				       altivec, i8)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d,
-				       SIMDE_POWER_ALTIVEC_VECTOR(signed short),
-				       altivec, i16)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d,
-				       SIMDE_POWER_ALTIVEC_VECTOR(signed int),
-				       altivec, i32)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
-	m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), altivec, u8)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
-	m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), altivec, u16)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d,
-				       SIMDE_POWER_ALTIVEC_VECTOR(unsigned int),
-				       altivec, u32)
-#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
-	m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(
-	m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
-#if defined(SIMDE_BUG_GCC_95782)
-SIMDE_FUNCTION_ATTRIBUTES
-SIMDE_POWER_ALTIVEC_VECTOR(double)
-simde__m128d_to_altivec_f64(simde__m128d value)
-{
-	simde__m128d_private r_ = simde__m128d_to_private(value);
-	return r_.altivec_f64;
-}
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int8x16_t, neon, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int16x8_t, neon, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int32x4_t, neon, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int64x2_t, neon, i64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint8x16_t, neon, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint16x8_t, neon, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint32x4_t, neon, u32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint64x2_t, neon, u64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, float32x4_t, neon, f32)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, float64x2_t, neon, f64)
+  #endif
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed char), altivec, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed short), altivec, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed int), altivec, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), altivec, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), altivec, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), altivec, u32)
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
+    #if defined(SIMDE_BUG_GCC_95782)
+      SIMDE_FUNCTION_ATTRIBUTES
+      SIMDE_POWER_ALTIVEC_VECTOR(double)
+      simde__m128d_to_altivec_f64(simde__m128d value) {
+        simde__m128d_private r_ = simde__m128d_to_private(value);
+        return r_.altivec_f64;
+      }
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde__m128d_from_altivec_f64(SIMDE_POWER_ALTIVEC_VECTOR(double)
-						   value)
-{
-	simde__m128d_private r_;
-	r_.altivec_f64 = value;
-	return simde__m128d_from_private(r_);
-}
-#else
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d,
-				       SIMDE_POWER_ALTIVEC_VECTOR(double),
-				       altivec, f64)
-#endif
-#endif
+      SIMDE_FUNCTION_ATTRIBUTES
+      simde__m128d
+      simde__m128d_from_altivec_f64(SIMDE_POWER_ALTIVEC_VECTOR(double) value) {
+        simde__m128d_private r_;
+        r_.altivec_f64 = value;
+        return simde__m128d_from_private(r_);
+      }
+    #else
+      SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(double), altivec, f64)
+    #endif
+  #endif
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, v128_t, wasm, v128);
-SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, v128_t, wasm, v128);
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, v128_t, wasm, v128);
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, v128_t, wasm, v128);
 #endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_set_pd(simde_float64 e1, simde_float64 e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_set_pd(e1, e0);
-#else
-	simde__m128d_private r_;
+simde__m128d
+simde_mm_set_pd (simde_float64 e1, simde_float64 e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_pd(e1, e0);
+  #else
+    simde__m128d_private r_;
 
-#if defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_make(e0, e1);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	SIMDE_ALIGN_TO_16 simde_float64 data[2] = {e0, e1};
-	r_.neon_f64 = vld1q_f64(data);
-#else
-	r_.f64[0] = e0;
-	r_.f64[1] = e1;
-#endif
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_make(e0, e1);
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      SIMDE_ALIGN_TO_16 simde_float64 data[2] = { e0, e1 };
+      r_.neon_f64 = vld1q_f64(data);
+    #else
+      r_.f64[0] = e0;
+      r_.f64[1] = e1;
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_set_pd(e1, e0) simde_mm_set_pd(e1, e0)
+  #define _mm_set_pd(e1, e0) simde_mm_set_pd(e1, e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_set1_pd(simde_float64 a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_set1_pd(a);
-#else
-	simde__m128d_private r_;
+simde__m128d
+simde_mm_set1_pd (simde_float64 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_pd(a);
+  #else
+    simde__m128d_private r_;
 
-#if defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_splat(a);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vdupq_n_f64(a);
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-	r_.altivec_f64 = vec_splats(HEDLEY_STATIC_CAST(double, a));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
-		r_.f64[i] = a;
-	}
-#endif
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_splat(a);
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vdupq_n_f64(a);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_f64 = vec_splats(HEDLEY_STATIC_CAST(double, a));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.f64[i] = a;
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #define simde_mm_set_pd1(a) simde_mm_set1_pd(a)
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_set1_pd(a) simde_mm_set1_pd(a)
-#define _mm_set_pd1(a) simde_mm_set1_pd(a)
+  #define _mm_set1_pd(a) simde_mm_set1_pd(a)
+  #define _mm_set_pd1(a) simde_mm_set1_pd(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_x_mm_abs_pd(simde__m128d a)
-{
-#if defined(SIMDE_X86_AVX512F_NATIVE) && \
-	(!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7, 4, 0))
-	return _mm512_castpd512_pd128(_mm512_abs_pd(_mm512_castpd128_pd512(a)));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
+simde__m128d
+simde_x_mm_abs_pd(simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    simde_float64 mask_;
+    uint64_t u64_ = UINT64_C(0x7FFFFFFFFFFFFFFF);
+    simde_memcpy(&mask_, &u64_, sizeof(u64_));
+    return _mm_and_pd(_mm_set1_pd(mask_), a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A32V8_NATIVE)
-	r_.neon_f32 = vabsq_f32(a_.neon_f32);
-#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	r_.altivec_f32 = vec_abs(a_.altivec_f32);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.f64[i] = simde_math_fabs(a_.f64[i]);
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vabsq_f64(a_.neon_f64);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_f64 = vec_abs(a_.altivec_f64);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_fabs(a_.f64[i]);
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_x_mm_not_pd(simde__m128d a)
-{
-#if defined(SIMDE_X86_AVX512VL_NATIVE)
-	__m128i ai = _mm_castpd_si128(a);
-	return _mm_castsi128_pd(_mm_ternarylogic_epi64(ai, ai, ai, 0x55));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
+simde__m128d
+simde_x_mm_not_pd(simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    __m128i ai = _mm_castpd_si128(a);
+    return _mm_castsi128_pd(_mm_ternarylogic_epi64(ai, ai, ai, 0x55));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vmvnq_s32(a_.neon_i32);
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-	r_.altivec_f64 = vec_nor(a_.altivec_f64, a_.altivec_f64);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i32 = vec_nor(a_.altivec_i32, a_.altivec_i32);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_v128_not(a_.wasm_v128);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32f = ~a_.i32f;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
-		r_.i32f[i] = ~(a_.i32f[i]);
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vmvnq_s32(a_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_f64 = vec_nor(a_.altivec_f64, a_.altivec_f64);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_nor(a_.altivec_i32, a_.altivec_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_not(a_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = ~a_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = ~(a_.i32f[i]);
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_x_mm_select_pd(simde__m128d a, simde__m128d b,
-				  simde__m128d mask)
-{
-/* This function is for when you want to blend two elements together
+simde__m128d
+simde_x_mm_select_pd(simde__m128d a, simde__m128d b, simde__m128d mask) {
+  /* This function is for when you want to blend two elements together
    * according to a mask.  It is similar to _mm_blendv_pd, except that
    * it is undefined whether the blend is based on the highest bit in
    * each lane (like blendv) or just bitwise operations.  This allows
@@ -515,4719 +496,4706 @@ simde__m128d simde_x_mm_select_pd(simde__m128d a, simde__m128d b,
    *
    * Basically, you promise that all the lanes in mask are either 0 or
    * ~0. */
-#if defined(SIMDE_X86_SSE4_1_NATIVE)
-	return _mm_blendv_pd(a, b, mask);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b),
-				 mask_ = simde__m128d_to_private(mask);
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_blendv_pd(a, b, mask);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b),
+      mask_ = simde__m128d_to_private(mask);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i64 = a_.i64 ^ ((a_.i64 ^ b_.i64) & mask_.i64);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 = vbslq_s64(mask_.neon_u64, b_.neon_i64, a_.neon_i64);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
-		r_.i64[i] = a_.i64[i] ^
-			    ((a_.i64[i] ^ b_.i64[i]) & mask_.i64[i]);
-	}
-#endif
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 ^ ((a_.i64 ^ b_.i64) & mask_.i64);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vbslq_s64(mask_.neon_u64, b_.neon_i64, a_.neon_i64);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] ^ ((a_.i64[i] ^ b_.i64[i]) & mask_.i64[i]);
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_add_epi8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_add_epi8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_add_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i8 = vaddq_s8(a_.neon_i8, b_.neon_i8);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i8 = vec_add(a_.altivec_i8, b_.altivec_i8);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i8x16_add(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i8 = a_.i8 + b_.i8;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
-		r_.i8[i] = a_.i8[i] + b_.i8[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vaddq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i8 = vec_add(a_.altivec_i8, b_.altivec_i8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_add(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 + b_.i8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] + b_.i8[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_add_epi8(a, b) simde_mm_add_epi8(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_add_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_add_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i16 = vaddq_s16(a_.neon_i16, b_.neon_i16);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i16 = vec_add(a_.altivec_i16, b_.altivec_i16);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i16x8_add(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i16 = a_.i16 + b_.i16;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.i16[i] = a_.i16[i] + b_.i16[i];
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_add_epi16(a, b) simde_mm_add_epi16(a, b)
+  #define _mm_add_epi8(a, b) simde_mm_add_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_add_epi32(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_add_epi32(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_add_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vaddq_s32(a_.neon_i32, b_.neon_i32);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i32 = vec_add(a_.altivec_i32, b_.altivec_i32);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i32x4_add(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32 = a_.i32 + b_.i32;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		r_.i32[i] = a_.i32[i] + b_.i32[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vaddq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i16 = vec_add(a_.altivec_i16, b_.altivec_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_add(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 + b_.i16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] + b_.i16[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_add_epi32(a, b) simde_mm_add_epi32(a, b)
+  #define _mm_add_epi16(a, b) simde_mm_add_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_add_epi64(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_add_epi64(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_add_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 = vaddq_s64(a_.neon_i64, b_.neon_i64);
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-	r_.altivec_i64 = vec_add(a_.altivec_i64, b_.altivec_i64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i64x2_add(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i64 = a_.i64 + b_.i64;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
-		r_.i64[i] = a_.i64[i] + b_.i64[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vaddq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_add(a_.altivec_i32, b_.altivec_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_add(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 + b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] + b_.i32[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_add_epi64(a, b) simde_mm_add_epi64(a, b)
+  #define _mm_add_epi32(a, b) simde_mm_add_epi32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_add_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_add_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128i
+simde_mm_add_epi64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vaddq_f64(a_.neon_f64, b_.neon_f64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_add(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	r_.altivec_f64 = vec_add(a_.altivec_f64, b_.altivec_f64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_add(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.f64 = a_.f64 + b_.f64;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.f64[i] = a_.f64[i] + b_.f64[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vaddq_s64(a_.neon_i64, b_.neon_i64);
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+      r_.altivec_i64 = vec_add(a_.altivec_i64, b_.altivec_i64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i64x2_add(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 + b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] + b_.i64[i];
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_add_pd(a, b) simde_mm_add_pd(a, b)
+  #define _mm_add_epi64(a, b) simde_mm_add_epi64(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_move_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_move_sd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128d
+simde_mm_add_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 =
-		vsetq_lane_f64(vgetq_lane_f64(b_.neon_f64, 0), a_.neon_f64, 0);
-#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-#if defined(HEDLEY_IBM_VERSION)
-	r_.altivec_f64 = vec_xxpermdi(a_.altivec_f64, b_.altivec_f64, 1);
-#else
-	r_.altivec_f64 = vec_xxpermdi(b_.altivec_f64, a_.altivec_f64, 1);
-#endif
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_v64x2_shuffle(a_.wasm_v128, b_.wasm_v128, 2, 1);
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 2, 1);
-#else
-	r_.f64[0] = b_.f64[0];
-	r_.f64[1] = a_.f64[1];
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vaddq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_add(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_f64 = vec_add(a_.altivec_f64, b_.altivec_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_add(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 + b_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f64[i] + b_.f64[i];
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_move_sd(a, b) simde_mm_move_sd(a, b)
+  #define _mm_add_pd(a, b) simde_mm_add_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_add_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_add_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_add_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128d
+simde_mm_move_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_move_sd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-	r_.f64[0] = a_.f64[0] + b_.f64[0];
-	r_.f64[1] = a_.f64[1];
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vsetq_lane_f64(vgetq_lane_f64(b_.neon_f64, 0), a_.neon_f64, 0);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      #if defined(HEDLEY_IBM_VERSION)
+        r_.altivec_f64 = vec_xxpermdi(a_.altivec_f64, b_.altivec_f64, 1);
+      #else
+        r_.altivec_f64 = vec_xxpermdi(b_.altivec_f64, a_.altivec_f64, 1);
+      #endif
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i64x2_shuffle(a_.wasm_v128, b_.wasm_v128, 2, 1);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 2, 1);
+    #else
+      r_.f64[0] = b_.f64[0];
+      r_.f64[1] = a_.f64[1];
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_add_sd(a, b) simde_mm_add_sd(a, b)
+  #define _mm_move_sd(a, b) simde_mm_move_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m64 simde_mm_add_si64(simde__m64 a, simde__m64 b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-	return _mm_add_si64(a, b);
-#else
-	simde__m64_private r_, a_ = simde__m64_to_private(a),
-			       b_ = simde__m64_to_private(b);
+simde__m128d
+simde_x_mm_broadcastlow_pd(simde__m128d a) {
+  /* This function broadcasts the first element in the input vector to
+   * all lanes.  It is used to avoid generating spurious exceptions in
+   * *_sd functions since there may be garbage in the upper lanes. */
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 = vadd_s64(a_.neon_i64, b_.neon_i64);
-#else
-	r_.i64[0] = a_.i64[0] + b_.i64[0];
-#endif
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castsi128_pd(_mm_shuffle_epi32(_mm_castpd_si128(a), 0x44));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
 
-	return simde__m64_from_private(r_);
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vdupq_laneq_f64(a_.neon_f64, 0);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_f64 = vec_splat(a_.altivec_f64, 0);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, a_.f64, 0, 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f64[0];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_add_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_add_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_add_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.f64[0] = a_.f64[0] + b_.f64[0];
+    r_.f64[1] = a_.f64[1];
+
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_add_si64(a, b) simde_mm_add_si64(a, b)
+  #define _mm_add_sd(a, b) simde_mm_add_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_adds_epi8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_adds_epi8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m64
+simde_mm_add_si64 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_add_si64(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i8 = vqaddq_s8(a_.neon_i8, b_.neon_i8);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i8x16_add_saturate(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i8 = vec_adds(a_.altivec_i8, b_.altivec_i8);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
-		const int_fast16_t tmp =
-			HEDLEY_STATIC_CAST(int_fast16_t, a_.i8[i]) +
-			HEDLEY_STATIC_CAST(int_fast16_t, b_.i8[i]);
-		r_.i8[i] = HEDLEY_STATIC_CAST(
-			int8_t,
-			((tmp < INT8_MAX) ? ((tmp > INT8_MIN) ? tmp : INT8_MIN)
-					  : INT8_MAX));
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vadd_s64(a_.neon_i64, b_.neon_i64);
+    #else
+      r_.i64[0] = a_.i64[0] + b_.i64[0];
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m64_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_adds_epi8(a, b) simde_mm_adds_epi8(a, b)
+  #define _mm_add_si64(a, b) simde_mm_add_si64(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_adds_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_adds_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_adds_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_adds_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i16 = vqaddq_s16(a_.neon_i16, b_.neon_i16);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i16x8_add_saturate(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i16 = vec_adds(a_.altivec_i16, b_.altivec_i16);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		const int_fast32_t tmp =
-			HEDLEY_STATIC_CAST(int_fast32_t, a_.i16[i]) +
-			HEDLEY_STATIC_CAST(int_fast32_t, b_.i16[i]);
-		r_.i16[i] = HEDLEY_STATIC_CAST(
-			int16_t,
-			((tmp < INT16_MAX)
-				 ? ((tmp > INT16_MIN) ? tmp : INT16_MIN)
-				 : INT16_MAX));
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vqaddq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_add_sat(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i8 = vec_adds(a_.altivec_i8, b_.altivec_i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = simde_math_adds_i8(a_.i8[i], b_.i8[i]);
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_adds_epi16(a, b) simde_mm_adds_epi16(a, b)
+  #define _mm_adds_epi8(a, b) simde_mm_adds_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_adds_epu8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_adds_epu8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_adds_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_adds_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u8 = vqaddq_u8(a_.neon_u8, b_.neon_u8);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_u8x16_add_saturate(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	r_.altivec_u8 = vec_adds(a_.altivec_u8, b_.altivec_u8);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u8) / sizeof(r_.u8[0])); i++) {
-		r_.u8[i] = ((UINT8_MAX - a_.u8[i]) > b_.u8[i])
-				   ? (a_.u8[i] + b_.u8[i])
-				   : UINT8_MAX;
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vqaddq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_add_sat(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i16 = vec_adds(a_.altivec_i16, b_.altivec_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = simde_math_adds_i16(a_.i16[i], b_.i16[i]);
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_adds_epu8(a, b) simde_mm_adds_epu8(a, b)
+  #define _mm_adds_epi16(a, b) simde_mm_adds_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_adds_epu16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_adds_epu16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_adds_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_adds_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u16 = vqaddq_u16(a_.neon_u16, b_.neon_u16);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_u16x8_add_saturate(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_u16 = vec_adds(a_.altivec_u16, b_.altivec_u16);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u16) / sizeof(r_.u16[0])); i++) {
-		r_.u16[i] = ((UINT16_MAX - a_.u16[i]) > b_.u16[i])
-				    ? (a_.u16[i] + b_.u16[i])
-				    : UINT16_MAX;
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vqaddq_u8(a_.neon_u8, b_.neon_u8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u8x16_add_sat(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_u8 = vec_adds(a_.altivec_u8, b_.altivec_u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = simde_math_adds_u8(a_.u8[i], b_.u8[i]);
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_adds_epu16(a, b) simde_mm_adds_epu16(a, b)
+  #define _mm_adds_epu8(a, b) simde_mm_adds_epu8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_and_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_and_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128i
+simde_mm_adds_epu16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_adds_epu16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vandq_s32(a_.neon_i32, b_.neon_i32);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_v128_and(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	r_.altivec_f64 = vec_and(a_.altivec_f64, b_.altivec_f64);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32f = a_.i32f & b_.i32f;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
-		r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vqaddq_u16(a_.neon_u16, b_.neon_u16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u16x8_add_sat(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u16 = vec_adds(a_.altivec_u16, b_.altivec_u16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = simde_math_adds_u16(a_.u16[i], b_.u16[i]);
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_and_pd(a, b) simde_mm_and_pd(a, b)
+  #define _mm_adds_epu16(a, b) simde_mm_adds_epu16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_and_si128(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_and_si128(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128d
+simde_mm_and_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_and_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vandq_s32(b_.neon_i32, a_.neon_i32);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_u32f = vec_and(a_.altivec_u32f, b_.altivec_u32f);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32f = a_.i32f & b_.i32f;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
-		r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vandq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_and(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_f64 = vec_and(a_.altivec_f64, b_.altivec_f64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_and_si128(a, b) simde_mm_and_si128(a, b)
+  #define _mm_and_pd(a, b) simde_mm_and_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_andnot_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_andnot_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128i
+simde_mm_and_si128 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_and_si128(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_v128_andnot(b_.wasm_v128, a_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	r_.altivec_f64 = vec_andc(b_.altivec_f64, a_.altivec_f64);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i32f = vec_andc(b_.altivec_i32f, a_.altivec_i32f);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32f = ~a_.i32f & b_.i32f;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u64) / sizeof(r_.u64[0])); i++) {
-		r_.u64[i] = ~a_.u64[i] & b_.u64[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vandq_s32(b_.neon_i32, a_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u32f = vec_and(a_.altivec_u32f, b_.altivec_u32f);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_andnot_pd(a, b) simde_mm_andnot_pd(a, b)
+  #define _mm_and_si128(a, b) simde_mm_and_si128(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_andnot_si128(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_andnot_si128(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128d
+simde_mm_andnot_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_andnot_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i32 = vec_andc(b_.altivec_i32, a_.altivec_i32);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32f = ~a_.i32f & b_.i32f;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
-		r_.i32f[i] = ~(a_.i32f[i]) & b_.i32f[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_andnot(b_.wasm_v128, a_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_f64 = vec_andc(b_.altivec_f64, a_.altivec_f64);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32f = vec_andc(b_.altivec_i32f, a_.altivec_i32f);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = ~a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = ~a_.u64[i] & b_.u64[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_andnot_si128(a, b) simde_mm_andnot_si128(a, b)
+  #define _mm_andnot_pd(a, b) simde_mm_andnot_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_xor_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_xor_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128i
+simde_mm_andnot_si128 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_andnot_si128(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32f = a_.i32f ^ b_.i32f;
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_v128_xor(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 = veorq_s64(a_.neon_i64, b_.neon_i64);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
-		r_.i32f[i] = a_.i32f[i] ^ b_.i32f[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i32 = vec_andc(b_.altivec_i32, a_.altivec_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = ~a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = ~(a_.i32f[i]) & b_.i32f[i];
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_xor_pd(a, b) simde_mm_xor_pd(a, b)
+  #define _mm_andnot_si128(a, b) simde_mm_andnot_si128(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_avg_epu8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_avg_epu8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128d
+simde_mm_xor_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_xor_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u8 = vrhaddq_u8(b_.neon_u8, a_.neon_u8);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_u8x16_avgr(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_u8 = vec_avg(a_.altivec_u8, b_.altivec_u8);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) &&      \
-	defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && \
-	defined(SIMDE_CONVERT_VECTOR_)
-	uint16_t wa SIMDE_VECTOR(32);
-	uint16_t wb SIMDE_VECTOR(32);
-	uint16_t wr SIMDE_VECTOR(32);
-	SIMDE_CONVERT_VECTOR_(wa, a_.u8);
-	SIMDE_CONVERT_VECTOR_(wb, b_.u8);
-	wr = (wa + wb + 1) >> 1;
-	SIMDE_CONVERT_VECTOR_(r_.u8, wr);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u8) / sizeof(r_.u8[0])); i++) {
-		r_.u8[i] = (a_.u8[i] + b_.u8[i] + 1) >> 1;
-	}
-#endif
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f ^ b_.i32f;
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_xor(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = veorq_s64(a_.neon_i64, b_.neon_i64);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] ^ b_.i32f[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_avg_epu8(a, b) simde_mm_avg_epu8(a, b)
+  #define _mm_xor_pd(a, b) simde_mm_xor_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_avg_epu16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_avg_epu16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_avg_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_avg_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u16 = vrhaddq_u16(b_.neon_u16, a_.neon_u16);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_u16x8_avgr(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_u16 = vec_avg(a_.altivec_u16, b_.altivec_u16);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) &&      \
-	defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && \
-	defined(SIMDE_CONVERT_VECTOR_)
-	uint32_t wa SIMDE_VECTOR(32);
-	uint32_t wb SIMDE_VECTOR(32);
-	uint32_t wr SIMDE_VECTOR(32);
-	SIMDE_CONVERT_VECTOR_(wa, a_.u16);
-	SIMDE_CONVERT_VECTOR_(wb, b_.u16);
-	wr = (wa + wb + 1) >> 1;
-	SIMDE_CONVERT_VECTOR_(r_.u16, wr);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u16) / sizeof(r_.u16[0])); i++) {
-		r_.u16[i] = (a_.u16[i] + b_.u16[i] + 1) >> 1;
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vrhaddq_u8(b_.neon_u8, a_.neon_u8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u8x16_avgr(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_u8 = vec_avg(a_.altivec_u8, b_.altivec_u8);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && defined(SIMDE_CONVERT_VECTOR_)
+      uint16_t wa SIMDE_VECTOR(32);
+      uint16_t wb SIMDE_VECTOR(32);
+      uint16_t wr SIMDE_VECTOR(32);
+      SIMDE_CONVERT_VECTOR_(wa, a_.u8);
+      SIMDE_CONVERT_VECTOR_(wb, b_.u8);
+      wr = (wa + wb + 1) >> 1;
+      SIMDE_CONVERT_VECTOR_(r_.u8, wr);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] + b_.u8[i] + 1) >> 1;
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_avg_epu16(a, b) simde_mm_avg_epu16(a, b)
+  #define _mm_avg_epu8(a, b) simde_mm_avg_epu8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_setzero_si128(void)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_setzero_si128();
-#else
-	simde__m128i_private r_;
+simde__m128i
+simde_mm_avg_epu16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_avg_epu16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vdupq_n_s32(0);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, 0));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i32x4_splat(INT32_C(0));
-#elif defined(SIMDE_VECTOR_SUBSCRIPT)
-	r_.i32 = __extension__(__typeof__(r_.i32)){0, 0, 0, 0};
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
-		r_.i32f[i] = 0;
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vrhaddq_u16(b_.neon_u16, a_.neon_u16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u16x8_avgr(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_u16 = vec_avg(a_.altivec_u16, b_.altivec_u16);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && defined(SIMDE_CONVERT_VECTOR_)
+      uint32_t wa SIMDE_VECTOR(32);
+      uint32_t wb SIMDE_VECTOR(32);
+      uint32_t wr SIMDE_VECTOR(32);
+      SIMDE_CONVERT_VECTOR_(wa, a_.u16);
+      SIMDE_CONVERT_VECTOR_(wb, b_.u16);
+      wr = (wa + wb + 1) >> 1;
+      SIMDE_CONVERT_VECTOR_(r_.u16, wr);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = (a_.u16[i] + b_.u16[i] + 1) >> 1;
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_setzero_si128() (simde_mm_setzero_si128())
+  #define _mm_avg_epu16(a, b) simde_mm_avg_epu16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_bslli_si128(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-{
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
+simde__m128i
+simde_mm_setzero_si128 (void) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_setzero_si128();
+  #else
+    simde__m128i_private r_;
 
-	if (HEDLEY_UNLIKELY((imm8 & ~15))) {
-		return simde_mm_setzero_si128();
-	}
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vdupq_n_s32(0);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, 0));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_splat(INT32_C(0));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT)
+      r_.i32 = __extension__ (__typeof__(r_.i32)) { 0, 0, 0, 0 };
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = 0;
+      }
+    #endif
 
-#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
-	r_.altivec_i8 =
-#if (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
-		vec_slo
-#else /* SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG */
-		vec_sro
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_setzero_si128() (simde_mm_setzero_si128())
 #endif
-		(a_.altivec_i8,
-		 vec_splats(HEDLEY_STATIC_CAST(unsigned char, imm8 * 8)));
-#elif defined(SIMDE_HAVE_INT128_) && (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
-	r_.u128[0] = a_.u128[0] << (imm8 * 8);
-#else
-	r_ = simde__m128i_to_private(simde_mm_setzero_si128());
-	for (int i = imm8;
-	     i < HEDLEY_STATIC_CAST(int, sizeof(r_.i8) / sizeof(r_.i8[0]));
-	     i++) {
-		r_.i8[i] = a_.i8[i - imm8];
-	}
-#endif
 
-	return simde__m128i_from_private(r_);
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_bslli_si128 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  if (HEDLEY_UNLIKELY((imm8 & ~15))) {
+    return simde_mm_setzero_si128();
+  }
+
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
+    r_.altivec_i8 =
+      #if (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
+        vec_slo
+      #else /* SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG */
+        vec_sro
+      #endif
+        (a_.altivec_i8, vec_splats(HEDLEY_STATIC_CAST(unsigned char, imm8 * 8)));
+  #elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    r_.altivec_i8 = vec_srb(a_.altivec_i8, vec_splats(HEDLEY_STATIC_CAST(unsigned char, (imm8 & 15) << 3)));
+  #elif defined(SIMDE_HAVE_INT128_) && (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
+    r_.u128[0] = a_.u128[0] << (imm8 * 8);
+  #else
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    for (int i = imm8 ; i < HEDLEY_STATIC_CAST(int, sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] = a_.i8[i - imm8];
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-#define simde_mm_bslli_si128(a, imm8) _mm_slli_si128(a, imm8)
+  #define simde_mm_bslli_si128(a, imm8) _mm_slli_si128(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
-#define simde_mm_bslli_si128(a, imm8)                                      \
-	simde__m128i_from_neon_i8(                                         \
-		((imm8) <= 0)                                              \
-			? simde__m128i_to_neon_i8(a)                       \
-			: (((imm8) > 15)                                   \
-				   ? (vdupq_n_s8(0))                       \
-				   : (vextq_s8(vdupq_n_s8(0),              \
-					       simde__m128i_to_neon_i8(a), \
-					       16 - (imm8)))))
-#elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-#define simde_mm_bslli_si128(a, imm8)                                          \
-	(__extension__({                                                       \
-		const simde__m128i_private simde__tmp_a_ =                     \
-			simde__m128i_to_private(a);                            \
-		const simde__m128i_private simde__tmp_z_ =                     \
-			simde__m128i_to_private(simde_mm_setzero_si128());     \
-		simde__m128i_private simde__tmp_r_;                            \
-		if (HEDLEY_UNLIKELY(imm8 > 15)) {                              \
-			simde__tmp_r_ = simde__m128i_to_private(               \
-				simde_mm_setzero_si128());                     \
-		} else {                                                       \
-			simde__tmp_r_.i8 = SIMDE_SHUFFLE_VECTOR_(              \
-				8, 16, simde__tmp_z_.i8, (simde__tmp_a_).i8,   \
-				HEDLEY_STATIC_CAST(int8_t, (16 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (17 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (18 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (19 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (20 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (21 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (22 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (23 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (24 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (25 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (26 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (27 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (28 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (29 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (30 - imm8) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (31 - imm8) & 31)); \
-		}                                                              \
-		simde__m128i_from_private(simde__tmp_r_);                      \
-	}))
+  #define simde_mm_bslli_si128(a, imm8) \
+  simde__m128i_from_neon_i8(((imm8) <= 0) ? simde__m128i_to_neon_i8(a) : (((imm8) > 15) ? (vdupq_n_s8(0)) : (vextq_s8(vdupq_n_s8(0), simde__m128i_to_neon_i8(a), 16 - (imm8)))))
+#elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && !defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+  #define simde_mm_bslli_si128(a, imm8) (__extension__ ({ \
+    const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
+    const simde__m128i_private simde__tmp_z_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
+    simde__m128i_private simde__tmp_r_; \
+    if (HEDLEY_UNLIKELY(imm8 > 15)) { \
+      simde__tmp_r_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
+    } else { \
+      simde__tmp_r_.i8 = \
+        SIMDE_SHUFFLE_VECTOR_(8, 16, \
+          simde__tmp_z_.i8, \
+          (simde__tmp_a_).i8, \
+          HEDLEY_STATIC_CAST(int8_t, (16 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (17 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (18 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (19 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (20 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (21 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (22 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (23 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (24 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (25 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (26 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (27 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (28 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (29 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (30 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (31 - imm8) & 31)); \
+    } \
+    simde__m128i_from_private(simde__tmp_r_); }))
 #endif
 #define simde_mm_slli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_bslli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
-#define _mm_slli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
+  #define _mm_bslli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
+  #define _mm_slli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_bsrli_si128(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-{
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
+simde__m128i
+simde_mm_bsrli_si128 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
 
-	if (HEDLEY_UNLIKELY((imm8 & ~15))) {
-		return simde_mm_setzero_si128();
-	}
+  if (HEDLEY_UNLIKELY((imm8 & ~15))) {
+    return simde_mm_setzero_si128();
+  }
 
-#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
-	r_.altivec_i8 =
-#if (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
-		vec_sro
-#else /* SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG */
-		vec_slo
-#endif
-		(a_.altivec_i8,
-		 vec_splats(HEDLEY_STATIC_CAST(unsigned char, imm8 * 8)));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
-		const int e = HEDLEY_STATIC_CAST(int, i) + imm8;
-		r_.i8[i] = (e < 16) ? a_.i8[e] : 0;
-	}
-#endif
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
+    r_.altivec_i8 =
+    #if (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
+      vec_sro
+    #else /* SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG */
+      vec_slo
+    #endif
+        (a_.altivec_i8, vec_splats(HEDLEY_STATIC_CAST(unsigned char, imm8 * 8)));
+  #elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+    r_.altivec_i8 = vec_slb(a_.altivec_i8, vec_splats(HEDLEY_STATIC_CAST(unsigned char, (imm8 & 15) << 3)));
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      const int e = HEDLEY_STATIC_CAST(int, i) + imm8;
+      r_.i8[i] = (e < 16) ? a_.i8[e] : 0;
+    }
+  #endif
 
-	return simde__m128i_from_private(r_);
+  return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-#define simde_mm_bsrli_si128(a, imm8) _mm_srli_si128(a, imm8)
+  #define simde_mm_bsrli_si128(a, imm8) _mm_srli_si128(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
-#define simde_mm_bsrli_si128(a, imm8)                                   \
-	simde__m128i_from_neon_i8(                                      \
-		((imm8 < 0) || (imm8 > 15))                             \
-			? vdupq_n_s8(0)                                 \
-			: (vextq_s8(simde__m128i_to_private(a).neon_i8, \
-				    vdupq_n_s8(0),                      \
-				    ((imm8 & 15) != 0) ? imm8 : (imm8 & 15))))
-#elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-#define simde_mm_bsrli_si128(a, imm8)                                          \
-	(__extension__({                                                       \
-		const simde__m128i_private simde__tmp_a_ =                     \
-			simde__m128i_to_private(a);                            \
-		const simde__m128i_private simde__tmp_z_ =                     \
-			simde__m128i_to_private(simde_mm_setzero_si128());     \
-		simde__m128i_private simde__tmp_r_ =                           \
-			simde__m128i_to_private(a);                            \
-		if (HEDLEY_UNLIKELY(imm8 > 15)) {                              \
-			simde__tmp_r_ = simde__m128i_to_private(               \
-				simde_mm_setzero_si128());                     \
-		} else {                                                       \
-			simde__tmp_r_.i8 = SIMDE_SHUFFLE_VECTOR_(              \
-				8, 16, simde__tmp_z_.i8, (simde__tmp_a_).i8,   \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 16) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 17) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 18) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 19) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 20) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 21) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 22) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 23) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 24) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 25) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 26) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 27) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 28) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 29) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 30) & 31),  \
-				HEDLEY_STATIC_CAST(int8_t, (imm8 + 31) & 31)); \
-		}                                                              \
-		simde__m128i_from_private(simde__tmp_r_);                      \
-	}))
+  #define simde_mm_bsrli_si128(a, imm8) \
+  simde__m128i_from_neon_i8(((imm8 < 0) || (imm8 > 15)) ? vdupq_n_s8(0) : (vextq_s8(simde__m128i_to_private(a).neon_i8, vdupq_n_s8(0), ((imm8 & 15) != 0) ? imm8 : (imm8 & 15))))
+#elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && !defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+  #define simde_mm_bsrli_si128(a, imm8) (__extension__ ({ \
+    const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
+    const simde__m128i_private simde__tmp_z_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
+    simde__m128i_private simde__tmp_r_ = simde__m128i_to_private(a); \
+    if (HEDLEY_UNLIKELY(imm8 > 15)) { \
+      simde__tmp_r_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
+    } else { \
+      simde__tmp_r_.i8 = \
+      SIMDE_SHUFFLE_VECTOR_(8, 16, \
+        simde__tmp_z_.i8, \
+        (simde__tmp_a_).i8, \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 16) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 17) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 18) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 19) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 20) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 21) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 22) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 23) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 24) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 25) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 26) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 27) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 28) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 29) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 30) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 31) & 31)); \
+    } \
+    simde__m128i_from_private(simde__tmp_r_); }))
 #endif
 #define simde_mm_srli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_bsrli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
-#define _mm_srli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_clflush(void const *p)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_clflush(p);
-#else
-	(void)p;
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_clflush(a, b) simde_mm_clflush()
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-int simde_mm_comieq_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_comieq_sd(a, b);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a),
-			     b_ = simde__m128d_to_private(b);
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return !!vgetq_lane_u64(vceqq_f64(a_.neon_f64, b_.neon_f64), 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) ==
-	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-#else
-	return a_.f64[0] == b_.f64[0];
-#endif
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_comieq_sd(a, b) simde_mm_comieq_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-int simde_mm_comige_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_comige_sd(a, b);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a),
-			     b_ = simde__m128d_to_private(b);
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return !!vgetq_lane_u64(vcgeq_f64(a_.neon_f64, b_.neon_f64), 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >=
-	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-#else
-	return a_.f64[0] >= b_.f64[0];
-#endif
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_comige_sd(a, b) simde_mm_comige_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-int simde_mm_comigt_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_comigt_sd(a, b);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a),
-			     b_ = simde__m128d_to_private(b);
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return !!vgetq_lane_u64(vcgtq_f64(a_.neon_f64, b_.neon_f64), 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >
-	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-#else
-	return a_.f64[0] > b_.f64[0];
-#endif
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_comigt_sd(a, b) simde_mm_comigt_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-int simde_mm_comile_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_comile_sd(a, b);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a),
-			     b_ = simde__m128d_to_private(b);
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return !!vgetq_lane_u64(vcleq_f64(a_.neon_f64, b_.neon_f64), 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <=
-	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-#else
-	return a_.f64[0] <= b_.f64[0];
-#endif
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_comile_sd(a, b) simde_mm_comile_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-int simde_mm_comilt_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_comilt_sd(a, b);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a),
-			     b_ = simde__m128d_to_private(b);
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return !!vgetq_lane_u64(vcltq_f64(a_.neon_f64, b_.neon_f64), 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <
-	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-#else
-	return a_.f64[0] < b_.f64[0];
-#endif
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_comilt_sd(a, b) simde_mm_comilt_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-int simde_mm_comineq_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_comineq_sd(a, b);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a),
-			     b_ = simde__m128d_to_private(b);
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return !vgetq_lane_u64(vceqq_f64(a_.neon_f64, b_.neon_f64), 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) !=
-	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-#else
-	return a_.f64[0] != b_.f64[0];
-#endif
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_comineq_sd(a, b) simde_mm_comineq_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_x_mm_copysign_pd(simde__m128d dest, simde__m128d src)
-{
-	simde__m128d_private r_, dest_ = simde__m128d_to_private(dest),
-				 src_ = simde__m128d_to_private(src);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	uint64x2_t sign_pos =
-		vreinterpretq_u64_f64(vdupq_n_f64(-SIMDE_FLOAT64_C(0.0)));
-#else
-	simde_float64 dbl_nz = -SIMDE_FLOAT64_C(0.0);
-	uint64_t u64_nz;
-	simde_memcpy(&u64_nz, &dbl_nz, sizeof(u64_nz));
-	uint64x2_t sign_pos = vdupq_n_u64(u64_nz);
-#endif
-	r_.neon_u64 = vbslq_u64(sign_pos, src_.neon_u64, dest_.neon_u64);
-#elif defined(SIMDE_POWER_ALTIVEC_P9_NATIVE)
-#if !defined(HEDLEY_IBM_VERSION)
-	r_.altivec_f64 = vec_cpsgn(dest_.altivec_f64, src_.altivec_f64);
-#else
-	r_.altivec_f64 = vec_cpsgn(src_.altivec_f64, dest_.altivec_f64);
-#endif
-#elif defined(simde_math_copysign)
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.f64[i] = simde_math_copysign(dest_.f64[i], src_.f64[i]);
-	}
-#else
-	simde__m128d sgnbit = simde_mm_set1_pd(-SIMDE_FLOAT64_C(0.0));
-	return simde_mm_xor_pd(simde_mm_and_pd(sgnbit, src),
-			       simde_mm_andnot_pd(sgnbit, dest));
-#endif
-
-	return simde__m128d_from_private(r_);
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_x_mm_xorsign_pd(simde__m128d dest, simde__m128d src)
-{
-	return simde_mm_xor_pd(simde_mm_and_pd(simde_mm_set1_pd(-0.0), src),
-			       dest);
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128 simde_mm_castpd_ps(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_castpd_ps(a);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return vreinterpretq_f32_f64(a);
-#else
-	simde__m128 r;
-	simde_memcpy(&r, &a, sizeof(a));
-	return r;
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_castpd_ps(a) simde_mm_castpd_ps(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_castpd_si128(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_castpd_si128(a);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return vreinterpretq_s64_f64(a);
-#else
-	simde__m128i r;
-	simde_memcpy(&r, &a, sizeof(a));
-	return r;
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_castpd_si128(a) simde_mm_castpd_si128(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_castps_pd(simde__m128 a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_castps_pd(a);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return vreinterpretq_f64_f32(a);
-#else
-	simde__m128d r;
-	simde_memcpy(&r, &a, sizeof(a));
-	return r;
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_castps_pd(a) simde_mm_castps_pd(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_castps_si128(simde__m128 a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_castps_si128(a);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	return simde__m128i_from_neon_i32(simde__m128_to_private(a).neon_i32);
-#else
-	simde__m128i r;
-	simde_memcpy(&r, &a, sizeof(a));
-	return r;
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_castps_si128(a) simde_mm_castps_si128(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_castsi128_pd(simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_castsi128_pd(a);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return vreinterpretq_f64_s64(a);
-#else
-	simde__m128d r;
-	simde_memcpy(&r, &a, sizeof(a));
-	return r;
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_castsi128_pd(a) simde_mm_castsi128_pd(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128 simde_mm_castsi128_ps(simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_castsi128_ps(a);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), a);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	return simde__m128_from_neon_i32(simde__m128i_to_private(a).neon_i32);
-#else
-	simde__m128 r;
-	simde_memcpy(&r, &a, sizeof(a));
-	return r;
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_castsi128_ps(a) simde_mm_castsi128_ps(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cmpeq_epi8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpeq_epi8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u8 = vceqq_s8(b_.neon_i8, a_.neon_i8);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i8x16_eq(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(
-		SIMDE_POWER_ALTIVEC_VECTOR(signed char),
-		vec_cmpeq(a_.altivec_i8, b_.altivec_i8));
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 == b_.i8));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
-		r_.i8[i] = (a_.i8[i] == b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpeq_epi8(a, b) simde_mm_cmpeq_epi8(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cmpeq_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpeq_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u16 = vceqq_s16(b_.neon_i16, a_.neon_i16);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i16x8_eq(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(
-		SIMDE_POWER_ALTIVEC_VECTOR(signed short),
-		vec_cmpeq(a_.altivec_i16, b_.altivec_i16));
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i16 = (a_.i16 == b_.i16);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.i16[i] = (a_.i16[i] == b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpeq_epi16(a, b) simde_mm_cmpeq_epi16(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cmpeq_epi32(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpeq_epi32(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u32 = vceqq_s32(b_.neon_i32, a_.neon_i32);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i32x4_eq(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(
-		SIMDE_POWER_ALTIVEC_VECTOR(signed int),
-		vec_cmpeq(a_.altivec_i32, b_.altivec_i32));
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), a_.i32 == b_.i32);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		r_.i32[i] = (a_.i32[i] == b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpeq_epi32(a, b) simde_mm_cmpeq_epi32(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpeq_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpeq_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_u64 = vceqq_s64(b_.neon_i64, a_.neon_i64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_eq(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(
-		SIMDE_POWER_ALTIVEC_VECTOR(double),
-		vec_cmpeq(a_.altivec_f64, b_.altivec_f64));
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.u64[i] = (a_.f64[i] == b_.f64[i]) ? ~UINT64_C(0)
-						     : UINT64_C(0);
-	}
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpeq_pd(a, b) simde_mm_cmpeq_pd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpeq_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpeq_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_cmpeq_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-	r_.u64[0] = (a_.u64[0] == b_.u64[0]) ? ~UINT64_C(0) : 0;
-	r_.u64[1] = a_.u64[1];
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpeq_sd(a, b) simde_mm_cmpeq_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpneq_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpneq_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_u32 = vmvnq_u32(
-		vreinterpretq_u32_u64(vceqq_f64(b_.neon_f64, a_.neon_f64)));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_ne(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 != b_.f64));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.u64[i] = (a_.f64[i] != b_.f64[i]) ? ~UINT64_C(0)
-						     : UINT64_C(0);
-	}
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpneq_pd(a, b) simde_mm_cmpneq_pd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpneq_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpneq_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_cmpneq_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-	r_.u64[0] = (a_.f64[0] != b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
-	r_.u64[1] = a_.u64[1];
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpneq_sd(a, b) simde_mm_cmpneq_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cmplt_epi8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmplt_epi8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u8 = vcltq_s8(a_.neon_i8, b_.neon_i8);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(
-		SIMDE_POWER_ALTIVEC_VECTOR(signed char),
-		vec_cmplt(a_.altivec_i8, b_.altivec_i8));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i8x16_lt(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 < b_.i8));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
-		r_.i8[i] = (a_.i8[i] < b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmplt_epi8(a, b) simde_mm_cmplt_epi8(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cmplt_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmplt_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u16 = vcltq_s16(a_.neon_i16, b_.neon_i16);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(
-		SIMDE_POWER_ALTIVEC_VECTOR(signed short),
-		vec_cmplt(a_.altivec_i16, b_.altivec_i16));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i16x8_lt(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i16 = HEDLEY_STATIC_CAST(__typeof__(r_.i16), (a_.i16 < b_.i16));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.i16[i] = (a_.i16[i] < b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmplt_epi16(a, b) simde_mm_cmplt_epi16(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cmplt_epi32(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmplt_epi32(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u32 = vcltq_s32(a_.neon_i32, b_.neon_i32);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(
-		SIMDE_POWER_ALTIVEC_VECTOR(signed int),
-		vec_cmplt(a_.altivec_i32, b_.altivec_i32));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i32x4_lt(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.i32 < b_.i32));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		r_.i32[i] = (a_.i32[i] < b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmplt_epi32(a, b) simde_mm_cmplt_epi32(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmplt_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmplt_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 < b_.f64));
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_u64 = vcltq_f64(a_.neon_f64, b_.neon_f64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_lt(a_.wasm_v128, b_.wasm_v128);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.u64[i] = (a_.f64[i] < b_.f64[i]) ? ~UINT64_C(0)
-						    : UINT64_C(0);
-	}
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmplt_pd(a, b) simde_mm_cmplt_pd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmplt_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmplt_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_cmplt_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-	r_.u64[0] = (a_.f64[0] < b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
-	r_.u64[1] = a_.u64[1];
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmplt_sd(a, b) simde_mm_cmplt_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmple_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmple_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_u64 = vcleq_f64(a_.neon_f64, b_.neon_f64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_le(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(
-		SIMDE_POWER_ALTIVEC_VECTOR(double),
-		vec_cmple(a_.altivec_f64, b_.altivec_f64));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.u64[i] = (a_.f64[i] <= b_.f64[i]) ? ~UINT64_C(0)
-						     : UINT64_C(0);
-	}
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmple_pd(a, b) simde_mm_cmple_pd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmple_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmple_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_cmple_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-	r_.u64[0] = (a_.f64[0] <= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
-	r_.u64[1] = a_.u64[1];
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmple_sd(a, b) simde_mm_cmple_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cmpgt_epi8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpgt_epi8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u8 = vcgtq_s8(a_.neon_i8, b_.neon_i8);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i8x16_gt(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(
-		SIMDE_POWER_ALTIVEC_VECTOR(signed char),
-		vec_cmpgt(a_.altivec_i8, b_.altivec_i8));
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 > b_.i8));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
-		r_.i8[i] = (a_.i8[i] > b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpgt_epi8(a, b) simde_mm_cmpgt_epi8(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cmpgt_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpgt_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u16 = vcgtq_s16(a_.neon_i16, b_.neon_i16);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i16x8_gt(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(
-		SIMDE_POWER_ALTIVEC_VECTOR(signed short),
-		vec_cmpgt(a_.altivec_i16, b_.altivec_i16));
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i16 = HEDLEY_STATIC_CAST(__typeof__(r_.i16), (a_.i16 > b_.i16));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpgt_epi16(a, b) simde_mm_cmpgt_epi16(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cmpgt_epi32(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpgt_epi32(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u32 = vcgtq_s32(a_.neon_i32, b_.neon_i32);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i32x4_gt(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(
-		SIMDE_POWER_ALTIVEC_VECTOR(signed int),
-		vec_cmpgt(a_.altivec_i32, b_.altivec_i32));
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.i32 > b_.i32));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		r_.i32[i] = (a_.i32[i] > b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpgt_epi32(a, b) simde_mm_cmpgt_epi32(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpgt_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpgt_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_u64 = vcgtq_f64(a_.neon_f64, b_.neon_f64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_gt(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_f64 =
-		HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double),
-				   vec_cmpgt(a_.altivec_f64, b_.altivec_f64));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.u64[i] = (a_.f64[i] > b_.f64[i]) ? ~UINT64_C(0)
-						    : UINT64_C(0);
-	}
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpgt_pd(a, b) simde_mm_cmpgt_pd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpgt_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-	return _mm_cmpgt_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_cmpgt_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-	r_.u64[0] = (a_.f64[0] > b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
-	r_.u64[1] = a_.u64[1];
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpgt_sd(a, b) simde_mm_cmpgt_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpge_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpge_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_u64 = vcgeq_f64(a_.neon_f64, b_.neon_f64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_ge(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_f64 =
-		HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double),
-				   vec_cmpge(a_.altivec_f64, b_.altivec_f64));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.u64[i] = (a_.f64[i] >= b_.f64[i]) ? ~UINT64_C(0)
-						     : UINT64_C(0);
-	}
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpge_pd(a, b) simde_mm_cmpge_pd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpge_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-	return _mm_cmpge_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_cmpge_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-	r_.u64[0] = (a_.f64[0] >= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
-	r_.u64[1] = a_.u64[1];
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpge_sd(a, b) simde_mm_cmpge_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpngt_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpngt_pd(a, b);
-#else
-	return simde_mm_cmple_pd(a, b);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpngt_pd(a, b) simde_mm_cmpngt_pd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpngt_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-	return _mm_cmpngt_sd(a, b);
-#else
-	return simde_mm_cmple_sd(a, b);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpngt_sd(a, b) simde_mm_cmpngt_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpnge_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpnge_pd(a, b);
-#else
-	return simde_mm_cmplt_pd(a, b);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpnge_pd(a, b) simde_mm_cmpnge_pd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpnge_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-	return _mm_cmpnge_sd(a, b);
-#else
-	return simde_mm_cmplt_sd(a, b);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpnge_sd(a, b) simde_mm_cmpnge_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpnlt_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpnlt_pd(a, b);
-#else
-	return simde_mm_cmpge_pd(a, b);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpnlt_pd(a, b) simde_mm_cmpnlt_pd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpnlt_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpnlt_sd(a, b);
-#else
-	return simde_mm_cmpge_sd(a, b);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpnlt_sd(a, b) simde_mm_cmpnlt_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpnle_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpnle_pd(a, b);
-#else
-	return simde_mm_cmpgt_pd(a, b);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpnle_pd(a, b) simde_mm_cmpnle_pd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpnle_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpnle_sd(a, b);
-#else
-	return simde_mm_cmpgt_sd(a, b);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpnle_sd(a, b) simde_mm_cmpnle_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpord_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpord_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	/* Note: NEON does not have ordered compare builtin
-        Need to compare a eq a and b eq b to check for NaN
-        Do AND of results to get final */
-	uint64x2_t ceqaa = vceqq_f64(a_.neon_f64, a_.neon_f64);
-	uint64x2_t ceqbb = vceqq_f64(b_.neon_f64, b_.neon_f64);
-	r_.neon_u64 = vandq_u64(ceqaa, ceqbb);
-#elif defined(simde_math_isnan)
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.u64[i] = (!simde_math_isnan(a_.f64[i]) &&
-			     !simde_math_isnan(b_.f64[i]))
-				    ? ~UINT64_C(0)
-				    : UINT64_C(0);
-	}
-#else
-	HEDLEY_UNREACHABLE();
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpord_pd(a, b) simde_mm_cmpord_pd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde_float64 simde_mm_cvtsd_f64(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-	return _mm_cvtsd_f64(a);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a);
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return HEDLEY_STATIC_CAST(simde_float64,
-				  vgetq_lane_f64(a_.neon_f64, 0));
-#else
-	return a_.f64[0];
-#endif
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtsd_f64(a) simde_mm_cvtsd_f64(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpord_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpord_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_cmpord_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(simde_math_isnan)
-	r_.u64[0] =
-		(!simde_math_isnan(a_.f64[0]) && !simde_math_isnan(b_.f64[0]))
-			? ~UINT64_C(0)
-			: UINT64_C(0);
-	r_.u64[1] = a_.u64[1];
-#else
-	HEDLEY_UNREACHABLE();
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpord_sd(a, b) simde_mm_cmpord_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpunord_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpunord_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	uint64x2_t ceqaa = vceqq_f64(a_.neon_f64, a_.neon_f64);
-	uint64x2_t ceqbb = vceqq_f64(b_.neon_f64, b_.neon_f64);
-	r_.neon_u64 = vreinterpretq_u64_u32(
-		vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(ceqaa, ceqbb))));
-#elif defined(simde_math_isnan)
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.u64[i] = (simde_math_isnan(a_.f64[i]) ||
-			     simde_math_isnan(b_.f64[i]))
-				    ? ~UINT64_C(0)
-				    : UINT64_C(0);
-	}
-#else
-	HEDLEY_UNREACHABLE();
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpunord_pd(a, b) simde_mm_cmpunord_pd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cmpunord_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cmpunord_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_cmpunord_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(simde_math_isnan)
-	r_.u64[0] = (simde_math_isnan(a_.f64[0]) || simde_math_isnan(b_.f64[0]))
-			    ? ~UINT64_C(0)
-			    : UINT64_C(0);
-	r_.u64[1] = a_.u64[1];
-#else
-	HEDLEY_UNREACHABLE();
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cmpunord_sd(a, b) simde_mm_cmpunord_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cvtepi32_pd(simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvtepi32_pd(a);
-#else
-	simde__m128d_private r_;
-	simde__m128i_private a_ = simde__m128i_to_private(a);
-
-#if defined(SIMDE_CONVERT_VECTOR_)
-	SIMDE_CONVERT_VECTOR_(r_.f64, a_.m64_private[0].i32);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.f64[i] = (simde_float64)a_.i32[i];
-	}
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtepi32_pd(a) simde_mm_cvtepi32_pd(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128 simde_mm_cvtepi32_ps(simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvtepi32_ps(a);
-#else
-	simde__m128_private r_;
-	simde__m128i_private a_ = simde__m128i_to_private(a);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_f32 = vcvtq_f32_s32(a_.neon_i32);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f32x4_convert_i32x4(a_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	HEDLEY_DIAGNOSTIC_PUSH
-#if HEDLEY_HAS_WARNING("-Wc11-extensions")
-#pragma clang diagnostic ignored "-Wc11-extensions"
-#endif
-	r_.altivec_f32 = vec_ctf(a_.altivec_i32, 0);
-	HEDLEY_DIAGNOSTIC_POP
-#elif defined(SIMDE_CONVERT_VECTOR_)
-	SIMDE_CONVERT_VECTOR_(r_.f32, a_.i32);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f32) / sizeof(r_.f32[0])); i++) {
-		r_.f32[i] = (simde_float32)a_.i32[i];
-	}
-#endif
-
-	return simde__m128_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtepi32_ps(a) simde_mm_cvtepi32_ps(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m64 simde_mm_cvtpd_pi32(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-	return _mm_cvtpd_pi32(a);
-#else
-	simde__m64_private r_;
-	simde__m128d_private a_ = simde__m128d_to_private(a);
-
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		simde_float64 v = simde_math_round(a_.f64[i]);
-#if defined(SIMDE_FAST_CONVERSION_RANGE)
-		r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
-#else
-		r_.i32[i] =
-			((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) &&
-			 (v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX)))
-				? SIMDE_CONVERT_FTOI(int32_t, v)
-				: INT32_MIN;
-#endif
-	}
-
-	return simde__m64_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtpd_pi32(a) simde_mm_cvtpd_pi32(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cvtpd_epi32(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvtpd_epi32(a);
-#else
-	simde__m128i_private r_;
-
-	r_.m64[0] = simde_mm_cvtpd_pi32(a);
-	r_.m64[1] = simde_mm_setzero_si64();
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtpd_epi32(a) simde_mm_cvtpd_epi32(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128 simde_mm_cvtpd_ps(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvtpd_ps(a);
-#else
-	simde__m128_private r_;
-	simde__m128d_private a_ = simde__m128d_to_private(a);
-
-#if defined(SIMDE_CONVERT_VECTOR_)
-	SIMDE_CONVERT_VECTOR_(r_.m64_private[0].f32, a_.f64);
-	r_.m64_private[1] = simde__m64_to_private(simde_mm_setzero_si64());
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f32 = vreinterpretq_f32_f64(
-		vcombine_f64(vreinterpret_f64_f32(vcvtx_f32_f64(a_.neon_f64)),
-			     vdup_n_f64(0)));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(a_.f64) / sizeof(a_.f64[0])); i++) {
-		r_.f32[i] = (simde_float32)a_.f64[i];
-	}
-	simde_memset(&(r_.m64_private[1]), 0, sizeof(r_.m64_private[1]));
-#endif
-
-	return simde__m128_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtpd_ps(a) simde_mm_cvtpd_ps(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cvtpi32_pd(simde__m64 a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-	return _mm_cvtpi32_pd(a);
-#else
-	simde__m128d_private r_;
-	simde__m64_private a_ = simde__m64_to_private(a);
-
-#if defined(SIMDE_CONVERT_VECTOR_)
-	SIMDE_CONVERT_VECTOR_(r_.f64, a_.i32);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.f64[i] = (simde_float64)a_.i32[i];
-	}
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtpi32_pd(a) simde_mm_cvtpi32_pd(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cvtps_epi32(simde__m128 a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvtps_epi32(a);
-#else
-	simde__m128i_private r_;
-	simde__m128_private a_ = simde__m128_to_private(a);
-
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(SIMDE_FAST_CONVERSION_RANGE)
-	r_.neon_i32 = vcvtnq_s32_f32(a_.neon_f32);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && \
-	defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_ROUND_TIES)
-	r_.neon_i32 = vcvtnq_s32_f32(a_.neon_f32);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && \
-	defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_ROUND_TIES)
-	HEDLEY_DIAGNOSTIC_PUSH
-	SIMDE_DIAGNOSTIC_DISABLE_C11_EXTENSIONS_
-	SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
-	r_.altivec_i32 = vec_cts(a_.altivec_f32, 1);
-	HEDLEY_DIAGNOSTIC_POP
-#else
-	a_ = simde__m128_to_private(
-		simde_x_mm_round_ps(a, SIMDE_MM_FROUND_TO_NEAREST_INT, 1));
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		simde_float32 v = simde_math_roundf(a_.f32[i]);
-#if defined(SIMDE_FAST_CONVERSION_RANGE)
-		r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
-#else
-		r_.i32[i] =
-			((v > HEDLEY_STATIC_CAST(simde_float32, INT32_MIN)) &&
-			 (v < HEDLEY_STATIC_CAST(simde_float32, INT32_MAX)))
-				? SIMDE_CONVERT_FTOI(int32_t, v)
-				: INT32_MIN;
-#endif
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtps_epi32(a) simde_mm_cvtps_epi32(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cvtps_pd(simde__m128 a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvtps_pd(a);
-#else
-	simde__m128d_private r_;
-	simde__m128_private a_ = simde__m128_to_private(a);
-
-#if defined(SIMDE_CONVERT_VECTOR_)
-	SIMDE_CONVERT_VECTOR_(r_.f64, a_.m64_private[0].f32);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vcvt_f64_f32(vget_low_f32(a_.neon_f32));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.f64[i] = a_.f32[i];
-	}
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtps_pd(a) simde_mm_cvtps_pd(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-int32_t simde_mm_cvtsd_si32(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvtsd_si32(a);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a);
-
-	simde_float64 v = simde_math_round(a_.f64[0]);
-#if defined(SIMDE_FAST_CONVERSION_RANGE)
-	return SIMDE_CONVERT_FTOI(int32_t, v);
-#else
-	return ((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) &&
-		(v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX)))
-		       ? SIMDE_CONVERT_FTOI(int32_t, v)
-		       : INT32_MIN;
-#endif
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtsd_si32(a) simde_mm_cvtsd_si32(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-int64_t simde_mm_cvtsd_si64(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
-#if defined(__PGI)
-	return _mm_cvtsd_si64x(a);
-#else
-	return _mm_cvtsd_si64(a);
-#endif
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a);
-	return SIMDE_CONVERT_FTOI(int64_t, simde_math_round(a_.f64[0]));
-#endif
-}
-#define simde_mm_cvtsd_si64x(a) simde_mm_cvtsd_si64(a)
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtsd_si64(a) simde_mm_cvtsd_si64(a)
-#define _mm_cvtsd_si64x(a) simde_mm_cvtsd_si64x(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128 simde_mm_cvtsd_ss(simde__m128 a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvtsd_ss(a, b);
-#else
-	simde__m128_private r_, a_ = simde__m128_to_private(a);
-	simde__m128d_private b_ = simde__m128d_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f32 = vsetq_lane_f32(
-		vcvtxd_f32_f64(vgetq_lane_f64(b_.neon_f64, 0)), a_.neon_f32, 0);
-#else
-	r_.f32[0] = HEDLEY_STATIC_CAST(simde_float32, b_.f64[0]);
-
-	SIMDE_VECTORIZE
-	for (size_t i = 1; i < (sizeof(r_) / sizeof(r_.i32[0])); i++) {
-		r_.i32[i] = a_.i32[i];
-	}
-#endif
-	return simde__m128_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtsd_ss(a, b) simde_mm_cvtsd_ss(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-int16_t simde_x_mm_cvtsi128_si16(simde__m128i a)
-{
-	simde__m128i_private a_ = simde__m128i_to_private(a);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	return vgetq_lane_s16(a_.neon_i16, 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return HEDLEY_STATIC_CAST(int16_t,
-				  wasm_i16x8_extract_lane(a_.wasm_v128, 0));
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-#if defined(SIMDE_BUG_GCC_95227)
-	(void)a_;
-#endif
-	return vec_extract(a_.altivec_i16, 0);
-#else
-	return a_.i16[0];
-#endif
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-int32_t simde_mm_cvtsi128_si32(simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvtsi128_si32(a);
-#else
-	simde__m128i_private a_ = simde__m128i_to_private(a);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	return vgetq_lane_s32(a_.neon_i32, 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return HEDLEY_STATIC_CAST(int32_t,
-				  wasm_i32x4_extract_lane(a_.wasm_v128, 0));
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-#if defined(SIMDE_BUG_GCC_95227)
-	(void)a_;
-#endif
-	return vec_extract(a_.altivec_i32, 0);
-#else
-	return a_.i32[0];
-#endif
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtsi128_si32(a) simde_mm_cvtsi128_si32(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-int64_t simde_mm_cvtsi128_si64(simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
-#if defined(__PGI)
-	return _mm_cvtsi128_si64x(a);
-#else
-	return _mm_cvtsi128_si64(a);
-#endif
-#else
-	simde__m128i_private a_ = simde__m128i_to_private(a);
-#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) && !defined(HEDLEY_IBM_VERSION)
-	return vec_extract(HEDLEY_REINTERPRET_CAST(
-				   SIMDE_POWER_ALTIVEC_VECTOR(signed long long),
-				   a_.i64),
-			   0);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	return vgetq_lane_s64(a_.neon_i64, 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return HEDLEY_STATIC_CAST(int64_t,
-				  wasm_i64x2_extract_lane(a_.wasm_v128, 0));
-#endif
-	return a_.i64[0];
-#endif
-}
-#define simde_mm_cvtsi128_si64x(a) simde_mm_cvtsi128_si64(a)
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtsi128_si64(a) simde_mm_cvtsi128_si64(a)
-#define _mm_cvtsi128_si64x(a) simde_mm_cvtsi128_si64x(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cvtsi32_sd(simde__m128d a, int32_t b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvtsi32_sd(a, b);
-#else
-	simde__m128d_private r_;
-	simde__m128d_private a_ = simde__m128d_to_private(a);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARCH_AMD64)
-	r_.neon_f64 = vsetq_lane_f64(HEDLEY_STATIC_CAST(float64_t, b),
-				     a_.neon_f64, 0);
-#else
-	r_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b);
-	r_.i64[1] = a_.i64[1];
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtsi32_sd(a, b) simde_mm_cvtsi32_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_cvtsi16_si128(int16_t a)
-{
-	simde__m128i_private r_;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i16 = vsetq_lane_s16(a, vdupq_n_s16(0), 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i16x8_make(a, 0, 0, 0, 0, 0, 0, 0);
-#else
-	r_.i16[0] = a;
-	r_.i16[1] = 0;
-	r_.i16[2] = 0;
-	r_.i16[3] = 0;
-	r_.i16[4] = 0;
-	r_.i16[5] = 0;
-	r_.i16[6] = 0;
-	r_.i16[7] = 0;
-#endif
-
-	return simde__m128i_from_private(r_);
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cvtsi32_si128(int32_t a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvtsi32_si128(a);
-#else
-	simde__m128i_private r_;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vsetq_lane_s32(a, vdupq_n_s32(0), 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i32x4_make(a, 0, 0, 0);
-#else
-	r_.i32[0] = a;
-	r_.i32[1] = 0;
-	r_.i32[2] = 0;
-	r_.i32[3] = 0;
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtsi32_si128(a) simde_mm_cvtsi32_si128(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cvtsi64_sd(simde__m128d a, int64_t b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
-#if !defined(__PGI)
-	return _mm_cvtsi64_sd(a, b);
-#else
-	return _mm_cvtsi64x_sd(a, b);
-#endif
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
-
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vsetq_lane_f64(HEDLEY_STATIC_CAST(float64_t, b),
-				     a_.neon_f64, 0);
-#else
-	r_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b);
-	r_.f64[1] = a_.f64[1];
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#define simde_mm_cvtsi64x_sd(a, b) simde_mm_cvtsi64_sd(a, b)
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtsi64_sd(a, b) simde_mm_cvtsi64_sd(a, b)
-#define _mm_cvtsi64x_sd(a, b) simde_mm_cvtsi64x_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cvtsi64_si128(int64_t a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
-#if !defined(__PGI)
-	return _mm_cvtsi64_si128(a);
-#else
-	return _mm_cvtsi64x_si128(a);
-#endif
-#else
-	simde__m128i_private r_;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 = vsetq_lane_s64(a, vdupq_n_s64(0), 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i64x2_make(a, 0);
-#else
-	r_.i64[0] = a;
-	r_.i64[1] = 0;
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#define simde_mm_cvtsi64x_si128(a) simde_mm_cvtsi64_si128(a)
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtsi64_si128(a) simde_mm_cvtsi64_si128(a)
-#define _mm_cvtsi64x_si128(a) simde_mm_cvtsi64x_si128(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_cvtss_sd(simde__m128d a, simde__m128 b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvtss_sd(a, b);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	float64x2_t temp = vcvt_f64_f32(vset_lane_f32(
-		vgetq_lane_f32(simde__m128_to_private(b).neon_f32, 0),
-		vdup_n_f32(0), 0));
-	return vsetq_lane_f64(
-		vgetq_lane_f64(simde__m128d_to_private(a).neon_f64, 1), temp,
-		1);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a);
-	simde__m128_private b_ = simde__m128_to_private(b);
-
-	a_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b_.f32[0]);
-
-	return simde__m128d_from_private(a_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvtss_sd(a, b) simde_mm_cvtss_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m64 simde_mm_cvttpd_pi32(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-	return _mm_cvttpd_pi32(a);
-#else
-	simde__m64_private r_;
-	simde__m128d_private a_ = simde__m128d_to_private(a);
-
-#if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_FAST_CONVERSION_RANGE)
-	SIMDE_CONVERT_VECTOR_(r_.i32, a_.f64);
-#else
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		simde_float64 v = a_.f64[i];
-#if defined(SIMDE_FAST_CONVERSION_RANGE)
-		r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
-#else
-		r_.i32[i] =
-			((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) &&
-			 (v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX)))
-				? SIMDE_CONVERT_FTOI(int32_t, v)
-				: INT32_MIN;
-#endif
-	}
-#endif
-
-	return simde__m64_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvttpd_pi32(a) simde_mm_cvttpd_pi32(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cvttpd_epi32(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvttpd_epi32(a);
-#else
-	simde__m128i_private r_;
-
-	r_.m64[0] = simde_mm_cvttpd_pi32(a);
-	r_.m64[1] = simde_mm_setzero_si64();
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvttpd_epi32(a) simde_mm_cvttpd_epi32(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_cvttps_epi32(simde__m128 a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvttps_epi32(a);
-#else
-	simde__m128i_private r_;
-	simde__m128_private a_ = simde__m128_to_private(a);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_FAST_CONVERSION_RANGE)
-	r_.neon_i32 = vcvtq_s32_f32(a_.neon_f32);
-#elif defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_FAST_CONVERSION_RANGE)
-	SIMDE_CONVERT_VECTOR_(r_.i32, a_.f32);
-#else
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		simde_float32 v = a_.f32[i];
-#if defined(SIMDE_FAST_CONVERSION_RANGE)
-		r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
-#else
-		r_.i32[i] =
-			((v > HEDLEY_STATIC_CAST(simde_float32, INT32_MIN)) &&
-			 (v < HEDLEY_STATIC_CAST(simde_float32, INT32_MAX)))
-				? SIMDE_CONVERT_FTOI(int32_t, v)
-				: INT32_MIN;
-#endif
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvttps_epi32(a) simde_mm_cvttps_epi32(a)
-#endif
-
+  #define _mm_bsrli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
+  #define _mm_srli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
+#endif
+
 SIMDE_FUNCTION_ATTRIBUTES
-int32_t simde_mm_cvttsd_si32(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_cvttsd_si32(a);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a);
-	simde_float64 v = a_.f64[0];
-#if defined(SIMDE_FAST_CONVERSION_RANGE)
-	return SIMDE_CONVERT_FTOI(int32_t, v);
-#else
-	return ((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) &&
-		(v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX)))
-		       ? SIMDE_CONVERT_FTOI(int32_t, v)
-		       : INT32_MIN;
-#endif
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvttsd_si32(a) simde_mm_cvttsd_si32(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-int64_t simde_mm_cvttsd_si64(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
-#if !defined(__PGI)
-	return _mm_cvttsd_si64(a);
-#else
-	return _mm_cvttsd_si64x(a);
-#endif
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a);
-	return SIMDE_CONVERT_FTOI(int64_t, a_.f64[0]);
-#endif
-}
-#define simde_mm_cvttsd_si64x(a) simde_mm_cvttsd_si64(a)
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_cvttsd_si64(a) simde_mm_cvttsd_si64(a)
-#define _mm_cvttsd_si64x(a) simde_mm_cvttsd_si64x(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_div_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_div_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.f64 = a_.f64 / b_.f64;
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vdivq_f64(a_.neon_f64, b_.neon_f64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_div(a_.wasm_v128, b_.wasm_v128);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.f64[i] = a_.f64[i] / b_.f64[i];
-	}
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_div_pd(a, b) simde_mm_div_pd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_div_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_div_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_div_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	float64x2_t temp = vdivq_f64(a_.neon_f64, b_.neon_f64);
-	r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
-#else
-	r_.f64[0] = a_.f64[0] / b_.f64[0];
-	r_.f64[1] = a_.f64[1];
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
+void
+simde_mm_clflush (void const* p) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_clflush(p);
+  #else
+    (void) p;
+  #endif
 }
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_clflush(a, b) simde_mm_clflush()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comieq_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_comieq_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return !!vgetq_lane_u64(vceqq_f64(a_.neon_f64, b_.neon_f64), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) == wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #else
+      return a_.f64[0] == b_.f64[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_comieq_sd(a, b) simde_mm_comieq_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comige_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_comige_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return !!vgetq_lane_u64(vcgeq_f64(a_.neon_f64, b_.neon_f64), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >= wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #else
+      return a_.f64[0] >= b_.f64[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_comige_sd(a, b) simde_mm_comige_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comigt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_comigt_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return !!vgetq_lane_u64(vcgtq_f64(a_.neon_f64, b_.neon_f64), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) > wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #else
+      return a_.f64[0] > b_.f64[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_comigt_sd(a, b) simde_mm_comigt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comile_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_comile_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return !!vgetq_lane_u64(vcleq_f64(a_.neon_f64, b_.neon_f64), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <= wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #else
+      return a_.f64[0] <= b_.f64[0];
+    #endif
+  #endif
+}
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_div_sd(a, b) simde_mm_div_sd(a, b)
+  #define _mm_comile_sd(a, b) simde_mm_comile_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int32_t simde_mm_extract_epi16(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 7)
-{
-	uint16_t r;
-	simde__m128i_private a_ = simde__m128i_to_private(a);
-
-#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-#if defined(SIMDE_BUG_GCC_95227)
-	(void)a_;
-	(void)imm8;
-#endif
-	r = HEDLEY_STATIC_CAST(uint16_t, vec_extract(a_.altivec_i16, imm8));
-#else
-	r = a_.u16[imm8 & 7];
-#endif
-
-	return HEDLEY_STATIC_CAST(int32_t, r);
+int
+simde_mm_comilt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_comilt_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return !!vgetq_lane_u64(vcltq_f64(a_.neon_f64, b_.neon_f64), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) < wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #else
+      return a_.f64[0] < b_.f64[0];
+    #endif
+  #endif
 }
-#if defined(SIMDE_X86_SSE2_NATIVE) && \
-	(!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(4, 6, 0))
-#define simde_mm_extract_epi16(a, imm8) _mm_extract_epi16(a, imm8)
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#define simde_mm_extract_epi16(a, imm8)                                       \
-	(HEDLEY_STATIC_CAST(                                                  \
-		 int32_t, vgetq_lane_s16(simde__m128i_to_private(a).neon_i16, \
-					 (imm8))) &                           \
-	 (INT32_C(0x0000ffff)))
-#endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_extract_epi16(a, imm8) simde_mm_extract_epi16(a, imm8)
+  #define _mm_comilt_sd(a, b) simde_mm_comilt_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_insert_epi16(simde__m128i a, int16_t i, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 7)
-{
-	simde__m128i_private a_ = simde__m128i_to_private(a);
-	a_.i16[imm8 & 7] = i;
-	return simde__m128i_from_private(a_);
+int
+simde_mm_comineq_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_comineq_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return !vgetq_lane_u64(vceqq_f64(a_.neon_f64, b_.neon_f64), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) != wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #else
+      return a_.f64[0] != b_.f64[0];
+    #endif
+  #endif
 }
-#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-#define simde_mm_insert_epi16(a, i, imm8) _mm_insert_epi16((a), (i), (imm8))
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#define simde_mm_insert_epi16(a, i, imm8) \
-	simde__m128i_from_neon_i16(       \
-		vsetq_lane_s16((i), simde__m128i_to_neon_i16(a), (imm8)))
-#endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_insert_epi16(a, i, imm8) simde_mm_insert_epi16(a, i, imm8)
+  #define _mm_comineq_sd(a, b) simde_mm_comineq_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128d
-simde_mm_load_pd(simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)])
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_load_pd(mem_addr);
-#else
-	simde__m128d_private r_;
+simde_x_mm_copysign_pd(simde__m128d dest, simde__m128d src) {
+  simde__m128d_private
+    r_,
+    dest_ = simde__m128d_to_private(dest),
+    src_ = simde__m128d_to_private(src);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vld1q_f64(mem_addr);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u32 =
-		vld1q_u32(HEDLEY_REINTERPRET_CAST(uint32_t const *, mem_addr));
-#else
-	simde_memcpy(&r_, SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128d),
-		     sizeof(r_));
-#endif
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t sign_pos = vreinterpretq_u64_f64(vdupq_n_f64(-SIMDE_FLOAT64_C(0.0)));
+    #else
+      simde_float64 dbl_nz = -SIMDE_FLOAT64_C(0.0);
+      uint64_t u64_nz;
+      simde_memcpy(&u64_nz, &dbl_nz, sizeof(u64_nz));
+      uint64x2_t sign_pos = vdupq_n_u64(u64_nz);
+    #endif
+    r_.neon_u64 = vbslq_u64(sign_pos, src_.neon_u64, dest_.neon_u64);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    #if defined(SIMDE_BUG_VEC_CPSGN_REVERSED_ARGS)
+      r_.altivec_f64 = vec_cpsgn(dest_.altivec_f64, src_.altivec_f64);
+    #else
+      r_.altivec_f64 = vec_cpsgn(src_.altivec_f64, dest_.altivec_f64);
+    #endif
+  #elif defined(simde_math_copysign)
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_copysign(dest_.f64[i], src_.f64[i]);
+    }
+  #else
+    simde__m128d sgnbit = simde_mm_set1_pd(-SIMDE_FLOAT64_C(0.0));
+    return simde_mm_xor_pd(simde_mm_and_pd(sgnbit, src), simde_mm_andnot_pd(sgnbit, dest));
+  #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+  return simde__m128d_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_x_mm_xorsign_pd(simde__m128d dest, simde__m128d src) {
+  return simde_mm_xor_pd(simde_mm_and_pd(simde_mm_set1_pd(-0.0), src), dest);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_castpd_ps (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castpd_ps(a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f32_f64(a);
+  #else
+    simde__m128 r;
+    simde_memcpy(&r, &a, sizeof(a));
+    return r;
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_load_pd(mem_addr) simde_mm_load_pd(mem_addr)
+  #define _mm_castpd_ps(a) simde_mm_castpd_ps(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_load1_pd(simde_float64 const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_load1_pd(mem_addr);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return simde__m128d_from_neon_f64(vld1q_dup_f64(mem_addr));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return simde__m128d_from_wasm_v128(wasm_v64x2_load_splat(mem_addr));
-#else
-	return simde_mm_set1_pd(*mem_addr);
+simde__m128i
+simde_mm_castpd_si128 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castpd_si128(a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_s64_f64(a);
+  #else
+    simde__m128i r;
+    simde_memcpy(&r, &a, sizeof(a));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_castpd_si128(a) simde_mm_castpd_si128(a)
 #endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_castps_pd (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castps_pd(a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f64_f32(a);
+  #else
+    simde__m128d r;
+    simde_memcpy(&r, &a, sizeof(a));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_castps_pd(a) simde_mm_castps_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_castps_si128 (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castps_si128(a);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return simde__m128i_from_neon_i32(simde__m128_to_private(a).neon_i32);
+  #else
+    simde__m128i r;
+    simde_memcpy(&r, &a, sizeof(a));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_castps_si128(a) simde_mm_castps_si128(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_castsi128_pd (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castsi128_pd(a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f64_s64(a);
+  #else
+    simde__m128d r;
+    simde_memcpy(&r, &a, sizeof(a));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_castsi128_pd(a) simde_mm_castsi128_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_castsi128_ps (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castsi128_ps(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), a);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return simde__m128_from_neon_i32(simde__m128i_to_private(a).neon_i32);
+  #else
+    simde__m128 r;
+    simde_memcpy(&r, &a, sizeof(a));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_castsi128_ps(a) simde_mm_castsi128_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpeq_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vceqq_s8(b_.neon_i8, a_.neon_i8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_eq(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), vec_cmpeq(a_.altivec_i8, b_.altivec_i8));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 == b_.i8));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (a_.i8[i] == b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpeq_epi8(a, b) simde_mm_cmpeq_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpeq_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vceqq_s16(b_.neon_i16, a_.neon_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_eq(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short), vec_cmpeq(a_.altivec_i16, b_.altivec_i16));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = (a_.i16 == b_.i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] == b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpeq_epi16(a, b) simde_mm_cmpeq_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpeq_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vceqq_s32(b_.neon_i32, a_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_eq(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), vec_cmpeq(a_.altivec_i32, b_.altivec_i32));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), a_.i32 == b_.i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = (a_.i32[i] == b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpeq_epi32(a, b) simde_mm_cmpeq_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpeq_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u64 = vceqq_f64(b_.neon_f64, a_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_eq(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpeq(a_.altivec_f64, b_.altivec_f64));
+    #elif defined(SIMDE_MIPS_MSA_NATIVE)
+      r_.msa_i32 = __msa_addv_w(a_.msa_i32, b_.msa_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (a_.f64[i] == b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpeq_pd(a, b) simde_mm_cmpeq_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpeq_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_cmpeq_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmpeq_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.u64[0] = (a_.u64[0] == b_.u64[0]) ? ~UINT64_C(0) : 0;
+    r_.u64[1] = a_.u64[1];
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpeq_sd(a, b) simde_mm_cmpeq_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpneq_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpneq_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u32 = vmvnq_u32(vreinterpretq_u32_u64(vceqq_f64(b_.neon_f64, a_.neon_f64)));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_ne(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 != b_.f64));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (a_.f64[i] != b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpneq_pd(a, b) simde_mm_cmpneq_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpneq_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpneq_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_cmpneq_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmpneq_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.u64[0] = (a_.f64[0] != b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+    r_.u64[1] = a_.u64[1];
+
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpneq_sd(a, b) simde_mm_cmpneq_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmplt_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmplt_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vcltq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char),vec_cmplt(a_.altivec_i8, b_.altivec_i8));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_lt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 < b_.i8));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (a_.i8[i] < b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmplt_epi8(a, b) simde_mm_cmplt_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmplt_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmplt_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vcltq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short), vec_cmplt(a_.altivec_i16, b_.altivec_i16));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_lt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = HEDLEY_STATIC_CAST(__typeof__(r_.i16), (a_.i16 < b_.i16));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] < b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmplt_epi16(a, b) simde_mm_cmplt_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmplt_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmplt_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vcltq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), vec_cmplt(a_.altivec_i32, b_.altivec_i32));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_lt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.i32 < b_.i32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = (a_.i32[i] < b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmplt_epi32(a, b) simde_mm_cmplt_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmplt_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmplt_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u64 = vcltq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmplt(a_.altivec_f64, b_.altivec_f64));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_lt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 < b_.f64));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (a_.f64[i] < b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmplt_pd(a, b) simde_mm_cmplt_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmplt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmplt_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_cmplt_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmplt_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.u64[0] = (a_.f64[0] < b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+    r_.u64[1] = a_.u64[1];
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmplt_sd(a, b) simde_mm_cmplt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmple_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmple_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u64 = vcleq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_le(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmple(a_.altivec_f64, b_.altivec_f64));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (a_.f64[i] <= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmple_pd(a, b) simde_mm_cmple_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmple_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmple_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_cmple_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmple_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.u64[0] = (a_.f64[0] <= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+    r_.u64[1] = a_.u64[1];
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmple_sd(a, b) simde_mm_cmple_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpgt_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpgt_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vcgtq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_gt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), vec_cmpgt(a_.altivec_i8, b_.altivec_i8));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 > b_.i8));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (a_.i8[i] > b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpgt_epi8(a, b) simde_mm_cmpgt_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpgt_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpgt_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vcgtq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_gt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short), vec_cmpgt(a_.altivec_i16, b_.altivec_i16));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = HEDLEY_STATIC_CAST(__typeof__(r_.i16), (a_.i16 > b_.i16));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpgt_epi16(a, b) simde_mm_cmpgt_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpgt_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpgt_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vcgtq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_gt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), vec_cmpgt(a_.altivec_i32, b_.altivec_i32));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.i32 > b_.i32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = (a_.i32[i] > b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpgt_epi32(a, b) simde_mm_cmpgt_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpgt_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpgt_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u64 = vcgtq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_gt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_f64 = HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpgt(a_.altivec_f64, b_.altivec_f64));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (a_.f64[i] > b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpgt_pd(a, b) simde_mm_cmpgt_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpgt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+    return _mm_cmpgt_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_cmpgt_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmpgt_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.u64[0] = (a_.f64[0] > b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+    r_.u64[1] = a_.u64[1];
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpgt_sd(a, b) simde_mm_cmpgt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpge_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpge_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u64 = vcgeq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_ge(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_f64 = HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpge(a_.altivec_f64, b_.altivec_f64));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (a_.f64[i] >= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpge_pd(a, b) simde_mm_cmpge_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpge_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+    return _mm_cmpge_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_cmpge_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmpge_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.u64[0] = (a_.f64[0] >= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+    r_.u64[1] = a_.u64[1];
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpge_sd(a, b) simde_mm_cmpge_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpngt_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpngt_pd(a, b);
+  #else
+    return simde_mm_cmple_pd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpngt_pd(a, b) simde_mm_cmpngt_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpngt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+    return _mm_cmpngt_sd(a, b);
+  #else
+    return simde_mm_cmple_sd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpngt_sd(a, b) simde_mm_cmpngt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpnge_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpnge_pd(a, b);
+  #else
+    return simde_mm_cmplt_pd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpnge_pd(a, b) simde_mm_cmpnge_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpnge_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+    return _mm_cmpnge_sd(a, b);
+  #else
+    return simde_mm_cmplt_sd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpnge_sd(a, b) simde_mm_cmpnge_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpnlt_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpnlt_pd(a, b);
+  #else
+    return simde_mm_cmpge_pd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpnlt_pd(a, b) simde_mm_cmpnlt_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpnlt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpnlt_sd(a, b);
+  #else
+    return simde_mm_cmpge_sd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpnlt_sd(a, b) simde_mm_cmpnlt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpnle_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpnle_pd(a, b);
+  #else
+    return simde_mm_cmpgt_pd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpnle_pd(a, b) simde_mm_cmpnle_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpnle_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpnle_sd(a, b);
+  #else
+    return simde_mm_cmpgt_sd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpnle_sd(a, b) simde_mm_cmpnle_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpord_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpord_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      /* Note: NEON does not have ordered compare builtin
+        Need to compare a eq a and b eq b to check for NaN
+        Do AND of results to get final */
+      uint64x2_t ceqaa = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t ceqbb = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      r_.neon_u64 = vandq_u64(ceqaa, ceqbb);
+    #elif defined(simde_math_isnan)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (!simde_math_isnan(a_.f64[i]) && !simde_math_isnan(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpord_pd(a, b) simde_mm_cmpord_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64
+simde_mm_cvtsd_f64 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+    return _mm_cvtsd_f64(a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return HEDLEY_STATIC_CAST(simde_float64, vgetq_lane_f64(a_.neon_f64, 0));
+    #else
+      return a_.f64[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsd_f64(a) simde_mm_cvtsd_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpord_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpord_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_cmpord_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmpord_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(simde_math_isnan)
+      r_.u64[0] = (!simde_math_isnan(a_.f64[0]) && !simde_math_isnan(b_.f64[0])) ? ~UINT64_C(0) : UINT64_C(0);
+      r_.u64[1] = a_.u64[1];
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpord_sd(a, b) simde_mm_cmpord_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpunord_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpunord_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t ceqaa = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t ceqbb = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      r_.neon_u64 = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(ceqaa, ceqbb))));
+    #elif defined(simde_math_isnan)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (simde_math_isnan(a_.f64[i]) || simde_math_isnan(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpunord_pd(a, b) simde_mm_cmpunord_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpunord_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpunord_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_cmpunord_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmpunord_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(simde_math_isnan)
+      r_.u64[0] = (simde_math_isnan(a_.f64[0]) || simde_math_isnan(b_.f64[0])) ? ~UINT64_C(0) : UINT64_C(0);
+      r_.u64[1] = a_.u64[1];
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpunord_sd(a, b) simde_mm_cmpunord_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cvtepi32_pd (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtepi32_pd(a);
+  #else
+    simde__m128d_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.f64, a_.m64_private[0].i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = (simde_float64) a_.i32[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtepi32_pd(a) simde_mm_cvtepi32_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtepi32_ps (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtepi32_ps(a);
+  #else
+    simde__m128_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vcvtq_f32_s32(a_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_convert_i32x4(a_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      HEDLEY_DIAGNOSTIC_PUSH
+      #if HEDLEY_HAS_WARNING("-Wc11-extensions")
+        #pragma clang diagnostic ignored "-Wc11-extensions"
+      #endif
+      r_.altivec_f32 = vec_ctf(a_.altivec_i32, 0);
+      HEDLEY_DIAGNOSTIC_POP
+    #elif defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.f32, a_.i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = (simde_float32) a_.i32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtepi32_ps(a) simde_mm_cvtepi32_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cvtpd_pi32 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtpd_pi32(a);
+  #else
+    simde__m64_private r_;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      simde_float64 v = simde_math_round(a_.f64[i]);
+      #if defined(SIMDE_FAST_CONVERSION_RANGE)
+        r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
+      #else
+        r_.i32[i] = ((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) && (v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX))) ?
+          SIMDE_CONVERT_FTOI(int32_t, v) : INT32_MIN;
+      #endif
+    }
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtpd_pi32(a) simde_mm_cvtpd_pi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtpd_epi32 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(SIMDE_BUG_PGI_30107)
+    return _mm_cvtpd_epi32(a);
+  #else
+    simde__m128i_private r_;
+
+    r_.m64[0] = simde_mm_cvtpd_pi32(a);
+    r_.m64[1] = simde_mm_setzero_si64();
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtpd_epi32(a) simde_mm_cvtpd_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtpd_ps (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtpd_ps(a);
+  #else
+    simde__m128_private r_;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f32 = vcombine_f32(vcvt_f32_f64(a_.neon_f64), vdup_n_f32(0.0f));
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_f32 = vec_float2(a_.altivec_f64, vec_splats(0.0));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_demote_f64x2_zero(a_.wasm_v128);
+    #elif HEDLEY_HAS_BUILTIN(__builtin_shufflevector) && HEDLEY_HAS_BUILTIN(__builtin_convertvector)
+      float __attribute__((__vector_size__(8))) z = { 0.0f, 0.0f };
+      r_.f32 =
+        __builtin_shufflevector(
+          __builtin_convertvector(__builtin_shufflevector(a_.f64, a_.f64, 0, 1), __typeof__(z)), z,
+          0, 1, 2, 3
+        );
+    #else
+      r_.f32[0] = HEDLEY_STATIC_CAST(simde_float32, a_.f64[0]);
+      r_.f32[1] = HEDLEY_STATIC_CAST(simde_float32, a_.f64[1]);
+      r_.f32[2] = SIMDE_FLOAT32_C(0.0);
+      r_.f32[3] = SIMDE_FLOAT32_C(0.0);
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtpd_ps(a) simde_mm_cvtpd_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cvtpi32_pd (simde__m64 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtpi32_pd(a);
+  #else
+    simde__m128d_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.f64, a_.i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = (simde_float64) a_.i32[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtpi32_pd(a) simde_mm_cvtpi32_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtps_epi32 (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtps_epi32(a);
+  #else
+    simde__m128i_private r_;
+    simde__m128_private a_;
+
+    #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_ROUND_TIES) && !defined(SIMDE_BUG_GCC_95399)
+      a_ = simde__m128_to_private(a);
+      r_.neon_i32 = vcvtnq_s32_f32(a_.neon_f32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_ROUND_TIES)
+      a_ = simde__m128_to_private(a);
+      HEDLEY_DIAGNOSTIC_PUSH
+      SIMDE_DIAGNOSTIC_DISABLE_C11_EXTENSIONS_
+      SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
+      r_.altivec_i32 = vec_cts(a_.altivec_f32, 1);
+      HEDLEY_DIAGNOSTIC_POP
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE) && defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_ROUND_TIES)
+      a_ = simde__m128_to_private(a);
+      r_.wasm_v128 = wasm_i32x4_trunc_sat_f32x4(a_.wasm_v128);
+    #else
+      a_ = simde__m128_to_private(simde_x_mm_round_ps(a, SIMDE_MM_FROUND_TO_NEAREST_INT, 1));
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        simde_float32 v = simde_math_roundf(a_.f32[i]);
+        #if defined(SIMDE_FAST_CONVERSION_RANGE)
+          r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
+        #else
+          r_.i32[i] = ((v > HEDLEY_STATIC_CAST(simde_float32, INT32_MIN)) && (v < HEDLEY_STATIC_CAST(simde_float32, INT32_MAX))) ?
+            SIMDE_CONVERT_FTOI(int32_t, v) : INT32_MIN;
+        #endif
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtps_epi32(a) simde_mm_cvtps_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cvtps_pd (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtps_pd(a);
+  #else
+    simde__m128d_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.f64, a_.m64_private[0].f32);
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vcvt_f64_f32(vget_low_f32(a_.neon_f32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f32[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtps_pd(a) simde_mm_cvtps_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_cvtsd_si32 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtsd_si32(a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    simde_float64 v = simde_math_round(a_.f64[0]);
+    #if defined(SIMDE_FAST_CONVERSION_RANGE)
+      return SIMDE_CONVERT_FTOI(int32_t, v);
+    #else
+      return ((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) && (v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX))) ?
+        SIMDE_CONVERT_FTOI(int32_t, v) : INT32_MIN;
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsd_si32(a) simde_mm_cvtsd_si32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_mm_cvtsd_si64 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    #if defined(__PGI)
+      return _mm_cvtsd_si64x(a);
+    #else
+      return _mm_cvtsd_si64(a);
+    #endif
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+    return SIMDE_CONVERT_FTOI(int64_t, simde_math_round(a_.f64[0]));
+  #endif
+}
+#define simde_mm_cvtsd_si64x(a) simde_mm_cvtsd_si64(a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
+  #define _mm_cvtsd_si64(a) simde_mm_cvtsd_si64(a)
+  #define _mm_cvtsd_si64x(a) simde_mm_cvtsd_si64x(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtsd_ss (simde__m128 a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtsd_ss(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+    simde__m128d_private b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f32 = vsetq_lane_f32(vcvtxd_f32_f64(vgetq_lane_f64(b_.neon_f64, 0)), a_.neon_f32, 0);
+    #else
+      r_.f32[0] = HEDLEY_STATIC_CAST(simde_float32, b_.f64[0]);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 1 ; i < (sizeof(r_) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i];
+      }
+    #endif
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsd_ss(a, b) simde_mm_cvtsd_ss(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int16_t
+simde_x_mm_cvtsi128_si16 (simde__m128i a) {
+  simde__m128i_private
+    a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vgetq_lane_s16(a_.neon_i16, 0);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return HEDLEY_STATIC_CAST(int16_t, wasm_i16x8_extract_lane(a_.wasm_v128, 0));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    #if defined(SIMDE_BUG_GCC_95227)
+      (void) a_;
+    #endif
+    return vec_extract(a_.altivec_i16, 0);
+  #else
+    return a_.i16[0];
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_cvtsi128_si32 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtsi128_si32(a);
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      return vgetq_lane_s32(a_.neon_i32, 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return HEDLEY_STATIC_CAST(int32_t, wasm_i32x4_extract_lane(a_.wasm_v128, 0));
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      #if defined(SIMDE_BUG_GCC_95227)
+        (void) a_;
+      #endif
+      return vec_extract(a_.altivec_i32, 0);
+    #else
+      return a_.i32[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsi128_si32(a) simde_mm_cvtsi128_si32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_mm_cvtsi128_si64 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    #if defined(__PGI)
+      return _mm_cvtsi128_si64x(a);
+    #else
+      return _mm_cvtsi128_si64(a);
+    #endif
+  #else
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) && !defined(HEDLEY_IBM_VERSION)
+    return vec_extract(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed long long), a_.i64), 0);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vgetq_lane_s64(a_.neon_i64, 0);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return HEDLEY_STATIC_CAST(int64_t, wasm_i64x2_extract_lane(a_.wasm_v128, 0));
+  #endif
+    return a_.i64[0];
+  #endif
+}
+#define simde_mm_cvtsi128_si64x(a) simde_mm_cvtsi128_si64(a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
+  #define _mm_cvtsi128_si64(a) simde_mm_cvtsi128_si64(a)
+  #define _mm_cvtsi128_si64x(a) simde_mm_cvtsi128_si64x(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cvtsi32_sd (simde__m128d a, int32_t b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtsi32_sd(a, b);
+  #else
+    simde__m128d_private r_;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vsetq_lane_f64(HEDLEY_STATIC_CAST(float64_t, b), a_.neon_f64, 0);
+    #else
+      r_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b);
+      r_.i64[1] = a_.i64[1];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsi32_sd(a, b) simde_mm_cvtsi32_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_cvtsi16_si128 (int16_t a) {
+  simde__m128i_private r_;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_i16 = vsetq_lane_s16(a, vdupq_n_s16(0), 0);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    r_.wasm_v128 = wasm_i16x8_make(a, 0, 0, 0, 0, 0, 0, 0);
+  #else
+    r_.i16[0] = a;
+    r_.i16[1] = 0;
+    r_.i16[2] = 0;
+    r_.i16[3] = 0;
+    r_.i16[4] = 0;
+    r_.i16[5] = 0;
+    r_.i16[6] = 0;
+    r_.i16[7] = 0;
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtsi32_si128 (int32_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtsi32_si128(a);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vsetq_lane_s32(a, vdupq_n_s32(0), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_make(a, 0, 0, 0);
+    #else
+      r_.i32[0] = a;
+      r_.i32[1] = 0;
+      r_.i32[2] = 0;
+      r_.i32[3] = 0;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsi32_si128(a) simde_mm_cvtsi32_si128(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cvtsi64_sd (simde__m128d a, int64_t b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    #if !defined(__PGI)
+      return _mm_cvtsi64_sd(a, b);
+    #else
+      return _mm_cvtsi64x_sd(a, b);
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vsetq_lane_f64(HEDLEY_STATIC_CAST(float64_t, b), a_.neon_f64, 0);
+    #else
+      r_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b);
+      r_.f64[1] = a_.f64[1];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#define simde_mm_cvtsi64x_sd(a, b) simde_mm_cvtsi64_sd(a, b)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
+  #define _mm_cvtsi64_sd(a, b) simde_mm_cvtsi64_sd(a, b)
+  #define _mm_cvtsi64x_sd(a, b) simde_mm_cvtsi64x_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtsi64_si128 (int64_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    #if !defined(__PGI)
+      return _mm_cvtsi64_si128(a);
+    #else
+      return _mm_cvtsi64x_si128(a);
+    #endif
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vsetq_lane_s64(a, vdupq_n_s64(0), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i64x2_make(a, 0);
+    #else
+      r_.i64[0] = a;
+      r_.i64[1] = 0;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#define simde_mm_cvtsi64x_si128(a) simde_mm_cvtsi64_si128(a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
+  #define _mm_cvtsi64_si128(a) simde_mm_cvtsi64_si128(a)
+  #define _mm_cvtsi64x_si128(a) simde_mm_cvtsi64x_si128(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cvtss_sd (simde__m128d a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtss_sd(a, b);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    float64x2_t temp = vcvt_f64_f32(vset_lane_f32(vgetq_lane_f32(simde__m128_to_private(b).neon_f32, 0), vdup_n_f32(0), 0));
+    return vsetq_lane_f64(vgetq_lane_f64(simde__m128d_to_private(a).neon_f64, 1), temp, 1);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a);
+    simde__m128_private b_ = simde__m128_to_private(b);
+
+    a_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b_.f32[0]);
+
+    return simde__m128d_from_private(a_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtss_sd(a, b) simde_mm_cvtss_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cvttpd_pi32 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvttpd_pi32(a);
+  #else
+    simde__m64_private r_;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_FAST_CONVERSION_RANGE)
+      SIMDE_CONVERT_VECTOR_(r_.i32, a_.f64);
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        simde_float64 v = a_.f64[i];
+        #if defined(SIMDE_FAST_CONVERSION_RANGE)
+          r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
+        #else
+          r_.i32[i] = ((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) && (v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX))) ?
+            SIMDE_CONVERT_FTOI(int32_t, v) : INT32_MIN;
+        #endif
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvttpd_pi32(a) simde_mm_cvttpd_pi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvttpd_epi32 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvttpd_epi32(a);
+  #else
+    simde__m128i_private r_;
+
+    r_.m64[0] = simde_mm_cvttpd_pi32(a);
+    r_.m64[1] = simde_mm_setzero_si64();
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvttpd_epi32(a) simde_mm_cvttpd_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvttps_epi32 (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvttps_epi32(a);
+  #else
+    simde__m128i_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vcvtq_s32_f32(a_.neon_f32);
+
+      #if !defined(SIMDE_FAST_CONVERSION_RANGE) || !defined(SIMDE_FAST_NANS)
+        /* Values below INT32_MIN saturate anyways, so we don't need to
+         * test for that. */
+        #if !defined(SIMDE_FAST_CONVERSION_RANGE) && !defined(SIMDE_FAST_NANS)
+          uint32x4_t valid_input =
+            vandq_u32(
+              vcltq_f32(a_.neon_f32, vdupq_n_f32(SIMDE_FLOAT32_C(2147483648.0))),
+              vceqq_f32(a_.neon_f32, a_.neon_f32)
+            );
+        #elif !defined(SIMDE_FAST_CONVERSION_RANGE)
+          uint32x4_t valid_input = vcltq_f32(a_.neon_f32, vdupq_n_f32(SIMDE_FLOAT32_C(2147483648.0)));
+        #elif !defined(SIMDE_FAST_NANS)
+          uint32x4_t valid_input = vceqq_f32(a_.neon_f32, a_.neon_f32);
+        #endif
+
+        r_.neon_i32 = vbslq_s32(valid_input, r_.neon_i32, vdupq_n_s32(INT32_MIN));
+      #endif
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_trunc_sat_f32x4(a_.wasm_v128);
+
+      #if !defined(SIMDE_FAST_CONVERSION_RANGE) || !defined(SIMDE_FAST_NANS)
+        #if !defined(SIMDE_FAST_CONVERSION_RANGE) && !defined(SIMDE_FAST_NANS)
+          v128_t valid_input =
+            wasm_v128_and(
+              wasm_f32x4_lt(a_.wasm_v128, wasm_f32x4_splat(SIMDE_FLOAT32_C(2147483648.0))),
+              wasm_f32x4_eq(a_.wasm_v128, a_.wasm_v128)
+            );
+        #elif !defined(SIMDE_FAST_CONVERSION_RANGE)
+          v128_t valid_input = wasm_f32x4_lt(a_.wasm_v128, wasm_f32x4_splat(SIMDE_FLOAT32_C(2147483648.0)));
+        #elif !defined(SIMDE_FAST_NANS)
+          v128_t valid_input = wasm_f32x4_eq(a_.wasm_v128, a_.wasm_v128);
+        #endif
+
+        r_.wasm_v128 = wasm_v128_bitselect(r_.wasm_v128, wasm_i32x4_splat(INT32_MIN), valid_input);
+      #endif
+    #elif defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i32, a_.f32);
+
+      #if !defined(SIMDE_FAST_CONVERSION_RANGE) || !defined(SIMDE_FAST_NANS)
+        #if !defined(SIMDE_FAST_CONVERSION_RANGE)
+          static const simde_float32 first_too_high SIMDE_VECTOR(16) = { SIMDE_FLOAT32_C(2147483648.0), SIMDE_FLOAT32_C(2147483648.0), SIMDE_FLOAT32_C(2147483648.0), SIMDE_FLOAT32_C(2147483648.0) };
+
+          __typeof__(r_.i32) valid_input =
+            HEDLEY_REINTERPRET_CAST(
+              __typeof__(r_.i32),
+              (a_.f32 < first_too_high) & (a_.f32 >= -first_too_high)
+            );
+        #elif !defined(SIMDE_FAST_NANS)
+          __typeof__(r_.i32) valid_input = HEDLEY_REINTERPRET_CAST( __typeof__(valid_input), a_.f32 == a_.f32);
+        #endif
+
+        __typeof__(r_.i32) invalid_output = { INT32_MIN, INT32_MIN, INT32_MIN, INT32_MIN };
+        r_.i32 = (r_.i32 & valid_input) | (invalid_output & ~valid_input);
+      #endif
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        simde_float32 v = a_.f32[i];
+        #if defined(SIMDE_FAST_CONVERSION_RANGE) && defined(SIMDE_FAST_NANS)
+          r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, v);
+        #else
+          r_.i32[i] = ((v > HEDLEY_STATIC_CAST(simde_float32, INT32_MIN)) && (v < HEDLEY_STATIC_CAST(simde_float32, INT32_MAX))) ?
+            SIMDE_CONVERT_FTOI(int32_t, v) : INT32_MIN;
+        #endif
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvttps_epi32(a) simde_mm_cvttps_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_cvttsd_si32 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvttsd_si32(a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+    simde_float64 v = a_.f64[0];
+    #if defined(SIMDE_FAST_CONVERSION_RANGE)
+      return SIMDE_CONVERT_FTOI(int32_t, v);
+    #else
+      return ((v > HEDLEY_STATIC_CAST(simde_float64, INT32_MIN)) && (v < HEDLEY_STATIC_CAST(simde_float64, INT32_MAX))) ?
+        SIMDE_CONVERT_FTOI(int32_t, v) : INT32_MIN;
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvttsd_si32(a) simde_mm_cvttsd_si32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_mm_cvttsd_si64 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    #if !defined(__PGI)
+      return _mm_cvttsd_si64(a);
+    #else
+      return _mm_cvttsd_si64x(a);
+    #endif
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+    return SIMDE_CONVERT_FTOI(int64_t, a_.f64[0]);
+  #endif
+}
+#define simde_mm_cvttsd_si64x(a) simde_mm_cvttsd_si64(a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
+  #define _mm_cvttsd_si64(a) simde_mm_cvttsd_si64(a)
+  #define _mm_cvttsd_si64x(a) simde_mm_cvttsd_si64x(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_div_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_div_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 / b_.f64;
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vdivq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 =  wasm_f64x2_div(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f64[i] / b_.f64[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_div_pd(a, b) simde_mm_div_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_div_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_div_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_div_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_div_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      float64x2_t temp = vdivq_f64(a_.neon_f64, b_.neon_f64);
+      r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
+    #else
+      r_.f64[0] = a_.f64[0] / b_.f64[0];
+      r_.f64[1] = a_.f64[1];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_div_sd(a, b) simde_mm_div_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_extract_epi16 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 7)  {
+  uint16_t r;
+  simde__m128i_private a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    #if defined(SIMDE_BUG_GCC_95227)
+      (void) a_;
+      (void) imm8;
+    #endif
+    r = HEDLEY_STATIC_CAST(uint16_t, vec_extract(a_.altivec_i16, imm8));
+  #else
+    r = a_.u16[imm8 & 7];
+  #endif
+
+  return  HEDLEY_STATIC_CAST(int32_t, r);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(4,6,0))
+  #define simde_mm_extract_epi16(a, imm8) _mm_extract_epi16(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_mm_extract_epi16(a, imm8) (HEDLEY_STATIC_CAST(int32_t, vgetq_lane_s16(simde__m128i_to_private(a).neon_i16, (imm8))) & (INT32_C(0x0000ffff)))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_extract_epi16(a, imm8) simde_mm_extract_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_insert_epi16 (simde__m128i a, int16_t i, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 7)  {
+  simde__m128i_private a_ = simde__m128i_to_private(a);
+  a_.i16[imm8 & 7] = i;
+  return simde__m128i_from_private(a_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+  #define simde_mm_insert_epi16(a, i, imm8) _mm_insert_epi16((a), (i), (imm8))
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_mm_insert_epi16(a, i, imm8) simde__m128i_from_neon_i16(vsetq_lane_s16((i), simde__m128i_to_neon_i16(a), (imm8)))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_insert_epi16(a, i, imm8) simde_mm_insert_epi16(a, i, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_load_pd (simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)]) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_load_pd(mem_addr);
+  #else
+    simde__m128d_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vld1q_f64(mem_addr);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vld1q_u32(HEDLEY_REINTERPRET_CAST(uint32_t const*, mem_addr));
+    #else
+      simde_memcpy(&r_, SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128d), sizeof(r_));
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_load_pd(mem_addr) simde_mm_load_pd(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_load1_pd (simde_float64 const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_load1_pd(mem_addr);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return simde__m128d_from_neon_f64(vld1q_dup_f64(mem_addr));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return simde__m128d_from_wasm_v128(wasm_v128_load64_splat(mem_addr));
+  #else
+    return simde_mm_set1_pd(*mem_addr);
+  #endif
 }
 #define simde_mm_load_pd1(mem_addr) simde_mm_load1_pd(mem_addr)
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_load_pd1(mem_addr) simde_mm_load1_pd(mem_addr)
-#define _mm_load1_pd(mem_addr) simde_mm_load1_pd(mem_addr)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_load_sd(simde_float64 const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_load_sd(mem_addr);
-#else
-	simde__m128d_private r_;
-
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vsetq_lane_f64(*mem_addr, vdupq_n_f64(0), 0);
-#else
-	r_.f64[0] = *mem_addr;
-	r_.u64[1] = UINT64_C(0);
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_load_sd(mem_addr) simde_mm_load_sd(mem_addr)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_load_si128(simde__m128i const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_load_si128(
-		HEDLEY_REINTERPRET_CAST(__m128i const *, mem_addr));
-#else
-	simde__m128i_private r_;
-
-#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i32 = vec_ld(
-		0, HEDLEY_REINTERPRET_CAST(
-			   SIMDE_POWER_ALTIVEC_VECTOR(int) const *, mem_addr));
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 =
-		vld1q_s32(HEDLEY_REINTERPRET_CAST(int32_t const *, mem_addr));
-#else
-	simde_memcpy(&r_, SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128i),
-		     sizeof(simde__m128i));
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_load_si128(mem_addr) simde_mm_load_si128(mem_addr)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_loadh_pd(simde__m128d a, simde_float64 const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_loadh_pd(a, mem_addr);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
-
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vcombine_f64(
-		vget_low_f64(a_.neon_f64),
-		vld1_f64(HEDLEY_REINTERPRET_CAST(const float64_t *, mem_addr)));
-#else
-	simde_float64 t;
-
-	simde_memcpy(&t, mem_addr, sizeof(t));
-	r_.f64[0] = a_.f64[0];
-	r_.f64[1] = t;
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_loadh_pd(a, mem_addr) simde_mm_loadh_pd(a, mem_addr)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_loadl_epi64(simde__m128i const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_loadl_epi64(mem_addr);
-#else
-	simde__m128i_private r_;
-
-	int64_t value;
-	simde_memcpy(&value, mem_addr, sizeof(value));
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 = vcombine_s64(
-		vld1_s64(HEDLEY_REINTERPRET_CAST(int64_t const *, mem_addr)),
-		vdup_n_s64(0));
-#else
-	r_.i64[0] = value;
-	r_.i64[1] = 0;
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_loadl_epi64(mem_addr) simde_mm_loadl_epi64(mem_addr)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_loadl_pd(simde__m128d a, simde_float64 const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_loadl_pd(a, mem_addr);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
-
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vcombine_f64(
-		vld1_f64(HEDLEY_REINTERPRET_CAST(const float64_t *, mem_addr)),
-		vget_high_f64(a_.neon_f64));
-#else
-	r_.f64[0] = *mem_addr;
-	r_.u64[1] = a_.u64[1];
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_loadl_pd(a, mem_addr) simde_mm_loadl_pd(a, mem_addr)
+  #define _mm_load_pd1(mem_addr) simde_mm_load1_pd(mem_addr)
+  #define _mm_load1_pd(mem_addr) simde_mm_load1_pd(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128d
-simde_mm_loadr_pd(simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)])
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_loadr_pd(mem_addr);
-#else
-	simde__m128d_private r_;
+simde_mm_load_sd (simde_float64 const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_load_sd(mem_addr);
+  #else
+    simde__m128d_private r_;
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vld1q_f64(mem_addr);
-	r_.neon_f64 = vextq_f64(r_.neon_f64, r_.neon_f64, 1);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 =
-		vld1q_s64(HEDLEY_REINTERPRET_CAST(int64_t const *, mem_addr));
-	r_.neon_i64 = vextq_s64(r_.neon_i64, r_.neon_i64, 1);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	v128_t tmp = wasm_v128_load(mem_addr);
-	r_.wasm_v128 = wasm_v64x2_shuffle(tmp, tmp, 1, 0);
-#else
-	r_.f64[0] = mem_addr[1];
-	r_.f64[1] = mem_addr[0];
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vsetq_lane_f64(*mem_addr, vdupq_n_f64(0), 0);
+    #else
+      r_.f64[0] = *mem_addr;
+      r_.u64[1] = UINT64_C(0);
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_loadr_pd(mem_addr) simde_mm_loadr_pd(mem_addr)
+  #define _mm_load_sd(mem_addr) simde_mm_load_sd(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_load_si128 (simde__m128i const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_load_si128(HEDLEY_REINTERPRET_CAST(__m128i const*, mem_addr));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_ld(0, HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(int) const*, mem_addr));
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vld1q_s32(HEDLEY_REINTERPRET_CAST(int32_t const*, mem_addr));
+    #else
+      simde_memcpy(&r_, SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128i), sizeof(simde__m128i));
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_load_si128(mem_addr) simde_mm_load_si128(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
 simde__m128d
-simde_mm_loadu_pd(simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)])
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_loadu_pd(mem_addr);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return vld1q_f64(mem_addr);
-#else
-	simde__m128d_private r_;
+simde_mm_loadh_pd (simde__m128d a, simde_float64 const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadh_pd(a, mem_addr);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
 
-	simde_memcpy(&r_, mem_addr, sizeof(r_));
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vcombine_f64(vget_low_f64(a_.neon_f64), vld1_f64(HEDLEY_REINTERPRET_CAST(const float64_t*, mem_addr)));
+    #else
+      simde_float64 t;
 
-	return simde__m128d_from_private(r_);
-#endif
+      simde_memcpy(&t, mem_addr, sizeof(t));
+      r_.f64[0] = a_.f64[0];
+      r_.f64[1] = t;
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_loadu_pd(mem_addr) simde_mm_loadu_pd(mem_addr)
+  #define _mm_loadh_pd(a, mem_addr) simde_mm_loadh_pd(a, mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_loadu_epi8(int8_t const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_loadu_si128(
-		SIMDE_ALIGN_CAST(simde__m128i const *, mem_addr));
-#else
-	simde__m128i_private r_;
+simde__m128i
+simde_mm_loadl_epi64 (simde__m128i const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadl_epi64(mem_addr);
+  #else
+    simde__m128i_private r_;
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i8 =
-		vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const *, mem_addr));
-#else
-	simde_memcpy(&r_, mem_addr, sizeof(r_));
-#endif
+    int64_t value;
+    simde_memcpy(&value, mem_addr, sizeof(value));
 
-	return simde__m128i_from_private(r_);
-#endif
-}
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vcombine_s64(vld1_s64(HEDLEY_REINTERPRET_CAST(int64_t const *, mem_addr)), vdup_n_s64(0));
+    #else
+      r_.i64[0] = value;
+      r_.i64[1] = 0;
+    #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_loadu_epi16(int16_t const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_loadu_si128(
-		SIMDE_ALIGN_CAST(simde__m128i const *, mem_addr));
-#else
-	simde__m128i_private r_;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i16 =
-		vld1q_s16(HEDLEY_REINTERPRET_CAST(int16_t const *, mem_addr));
-#else
-	simde_memcpy(&r_, mem_addr, sizeof(r_));
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_loadu_epi32(int32_t const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_loadu_si128(
-		SIMDE_ALIGN_CAST(simde__m128i const *, mem_addr));
-#else
-	simde__m128i_private r_;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 =
-		vld1q_s32(HEDLEY_REINTERPRET_CAST(int32_t const *, mem_addr));
-#else
-	simde_memcpy(&r_, mem_addr, sizeof(r_));
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_loadu_epi64(int64_t const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_loadu_si128(
-		SIMDE_ALIGN_CAST(simde__m128i const *, mem_addr));
-#else
-	simde__m128i_private r_;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 =
-		vld1q_s64(HEDLEY_REINTERPRET_CAST(int64_t const *, mem_addr));
-#else
-	simde_memcpy(&r_, mem_addr, sizeof(r_));
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_loadu_si128(void const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_loadu_si128(HEDLEY_STATIC_CAST(__m128i const *, mem_addr));
-#else
-	simde__m128i_private r_;
-
-#if HEDLEY_GNUC_HAS_ATTRIBUTE(may_alias, 3, 3, 0)
-	HEDLEY_DIAGNOSTIC_PUSH
-	SIMDE_DIAGNOSTIC_DISABLE_PACKED_
-	struct simde_mm_loadu_si128_s {
-		__typeof__(r_) v;
-	} __attribute__((__packed__, __may_alias__));
-	r_ = HEDLEY_REINTERPRET_CAST(const struct simde_mm_loadu_si128_s *,
-				     mem_addr)
-		     ->v;
-	HEDLEY_DIAGNOSTIC_POP
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	/* Note that this is a lower priority than the struct above since
-       * clang assumes mem_addr is aligned (since it is a __m128i*). */
-	r_.neon_i32 =
-		vld1q_s32(HEDLEY_REINTERPRET_CAST(int32_t const *, mem_addr));
-#else
-	simde_memcpy(&r_, mem_addr, sizeof(r_));
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_loadu_si128(mem_addr) simde_mm_loadu_si128(mem_addr)
+  #define _mm_loadl_epi64(mem_addr) simde_mm_loadl_epi64(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_madd_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_madd_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128d
+simde_mm_loadl_pd (simde__m128d a, simde_float64 const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadl_pd(a, mem_addr);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	int32x4_t pl =
-		vmull_s16(vget_low_s16(a_.neon_i16), vget_low_s16(b_.neon_i16));
-	int32x4_t ph = vmull_high_s16(a_.neon_i16, b_.neon_i16);
-	r_.neon_i32 = vpaddq_s32(pl, ph);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	int32x4_t pl =
-		vmull_s16(vget_low_s16(a_.neon_i16), vget_low_s16(b_.neon_i16));
-	int32x4_t ph = vmull_s16(vget_high_s16(a_.neon_i16),
-				 vget_high_s16(b_.neon_i16));
-	int32x2_t rl = vpadd_s32(vget_low_s32(pl), vget_high_s32(pl));
-	int32x2_t rh = vpadd_s32(vget_low_s32(ph), vget_high_s32(ph));
-	r_.neon_i32 = vcombine_s32(rl, rh);
-#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	static const SIMDE_POWER_ALTIVEC_VECTOR(int) tz = {0, 0, 0, 0};
-	r_.altivec_i32 = vec_msum(a_.altivec_i16, b_.altivec_i16, tz);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.i16[0])); i += 2) {
-		r_.i32[i / 2] = (a_.i16[i] * b_.i16[i]) +
-				(a_.i16[i + 1] * b_.i16[i + 1]);
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vcombine_f64(vld1_f64(
+        HEDLEY_REINTERPRET_CAST(const float64_t*, mem_addr)), vget_high_f64(a_.neon_f64));
+    #else
+      r_.f64[0] = *mem_addr;
+      r_.u64[1] = a_.u64[1];
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_madd_epi16(a, b) simde_mm_madd_epi16(a, b)
+  #define _mm_loadl_pd(a, mem_addr) simde_mm_loadl_pd(a, mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_maskmoveu_si128(simde__m128i a, simde__m128i mask,
-			      int8_t mem_addr[HEDLEY_ARRAY_PARAM(16)])
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_maskmoveu_si128(a, mask, HEDLEY_REINTERPRET_CAST(char *, mem_addr));
-#else
-	simde__m128i_private a_ = simde__m128i_to_private(a),
-			     mask_ = simde__m128i_to_private(mask);
+simde__m128d
+simde_mm_loadr_pd (simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)]) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadr_pd(mem_addr);
+  #else
+    simde__m128d_private
+      r_;
 
-	for (size_t i = 0; i < (sizeof(a_.i8) / sizeof(a_.i8[0])); i++) {
-		if (mask_.u8[i] & 0x80) {
-			mem_addr[i] = a_.i8[i];
-		}
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vld1q_f64(mem_addr);
+      r_.neon_f64 = vextq_f64(r_.neon_f64, r_.neon_f64, 1);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vld1q_s64(HEDLEY_REINTERPRET_CAST(int64_t const *, mem_addr));
+      r_.neon_i64 = vextq_s64(r_.neon_i64, r_.neon_i64, 1);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      v128_t tmp = wasm_v128_load(mem_addr);
+      r_.wasm_v128 = wasm_i64x2_shuffle(tmp, tmp, 1, 0);
+    #else
+      r_.f64[0] = mem_addr[1];
+      r_.f64[1] = mem_addr[0];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_maskmoveu_si128(a, mask, mem_addr) \
-	simde_mm_maskmoveu_si128(              \
-		(a), (mask),                   \
-		SIMDE_CHECKED_REINTERPRET_CAST(int8_t *, char *, (mem_addr)))
+  #define _mm_loadr_pd(mem_addr) simde_mm_loadr_pd(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int32_t simde_mm_movemask_epi8(simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__INTEL_COMPILER)
-	/* ICC has trouble with _mm_movemask_epi8 at -O2 and above: */
-	return _mm_movemask_epi8(a);
-#else
-	int32_t r = 0;
-	simde__m128i_private a_ = simde__m128i_to_private(a);
+simde__m128d
+simde_mm_loadu_pd (simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)]) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_pd(mem_addr);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vld1q_f64(mem_addr);
+  #else
+    simde__m128d_private r_;
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	uint8x16_t input = a_.neon_u8;
-	const int8_t xr[16] = {-7, -6, -5, -4, -3, -2, -1, 0,
-			       -7, -6, -5, -4, -3, -2, -1, 0};
-	const uint8x16_t mask_and = vdupq_n_u8(0x80);
-	const int8x16_t mask_shift = vld1q_s8(xr);
-	const uint8x16_t mask_result =
-		vshlq_u8(vandq_u8(input, mask_and), mask_shift);
-	uint8x8_t lo = vget_low_u8(mask_result);
-	uint8x8_t hi = vget_high_u8(mask_result);
-	r = vaddv_u8(lo) + (vaddv_u8(hi) << 8);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	// Use increasingly wide shifts+adds to collect the sign bits
-	// together.
-	// Since the widening shifts would be rather confusing to follow in little endian, everything
-	// will be illustrated in big endian order instead. This has a different result - the bits
-	// would actually be reversed on a big endian machine.
+    simde_memcpy(&r_, mem_addr, sizeof(r_));
 
-	// Starting input (only half the elements are shown):
-	// 89 ff 1d c0 00 10 99 33
-	uint8x16_t input = a_.neon_u8;
-
-	// Shift out everything but the sign bits with an unsigned shift right.
-	//
-	// Bytes of the vector::
-	// 89 ff 1d c0 00 10 99 33
-	// \  \  \  \  \  \  \  \    high_bits = (uint16x4_t)(input >> 7)
-	//  |  |  |  |  |  |  |  |
-	// 01 01 00 01 00 00 01 00
-	//
-	// Bits of first important lane(s):
-	// 10001001 (89)
-	// \______
-	//        |
-	// 00000001 (01)
-	uint16x8_t high_bits = vreinterpretq_u16_u8(vshrq_n_u8(input, 7));
-
-	// Merge the even lanes together with a 16-bit unsigned shift right + add.
-	// 'xx' represents garbage data which will be ignored in the final result.
-	// In the important bytes, the add functions like a binary OR.
-	//
-	// 01 01 00 01 00 00 01 00
-	//  \_ |  \_ |  \_ |  \_ |   paired16 = (uint32x4_t)(input + (input >> 7))
-	//    \|    \|    \|    \|
-	// xx 03 xx 01 xx 00 xx 02
-	//
-	// 00000001 00000001 (01 01)
-	//        \_______ |
-	//                \|
-	// xxxxxxxx xxxxxx11 (xx 03)
-	uint32x4_t paired16 =
-		vreinterpretq_u32_u16(vsraq_n_u16(high_bits, high_bits, 7));
-
-	// Repeat with a wider 32-bit shift + add.
-	// xx 03 xx 01 xx 00 xx 02
-	//     \____ |     \____ |  paired32 = (uint64x1_t)(paired16 + (paired16 >> 14))
-	//          \|          \|
-	// xx xx xx 0d xx xx xx 02
-	//
-	// 00000011 00000001 (03 01)
-	//        \\_____ ||
-	//         '----.\||
-	// xxxxxxxx xxxx1101 (xx 0d)
-	uint64x2_t paired32 =
-		vreinterpretq_u64_u32(vsraq_n_u32(paired16, paired16, 14));
-
-	// Last, an even wider 64-bit shift + add to get our result in the low 8 bit lanes.
-	// xx xx xx 0d xx xx xx 02
-	//            \_________ |   paired64 = (uint8x8_t)(paired32 + (paired32 >> 28))
-	//                      \|
-	// xx xx xx xx xx xx xx d2
-	//
-	// 00001101 00000010 (0d 02)
-	//     \   \___ |  |
-	//      '---.  \|  |
-	// xxxxxxxx 11010010 (xx d2)
-	uint8x16_t paired64 =
-		vreinterpretq_u8_u64(vsraq_n_u64(paired32, paired32, 28));
-
-	// Extract the low 8 bits from each 64-bit lane with 2 8-bit extracts.
-	// xx xx xx xx xx xx xx d2
-	//                      ||  return paired64[0]
-	//                      d2
-	// Note: Little endian would return the correct value 4b (01001011) instead.
-	r = vgetq_lane_u8(paired64, 0) |
-	    (HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u8(paired64, 8)) << 8);
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
-	!defined(HEDLEY_IBM_VERSION) &&         \
-	(SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
-	static const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)
-		perm = {120, 112, 104, 96, 88, 80, 72, 64,
-			56,  48,  40,  32, 24, 16, 8,  0};
-	r = HEDLEY_STATIC_CAST(
-		int32_t, vec_extract(vec_vbpermq(a_.altivec_u8, perm), 1));
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
-	!defined(HEDLEY_IBM_VERSION) &&         \
-	(SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG)
-	static const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)
-		perm = {120, 112, 104, 96, 88, 80, 72, 64,
-			56,  48,  40,  32, 24, 16, 8,  0};
-	r = HEDLEY_STATIC_CAST(
-		int32_t, vec_extract(vec_vbpermq(a_.altivec_u8, perm), 14));
-#else
-	SIMDE_VECTORIZE_REDUCTION(| : r)
-	for (size_t i = 0; i < (sizeof(a_.u8) / sizeof(a_.u8[0])); i++) {
-		r |= (a_.u8[15 - i] >> 7) << (15 - i);
-	}
-#endif
-
-	return r;
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_movemask_epi8(a) simde_mm_movemask_epi8(a)
+  #define _mm_loadu_pd(mem_addr) simde_mm_loadu_pd(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int32_t simde_mm_movemask_pd(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_movemask_pd(a);
-#else
-	int32_t r = 0;
-	simde__m128d_private a_ = simde__m128d_to_private(a);
+simde__m128i
+simde_mm_loadu_epi8(void const * mem_addr) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE) && !defined(SIMDE_BUG_GCC_95483) && !defined(SIMDE_BUG_CLANG_REV_344862)
+    return _mm_loadu_epi8(mem_addr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, mem_addr));
+  #else
+    simde__m128i_private r_;
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	static const int64_t shift_amount[] = {0, 1};
-	const int64x2_t shift = vld1q_s64(shift_amount);
-	uint64x2_t tmp = vshrq_n_u64(a_.neon_u64, 63);
-	return HEDLEY_STATIC_CAST(int32_t, vaddvq_u64(vshlq_u64(tmp, shift)));
-#else
-	SIMDE_VECTORIZE_REDUCTION(| : r)
-	for (size_t i = 0; i < (sizeof(a_.u64) / sizeof(a_.u64[0])); i++) {
-		r |= (a_.u64[i] >> 63) << i;
-	}
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const*, mem_addr));
+    #else
+      simde_memcpy(&r_, mem_addr, sizeof(r_));
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#define simde_x_mm_loadu_epi8(mem_addr) simde_mm_loadu_epi8(mem_addr)
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && (defined(SIMDE_BUG_GCC_95483) || defined(SIMDE_BUG_CLANG_REV_344862)))
+  #undef _mm_loadu_epi8
+  #define _mm_loadu_epi8(a) simde_mm_loadu_epi8(a)
 #endif
 
-	return r;
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_loadu_epi16(void const * mem_addr) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE) && !defined(SIMDE_BUG_GCC_95483) && !defined(SIMDE_BUG_CLANG_REV_344862)
+    return _mm_loadu_epi16(mem_addr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, mem_addr));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vreinterpretq_s16_s8(vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const*, mem_addr)));
+    #else
+      simde_memcpy(&r_, mem_addr, sizeof(r_));
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#define simde_x_mm_loadu_epi16(mem_addr) simde_mm_loadu_epi16(mem_addr)
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) || defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && (defined(SIMDE_BUG_GCC_95483) || defined(SIMDE_BUG_CLANG_REV_344862)))
+  #undef _mm_loadu_epi16
+  #define _mm_loadu_epi16(a) simde_mm_loadu_epi16(a)
 #endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_loadu_epi32(void const * mem_addr) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && !defined(SIMDE_BUG_GCC_95483) && !defined(SIMDE_BUG_CLANG_REV_344862)
+    return _mm_loadu_epi32(mem_addr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, mem_addr));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vreinterpretq_s32_s8(vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const*, mem_addr)));
+    #else
+      simde_memcpy(&r_, mem_addr, sizeof(r_));
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#define simde_x_mm_loadu_epi32(mem_addr) simde_mm_loadu_epi32(mem_addr)
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && (defined(SIMDE_BUG_GCC_95483) || defined(SIMDE_BUG_CLANG_REV_344862)))
+  #undef _mm_loadu_epi32
+  #define _mm_loadu_epi32(a) simde_mm_loadu_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_loadu_epi64(void const * mem_addr) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && !defined(SIMDE_BUG_GCC_95483) && !defined(SIMDE_BUG_CLANG_REV_344862)
+    return _mm_loadu_epi64(mem_addr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(__m128i const *, mem_addr));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vreinterpretq_s64_s8(vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const*, mem_addr)));
+    #else
+      simde_memcpy(&r_, mem_addr, sizeof(r_));
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#define simde_x_mm_loadu_epi64(mem_addr) simde_mm_loadu_epi64(mem_addr)
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && (defined(SIMDE_BUG_GCC_95483) || defined(SIMDE_BUG_CLANG_REV_344862)))
+  #undef _mm_loadu_epi64
+  #define _mm_loadu_epi64(a) simde_mm_loadu_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_loadu_si128 (void const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(HEDLEY_STATIC_CAST(__m128i const*, mem_addr));
+  #else
+    simde__m128i_private r_;
+
+    #if HEDLEY_GNUC_HAS_ATTRIBUTE(may_alias,3,3,0)
+      HEDLEY_DIAGNOSTIC_PUSH
+      SIMDE_DIAGNOSTIC_DISABLE_PACKED_
+      struct simde_mm_loadu_si128_s {
+        __typeof__(r_) v;
+      } __attribute__((__packed__, __may_alias__));
+      r_ = HEDLEY_REINTERPRET_CAST(const struct simde_mm_loadu_si128_s *, mem_addr)->v;
+      HEDLEY_DIAGNOSTIC_POP
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const*, mem_addr));
+    #else
+      simde_memcpy(&r_, mem_addr, sizeof(r_));
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_movemask_pd(a) simde_mm_movemask_pd(a)
+  #define _mm_loadu_si128(mem_addr) simde_mm_loadu_si128(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m64 simde_mm_movepi64_pi64(simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-	return _mm_movepi64_pi64(a);
-#else
-	simde__m64_private r_;
-	simde__m128i_private a_ = simde__m128i_to_private(a);
+simde__m128i
+simde_mm_madd_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_madd_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_i64 = vget_low_s64(a_.neon_i64);
-#else
-	r_.i64[0] = a_.i64[0];
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      int32x4_t pl = vmull_s16(vget_low_s16(a_.neon_i16),  vget_low_s16(b_.neon_i16));
+      int32x4_t ph = vmull_high_s16(a_.neon_i16, b_.neon_i16);
+      r_.neon_i32 = vpaddq_s32(pl, ph);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int32x4_t pl = vmull_s16(vget_low_s16(a_.neon_i16),  vget_low_s16(b_.neon_i16));
+      int32x4_t ph = vmull_s16(vget_high_s16(a_.neon_i16), vget_high_s16(b_.neon_i16));
+      int32x2_t rl = vpadd_s32(vget_low_s32(pl), vget_high_s32(pl));
+      int32x2_t rh = vpadd_s32(vget_low_s32(ph), vget_high_s32(ph));
+      r_.neon_i32 = vcombine_s32(rl, rh);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_msum(a_.altivec_i16, b_.altivec_i16, vec_splats(0));
+    #elif defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i32 = vec_mule(a_.altivec_i16, b_.altivec_i16) + vec_mulo(a_.altivec_i16, b_.altivec_i16);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_CONVERT_VECTOR_) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      int32_t SIMDE_VECTOR(32) a32, b32, p32;
+      SIMDE_CONVERT_VECTOR_(a32, a_.i16);
+      SIMDE_CONVERT_VECTOR_(b32, b_.i16);
+      p32 = a32 * b32;
+      r_.i32 =
+        __builtin_shufflevector(p32, p32, 0, 2, 4, 6) +
+        __builtin_shufflevector(p32, p32, 1, 3, 5, 7);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i16[0])) ; i += 2) {
+        r_.i32[i / 2] = (a_.i16[i] * b_.i16[i]) + (a_.i16[i + 1] * b_.i16[i + 1]);
+      }
+    #endif
 
-	return simde__m64_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_movepi64_pi64(a) simde_mm_movepi64_pi64(a)
+  #define _mm_madd_epi16(a, b) simde_mm_madd_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_movpi64_epi64(simde__m64 a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-	return _mm_movpi64_epi64(a);
-#else
-	simde__m128i_private r_;
-	simde__m64_private a_ = simde__m64_to_private(a);
+void
+simde_mm_maskmoveu_si128 (simde__m128i a, simde__m128i mask, int8_t mem_addr[HEDLEY_ARRAY_PARAM(16)]) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_maskmoveu_si128(a, mask, HEDLEY_REINTERPRET_CAST(char*, mem_addr));
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      mask_ = simde__m128i_to_private(mask);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 = vcombine_s64(a_.neon_i64, vdup_n_s64(0));
-#else
-	r_.i64[0] = a_.i64[0];
-	r_.i64[1] = 0;
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
+    for (size_t i = 0 ; i < (sizeof(a_.i8) / sizeof(a_.i8[0])) ; i++) {
+      if (mask_.u8[i] & 0x80) {
+        mem_addr[i] = a_.i8[i];
+      }
+    }
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_movpi64_epi64(a) simde_mm_movpi64_epi64(a)
+  #define _mm_maskmoveu_si128(a, mask, mem_addr) simde_mm_maskmoveu_si128((a), (mask), SIMDE_CHECKED_REINTERPRET_CAST(int8_t*, char*, (mem_addr)))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_min_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_min_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+int32_t
+simde_mm_movemask_epi8 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__INTEL_COMPILER)
+    /* ICC has trouble with _mm_movemask_epi8 at -O2 and above: */
+    return _mm_movemask_epi8(a);
+  #else
+    int32_t r = 0;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i16 = vminq_s16(a_.neon_i16, b_.neon_i16);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i16x8_min(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i16 = vec_min(a_.altivec_i16, b_.altivec_i16);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.i16[i] = (a_.i16[i] < b_.i16[i]) ? a_.i16[i] : b_.i16[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      /* https://github.com/WebAssembly/simd/pull/201#issue-380682845 */
+      static const uint8_t md[16] = {
+        1 << 0, 1 << 1, 1 << 2, 1 << 3,
+        1 << 4, 1 << 5, 1 << 6, 1 << 7,
+        1 << 0, 1 << 1, 1 << 2, 1 << 3,
+        1 << 4, 1 << 5, 1 << 6, 1 << 7,
+      };
 
-	return simde__m128i_from_private(r_);
-#endif
+      /* Extend sign bit over entire lane */
+      uint8x16_t extended = vreinterpretq_u8_s8(vshrq_n_s8(a_.neon_i8, 7));
+      /* Clear all but the bit we're interested in. */
+      uint8x16_t masked = vandq_u8(vld1q_u8(md), extended);
+      /* Alternate bytes from low half and high half */
+      uint8x8x2_t tmp = vzip_u8(vget_low_u8(masked), vget_high_u8(masked));
+      uint16x8_t x = vreinterpretq_u16_u8(vcombine_u8(tmp.val[0], tmp.val[1]));
+      #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+        r = vaddvq_u16(x);
+      #else
+        uint64x2_t t64 = vpaddlq_u32(vpaddlq_u16(x));
+        r =
+          HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u64(t64, 0)) +
+          HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u64(t64, 1));
+      #endif
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && !defined(HEDLEY_IBM_VERSION) && (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
+      static const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) perm = { 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 0 };
+      r = HEDLEY_STATIC_CAST(int32_t, vec_extract(vec_vbpermq(a_.altivec_u8, perm), 1));
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && !defined(HEDLEY_IBM_VERSION) && (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG)
+      static const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) perm = { 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 0 };
+      r = HEDLEY_STATIC_CAST(int32_t, vec_extract(vec_vbpermq(a_.altivec_u8, perm), 14));
+    #else
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u8) / sizeof(a_.u8[0])) ; i++) {
+        r |= (a_.u8[15 - i] >> 7) << (15 - i);
+      }
+    #endif
+
+    return r;
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_min_epi16(a, b) simde_mm_min_epi16(a, b)
+  #define _mm_movemask_epi8(a) simde_mm_movemask_epi8(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_min_epu8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_min_epu8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+int32_t
+simde_mm_movemask_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_movemask_pd(a);
+  #else
+    int32_t r = 0;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u8 = vminq_u8(a_.neon_u8, b_.neon_u8);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_u8x16_min(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_u8 = vec_min(a_.altivec_u8, b_.altivec_u8);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u8) / sizeof(r_.u8[0])); i++) {
-		r_.u8[i] = (a_.u8[i] < b_.u8[i]) ? a_.u8[i] : b_.u8[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      HEDLEY_DIAGNOSTIC_PUSH
+      SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
+      uint64x2_t shifted = vshrq_n_u64(a_.neon_u64, 63);
+      r =
+        HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u64(shifted, 0)) +
+        (HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u64(shifted, 1)) << 1);
+      HEDLEY_DIAGNOSTIC_POP
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && defined(SIMDE_BUG_CLANG_50932)
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) idx = { 64, 0, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128 };
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) res = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_bperm(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned __int128), a_.altivec_u64), idx));
+      r = HEDLEY_STATIC_CAST(int32_t, vec_extract(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), res), 2));
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) idx = { 64, 0, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128 };
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) res = vec_bperm(a_.altivec_u8, idx);
+      r = HEDLEY_STATIC_CAST(int32_t, vec_extract(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), res), 2));
+    #else
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u64) / sizeof(a_.u64[0])) ; i++) {
+        r |= (a_.u64[i] >> 63) << i;
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return r;
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_min_epu8(a, b) simde_mm_min_epu8(a, b)
+  #define _mm_movemask_pd(a) simde_mm_movemask_pd(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_min_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_min_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m64
+simde_mm_movepi64_pi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movepi64_pi64(a);
+  #else
+    simde__m64_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
 
-#if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-	r_.altivec_f64 = vec_min(a_.altivec_f64, b_.altivec_f64);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vminq_f64(a_.neon_f64, b_.neon_f64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_min(a_.wasm_v128, b_.wasm_v128);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.f64[i] = (a_.f64[i] < b_.f64[i]) ? a_.f64[i] : b_.f64[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i64 = vget_low_s64(a_.neon_i64);
+    #else
+      r_.i64[0] = a_.i64[0];
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m64_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_min_pd(a, b) simde_mm_min_pd(a, b)
+  #define _mm_movepi64_pi64(a) simde_mm_movepi64_pi64(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_min_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_min_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_min_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128i
+simde_mm_movpi64_epi64 (simde__m64 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movpi64_epi64(a);
+  #else
+    simde__m128i_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	float64x2_t temp = vminq_f64(a_.neon_f64, b_.neon_f64);
-	r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
-#else
-	r_.f64[0] = (a_.f64[0] < b_.f64[0]) ? a_.f64[0] : b_.f64[0];
-	r_.f64[1] = a_.f64[1];
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vcombine_s64(a_.neon_i64, vdup_n_s64(0));
+    #else
+      r_.i64[0] = a_.i64[0];
+      r_.i64[1] = 0;
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_min_sd(a, b) simde_mm_min_sd(a, b)
+  #define _mm_movpi64_epi64(a) simde_mm_movpi64_epi64(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_max_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_max_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_min_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_min_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i16 = vmaxq_s16(a_.neon_i16, b_.neon_i16);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i16x8_max(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i16 = vec_max(a_.altivec_i16, b_.altivec_i16);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? a_.i16[i] : b_.i16[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vminq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_min(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i16 = vec_min(a_.altivec_i16, b_.altivec_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] < b_.i16[i]) ? a_.i16[i] : b_.i16[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_max_epi16(a, b) simde_mm_max_epi16(a, b)
+  #define _mm_min_epi16(a, b) simde_mm_min_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_max_epu8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_max_epu8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_min_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_min_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u8 = vmaxq_u8(a_.neon_u8, b_.neon_u8);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_u8x16_max(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_u8 = vec_max(a_.altivec_u8, b_.altivec_u8);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u8) / sizeof(r_.u8[0])); i++) {
-		r_.u8[i] = (a_.u8[i] > b_.u8[i]) ? a_.u8[i] : b_.u8[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vminq_u8(a_.neon_u8, b_.neon_u8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u8x16_min(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_u8 = vec_min(a_.altivec_u8, b_.altivec_u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] < b_.u8[i]) ? a_.u8[i] : b_.u8[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_max_epu8(a, b) simde_mm_max_epu8(a, b)
+  #define _mm_min_epu8(a, b) simde_mm_min_epu8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_max_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_max_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128d
+simde_mm_min_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_min_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-	r_.altivec_f64 = vec_max(a_.altivec_f64, b_.altivec_f64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_max(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vmaxq_f64(a_.neon_f64, b_.neon_f64);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.f64[i] = (a_.f64[i] > b_.f64[i]) ? a_.f64[i] : b_.f64[i];
-	}
-#endif
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_f64 = vec_min(a_.altivec_f64, b_.altivec_f64);
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vminq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_min(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = (a_.f64[i] < b_.f64[i]) ? a_.f64[i] : b_.f64[i];
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_max_pd(a, b) simde_mm_max_pd(a, b)
+  #define _mm_min_pd(a, b) simde_mm_min_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_max_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_max_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_max_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128d
+simde_mm_min_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_min_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_min_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_min_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	float64x2_t temp = vmaxq_f64(a_.neon_f64, b_.neon_f64);
-	r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
-#else
-	r_.f64[0] = (a_.f64[0] > b_.f64[0]) ? a_.f64[0] : b_.f64[0];
-	r_.f64[1] = a_.f64[1];
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      float64x2_t temp = vminq_f64(a_.neon_f64, b_.neon_f64);
+      r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
+    #else
+      r_.f64[0] = (a_.f64[0] < b_.f64[0]) ? a_.f64[0] : b_.f64[0];
+      r_.f64[1] = a_.f64[1];
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_max_sd(a, b) simde_mm_max_sd(a, b)
+  #define _mm_min_sd(a, b) simde_mm_min_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_move_epi64(simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_move_epi64(a);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
+simde__m128i
+simde_mm_max_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_max_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 = vsetq_lane_s64(0, a_.neon_i64, 1);
-#else
-	r_.i64[0] = a_.i64[0];
-	r_.i64[1] = 0;
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vmaxq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_max(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i16 = vec_max(a_.altivec_i16, b_.altivec_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? a_.i16[i] : b_.i16[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_move_epi64(a) simde_mm_move_epi64(a)
+  #define _mm_max_epi16(a, b) simde_mm_max_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_mul_epu32(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_mul_epu32(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_max_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_max_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	uint32x2_t a_lo = vmovn_u64(a_.neon_u64);
-	uint32x2_t b_lo = vmovn_u64(b_.neon_u64);
-	r_.neon_u64 = vmull_u32(a_lo, b_lo);
-#elif defined(SIMDE_SHUFFLE_VECTOR_) && \
-	(SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
-	__typeof__(a_.u32) z = {
-		0,
-	};
-	a_.u32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.u32, z, 0, 4, 2, 6);
-	b_.u32 = SIMDE_SHUFFLE_VECTOR_(32, 16, b_.u32, z, 0, 4, 2, 6);
-	r_.u64 = HEDLEY_REINTERPRET_CAST(__typeof__(r_.u64), a_.u32) *
-		 HEDLEY_REINTERPRET_CAST(__typeof__(r_.u64), b_.u32);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u64) / sizeof(r_.u64[0])); i++) {
-		r_.u64[i] = HEDLEY_STATIC_CAST(uint64_t, a_.u32[i * 2]) *
-			    HEDLEY_STATIC_CAST(uint64_t, b_.u32[i * 2]);
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vmaxq_u8(a_.neon_u8, b_.neon_u8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u8x16_max(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_u8 = vec_max(a_.altivec_u8, b_.altivec_u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] > b_.u8[i]) ? a_.u8[i] : b_.u8[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_mul_epu32(a, b) simde_mm_mul_epu32(a, b)
+  #define _mm_max_epu8(a, b) simde_mm_max_epu8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_mul_epi64(simde__m128i a, simde__m128i b)
-{
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128d
+simde_mm_max_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_max_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i64 = a_.i64 * b_.i64;
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vmulq_s64(a_.neon_f64, b_.neon_f64);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
-		r_.i64[i] = a_.i64[i] * b_.i64[i];
-	}
-#endif
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_f64 = vec_max(a_.altivec_f64, b_.altivec_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_max(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vmaxq_f64(a_.neon_f64, b_.neon_f64);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = (a_.f64[i] > b_.f64[i]) ? a_.f64[i] : b_.f64[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_mod_epi64(simde__m128i a, simde__m128i b)
-{
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
-
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i64 = a_.i64 % b_.i64;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
-		r_.i64[i] = a_.i64[i] % b_.i64[i];
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_mul_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_mul_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.f64 = a_.f64 * b_.f64;
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vmulq_f64(a_.neon_f64, b_.neon_f64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_mul(a_.wasm_v128, b_.wasm_v128);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.f64[i] = a_.f64[i] * b_.f64[i];
-	}
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_mul_pd(a, b) simde_mm_mul_pd(a, b)
+  #define _mm_max_pd(a, b) simde_mm_max_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_mul_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_mul_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_mul_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128d
+simde_mm_max_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_max_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_max_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_max_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	float64x2_t temp = vmulq_f64(a_.neon_f64, b_.neon_f64);
-	r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
-#else
-	r_.f64[0] = a_.f64[0] * b_.f64[0];
-	r_.f64[1] = a_.f64[1];
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      float64x2_t temp = vmaxq_f64(a_.neon_f64, b_.neon_f64);
+      r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
+    #else
+      r_.f64[0] = (a_.f64[0] > b_.f64[0]) ? a_.f64[0] : b_.f64[0];
+      r_.f64[1] = a_.f64[1];
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_mul_sd(a, b) simde_mm_mul_sd(a, b)
+  #define _mm_max_sd(a, b) simde_mm_max_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m64 simde_mm_mul_su32(simde__m64 a, simde__m64 b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE) && \
-	!defined(__PGI)
-	return _mm_mul_su32(a, b);
-#else
-	simde__m64_private r_, a_ = simde__m64_to_private(a),
-			       b_ = simde__m64_to_private(b);
+simde__m128i
+simde_mm_move_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_move_epi64(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.u64[0] = vget_lane_u64(
-		vget_low_u64(vmull_u32(vreinterpret_u32_s64(a_.neon_i64),
-				       vreinterpret_u32_s64(b_.neon_i64))),
-		0);
-#else
-	r_.u64[0] = HEDLEY_STATIC_CAST(uint64_t, a_.u32[0]) *
-		    HEDLEY_STATIC_CAST(uint64_t, b_.u32[0]);
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vsetq_lane_s64(0, a_.neon_i64, 1);
+    #else
+      r_.i64[0] = a_.i64[0];
+      r_.i64[1] = 0;
+    #endif
 
-	return simde__m64_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_mul_su32(a, b) simde_mm_mul_su32(a, b)
+  #define _mm_move_epi64(a) simde_mm_move_epi64(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_mulhi_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_mulhi_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_mul_epu32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mul_epu32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	int16x4_t a3210 = vget_low_s16(a_.neon_i16);
-	int16x4_t b3210 = vget_low_s16(b_.neon_i16);
-	int32x4_t ab3210 = vmull_s16(a3210, b3210); /* 3333222211110000 */
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	int32x4_t ab7654 = vmull_high_s16(a_.neon_i16, b_.neon_i16);
-	r_.neon_i16 = vuzp2q_s16(vreinterpretq_s16_s32(ab3210),
-				 vreinterpretq_s16_s32(ab7654));
-#else
-	int16x4_t a7654 = vget_high_s16(a_.neon_i16);
-	int16x4_t b7654 = vget_high_s16(b_.neon_i16);
-	int32x4_t ab7654 = vmull_s16(a7654, b7654); /* 7777666655554444 */
-	uint16x8x2_t rv = vuzpq_u16(vreinterpretq_u16_s32(ab3210),
-				    vreinterpretq_u16_s32(ab7654));
-	r_.neon_u16 = rv.val[1];
-#endif
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.u16[i] = HEDLEY_STATIC_CAST(
-			uint16_t,
-			(HEDLEY_STATIC_CAST(
-				 uint32_t,
-				 HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) *
-					 HEDLEY_STATIC_CAST(int32_t,
-							    b_.i16[i])) >>
-			 16));
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x2_t a_lo = vmovn_u64(a_.neon_u64);
+      uint32x2_t b_lo = vmovn_u64(b_.neon_u64);
+      r_.neon_u64 = vmull_u32(a_lo, b_lo);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_) && (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
+      __typeof__(a_.u32) z = { 0, };
+      a_.u32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.u32, z, 0, 4, 2, 6);
+      b_.u32 = SIMDE_SHUFFLE_VECTOR_(32, 16, b_.u32, z, 0, 4, 2, 6);
+      r_.u64 = HEDLEY_REINTERPRET_CAST(__typeof__(r_.u64), a_.u32) *
+               HEDLEY_REINTERPRET_CAST(__typeof__(r_.u64), b_.u32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = HEDLEY_STATIC_CAST(uint64_t, a_.u32[i * 2]) * HEDLEY_STATIC_CAST(uint64_t, b_.u32[i * 2]);
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_mulhi_epi16(a, b) simde_mm_mulhi_epi16(a, b)
+  #define _mm_mul_epu32(a, b) simde_mm_mul_epu32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_mulhi_epu16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-	return _mm_mulhi_epu16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_x_mm_mul_epi64 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	uint16x4_t a3210 = vget_low_u16(a_.neon_u16);
-	uint16x4_t b3210 = vget_low_u16(b_.neon_u16);
-	uint32x4_t ab3210 = vmull_u16(a3210, b3210); /* 3333222211110000 */
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	uint32x4_t ab7654 = vmull_high_u16(a_.neon_u16, b_.neon_u16);
-	r_.neon_u16 = vuzp2q_u16(vreinterpretq_u16_u32(ab3210),
-				 vreinterpretq_u16_u32(ab7654));
-#else
-	uint16x4_t a7654 = vget_high_u16(a_.neon_u16);
-	uint16x4_t b7654 = vget_high_u16(b_.neon_u16);
-	uint32x4_t ab7654 = vmull_u16(a7654, b7654); /* 7777666655554444 */
-	uint16x8x2_t neon_r = vuzpq_u16(vreinterpretq_u16_u32(ab3210),
-					vreinterpretq_u16_u32(ab7654));
-	r_.neon_u16 = neon_r.val[1];
-#endif
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u16) / sizeof(r_.u16[0])); i++) {
-		r_.u16[i] = HEDLEY_STATIC_CAST(
-			uint16_t,
-			HEDLEY_STATIC_CAST(uint32_t, a_.u16[i]) *
-					HEDLEY_STATIC_CAST(uint32_t,
-							   b_.u16[i]) >>
-				16);
-	}
-#endif
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.i64 = a_.i64 * b_.i64;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i64[i] * b_.i64[i];
+    }
+  #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+  return simde__m128i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_mod_epi64 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_PGI_30104)
+    r_.i64 = a_.i64 % b_.i64;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i64[i] % b_.i64[i];
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_mul_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mul_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 * b_.f64;
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vmulq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_mul(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f64[i] * b_.f64[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_mulhi_epu16(a, b) simde_mm_mulhi_epu16(a, b)
+  #define _mm_mul_pd(a, b) simde_mm_mul_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_mullo_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_mullo_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128d
+simde_mm_mul_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mul_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_mul_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_mul_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i16 = vmulq_s16(a_.neon_i16, b_.neon_i16);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	(void)a_;
-	(void)b_;
-	r_.altivec_i16 = vec_mul(a_.altivec_i16, b_.altivec_i16);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.u16[i] = HEDLEY_STATIC_CAST(
-			uint16_t,
-			HEDLEY_STATIC_CAST(uint32_t, a_.u16[i]) *
-				HEDLEY_STATIC_CAST(uint32_t, b_.u16[i]));
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      float64x2_t temp = vmulq_f64(a_.neon_f64, b_.neon_f64);
+      r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
+    #else
+      r_.f64[0] = a_.f64[0] * b_.f64[0];
+      r_.f64[1] = a_.f64[1];
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_mullo_epi16(a, b) simde_mm_mullo_epi16(a, b)
+  #define _mm_mul_sd(a, b) simde_mm_mul_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_or_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_or_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m64
+simde_mm_mul_su32 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE) && !defined(__PGI)
+    return _mm_mul_su32(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32f = a_.i32f | b_.i32f;
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_v128_or(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 = vorrq_s64(a_.neon_i64, b_.neon_i64);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
-		r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.u64[0] = vget_lane_u64(vget_low_u64(vmull_u32(vreinterpret_u32_s64(a_.neon_i64), vreinterpret_u32_s64(b_.neon_i64))), 0);
+    #else
+      r_.u64[0] = HEDLEY_STATIC_CAST(uint64_t, a_.u32[0]) * HEDLEY_STATIC_CAST(uint64_t, b_.u32[0]);
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m64_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_or_pd(a, b) simde_mm_or_pd(a, b)
+  #define _mm_mul_su32(a, b) simde_mm_mul_su32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_or_si128(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_or_si128(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_mulhi_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mulhi_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vorrq_s32(a_.neon_i32, b_.neon_i32);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i32 = vec_or(a_.altivec_i32, b_.altivec_i32);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32f = a_.i32f | b_.i32f;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
-		r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int16x4_t a3210 = vget_low_s16(a_.neon_i16);
+      int16x4_t b3210 = vget_low_s16(b_.neon_i16);
+      int32x4_t ab3210 = vmull_s16(a3210, b3210); /* 3333222211110000 */
+      #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+        int32x4_t ab7654 = vmull_high_s16(a_.neon_i16, b_.neon_i16);
+        r_.neon_i16 = vuzp2q_s16(vreinterpretq_s16_s32(ab3210), vreinterpretq_s16_s32(ab7654));
+      #else
+        int16x4_t a7654 = vget_high_s16(a_.neon_i16);
+        int16x4_t b7654 = vget_high_s16(b_.neon_i16);
+        int32x4_t ab7654 = vmull_s16(a7654, b7654); /* 7777666655554444 */
+        uint16x8x2_t rv = vuzpq_u16(vreinterpretq_u16_s32(ab3210), vreinterpretq_u16_s32(ab7654));
+        r_.neon_u16 = rv.val[1];
+      #endif
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, (HEDLEY_STATIC_CAST(uint32_t, HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) * HEDLEY_STATIC_CAST(int32_t, b_.i16[i])) >> 16));
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_or_si128(a, b) simde_mm_or_si128(a, b)
+  #define _mm_mulhi_epi16(a, b) simde_mm_mulhi_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_packs_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_packs_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_mulhi_epu16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+    return _mm_mulhi_epu16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i8 =
-		vcombine_s8(vqmovn_s16(a_.neon_i16), vqmovn_s16(b_.neon_i16));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.i8[i] = (a_.i16[i] > INT8_MAX)
-				   ? INT8_MAX
-				   : ((a_.i16[i] < INT8_MIN)
-					      ? INT8_MIN
-					      : HEDLEY_STATIC_CAST(int8_t,
-								   a_.i16[i]));
-		r_.i8[i + 8] = (b_.i16[i] > INT8_MAX)
-				       ? INT8_MAX
-				       : ((b_.i16[i] < INT8_MIN)
-						  ? INT8_MIN
-						  : HEDLEY_STATIC_CAST(
-							    int8_t, b_.i16[i]));
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint16x4_t a3210 = vget_low_u16(a_.neon_u16);
+      uint16x4_t b3210 = vget_low_u16(b_.neon_u16);
+      uint32x4_t ab3210 = vmull_u16(a3210, b3210); /* 3333222211110000 */
+      #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+        uint32x4_t ab7654 = vmull_high_u16(a_.neon_u16, b_.neon_u16);
+        r_.neon_u16 = vuzp2q_u16(vreinterpretq_u16_u32(ab3210), vreinterpretq_u16_u32(ab7654));
+      #else
+        uint16x4_t a7654 = vget_high_u16(a_.neon_u16);
+        uint16x4_t b7654 = vget_high_u16(b_.neon_u16);
+        uint32x4_t ab7654 = vmull_u16(a7654, b7654); /* 7777666655554444 */
+        uint16x8x2_t neon_r = vuzpq_u16(vreinterpretq_u16_u32(ab3210), vreinterpretq_u16_u32(ab7654));
+        r_.neon_u16 = neon_r.val[1];
+      #endif
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, HEDLEY_STATIC_CAST(uint32_t, a_.u16[i]) * HEDLEY_STATIC_CAST(uint32_t, b_.u16[i]) >> 16);
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_packs_epi16(a, b) simde_mm_packs_epi16(a, b)
+  #define _mm_mulhi_epu16(a, b) simde_mm_mulhi_epu16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_packs_epi32(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_packs_epi32(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_mullo_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mullo_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i16 =
-		vcombine_s16(vqmovn_s32(a_.neon_i32), vqmovn_s32(b_.neon_i32));
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i16 = vec_packs(a_.altivec_i32, b_.altivec_i32);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		r_.i16[i] = (a_.i32[i] > INT16_MAX)
-				    ? INT16_MAX
-				    : ((a_.i32[i] < INT16_MIN)
-					       ? INT16_MIN
-					       : HEDLEY_STATIC_CAST(int16_t,
-								    a_.i32[i]));
-		r_.i16[i + 4] =
-			(b_.i32[i] > INT16_MAX)
-				? INT16_MAX
-				: ((b_.i32[i] < INT16_MIN)
-					   ? INT16_MIN
-					   : HEDLEY_STATIC_CAST(int16_t,
-								b_.i32[i]));
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vmulq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      (void) a_;
+      (void) b_;
+      r_.altivec_i16 = vec_mul(a_.altivec_i16, b_.altivec_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, HEDLEY_STATIC_CAST(uint32_t, a_.u16[i]) * HEDLEY_STATIC_CAST(uint32_t, b_.u16[i]));
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_packs_epi32(a, b) simde_mm_packs_epi32(a, b)
+  #define _mm_mullo_epi16(a, b) simde_mm_mullo_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_packus_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_packus_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128d
+simde_mm_or_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u8 =
-		vcombine_u8(vqmovun_s16(a_.neon_i16), vqmovun_s16(b_.neon_i16));
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_u8 = vec_packsu(a_.altivec_i16, b_.altivec_i16);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.u8[i] = (a_.i16[i] > UINT8_MAX)
-				   ? UINT8_MAX
-				   : ((a_.i16[i] < 0)
-					      ? UINT8_C(0)
-					      : HEDLEY_STATIC_CAST(uint8_t,
-								   a_.i16[i]));
-		r_.u8[i + 8] =
-			(b_.i16[i] > UINT8_MAX)
-				? UINT8_MAX
-				: ((b_.i16[i] < 0)
-					   ? UINT8_C(0)
-					   : HEDLEY_STATIC_CAST(uint8_t,
-								b_.i16[i]));
-	}
-#endif
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f | b_.i32f;
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_or(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vorrq_s64(a_.neon_i64, b_.neon_i64);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_packus_epi16(a, b) simde_mm_packus_epi16(a, b)
+  #define _mm_or_pd(a, b) simde_mm_or_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_pause(void)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_pause();
-#endif
+simde__m128i
+simde_mm_or_si128 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vorrq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_or(a_.altivec_i32, b_.altivec_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f | b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_pause() (simde_mm_pause())
+  #define _mm_or_si128(a, b) simde_mm_or_si128(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_sad_epu8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_sad_epu8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_packs_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_packs_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	const uint16x8_t t = vpaddlq_u8(vabdq_u8(a_.neon_u8, b_.neon_u8));
-	r_.neon_u64 = vcombine_u64(vpaddl_u32(vpaddl_u16(vget_low_u16(t))),
-				   vpaddl_u32(vpaddl_u16(vget_high_u16(t))));
-#else
-	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
-		uint16_t tmp = 0;
-		SIMDE_VECTORIZE_REDUCTION(+ : tmp)
-		for (size_t j = 0; j < ((sizeof(r_.u8) / sizeof(r_.u8[0])) / 2);
-		     j++) {
-			const size_t e = j + (i * 8);
-			tmp += (a_.u8[e] > b_.u8[e]) ? (a_.u8[e] - b_.u8[e])
-						     : (b_.u8[e] - a_.u8[e]);
-		}
-		r_.i64[i] = tmp;
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vcombine_s8(vqmovn_s16(a_.neon_i16), vqmovn_s16(b_.neon_i16));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i8[i]     = (a_.i16[i] > INT8_MAX) ? INT8_MAX : ((a_.i16[i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, a_.i16[i]));
+        r_.i8[i + 8] = (b_.i16[i] > INT8_MAX) ? INT8_MAX : ((b_.i16[i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, b_.i16[i]));
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sad_epu8(a, b) simde_mm_sad_epu8(a, b)
+  #define _mm_packs_epi16(a, b) simde_mm_packs_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_set_epi8(int8_t e15, int8_t e14, int8_t e13, int8_t e12,
-			       int8_t e11, int8_t e10, int8_t e9, int8_t e8,
-			       int8_t e7, int8_t e6, int8_t e5, int8_t e4,
-			       int8_t e3, int8_t e2, int8_t e1, int8_t e0)
-{
+simde__m128i
+simde_mm_packs_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_packs_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_set_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5,
-			    e4, e3, e2, e1, e0);
-#else
-	simde__m128i_private r_;
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vcombine_s16(vqmovn_s32(a_.neon_i32), vqmovn_s32(b_.neon_i32));
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i16 = vec_packs(a_.altivec_i32, b_.altivec_i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i16[i]     = (a_.i32[i] > INT16_MAX) ? INT16_MAX : ((a_.i32[i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, a_.i32[i]));
+        r_.i16[i + 4] = (b_.i32[i] > INT16_MAX) ? INT16_MAX : ((b_.i32[i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, b_.i32[i]));
+      }
+    #endif
 
-#if defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i8x16_make(e0, e1, e2, e3, e4, e5, e6, e7, e8, e9,
-				       e10, e11, e12, e13, e14, e15);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	SIMDE_ALIGN_LIKE_16(int8x16_t)
-	int8_t data[16] = {e0, e1, e2,  e3,  e4,  e5,  e6,  e7,
-			   e8, e9, e10, e11, e12, e13, e14, e15};
-	r_.neon_i8 = vld1q_s8(data);
-#else
-	r_.i8[0] = e0;
-	r_.i8[1] = e1;
-	r_.i8[2] = e2;
-	r_.i8[3] = e3;
-	r_.i8[4] = e4;
-	r_.i8[5] = e5;
-	r_.i8[6] = e6;
-	r_.i8[7] = e7;
-	r_.i8[8] = e8;
-	r_.i8[9] = e9;
-	r_.i8[10] = e10;
-	r_.i8[11] = e11;
-	r_.i8[12] = e12;
-	r_.i8[13] = e13;
-	r_.i8[14] = e14;
-	r_.i8[15] = e15;
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_set_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, \
-		     e2, e1, e0)                                               \
-	simde_mm_set_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5,    \
-			  e4, e3, e2, e1, e0)
+  #define _mm_packs_epi32(a, b) simde_mm_packs_epi32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_set_epi16(int16_t e7, int16_t e6, int16_t e5, int16_t e4,
-				int16_t e3, int16_t e2, int16_t e1, int16_t e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_set_epi16(e7, e6, e5, e4, e3, e2, e1, e0);
-#else
-	simde__m128i_private r_;
+simde__m128i
+simde_mm_packus_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_packus_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	SIMDE_ALIGN_LIKE_16(int16x8_t)
-	int16_t data[8] = {e0, e1, e2, e3, e4, e5, e6, e7};
-	r_.neon_i16 = vld1q_s16(data);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i16x8_make(e0, e1, e2, e3, e4, e5, e6, e7);
-#else
-	r_.i16[0] = e0;
-	r_.i16[1] = e1;
-	r_.i16[2] = e2;
-	r_.i16[3] = e3;
-	r_.i16[4] = e4;
-	r_.i16[5] = e5;
-	r_.i16[6] = e6;
-	r_.i16[7] = e7;
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vcombine_u8(vqmovun_s16(a_.neon_i16), vqmovun_s16(b_.neon_i16));
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u8 = vec_packsu(a_.altivec_i16, b_.altivec_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.u8[i]     = (a_.i16[i] > UINT8_MAX) ? UINT8_MAX : ((a_.i16[i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, a_.i16[i]));
+        r_.u8[i + 8] = (b_.i16[i] > UINT8_MAX) ? UINT8_MAX : ((b_.i16[i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, b_.i16[i]));
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_set_epi16(e7, e6, e5, e4, e3, e2, e1, e0) \
-	simde_mm_set_epi16(e7, e6, e5, e4, e3, e2, e1, e0)
+  #define _mm_packus_epi16(a, b) simde_mm_packus_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_loadu_si16(void const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) &&                 \
-	(SIMDE_DETECT_CLANG_VERSION_CHECK(8, 0, 0) || \
-	 HEDLEY_GCC_VERSION_CHECK(11, 0, 0) ||        \
-	 HEDLEY_INTEL_VERSION_CHECK(20, 21, 1))
-	return _mm_loadu_si16(mem_addr);
-#else
-	int16_t val;
-	simde_memcpy(&val, mem_addr, sizeof(val));
-	return simde_x_mm_cvtsi16_si128(val);
-#endif
+void
+simde_mm_pause (void) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_pause();
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_loadu_si16(mem_addr) simde_mm_loadu_si16(mem_addr)
+  #define _mm_pause() (simde_mm_pause())
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_set_epi32(int32_t e3, int32_t e2, int32_t e1, int32_t e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_set_epi32(e3, e2, e1, e0);
-#else
-	simde__m128i_private r_;
+simde__m128i
+simde_mm_sad_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sad_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	SIMDE_ALIGN_LIKE_16(int32x4_t) int32_t data[4] = {e0, e1, e2, e3};
-	r_.neon_i32 = vld1q_s32(data);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i32x4_make(e0, e1, e2, e3);
-#else
-	r_.i32[0] = e0;
-	r_.i32[1] = e1;
-	r_.i32[2] = e2;
-	r_.i32[3] = e3;
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      const uint16x8_t t = vpaddlq_u8(vabdq_u8(a_.neon_u8, b_.neon_u8));
+      r_.neon_u64 = vcombine_u64(
+        vpaddl_u32(vpaddl_u16(vget_low_u16(t))),
+        vpaddl_u32(vpaddl_u16(vget_high_u16(t))));
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        uint16_t tmp = 0;
+        SIMDE_VECTORIZE_REDUCTION(+:tmp)
+        for (size_t j = 0 ; j < ((sizeof(r_.u8) / sizeof(r_.u8[0])) / 2) ; j++) {
+          const size_t e = j + (i * 8);
+          tmp += (a_.u8[e] > b_.u8[e]) ? (a_.u8[e] - b_.u8[e]) : (b_.u8[e] - a_.u8[e]);
+        }
+        r_.i64[i] = tmp;
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_set_epi32(e3, e2, e1, e0) simde_mm_set_epi32(e3, e2, e1, e0)
+  #define _mm_sad_epu8(a, b) simde_mm_sad_epu8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_loadu_si32(void const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) &&                 \
-	(SIMDE_DETECT_CLANG_VERSION_CHECK(8, 0, 0) || \
-	 HEDLEY_GCC_VERSION_CHECK(11, 0, 0) ||        \
-	 HEDLEY_INTEL_VERSION_CHECK(20, 21, 1))
-	return _mm_loadu_si32(mem_addr);
-#else
-	int32_t val;
-	simde_memcpy(&val, mem_addr, sizeof(val));
-	return simde_mm_cvtsi32_si128(val);
-#endif
+simde__m128i
+simde_mm_set_epi8 (int8_t e15, int8_t e14, int8_t e13, int8_t e12,
+       int8_t e11, int8_t e10, int8_t  e9, int8_t  e8,
+       int8_t  e7, int8_t  e6, int8_t  e5, int8_t  e4,
+       int8_t  e3, int8_t  e2, int8_t  e1, int8_t  e0) {
+
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_epi8(
+      e15, e14, e13, e12, e11, e10,  e9,  e8,
+       e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_make(
+         e0,  e1,  e2,  e3,  e4,  e5,  e6,  e7,
+         e8,  e9, e10, e11, e12, e13, e14, e15);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_LIKE_16(int8x16_t) int8_t data[16] = {
+        e0,  e1,  e2,  e3,
+        e4,  e5,  e6,  e7,
+        e8,  e9,  e10, e11,
+        e12, e13, e14, e15};
+      r_.neon_i8 = vld1q_s8(data);
+    #else
+      r_.i8[ 0] =  e0;
+      r_.i8[ 1] =  e1;
+      r_.i8[ 2] =  e2;
+      r_.i8[ 3] =  e3;
+      r_.i8[ 4] =  e4;
+      r_.i8[ 5] =  e5;
+      r_.i8[ 6] =  e6;
+      r_.i8[ 7] =  e7;
+      r_.i8[ 8] =  e8;
+      r_.i8[ 9] =  e9;
+      r_.i8[10] = e10;
+      r_.i8[11] = e11;
+      r_.i8[12] = e12;
+      r_.i8[13] = e13;
+      r_.i8[14] = e14;
+      r_.i8[15] = e15;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_loadu_si32(mem_addr) simde_mm_loadu_si32(mem_addr)
+  #define _mm_set_epi8(e15, e14, e13, e12, e11, e10,  e9,  e8,  e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0) simde_mm_set_epi8(e15, e14, e13, e12, e11, e10,  e9,  e8,  e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_set_epi64(simde__m64 e1, simde__m64 e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-	return _mm_set_epi64(e1, e0);
-#else
-	simde__m128i_private r_;
+simde__m128i
+simde_mm_set_epi16 (int16_t e7, int16_t e6, int16_t e5, int16_t e4,
+        int16_t e3, int16_t e2, int16_t e1, int16_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_epi16(e7, e6, e5, e4, e3, e2, e1, e0);
+  #else
+    simde__m128i_private r_;
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 = vcombine_s64(simde__m64_to_neon_i64(e0),
-				   simde__m64_to_neon_i64(e1));
-#else
-	r_.m64[0] = e0;
-	r_.m64[1] = e1;
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_LIKE_16(int16x8_t) int16_t data[8] = { e0, e1, e2, e3, e4, e5, e6, e7 };
+      r_.neon_i16 = vld1q_s16(data);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_make(e0, e1, e2, e3, e4, e5, e6, e7);
+    #else
+      r_.i16[0] = e0;
+      r_.i16[1] = e1;
+      r_.i16[2] = e2;
+      r_.i16[3] = e3;
+      r_.i16[4] = e4;
+      r_.i16[5] = e5;
+      r_.i16[6] = e6;
+      r_.i16[7] = e7;
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_set_epi64(e1, e0) (simde_mm_set_epi64((e1), (e0)))
+  #define _mm_set_epi16(e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0) simde_mm_set_epi16(e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_set_epi64x(int64_t e1, int64_t e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && \
-	(!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19, 0, 0))
-	return _mm_set_epi64x(e1, e0);
-#else
-	simde__m128i_private r_;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	SIMDE_ALIGN_LIKE_16(int64x2_t) int64_t data[2] = {e0, e1};
-	r_.neon_i64 = vld1q_s64(data);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i64x2_make(e0, e1);
-#else
-	r_.i64[0] = e0;
-	r_.i64[1] = e1;
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
+simde__m128i
+simde_mm_loadu_si16 (void const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && ( \
+      SIMDE_DETECT_CLANG_VERSION_CHECK(8,0,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(20,21,1))
+    return _mm_loadu_si16(mem_addr);
+  #else
+    int16_t val;
+    simde_memcpy(&val, mem_addr, sizeof(val));
+    return simde_x_mm_cvtsi16_si128(val);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_set_epi64x(e1, e0) simde_mm_set_epi64x(e1, e0)
+  #define _mm_loadu_si16(mem_addr) simde_mm_loadu_si16(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_loadu_si64(void const *mem_addr)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) &&                 \
-	(SIMDE_DETECT_CLANG_VERSION_CHECK(8, 0, 0) || \
-	 HEDLEY_GCC_VERSION_CHECK(11, 0, 0) ||        \
-	 HEDLEY_INTEL_VERSION_CHECK(20, 21, 1))
-	return _mm_loadu_si64(mem_addr);
-#else
-	int64_t val;
-	simde_memcpy(&val, mem_addr, sizeof(val));
-	return simde_mm_cvtsi64_si128(val);
-#endif
+simde__m128i
+simde_mm_set_epi32 (int32_t e3, int32_t e2, int32_t e1, int32_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_epi32(e3, e2, e1, e0);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_LIKE_16(int32x4_t) int32_t data[4] = { e0, e1, e2, e3 };
+      r_.neon_i32 = vld1q_s32(data);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_make(e0, e1, e2, e3);
+    #else
+      r_.i32[0] = e0;
+      r_.i32[1] = e1;
+      r_.i32[2] = e2;
+      r_.i32[3] = e3;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_loadu_si64(mem_addr) simde_mm_loadu_si64(mem_addr)
+  #define _mm_set_epi32(e3,  e2,  e1,  e0) simde_mm_set_epi32(e3,  e2,  e1,  e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_set_epu8(uint8_t e15, uint8_t e14, uint8_t e13,
-				 uint8_t e12, uint8_t e11, uint8_t e10,
-				 uint8_t e9, uint8_t e8, uint8_t e7, uint8_t e6,
-				 uint8_t e5, uint8_t e4, uint8_t e3, uint8_t e2,
-				 uint8_t e1, uint8_t e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_set_epi8(
-		HEDLEY_STATIC_CAST(char, e15), HEDLEY_STATIC_CAST(char, e14),
-		HEDLEY_STATIC_CAST(char, e13), HEDLEY_STATIC_CAST(char, e12),
-		HEDLEY_STATIC_CAST(char, e11), HEDLEY_STATIC_CAST(char, e10),
-		HEDLEY_STATIC_CAST(char, e9), HEDLEY_STATIC_CAST(char, e8),
-		HEDLEY_STATIC_CAST(char, e7), HEDLEY_STATIC_CAST(char, e6),
-		HEDLEY_STATIC_CAST(char, e5), HEDLEY_STATIC_CAST(char, e4),
-		HEDLEY_STATIC_CAST(char, e3), HEDLEY_STATIC_CAST(char, e2),
-		HEDLEY_STATIC_CAST(char, e1), HEDLEY_STATIC_CAST(char, e0));
-#else
-	simde__m128i_private r_;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	SIMDE_ALIGN_LIKE_16(uint8x16_t)
-	uint8_t data[16] = {e0, e1, e2,  e3,  e4,  e5,  e6,  e7,
-			    e8, e9, e10, e11, e12, e13, e14, e15};
-	r_.neon_u8 = vld1q_u8(data);
-#else
-	r_.u8[0] = e0;
-	r_.u8[1] = e1;
-	r_.u8[2] = e2;
-	r_.u8[3] = e3;
-	r_.u8[4] = e4;
-	r_.u8[5] = e5;
-	r_.u8[6] = e6;
-	r_.u8[7] = e7;
-	r_.u8[8] = e8;
-	r_.u8[9] = e9;
-	r_.u8[10] = e10;
-	r_.u8[11] = e11;
-	r_.u8[12] = e12;
-	r_.u8[13] = e13;
-	r_.u8[14] = e14;
-	r_.u8[15] = e15;
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_set_epu16(uint16_t e7, uint16_t e6, uint16_t e5,
-				  uint16_t e4, uint16_t e3, uint16_t e2,
-				  uint16_t e1, uint16_t e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_set_epi16(
-		HEDLEY_STATIC_CAST(short, e7), HEDLEY_STATIC_CAST(short, e6),
-		HEDLEY_STATIC_CAST(short, e5), HEDLEY_STATIC_CAST(short, e4),
-		HEDLEY_STATIC_CAST(short, e3), HEDLEY_STATIC_CAST(short, e2),
-		HEDLEY_STATIC_CAST(short, e1), HEDLEY_STATIC_CAST(short, e0));
-#else
-	simde__m128i_private r_;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	SIMDE_ALIGN_LIKE_16(uint16x8_t)
-	uint16_t data[8] = {e0, e1, e2, e3, e4, e5, e6, e7};
-	r_.neon_u16 = vld1q_u16(data);
-#else
-	r_.u16[0] = e0;
-	r_.u16[1] = e1;
-	r_.u16[2] = e2;
-	r_.u16[3] = e3;
-	r_.u16[4] = e4;
-	r_.u16[5] = e5;
-	r_.u16[6] = e6;
-	r_.u16[7] = e7;
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_set_epu32(uint32_t e3, uint32_t e2, uint32_t e1,
-				  uint32_t e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_set_epi32(HEDLEY_STATIC_CAST(int, e3),
-			     HEDLEY_STATIC_CAST(int, e2),
-			     HEDLEY_STATIC_CAST(int, e1),
-			     HEDLEY_STATIC_CAST(int, e0));
-#else
-	simde__m128i_private r_;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	SIMDE_ALIGN_LIKE_16(uint32x4_t) uint32_t data[4] = {e0, e1, e2, e3};
-	r_.neon_u32 = vld1q_u32(data);
-#else
-	r_.u32[0] = e0;
-	r_.u32[1] = e1;
-	r_.u32[2] = e2;
-	r_.u32[3] = e3;
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_set_epu64x(uint64_t e1, uint64_t e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && \
-	(!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19, 0, 0))
-	return _mm_set_epi64x(HEDLEY_STATIC_CAST(int64_t, e1),
-			      HEDLEY_STATIC_CAST(int64_t, e0));
-#else
-	simde__m128i_private r_;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	SIMDE_ALIGN_LIKE_16(uint64x2_t) uint64_t data[2] = {e0, e1};
-	r_.neon_u64 = vld1q_u64(data);
-#else
-	r_.u64[0] = e0;
-	r_.u64[1] = e1;
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_set_sd(simde_float64 a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_set_sd(a);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	return vsetq_lane_f64(a, vdupq_n_f64(SIMDE_FLOAT64_C(0.0)), 0);
-#else
-	return simde_mm_set_pd(SIMDE_FLOAT64_C(0.0), a);
-#endif
+simde__m128i
+simde_mm_loadu_si32 (void const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && ( \
+      SIMDE_DETECT_CLANG_VERSION_CHECK(8,0,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(20,21,1))
+    return _mm_loadu_si32(mem_addr);
+  #else
+    int32_t val;
+    simde_memcpy(&val, mem_addr, sizeof(val));
+    return simde_mm_cvtsi32_si128(val);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_set_sd(a) simde_mm_set_sd(a)
+  #define _mm_loadu_si32(mem_addr) simde_mm_loadu_si32(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_set1_epi8(int8_t a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_set1_epi8(a);
-#else
-	simde__m128i_private r_;
+simde__m128i
+simde_mm_set_epi64 (simde__m64 e1, simde__m64 e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set_epi64(e1, e0);
+  #else
+    simde__m128i_private r_;
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i8 = vdupq_n_s8(a);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i8x16_splat(a);
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-	r_.altivec_i8 = vec_splats(HEDLEY_STATIC_CAST(signed char, a));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
-		r_.i8[i] = a;
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vcombine_s64(simde__m64_to_neon_i64(e0), simde__m64_to_neon_i64(e1));
+    #else
+      r_.m64[0] = e0;
+      r_.m64[1] = e1;
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_set1_epi8(a) simde_mm_set1_epi8(a)
+  #define _mm_set_epi64(e1, e0) (simde_mm_set_epi64((e1), (e0)))
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_set1_epi16(int16_t a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_set1_epi16(a);
-#else
-	simde__m128i_private r_;
+simde__m128i
+simde_mm_set_epi64x (int64_t e1, int64_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,0,0))
+    return _mm_set_epi64x(e1, e0);
+  #else
+    simde__m128i_private r_;
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i16 = vdupq_n_s16(a);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i16x8_splat(a);
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-	r_.altivec_i16 = vec_splats(HEDLEY_STATIC_CAST(signed short, a));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.i16[i] = a;
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_LIKE_16(int64x2_t) int64_t data[2] = {e0, e1};
+      r_.neon_i64 = vld1q_s64(data);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i64x2_make(e0, e1);
+    #else
+      r_.i64[0] = e0;
+      r_.i64[1] = e1;
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_set1_epi16(a) simde_mm_set1_epi16(a)
+  #define _mm_set_epi64x(e1, e0) simde_mm_set_epi64x(e1, e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_set1_epi32(int32_t a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_set1_epi32(a);
-#else
-	simde__m128i_private r_;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vdupq_n_s32(a);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i32x4_splat(a);
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-	r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, a));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		r_.i32[i] = a;
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
+simde__m128i
+simde_mm_loadu_si64 (void const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && ( \
+      SIMDE_DETECT_CLANG_VERSION_CHECK(8,0,0) || \
+      HEDLEY_GCC_VERSION_CHECK(11,0,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(20,21,1))
+    return _mm_loadu_si64(mem_addr);
+  #else
+  int64_t val;
+    simde_memcpy(&val, mem_addr, sizeof(val));
+    return simde_mm_cvtsi64_si128(val);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_set1_epi32(a) simde_mm_set1_epi32(a)
+  #define _mm_loadu_si64(mem_addr) simde_mm_loadu_si64(mem_addr)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_set1_epi64x(int64_t a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && \
-	(!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19, 0, 0))
-	return _mm_set1_epi64x(a);
-#else
-	simde__m128i_private r_;
+simde__m128i
+simde_x_mm_set_epu8 (uint8_t e15, uint8_t e14, uint8_t e13, uint8_t e12,
+         uint8_t e11, uint8_t e10, uint8_t  e9, uint8_t  e8,
+         uint8_t  e7, uint8_t  e6, uint8_t  e5, uint8_t  e4,
+         uint8_t  e3, uint8_t  e2, uint8_t  e1, uint8_t  e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_epi8(
+      HEDLEY_STATIC_CAST(char, e15), HEDLEY_STATIC_CAST(char, e14), HEDLEY_STATIC_CAST(char, e13), HEDLEY_STATIC_CAST(char, e12),
+      HEDLEY_STATIC_CAST(char, e11), HEDLEY_STATIC_CAST(char, e10), HEDLEY_STATIC_CAST(char,  e9), HEDLEY_STATIC_CAST(char,  e8),
+      HEDLEY_STATIC_CAST(char,  e7), HEDLEY_STATIC_CAST(char,  e6), HEDLEY_STATIC_CAST(char,  e5), HEDLEY_STATIC_CAST(char,  e4),
+      HEDLEY_STATIC_CAST(char,  e3), HEDLEY_STATIC_CAST(char,  e2), HEDLEY_STATIC_CAST(char,  e1), HEDLEY_STATIC_CAST(char,  e0));
+  #else
+    simde__m128i_private r_;
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 = vdupq_n_s64(a);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i64x2_splat(a);
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-	r_.altivec_i64 = vec_splats(HEDLEY_STATIC_CAST(signed long long, a));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
-		r_.i64[i] = a;
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_LIKE_16(uint8x16_t) uint8_t data[16] = {
+        e0,  e1,  e2,  e3,
+        e4,  e5,  e6,  e7,
+        e8,  e9,  e10, e11,
+        e12, e13, e14, e15};
+      r_.neon_u8 = vld1q_u8(data);
+    #else
+      r_.u8[ 0] =  e0; r_.u8[ 1] =  e1; r_.u8[ 2] =  e2; r_.u8[ 3] =  e3;
+      r_.u8[ 4] =  e4; r_.u8[ 5] =  e5; r_.u8[ 6] =  e6; r_.u8[ 7] =  e7;
+      r_.u8[ 8] =  e8; r_.u8[ 9] =  e9; r_.u8[10] = e10; r_.u8[11] = e11;
+      r_.u8[12] = e12; r_.u8[13] = e13; r_.u8[14] = e14; r_.u8[15] = e15;
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set_epu16 (uint16_t e7, uint16_t e6, uint16_t e5, uint16_t e4,
+          uint16_t e3, uint16_t e2, uint16_t e1, uint16_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_epi16(
+      HEDLEY_STATIC_CAST(short,  e7), HEDLEY_STATIC_CAST(short,  e6), HEDLEY_STATIC_CAST(short,  e5), HEDLEY_STATIC_CAST(short,  e4),
+      HEDLEY_STATIC_CAST(short,  e3), HEDLEY_STATIC_CAST(short,  e2), HEDLEY_STATIC_CAST(short,  e1), HEDLEY_STATIC_CAST(short,  e0));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_LIKE_16(uint16x8_t) uint16_t data[8] = { e0, e1, e2, e3, e4, e5, e6, e7 };
+      r_.neon_u16 = vld1q_u16(data);
+    #else
+      r_.u16[0] = e0; r_.u16[1] = e1; r_.u16[2] = e2; r_.u16[3] = e3;
+      r_.u16[4] = e4; r_.u16[5] = e5; r_.u16[6] = e6; r_.u16[7] = e7;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set_epu32 (uint32_t e3, uint32_t e2, uint32_t e1, uint32_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_epi32(
+      HEDLEY_STATIC_CAST(int,  e3), HEDLEY_STATIC_CAST(int,  e2), HEDLEY_STATIC_CAST(int,  e1), HEDLEY_STATIC_CAST(int,  e0));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_LIKE_16(uint32x4_t) uint32_t data[4] = { e0, e1, e2, e3 };
+      r_.neon_u32 = vld1q_u32(data);
+    #else
+      r_.u32[0] = e0;
+      r_.u32[1] = e1;
+      r_.u32[2] = e2;
+      r_.u32[3] = e3;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set_epu64x (uint64_t e1, uint64_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,0,0))
+    return _mm_set_epi64x(HEDLEY_STATIC_CAST(int64_t,  e1), HEDLEY_STATIC_CAST(int64_t,  e0));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_LIKE_16(uint64x2_t) uint64_t data[2] = {e0, e1};
+      r_.neon_u64 = vld1q_u64(data);
+    #else
+      r_.u64[0] = e0;
+      r_.u64[1] = e1;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_set_sd (simde_float64 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_sd(a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vsetq_lane_f64(a, vdupq_n_f64(SIMDE_FLOAT64_C(0.0)), 0);
+  #else
+    return simde_mm_set_pd(SIMDE_FLOAT64_C(0.0), a);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_set1_epi64x(a) simde_mm_set1_epi64x(a)
+  #define _mm_set_sd(a) simde_mm_set_sd(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_set1_epi64(simde__m64 a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-	return _mm_set1_epi64(a);
-#else
-	simde__m64_private a_ = simde__m64_to_private(a);
-	return simde_mm_set1_epi64x(a_.i64[0]);
-#endif
+simde__m128i
+simde_mm_set1_epi8 (int8_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_epi8(a);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vdupq_n_s8(a);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_splat(a);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i8 = vec_splats(HEDLEY_STATIC_CAST(signed char, a));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_set1_epi64(a) simde_mm_set1_epi64(a)
+  #define _mm_set1_epi8(a) simde_mm_set1_epi8(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_set1_epu8(uint8_t value)
-{
-#if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-	return simde__m128i_from_altivec_u8(
-		vec_splats(HEDLEY_STATIC_CAST(unsigned char, value)));
-#else
-	return simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, value));
-#endif
-}
+simde__m128i
+simde_mm_set1_epi16 (int16_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_epi16(a);
+  #else
+    simde__m128i_private r_;
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_set1_epu16(uint16_t value)
-{
-#if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-	return simde__m128i_from_altivec_u16(
-		vec_splats(HEDLEY_STATIC_CAST(unsigned short, value)));
-#else
-	return simde_mm_set1_epi16(HEDLEY_STATIC_CAST(int16_t, value));
-#endif
-}
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vdupq_n_s16(a);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_splat(a);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i16 = vec_splats(HEDLEY_STATIC_CAST(signed short, a));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a;
+      }
+    #endif
 
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_set1_epu32(uint32_t value)
-{
-#if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-	return simde__m128i_from_altivec_u32(
-		vec_splats(HEDLEY_STATIC_CAST(unsigned int, value)));
-#else
-	return simde_mm_set1_epi32(HEDLEY_STATIC_CAST(int32_t, value));
-#endif
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_set1_epu64(uint64_t value)
-{
-#if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-	return simde__m128i_from_altivec_u64(
-		vec_splats(HEDLEY_STATIC_CAST(unsigned long long, value)));
-#else
-	return simde_mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, value));
-#endif
-}
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_setr_epi8(int8_t e15, int8_t e14, int8_t e13, int8_t e12,
-				int8_t e11, int8_t e10, int8_t e9, int8_t e8,
-				int8_t e7, int8_t e6, int8_t e5, int8_t e4,
-				int8_t e3, int8_t e2, int8_t e1, int8_t e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_setr_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5,
-			     e4, e3, e2, e1, e0);
-#else
-	return simde_mm_set_epi8(e0, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10,
-				 e11, e12, e13, e14, e15);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_setr_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4,  \
-		      e3, e2, e1, e0)                                        \
-	simde_mm_setr_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, \
-			   e4, e3, e2, e1, e0)
+  #define _mm_set1_epi16(a) simde_mm_set1_epi16(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_setr_epi16(int16_t e7, int16_t e6, int16_t e5, int16_t e4,
-				 int16_t e3, int16_t e2, int16_t e1, int16_t e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_setr_epi16(e7, e6, e5, e4, e3, e2, e1, e0);
-#else
-	return simde_mm_set_epi16(e0, e1, e2, e3, e4, e5, e6, e7);
-#endif
+simde__m128i
+simde_mm_set1_epi32 (int32_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_epi32(a);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vdupq_n_s32(a);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_splat(a);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, a));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_setr_epi16(e7, e6, e5, e4, e3, e2, e1, e0) \
-	simde_mm_setr_epi16(e7, e6, e5, e4, e3, e2, e1, e0)
+  #define _mm_set1_epi32(a) simde_mm_set1_epi32(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_setr_epi32(int32_t e3, int32_t e2, int32_t e1, int32_t e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_setr_epi32(e3, e2, e1, e0);
-#else
-	return simde_mm_set_epi32(e0, e1, e2, e3);
-#endif
+simde__m128i
+simde_mm_set1_epi64x (int64_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,0,0))
+    return _mm_set1_epi64x(a);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vdupq_n_s64(a);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i64x2_splat(a);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_i64 = vec_splats(HEDLEY_STATIC_CAST(signed long long, a));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_setr_epi32(e3, e2, e1, e0) simde_mm_setr_epi32(e3, e2, e1, e0)
+  #define _mm_set1_epi64x(a) simde_mm_set1_epi64x(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_setr_epi64(simde__m64 e1, simde__m64 e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-	return _mm_setr_epi64(e1, e0);
-#else
-	return simde_mm_set_epi64(e0, e1);
-#endif
+simde__m128i
+simde_mm_set1_epi64 (simde__m64 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set1_epi64(a);
+  #else
+    simde__m64_private a_ = simde__m64_to_private(a);
+    return simde_mm_set1_epi64x(a_.i64[0]);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_setr_epi64(e1, e0) (simde_mm_setr_epi64((e1), (e0)))
+  #define _mm_set1_epi64(a) simde_mm_set1_epi64(a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_setr_pd(simde_float64 e1, simde_float64 e0)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_setr_pd(e1, e0);
-#else
-	return simde_mm_set_pd(e0, e1);
-#endif
+simde__m128i
+simde_x_mm_set1_epu8 (uint8_t value) {
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return simde__m128i_from_altivec_u8(vec_splats(HEDLEY_STATIC_CAST(unsigned char, value)));
+  #else
+    return simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, value));
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set1_epu16 (uint16_t value) {
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return simde__m128i_from_altivec_u16(vec_splats(HEDLEY_STATIC_CAST(unsigned short, value)));
+  #else
+    return simde_mm_set1_epi16(HEDLEY_STATIC_CAST(int16_t, value));
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set1_epu32 (uint32_t value) {
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return simde__m128i_from_altivec_u32(vec_splats(HEDLEY_STATIC_CAST(unsigned int, value)));
+  #else
+    return simde_mm_set1_epi32(HEDLEY_STATIC_CAST(int32_t, value));
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set1_epu64 (uint64_t value) {
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return simde__m128i_from_altivec_u64(vec_splats(HEDLEY_STATIC_CAST(unsigned long long, value)));
+  #else
+    return simde_mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, value));
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_setr_epi8 (int8_t e15, int8_t e14, int8_t e13, int8_t e12,
+        int8_t e11, int8_t e10, int8_t  e9, int8_t  e8,
+        int8_t  e7, int8_t  e6, int8_t  e5, int8_t  e4,
+        int8_t  e3, int8_t  e2, int8_t  e1, int8_t  e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_setr_epi8(
+      e15, e14, e13, e12, e11, e10,  e9,    e8,
+      e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
+  #else
+    return simde_mm_set_epi8(
+      e0, e1, e2, e3, e4, e5, e6, e7,
+      e8, e9, e10, e11, e12, e13, e14, e15);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_setr_pd(e1, e0) simde_mm_setr_pd(e1, e0)
+  #define _mm_setr_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0) simde_mm_setr_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_setzero_pd(void)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_setzero_pd();
-#else
-	return simde_mm_castsi128_pd(simde_mm_setzero_si128());
-#endif
+simde__m128i
+simde_mm_setr_epi16 (int16_t e7, int16_t e6, int16_t e5, int16_t e4,
+         int16_t e3, int16_t e2, int16_t e1, int16_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_setr_epi16(e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
+  #else
+    return simde_mm_set_epi16(e0, e1, e2, e3, e4, e5, e6, e7);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_setzero_pd() simde_mm_setzero_pd()
+  #define _mm_setr_epi16(e7, e6, e5, e4, e3, e2, e1, e0) simde_mm_setr_epi16(e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_setr_epi32 (int32_t e3, int32_t e2, int32_t e1, int32_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_setr_epi32(e3, e2, e1, e0);
+  #else
+    return simde_mm_set_epi32(e0, e1, e2, e3);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_setr_epi32(e3, e2, e1, e0) simde_mm_setr_epi32(e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_setr_epi64 (simde__m64 e1, simde__m64 e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_setr_epi64(e1, e0);
+  #else
+    return simde_mm_set_epi64(e0, e1);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_setr_epi64(e1, e0) (simde_mm_setr_epi64((e1), (e0)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_setr_pd (simde_float64 e1, simde_float64 e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_setr_pd(e1, e0);
+  #else
+    return simde_mm_set_pd(e0, e1);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_setr_pd(e1, e0) simde_mm_setr_pd(e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_setzero_pd (void) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_setzero_pd();
+  #else
+    return simde_mm_castsi128_pd(simde_mm_setzero_si128());
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_setzero_pd() simde_mm_setzero_pd()
 #endif
 
 #if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
@@ -5236,37 +5204,37 @@ SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_undefined_pd(void)
-{
-	simde__m128d_private r_;
+simde__m128d
+simde_mm_undefined_pd (void) {
+  simde__m128d_private r_;
 
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE__HAVE_UNDEFINED128)
-	r_.n = _mm_undefined_pd();
-#elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
-	r_ = simde__m128d_to_private(simde_mm_setzero_pd());
-#endif
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE__HAVE_UNDEFINED128)
+    r_.n = _mm_undefined_pd();
+  #elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+    r_ = simde__m128d_to_private(simde_mm_setzero_pd());
+  #endif
 
-	return simde__m128d_from_private(r_);
+  return simde__m128d_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_undefined_pd() simde_mm_undefined_pd()
+  #define _mm_undefined_pd() simde_mm_undefined_pd()
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_undefined_si128(void)
-{
-	simde__m128i_private r_;
+simde__m128i
+simde_mm_undefined_si128 (void) {
+  simde__m128i_private r_;
 
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE__HAVE_UNDEFINED128)
-	r_.n = _mm_undefined_si128();
-#elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
-	r_ = simde__m128i_to_private(simde_mm_setzero_si128());
-#endif
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE__HAVE_UNDEFINED128)
+    r_.n = _mm_undefined_si128();
+  #elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+  #endif
 
-	return simde__m128i_from_private(r_);
+  return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_undefined_si128() (simde_mm_undefined_si128())
+  #define _mm_undefined_si128() (simde_mm_undefined_si128())
 #endif
 
 #if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
@@ -5274,2272 +5242,2176 @@ HEDLEY_DIAGNOSTIC_POP
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_x_mm_setone_pd(void)
-{
-	return simde_mm_castps_pd(simde_x_mm_setone_ps());
+simde__m128d
+simde_x_mm_setone_pd (void) {
+  return simde_mm_castps_pd(simde_x_mm_setone_ps());
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_setone_si128(void)
-{
-	return simde_mm_castps_si128(simde_x_mm_setone_ps());
+simde__m128i
+simde_x_mm_setone_si128 (void) {
+  return simde_mm_castps_si128(simde_x_mm_setone_ps());
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_shuffle_epi32(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-{
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
+simde__m128i
+simde_mm_shuffle_epi32 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
 
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		r_.i32[i] = a_.i32[(imm8 >> (i * 2)) & 3];
-	}
+  for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+    r_.i32[i] = a_.i32[(imm8 >> (i * 2)) & 3];
+  }
 
-	return simde__m128i_from_private(r_);
+  return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-#define simde_mm_shuffle_epi32(a, imm8) _mm_shuffle_epi32((a), (imm8))
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#define simde_mm_shuffle_epi32(a, imm8)                                       \
-	__extension__({                                                       \
-		int32x4_t ret;                                                \
-		ret = vmovq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s64(a),    \
-						 (imm8) & (0x3)));            \
-		ret = vsetq_lane_s32(vgetq_lane_s32(vreinterpretq_s32_s64(a), \
-						    ((imm8) >> 2) & 0x3),     \
-				     ret, 1);                                 \
-		ret = vsetq_lane_s32(vgetq_lane_s32(vreinterpretq_s32_s64(a), \
-						    ((imm8) >> 4) & 0x3),     \
-				     ret, 2);                                 \
-		ret = vsetq_lane_s32(vgetq_lane_s32(vreinterpretq_s32_s64(a), \
-						    ((imm8) >> 6) & 0x3),     \
-				     ret, 3);                                 \
-		vreinterpretq_s64_s32(ret);                                   \
-	})
+  #define simde_mm_shuffle_epi32(a, imm8) _mm_shuffle_epi32((a), (imm8))
 #elif defined(SIMDE_SHUFFLE_VECTOR_)
-#define simde_mm_shuffle_epi32(a, imm8)                               \
-	(__extension__({                                              \
-		const simde__m128i_private simde__tmp_a_ =            \
-			simde__m128i_to_private(a);                   \
-		simde__m128i_from_private((simde__m128i_private){     \
-			.i32 = SIMDE_SHUFFLE_VECTOR_(                 \
-				32, 16, (simde__tmp_a_).i32,          \
-				(simde__tmp_a_).i32, ((imm8)) & 3,    \
-				((imm8) >> 2) & 3, ((imm8) >> 4) & 3, \
-				((imm8) >> 6) & 3)});                 \
-	}))
+  #define simde_mm_shuffle_epi32(a, imm8) (__extension__ ({ \
+      const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
+      simde__m128i_from_private((simde__m128i_private) { .i32 = \
+        SIMDE_SHUFFLE_VECTOR_(32, 16, \
+          (simde__tmp_a_).i32, \
+          (simde__tmp_a_).i32, \
+          ((imm8)     ) & 3, \
+          ((imm8) >> 2) & 3, \
+          ((imm8) >> 4) & 3, \
+          ((imm8) >> 6) & 3) }); }))
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_STATEMENT_EXPR_)
+  #define simde_mm_shuffle_epi32(a, imm8) \
+    (__extension__ ({ \
+      const int32x4_t simde_mm_shuffle_epi32_a_ = simde__m128i_to_neon_i32(a); \
+      int32x4_t simde_mm_shuffle_epi32_r_; \
+      simde_mm_shuffle_epi32_r_ = vmovq_n_s32(vgetq_lane_s32(simde_mm_shuffle_epi32_a_, (imm8) & (0x3))); \
+      simde_mm_shuffle_epi32_r_ = vsetq_lane_s32(vgetq_lane_s32(simde_mm_shuffle_epi32_a_, ((imm8) >> 2) & 0x3), simde_mm_shuffle_epi32_r_, 1); \
+      simde_mm_shuffle_epi32_r_ = vsetq_lane_s32(vgetq_lane_s32(simde_mm_shuffle_epi32_a_, ((imm8) >> 4) & 0x3), simde_mm_shuffle_epi32_r_, 2); \
+      simde_mm_shuffle_epi32_r_ = vsetq_lane_s32(vgetq_lane_s32(simde_mm_shuffle_epi32_a_, ((imm8) >> 6) & 0x3), simde_mm_shuffle_epi32_r_, 3); \
+      vreinterpretq_s64_s32(simde_mm_shuffle_epi32_r_); \
+    }))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_shuffle_epi32(a, imm8) simde_mm_shuffle_epi32(a, imm8)
+  #define _mm_shuffle_epi32(a, imm8) simde_mm_shuffle_epi32(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_shuffle_pd(simde__m128d a, simde__m128d b, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 3)
-{
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128d
+simde_mm_shuffle_pd (simde__m128d a, simde__m128d b, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 3)  {
+  simde__m128d_private
+    r_,
+    a_ = simde__m128d_to_private(a),
+    b_ = simde__m128d_to_private(b);
 
-	r_.f64[0] = ((imm8 & 1) == 0) ? a_.f64[0] : a_.f64[1];
-	r_.f64[1] = ((imm8 & 2) == 0) ? b_.f64[0] : b_.f64[1];
+  r_.f64[0] = ((imm8 & 1) == 0) ? a_.f64[0] : a_.f64[1];
+  r_.f64[1] = ((imm8 & 2) == 0) ? b_.f64[0] : b_.f64[1];
 
-	return simde__m128d_from_private(r_);
+  return simde__m128d_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
-#define simde_mm_shuffle_pd(a, b, imm8) _mm_shuffle_pd((a), (b), (imm8))
+  #define simde_mm_shuffle_pd(a, b, imm8) _mm_shuffle_pd((a), (b), (imm8))
 #elif defined(SIMDE_SHUFFLE_VECTOR_)
-#define simde_mm_shuffle_pd(a, b, imm8)                                     \
-	(__extension__({                                                    \
-		simde__m128d_from_private((simde__m128d_private){           \
-			.f64 = SIMDE_SHUFFLE_VECTOR_(                       \
-				64, 16, simde__m128d_to_private(a).f64,     \
-				simde__m128d_to_private(b).f64,             \
-				(((imm8)) & 1), (((imm8) >> 1) & 1) + 2)}); \
-	}))
+  #define simde_mm_shuffle_pd(a, b, imm8) (__extension__ ({ \
+      simde__m128d_from_private((simde__m128d_private) { .f64 = \
+        SIMDE_SHUFFLE_VECTOR_(64, 16, \
+          simde__m128d_to_private(a).f64, \
+          simde__m128d_to_private(b).f64, \
+          (((imm8)     ) & 1), \
+          (((imm8) >> 1) & 1) + 2) }); }))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_shuffle_pd(a, b, imm8) simde_mm_shuffle_pd(a, b, imm8)
+  #define _mm_shuffle_pd(a, b, imm8) simde_mm_shuffle_pd(a, b, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_shufflehi_epi16(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-{
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
+simde__m128i
+simde_mm_shufflehi_epi16 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
 
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2);
-	     i++) {
-		r_.i16[i] = a_.i16[i];
-	}
-	for (size_t i = ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2);
-	     i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.i16[i] = a_.i16[((imm8 >> ((i - 4) * 2)) & 3) + 4];
-	}
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2) ; i++) {
+    r_.i16[i] = a_.i16[i];
+  }
+  for (size_t i = ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2) ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+    r_.i16[i] = a_.i16[((imm8 >> ((i - 4) * 2)) & 3) + 4];
+  }
 
-	return simde__m128i_from_private(r_);
+  return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-#define simde_mm_shufflehi_epi16(a, imm8) _mm_shufflehi_epi16((a), (imm8))
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#define simde_mm_shufflehi_epi16(a, imm8)                                      \
-	__extension__({                                                        \
-		int16x8_t ret = vreinterpretq_s16_s64(a);                      \
-		int16x4_t highBits = vget_high_s16(ret);                       \
-		ret = vsetq_lane_s16(vget_lane_s16(highBits, (imm8) & (0x3)),  \
-				     ret, 4);                                  \
-		ret = vsetq_lane_s16(                                          \
-			vget_lane_s16(highBits, ((imm8) >> 2) & 0x3), ret, 5); \
-		ret = vsetq_lane_s16(                                          \
-			vget_lane_s16(highBits, ((imm8) >> 4) & 0x3), ret, 6); \
-		ret = vsetq_lane_s16(                                          \
-			vget_lane_s16(highBits, ((imm8) >> 6) & 0x3), ret, 7); \
-		vreinterpretq_s64_s16(ret);                                    \
-	})
+  #define simde_mm_shufflehi_epi16(a, imm8) _mm_shufflehi_epi16((a), (imm8))
 #elif defined(SIMDE_SHUFFLE_VECTOR_)
-#define simde_mm_shufflehi_epi16(a, imm8)                                    \
-	(__extension__({                                                     \
-		const simde__m128i_private simde__tmp_a_ =                   \
-			simde__m128i_to_private(a);                          \
-		simde__m128i_from_private((simde__m128i_private){            \
-			.i16 = SIMDE_SHUFFLE_VECTOR_(                        \
-				16, 16, (simde__tmp_a_).i16,                 \
-				(simde__tmp_a_).i16, 0, 1, 2, 3,             \
-				(((imm8)) & 3) + 4, (((imm8) >> 2) & 3) + 4, \
-				(((imm8) >> 4) & 3) + 4,                     \
-				(((imm8) >> 6) & 3) + 4)});                  \
-	}))
+  #define simde_mm_shufflehi_epi16(a, imm8) (__extension__ ({ \
+      const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
+      simde__m128i_from_private((simde__m128i_private) { .i16 = \
+        SIMDE_SHUFFLE_VECTOR_(16, 16, \
+          (simde__tmp_a_).i16, \
+          (simde__tmp_a_).i16, \
+          0, 1, 2, 3, \
+          (((imm8)     ) & 3) + 4, \
+          (((imm8) >> 2) & 3) + 4, \
+          (((imm8) >> 4) & 3) + 4, \
+          (((imm8) >> 6) & 3) + 4) }); }))
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_STATEMENT_EXPR_)
+  #define simde_mm_shufflehi_epi16(a, imm8) \
+    (__extension__ ({ \
+      int16x8_t simde_mm_shufflehi_epi16_a_ = simde__m128i_to_neon_i16(a); \
+      int16x8_t simde_mm_shufflehi_epi16_r_ = simde_mm_shufflehi_epi16_a_; \
+      simde_mm_shufflehi_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflehi_epi16_a_, (((imm8)     ) & 0x3) + 4), simde_mm_shufflehi_epi16_r_, 4); \
+      simde_mm_shufflehi_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflehi_epi16_a_, (((imm8) >> 2) & 0x3) + 4), simde_mm_shufflehi_epi16_r_, 5); \
+      simde_mm_shufflehi_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflehi_epi16_a_, (((imm8) >> 4) & 0x3) + 4), simde_mm_shufflehi_epi16_r_, 6); \
+      simde_mm_shufflehi_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflehi_epi16_a_, (((imm8) >> 6) & 0x3) + 4), simde_mm_shufflehi_epi16_r_, 7); \
+      simde__m128i_from_neon_i16(simde_mm_shufflehi_epi16_r_); \
+    }))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_shufflehi_epi16(a, imm8) simde_mm_shufflehi_epi16(a, imm8)
+  #define _mm_shufflehi_epi16(a, imm8) simde_mm_shufflehi_epi16(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_shufflelo_epi16(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-{
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
+simde__m128i
+simde_mm_shufflelo_epi16 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
 
-	for (size_t i = 0; i < ((sizeof(r_.i16) / sizeof(r_.i16[0])) / 2);
-	     i++) {
-		r_.i16[i] = a_.i16[((imm8 >> (i * 2)) & 3)];
-	}
-	SIMDE_VECTORIZE
-	for (size_t i = ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2);
-	     i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.i16[i] = a_.i16[i];
-	}
+  for (size_t i = 0 ; i < ((sizeof(r_.i16) / sizeof(r_.i16[0])) / 2) ; i++) {
+    r_.i16[i] = a_.i16[((imm8 >> (i * 2)) & 3)];
+  }
+  SIMDE_VECTORIZE
+  for (size_t i = ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2) ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+    r_.i16[i] = a_.i16[i];
+  }
 
-	return simde__m128i_from_private(r_);
+  return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-#define simde_mm_shufflelo_epi16(a, imm8) _mm_shufflelo_epi16((a), (imm8))
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#define simde_mm_shufflelo_epi16(a, imm8)                                     \
-	__extension__({                                                       \
-		int16x8_t ret = vreinterpretq_s16_s64(a);                     \
-		int16x4_t lowBits = vget_low_s16(ret);                        \
-		ret = vsetq_lane_s16(vget_lane_s16(lowBits, (imm8) & (0x3)),  \
-				     ret, 0);                                 \
-		ret = vsetq_lane_s16(                                         \
-			vget_lane_s16(lowBits, ((imm8) >> 2) & 0x3), ret, 1); \
-		ret = vsetq_lane_s16(                                         \
-			vget_lane_s16(lowBits, ((imm8) >> 4) & 0x3), ret, 2); \
-		ret = vsetq_lane_s16(                                         \
-			vget_lane_s16(lowBits, ((imm8) >> 6) & 0x3), ret, 3); \
-		vreinterpretq_s64_s16(ret);                                   \
-	})
+  #define simde_mm_shufflelo_epi16(a, imm8) _mm_shufflelo_epi16((a), (imm8))
 #elif defined(SIMDE_SHUFFLE_VECTOR_)
-#define simde_mm_shufflelo_epi16(a, imm8)                                 \
-	(__extension__({                                                  \
-		const simde__m128i_private simde__tmp_a_ =                \
-			simde__m128i_to_private(a);                       \
-		simde__m128i_from_private((simde__m128i_private){         \
-			.i16 = SIMDE_SHUFFLE_VECTOR_(                     \
-				16, 16, (simde__tmp_a_).i16,              \
-				(simde__tmp_a_).i16, (((imm8)) & 3),      \
-				(((imm8) >> 2) & 3), (((imm8) >> 4) & 3), \
-				(((imm8) >> 6) & 3), 4, 5, 6, 7)});       \
-	}))
+  #define simde_mm_shufflelo_epi16(a, imm8) (__extension__ ({ \
+      const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
+      simde__m128i_from_private((simde__m128i_private) { .i16 = \
+        SIMDE_SHUFFLE_VECTOR_(16, 16, \
+          (simde__tmp_a_).i16, \
+          (simde__tmp_a_).i16, \
+          (((imm8)     ) & 3), \
+          (((imm8) >> 2) & 3), \
+          (((imm8) >> 4) & 3), \
+          (((imm8) >> 6) & 3), \
+          4, 5, 6, 7) }); }))
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_STATEMENT_EXPR_)
+  #define simde_mm_shufflelo_epi16(a, imm8) \
+    (__extension__({ \
+      int16x8_t simde_mm_shufflelo_epi16_a_ = simde__m128i_to_neon_i16(a); \
+      int16x8_t simde_mm_shufflelo_epi16_r_ = simde_mm_shufflelo_epi16_a_; \
+      simde_mm_shufflelo_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflelo_epi16_a_, (((imm8)     ) & 0x3)), simde_mm_shufflelo_epi16_r_, 0); \
+      simde_mm_shufflelo_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflelo_epi16_a_, (((imm8) >> 2) & 0x3)), simde_mm_shufflelo_epi16_r_, 1); \
+      simde_mm_shufflelo_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflelo_epi16_a_, (((imm8) >> 4) & 0x3)), simde_mm_shufflelo_epi16_r_, 2); \
+      simde_mm_shufflelo_epi16_r_ = vsetq_lane_s16(vgetq_lane_s16(simde_mm_shufflelo_epi16_a_, (((imm8) >> 6) & 0x3)), simde_mm_shufflelo_epi16_r_, 3); \
+      simde__m128i_from_neon_i16(simde_mm_shufflelo_epi16_r_); \
+    }))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_shufflelo_epi16(a, imm8) simde_mm_shufflelo_epi16(a, imm8)
+  #define _mm_shufflelo_epi16(a, imm8) simde_mm_shufflelo_epi16(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_sll_epi16(simde__m128i a, simde__m128i count)
-{
+simde__m128i
+simde_mm_sll_epi16 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sll_epi16(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    if (count_.u64[0] > 15)
+      return simde_mm_setzero_si128();
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.u16 = (a_.u16 << count_.u64[0]);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vshlq_u16(a_.neon_u16, vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, count_.u64[0])));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = ((wasm_i64x2_extract_lane(count_.wasm_v128, 0) < 16) ? wasm_i16x8_shl(a_.wasm_v128, HEDLEY_STATIC_CAST(int32_t, wasm_i64x2_extract_lane(count_.wasm_v128, 0))) : wasm_i16x8_const(0,0,0,0,0,0,0,0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, (a_.u16[i] << count_.u64[0]));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sll_epi16(a, count) simde_mm_sll_epi16((a), (count))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sll_epi32 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sll_epi32(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    if (count_.u64[0] > 31)
+      return simde_mm_setzero_si128();
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.u32 = (a_.u32 << count_.u64[0]);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vshlq_u32(a_.neon_u32, vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, count_.u64[0])));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = ((wasm_i64x2_extract_lane(count_.wasm_v128, 0) < 32) ? wasm_i32x4_shl(a_.wasm_v128, HEDLEY_STATIC_CAST(int32_t, wasm_i64x2_extract_lane(count_.wasm_v128, 0))) : wasm_i32x4_const(0,0,0,0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = HEDLEY_STATIC_CAST(uint32_t, (a_.u32[i] << count_.u64[0]));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sll_epi32(a, count) (simde_mm_sll_epi32(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sll_epi64 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sll_epi64(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    if (count_.u64[0] > 63)
+      return simde_mm_setzero_si128();
+
+    const int_fast16_t s = HEDLEY_STATIC_CAST(int_fast16_t, count_.u64[0]);
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u64 = vshlq_u64(a_.neon_u64, vdupq_n_s64(HEDLEY_STATIC_CAST(int64_t, s)));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = (s < 64) ? wasm_i64x2_shl(a_.wasm_v128, s) : wasm_i64x2_const(0,0);
+    #else
+      #if !defined(SIMDE_BUG_GCC_94488)
+        SIMDE_VECTORIZE
+      #endif
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] << s;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sll_epi64(a, count) (simde_mm_sll_epi64(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_sqrt_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sqrt_pd(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vsqrtq_f64(a_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_sqrt(a_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) || defined(SIMDE_ZARCH_ZVECTOR_13_NATIVE)
+      r_.altivec_f64 = vec_sqrt(a_.altivec_f64);
+    #elif defined(simde_math_sqrt)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_sqrt(a_.f64[i]);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sqrt_pd(a) simde_mm_sqrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_sqrt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sqrt_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_sqrt_pd(b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_sqrt_pd(simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(simde_math_sqrt)
+      r_.f64[0] = simde_math_sqrt(b_.f64[0]);
+      r_.f64[1] = a_.f64[1];
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sqrt_sd(a, b) simde_mm_sqrt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srl_epi16 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_srl_epi16(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    const int cnt = HEDLEY_STATIC_CAST(int, (count_.i64[0] > 16 ? 16 : count_.i64[0]));
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vshlq_u16(a_.neon_u16, vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = a_.u16[i] >> cnt;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_srl_epi16(a, count) (simde_mm_srl_epi16(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srl_epi32 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_srl_epi32(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    const int cnt = HEDLEY_STATIC_CAST(int, (count_.i64[0] > 32 ? 32 : count_.i64[0]));
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vshlq_u32(a_.neon_u32, vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, -cnt)));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u32x4_shr(a_.wasm_v128, cnt);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] >> cnt;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_srl_epi32(a, count) (simde_mm_srl_epi32(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srl_epi64 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_srl_epi64(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    const int cnt = HEDLEY_STATIC_CAST(int, (count_.i64[0] > 64 ? 64 : count_.i64[0]));
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u64 = vshlq_u64(a_.neon_u64, vdupq_n_s64(HEDLEY_STATIC_CAST(int64_t, -cnt)));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u64x2_shr(a_.wasm_v128, cnt);
+    #else
+      #if !defined(SIMDE_BUG_GCC_94488)
+        SIMDE_VECTORIZE
+      #endif
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] >> cnt;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_srl_epi64(a, count) (simde_mm_srl_epi64(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srai_epi16 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  /* MSVC requires a range of (0, 255). */
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  const int cnt = (imm8 & ~15) ? 15 : imm8;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_i16 = vshlq_s16(a_.neon_i16, vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    r_.wasm_v128 = wasm_i16x8_shr(a_.wasm_v128, cnt);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = a_.i16[i] >> cnt;
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
 #if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_sll_epi16(a, count);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 count_ = simde__m128i_to_private(count);
+  #define simde_mm_srai_epi16(a, imm8) _mm_srai_epi16((a), (imm8))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_srai_epi16(a, imm8) simde_mm_srai_epi16(a, imm8)
+#endif
 
-	if (count_.u64[0] > 15)
-		return simde_mm_setzero_si128();
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srai_epi32 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  /* MSVC requires a range of (0, 255). */
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-	r_.u16 = (a_.u16 << count_.u64[0]);
+  const int cnt = (imm8 & ~31) ? 31 : imm8;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_i32 = vshlq_s32(a_.neon_i32, vdupq_n_s32(-cnt));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    r_.wasm_v128 = wasm_i32x4_shr(a_.wasm_v128, cnt);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a_.i32[i] >> cnt;
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  #define simde_mm_srai_epi32(a, imm8) _mm_srai_epi32((a), (imm8))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_srai_epi32(a, imm8) simde_mm_srai_epi32(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sra_epi16 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sra_epi16(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    const int cnt = HEDLEY_STATIC_CAST(int, (count_.i64[0] > 15 ? 15 : count_.i64[0]));
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vshlq_s16(a_.neon_i16, vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_shr(a_.wasm_v128, cnt);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] >> cnt;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sra_epi16(a, count) (simde_mm_sra_epi16(a, count))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sra_epi32 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(SIMDE_BUG_GCC_BAD_MM_SRA_EPI32)
+    return _mm_sra_epi32(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    const int cnt = count_.u64[0] > 31 ? 31 : HEDLEY_STATIC_CAST(int, count_.u64[0]);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vshlq_s32(a_.neon_i32, vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, -cnt)));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_shr(a_.wasm_v128, cnt);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] >> cnt;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sra_epi32(a, count) (simde_mm_sra_epi32(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_slli_epi16 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+  if (HEDLEY_UNLIKELY((imm8 > 15))) {
+    return simde_mm_setzero_si128();
+  }
+
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.i16 = a_.i16 << SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8 & 0xff);
+  #else
+    const int s = (imm8 > HEDLEY_STATIC_CAST(int, sizeof(r_.i16[0]) * CHAR_BIT) - 1) ? 0 : imm8;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, a_.i16[i] << s);
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  #define simde_mm_slli_epi16(a, imm8) _mm_slli_epi16(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u16 = vshlq_u16(a_.neon_u16, vdupq_n_s16(HEDLEY_STATIC_CAST(
-						     int16_t, count_.u64[0])));
+  #define simde_mm_slli_epi16(a, imm8) \
+    (((imm8) <= 0) ? \
+      (a) : \
+      simde__m128i_from_neon_i16( \
+        ((imm8) > 15) ? \
+          vandq_s16(simde__m128i_to_neon_i16(a), vdupq_n_s16(0)) : \
+          vshlq_n_s16(simde__m128i_to_neon_i16(a), ((imm8) & 15))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 =
-		((wasm_i64x2_extract_lane(count_.wasm_v128, 0) < 16)
-			 ? wasm_i16x8_shl(a_.wasm_v128,
-					  HEDLEY_STATIC_CAST(
-						  int32_t,
-						  wasm_i64x2_extract_lane(
-							  count_.wasm_v128, 0)))
-			 : wasm_i16x8_const(0, 0, 0, 0, 0, 0, 0, 0));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u16) / sizeof(r_.u16[0])); i++) {
-		r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t,
-					       (a_.u16[i] << count_.u64[0]));
-	}
+  #define simde_mm_slli_epi16(a, imm8) \
+    ((imm8 < 16) ? wasm_i16x8_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i16x8_const(0,0,0,0,0,0,0,0))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_mm_slli_epi16(a, imm8) \
+    ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_altivec_i16(vec_sl(simde__m128i_to_altivec_i16(a), vec_splat_u16(HEDLEY_STATIC_CAST(unsigned short, imm8)))))
 #endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sll_epi16(a, count) simde_mm_sll_epi16((a), (count))
+  #define _mm_slli_epi16(a, imm8) simde_mm_slli_epi16(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_sll_epi32(simde__m128i a, simde__m128i count)
-{
+simde__m128i
+simde_mm_slli_epi32 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+  if (HEDLEY_UNLIKELY((imm8 > 31))) {
+    return simde_mm_setzero_si128();
+  }
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.i32 = a_.i32 << imm8;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a_.i32[i] << (imm8 & 0xff);
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
 #if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_sll_epi32(a, count);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 count_ = simde__m128i_to_private(count);
-
-	if (count_.u64[0] > 31)
-		return simde_mm_setzero_si128();
-
-#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-	r_.u32 = (a_.u32 << count_.u64[0]);
+  #define simde_mm_slli_epi32(a, imm8) _mm_slli_epi32(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u32 = vshlq_u32(a_.neon_u32, vdupq_n_s32(HEDLEY_STATIC_CAST(
-						     int32_t, count_.u64[0])));
+  #define simde_mm_slli_epi32(a, imm8) \
+    (((imm8) <= 0) ? \
+      (a) : \
+      simde__m128i_from_neon_i32( \
+        ((imm8) > 31) ? \
+          vandq_s32(simde__m128i_to_neon_i32(a), vdupq_n_s32(0)) : \
+          vshlq_n_s32(simde__m128i_to_neon_i32(a), ((imm8) & 31))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 =
-		((wasm_i64x2_extract_lane(count_.wasm_v128, 0) < 32)
-			 ? wasm_i32x4_shl(a_.wasm_v128,
-					  HEDLEY_STATIC_CAST(
-						  int32_t,
-						  wasm_i64x2_extract_lane(
-							  count_.wasm_v128, 0)))
-			 : wasm_i32x4_const(0, 0, 0, 0));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u32) / sizeof(r_.u32[0])); i++) {
-		r_.u32[i] = HEDLEY_STATIC_CAST(uint32_t,
-					       (a_.u32[i] << count_.u64[0]));
-	}
+  #define simde_mm_slli_epi32(a, imm8) \
+    ((imm8 < 32) ? wasm_i32x4_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i32x4_const(0,0,0,0))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_mm_slli_epi32(a, imm8) \
+     (__extension__ ({ \
+       simde__m128i ret; \
+       if ((imm8) <= 0) { \
+         ret = a; \
+       } else if ((imm8) > 31) { \
+         ret = simde_mm_setzero_si128(); \
+       } else { \
+         ret = simde__m128i_from_altivec_i32( \
+           vec_sl(simde__m128i_to_altivec_i32(a), \
+             vec_splats(HEDLEY_STATIC_CAST(unsigned int, (imm8) & 31)))); \
+       } \
+       ret; \
+     }))
 #endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sll_epi32(a, count) (simde_mm_sll_epi32(a, (count)))
+  #define _mm_slli_epi32(a, imm8) simde_mm_slli_epi32(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_sll_epi64(simde__m128i a, simde__m128i count)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_sll_epi64(a, count);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 count_ = simde__m128i_to_private(count);
+simde__m128i
+simde_mm_slli_epi64 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+  if (HEDLEY_UNLIKELY((imm8 > 63))) {
+    return simde_mm_setzero_si128();
+  }
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
 
-	if (count_.u64[0] > 63)
-		return simde_mm_setzero_si128();
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.i64 = a_.i64 << imm8;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i64[i] << (imm8 & 0xff);
+    }
+  #endif
 
-	const int_fast16_t s = HEDLEY_STATIC_CAST(int_fast16_t, count_.u64[0]);
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u64 = vshlq_u64(a_.neon_u64,
-				vdupq_n_s64(HEDLEY_STATIC_CAST(int64_t, s)));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = (s < 64) ? wasm_i64x2_shl(a_.wasm_v128, s)
-				: wasm_i64x2_const(0, 0);
-#else
-#if !defined(SIMDE_BUG_GCC_94488)
-	SIMDE_VECTORIZE
-#endif
-	for (size_t i = 0; i < (sizeof(r_.u64) / sizeof(r_.u64[0])); i++) {
-		r_.u64[i] = a_.u64[i] << s;
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sll_epi64(a, count) (simde_mm_sll_epi64(a, (count)))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_sqrt_pd(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_sqrt_pd(a);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
-
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vsqrtq_f64(a_.neon_f64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_sqrt(a_.wasm_v128);
-#elif defined(simde_math_sqrt)
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.f64[i] = simde_math_sqrt(a_.f64[i]);
-	}
-#else
-	HEDLEY_UNREACHABLE();
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sqrt_pd(a) simde_mm_sqrt_pd(a)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_sqrt_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_sqrt_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_sqrt_pd(b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
-
-#if defined(simde_math_sqrt)
-	r_.f64[0] = simde_math_sqrt(b_.f64[0]);
-	r_.f64[1] = a_.f64[1];
-#else
-	HEDLEY_UNREACHABLE();
-#endif
-
-	return simde__m128d_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sqrt_sd(a, b) simde_mm_sqrt_sd(a, b)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_srl_epi16(simde__m128i a, simde__m128i count)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_srl_epi16(a, count);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 count_ = simde__m128i_to_private(count);
-
-	const int cnt = HEDLEY_STATIC_CAST(
-		int, (count_.i64[0] > 16 ? 16 : count_.i64[0]));
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u16 = vshlq_u16(a_.neon_u16,
-				vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u16) / sizeof(r_.u16[0])); i++) {
-		r_.u16[i] = a_.u16[i] >> cnt;
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_srl_epi16(a, count) (simde_mm_srl_epi16(a, (count)))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_srl_epi32(simde__m128i a, simde__m128i count)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_srl_epi32(a, count);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 count_ = simde__m128i_to_private(count);
-
-	const int cnt = HEDLEY_STATIC_CAST(
-		int, (count_.i64[0] > 32 ? 32 : count_.i64[0]));
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u32 = vshlq_u32(a_.neon_u32,
-				vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, -cnt)));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_u32x4_shr(a_.wasm_v128, cnt);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u32) / sizeof(r_.u32[0])); i++) {
-		r_.u32[i] = a_.u32[i] >> cnt;
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_srl_epi32(a, count) (simde_mm_srl_epi32(a, (count)))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_srl_epi64(simde__m128i a, simde__m128i count)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_srl_epi64(a, count);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 count_ = simde__m128i_to_private(count);
-
-	const int cnt = HEDLEY_STATIC_CAST(
-		int, (count_.i64[0] > 64 ? 64 : count_.i64[0]));
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u64 = vshlq_u64(a_.neon_u64,
-				vdupq_n_s64(HEDLEY_STATIC_CAST(int64_t, -cnt)));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_u64x2_shr(a_.wasm_v128, cnt);
-#else
-#if !defined(SIMDE_BUG_GCC_94488)
-	SIMDE_VECTORIZE
-#endif
-	for (size_t i = 0; i < (sizeof(r_.u64) / sizeof(r_.u64[0])); i++) {
-		r_.u64[i] = a_.u64[i] >> cnt;
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_srl_epi64(a, count) (simde_mm_srl_epi64(a, (count)))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_srai_epi16(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-{
-	/* MSVC requires a range of (0, 255). */
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
-
-	const int cnt = (imm8 & ~15) ? 15 : imm8;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i16 = vshlq_s16(a_.neon_i16,
-				vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i16x8_shr(a_.wasm_v128, cnt);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.i16[0])); i++) {
-		r_.i16[i] = a_.i16[i] >> cnt;
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
+  return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-#define simde_mm_srai_epi16(a, imm8) _mm_srai_epi16((a), (imm8))
-#endif
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_srai_epi16(a, imm8) simde_mm_srai_epi16(a, imm8)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_srai_epi32(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-{
-	/* MSVC requires a range of (0, 255). */
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
-
-	const int cnt = (imm8 & ~31) ? 31 : imm8;
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vshlq_s32(a_.neon_i32, vdupq_n_s32(-cnt));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i32x4_shr(a_.wasm_v128, cnt);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.i32[0])); i++) {
-		r_.i32[i] = a_.i32[i] >> cnt;
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-}
-#if defined(SIMDE_X86_SSE2_NATIVE)
-#define simde_mm_srai_epi32(a, imm8) _mm_srai_epi32((a), (imm8))
-#endif
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_srai_epi32(a, imm8) simde_mm_srai_epi32(a, imm8)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_sra_epi16(simde__m128i a, simde__m128i count)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_sra_epi16(a, count);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 count_ = simde__m128i_to_private(count);
-
-	const int cnt = HEDLEY_STATIC_CAST(
-		int, (count_.i64[0] > 15 ? 15 : count_.i64[0]));
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i16 = vshlq_s16(a_.neon_i16,
-				vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i16x8_shr(a_.wasm_v128, cnt);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.i16[i] = a_.i16[i] >> cnt;
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sra_epi16(a, count) (simde_mm_sra_epi16(a, count))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_sra_epi32(simde__m128i a, simde__m128i count)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(SIMDE_BUG_GCC_BAD_MM_SRA_EPI32)
-	return _mm_sra_epi32(a, count);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 count_ = simde__m128i_to_private(count);
-
-	const int cnt = count_.u64[0] > 31
-				? 31
-				: HEDLEY_STATIC_CAST(int, count_.u64[0]);
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vshlq_s32(a_.neon_i32,
-				vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, -cnt)));
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i32x4_shr(a_.wasm_v128, cnt);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		r_.i32[i] = a_.i32[i] >> cnt;
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-#endif
-}
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sra_epi32(a, count) (simde_mm_sra_epi32(a, (count)))
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_slli_epi16(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-{
-	if (HEDLEY_UNLIKELY((imm8 > 15))) {
-		return simde_mm_setzero_si128();
-	}
-
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
-
-#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-	r_.i16 = a_.i16 << (imm8 & 0xff);
-#else
-	const int s =
-		(imm8 >
-		 HEDLEY_STATIC_CAST(int, sizeof(r_.i16[0]) * CHAR_BIT) - 1)
-			? 0
-			: imm8;
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, a_.i16[i] << s);
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-}
-#if defined(SIMDE_X86_SSE2_NATIVE)
-#define simde_mm_slli_epi16(a, imm8) _mm_slli_epi16(a, imm8)
+  #define simde_mm_slli_epi64(a, imm8) _mm_slli_epi64(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#define simde_mm_slli_epi16(a, imm8)                                        \
-	(__extension__({                                                    \
-		simde__m128i ret;                                           \
-		if ((imm8) <= 0) {                                          \
-			ret = a;                                            \
-		} else if ((imm8) > 15) {                                   \
-			ret = simde_mm_setzero_si128();                     \
-		} else {                                                    \
-			ret = simde__m128i_from_neon_i16(vshlq_n_s16(       \
-				simde__m128i_to_neon_i16(a), ((imm8)&15))); \
-		}                                                           \
-		ret;                                                        \
-	}))
+  #define simde_mm_slli_epi64(a, imm8) \
+    (((imm8) <= 0) ? \
+      (a) : \
+      simde__m128i_from_neon_i64( \
+        ((imm8) > 63) ? \
+          vandq_s64(simde__m128i_to_neon_i64(a), vdupq_n_s64(0)) : \
+          vshlq_n_s64(simde__m128i_to_neon_i64(a), ((imm8) & 63))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-#define simde_mm_slli_epi16(a, imm8)                                          \
-	((imm8 < 16)                                                          \
-		 ? wasm_i16x8_shl(simde__m128i_to_private(a).wasm_v128, imm8) \
-		 : wasm_i16x8_const(0, 0, 0, 0, 0, 0, 0, 0))
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-#define simde_mm_slli_epi16(a, imm8)                                     \
-	((imm8 & ~15) ? simde_mm_setzero_si128()                         \
-		      : simde__m128i_from_altivec_i16(                   \
-				vec_sl(simde__m128i_to_altivec_i16(a),   \
-				       vec_splat_u16(HEDLEY_STATIC_CAST( \
-					       unsigned short, imm8)))))
+  #define simde_mm_slli_epi64(a, imm8) \
+    ((imm8 < 64) ? wasm_i64x2_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i64x2_const(0,0))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_slli_epi16(a, imm8) simde_mm_slli_epi16(a, imm8)
+  #define _mm_slli_epi64(a, imm8) simde_mm_slli_epi64(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_slli_epi32(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-{
-	if (HEDLEY_UNLIKELY((imm8 > 31))) {
-		return simde_mm_setzero_si128();
-	}
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
+simde__m128i
+simde_mm_srli_epi16 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+  if (HEDLEY_UNLIKELY((imm8 > 15))) {
+    return simde_mm_setzero_si128();
+  }
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-	r_.i32 = a_.i32 << imm8;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		r_.i32[i] = a_.i32[i] << (imm8 & 0xff);
-	}
-#endif
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u16 = a_.u16 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.u16[i] = a_.u16[i] >> (imm8 & 0xff);
+    }
+  #endif
 
-	return simde__m128i_from_private(r_);
+  return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-#define simde_mm_slli_epi32(a, imm8) _mm_slli_epi32(a, imm8)
+  #define simde_mm_srli_epi16(a, imm8) _mm_srli_epi16(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#define simde_mm_slli_epi32(a, imm8)                                        \
-	(__extension__({                                                    \
-		simde__m128i ret;                                           \
-		if ((imm8) <= 0) {                                          \
-			ret = a;                                            \
-		} else if ((imm8) > 31) {                                   \
-			ret = simde_mm_setzero_si128();                     \
-		} else {                                                    \
-			ret = simde__m128i_from_neon_i32(vshlq_n_s32(       \
-				simde__m128i_to_neon_i32(a), ((imm8)&31))); \
-		}                                                           \
-		ret;                                                        \
-	}))
+  #define simde_mm_srli_epi16(a, imm8) \
+    (((imm8) <= 0) ? \
+      (a) : \
+      simde__m128i_from_neon_u16( \
+        ((imm8) > 15) ? \
+          vandq_u16(simde__m128i_to_neon_u16(a), vdupq_n_u16(0)) : \
+          vshrq_n_u16(simde__m128i_to_neon_u16(a), ((imm8) & 15) | (((imm8) & 15) == 0))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-#define simde_mm_slli_epi32(a, imm8)                                          \
-	((imm8 < 32)                                                          \
-		 ? wasm_i32x4_shl(simde__m128i_to_private(a).wasm_v128, imm8) \
-		 : wasm_i32x4_const(0, 0, 0, 0))
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-#define simde_mm_slli_epi32(a, imm8)                                        \
-	(__extension__({                                                    \
-		simde__m128i ret;                                           \
-		if ((imm8) <= 0) {                                          \
-			ret = a;                                            \
-		} else if ((imm8) > 31) {                                   \
-			ret = simde_mm_setzero_si128();                     \
-		} else {                                                    \
-			ret = simde__m128i_from_altivec_i32(                \
-				vec_sl(simde__m128i_to_altivec_i32(a),      \
-				       vec_splats(HEDLEY_STATIC_CAST(       \
-					       unsigned int, (imm8)&31)))); \
-		}                                                           \
-		ret;                                                        \
-	}))
+  #define simde_mm_srli_epi16(a, imm8) \
+    ((imm8 < 16) ? wasm_u16x8_shr(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i16x8_const(0,0,0,0,0,0,0,0))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_mm_srli_epi16(a, imm8) \
+    ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_altivec_i16(vec_sr(simde__m128i_to_altivec_i16(a), vec_splat_u16(HEDLEY_STATIC_CAST(unsigned short, imm8)))))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_slli_epi32(a, imm8) simde_mm_slli_epi32(a, imm8)
+  #define _mm_srli_epi16(a, imm8) simde_mm_srli_epi16(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_slli_epi64(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-{
-	if (HEDLEY_UNLIKELY((imm8 > 63))) {
-		return simde_mm_setzero_si128();
-	}
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
+simde__m128i
+simde_mm_srli_epi32 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+  if (HEDLEY_UNLIKELY((imm8 > 31))) {
+    return simde_mm_setzero_si128();
+  }
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-	r_.i64 = a_.i64 << imm8;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
-		r_.i64[i] = a_.i64[i] << (imm8 & 0xff);
-	}
-#endif
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u32 = a_.u32 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8 & 0xff);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.u32[i] = a_.u32[i] >> (imm8 & 0xff);
+    }
+  #endif
 
-	return simde__m128i_from_private(r_);
+  return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-#define simde_mm_slli_epi64(a, imm8) _mm_slli_epi64(a, imm8)
+  #define simde_mm_srli_epi32(a, imm8) _mm_srli_epi32(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#define simde_mm_slli_epi64(a, imm8)                                        \
-	(__extension__({                                                    \
-		simde__m128i ret;                                           \
-		if ((imm8) <= 0) {                                          \
-			ret = a;                                            \
-		} else if ((imm8) > 63) {                                   \
-			ret = simde_mm_setzero_si128();                     \
-		} else {                                                    \
-			ret = simde__m128i_from_neon_i64(vshlq_n_s64(       \
-				simde__m128i_to_neon_i64(a), ((imm8)&63))); \
-		}                                                           \
-		ret;                                                        \
-	}))
+  #define simde_mm_srli_epi32(a, imm8) \
+    (((imm8) <= 0) ? \
+      (a) : \
+      simde__m128i_from_neon_u32( \
+        ((imm8) > 31) ? \
+          vandq_u32(simde__m128i_to_neon_u32(a), vdupq_n_u32(0)) : \
+          vshrq_n_u32(simde__m128i_to_neon_u32(a), ((imm8) & 31) | (((imm8) & 31) == 0))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-#define simde_mm_slli_epi64(a, imm8)                                          \
-	((imm8 < 64)                                                          \
-		 ? wasm_i64x2_shl(simde__m128i_to_private(a).wasm_v128, imm8) \
-		 : wasm_i64x2_const(0, 0))
+  #define simde_mm_srli_epi32(a, imm8) \
+    ((imm8 < 32) ? wasm_u32x4_shr(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i32x4_const(0,0,0,0))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_mm_srli_epi32(a, imm8) \
+    (__extension__ ({ \
+        simde__m128i ret; \
+        if ((imm8) <= 0) { \
+            ret = a; \
+        } else if ((imm8) > 31) { \
+            ret = simde_mm_setzero_si128(); \
+        } else { \
+            ret = simde__m128i_from_altivec_i32( \
+              vec_sr(simde__m128i_to_altivec_i32(a), \
+                vec_splats(HEDLEY_STATIC_CAST(unsigned int, (imm8) & 31)))); \
+        } \
+        ret; \
+    }))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_slli_epi64(a, imm8) simde_mm_slli_epi64(a, imm8)
+  #define _mm_srli_epi32(a, imm8) simde_mm_srli_epi32(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_srli_epi16(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-{
-	if (HEDLEY_UNLIKELY((imm8 > 15))) {
-		return simde_mm_setzero_si128();
-	}
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
+simde__m128i
+simde_mm_srli_epi64 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-	r_.u16 = a_.u16 >> imm8;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.u16[i] = a_.u16[i] >> (imm8 & 0xff);
-	}
-#endif
+  if (HEDLEY_UNLIKELY((imm8 & 63) != imm8))
+    return simde_mm_setzero_si128();
 
-	return simde__m128i_from_private(r_);
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_u64 = vshlq_u64(a_.neon_u64, vdupq_n_s64(-imm8));
+  #else
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_94488)
+      r_.u64 = a_.u64 >> SIMDE_CAST_VECTOR_SHIFT_COUNT(8, imm8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] >> imm8;
+      }
+    #endif
+  #endif
+
+  return simde__m128i_from_private(r_);
 }
 #if defined(SIMDE_X86_SSE2_NATIVE)
-#define simde_mm_srli_epi16(a, imm8) _mm_srli_epi16(a, imm8)
+  #define simde_mm_srli_epi64(a, imm8) _mm_srli_epi64(a, imm8)
 #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#define simde_mm_srli_epi16(a, imm8)                                  \
-	(__extension__({                                              \
-		simde__m128i ret;                                     \
-		if ((imm8) <= 0) {                                    \
-			ret = a;                                      \
-		} else if ((imm8) > 15) {                             \
-			ret = simde_mm_setzero_si128();               \
-		} else {                                              \
-			ret = simde__m128i_from_neon_u16(vshrq_n_u16( \
-				simde__m128i_to_neon_u16(a),          \
-				(((imm8)&15) | (((imm8)&15) == 0)))); \
-		}                                                     \
-		ret;                                                  \
-	}))
+  #define simde_mm_srli_epi64(a, imm8) \
+    (((imm8) <= 0) ? \
+      (a) : \
+      simde__m128i_from_neon_u64( \
+        ((imm8) > 63) ? \
+          vandq_u64(simde__m128i_to_neon_u64(a), vdupq_n_u64(0)) : \
+          vshrq_n_u64(simde__m128i_to_neon_u64(a), ((imm8) & 63) | (((imm8) & 63) == 0))))
 #elif defined(SIMDE_WASM_SIMD128_NATIVE)
-#define simde_mm_srli_epi16(a, imm8)                                          \
-	((imm8 < 16)                                                          \
-		 ? wasm_u16x8_shr(simde__m128i_to_private(a).wasm_v128, imm8) \
-		 : wasm_i16x8_const(0, 0, 0, 0, 0, 0, 0, 0))
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-#define simde_mm_srli_epi16(a, imm8)                                     \
-	((imm8 & ~15) ? simde_mm_setzero_si128()                         \
-		      : simde__m128i_from_altivec_i16(                   \
-				vec_sr(simde__m128i_to_altivec_i16(a),   \
-				       vec_splat_u16(HEDLEY_STATIC_CAST( \
-					       unsigned short, imm8)))))
+  #define simde_mm_srli_epi64(a, imm8) \
+    ((imm8 < 64) ? wasm_u64x2_shr(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i64x2_const(0,0))
 #endif
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_srli_epi16(a, imm8) simde_mm_srli_epi16(a, imm8)
+  #define _mm_srli_epi64(a, imm8) simde_mm_srli_epi64(a, imm8)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_srli_epi32(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-{
-	if (HEDLEY_UNLIKELY((imm8 > 31))) {
-		return simde_mm_setzero_si128();
-	}
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
-
-#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
-	r_.u32 = a_.u32 >> (imm8 & 0xff);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		r_.u32[i] = a_.u32[i] >> (imm8 & 0xff);
-	}
-#endif
-
-	return simde__m128i_from_private(r_);
-}
-#if defined(SIMDE_X86_SSE2_NATIVE)
-#define simde_mm_srli_epi32(a, imm8) _mm_srli_epi32(a, imm8)
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#define simde_mm_srli_epi32(a, imm8)                                  \
-	(__extension__({                                              \
-		simde__m128i ret;                                     \
-		if ((imm8) <= 0) {                                    \
-			ret = a;                                      \
-		} else if ((imm8) > 31) {                             \
-			ret = simde_mm_setzero_si128();               \
-		} else {                                              \
-			ret = simde__m128i_from_neon_u32(vshrq_n_u32( \
-				simde__m128i_to_neon_u32(a),          \
-				(((imm8)&31) | (((imm8)&31) == 0)))); \
-		}                                                     \
-		ret;                                                  \
-	}))
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-#define simde_mm_srli_epi32(a, imm8)                                          \
-	((imm8 < 32)                                                          \
-		 ? wasm_u32x4_shr(simde__m128i_to_private(a).wasm_v128, imm8) \
-		 : wasm_i32x4_const(0, 0, 0, 0))
-#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
-#define simde_mm_srli_epi32(a, imm8)                                        \
-	(__extension__({                                                    \
-		simde__m128i ret;                                           \
-		if ((imm8) <= 0) {                                          \
-			ret = a;                                            \
-		} else if ((imm8) > 31) {                                   \
-			ret = simde_mm_setzero_si128();                     \
-		} else {                                                    \
-			ret = simde__m128i_from_altivec_i32(                \
-				vec_sr(simde__m128i_to_altivec_i32(a),      \
-				       vec_splats(HEDLEY_STATIC_CAST(       \
-					       unsigned int, (imm8)&31)))); \
-		}                                                           \
-		ret;                                                        \
-	}))
-#endif
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_srli_epi32(a, imm8) simde_mm_srli_epi32(a, imm8)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_srli_epi64(simde__m128i a, const int imm8)
-	SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)
-{
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
-
-	if (HEDLEY_UNLIKELY((imm8 & 63) != imm8))
-		return simde_mm_setzero_si128();
-
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u64 = vshlq_u64(a_.neon_u64, vdupq_n_s64(-imm8));
-#else
-#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_94488)
-	r_.u64 = a_.u64 >> imm8;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
-		r_.u64[i] = a_.u64[i] >> imm8;
-	}
-#endif
-#endif
-
-	return simde__m128i_from_private(r_);
-}
-#if defined(SIMDE_X86_SSE2_NATIVE)
-#define simde_mm_srli_epi64(a, imm8) _mm_srli_epi64(a, imm8)
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-#define simde_mm_srli_epi64(a, imm8)                                  \
-	(__extension__({                                              \
-		simde__m128i ret;                                     \
-		if ((imm8) <= 0) {                                    \
-			ret = a;                                      \
-		} else if ((imm8) > 63) {                             \
-			ret = simde_mm_setzero_si128();               \
-		} else {                                              \
-			ret = simde__m128i_from_neon_u64(vshrq_n_u64( \
-				simde__m128i_to_neon_u64(a),          \
-				(((imm8)&63) | (((imm8)&63) == 0)))); \
-		}                                                     \
-		ret;                                                  \
-	}))
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-#define simde_mm_srli_epi64(a, imm8)                                          \
-	((imm8 < 64)                                                          \
-		 ? wasm_u64x2_shr(simde__m128i_to_private(a).wasm_v128, imm8) \
-		 : wasm_i64x2_const(0, 0))
-#endif
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_srli_epi64(a, imm8) simde_mm_srli_epi64(a, imm8)
-#endif
-
-SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_store_pd(simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)],
-		       simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_store_pd(mem_addr, a);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	vst1q_f64(mem_addr, simde__m128d_to_private(a).neon_f64);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	vst1q_s64(HEDLEY_REINTERPRET_CAST(int64_t *, mem_addr),
-		  simde__m128d_to_private(a).neon_i64);
-#else
-	simde_memcpy(SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128d), &a,
-		     sizeof(a));
-#endif
+void
+simde_mm_store_pd (simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_store_pd(mem_addr, a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst1q_f64(mem_addr, simde__m128d_to_private(a).neon_f64);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1q_s64(HEDLEY_REINTERPRET_CAST(int64_t*, mem_addr), simde__m128d_to_private(a).neon_i64);
+  #else
+    simde_memcpy(SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128d), &a, sizeof(a));
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_store_pd(mem_addr, a) \
-	simde_mm_store_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
+  #define _mm_store_pd(mem_addr, a) simde_mm_store_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_store1_pd(simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)],
-			simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_store1_pd(mem_addr, a);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a);
+void
+simde_mm_store1_pd (simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_store1_pd(mem_addr, a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	vst1q_f64(mem_addr, vdupq_laneq_f64(a_.neon_f64, 0));
-#else
-	mem_addr[0] = a_.f64[0];
-	mem_addr[1] = a_.f64[0];
-#endif
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      vst1q_f64(mem_addr, vdupq_laneq_f64(a_.neon_f64, 0));
+    #else
+      mem_addr[0] = a_.f64[0];
+      mem_addr[1] = a_.f64[0];
+    #endif
+  #endif
 }
-#define simde_mm_store_pd1(mem_addr, a) \
-	simde_mm_store1_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
+#define simde_mm_store_pd1(mem_addr, a) simde_mm_store1_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_store1_pd(mem_addr, a) \
-	simde_mm_store1_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
-#define _mm_store_pd1(mem_addr, a) \
-	simde_mm_store_pd1(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
+  #define _mm_store1_pd(mem_addr, a) simde_mm_store1_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+  #define _mm_store_pd1(mem_addr, a) simde_mm_store_pd1(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_store_sd(simde_float64 *mem_addr, simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_store_sd(mem_addr, a);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a);
+void
+simde_mm_store_sd (simde_float64* mem_addr, simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_store_sd(mem_addr, a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	const simde_float64 v = vgetq_lane_f64(a_.neon_f64, 0);
-	simde_memcpy(mem_addr, &v, sizeof(v));
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	const int64_t v = vgetq_lane_s64(a_.neon_i64, 0);
-	simde_memcpy(HEDLEY_REINTERPRET_CAST(int64_t *, mem_addr), &v,
-		     sizeof(v));
-#else
-	simde_float64 v = a_.f64[0];
-	simde_memcpy(mem_addr, &v, sizeof(simde_float64));
-#endif
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      const simde_float64 v = vgetq_lane_f64(a_.neon_f64, 0);
+      simde_memcpy(mem_addr, &v, sizeof(v));
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      const int64_t v = vgetq_lane_s64(a_.neon_i64, 0);
+      simde_memcpy(HEDLEY_REINTERPRET_CAST(int64_t*, mem_addr), &v, sizeof(v));
+    #else
+      simde_float64 v = a_.f64[0];
+      simde_memcpy(mem_addr, &v, sizeof(simde_float64));
+    #endif
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_store_sd(mem_addr, a) \
-	simde_mm_store_sd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
+  #define _mm_store_sd(mem_addr, a) simde_mm_store_sd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_store_si128(simde__m128i *mem_addr, simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_store_si128(HEDLEY_STATIC_CAST(__m128i *, mem_addr), a);
-#else
-	simde__m128i_private a_ = simde__m128i_to_private(a);
+void
+simde_mm_store_si128 (simde__m128i* mem_addr, simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_store_si128(HEDLEY_STATIC_CAST(__m128i*, mem_addr), a);
+  #else
+    simde__m128i_private a_ = simde__m128i_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	vst1q_s32(HEDLEY_REINTERPRET_CAST(int32_t *, mem_addr), a_.neon_i32);
-#else
-	simde_memcpy(SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128i), &a_,
-		     sizeof(a_));
-#endif
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      vst1q_s32(HEDLEY_REINTERPRET_CAST(int32_t*, mem_addr), a_.neon_i32);
+    #else
+      simde_memcpy(SIMDE_ALIGN_ASSUME_LIKE(mem_addr, simde__m128i), &a_, sizeof(a_));
+    #endif
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_store_si128(mem_addr, a) simde_mm_store_si128(mem_addr, a)
+  #define _mm_store_si128(mem_addr, a) simde_mm_store_si128(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_storeh_pd(simde_float64 *mem_addr, simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_storeh_pd(mem_addr, a);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a);
+void
+  simde_mm_storeh_pd (simde_float64* mem_addr, simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_storeh_pd(mem_addr, a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	*mem_addr = vgetq_lane_f64(a_.neon_f64, 1);
-#else
-	*mem_addr = a_.f64[1];
-#endif
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      *mem_addr = vgetq_lane_f64(a_.neon_f64, 1);
+    #else
+      *mem_addr = a_.f64[1];
+    #endif
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_storeh_pd(mem_addr, a) \
-	simde_mm_storeh_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
+  #define _mm_storeh_pd(mem_addr, a) simde_mm_storeh_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_storel_epi64(simde__m128i *mem_addr, simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_storel_epi64(HEDLEY_STATIC_CAST(__m128i *, mem_addr), a);
-#else
-	simde__m128i_private a_ = simde__m128i_to_private(a);
-	int64_t tmp;
+void
+simde_mm_storel_epi64 (simde__m128i* mem_addr, simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_storel_epi64(HEDLEY_STATIC_CAST(__m128i*, mem_addr), a);
+  #else
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+    int64_t tmp;
 
-	/* memcpy to prevent aliasing, tmp because we can't take the
+    /* memcpy to prevent aliasing, tmp because we can't take the
      * address of a vector element. */
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	tmp = vgetq_lane_s64(a_.neon_i64, 0);
-#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
-#if defined(SIMDE_BUG_GCC_95227)
-	(void)a_;
-#endif
-	tmp = vec_extract(a_.altivec_i64, 0);
-#else
-	tmp = a_.i64[0];
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      tmp = vgetq_lane_s64(a_.neon_i64, 0);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      #if defined(SIMDE_BUG_GCC_95227)
+        (void) a_;
+      #endif
+      tmp = vec_extract(a_.altivec_i64, 0);
+    #else
+      tmp = a_.i64[0];
+    #endif
 
-	simde_memcpy(mem_addr, &tmp, sizeof(tmp));
-#endif
+    simde_memcpy(mem_addr, &tmp, sizeof(tmp));
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_storel_epi64(mem_addr, a) simde_mm_storel_epi64(mem_addr, a)
+  #define _mm_storel_epi64(mem_addr, a) simde_mm_storel_epi64(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_storel_pd(simde_float64 *mem_addr, simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_storel_pd(mem_addr, a);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a);
+void
+simde_mm_storel_pd (simde_float64* mem_addr, simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_storel_pd(mem_addr, a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
 
-	simde_float64 tmp;
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	tmp = vgetq_lane_f64(a_.neon_f64, 0);
-#else
-	tmp = a_.f64[0];
-#endif
-	simde_memcpy(mem_addr, &tmp, sizeof(tmp));
-#endif
+    simde_float64 tmp;
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      tmp = vgetq_lane_f64(a_.neon_f64, 0);
+    #else
+      tmp = a_.f64[0];
+    #endif
+    simde_memcpy(mem_addr, &tmp, sizeof(tmp));
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_storel_pd(mem_addr, a) \
-	simde_mm_storel_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
+  #define _mm_storel_pd(mem_addr, a) simde_mm_storel_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_storer_pd(simde_float64 mem_addr[2], simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_storer_pd(mem_addr, a);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a);
+void
+simde_mm_storer_pd (simde_float64 mem_addr[2], simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_storer_pd(mem_addr, a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	vst1q_s64(HEDLEY_REINTERPRET_CAST(int64_t *, mem_addr),
-		  vextq_s64(a_.neon_i64, a_.neon_i64, 1));
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	a_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, a_.f64, 1, 0);
-	simde_mm_store_pd(mem_addr, simde__m128d_from_private(a_));
-#else
-	mem_addr[0] = a_.f64[1];
-	mem_addr[1] = a_.f64[0];
-#endif
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      vst1q_s64(HEDLEY_REINTERPRET_CAST(int64_t*, mem_addr), vextq_s64(a_.neon_i64, a_.neon_i64, 1));
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      a_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, a_.f64, 1, 0);
+      simde_mm_store_pd(mem_addr, simde__m128d_from_private(a_));
+    #else
+      mem_addr[0] = a_.f64[1];
+      mem_addr[1] = a_.f64[0];
+    #endif
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_storer_pd(mem_addr, a) \
-	simde_mm_storer_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
+  #define _mm_storer_pd(mem_addr, a) simde_mm_storer_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_storeu_pd(simde_float64 *mem_addr, simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_storeu_pd(mem_addr, a);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	vst1q_f64(mem_addr, simde__m128d_to_private(a).neon_f64);
-#else
-	simde_memcpy(mem_addr, &a, sizeof(a));
-#endif
+void
+simde_mm_storeu_pd (simde_float64* mem_addr, simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_storeu_pd(mem_addr, a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst1q_f64(mem_addr, simde__m128d_to_private(a).neon_f64);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_storeu_pd(mem_addr, a) \
-	simde_mm_storeu_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
+  #define _mm_storeu_pd(mem_addr, a) simde_mm_storeu_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_storeu_si128(simde__m128i *mem_addr, simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_storeu_si128(HEDLEY_STATIC_CAST(__m128i *, mem_addr), a);
-#else
-	simde_memcpy(mem_addr, &a, sizeof(a));
-#endif
+void
+simde_mm_storeu_si128 (void* mem_addr, simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_storeu_si128(HEDLEY_STATIC_CAST(__m128i*, mem_addr), a);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_storeu_si128(mem_addr, a) simde_mm_storeu_si128(mem_addr, a)
+  #define _mm_storeu_si128(mem_addr, a) simde_mm_storeu_si128(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_storeu_si16(void *mem_addr, simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) &&                 \
-	(SIMDE_DETECT_CLANG_VERSION_CHECK(8, 0, 0) || \
-	 HEDLEY_GCC_VERSION_CHECK(11, 0, 0) ||        \
-	 HEDLEY_INTEL_VERSION_CHECK(20, 21, 1))
-	_mm_storeu_si16(mem_addr, a);
-#else
-	int16_t val = simde_x_mm_cvtsi128_si16(a);
-	simde_memcpy(mem_addr, &val, sizeof(val));
-#endif
+void
+simde_mm_storeu_si16 (void* mem_addr, simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && ( \
+      SIMDE_DETECT_CLANG_VERSION_CHECK(8,0,0) || \
+      HEDLEY_GCC_VERSION_CHECK(11,0,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(20,21,1))
+    _mm_storeu_si16(mem_addr, a);
+  #else
+    int16_t val = simde_x_mm_cvtsi128_si16(a);
+    simde_memcpy(mem_addr, &val, sizeof(val));
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_storeu_si16(mem_addr, a) simde_mm_storeu_si16(mem_addr, a)
+  #define _mm_storeu_si16(mem_addr, a) simde_mm_storeu_si16(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_storeu_si32(void *mem_addr, simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) &&                 \
-	(SIMDE_DETECT_CLANG_VERSION_CHECK(8, 0, 0) || \
-	 HEDLEY_GCC_VERSION_CHECK(11, 0, 0) ||        \
-	 HEDLEY_INTEL_VERSION_CHECK(20, 21, 1))
-	_mm_storeu_si32(mem_addr, a);
-#else
-	int32_t val = simde_mm_cvtsi128_si32(a);
-	simde_memcpy(mem_addr, &val, sizeof(val));
-#endif
+void
+simde_mm_storeu_si32 (void* mem_addr, simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && ( \
+      SIMDE_DETECT_CLANG_VERSION_CHECK(8,0,0) || \
+      HEDLEY_GCC_VERSION_CHECK(11,0,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(20,21,1))
+    _mm_storeu_si32(mem_addr, a);
+  #else
+    int32_t val = simde_mm_cvtsi128_si32(a);
+    simde_memcpy(mem_addr, &val, sizeof(val));
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_storeu_si32(mem_addr, a) simde_mm_storeu_si32(mem_addr, a)
+  #define _mm_storeu_si32(mem_addr, a) simde_mm_storeu_si32(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_storeu_si64(void *mem_addr, simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) &&                 \
-	(SIMDE_DETECT_CLANG_VERSION_CHECK(8, 0, 0) || \
-	 HEDLEY_GCC_VERSION_CHECK(11, 0, 0) ||        \
-	 HEDLEY_INTEL_VERSION_CHECK(20, 21, 1))
-	_mm_storeu_si64(mem_addr, a);
-#else
-	int64_t val = simde_mm_cvtsi128_si64(a);
-	simde_memcpy(mem_addr, &val, sizeof(val));
-#endif
+void
+simde_mm_storeu_si64 (void* mem_addr, simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && ( \
+      SIMDE_DETECT_CLANG_VERSION_CHECK(8,0,0) || \
+      HEDLEY_GCC_VERSION_CHECK(11,0,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(20,21,1))
+    _mm_storeu_si64(mem_addr, a);
+  #else
+    int64_t val = simde_mm_cvtsi128_si64(a);
+    simde_memcpy(mem_addr, &val, sizeof(val));
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_storeu_si64(mem_addr, a) simde_mm_storeu_si64(mem_addr, a)
+  #define _mm_storeu_si64(mem_addr, a) simde_mm_storeu_si64(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_stream_pd(simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)],
-			simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_stream_pd(mem_addr, a);
-#else
-	simde_memcpy(mem_addr, &a, sizeof(a));
-#endif
+void
+simde_mm_stream_pd (simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_stream_pd(mem_addr, a);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_stream_pd(mem_addr, a) \
-	simde_mm_stream_pd(HEDLEY_REINTERPRET_CAST(double *, mem_addr), a)
+  #define _mm_stream_pd(mem_addr, a) simde_mm_stream_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_stream_si128(simde__m128i *mem_addr, simde__m128i a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
-	_mm_stream_si128(HEDLEY_STATIC_CAST(__m128i *, mem_addr), a);
-#else
-	simde_memcpy(mem_addr, &a, sizeof(a));
-#endif
+void
+simde_mm_stream_si128 (simde__m128i* mem_addr, simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    _mm_stream_si128(HEDLEY_STATIC_CAST(__m128i*, mem_addr), a);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_stream_si128(mem_addr, a) simde_mm_stream_si128(mem_addr, a)
+  #define _mm_stream_si128(mem_addr, a) simde_mm_stream_si128(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_stream_si32(int32_t *mem_addr, int32_t a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_stream_si32(mem_addr, a);
-#else
-	*mem_addr = a;
-#endif
+void
+simde_mm_stream_si32 (int32_t* mem_addr, int32_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_stream_si32(mem_addr, a);
+  #else
+    *mem_addr = a;
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_stream_si32(mem_addr, a) simde_mm_stream_si32(mem_addr, a)
+  #define _mm_stream_si32(mem_addr, a) simde_mm_stream_si32(mem_addr, a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_stream_si64(int64_t *mem_addr, int64_t a)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64) && \
-	!defined(HEDLEY_MSVC_VERSION)
-	_mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(long long int *,
-						       int64_t *, mem_addr),
-			a);
-#else
-	*mem_addr = a;
-#endif
+void
+simde_mm_stream_si64 (int64_t* mem_addr, int64_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64) && !defined(HEDLEY_MSVC_VERSION)
+    _mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(long long int*, int64_t*, mem_addr), a);
+  #else
+    *mem_addr = a;
+  #endif
 }
 #define simde_mm_stream_si64x(mem_addr, a) simde_mm_stream_si64(mem_addr, a)
-#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_stream_si64(mem_addr, a)                                  \
-	simde_mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(          \
-				     int64_t *, __int64 *, mem_addr), \
-			     a)
-#define _mm_stream_si64x(mem_addr, a)                                 \
-	simde_mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(          \
-				     int64_t *, __int64 *, mem_addr), \
-			     a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES) || (defined(SIMDE_ENABLE_NATIVE_ALIASES) && !defined(SIMDE_ARCH_AMD64))
+  #define _mm_stream_si64(mem_addr, a) simde_mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(int64_t*, __int64*, mem_addr), a)
+  #define _mm_stream_si64x(mem_addr, a) simde_mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(int64_t*, __int64*, mem_addr), a)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_sub_epi8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_sub_epi8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_sub_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i8 = vsubq_s8(a_.neon_i8, b_.neon_i8);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i8 = a_.i8 - b_.i8;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i8) / sizeof(r_.i8[0])); i++) {
-		r_.i8[i] = a_.i8[i] - b_.i8[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vsubq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 - b_.i8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] - b_.i8[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sub_epi8(a, b) simde_mm_sub_epi8(a, b)
+  #define _mm_sub_epi8(a, b) simde_mm_sub_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_sub_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_sub_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_sub_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i16 = vsubq_s16(a_.neon_i16, b_.neon_i16);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i16 = a_.i16 - b_.i16;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i16) / sizeof(r_.i16[0])); i++) {
-		r_.i16[i] = a_.i16[i] - b_.i16[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vsubq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 - b_.i16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] - b_.i16[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sub_epi16(a, b) simde_mm_sub_epi16(a, b)
+  #define _mm_sub_epi16(a, b) simde_mm_sub_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_sub_epi32(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_sub_epi32(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_sub_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vsubq_s32(a_.neon_i32, b_.neon_i32);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32 = a_.i32 - b_.i32;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
-		r_.i32[i] = a_.i32[i] - b_.i32[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vsubq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 - b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] - b_.i32[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sub_epi32(a, b) simde_mm_sub_epi32(a, b)
+  #define _mm_sub_epi32(a, b) simde_mm_sub_epi32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_sub_epi64(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_sub_epi64(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_sub_epi64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_epi64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 = vsubq_s64(a_.neon_i64, b_.neon_i64);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i64 = a_.i64 - b_.i64;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
-		r_.i64[i] = a_.i64[i] - b_.i64[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vsubq_s64(a_.neon_i64, b_.neon_i64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 - b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] - b_.i64[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sub_epi64(a, b) simde_mm_sub_epi64(a, b)
+  #define _mm_sub_epi64(a, b) simde_mm_sub_epi64(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_sub_epu32(simde__m128i a, simde__m128i b)
-{
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_x_mm_sub_epu32 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.u32 = a_.u32 - b_.u32;
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u32 = vsubq_u32(a_.neon_u32, b_.neon_u32);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.u32) / sizeof(r_.u32[0])); i++) {
-		r_.u32[i] = a_.u32[i] - b_.u32[i];
-	}
-#endif
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.u32 = a_.u32 - b_.u32;
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_u32 = vsubq_u32(a_.neon_u32, b_.neon_u32);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+      r_.u32[i] = a_.u32[i] - b_.u32[i];
+    }
+  #endif
 
-	return simde__m128i_from_private(r_);
+  return simde__m128i_from_private(r_);
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_sub_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_sub_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128d
+simde_mm_sub_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.f64 = a_.f64 - b_.f64;
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vsubq_f64(a_.neon_f64, b_.neon_f64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_sub(a_.wasm_v128, b_.wasm_v128);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.f64[i] = a_.f64[i] - b_.f64[i];
-	}
-#endif
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 - b_.f64;
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vsubq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_sub(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f64[i] - b_.f64[i];
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sub_pd(a, b) simde_mm_sub_pd(a, b)
+  #define _mm_sub_pd(a, b) simde_mm_sub_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_sub_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_sub_sd(a, b);
-#elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
-	return simde_mm_move_sd(a, simde_mm_sub_pd(a, b));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128d
+simde_mm_sub_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_FAST_EXCEPTIONS)
+    return simde_mm_move_sd(a, simde_mm_sub_pd(a, b));
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_sub_pd(simde_x_mm_broadcastlow_pd(a), simde_x_mm_broadcastlow_pd(b)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-	r_.f64[0] = a_.f64[0] - b_.f64[0];
-	r_.f64[1] = a_.f64[1];
+    r_.f64[0] = a_.f64[0] - b_.f64[0];
+    r_.f64[1] = a_.f64[1];
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sub_sd(a, b) simde_mm_sub_sd(a, b)
+  #define _mm_sub_sd(a, b) simde_mm_sub_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m64 simde_mm_sub_si64(simde__m64 a, simde__m64 b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
-	return _mm_sub_si64(a, b);
-#else
-	simde__m64_private r_, a_ = simde__m64_to_private(a),
-			       b_ = simde__m64_to_private(b);
+simde__m64
+simde_mm_sub_si64 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sub_si64(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
 
-#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i64 = a_.i64 - b_.i64;
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i64 = vsub_s64(a_.neon_i64, b_.neon_i64);
-#else
-	r_.i64[0] = a_.i64[0] - b_.i64[0];
-#endif
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 - b_.i64;
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vsub_s64(a_.neon_i64, b_.neon_i64);
+    #else
+      r_.i64[0] = a_.i64[0] - b_.i64[0];
+    #endif
 
-	return simde__m64_from_private(r_);
-#endif
+    return simde__m64_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_sub_si64(a, b) simde_mm_sub_si64(a, b)
+  #define _mm_sub_si64(a, b) simde_mm_sub_si64(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_subs_epi8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_subs_epi8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_subs_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_subs_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i8 = vqsubq_s8(a_.neon_i8, b_.neon_i8);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i8x16_sub_saturate(a_.wasm_v128, b_.wasm_v128);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.i8[0])); i++) {
-		if (((b_.i8[i]) > 0 && (a_.i8[i]) < INT8_MIN + (b_.i8[i]))) {
-			r_.i8[i] = INT8_MIN;
-		} else if ((b_.i8[i]) < 0 &&
-			   (a_.i8[i]) > INT8_MAX + (b_.i8[i])) {
-			r_.i8[i] = INT8_MAX;
-		} else {
-			r_.i8[i] = (a_.i8[i]) - (b_.i8[i]);
-		}
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vqsubq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_sub_sat(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = simde_math_subs_i8(a_.i8[i], b_.i8[i]);
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_subs_epi8(a, b) simde_mm_subs_epi8(a, b)
+  #define _mm_subs_epi8(a, b) simde_mm_subs_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_subs_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_subs_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_subs_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_subs_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i16 = vqsubq_s16(a_.neon_i16, b_.neon_i16);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_i16x8_sub_saturate(a_.wasm_v128, b_.wasm_v128);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.i16[0])); i++) {
-		if (((b_.i16[i]) > 0 &&
-		     (a_.i16[i]) < INT16_MIN + (b_.i16[i]))) {
-			r_.i16[i] = INT16_MIN;
-		} else if ((b_.i16[i]) < 0 &&
-			   (a_.i16[i]) > INT16_MAX + (b_.i16[i])) {
-			r_.i16[i] = INT16_MAX;
-		} else {
-			r_.i16[i] = (a_.i16[i]) - (b_.i16[i]);
-		}
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vqsubq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_sub_sat(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = simde_math_subs_i16(a_.i16[i], b_.i16[i]);
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_subs_epi16(a, b) simde_mm_subs_epi16(a, b)
+  #define _mm_subs_epi16(a, b) simde_mm_subs_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_subs_epu8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_subs_epu8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_subs_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_subs_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u8 = vqsubq_u8(a_.neon_u8, b_.neon_u8);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_u8x16_sub_saturate(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_u8 = vec_subs(a_.altivec_u8, b_.altivec_u8);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.i8[0])); i++) {
-		const int32_t x = a_.u8[i] - b_.u8[i];
-		if (x < 0) {
-			r_.u8[i] = 0;
-		} else if (x > UINT8_MAX) {
-			r_.u8[i] = UINT8_MAX;
-		} else {
-			r_.u8[i] = HEDLEY_STATIC_CAST(uint8_t, x);
-		}
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vqsubq_u8(a_.neon_u8, b_.neon_u8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u8x16_sub_sat(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u8 = vec_subs(a_.altivec_u8, b_.altivec_u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = simde_math_subs_u8(a_.u8[i], b_.u8[i]);
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_subs_epu8(a, b) simde_mm_subs_epu8(a, b)
+  #define _mm_subs_epu8(a, b) simde_mm_subs_epu8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_subs_epu16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_subs_epu16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_subs_epu16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_subs_epu16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_u16 = vqsubq_u16(a_.neon_u16, b_.neon_u16);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_u16x8_sub_saturate(a_.wasm_v128, b_.wasm_v128);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_u16 = vec_subs(a_.altivec_u16, b_.altivec_u16);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_) / sizeof(r_.i16[0])); i++) {
-		const int32_t x = a_.u16[i] - b_.u16[i];
-		if (x < 0) {
-			r_.u16[i] = 0;
-		} else if (x > UINT16_MAX) {
-			r_.u16[i] = UINT16_MAX;
-		} else {
-			r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, x);
-		}
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vqsubq_u16(a_.neon_u16, b_.neon_u16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u16x8_sub_sat(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u16 = vec_subs(a_.altivec_u16, b_.altivec_u16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = simde_math_subs_u16(a_.u16[i], b_.u16[i]);
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_subs_epu16(a, b) simde_mm_subs_epu16(a, b)
+  #define _mm_subs_epu16(a, b) simde_mm_subs_epu16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int simde_mm_ucomieq_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_ucomieq_sd(a, b);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a),
-			     b_ = simde__m128d_to_private(b);
-	int r;
+int
+simde_mm_ucomieq_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_ucomieq_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    int r;
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
-	uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
-	uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(
-		vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
-	uint64x2_t a_eq_b = vceqq_f64(a_.neon_f64, b_.neon_f64);
-	r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_eq_b), 0) != 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) ==
-	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-#elif defined(SIMDE_HAVE_FENV_H)
-	fenv_t envp;
-	int x = feholdexcept(&envp);
-	r = a_.f64[0] == b_.f64[0];
-	if (HEDLEY_LIKELY(x == 0))
-		fesetenv(&envp);
-#else
-	r = a_.f64[0] == b_.f64[0];
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
+      uint64x2_t a_eq_b = vceqq_f64(a_.neon_f64, b_.neon_f64);
+      r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_eq_b), 0) != 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) == wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r =  a_.f64[0] == b_.f64[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r =  a_.f64[0] == b_.f64[0];
+    #endif
 
-	return r;
-#endif
+    return r;
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_ucomieq_sd(a, b) simde_mm_ucomieq_sd(a, b)
+  #define _mm_ucomieq_sd(a, b) simde_mm_ucomieq_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int simde_mm_ucomige_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_ucomige_sd(a, b);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a),
-			     b_ = simde__m128d_to_private(b);
-	int r;
+int
+simde_mm_ucomige_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_ucomige_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    int r;
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
-	uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
-	uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
-	uint64x2_t a_ge_b = vcgeq_f64(a_.neon_f64, b_.neon_f64);
-	r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_ge_b), 0) != 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >=
-	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-#elif defined(SIMDE_HAVE_FENV_H)
-	fenv_t envp;
-	int x = feholdexcept(&envp);
-	r = a_.f64[0] >= b_.f64[0];
-	if (HEDLEY_LIKELY(x == 0))
-		fesetenv(&envp);
-#else
-	r = a_.f64[0] >= b_.f64[0];
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
+      uint64x2_t a_ge_b = vcgeq_f64(a_.neon_f64, b_.neon_f64);
+      r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_ge_b), 0) != 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >= wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f64[0] >= b_.f64[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f64[0] >= b_.f64[0];
+    #endif
 
-	return r;
-#endif
+    return r;
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_ucomige_sd(a, b) simde_mm_ucomige_sd(a, b)
+  #define _mm_ucomige_sd(a, b) simde_mm_ucomige_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int simde_mm_ucomigt_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_ucomigt_sd(a, b);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a),
-			     b_ = simde__m128d_to_private(b);
-	int r;
+int
+simde_mm_ucomigt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_ucomigt_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    int r;
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
-	uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
-	uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
-	uint64x2_t a_gt_b = vcgtq_f64(a_.neon_f64, b_.neon_f64);
-	r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_gt_b), 0) != 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >
-	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-#elif defined(SIMDE_HAVE_FENV_H)
-	fenv_t envp;
-	int x = feholdexcept(&envp);
-	r = a_.f64[0] > b_.f64[0];
-	if (HEDLEY_LIKELY(x == 0))
-		fesetenv(&envp);
-#else
-	r = a_.f64[0] > b_.f64[0];
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
+      uint64x2_t a_gt_b = vcgtq_f64(a_.neon_f64, b_.neon_f64);
+      r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_gt_b), 0) != 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) > wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f64[0] > b_.f64[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f64[0] > b_.f64[0];
+    #endif
 
-	return r;
-#endif
+    return r;
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_ucomigt_sd(a, b) simde_mm_ucomigt_sd(a, b)
+  #define _mm_ucomigt_sd(a, b) simde_mm_ucomigt_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int simde_mm_ucomile_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_ucomile_sd(a, b);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a),
-			     b_ = simde__m128d_to_private(b);
-	int r;
+int
+simde_mm_ucomile_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_ucomile_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    int r;
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
-	uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
-	uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(
-		vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
-	uint64x2_t a_le_b = vcleq_f64(a_.neon_f64, b_.neon_f64);
-	r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_le_b), 0) != 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <=
-	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-#elif defined(SIMDE_HAVE_FENV_H)
-	fenv_t envp;
-	int x = feholdexcept(&envp);
-	r = a_.f64[0] <= b_.f64[0];
-	if (HEDLEY_LIKELY(x == 0))
-		fesetenv(&envp);
-#else
-	r = a_.f64[0] <= b_.f64[0];
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
+      uint64x2_t a_le_b = vcleq_f64(a_.neon_f64, b_.neon_f64);
+      r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_le_b), 0) != 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <= wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f64[0] <= b_.f64[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f64[0] <= b_.f64[0];
+    #endif
 
-	return r;
-#endif
+    return r;
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_ucomile_sd(a, b) simde_mm_ucomile_sd(a, b)
+  #define _mm_ucomile_sd(a, b) simde_mm_ucomile_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int simde_mm_ucomilt_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_ucomilt_sd(a, b);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a),
-			     b_ = simde__m128d_to_private(b);
-	int r;
+int
+simde_mm_ucomilt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_ucomilt_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    int r;
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
-	uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
-	uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(
-		vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
-	uint64x2_t a_lt_b = vcltq_f64(a_.neon_f64, b_.neon_f64);
-	r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_lt_b), 0) != 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <
-	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-#elif defined(SIMDE_HAVE_FENV_H)
-	fenv_t envp;
-	int x = feholdexcept(&envp);
-	r = a_.f64[0] < b_.f64[0];
-	if (HEDLEY_LIKELY(x == 0))
-		fesetenv(&envp);
-#else
-	r = a_.f64[0] < b_.f64[0];
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
+      uint64x2_t a_lt_b = vcltq_f64(a_.neon_f64, b_.neon_f64);
+      r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_lt_b), 0) != 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) < wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f64[0] < b_.f64[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f64[0] < b_.f64[0];
+    #endif
 
-	return r;
-#endif
+    return r;
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_ucomilt_sd(a, b) simde_mm_ucomilt_sd(a, b)
+  #define _mm_ucomilt_sd(a, b) simde_mm_ucomilt_sd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-int simde_mm_ucomineq_sd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_ucomineq_sd(a, b);
-#else
-	simde__m128d_private a_ = simde__m128d_to_private(a),
-			     b_ = simde__m128d_to_private(b);
-	int r;
+int
+simde_mm_ucomineq_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_ucomineq_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    int r;
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
-	uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
-	uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
-	uint64x2_t a_neq_b = vreinterpretq_u64_u32(vmvnq_u32(
-		vreinterpretq_u32_u64(vceqq_f64(a_.neon_f64, b_.neon_f64))));
-	r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_neq_b), 0) != 0);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	return wasm_f64x2_extract_lane(a_.wasm_v128, 0) !=
-	       wasm_f64x2_extract_lane(b_.wasm_v128, 0);
-#elif defined(SIMDE_HAVE_FENV_H)
-	fenv_t envp;
-	int x = feholdexcept(&envp);
-	r = a_.f64[0] != b_.f64[0];
-	if (HEDLEY_LIKELY(x == 0))
-		fesetenv(&envp);
-#else
-	r = a_.f64[0] != b_.f64[0];
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
+      uint64x2_t a_neq_b = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vceqq_f64(a_.neon_f64, b_.neon_f64))));
+      r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_neq_b), 0) != 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) != wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f64[0] != b_.f64[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f64[0] != b_.f64[0];
+    #endif
 
-	return r;
-#endif
+    return r;
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_ucomineq_sd(a, b) simde_mm_ucomineq_sd(a, b)
+  #define _mm_ucomineq_sd(a, b) simde_mm_ucomineq_sd(a, b)
 #endif
 
 #if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
-HEDLEY_DIAGNOSTIC_PUSH
-SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
+  HEDLEY_DIAGNOSTIC_PUSH
+  SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
 #endif
 
 #if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
-HEDLEY_DIAGNOSTIC_POP
+  HEDLEY_DIAGNOSTIC_POP
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_lfence(void)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_lfence();
-#else
-	simde_mm_sfence();
-#endif
+void
+simde_mm_lfence (void) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_lfence();
+  #else
+    simde_mm_sfence();
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_lfence() simde_mm_lfence()
+  #define _mm_lfence() simde_mm_lfence()
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-void simde_mm_mfence(void)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	_mm_mfence();
-#else
-	simde_mm_sfence();
-#endif
+void
+simde_mm_mfence (void) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_mfence();
+  #else
+    simde_mm_sfence();
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_mfence() simde_mm_mfence()
+  #define _mm_mfence() simde_mm_mfence()
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_unpackhi_epi8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_unpackhi_epi8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_unpackhi_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpackhi_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_i8 = vzip2q_s8(a_.neon_i8, b_.neon_i8);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	int8x8_t a1 = vreinterpret_s8_s16(vget_high_s16(a_.neon_i16));
-	int8x8_t b1 = vreinterpret_s8_s16(vget_high_s16(b_.neon_i16));
-	int8x8x2_t result = vzip_s8(a1, b1);
-	r_.neon_i8 = vcombine_s8(result.val[0], result.val[1]);
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.i8, b_.i8, 8, 24, 9, 25, 10, 26,
-				      11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i8[0])) / 2); i++) {
-		r_.i8[(i * 2)] =
-			a_.i8[i + ((sizeof(r_) / sizeof(r_.i8[0])) / 2)];
-		r_.i8[(i * 2) + 1] =
-			b_.i8[i + ((sizeof(r_) / sizeof(r_.i8[0])) / 2)];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i8 = vzip2q_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int8x8_t a1 = vreinterpret_s8_s16(vget_high_s16(a_.neon_i16));
+      int8x8_t b1 = vreinterpret_s8_s16(vget_high_s16(b_.neon_i16));
+      int8x8x2_t result = vzip_s8(a1, b1);
+      r_.neon_i8 = vcombine_s8(result.val[0], result.val[1]);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.i8, b_.i8, 8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i8[0])) / 2) ; i++) {
+        r_.i8[(i * 2)]     = a_.i8[i + ((sizeof(r_) / sizeof(r_.i8[0])) / 2)];
+        r_.i8[(i * 2) + 1] = b_.i8[i + ((sizeof(r_) / sizeof(r_.i8[0])) / 2)];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_unpackhi_epi8(a, b) simde_mm_unpackhi_epi8(a, b)
+  #define _mm_unpackhi_epi8(a, b) simde_mm_unpackhi_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_unpackhi_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_unpackhi_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_unpackhi_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpackhi_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_i16 = vzip2q_s16(a_.neon_i16, b_.neon_i16);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	int16x4_t a1 = vget_high_s16(a_.neon_i16);
-	int16x4_t b1 = vget_high_s16(b_.neon_i16);
-	int16x4x2_t result = vzip_s16(a1, b1);
-	r_.neon_i16 = vcombine_s16(result.val[0], result.val[1]);
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.i16, b_.i16, 4, 12, 5, 13, 6,
-				       14, 7, 15);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i16[0])) / 2); i++) {
-		r_.i16[(i * 2)] =
-			a_.i16[i + ((sizeof(r_) / sizeof(r_.i16[0])) / 2)];
-		r_.i16[(i * 2) + 1] =
-			b_.i16[i + ((sizeof(r_) / sizeof(r_.i16[0])) / 2)];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i16 = vzip2q_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int16x4_t a1 = vget_high_s16(a_.neon_i16);
+      int16x4_t b1 = vget_high_s16(b_.neon_i16);
+      int16x4x2_t result = vzip_s16(a1, b1);
+      r_.neon_i16 = vcombine_s16(result.val[0], result.val[1]);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.i16, b_.i16, 4, 12, 5, 13, 6, 14, 7, 15);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i16[0])) / 2) ; i++) {
+        r_.i16[(i * 2)]     = a_.i16[i + ((sizeof(r_) / sizeof(r_.i16[0])) / 2)];
+        r_.i16[(i * 2) + 1] = b_.i16[i + ((sizeof(r_) / sizeof(r_.i16[0])) / 2)];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_unpackhi_epi16(a, b) simde_mm_unpackhi_epi16(a, b)
+  #define _mm_unpackhi_epi16(a, b) simde_mm_unpackhi_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_unpackhi_epi32(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_unpackhi_epi32(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_unpackhi_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpackhi_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_i32 = vzip2q_s32(a_.neon_i32, b_.neon_i32);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	int32x2_t a1 = vget_high_s32(a_.neon_i32);
-	int32x2_t b1 = vget_high_s32(b_.neon_i32);
-	int32x2x2_t result = vzip_s32(a1, b1);
-	r_.neon_i32 = vcombine_s32(result.val[0], result.val[1]);
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.i32, b_.i32, 2, 6, 3, 7);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i32[0])) / 2); i++) {
-		r_.i32[(i * 2)] =
-			a_.i32[i + ((sizeof(r_) / sizeof(r_.i32[0])) / 2)];
-		r_.i32[(i * 2) + 1] =
-			b_.i32[i + ((sizeof(r_) / sizeof(r_.i32[0])) / 2)];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i32 = vzip2q_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int32x2_t a1 = vget_high_s32(a_.neon_i32);
+      int32x2_t b1 = vget_high_s32(b_.neon_i32);
+      int32x2x2_t result = vzip_s32(a1, b1);
+      r_.neon_i32 = vcombine_s32(result.val[0], result.val[1]);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.i32, b_.i32, 2, 6, 3, 7);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i32[0])) / 2) ; i++) {
+        r_.i32[(i * 2)]     = a_.i32[i + ((sizeof(r_) / sizeof(r_.i32[0])) / 2)];
+        r_.i32[(i * 2) + 1] = b_.i32[i + ((sizeof(r_) / sizeof(r_.i32[0])) / 2)];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_unpackhi_epi32(a, b) simde_mm_unpackhi_epi32(a, b)
+  #define _mm_unpackhi_epi32(a, b) simde_mm_unpackhi_epi32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_unpackhi_epi64(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_unpackhi_epi64(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_unpackhi_epi64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpackhi_epi64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	int64x1_t a_h = vget_high_s64(a_.neon_i64);
-	int64x1_t b_h = vget_high_s64(b_.neon_i64);
-	r_.neon_i64 = vcombine_s64(a_h, b_h);
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.i64, b_.i64, 1, 3);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i64[0])) / 2); i++) {
-		r_.i64[(i * 2)] =
-			a_.i64[i + ((sizeof(r_) / sizeof(r_.i64[0])) / 2)];
-		r_.i64[(i * 2) + 1] =
-			b_.i64[i + ((sizeof(r_) / sizeof(r_.i64[0])) / 2)];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int64x1_t a_h = vget_high_s64(a_.neon_i64);
+      int64x1_t b_h = vget_high_s64(b_.neon_i64);
+      r_.neon_i64 = vcombine_s64(a_h, b_h);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.i64, b_.i64, 1, 3);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i64[0])) / 2) ; i++) {
+        r_.i64[(i * 2)]     = a_.i64[i + ((sizeof(r_) / sizeof(r_.i64[0])) / 2)];
+        r_.i64[(i * 2) + 1] = b_.i64[i + ((sizeof(r_) / sizeof(r_.i64[0])) / 2)];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_unpackhi_epi64(a, b) simde_mm_unpackhi_epi64(a, b)
+  #define _mm_unpackhi_epi64(a, b) simde_mm_unpackhi_epi64(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_unpackhi_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_unpackhi_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128d
+simde_mm_unpackhi_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpackhi_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	float64x1_t a_l = vget_high_f64(a_.f64);
-	float64x1_t b_l = vget_high_f64(b_.f64);
-	r_.neon_f64 = vcombine_f64(a_l, b_l);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_v64x2_shuffle(a_.wasm_v128, b_.wasm_v128, 1, 3);
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 1, 3);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.f64[0])) / 2); i++) {
-		r_.f64[(i * 2)] =
-			a_.f64[i + ((sizeof(r_) / sizeof(r_.f64[0])) / 2)];
-		r_.f64[(i * 2) + 1] =
-			b_.f64[i + ((sizeof(r_) / sizeof(r_.f64[0])) / 2)];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vzip2q_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i64x2_shuffle(a_.wasm_v128, b_.wasm_v128, 1, 3);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 1, 3);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.f64[0])) / 2) ; i++) {
+        r_.f64[(i * 2)]     = a_.f64[i + ((sizeof(r_) / sizeof(r_.f64[0])) / 2)];
+        r_.f64[(i * 2) + 1] = b_.f64[i + ((sizeof(r_) / sizeof(r_.f64[0])) / 2)];
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_unpackhi_pd(a, b) simde_mm_unpackhi_pd(a, b)
+  #define _mm_unpackhi_pd(a, b) simde_mm_unpackhi_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_unpacklo_epi8(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_unpacklo_epi8(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_unpacklo_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpacklo_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_i8 = vzip1q_s8(a_.neon_i8, b_.neon_i8);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	int8x8_t a1 = vreinterpret_s8_s16(vget_low_s16(a_.neon_i16));
-	int8x8_t b1 = vreinterpret_s8_s16(vget_low_s16(b_.neon_i16));
-	int8x8x2_t result = vzip_s8(a1, b1);
-	r_.neon_i8 = vcombine_s8(result.val[0], result.val[1]);
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.i8, b_.i8, 0, 16, 1, 17, 2, 18,
-				      3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i8[0])) / 2); i++) {
-		r_.i8[(i * 2)] = a_.i8[i];
-		r_.i8[(i * 2) + 1] = b_.i8[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i8 = vzip1q_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int8x8_t a1 = vreinterpret_s8_s16(vget_low_s16(a_.neon_i16));
+      int8x8_t b1 = vreinterpret_s8_s16(vget_low_s16(b_.neon_i16));
+      int8x8x2_t result = vzip_s8(a1, b1);
+      r_.neon_i8 = vcombine_s8(result.val[0], result.val[1]);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.i8, b_.i8, 0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i8[0])) / 2) ; i++) {
+        r_.i8[(i * 2)]     = a_.i8[i];
+        r_.i8[(i * 2) + 1] = b_.i8[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_unpacklo_epi8(a, b) simde_mm_unpacklo_epi8(a, b)
+  #define _mm_unpacklo_epi8(a, b) simde_mm_unpacklo_epi8(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_unpacklo_epi16(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_unpacklo_epi16(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_unpacklo_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpacklo_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_i16 = vzip1q_s16(a_.neon_i16, b_.neon_i16);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	int16x4_t a1 = vget_low_s16(a_.neon_i16);
-	int16x4_t b1 = vget_low_s16(b_.neon_i16);
-	int16x4x2_t result = vzip_s16(a1, b1);
-	r_.neon_i16 = vcombine_s16(result.val[0], result.val[1]);
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.i16, b_.i16, 0, 8, 1, 9, 2,
-				       10, 3, 11);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i16[0])) / 2); i++) {
-		r_.i16[(i * 2)] = a_.i16[i];
-		r_.i16[(i * 2) + 1] = b_.i16[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i16 = vzip1q_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int16x4_t a1 = vget_low_s16(a_.neon_i16);
+      int16x4_t b1 = vget_low_s16(b_.neon_i16);
+      int16x4x2_t result = vzip_s16(a1, b1);
+      r_.neon_i16 = vcombine_s16(result.val[0], result.val[1]);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.i16, b_.i16, 0, 8, 1, 9, 2, 10, 3, 11);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i16[0])) / 2) ; i++) {
+        r_.i16[(i * 2)]     = a_.i16[i];
+        r_.i16[(i * 2) + 1] = b_.i16[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_unpacklo_epi16(a, b) simde_mm_unpacklo_epi16(a, b)
+  #define _mm_unpacklo_epi16(a, b) simde_mm_unpacklo_epi16(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_unpacklo_epi32(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_unpacklo_epi32(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_unpacklo_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpacklo_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_i32 = vzip1q_s32(a_.neon_i32, b_.neon_i32);
-#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	int32x2_t a1 = vget_low_s32(a_.neon_i32);
-	int32x2_t b1 = vget_low_s32(b_.neon_i32);
-	int32x2x2_t result = vzip_s32(a1, b1);
-	r_.neon_i32 = vcombine_s32(result.val[0], result.val[1]);
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.i32, b_.i32, 0, 4, 1, 5);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i32[0])) / 2); i++) {
-		r_.i32[(i * 2)] = a_.i32[i];
-		r_.i32[(i * 2) + 1] = b_.i32[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i32 = vzip1q_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int32x2_t a1 = vget_low_s32(a_.neon_i32);
+      int32x2_t b1 = vget_low_s32(b_.neon_i32);
+      int32x2x2_t result = vzip_s32(a1, b1);
+      r_.neon_i32 = vcombine_s32(result.val[0], result.val[1]);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.i32, b_.i32, 0, 4, 1, 5);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i32[0])) / 2) ; i++) {
+        r_.i32[(i * 2)]     = a_.i32[i];
+        r_.i32[(i * 2) + 1] = b_.i32[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_unpacklo_epi32(a, b) simde_mm_unpacklo_epi32(a, b)
+  #define _mm_unpacklo_epi32(a, b) simde_mm_unpacklo_epi32(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_unpacklo_epi64(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_unpacklo_epi64(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_unpacklo_epi64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpacklo_epi64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	int64x1_t a_l = vget_low_s64(a_.i64);
-	int64x1_t b_l = vget_low_s64(b_.i64);
-	r_.neon_i64 = vcombine_s64(a_l, b_l);
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.i64, b_.i64, 0, 2);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.i64[0])) / 2); i++) {
-		r_.i64[(i * 2)] = a_.i64[i];
-		r_.i64[(i * 2) + 1] = b_.i64[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int64x1_t a_l = vget_low_s64(a_.neon_i64);
+      int64x1_t b_l = vget_low_s64(b_.neon_i64);
+      r_.neon_i64 = vcombine_s64(a_l, b_l);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.i64, b_.i64, 0, 2);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i64[0])) / 2) ; i++) {
+        r_.i64[(i * 2)]     = a_.i64[i];
+        r_.i64[(i * 2) + 1] = b_.i64[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_unpacklo_epi64(a, b) simde_mm_unpacklo_epi64(a, b)
+  #define _mm_unpacklo_epi64(a, b) simde_mm_unpacklo_epi64(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_mm_unpacklo_pd(simde__m128d a, simde__m128d b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_unpacklo_pd(a, b);
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a),
-				 b_ = simde__m128d_to_private(b);
+simde__m128d
+simde_mm_unpacklo_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpacklo_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	float64x1_t a_l = vget_low_f64(a_.f64);
-	float64x1_t b_l = vget_low_f64(b_.f64);
-	r_.neon_f64 = vcombine_f64(a_l, b_l);
-#elif defined(SIMDE_SHUFFLE_VECTOR_)
-	r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 0, 2);
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < ((sizeof(r_) / sizeof(r_.f64[0])) / 2); i++) {
-		r_.f64[(i * 2)] = a_.f64[i];
-		r_.f64[(i * 2) + 1] = b_.f64[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vzip1q_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 0, 2);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.f64[0])) / 2) ; i++) {
+        r_.f64[(i * 2)]     = a_.f64[i];
+        r_.f64[(i * 2) + 1] = b_.f64[i];
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_unpacklo_pd(a, b) simde_mm_unpacklo_pd(a, b)
+  #define _mm_unpacklo_pd(a, b) simde_mm_unpacklo_pd(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128d simde_x_mm_negate_pd(simde__m128d a)
-{
-#if defined(SIMDE_X86_SSE_NATIVE)
-	return simde_mm_xor_pd(a, _mm_set1_pd(SIMDE_FLOAT64_C(-0.0)));
-#else
-	simde__m128d_private r_, a_ = simde__m128d_to_private(a);
+simde__m128d
+simde_x_mm_negate_pd(simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return simde_mm_xor_pd(a, _mm_set1_pd(SIMDE_FLOAT64_C(-0.0)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
 
-#if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
-	(!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8, 1, 0))
-	r_.altivec_f64 = vec_neg(a_.altivec_f64);
-#elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
-	r_.neon_f64 = vnegq_f64(a_.neon_f64);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_f64x2_neg(a_.wasm_v128);
-#elif defined(SIMDE_VECTOR_NEGATE)
-	r_.f64 = -a_.f64;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
-		r_.f64[i] = -a_.f64[i];
-	}
-#endif
+    #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
+        (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,1,0))
+      r_.altivec_f64 = vec_neg(a_.altivec_f64);
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vnegq_f64(a_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_neg(a_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_NEGATE)
+      r_.f64 = -a_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = -a_.f64[i];
+      }
+    #endif
 
-	return simde__m128d_from_private(r_);
-#endif
+    return simde__m128d_from_private(r_);
+  #endif
 }
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_mm_xor_si128(simde__m128i a, simde__m128i b)
-{
-#if defined(SIMDE_X86_SSE2_NATIVE)
-	return _mm_xor_si128(a, b);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a),
-				 b_ = simde__m128i_to_private(b);
+simde__m128i
+simde_mm_xor_si128 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_xor_si128(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = veorq_s32(a_.neon_i32, b_.neon_i32);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i32 = vec_xor(a_.altivec_i32, b_.altivec_i32);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32f = a_.i32f ^ b_.i32f;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
-		r_.i32f[i] = a_.i32f[i] ^ b_.i32f[i];
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = veorq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_xor(a_.altivec_i32, b_.altivec_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f ^ b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] ^ b_.i32f[i];
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _mm_xor_si128(a, b) simde_mm_xor_si128(a, b)
+  #define _mm_xor_si128(a, b) simde_mm_xor_si128(a, b)
 #endif
 
 SIMDE_FUNCTION_ATTRIBUTES
-simde__m128i simde_x_mm_not_si128(simde__m128i a)
-{
-#if defined(SIMDE_X86_AVX512VL_NATIVE)
-	return _mm_ternarylogic_epi32(a, a, a, 0x55);
-#else
-	simde__m128i_private r_, a_ = simde__m128i_to_private(a);
+simde__m128i
+simde_x_mm_not_si128 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_ternarylogic_epi32(a, a, a, 0x55);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
 
-#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
-	r_.neon_i32 = vmvnq_s32(a_.neon_i32);
-#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
-	r_.altivec_i32 = vec_nor(a_.altivec_i32, a_.altivec_i32);
-#elif defined(SIMDE_WASM_SIMD128_NATIVE)
-	r_.wasm_v128 = wasm_v128_not(a_.wasm_v128);
-#elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
-	r_.i32f = ~a_.i32f;
-#else
-	SIMDE_VECTORIZE
-	for (size_t i = 0; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])); i++) {
-		r_.i32f[i] = ~(a_.i32f[i]);
-	}
-#endif
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vmvnq_s32(a_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_nor(a_.altivec_i32, a_.altivec_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_not(a_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = ~a_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = ~(a_.i32f[i]);
+      }
+    #endif
 
-	return simde__m128i_from_private(r_);
-#endif
+    return simde__m128i_from_private(r_);
+  #endif
 }
 
 #define SIMDE_MM_SHUFFLE2(x, y) (((x) << 1) | (y))
 #if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
-#define _MM_SHUFFLE2(x, y) SIMDE_MM_SHUFFLE2(x, y)
+  #define _MM_SHUFFLE2(x, y) SIMDE_MM_SHUFFLE2(x, y)
 #endif
 
 SIMDE_END_DECLS_


### PR DESCRIPTION

### Description
Update `simde` to `22b8b97`. This enables ARM64 NEON functionality on Windows ARM64 and possibly other ARM64 systems. 

### Motivation and Context
The current version of `simde` can't recognize Windows ARM64 as a ARM64 machine, and would use software implementation as a fallback.

I set up a Windows ARM64 CI (https://github.com/simd-everywhere/simde/pull/877) and added ARM64EC handling logic (https://github.com/simd-everywhere/simde/pull/884) to the `simde` upstream. 

Huge thanks to @nemequ!



### How Has This Been Tested?
Not yet tested. 
- [ ] Compile the built-in test from `simde`
- [x] Compile OBS-Studio on the `master` branch
- [ ] Check for crash and performance regression
- [ ] Compile OBS-Studio on the `windows-arm64` branch
- [ ] Check for crash and performance regression



### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
