### PR TITLE
UI: Show autoremux progress bar

### DIFF
--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -864,6 +864,7 @@ void OBSRemux::beginRemux()
 void OBSRemux::AutoRemux(QString inFile, QString outFile)
 {
 	if (inFile != "" && outFile != "" && autoRemux) {
+		ui->progressBar->setVisible(true);
 		emit remux(inFile, outFile);
 		autoRemuxFile = outFile;
 	}


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes a bug where the progress bar for autoremuxes wouldn't be made
visible when it started, and only a blank popup window appeared.

Turns out that the progress bar wasn't made visible when autoremuxing, only for normal remux:
https://github.com/obsproject/obs-studio/blob/725fce78bafda3834767d75be04a961eed8967f0/UI/window-remux.cpp#L856

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When stopping a recording and autoremux is enabled, this blank window appeared:
<img width="593" alt="Bildschirmfoto 2021-08-07 um 23 03 06" src="https://user-images.githubusercontent.com/59806498/128614596-4f1916fc-44a2-4eac-a39a-1ad7481f93bd.png">

The moment the remux is finished, the progress bar appears in the window:
<img width="1075" alt="Bildschirmfoto 2021-08-07 um 23 03 32" src="https://user-images.githubusercontent.com/59806498/128614608-4729c3e5-66ea-477a-96b3-398c75847e64.png">

This is obviously not how the progress bar is supposed to work :D.
On smaller recordings most people probably don't notice, but bigger files (>200MB in my case) that take longer definitely made this issue obvious.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12, compiled and run.
Progress bar is properly shown during the remux:

<img width="280" alt="Bildschirmfoto 2021-08-07 um 23 32 45" src="https://user-images.githubusercontent.com/59806498/128614644-94c9a50a-7f8c-4a84-962e-8a0730156ac4.png">

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
