### PR TITLE
Various optimizations for media playback

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -364,9 +364,8 @@ struct gs_vertex_buffer : gs_obj {
 
 	void FlushBuffer(ID3D11Buffer *buffer, void *array, size_t elementSize);
 
-	void MakeBufferList(gs_vertex_shader *shader,
-			    vector<ID3D11Buffer *> &buffers,
-			    vector<uint32_t> &strides);
+	UINT MakeBufferList(gs_vertex_shader *shader, ID3D11Buffer **buffers,
+			    uint32_t *strides);
 
 	void InitBuffer(const size_t elementSize, const size_t numVerts,
 			void *array, ID3D11Buffer **buffer);

--- a/libobs/graphics/effect.c
+++ b/libobs/graphics/effect.c
@@ -129,7 +129,7 @@ void gs_technique_end(gs_technique_t *tech)
 	for (i = 0; i < effect->params.num; i++) {
 		struct gs_effect_param *param = params + i;
 
-		da_free(param->cur_val);
+		da_resize(param->cur_val, 0);
 		param->changed = false;
 		if (param->next_sampler)
 			param->next_sampler = NULL;


### PR DESCRIPTION
### Description
Fix a couple issues, one is heavy lock contention on allocations, and the other issue is CPU usage from busy-waiting for accurate times when we don't care about accuracy all that much.

### Motivation and Context
OBS uses a lot of CPU when there are many media sources, and can even lock up entirely.

### How Has This Been Tested?
OBS no longer freezes because of allocation locks with many sources on my machine, and saw CPU usage drop from 1.1% to 0.8% when one video is playing for the sleep change. No new leaks for the darray usage change.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.