### PR TITLE
v4l2loopback: Add support for non-Linux environments

### DIFF
--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -127,13 +127,19 @@ static bool try_connect(void *data, const char *device)
 	if (vcam->device < 0)
 		return false;
 
-	if (ioctl(vcam->device, VIDIOC_QUERYCAP, &capability) < 0)
+	if (ioctl(vcam->device, VIDIOC_QUERYCAP, &capability) < 0) {
+		close(vcam->device);
+		vcam->device = -1;
 		return false;
+	}
 
 	format.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
 
-	if (ioctl(vcam->device, VIDIOC_G_FMT, &format) < 0)
+	if (ioctl(vcam->device, VIDIOC_G_FMT, &format) < 0) {
+		close(vcam->device);
+		vcam->device = -1;
 		return false;
+	}
 
 	struct obs_video_info ovi;
 	obs_get_video_info(&ovi);
@@ -145,16 +151,22 @@ static bool try_connect(void *data, const char *device)
 	parm.parm.output.timeperframe.numerator = ovi.fps_den;
 	parm.parm.output.timeperframe.denominator = ovi.fps_num;
 
-	if (ioctl(vcam->device, VIDIOC_S_PARM, &parm) < 0)
+	if (ioctl(vcam->device, VIDIOC_S_PARM, &parm) < 0) {
+		close(vcam->device);
+		vcam->device = -1;
 		return false;
+	}
 
 	format.fmt.pix.width = width;
 	format.fmt.pix.height = height;
 	format.fmt.pix.pixelformat = V4L2_PIX_FMT_YUYV;
 	format.fmt.pix.sizeimage = vcam->frame_size;
 
-	if (ioctl(vcam->device, VIDIOC_S_FMT, &format) < 0)
+	if (ioctl(vcam->device, VIDIOC_S_FMT, &format) < 0) {
+		close(vcam->device);
+		vcam->device = -1;
 		return false;
+	}
 
 	struct video_scale_info vsi = {0};
 	vsi.format = VIDEO_FORMAT_YUY2;

--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -28,6 +28,7 @@ static void virtualcam_destroy(void *data)
 	bfree(data);
 }
 
+#if defined(__linux__)
 static bool is_flatpak_sandbox(void)
 {
 	static bool flatpak_info_exists = false;
@@ -99,6 +100,32 @@ static int loopback_module_load()
 	return run_command(
 		"pkexec modprobe v4l2loopback exclusive_caps=1 card_label='OBS Virtual Camera' && sleep 0.5");
 }
+#else
+bool loopback_module_available()
+{
+	struct v4l2_capability capability;
+	char new_device[16];
+	int fd;
+	int i;
+
+	for (i = 0; i != 32; i++) {
+		snprintf(new_device, 16, "/dev/video%d", i);
+		fd = open(new_device, O_RDWR);
+		if (fd < 0)
+			continue;
+		if (ioctl(fd, VIDIOC_QUERYCAP, &capability) < 0) {
+			close(fd);
+			continue;
+		}
+		if (capability.capabilities & V4L2_CAP_VIDEO_OUTPUT) {
+			close(fd);
+			return true;
+		}
+		close(fd);
+	}
+	return false;
+}
+#endif
 
 static void *virtualcam_create(obs_data_t *settings, obs_output_t *output)
 {
@@ -192,10 +219,12 @@ static bool virtualcam_start(void *data)
 	bool success = false;
 	int n;
 
+#if defined(__linux__)
 	if (!loopback_module_loaded()) {
 		if (loopback_module_load() != 0)
 			return false;
 	}
+#endif
 
 	n = scandir("/dev", &list, scanfilter,
 #if defined(__linux__)
@@ -210,7 +239,10 @@ static bool virtualcam_start(void *data)
 
 	for (int i = 0; i < n; i++) {
 		char device[32];
-
+#if !defined(__linux__)
+		if (strstr(list[i]->d_name, "video") != list[i]->d_name)
+			continue;
+#endif
 		snprintf(device, 32, "/dev/%s", list[i]->d_name);
 
 		if (try_connect(vcam, device)) {


### PR DESCRIPTION
Ifdef code specific to Linux to allow the v4l2loopback support to detect
the v4l2 loopback device under FreeBSD/webcamd.

Signed-off-by: Hans Petter Selasky <hps@selasky.org>

### Description
Make the virtual webcam support work under FreeBSD/webcamd.

### Motivation and Context
Fixes detection of the service.

### How Has This Been Tested?
1) Run:
webcamd -c v4l2loopback -U webcamd -G webcamd -B

2) Run:
obs &

3) Click start virtual webcam in UI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
