### PR TITLE
frontend-tools: Fix crash on shutdown

### DIFF
--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -568,9 +568,15 @@ static void obs_event(enum obs_frontend_event event, void *)
 		delete scriptsWindow;
 		delete scriptLogWindow;
 
+		scriptData = nullptr;
+		scriptsWindow = nullptr;
+		scriptLogWindow = nullptr;
+
 	} else if (event == OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP) {
-		scriptLogWindow->hide();
-		scriptLogWindow->Clear();
+		if (scriptLogWindow) {
+			scriptLogWindow->hide();
+			scriptLogWindow->Clear();
+		}
 
 		delete scriptData;
 		scriptData = new ScriptData;


### PR DESCRIPTION
### Description
Fix crash on shutdown

### Motivation and Context
crash on shutdown introduced by #4504

### How Has This Been Tested?
On windows 64 bit

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
