### PR TITLE
UI: Create YouTube LiveStream objects as non-reusable

### DIFF
--- a/UI/youtube-api-wrappers.cpp
+++ b/UI/youtube-api-wrappers.cpp
@@ -238,7 +238,7 @@ bool YoutubeApiWrappers::InsertStream(StreamDescription &stream)
 		return false;
 	}
 	const QByteArray url = YOUTUBE_LIVE_STREAM_URL
-		"?part=snippet,cdn,status";
+		"?part=snippet,cdn,status,contentDetails";
 	const Json data = Json::object{
 		{"snippet",
 		 Json::object{
@@ -250,6 +250,7 @@ bool YoutubeApiWrappers::InsertStream(StreamDescription &stream)
 			 {"ingestionType", "rtmp"},
 			 {"resolution", "variable"},
 		 }},
+		{"contentDetails", Json::object{{"isReusable", false}}},
 	};
 	Json json_out;
 	if (!InsertCommand(url, "application/json", "", data.dump().c_str(),


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change makes `LiveStream` object created by OBS non-reusable, meaning the stream key is deleted once the broadcast ends and does not show up in the YouTube Web UI or API.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
As observed by @Gol-D-Ace during testing the current implementation would create a new stream key every time a broadcast is started, resulting in the list of stream keys on the YouTube websites containing duplicates for every time a stream was started in OBS.

Using this method the YouTube website will show "Auto-generated key" instead and the key will not be exposed through the Web UI. It will be automatically disposed of when the broadcast ends.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
1. Started stream
2. Stopped stream
3. Observed that no stream key was left visible on the YouTube API or website

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
