### PR TITLE
graphics-hook: Fix D3D11On12 usages

### DIFF
--- a/plugins/win-capture/graphics-hook/d3d12-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d12-capture.cpp
@@ -89,10 +89,9 @@ static bool create_d3d12_tex(bb_info &bb)
 
 	for (UINT i = 0; i < bb.count; i++) {
 		hr = data.device11on12->CreateWrappedResource(
-			bb.backbuffer[i], &rf11,
-			D3D12_RESOURCE_STATE_COPY_SOURCE,
-			D3D12_RESOURCE_STATE_PRESENT, __uuidof(ID3D11Resource),
-			(void **)&data.backbuffer11[i]);
+			bb.backbuffer[i], &rf11, D3D12_RESOURCE_STATE_PRESENT,
+			D3D12_RESOURCE_STATE_PRESENT,
+			IID_PPV_ARGS(&data.backbuffer11[i]));
 		if (FAILED(hr)) {
 			hlog_hr("create_d3d12_tex: failed to create "
 				"backbuffer11",
@@ -119,14 +118,8 @@ static bool create_d3d12_tex(bb_info &bb)
 		return false;
 	}
 
-	for (UINT i = 0; i < bb.count; i++) {
-		data.device11on12->ReleaseWrappedResources(
-			&data.backbuffer11[i], 1);
-	}
-
 	IDXGIResource *dxgi_res;
-	hr = data.copy_tex->QueryInterface(__uuidof(IDXGIResource),
-					   (void **)&dxgi_res);
+	hr = data.copy_tex->QueryInterface(&dxgi_res);
 	if (FAILED(hr)) {
 		hlog_hr("create_d3d12_tex: failed to query "
 			"IDXGIResource interface from texture",
@@ -249,7 +242,7 @@ static inline bool d3d12_init_format(IDXGISwapChain *swap, HWND &window,
 	data.cx = desc.BufferDesc.Width;
 	data.cy = desc.BufferDesc.Height;
 
-	hr = swap->QueryInterface(__uuidof(IDXGISwapChain3), (void **)&swap3);
+	hr = swap->QueryInterface(&swap3);
 	if (SUCCEEDED(hr)) {
 		data.dxgi_1_4 = true;
 		hlog("We're DXGI1.4 boys!");
@@ -274,8 +267,7 @@ static inline bool d3d12_init_format(IDXGISwapChain *swap, HWND &window,
 	}
 
 	for (UINT i = 0; i < bb.count; i++) {
-		hr = swap->GetBuffer(i, __uuidof(ID3D12Resource),
-				     (void **)&bb.backbuffer[i]);
+		hr = swap->GetBuffer(i, IID_PPV_ARGS(&bb.backbuffer[i]));
 		if (SUCCEEDED(hr)) {
 			bb.backbuffer[i]->Release();
 		} else {


### PR DESCRIPTION
### Description
Use D3D12_RESOURCE_STATE_PRESENT for CreateWrappedResource arguments. We
should assume the application will set the backbuffer to PRESENT, and
expect that to be preserved across the Present() call.

Remove unnecessary calls to ReleaseWrappedResources.

Clean up (void**) casts with modern patterns.

### Motivation and Context
Noticed some bad usages from code inspection.

### How Has This Been Tested?
Debugger breakpoint inspection of MS DX12 sample using game capture hook.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.