### PR TITLE
Don't trigger hotkeys without modifiers if user is holding down modifiers (strict)

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -1194,9 +1194,10 @@ static inline bool modifiers_match(obs_hotkey_binding_t *binding,
 				   uint32_t modifiers_, bool strict_modifiers)
 {
 	uint32_t modifiers = binding->key.modifiers;
-	return !modifiers ||
-	       (!strict_modifiers && (modifiers & modifiers_) == modifiers) ||
-	       (strict_modifiers && modifiers == modifiers_);
+	if (!strict_modifiers)
+		return (modifiers & modifiers_) == modifiers;
+	else
+		return modifiers == modifiers_;
 }
 
 static inline bool is_pressed(obs_key_t key)
@@ -1243,7 +1244,7 @@ static inline void handle_binding(obs_hotkey_binding_t *binding,
 		modifiers_match(binding, modifiers, strict_modifiers);
 	bool modifiers_only = binding->key.key == OBS_KEY_NONE;
 
-	if (!binding->key.modifiers)
+	if (!strict_modifiers && !binding->key.modifiers)
 		binding->modifiers_match = true;
 
 	if (modifiers_only)

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -990,6 +990,7 @@ static inline bool obs_init_hotkeys(void)
 			   NULL))
 		goto fail;
 
+	hotkeys->strict_modifiers = true;
 	hotkeys->hotkey_thread_initialized = true;
 
 	success = true;


### PR DESCRIPTION
### Description
(This description has been revised from the original, since a proposed UI component has been removed)
Trigger hotkeys only when the key and modifiers pressed by the user exactly match the hotkey definition.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To fix #4408.

Suppose a user defines hotkey actions for "1", "Ctrl-1", "Alt-1", and "Ctrl-Alt-1." With the code in OBS 27 or earlier, if they then press "Ctrl-Alt-1", ALL FOUR actions will be triggered, in an order that may change between runs of OBS (presumably due to how the json is loaded).

While there may be some use case for this, requiring exact matches greatly expands the number of actions that can be invoked independently by hotkeys.

<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Bug reports
[https://github.com/obsproject/obs-studio/issues/4408](url)
[https://obsproject.com/mantis/view.php?id=925](url)
[https://obsproject.com/mantis/view.php?id=1468](url)
[https://obsproject.com/mantis/view.php?id=1571](url) (duplicate of 1468)

Forum posts complaining about the current behavior
[https://ideas.obsproject.com/posts/...at-ctrl-alt-x-doesnt-trigger-ctrl-x-and-alt-x](url)
[https://obsproject.com/forum/thread...iably-for-scene-selection.146242/#post-535412](url)
[https://obsproject.com/forum/threads/hotkey-modifier-bug.79197/#post-333409](url)
[https://obsproject.com/forum/threads/please-fix-the-hotkeys.79150/#post-333256](url)
[https://obsproject.com/forum/threads/hotkey-modifier-issue.78002/#post-329251](url)

There is a pull request from 2020 that attempts to fix this 
[https://github.com/obsproject/obs-studio/pull/2785](url)
This pull has a number of problems, both in functionality and in coding), as noted in my comment on the pull request.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested using
- A scene collection with scenes showing white text at different positions
- A Lua script that logs changes to the Program scene, and with handlers for four hotkeys that simply log the hotkey.

After assigning hotkeys with various modifiers to change scenes and trigger the Lua script, you can observe the script log window and see the behavior of v27 and modified code. In many cases you can see flashes caused by transient scene switching when in v28, or with the fix in legacy mode.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
