### PR TITLE
linux-capture: Load XSHM capture on EGL/X11

### DIFF
--- a/plugins/linux-capture/linux-capture.c
+++ b/plugins/linux-capture/linux-capture.c
@@ -40,12 +40,27 @@ extern void xcomposite_unload(void);
 
 bool obs_module_load(void)
 {
-	if (obs_get_nix_platform() == OBS_NIX_PLATFORM_X11_GLX) {
+	enum obs_nix_platform_type platform = obs_get_nix_platform();
+
+	switch (platform) {
+	case OBS_NIX_PLATFORM_X11_GLX:
 		obs_register_source(&xshm_input);
 		xcomposite_load();
+		break;
+
+	case OBS_NIX_PLATFORM_X11_EGL:
+		obs_register_source(&xshm_input);
 #ifdef ENABLE_PIPEWIRE
-	} else {
 		pipewire_capture_load();
+#endif
+		break;
+
+#ifdef ENABLE_WAYLAND
+	case OBS_NIX_PLATFORM_WAYLAND:
+#ifdef ENABLE_PIPEWIRE
+		pipewire_capture_load();
+#endif
+		break;
 #endif
 	}
 


### PR DESCRIPTION
### Description

Load the XSHM capture on EGL/X11 too, in addition to the PipeWire captures.  Rework the obs_module_load() function of linux-capture to use a switch statement, and load XSHM both on EGL/X11 and GLX/X11.

Fixes https://github.com/obsproject/obs-studio/issues/5122

### Motivation and Context

Unlike Xcomposite, the XSHM plugin does not use GLX code, and thus can be used on when EGL renderer is used. It still is X11-specific though, and shouldn't be used on Wayland.

### How Has This Been Tested?

 * On Linux, run OBS Studio on X11 with `OBS_USE_EGL=1`
 * The XSHM window capture must be enabled (but *not* the Xcomposite screen capture)
 * The PipeWire captures must be enabled

### Types of changes

 - Bug fix (non-breaking change which fixes an issue) -->

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
