### PR TITLE
obs-outputs: Fix binding to IPv6 addresses on *nix

### DIFF
--- a/plugins/obs-outputs/net-if.c
+++ b/plugins/obs-outputs/net-if.c
@@ -60,7 +60,7 @@ static void netif_convert_to_string(char *dest,
 			  temp_char, INET6_ADDRSTRLEN);
 	else if (family == AF_INET6)
 		inet_ntop(family,
-			  &(((struct sockaddr_in *)byte_address)->sin_addr),
+			  &(((struct sockaddr_in6 *)byte_address)->sin6_addr),
 			  temp_char, INET6_ADDRSTRLEN);
 #else
 	if (family == AF_INET)
@@ -116,12 +116,12 @@ bool netif_str_to_addr(struct sockaddr_storage *out, int *addr_len,
 		warn("Could not parse address, error code: %d", GetLastError());
 	return ret != SOCKET_ERROR;
 #else
-	struct sockaddr_in *sin = (struct sockaddr_in *)out;
-	if (inet_pton(out->ss_family, addr, &sin->sin_addr)) {
-		*addr_len = ipv6 ? sizeof(struct sockaddr_in6)
-				 : sizeof(struct sockaddr_in);
+	*addr_len = ipv6 ? sizeof(struct sockaddr_in6)
+			 : sizeof(struct sockaddr_in);
+	void *dst = ipv6 ? &((struct sockaddr_in6 *)out)->sin6_addr
+			 : &((struct sockaddr_in *)out)->sin_addr;
+	if (inet_pton(out->ss_family, addr, dst))
 		return true;
-	}
 
 	return false;
 #endif


### PR DESCRIPTION
### Description / Motivation and Context
Fix inet_ntop()/inet_pton() being called with an incorrect argument for
IPv6 addresses.

On Linux, the offset of the sin_addr and sin6_addr fields differ and
the confusion on the inet_ntop() call produces an erroneous IPv6 string
representation such as "0:0:2001:db8::". This is visible on the UI,
Settings -> Advanced -> Network -> Bind to IP.

The same goes for the inet_pton() call.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Tested on my Linux machine that OBS Studio can bind to the specified IPv6 address and connect to an RTMP server.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
