### PR TITLE
UI: Add option to automatically delete autoremux files

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1012,6 +1012,7 @@ Basic.Settings.Advanced.Hotkeys.DisableHotkeysInFocus="Disable hotkeys when main
 Basic.Settings.Advanced.Hotkeys.DisableHotkeysOutOfFocus="Disable hotkeys when main window is not in focus"
 Basic.Settings.Advanced.AutoRemux="Automatically remux to mp4"
 Basic.Settings.Advanced.AutoRemux.MP4="(record as mkv)"
+Basic.Settings.Advanced.AutoRemuxDelete="Move original file to trash after automatically remuxing (if available)"
 
 # advanced audio properties
 Basic.AdvAudio="Advanced Audio Properties"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -5020,7 +5020,7 @@
                      </property>
                     </widget>
                    </item>
-                   <item row="3" column="1">
+                   <item row="4" column="1">
                     <layout class="QHBoxLayout" name="horizontalLayout_14">
                      <property name="leftMargin">
                       <number>0</number>
@@ -5052,7 +5052,7 @@
                      </item>
                     </layout>
                    </item>
-                   <item row="3" column="0">
+                   <item row="4" column="0">
                     <widget class="QLabel" name="label_57">
                      <property name="text">
                       <string>Basic.Settings.Output.ReplayBuffer.Prefix</string>
@@ -5084,6 +5084,29 @@
                    </item>
                    <item row="2" column="0">
                     <spacer name="horizontalSpacer_16">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="3" column="1">
+                    <widget class="QCheckBox" name="autoRemuxDelete">
+                     <property name="enabled">
+                      <bool>false</bool>
+                     </property>
+                     <property name="text">
+                      <string>Basic.Settings.Advanced.AutoRemuxDelete</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="0">
+                    <spacer name="horizontalSpacer_27">
                      <property name="orientation">
                       <enum>Qt::Horizontal</enum>
                      </property>
@@ -5702,6 +5725,7 @@
   <tabstop>filenameFormatting</tabstop>
   <tabstop>overwriteIfExists</tabstop>
   <tabstop>autoRemux</tabstop>
+  <tabstop>autoRemuxDelete</tabstop>
   <tabstop>simpleRBPrefix</tabstop>
   <tabstop>simpleRBSuffix</tabstop>
   <tabstop>streamDelayEnable</tabstop>
@@ -6072,6 +6096,12 @@
      <y>291</y>
     </hint>
    </hints>
+  </connection>
+  <connection>
+   <sender>autoRemux</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>autoRemuxDelete</receiver>
+   <slot>setEnabled(bool)</slot>
   </connection>
   <connection>
    <sender>streamDelayEnable</sender>

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -558,6 +558,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->enableLowLatencyMode, CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->hotkeyFocusType,      COMBO_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->autoRemux,            CHECK_CHANGED,  ADV_CHANGED);
+	HookWidget(ui->autoRemuxDelete,      CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->dynBitrate,           CHECK_CHANGED,  ADV_CHANGED);
 	/* clang-format on */
 
@@ -2502,6 +2503,8 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	int rbTime = config_get_int(main->Config(), "AdvOut", "RecRBTime");
 	int rbSize = config_get_int(main->Config(), "AdvOut", "RecRBSize");
 	bool autoRemux = config_get_bool(main->Config(), "Video", "AutoRemux");
+	bool autoRemuxDelete =
+		config_get_bool(main->Config(), "Video", "AutoRemuxDelete");
 	const char *hotkeyFocusType = config_get_string(
 		App()->GlobalConfig(), "General", "HotkeyFocusType");
 	bool dynBitrate =
@@ -2533,7 +2536,16 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	ui->streamDelayPreserve->setChecked(preserveDelay);
 	ui->streamDelayEnable->setChecked(enableDelay);
 	ui->autoRemux->setChecked(autoRemux);
+	ui->autoRemuxDelete->setChecked(autoRemuxDelete);
 	ui->dynBitrate->setChecked(dynBitrate);
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+	// Hide option to autodelete remuxed files on QT versions older than 5.15
+	int row;
+	ui->formLayout_17->getWidgetPosition(ui->autoRemuxDelete, &row,
+					     nullptr);
+	ui->formLayout_17->removeRow(row);
+#endif
 
 	SetComboByName(ui->colorFormat, videoColorFormat);
 	SetComboByName(ui->colorSpace, videoColorSpace);
@@ -3256,6 +3268,7 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	SaveSpinBox(ui->reconnectMaxRetries, "Output", "MaxRetries");
 	SaveComboData(ui->bindToIP, "Output", "BindIP");
 	SaveCheckBox(ui->autoRemux, "Video", "AutoRemux");
+	SaveCheckBox(ui->autoRemuxDelete, "Video", "AutoRemuxDelete");
 	SaveCheckBox(ui->dynBitrate, "Output", "DynamicBitrate");
 
 #if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO

--- a/UI/window-remux.hpp
+++ b/UI/window-remux.hpp
@@ -57,7 +57,8 @@ class OBSRemux : public QDialog {
 	virtual void reject() override;
 
 	bool autoRemux;
-	QString autoRemuxFile;
+	QString autoRemuxInFile;
+	QString autoRemuxOutFile;
 
 public:
 	explicit OBSRemux(const char *recPath, QWidget *parent = nullptr,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->
*Edited to reflect newest version of this PR*

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a setting to Advanced that lets OBS automatically move recordings
to trash after being autoremuxed. Requires autoremux to be enabled as
well as QT 5.15 (and the OS to have a trash).

Screenshots:
<img width="867" alt="image" src="https://user-images.githubusercontent.com/59806498/131120232-b4d2d813-eacb-497f-8af2-e146e1627adf.png">
<img width="918" alt="image" src="https://user-images.githubusercontent.com/59806498/131120253-d5dc970f-3bc8-49f6-af81-8ef71ea2b5ec.png">
<img width="845" alt="image" src="https://user-images.githubusercontent.com/59806498/131120271-d69cabbf-199d-4112-8540-83ecf5aa7d03.png">


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Autoremux is a great feature for anyone who wants to record MP4, but still wants to be safe of recordings being corrupted.
Unfortunately, it leaves you with a recording folder looking like this:
<img width="287" alt="image" src="https://user-images.githubusercontent.com/59806498/128431836-86209ad7-484c-4e0b-b4df-ca79b76d1d90.png">
Besides being unpleasing to work with, the storage required on your hard drive is doubled if you don't always delete the original file yourself.
This is a QOL change making it easier (and maybe a little more appealing) to use autoremux and not record directly to MP4, since the result is the same - an MP4-File. The difference would be that well, your protected against corruptions.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12, Intel

If the option is selected, once the recording is ended, the MP4 gets created and the (in my case) .mkv moved to the trash bin, leaving only the MP4.
If the box is not ticked, both files will stay, as they currently do.
If autoremux is disabled all together, the checkbox is greyed out, but will remember its state.
Manual remux isn't affected by this change, as expected.

While I can't test Windows and Linux, it should behave the same since only QT functions are used.
With QT older than 5.15, the option shouln't be available in the first place.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
