### PR TITLE
UI: Dim hidden source items in source tree

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -61,7 +61,8 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_)
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 	const char *id = obs_source_get_id(source);
 
-	QLabel *iconLabel = nullptr;
+	bool sourceVisible = obs_sceneitem_visible(sceneitem);
+
 	if (tree->iconsVisible) {
 		QIcon icon;
 
@@ -77,13 +78,14 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_)
 		iconLabel = new QLabel();
 		iconLabel->setPixmap(pixmap);
 		iconLabel->setFixedSize(16, 16);
+		iconLabel->setEnabled(sourceVisible);
 		iconLabel->setStyleSheet("background: none");
 	}
 
 	vis = new VisibilityCheckBox();
 	vis->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 	vis->setFixedSize(16, 16);
-	vis->setChecked(obs_sceneitem_visible(sceneitem));
+	vis->setChecked(sourceVisible);
 	vis->setStyleSheet("background: none");
 	vis->setAccessibleName(QTStr("Basic.Main.Sources.Visibility"));
 	vis->setAccessibleDescription(
@@ -102,6 +104,7 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_)
 	label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 	label->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
 	label->setAttribute(Qt::WA_TranslucentBackground);
+	label->setEnabled(sourceVisible);
 
 #ifdef __APPLE__
 	vis->setAttribute(Qt::WA_LayoutUsesWidgetRect);
@@ -506,6 +509,10 @@ bool SourceTreeItem::eventFilter(QObject *object, QEvent *event)
 
 void SourceTreeItem::VisibilityChanged(bool visible)
 {
+	if (iconLabel) {
+		iconLabel->setEnabled(visible);
+	}
+	label->setEnabled(visible);
 	vis->setChecked(visible);
 }
 

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -62,6 +62,7 @@ public:
 private:
 	QSpacerItem *spacer = nullptr;
 	QCheckBox *expand = nullptr;
+	QLabel *iconLabel = nullptr;
 	VisibilityCheckBox *vis = nullptr;
 	LockedCheckBox *lock = nullptr;
 	QHBoxLayout *boxLayout = nullptr;


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Dims the items of hidden sources in the sources dock to make it more
obvious that they are not visible. Both the icon and the sources name
are affected.

Before: 
<img width="244" alt="image" src="https://user-images.githubusercontent.com/59806498/128242591-15a7a763-404b-4299-9911-6e5a77209b0f.png">
After: 
<img width="243" alt="image" src="https://user-images.githubusercontent.com/59806498/128242667-0d01edbd-7f2f-4fe8-9f4a-a9e42e85dbb8.png">

I also wanted to change the lock to always be dimmed, but the colour seems to be baked into the .svg files of the icons. The solution would probably be to create a third icon (which shows the closed lock in dimmed) and switch to that when the source is hidden, unfortunately how the icons get into the program with QT is magic to me. I'll leave that either for someone else to do or would need further advice from someone knowledgeable in that department.

`QLabel *iconLabel` has been moved to the header to give other functions access to it.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Saw this on the ideas page and thought it was a good idea.
https://ideas.obsproject.com/posts/1464/make-hidden-sources-more-obvious



### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Environment: macOS 12.0, Intel.
Compiled and ran, everything seems to work as expected.
Other themes respect the changes (tested with Rachni), and disabling and enabling icons from the `View` menu also doesn't break anything.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
