### PR TITLE
UI: Autoremux Replay Buffer

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6395,7 +6395,7 @@ void OBSBasic::StreamingStop(int code, QString last_error)
 	}
 }
 
-void OBSBasic::AutoRemux()
+void OBSBasic::AutoRemux(QString input)
 {
 	bool autoRemux = config_get_bool(Config(), "Video", "AutoRemux");
 
@@ -6409,7 +6409,6 @@ void OBSBasic::AutoRemux()
 	if (ffmpegOutput)
 		return;
 
-	QString input = outputHandler->lastRecordingPath.c_str();
 	if (input.isEmpty())
 		return;
 
@@ -6571,7 +6570,7 @@ void OBSBasic::RecordingStop(int code, QString last_error)
 	if (diskFullTimer->isActive())
 		diskFullTimer->stop();
 
-	AutoRemux();
+	AutoRemux(outputHandler->lastRecordingPath.c_str());
 
 	OnDeactivate();
 	UpdatePause(false);
@@ -6721,6 +6720,8 @@ void OBSBasic::ReplayBufferSaved()
 
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED);
+
+	AutoRemux(path);
 }
 
 void OBSBasic::ReplayBufferStop(int code)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -745,7 +745,7 @@ private:
 
 	static void HotkeyTriggered(void *data, obs_hotkey_id id, bool pressed);
 
-	void AutoRemux();
+	void AutoRemux(QString input);
 
 	void UpdatePause(bool activate = true);
 	void UpdateReplayBuffer(bool activate = true);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Replays from the replay buffer will be automatically remuxed to MP4 like
recordings are, if autoremux is enabled.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #4998 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0, compiled and run.

When the Replay Buffer is saved, the replay is being remuxed. Works both by saving from UI as well as frontend-api.
Recording autoremux is unaffected. When stopping recoding and saving buffer at the same time, both files will get remuxed properly.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
