### PR TITLE
libobs/util: Fix reading memory usage on Linux

### DIFF
--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -1001,7 +1001,8 @@ bool os_get_proc_memory_usage(os_proc_memory_usage_t *usage)
 	if (!os_get_proc_memory_usage_internal(&statm))
 		return false;
 
-	usage->resident_size = statm.resident_size;
+	usage->resident_size =
+		(uint64_t)statm.resident_size * sysconf(_SC_PAGESIZE);
 	usage->virtual_size = statm.virtual_size;
 	return true;
 }
@@ -1011,7 +1012,7 @@ uint64_t os_get_proc_resident_size(void)
 	statm_t statm = {};
 	if (!os_get_proc_memory_usage_internal(&statm))
 		return 0;
-	return (uint64_t)statm.resident_size;
+	return (uint64_t)statm.resident_size * sysconf(_SC_PAGESIZE);
 }
 
 uint64_t os_get_proc_virtual_size(void)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The unit of `/proc/<pid>/statm` is the page size of the system. The value retrieved from `statm` should be multiplied by `sysconf(_SC_PAGESIZE)`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Memory usage displayed on Stats was too small due to a misaligned unit of `resident_size` read from `statm` file and libobs's `os_proc_memory_usage.resident_size`.

This is the Stats window before fixing the issue. Memory usage is 0.1 MB, which is obviously too small.
![linux-stats-memory-too-small](https://user-images.githubusercontent.com/780600/128583345-5f2906de-94df-4f17-8efc-da4a8ff0b181.png)

This article shows a screenshot with `Memory Usage 0.0 MB` on OBS Studio 25.0.8 from PPA. I checked changes from 25.0.8 in stats window and util but cannot found any fix of the memory usage.
https://www.linuxandubuntu.com/home/obs-studio-stream-from-linux

This is the Stats window after fixing the issue.
![linux-stats-fixed](https://user-images.githubusercontent.com/780600/128583393-517a741f-01c0-4201-aa84-99274d2eb33f.png)
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I tested as screenshots above on CentOS 8.
I have not tested on Ubuntu. Someone who can test on Ubuntu will be welcomed.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
