### PR TITLE
UI,obs-transitions: Enable missing files dialog for stinger transition

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1791,7 +1791,8 @@ obs_data_array_t *OBSBasic::SaveTransitions()
 	return transitions;
 }
 
-void OBSBasic::LoadTransitions(obs_data_array_t *transitions)
+void OBSBasic::LoadTransitions(obs_data_array_t *transitions,
+			       obs_load_source_cb cb, void *private_data)
 {
 	size_t count = obs_data_array_count(transitions);
 
@@ -1806,6 +1807,8 @@ void OBSBasic::LoadTransitions(obs_data_array_t *transitions)
 		if (!obs_obj_invalid(source)) {
 			InitTransition(source);
 			AddTransitionBeforeSeparator(QT_UTF8(name), source);
+			if (cb)
+				cb(private_data, source);
 		}
 
 		obs_data_release(settings);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1047,7 +1047,7 @@ void OBSBasic::LoadData(obs_data_t *data, const char *file)
 	obs_load_sources(sources, cb, files);
 
 	if (transitions)
-		LoadTransitions(transitions);
+		LoadTransitions(transitions, cb, files);
 	if (sceneOrder)
 		LoadSceneListOrder(sceneOrder);
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -404,7 +404,8 @@ private:
 	obs_source_t *FindTransition(const char *name);
 	OBSSource GetCurrentTransition();
 	obs_data_array_t *SaveTransitions();
-	void LoadTransitions(obs_data_array_t *transitions);
+	void LoadTransitions(obs_data_array_t *transitions,
+			     obs_load_source_cb cb, void *private_data);
 
 	obs_source_t *fadeTransition;
 	obs_source_t *cutTransition;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds transitions to the missing files check, allowing for stinger
transitions to be shown in the dialog

With my transition named "Stinger", this is how it looks.
<img width="666" alt="Bildschirmfoto 2021-08-15 um 20 09 10" src="https://user-images.githubusercontent.com/59806498/129490816-0a2fb1c2-ec6c-44af-95c4-55388fd0270f.png">

Also works with the separate matte file (even though that isn't yet enabled in OBS anyways).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When a stinger file got removed/renamed/whatever, the transition would silently not show up. 
This should help fix this.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0 beta 5, Compiled and run

When moving or renaming the file, the dialog would pop up as intended, and
setting a new file will change the setting in the properties window

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
