### PR TITLE
UI: Add menu bar item to show missing files dialog

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -435,6 +435,8 @@ MissingFiles.Cleared="Cleared"
 MissingFiles.Found="Found"
 MissingFiles.AutoSearch="Additional file matches found"
 MissingFiles.AutoSearchText="OBS has found additional matches for missing files in that directory. Would you like to add them?"
+MissingFiles.NoMissing.Title="Missing Files Check"
+MissingFiles.NoMissing.Text="No files appear to be missing."
 
 # update dialog
 UpdateAvailable="New Update Available"
@@ -659,6 +661,7 @@ Basic.MainMenu.File.Remux="Re&mux Recordings"
 Basic.MainMenu.File.Settings="&Settings"
 Basic.MainMenu.File.ShowSettingsFolder="Show Settings Folder"
 Basic.MainMenu.File.ShowProfileFolder="Show Profile Folder"
+Basic.MainMenu.File.ShowMissingFiles="Check for Missing Files"
 Basic.MainMenu.AlwaysOnTop="&Always On Top"
 Basic.MainMenu.File.Exit="E&xit"
 

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -627,6 +627,8 @@
     <addaction name="actionImportSceneCollection"/>
     <addaction name="actionExportSceneCollection"/>
     <addaction name="separator"/>
+    <addaction name="actionShowMissingFiles"/>
+    <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="viewMenu">
     <property name="title">
@@ -1806,6 +1808,11 @@
   <action name="actionExportSceneCollection">
    <property name="text">
     <string>Export</string>
+   </property>
+  </action>
+  <action name="actionShowMissingFiles">
+   <property name="text">
+    <string>Basic.MainMenu.File.ShowMissingFiles</string>
    </property>
   </action>
   <action name="actionNewProfile">

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -907,6 +907,7 @@ private slots:
 	void on_actionShow_Recordings_triggered();
 	void on_actionRemux_triggered();
 	void on_action_Settings_triggered();
+	void on_actionShowMissingFiles_triggered();
 	void on_actionAdvAudioProperties_triggered();
 	void AdvAudioPropsClicked();
 	void AdvAudioPropsDestroyed();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds an entry to the "Scene Collection" tab of the menu bar that makes
the missing files dialog come back in case it got dismissed of files got
removed while OBS was open.

This is the UI change (edited):
<img width="819" alt="image" src="https://user-images.githubusercontent.com/59806498/129726732-257683a5-9e95-4555-852f-c7ec6f525ee5.png">


If files are missing, the regular missing files dialog shows up.
If no files are missing, this popup will show:
<img width="324" alt="image" src="https://user-images.githubusercontent.com/59806498/129495519-7406aa08-e982-4a69-ae47-64a0951b3a8e.png">

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Currently, the only way to get the missing files dialog back is by either switching scene collections or by restarting OBS.
Sometimes it would be good to get it back more easily, for example if you dismissed it when it came up originally only to notice that you in fact do need it. This should simplify that process.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0 beta 5, compiled and run.

Popups show as intended (described above).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
