### PR TITLE
UI: Ignore scroll on QComboBoxes and QSpinBoxes when not in focus

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -1,14 +1,14 @@
 #include <QHBoxLayout>
 #include <QGridLayout>
 #include <QLabel>
-#include <QSpinBox>
-#include <QComboBox>
 #include <QCheckBox>
 #include <cmath>
 #include "qt-wrappers.hpp"
 #include "obs-app.hpp"
 #include "adv-audio-control.hpp"
 #include "window-basic-main.hpp"
+#include "combobox-ignorewheel.hpp"
+#include "spinbox-ignorewheel.hpp"
 
 #ifndef NSEC_PER_MSEC
 #define NSEC_PER_MSEC 1000000
@@ -37,14 +37,14 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	nameLabel = new QLabel();
 	active = new QLabel();
 	stackedWidget = new QStackedWidget();
-	volume = new QDoubleSpinBox();
-	percent = new QSpinBox();
+	volume = new DoubleSpinBoxIgnoreScroll();
+	percent = new SpinBoxIgnoreScroll();
 	forceMono = new QCheckBox();
 	balance = new BalanceSlider();
 #if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	monitoringType = new QComboBox();
+	monitoringType = new ComboBoxIgnoreScroll();
 #endif
-	syncOffset = new QSpinBox();
+	syncOffset = new SpinBoxIgnoreScroll();
 	mixer1 = new QCheckBox();
 	mixer2 = new QCheckBox();
 	mixer3 = new QCheckBox();

--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -3,15 +3,14 @@
 #include <obs.hpp>
 #include <QWidget>
 #include <QPointer>
-#include <QDoubleSpinBox>
 #include <QStackedWidget>
 #include "balance-slider.hpp"
+#include "combobox-ignorewheel.hpp"
+#include "spinbox-ignorewheel.hpp"
 
 class QGridLayout;
 class QLabel;
-class QSpinBox;
 class QCheckBox;
-class QComboBox;
 
 enum class VolumeType {
 	dB,
@@ -33,14 +32,14 @@ private:
 	QPointer<QLabel> nameLabel;
 	QPointer<QLabel> active;
 	QPointer<QStackedWidget> stackedWidget;
-	QPointer<QSpinBox> percent;
-	QPointer<QDoubleSpinBox> volume;
+	QPointer<SpinBoxIgnoreScroll> percent;
+	QPointer<DoubleSpinBoxIgnoreScroll> volume;
 	QPointer<QCheckBox> forceMono;
 	QPointer<BalanceSlider> balance;
 	QPointer<QLabel> labelL;
 	QPointer<QLabel> labelR;
-	QPointer<QSpinBox> syncOffset;
-	QPointer<QComboBox> monitoringType;
+	QPointer<SpinBoxIgnoreScroll> syncOffset;
+	QPointer<ComboBoxIgnoreScroll> monitoringType;
 	QPointer<QCheckBox> mixer1;
 	QPointer<QCheckBox> mixer2;
 	QPointer<QCheckBox> mixer3;

--- a/UI/balance-slider.hpp
+++ b/UI/balance-slider.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
-#include <QSlider>
+#include "slider-ignorewheel.hpp"
 #include <QMouseEvent>
 
-class BalanceSlider : public QSlider {
+class BalanceSlider : public SliderIgnoreScroll {
 	Q_OBJECT
 
 public:
-	inline BalanceSlider(QWidget *parent = 0) : QSlider(parent) {}
+	inline BalanceSlider(QWidget *parent = 0) : SliderIgnoreScroll(parent)
+	{
+	}
 
 signals:
 	void doubleClicked();

--- a/UI/double-slider.hpp
+++ b/UI/double-slider.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <QSlider>
 #include "slider-ignorewheel.hpp"
 
 class DoubleSlider : public SliderIgnoreScroll {

--- a/UI/forms/AutoConfigStreamPage.ui
+++ b/UI/forms/AutoConfigStreamPage.ui
@@ -89,7 +89,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QComboBox" name="service"/>
+          <widget class="ComboBoxIgnoreScroll" name="service"/>
          </item>
          <item>
           <widget class="UrlPushButton" name="moreInfoButton">
@@ -247,7 +247,7 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QComboBox" name="server"/>
+            <widget class="ComboBoxIgnoreScroll" name="server"/>
            </item>
           </layout>
          </widget>
@@ -341,7 +341,7 @@
         </widget>
        </item>
        <item row="2" column="1">
-        <widget class="QSpinBox" name="bitrate">
+        <widget class="SpinBoxIgnoreScroll" name="bitrate">
          <property name="suffix">
           <string notr="true"/>
          </property>
@@ -507,6 +507,16 @@
    <class>UrlPushButton</class>
    <extends>QPushButton</extends>
    <header>url-push-button.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>ComboBoxIgnoreScroll</class>
+   <extends>QComboBox</extends>
+   <header>combobox-ignorewheel.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>SpinBoxIgnoreScroll</class>
+   <extends>QSpinBox</extends>
+   <header>spinbox-ignorewheel.hpp</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/UI/forms/AutoConfigVideoPage.ui
+++ b/UI/forms/AutoConfigVideoPage.ui
@@ -33,7 +33,7 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QComboBox" name="canvasRes"/>
+      <widget class="ComboBoxIgnoreScroll" name="canvasRes"/>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_3">
@@ -46,7 +46,7 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QComboBox" name="fps"/>
+      <widget class="ComboBoxIgnoreScroll" name="fps"/>
      </item>
      <item row="3" column="0">
       <spacer name="horizontalSpacer">
@@ -91,6 +91,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+   <customwidget>
+    <class>ComboBoxIgnoreScroll</class>
+    <extends>QComboBox</extends>
+    <header>combobox-ignorewheel.hpp</header>
+   </customwidget>
+  </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1161,7 +1161,7 @@
            <number>4</number>
           </property>
           <item>
-           <widget class="QComboBox" name="transitions">
+           <widget class="ComboBoxIgnoreScroll" name="transitions">
             <property name="minimumSize">
              <size>
               <width>120</width>
@@ -1232,7 +1232,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QSpinBox" name="transitionDuration">
+           <widget class="SpinBoxIgnoreScroll" name="transitionDuration">
             <property name="accessibleName">
              <string>Basic.TransitionDuration</string>
             </property>
@@ -2155,6 +2155,16 @@
    <class>RecordButton</class>
    <extends>QPushButton</extends>
    <header>record-button.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>ComboBoxIgnoreScroll</class>
+   <extends>QComboBox</extends>
+   <header>combobox-ignorewheel.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>SpinBoxIgnoreScroll</class>
+   <extends>QSpinBox</extends>
+   <header>spinbox-ignorewheel.hpp</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -197,7 +197,7 @@
                     </widget>
                    </item>
                    <item row="0" column="1">
-                    <widget class="QComboBox" name="language"/>
+                    <widget class="ComboBoxIgnoreScroll" name="language"/>
                    </item>
                    <item row="1" column="0">
                     <widget class="QLabel" name="label_42">
@@ -210,7 +210,7 @@
                     </widget>
                    </item>
                    <item row="1" column="1">
-                    <widget class="QComboBox" name="theme"/>
+                    <widget class="ComboBoxIgnoreScroll" name="theme"/>
                    </item>
                    <item row="2" column="0">
                     <spacer name="horizontalSpacer_3">
@@ -402,7 +402,7 @@
                     </widget>
                    </item>
                    <item row="1" column="1">
-                    <widget class="QDoubleSpinBox" name="snapDistance">
+                    <widget class="DoubleSpinBoxIgnoreScroll" name="snapDistance">
                      <property name="decimals">
                       <number>1</number>
                      </property>
@@ -767,7 +767,7 @@
                     </widget>
                    </item>
                    <item row="3" column="1">
-                    <widget class="QComboBox" name="multiviewLayout"/>
+                    <widget class="ComboBoxIgnoreScroll" name="multiviewLayout"/>
                    </item>
                    <item row="3" column="0">
                     <widget class="QLabel" name="label_64">
@@ -846,7 +846,7 @@
                 <number>0</number>
                </property>
                <item>
-                <widget class="QComboBox" name="service">
+                <widget class="ComboBoxIgnoreScroll" name="service">
                  <property name="maxVisibleItems">
                   <number>20</number>
                  </property>
@@ -1020,7 +1020,7 @@
                   <number>0</number>
                  </property>
                  <item>
-                  <widget class="QComboBox" name="server"/>
+                  <widget class="ComboBoxIgnoreScroll" name="server"/>
                  </item>
                 </layout>
                </widget>
@@ -1235,7 +1235,7 @@
               </widget>
              </item>
              <item row="8" column="1">
-              <widget class="QComboBox" name="twitchAddonDropdown"/>
+              <widget class="ComboBoxIgnoreScroll" name="twitchAddonDropdown"/>
              </item>
              <item row="8" column="0">
               <widget class="QLabel" name="twitchAddonLabel">
@@ -1410,7 +1410,7 @@
                  </widget>
                 </item>
                 <item row="0" column="1">
-                 <widget class="QComboBox" name="outputMode">
+                 <widget class="ComboBoxIgnoreScroll" name="outputMode">
                   <property name="enabled">
                    <bool>true</bool>
                   </property>
@@ -1495,7 +1495,7 @@
                      </widget>
                     </item>
                     <item row="0" column="1">
-                     <widget class="QSpinBox" name="simpleOutputVBitrate">
+                     <widget class="SpinBoxIgnoreScroll" name="simpleOutputVBitrate">
                       <property name="minimum">
                        <number>200</number>
                       </property>
@@ -1518,7 +1518,7 @@
                      </widget>
                     </item>
                     <item row="1" column="1">
-                     <widget class="QComboBox" name="simpleOutStrEncoder"/>
+                     <widget class="ComboBoxIgnoreScroll" name="simpleOutStrEncoder"/>
                     </item>
                     <item row="2" column="0">
                      <widget class="QLabel" name="label_20">
@@ -1531,7 +1531,7 @@
                      </widget>
                     </item>
                     <item row="2" column="1">
-                     <widget class="QComboBox" name="simpleOutputABitrate">
+                     <widget class="ComboBoxIgnoreScroll" name="simpleOutputABitrate">
                       <property name="currentIndex">
                        <number>8</number>
                       </property>
@@ -1616,7 +1616,7 @@
                      </widget>
                     </item>
                     <item row="4" column="1">
-                     <widget class="QComboBox" name="simpleOutPreset"/>
+                     <widget class="ComboBoxIgnoreScroll" name="simpleOutPreset"/>
                     </item>
                     <item row="5" column="0">
                      <widget class="QLabel" name="label_23">
@@ -1713,7 +1713,7 @@
                      </widget>
                     </item>
                     <item row="2" column="1">
-                     <widget class="QComboBox" name="simpleOutRecQuality"/>
+                     <widget class="ComboBoxIgnoreScroll" name="simpleOutRecQuality"/>
                     </item>
                     <item row="3" column="0">
                      <widget class="QLabel" name="simpleOutRecFormatLabel">
@@ -1726,7 +1726,7 @@
                      </widget>
                     </item>
                     <item row="3" column="1">
-                     <widget class="QComboBox" name="simpleOutRecFormat">
+                     <widget class="ComboBoxIgnoreScroll" name="simpleOutRecFormat">
                       <item>
                        <property name="text">
                         <string notr="true">flv</string>
@@ -1770,7 +1770,7 @@
                      </widget>
                     </item>
                     <item row="4" column="1">
-                     <widget class="QComboBox" name="simpleOutRecEncoder"/>
+                     <widget class="ComboBoxIgnoreScroll" name="simpleOutRecEncoder"/>
                     </item>
                     <item row="5" column="0">
                      <widget class="QLabel" name="label_420">
@@ -1818,7 +1818,7 @@
                      </widget>
                     </item>
                     <item row="0" column="1">
-                     <widget class="QSpinBox" name="simpleRBSecMax">
+                     <widget class="SpinBoxIgnoreScroll" name="simpleRBSecMax">
                       <property name="suffix">
                        <string notr="true"> sec</string>
                       </property>
@@ -1841,7 +1841,7 @@
                      </widget>
                     </item>
                     <item row="1" column="1">
-                     <widget class="QSpinBox" name="simpleRBMegsMax">
+                     <widget class="SpinBoxIgnoreScroll" name="simpleRBMegsMax">
                       <property name="suffix">
                        <string notr="true"> MB</string>
                       </property>
@@ -2083,7 +2083,7 @@
                             </widget>
                            </item>
                            <item row="2" column="1">
-                            <widget class="QComboBox" name="advOutEncoder"/>
+                            <widget class="ComboBoxIgnoreScroll" name="advOutEncoder"/>
                            </item>
                            <item row="3" column="0">
                             <widget class="QCheckBox" name="advOutUseRescale">
@@ -2102,7 +2102,7 @@
                             </widget>
                            </item>
                            <item row="3" column="1">
-                            <widget class="QComboBox" name="advOutRescale">
+                            <widget class="ComboBoxIgnoreScroll" name="advOutRescale">
                              <property name="enabled">
                               <bool>false</bool>
                              </property>
@@ -2171,7 +2171,7 @@
                          </widget>
                         </item>
                         <item row="0" column="1">
-                         <widget class="QComboBox" name="advOutRecType">
+                         <widget class="ComboBoxIgnoreScroll" name="advOutRecType">
                           <item>
                            <property name="text">
                             <string>Basic.Settings.Output.Adv.Recording.Type.Standard</string>
@@ -2291,7 +2291,7 @@
                              </widget>
                             </item>
                             <item row="2" column="1">
-                             <widget class="QComboBox" name="advOutRecFormat">
+                             <widget class="ComboBoxIgnoreScroll" name="advOutRecFormat">
                               <item>
                                <property name="text">
                                 <string notr="true">flv</string>
@@ -2342,7 +2342,7 @@
                              </widget>
                             </item>
                             <item row="4" column="1">
-                             <widget class="QComboBox" name="advOutRecEncoder"/>
+                             <widget class="ComboBoxIgnoreScroll" name="advOutRecEncoder"/>
                             </item>
                             <item row="5" column="0">
                              <widget class="QCheckBox" name="advOutRecUseRescale">
@@ -2376,7 +2376,7 @@
                                 <number>0</number>
                                </property>
                                <item>
-                                <widget class="QComboBox" name="advOutRecRescale">
+                                <widget class="ComboBoxIgnoreScroll" name="advOutRecRescale">
                                  <property name="enabled">
                                   <bool>false</bool>
                                  </property>
@@ -2679,7 +2679,7 @@
                           </widget>
                          </item>
                          <item row="3" column="1">
-                          <widget class="QComboBox" name="advOutFFFormat"/>
+                          <widget class="ComboBoxIgnoreScroll" name="advOutFFFormat"/>
                          </item>
                          <item row="4" column="0">
                           <widget class="QLabel" name="label_44">
@@ -2721,7 +2721,7 @@
                           </widget>
                          </item>
                          <item row="0" column="1">
-                          <widget class="QComboBox" name="advOutFFType">
+                          <widget class="ComboBoxIgnoreScroll" name="advOutFFType">
                            <item>
                             <property name="text">
                              <string>Basic.Settings.Output.Adv.FFmpeg.Type.RecordToFile</string>
@@ -2768,7 +2768,7 @@
                           </widget>
                          </item>
                          <item row="6" column="1">
-                          <widget class="QSpinBox" name="advOutFFVBitrate">
+                          <widget class="SpinBoxIgnoreScroll" name="advOutFFVBitrate">
                            <property name="minimum">
                             <number>0</number>
                            </property>
@@ -2791,7 +2791,7 @@
                           </widget>
                          </item>
                          <item row="7" column="1">
-                          <widget class="QSpinBox" name="advOutFFVGOPSize">
+                          <widget class="SpinBoxIgnoreScroll" name="advOutFFVGOPSize">
                            <property name="maximum">
                             <number>1000000000</number>
                            </property>
@@ -2817,7 +2817,7 @@
                           </widget>
                          </item>
                          <item row="8" column="1">
-                          <widget class="QComboBox" name="advOutFFRescale">
+                          <widget class="ComboBoxIgnoreScroll" name="advOutFFRescale">
                            <property name="enabled">
                             <bool>false</bool>
                            </property>
@@ -2834,7 +2834,7 @@
                           </widget>
                          </item>
                          <item row="10" column="1">
-                          <widget class="QComboBox" name="advOutFFVEncoder"/>
+                          <widget class="ComboBoxIgnoreScroll" name="advOutFFVEncoder"/>
                          </item>
                          <item row="10" column="0">
                           <widget class="QLabel" name="label_37">
@@ -2860,7 +2860,7 @@
                           </widget>
                          </item>
                          <item row="12" column="1">
-                          <widget class="QSpinBox" name="advOutFFABitrate">
+                          <widget class="SpinBoxIgnoreScroll" name="advOutFFABitrate">
                            <property name="minimum">
                             <number>32</number>
                            </property>
@@ -2972,7 +2972,7 @@
                           </widget>
                          </item>
                          <item row="14" column="1">
-                          <widget class="QComboBox" name="advOutFFAEncoder"/>
+                          <widget class="ComboBoxIgnoreScroll" name="advOutFFAEncoder"/>
                          </item>
                          <item row="15" column="0">
                           <widget class="QLabel" name="label_46">
@@ -3051,7 +3051,7 @@
                             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                            </property>
                            <item row="0" column="1">
-                            <widget class="QComboBox" name="advOutTrack1Bitrate">
+                            <widget class="ComboBoxIgnoreScroll" name="advOutTrack1Bitrate">
                              <property name="currentIndex">
                               <number>8</number>
                              </property>
@@ -3185,7 +3185,7 @@
                             </widget>
                            </item>
                            <item row="0" column="1">
-                            <widget class="QComboBox" name="advOutTrack2Bitrate">
+                            <widget class="ComboBoxIgnoreScroll" name="advOutTrack2Bitrate">
                              <property name="currentIndex">
                               <number>8</number>
                              </property>
@@ -3300,7 +3300,7 @@
                             </widget>
                            </item>
                            <item row="0" column="1">
-                            <widget class="QComboBox" name="advOutTrack3Bitrate">
+                            <widget class="ComboBoxIgnoreScroll" name="advOutTrack3Bitrate">
                              <property name="currentIndex">
                               <number>8</number>
                              </property>
@@ -3415,7 +3415,7 @@
                             </widget>
                            </item>
                            <item row="0" column="1">
-                            <widget class="QComboBox" name="advOutTrack4Bitrate">
+                            <widget class="ComboBoxIgnoreScroll" name="advOutTrack4Bitrate">
                              <property name="currentIndex">
                               <number>8</number>
                              </property>
@@ -3530,7 +3530,7 @@
                             </widget>
                            </item>
                            <item row="0" column="1">
-                            <widget class="QComboBox" name="advOutTrack5Bitrate">
+                            <widget class="ComboBoxIgnoreScroll" name="advOutTrack5Bitrate">
                              <property name="currentIndex">
                               <number>8</number>
                              </property>
@@ -3645,7 +3645,7 @@
                             </widget>
                            </item>
                            <item row="0" column="1">
-                            <widget class="QComboBox" name="advOutTrack6Bitrate">
+                            <widget class="ComboBoxIgnoreScroll" name="advOutTrack6Bitrate">
                              <property name="currentIndex">
                               <number>8</number>
                              </property>
@@ -3765,7 +3765,7 @@
                          </widget>
                         </item>
                         <item row="0" column="1">
-                         <widget class="QSpinBox" name="advRBSecMax">
+                         <widget class="SpinBoxIgnoreScroll" name="advRBSecMax">
                           <property name="suffix">
                            <string notr="true"> s</string>
                           </property>
@@ -3788,7 +3788,7 @@
                          </widget>
                         </item>
                         <item row="1" column="1">
-                         <widget class="QSpinBox" name="advRBMegsMax">
+                         <widget class="SpinBoxIgnoreScroll" name="advRBMegsMax">
                           <property name="suffix">
                            <string> MB</string>
                           </property>
@@ -3925,7 +3925,7 @@
                     </widget>
                    </item>
                    <item row="0" column="1">
-                    <widget class="QComboBox" name="sampleRate">
+                    <widget class="ComboBoxIgnoreScroll" name="sampleRate">
                      <property name="currentText">
                       <string notr="true">44.1 kHz</string>
                      </property>
@@ -3955,7 +3955,7 @@
                     </widget>
                    </item>
                    <item row="1" column="1">
-                    <widget class="QComboBox" name="channelSetup">
+                    <widget class="ComboBoxIgnoreScroll" name="channelSetup">
                      <property name="currentText">
                       <string>Mono</string>
                      </property>
@@ -4037,7 +4037,7 @@
                     </widget>
                    </item>
                    <item row="0" column="1">
-                    <widget class="QComboBox" name="desktopAudioDevice1">
+                    <widget class="ComboBoxIgnoreScroll" name="desktopAudioDevice1">
                      <property name="enabled">
                       <bool>true</bool>
                      </property>
@@ -4057,7 +4057,7 @@
                     </widget>
                    </item>
                    <item row="1" column="1">
-                    <widget class="QComboBox" name="desktopAudioDevice2">
+                    <widget class="ComboBoxIgnoreScroll" name="desktopAudioDevice2">
                      <property name="enabled">
                       <bool>true</bool>
                      </property>
@@ -4074,7 +4074,7 @@
                     </widget>
                    </item>
                    <item row="2" column="1">
-                    <widget class="QComboBox" name="auxAudioDevice1">
+                    <widget class="ComboBoxIgnoreScroll" name="auxAudioDevice1">
                      <property name="enabled">
                       <bool>true</bool>
                      </property>
@@ -4091,7 +4091,7 @@
                     </widget>
                    </item>
                    <item row="3" column="1">
-                    <widget class="QComboBox" name="auxAudioDevice2">
+                    <widget class="ComboBoxIgnoreScroll" name="auxAudioDevice2">
                      <property name="enabled">
                       <bool>true</bool>
                      </property>
@@ -4108,14 +4108,14 @@
                     </widget>
                    </item>
                    <item row="4" column="1">
-                    <widget class="QComboBox" name="auxAudioDevice3">
+                    <widget class="ComboBoxIgnoreScroll" name="auxAudioDevice3">
                      <property name="enabled">
                       <bool>true</bool>
                      </property>
                     </widget>
                    </item>
                    <item row="5" column="1">
-                    <widget class="QComboBox" name="auxAudioDevice4">
+                    <widget class="ComboBoxIgnoreScroll" name="auxAudioDevice4">
                      <property name="enabled">
                       <bool>true</bool>
                      </property>
@@ -4169,7 +4169,7 @@
                     </widget>
                    </item>
                    <item row="0" column="1">
-                    <widget class="QComboBox" name="meterDecayRate">
+                    <widget class="ComboBoxIgnoreScroll" name="meterDecayRate">
                      <property name="currentText">
                       <string>Basic.Settings.Audio.MeterDecayRate.Fast</string>
                      </property>
@@ -4204,7 +4204,7 @@
                     </widget>
                    </item>
                    <item row="1" column="1">
-                    <widget class="QComboBox" name="peakMeterType">
+                    <widget class="ComboBoxIgnoreScroll" name="peakMeterType">
                      <property name="currentIndex">
                       <number>0</number>
                      </property>
@@ -4249,7 +4249,7 @@
                     </widget>
                    </item>
                    <item row="0" column="1">
-                    <widget class="QComboBox" name="monitoringDevice"/>
+                    <widget class="ComboBoxIgnoreScroll" name="monitoringDevice"/>
                    </item>
                    <item row="1" column="0">
                     <spacer name="horizontalSpacer_11">
@@ -4373,7 +4373,7 @@
             <number>6</number>
            </property>
            <item>
-            <widget class="QComboBox" name="baseResolution">
+            <widget class="ComboBoxIgnoreScroll" name="baseResolution">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -4424,14 +4424,14 @@
           </widget>
          </item>
          <item row="5" column="1">
-          <widget class="QComboBox" name="downscaleFilter">
+          <widget class="ComboBoxIgnoreScroll" name="downscaleFilter">
            <property name="enabled">
             <bool>true</bool>
            </property>
           </widget>
          </item>
          <item row="6" column="0">
-          <widget class="QComboBox" name="fpsType">
+          <widget class="ComboBoxIgnoreScroll" name="fpsType">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -4481,7 +4481,7 @@
               <number>0</number>
              </property>
              <item alignment="Qt::AlignTop">
-              <widget class="QComboBox" name="fpsCommon">
+              <widget class="ComboBoxIgnoreScroll" name="fpsCommon">
                <property name="currentText">
                 <string notr="true">10</string>
                </property>
@@ -4557,7 +4557,7 @@
               <number>0</number>
              </property>
              <item alignment="Qt::AlignTop">
-              <widget class="QSpinBox" name="fpsInteger">
+              <widget class="SpinBoxIgnoreScroll" name="fpsInteger">
                <property name="minimum">
                 <number>1</number>
                </property>
@@ -4592,7 +4592,7 @@
               <number>0</number>
              </property>
              <item row="0" column="1">
-              <widget class="QSpinBox" name="fpsNumerator">
+              <widget class="SpinBoxIgnoreScroll" name="fpsNumerator">
                <property name="minimum">
                 <number>1</number>
                </property>
@@ -4605,7 +4605,7 @@
               </widget>
              </item>
              <item row="1" column="1">
-              <widget class="QSpinBox" name="fpsDenominator">
+              <widget class="SpinBoxIgnoreScroll" name="fpsDenominator">
                <property name="minimum">
                 <number>1</number>
                </property>
@@ -4657,7 +4657,7 @@
             <number>6</number>
            </property>
            <item>
-            <widget class="QComboBox" name="outputResolution">
+            <widget class="ComboBoxIgnoreScroll" name="outputResolution">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -4785,7 +4785,7 @@
                     </widget>
                    </item>
                    <item row="0" column="1">
-                    <widget class="QComboBox" name="processPriority"/>
+                    <widget class="ComboBoxIgnoreScroll" name="processPriority"/>
                    </item>
                    <item row="1" column="0">
                     <spacer name="horizontalSpacer_13">
@@ -4829,7 +4829,7 @@
                     </widget>
                    </item>
                    <item row="0" column="1">
-                    <widget class="QComboBox" name="renderer">
+                    <widget class="ComboBoxIgnoreScroll" name="renderer">
                      <property name="currentText">
                       <string notr="true"/>
                      </property>
@@ -4849,7 +4849,7 @@
                     </widget>
                    </item>
                    <item row="1" column="1">
-                    <widget class="QComboBox" name="adapter">
+                    <widget class="ComboBoxIgnoreScroll" name="adapter">
                      <property name="enabled">
                       <bool>false</bool>
                      </property>
@@ -4878,7 +4878,7 @@
                     </widget>
                    </item>
                    <item row="2" column="1">
-                    <widget class="QComboBox" name="colorFormat">
+                    <widget class="ComboBoxIgnoreScroll" name="colorFormat">
                      <item>
                       <property name="text">
                        <string notr="true">NV12</string>
@@ -4946,7 +4946,7 @@
                       <number>0</number>
                      </property>
                      <item>
-                      <widget class="QComboBox" name="colorSpace">
+                      <widget class="ComboBoxIgnoreScroll" name="colorSpace">
                        <item>
                         <property name="text">
                          <string notr="true">sRGB</string>
@@ -4981,7 +4981,7 @@
                       </widget>
                      </item>
                      <item>
-                      <widget class="QComboBox" name="colorRange"/>
+                      <widget class="ComboBoxIgnoreScroll" name="colorRange"/>
                      </item>
                     </layout>
                    </item>
@@ -5171,7 +5171,7 @@
                        <number>0</number>
                       </property>
                       <item>
-                       <widget class="QSpinBox" name="streamDelaySec">
+                       <widget class="SpinBoxIgnoreScroll" name="streamDelaySec">
                         <property name="enabled">
                          <bool>true</bool>
                         </property>
@@ -5281,7 +5281,7 @@
                       <number>0</number>
                      </property>
                      <item>
-                      <widget class="QSpinBox" name="reconnectRetryDelay">
+                      <widget class="SpinBoxIgnoreScroll" name="reconnectRetryDelay">
                        <property name="suffix">
                         <string> s</string>
                        </property>
@@ -5310,7 +5310,7 @@
                       </widget>
                      </item>
                      <item>
-                      <widget class="QSpinBox" name="reconnectMaxRetries">
+                      <widget class="SpinBoxIgnoreScroll" name="reconnectMaxRetries">
                        <property name="minimum">
                         <number>1</number>
                        </property>
@@ -5373,7 +5373,7 @@
                     </widget>
                    </item>
                    <item row="0" column="1">
-                    <widget class="QComboBox" name="bindToIP"/>
+                    <widget class="ComboBoxIgnoreScroll" name="bindToIP"/>
                    </item>
                    <item row="2" column="1">
                     <widget class="QCheckBox" name="enableNewSocketLoop">
@@ -5470,7 +5470,7 @@
                     </widget>
                    </item>
                    <item row="0" column="1">
-                    <widget class="QComboBox" name="hotkeyFocusType"/>
+                    <widget class="ComboBoxIgnoreScroll" name="hotkeyFocusType"/>
                    </item>
                    <item row="1" column="0">
                     <spacer name="horizontalSpacer_14">
@@ -5557,6 +5557,21 @@
    <class>UrlPushButton</class>
    <extends>QPushButton</extends>
    <header>url-push-button.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>ComboBoxIgnoreScroll</class>
+   <extends>QComboBox</extends>
+   <header>combobox-ignorewheel.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>SpinBoxIgnoreScroll</class>
+   <extends>QSpinBox</extends>
+   <header>spinbox-ignorewheel.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>DoubleSpinBoxIgnoreScroll</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>spinbox-ignorewheel.hpp</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/UI/forms/OBSBasicTransform.ui
+++ b/UI/forms/OBSBasicTransform.ui
@@ -69,7 +69,7 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QDoubleSpinBox" name="positionX">
+         <widget class="DoubleSpinBoxIgnoreScroll" name="positionX">
           <property name="minimumSize">
            <size>
             <width>100</width>
@@ -91,7 +91,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QDoubleSpinBox" name="positionY">
+         <widget class="DoubleSpinBoxIgnoreScroll" name="positionY">
           <property name="minimumSize">
            <size>
             <width>100</width>
@@ -126,7 +126,7 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QDoubleSpinBox" name="rotation">
+      <widget class="DoubleSpinBoxIgnoreScroll" name="rotation">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -185,7 +185,7 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QDoubleSpinBox" name="sizeX">
+         <widget class="DoubleSpinBoxIgnoreScroll" name="sizeX">
           <property name="minimumSize">
            <size>
             <width>100</width>
@@ -210,7 +210,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QDoubleSpinBox" name="sizeY">
+         <widget class="DoubleSpinBoxIgnoreScroll" name="sizeY">
           <property name="minimumSize">
            <size>
             <width>100</width>
@@ -248,7 +248,7 @@
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="QComboBox" name="align">
+      <widget class="ComboBoxIgnoreScroll" name="align">
        <property name="accessibleName">
         <string>Basic.TransformWindow.Alignment</string>
        </property>
@@ -326,7 +326,7 @@
       </widget>
      </item>
      <item row="5" column="1">
-      <widget class="QComboBox" name="boundsType">
+      <widget class="ComboBoxIgnoreScroll" name="boundsType">
        <property name="accessibleName">
         <string>Basic.TransformWindow.BoundsType</string>
        </property>
@@ -378,7 +378,7 @@
       </widget>
      </item>
      <item row="6" column="1">
-      <widget class="QComboBox" name="boundsAlign">
+      <widget class="ComboBoxIgnoreScroll" name="boundsAlign">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -467,7 +467,7 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QDoubleSpinBox" name="boundsWidth">
+         <widget class="DoubleSpinBoxIgnoreScroll" name="boundsWidth">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -492,7 +492,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QDoubleSpinBox" name="boundsHeight">
+         <widget class="DoubleSpinBoxIgnoreScroll" name="boundsHeight">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -545,7 +545,7 @@
      <item row="9" column="1">
       <layout class="QGridLayout" name="gridLayout">
        <item row="0" column="1">
-        <widget class="QSpinBox" name="cropLeft">
+        <widget class="SpinBoxIgnoreScroll" name="cropLeft">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -567,7 +567,7 @@
         </widget>
        </item>
        <item row="0" column="3">
-        <widget class="QSpinBox" name="cropRight">
+        <widget class="SpinBoxIgnoreScroll" name="cropRight">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -615,7 +615,7 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QSpinBox" name="cropTop">
+        <widget class="SpinBoxIgnoreScroll" name="cropTop">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -637,7 +637,7 @@
         </widget>
        </item>
        <item row="1" column="3">
-        <widget class="QSpinBox" name="cropBottom">
+        <widget class="SpinBoxIgnoreScroll" name="cropBottom">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -723,6 +723,23 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ComboBoxIgnoreScroll</class>
+   <extends>QComboBox</extends>
+   <header>combobox-ignorewheel.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>SpinBoxIgnoreScroll</class>
+   <extends>QSpinBox</extends>
+   <header>spinbox-ignorewheel.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>DoubleSpinBoxIgnoreScroll</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>spinbox-ignorewheel.hpp</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/UI/forms/source-toolbar/device-select-toolbar.ui
+++ b/UI/forms/source-toolbar/device-select-toolbar.ui
@@ -64,7 +64,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QComboBox" name="device">
+    <widget class="ComboBoxIgnoreScroll" name="device">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -128,6 +128,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ComboBoxIgnoreScroll</class>
+   <extends>QComboBox</extends>
+   <header>combobox-ignorewheel.hpp</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/UI/forms/source-toolbar/game-capture-toolbar.ui
+++ b/UI/forms/source-toolbar/game-capture-toolbar.ui
@@ -61,7 +61,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QComboBox" name="mode">
+    <widget class="ComboBoxIgnoreScroll" name="mode">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -108,7 +108,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QComboBox" name="window">
+    <widget class="ComboBoxIgnoreScroll" name="window">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -150,6 +150,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ComboBoxIgnoreScroll</class>
+   <extends>QComboBox</extends>
+   <header>combobox-ignorewheel.hpp</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/UI/frontend-plugins/frontend-tools/forms/auto-scene-switcher.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/auto-scene-switcher.ui
@@ -17,7 +17,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QComboBox" name="windows">
+      <widget class="ComboBoxIgnoreScroll" name="windows">
        <property name="editable">
         <bool>true</bool>
        </property>
@@ -27,7 +27,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="scenes">
+      <widget class="ComboBoxIgnoreScroll" name="scenes">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -179,7 +179,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="noMatchSwitchScene">
+          <widget class="ComboBoxIgnoreScroll" name="noMatchSwitchScene">
            <property name="enabled">
             <bool>false</bool>
            </property>
@@ -206,7 +206,7 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QSpinBox" name="checkInterval">
+      <widget class="SpinBoxIgnoreScroll" name="checkInterval">
        <property name="minimumSize">
         <size>
          <width>100</width>
@@ -288,6 +288,18 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ComboBoxIgnoreScroll</class>
+   <extends>QComboBox</extends>
+   <header>../combobox-ignorewheel.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>SpinBoxIgnoreScroll</class>
+   <extends>QSpinBox</extends>
+   <header>../spinbox-ignorewheel.hpp</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/UI/frontend-plugins/frontend-tools/forms/output-timer.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/output-timer.ui
@@ -22,7 +22,7 @@
     </widget>
    </item>
    <item row="3" column="2">
-    <widget class="QSpinBox" name="recordingTimerHours">
+    <widget class="SpinBoxIgnoreScroll" name="recordingTimerHours">
      <property name="minimum">
       <number>0</number>
      </property>
@@ -35,7 +35,7 @@
     </widget>
    </item>
    <item row="0" column="6">
-    <widget class="QSpinBox" name="streamingTimerSeconds">
+    <widget class="SpinBoxIgnoreScroll" name="streamingTimerSeconds">
      <property name="minimum">
       <number>0</number>
      </property>
@@ -58,7 +58,7 @@
     </widget>
    </item>
    <item row="3" column="4">
-    <widget class="QSpinBox" name="recordingTimerMinutes">
+    <widget class="SpinBoxIgnoreScroll" name="recordingTimerMinutes">
      <property name="minimum">
       <number>0</number>
      </property>
@@ -78,7 +78,7 @@
     </widget>
    </item>
    <item row="0" column="4">
-    <widget class="QSpinBox" name="streamingTimerMinutes">
+    <widget class="SpinBoxIgnoreScroll" name="streamingTimerMinutes">
      <property name="maximum">
       <number>59</number>
      </property>
@@ -126,7 +126,7 @@
     </widget>
    </item>
    <item row="0" column="2">
-    <widget class="QSpinBox" name="streamingTimerHours">
+    <widget class="SpinBoxIgnoreScroll" name="streamingTimerHours">
      <property name="minimum">
       <number>0</number>
      </property>
@@ -160,7 +160,7 @@
     </widget>
    </item>
    <item row="3" column="6">
-    <widget class="QSpinBox" name="recordingTimerSeconds">
+    <widget class="SpinBoxIgnoreScroll" name="recordingTimerSeconds">
      <property name="minimum">
       <number>0</number>
      </property>
@@ -245,6 +245,13 @@
   <tabstop>autoStartRecordTimer</tabstop>
   <tabstop>pauseRecordTimer</tabstop>
  </tabstops>
+ <customwidgets>
+  <customwidget>
+   <class>SpinBoxIgnoreScroll</class>
+   <extends>QSpinBox</extends>
+   <header>../spinbox-ignorewheel.hpp</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -385,7 +385,7 @@ void OBSPropertiesView::AddFloat(obs_property_t *prop, QFormLayout *layout,
 
 	const char *name = obs_property_name(prop);
 	double val = obs_data_get_double(settings, name);
-	QDoubleSpinBox *spin = new QDoubleSpinBox();
+	QDoubleSpinBox *spin = new DoubleSpinBoxIgnoreScroll();
 
 	if (!obs_property_enabled(prop))
 		spin->setEnabled(false);

--- a/UI/spinbox-ignorewheel.cpp
+++ b/UI/spinbox-ignorewheel.cpp
@@ -12,3 +12,17 @@ void SpinBoxIgnoreScroll::wheelEvent(QWheelEvent *event)
 	else
 		QSpinBox::wheelEvent(event);
 }
+
+DoubleSpinBoxIgnoreScroll::DoubleSpinBoxIgnoreScroll(QWidget *parent)
+	: QDoubleSpinBox(parent)
+{
+	setFocusPolicy(Qt::StrongFocus);
+}
+
+void DoubleSpinBoxIgnoreScroll::wheelEvent(QWheelEvent *event)
+{
+	if (!hasFocus())
+		event->ignore();
+	else
+		QDoubleSpinBox::wheelEvent(event);
+}

--- a/UI/spinbox-ignorewheel.hpp
+++ b/UI/spinbox-ignorewheel.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QSpinBox>
+#include <QDoubleSpinBox>
 #include <QInputEvent>
 #include <QtCore/QObject>
 
@@ -9,6 +10,15 @@ class SpinBoxIgnoreScroll : public QSpinBox {
 
 public:
 	SpinBoxIgnoreScroll(QWidget *parent = nullptr);
+
+protected:
+	virtual void wheelEvent(QWheelEvent *event) override;
+};
+
+class DoubleSpinBoxIgnoreScroll : public QDoubleSpinBox {
+
+public:
+	DoubleSpinBoxIgnoreScroll(QWidget *parent = nullptr);
 
 protected:
 	virtual void wheelEvent(QWheelEvent *event) override;

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -25,6 +25,7 @@
 #include "window-namedialog.hpp"
 #include "menu-button.hpp"
 #include "slider-ignorewheel.hpp"
+#include "spinbox-ignorewheel.hpp"
 #include "qt-wrappers.hpp"
 
 #include "obs-hotkey.h"
@@ -1037,7 +1038,7 @@ QMenu *OBSBasic::CreatePerSceneTransitionMenu()
 	const char *curTransition = obs_data_get_string(data, "transition");
 	int curDuration = (int)obs_data_get_int(data, "transition_duration");
 
-	QSpinBox *duration = new QSpinBox(menu);
+	QSpinBox *duration = new SpinBoxIgnoreScroll(menu);
 	duration->setMinimum(50);
 	duration->setSuffix("ms");
 	duration->setMaximum(20000);
@@ -1143,7 +1144,7 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 	if (curDuration <= 0)
 		curDuration = obs_frontend_get_transition_duration();
 
-	QSpinBox *duration = new QSpinBox(menu);
+	QSpinBox *duration = new SpinBoxIgnoreScroll(menu);
 	duration->setMinimum(50);
 	duration->setSuffix("ms");
 	duration->setMaximum(20000);
@@ -1319,7 +1320,7 @@ QMenu *OBSBasic::CreateTransitionMenu(QWidget *parent, QuickTransition *qt)
 		menu->addSeparator();
 	}
 
-	QSpinBox *duration = new QSpinBox(menu);
+	QSpinBox *duration = new SpinBoxIgnoreScroll(menu);
 	if (qt)
 		duration->setProperty("id", qt->id);
 	duration->setMinimum(50);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4975,7 +4975,7 @@ void OBSBasicSettings::RecreateOutputResolutionWidget()
 	bool changed = WidgetChanged(ui->outputResolution);
 
 	delete ui->outputResolution;
-	ui->outputResolution = new QComboBox(ui->videoPage);
+	ui->outputResolution = new ComboBoxIgnoreScroll(ui->videoPage);
 	ui->outputResolution->setObjectName(
 		QString::fromUtf8("outputResolution"));
 	ui->outputResolution->setSizePolicy(sizePolicy);

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -29,6 +29,7 @@
 #include <obs.hpp>
 
 #include "auth-base.hpp"
+#include "spinbox-ignorewheel.hpp"
 
 class OBSBasic;
 class QAbstractButton;
@@ -57,7 +58,7 @@ public slots:
 	}
 };
 
-class SilentUpdateSpinBox : public QSpinBox {
+class SilentUpdateSpinBox : public SpinBoxIgnoreScroll {
 	Q_OBJECT
 
 public slots:


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
In OBS, dropdown lists as well as number input fields (SpinBoxes) have the behaviour that if the mouse is hovering over them, scrolling with the mouse wheel will change the current selection.

This PR removes that behaviour when the box isn't focused by using a custom subclass that was introduced for exactly that in #1811 - only that that PR changed it for just the source properties view and nothing else.
The new behaviour is what Fenrir requested in https://github.com/obsproject/obs-studio/discussions/4980#discussioncomment-966815 - it doesn't work when unfocused, clicking on it will enable hoverscroll as before.

This PR expands that to all instances of `QComboBox` and `QSpinBox` in OBS (except decklink-captions, where I couldn't get the header to point to the correct file, and when I did, the post-compilation dylib linker failed).

Third-party plugins are not affected. If we wanted to get a truly universal behaviour on this which includes those, I suspect patching QT would be the only option, which I honestly think is overkill, though should be possible - but it wouldn't apply to Linux, right?

Commits have been made separately for each area of OBS, so that in case it does break something in the future (which I don't expect), they could be reverted individually.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This "hoverscroll" is unintuive and potentially dangerous behaviour. See discussion #4980


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled with CI and tested on Windows 11 and macOS 12
As expected, hoverscroll now only works when first clicking on the dropdown menu / spin box. (info for testers: Mac versions of OBS (and perhaps QT) didn't have hoverscroll over QComboBoxes in the first place, there only QSpinBoxes are affected.)

No testing on Linux.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Somewhere between `Bug Fix` and `Enhancement`, depends on the point of view
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.