### PR TITLE
RFC 45-1: Add protocol in Outputs API and check service protocol in the "UI"

### DIFF
--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -234,7 +234,15 @@ Output Definition Structure (obs_output_info)
    This variable specifies which codecs are supported by an encoded
    output, separated by semicolon.
 
-   (Optional, though recommended)
+   Required if **OBS_OUTPUT_SERVICE** flag is set, otherwise
+   recommended.
+
+.. member:: const char *obs_output_info.protocols
+
+   This variable specifies which protocols are supported by an output,
+   separated by semicolon.
+
+   Required only if **OBS_OUTPUT_SERVICE** flag is set.
 
 .. _output_signal_handler_reference:
 
@@ -682,6 +690,22 @@ General Output Functions
               uint32_t obs_get_output_flags(const char *id)
 
    :return: The output capability flags
+
+---------------------
+
+.. function:: const char *obs_output_get_protocols(const obs_output_t *output)
+
+   :return: Supported protocols, separated by semicolon. Always NULL if the
+            output is not **OBS_OUTPUT_SERVICE**.
+
+---------------------
+
+.. function:: bool obs_is_output_protocol_registered(const char *protocol)
+
+   Check if one of the registered output use the given protocol.
+
+   :return:                 A boolean showing if an output with the given
+                            protocol is registered
 
 ---------------------
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -411,6 +411,8 @@ struct obs_core_data {
 	obs_data_t *private_data;
 
 	volatile bool valid;
+
+	DARRAY(char *) protocols;
 };
 
 /* user hotkeys */

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -836,6 +836,9 @@ void obs_register_output_s(const struct obs_output_info *info, size_t size)
 	CHECK_REQUIRED_VAL_(info, start, obs_register_output);
 	CHECK_REQUIRED_VAL_(info, stop, obs_register_output);
 
+	if (info->flags & OBS_OUTPUT_SERVICE)
+		CHECK_REQUIRED_VAL_(info, protocols, obs_register_output);
+
 	if (info->flags & OBS_OUTPUT_ENCODED) {
 		CHECK_REQUIRED_VAL_(info, encoded_packet, obs_register_output);
 	} else {
@@ -856,6 +859,24 @@ void obs_register_output_s(const struct obs_output_info *info, size_t size)
 #undef CHECK_REQUIRED_VAL_
 
 	REGISTER_OBS_DEF(size, obs_output_info, obs->output_types, info);
+
+	if (info->flags & OBS_OUTPUT_SERVICE) {
+		char **protocols = strlist_split(info->protocols, ';', false);
+		for (char **protocol = protocols; *protocol; ++protocol) {
+			bool skip = false;
+			for (size_t i = 0; i < obs->data.protocols.num; i++) {
+				if (strcmp(*protocol,
+					   obs->data.protocols.array[i]) == 0)
+					skip = true;
+			}
+
+			if (skip)
+				continue;
+			char *new_prtcl = bstrdup(*protocol);
+			da_push_back(obs->data.protocols, &new_prtcl);
+		}
+		strlist_free(protocols);
+	}
 	return;
 
 error:

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2713,3 +2713,13 @@ const char *obs_output_get_supported_audio_codecs(const obs_output_t *output)
 		       ? output->info.encoded_audio_codecs
 		       : NULL;
 }
+
+const char *obs_output_get_protocols(const obs_output_t *output)
+{
+	if (!obs_output_valid(output, "obs_output_get_protocols"))
+		return NULL;
+
+	return (output->info.flags & OBS_OUTPUT_SERVICE)
+		       ? output->info.protocols
+		       : NULL;
+}

--- a/libobs/obs-output.h
+++ b/libobs/obs-output.h
@@ -77,6 +77,9 @@ struct obs_output_info {
 
 	/* raw audio callback for multi track outputs */
 	void (*raw_audio2)(void *data, size_t idx, struct audio_data *frames);
+
+	/* required if OBS_OUTPUT_SERVICE */
+	const char *protocols;
 };
 
 EXPORT void obs_register_output_s(const struct obs_output_info *info,

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1078,6 +1078,10 @@ static void obs_free_data(void)
 	da_free(data->draw_callbacks);
 	da_free(data->tick_callbacks);
 	obs_data_release(data->private_data);
+
+	for (size_t i = 0; i < data->protocols.num; i++)
+		bfree(data->protocols.array[i]);
+	da_free(data->protocols);
 }
 
 static const char *obs_signals[] = {
@@ -3451,4 +3455,14 @@ bool obs_weak_object_references_object(obs_weak_object_t *weak,
 				       obs_object_t *object)
 {
 	return weak && object && weak->object == object;
+}
+
+bool obs_is_output_protocol_registered(const char *protocol)
+{
+	for (size_t i = 0; i < obs->data.protocols.num; i++) {
+		if (strcmp(protocol, obs->data.protocols.array[i]) == 0)
+			return true;
+	}
+
+	return false;
 }

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2211,6 +2211,10 @@ obs_output_get_supported_video_codecs(const obs_output_t *output);
 EXPORT const char *
 obs_output_get_supported_audio_codecs(const obs_output_t *output);
 
+EXPORT const char *obs_output_get_protocols(const obs_output_t *output);
+
+EXPORT bool obs_is_output_protocol_registered(const char *protocol);
+
 /* ------------------------------------------------------------------------- */
 /* Functions used by outputs */
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
@@ -331,6 +331,7 @@ struct obs_output_info ffmpeg_hls_muxer = {
 	.id = "ffmpeg_hls_muxer",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_MULTI_TRACK |
 		 OBS_OUTPUT_SERVICE,
+	.protocols = "HLS",
 #ifdef ENABLE_HEVC
 	.encoded_video_codecs = "h264;hevc",
 #else

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -1289,6 +1289,7 @@ struct obs_output_info ffmpeg_mpegts_muxer = {
 	.id = "ffmpeg_mpegts_muxer",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_MULTI_TRACK |
 		 OBS_OUTPUT_SERVICE,
+	.protocols = "SRT;RIST",
 #ifdef ENABLE_HEVC
 	.encoded_video_codecs = "h264;hevc;av1",
 #else

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -944,6 +944,7 @@ struct obs_output_info ffmpeg_mpegts_muxer = {
 	.id = "ffmpeg_mpegts_muxer",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_MULTI_TRACK |
 		 OBS_OUTPUT_SERVICE,
+	.protocols = "SRT;RIST",
 	.encoded_video_codecs = "h264;av1",
 	.encoded_audio_codecs = "aac",
 	.get_name = ffmpeg_mpegts_mux_getname,

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -1159,6 +1159,7 @@ static int _ftl_error_to_obs_error(int status)
 struct obs_output_info ftl_output_info = {
 	.id = "ftl_output",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_SERVICE,
+	.protocols = "FTL",
 	.encoded_video_codecs = "h264",
 	.encoded_audio_codecs = "opus",
 	.get_name = ftl_stream_getname,

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -1642,6 +1642,11 @@ struct obs_output_info rtmp_output_info = {
 	.id = "rtmp_output",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_SERVICE |
 		 OBS_OUTPUT_MULTI_TRACK,
+#ifdef NO_CRYPTO
+	.protocols = "RTMP",
+#else
+	.protocols = "RTMP;RTMPS",
+#endif
 	.encoded_video_codecs = "h264",
 	.encoded_audio_codecs = "aac",
 	.get_name = rtmp_stream_getname,

--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v4",
-    "version": 220,
+    "version": 221,
     "files": [
         {
             "name": "services.json",
-            "version": 220
+            "version": 221
         }
     ]
 }

--- a/plugins/rtmp-services/data/schema/service-schema-v4.json
+++ b/plugins/rtmp-services/data/schema/service-schema-v4.json
@@ -16,6 +16,18 @@
                         "description": "Name of the streaming service. Will be displayed in the Service dropdown.",
                         "minLength": 1
                     },
+                    "protocol" : {
+                        "type": "string",
+                        "description": "Protocol used by the service. If missing the service is considered using RTMP or RTMPS.",
+                        "enum": [
+                            "RTMP",
+                            "RTMPS",
+                            "HLS",
+                            "FTL",
+                            "SRT",
+                            "RIST"
+                        ]
+                    },
                     "common": {
                         "type": "boolean",
                         "description": "Whether or not the service is shown in the list before it is expanded to all services by the user.",
@@ -200,6 +212,18 @@
                 "required": [
                     "name",
                     "servers"
+		],
+                "allOf": [
+                    {
+                        "$comment": "Require protocol field if not an RTMP(S) URL",
+                        "if": { "not": { "properties": { "servers": { "items": { "properties": { "url": { "format": "uri", "pattern": "^rtmps?://" } } } } } } },
+                        "then": { "required": ["protocol"] }
+                    },
+                    {
+                        "$comment": "Require recommended output field if protocol field is not RTMP(S)",
+                        "if": { "required": ["protocol"], "properties": { "protocol": { "pattern": "^(HLS|SRT|RIST|FTL)$" } } },
+                        "then": { "properties": { "recommended": { "required": ["output"] } } }
+                    }
                 ]
             },
             "additionalItems": true

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -204,6 +204,7 @@
             "common": false,
             "more_info_link": "https://developers.google.com/youtube/v3/live/guides/ingestion-protocol-comparison",
             "stream_key_link": "https://www.youtube.com/live_dashboard",
+            "protocol": "HLS",
             "supported video codecs": [
                 "h264",
                 "hevc"
@@ -1445,6 +1446,7 @@
         {
             "name": "YouNow",
             "common": false,
+            "protocol": "FTL",
             "supported audio codecs": [
                 "opus"
             ],
@@ -1687,6 +1689,7 @@
         },
         {
             "name": "SHOWROOM",
+            "protocol": "RTMP",
             "servers": [
                 {
                     "name": "Default",
@@ -1821,6 +1824,7 @@
         {
             "name": "Glimesh",
             "stream_key_link": "https://glimesh.tv/users/settings/stream",
+            "protocol": "FTL",
             "supported audio codecs": [
                 "opus"
             ],
@@ -2024,6 +2028,7 @@
         },
         {
             "name": "Dacast",
+            "protocol": "RTMP",
             "servers": [
                 {
                     "name": "Default",


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
**This PR is about the [RFC 45](https://github.com/obsproject/rfcs/pull/45).**

- Add a "protocols" and "protocols_prefixes" fields in `obs_output_info` and add protocols to outputs meant for serv
- Make the UI skip services where the protocol is not registered and also skip RTMPS servers for service providing RTMP and RTMPS server when the later is not registered.

<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Part of the implementation of the RFC 45.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
**Artifacts from Github actions will not much help with testing this PR since it build with all protocol support.**
- Build OBS without FTL support and check if "Glimesh" service is not shown.
- Build OBS without RTMPS support and check if "YouTube - RTMPS" RTMPS servers, "Facebook Live" service and "STAGE TEN" are not shown, RTMPS servers from other services are also not shown.
- Build OBS with support for both and check those three services are shown.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
  - Showing services that are not supported is sort of a bug
- New feature (non-breaking change which adds functionality)
- Documentation (a change to documentation pages)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
