### PR TITLE
UI: Show source icon in context bar

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -259,6 +259,31 @@
            <number>0</number>
           </property>
           <item>
+           <widget class="QLabel" name="contextSourceIcon">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>22</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>22</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QLabel" name="contextSourceLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3123,6 +3123,19 @@ void OBSBasic::UpdateContextBar(bool force)
 			ui->emptySpace->layout()->addWidget(c);
 		}
 
+		QIcon icon;
+
+		if (strcmp(id, "scene") == 0)
+			icon = GetSceneIcon();
+		else if (strcmp(id, "group") == 0)
+			icon = GetGroupIcon();
+		else
+			icon = GetSourceIcon(id);
+
+		QPixmap pixmap = icon.pixmap(QSize(16, 16));
+		ui->contextSourceIcon->setPixmap(pixmap);
+		ui->contextSourceIcon->show();
+
 		const char *name = obs_source_get_name(source);
 		ui->contextSourceLabel->setText(name);
 
@@ -3130,6 +3143,7 @@ void OBSBasic::UpdateContextBar(bool force)
 		ui->sourcePropertiesButton->setEnabled(
 			obs_source_configurable(source));
 	} else {
+		ui->contextSourceIcon->hide();
 		ui->contextSourceLabel->setText(
 			QTStr("ContextBar.NoSelectedSource"));
 


### PR DESCRIPTION
### Description
This shows the source icon next to the source label in the
context bar.

![Screenshot from 2021-08-15 11-50-40](https://user-images.githubusercontent.com/19962531/129486319-a7f801d9-5794-48fc-9277-8c00f8a8653f.png)

### Motivation and Context
Makes it easier for users to tell what the current source is.

### How Has This Been Tested?
Switched between sources to make sure icon updated properly.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
