### PR TITLE
rtmp-services: Add "Rawa.TV"

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 178,
+	"version": 179,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 178
+			"version": 179
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -541,6 +541,18 @@
             }
         },
         {
+            "name": "Rawa.TV",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://live.rawa.tv:1935/ingest"
+                }
+            ],
+            "recommended": {
+                "keyint": 2
+            }
+        },
+        {
             "name": "Restream.io",
             "alt_names": [
                 "Restream.io - RTMP",


### PR DESCRIPTION
### Description
Adds [Rawa.TV](https://rawa.tv) to rtmp services list.
A gaming live streaming platform in middle east
### Motivation and Context
Add support for "Rawa.TV" in rtmp services.
### How Has This Been Tested?
Local Build & CI Build
### Types of changes
- New feature (non-breaking change which adds functionality)
### Checklist:
- [x] My code has been run through  [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [contributing document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.