### PR TITLE
Various YouTube Integration improvements and fixes

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1220,6 +1220,7 @@ YouTube.Actions.Error.NoStreamCreated="No stream created. Please relink your acc
 YouTube.Actions.Error.YouTubeApi="YouTube API Error. Please see the log file for more information."
 YouTube.Actions.Error.BroadcastNotFound="The selected broadcast was not found."
 
+YouTube.Actions.EventsLoading="Loading list of events..."
 YouTube.Actions.EventCreated.Title="Event Created"
 YouTube.Actions.EventCreated.Text="Event successfully created."
 

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1176,8 +1176,10 @@ ContextBar.MediaControls.BlindSeek="Media Seek Widget"
 # YouTube Actions and Auth
 YouTube.Auth.Ok="Authorization completed successfully.\nYou can now close this page."
 YouTube.Auth.NoCode="The authorization process was not completed."
+YouTube.Auth.NoChannels="No channel(s) available on selected account"
 YouTube.Auth.WaitingAuth.Title="YouTube User Authorization"
 YouTube.Auth.WaitingAuth.Text="Please complete the authorization in your external browser.<br>If the external browser does not open, follow this link and complete the authorization:<br>%1"
+YouTube.AuthError.Text="Failed to get channel information: %1."
 
 YouTube.Actions.CreateNewEvent="Create a new event"
 YouTube.Actions.Title="Title*"
@@ -1216,16 +1218,23 @@ YouTube.Actions.Error.General="YouTube access error. Please check your network c
 YouTube.Actions.Error.NoBroadcastCreated="Broadcast creation error '%1'.<br/>A detailed error description can be found at <a href='https://developers.google.com/youtube/v3/live/docs/errors'>https://developers.google.com/youtube/v3/live/docs/errors</a>"
 YouTube.Actions.Error.NoStreamCreated="No stream created. Please relink your account."
 YouTube.Actions.Error.YouTubeApi="YouTube API Error. Please see the log file for more information."
+YouTube.Actions.Error.BroadcastNotFound="The selected broadcast was not found."
 
 YouTube.Actions.EventCreated.Title="Event Created"
 YouTube.Actions.EventCreated.Text="Event successfully created."
 
 YouTube.Actions.ChooseEvent="Choose an Event"
 YouTube.Actions.Stream="Stream"
-YouTube.Actions.Stream.ScheduledFor="scheduled for"
+YouTube.Actions.Stream.ScheduledFor="Scheduled for %1"
+YouTube.Actions.Stream.Resume="Resume interrupted stream"
+YouTube.Actions.Stream.YTStudio="Automatically created by YouTube Studio"
 
 YouTube.Actions.Notify.Title="YouTube"
 YouTube.Actions.Notify.CreatingBroadcast="Creating a new Live Broadcast, please wait..."
 
 YouTube.Actions.AutoStartStreamingWarning="Auto start is disabled for this stream, you should click \"GO LIVE\"."
 YouTube.Actions.AutoStopStreamingWarning="You will not be able to reconnect.<br>Your stream will stop and you will no longer be live."
+
+# YouTube API errors in format "YouTube.Errors.<error reason>"
+YouTube.Errors.liveStreamingNotEnabled="Live streaming is not enabled on the selected YouTube channel.<br/><br/>See <a href='https://www.youtube.com/features'>youtube.com/features</a> for more information."
+YouTube.Errors.livePermissionBlocked="Live streaming is unavailable on the selected YouTube Channel.<br/>Please note that it may take up to 24 hours for live streaming to become available after enabling it in your channel settings.<br/><br/>See <a href='https://www.youtube.com/features'>youtube.com/features</a> for details."

--- a/UI/remote-text.cpp
+++ b/UI/remote-text.cpp
@@ -123,7 +123,7 @@ bool GetRemoteFile(const char *url, std::string &str, std::string &error,
 		   long *responseCode, const char *contentType,
 		   std::string request_type, const char *postData,
 		   std::vector<std::string> extraHeaders,
-		   std::string *signature, int timeoutSec)
+		   std::string *signature, int timeoutSec, bool fail_on_error)
 {
 	vector<string> header_in_list;
 	char error_in[CURL_ERROR_SIZE];
@@ -158,7 +158,8 @@ bool GetRemoteFile(const char *url, std::string &str, std::string &error,
 		curl_easy_setopt(curl.get(), CURLOPT_ACCEPT_ENCODING, "");
 		curl_easy_setopt(curl.get(), CURLOPT_HTTPHEADER, header);
 		curl_easy_setopt(curl.get(), CURLOPT_ERRORBUFFER, error_in);
-		curl_easy_setopt(curl.get(), CURLOPT_FAILONERROR, 1L);
+		if (fail_on_error)
+			curl_easy_setopt(curl.get(), CURLOPT_FAILONERROR, 1L);
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION,
 				 string_write);
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &str);

--- a/UI/remote-text.hpp
+++ b/UI/remote-text.hpp
@@ -68,4 +68,5 @@ bool GetRemoteFile(
 	long *responseCode = nullptr, const char *contentType = nullptr,
 	std::string request_type = "", const char *postData = nullptr,
 	std::vector<std::string> extraHeaders = std::vector<std::string>(),
-	std::string *signature = nullptr, int timeoutSec = 0);
+	std::string *signature = nullptr, int timeoutSec = 0,
+	bool fail_on_error = true);

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -437,7 +437,10 @@ static void get_yt_ch_title(Ui::OBSBasicSettings *ui,
 			if (IsYouTubeService(
 				    QT_TO_UTF8(ui->service->currentText()))) {
 				ui->connectedAccountText->setText(
-					QTStr("Auth.LoadingChannel.Error"));
+					ytAuth->GetLastError().isEmpty()
+						? QTStr("Auth.LoadingChannel.Error")
+						: QTStr("YouTube.AuthError.Text")
+							  .arg(ytAuth->GetLastError()));
 			}
 		}
 	}

--- a/UI/window-youtube-actions.cpp
+++ b/UI/window-youtube-actions.cpp
@@ -135,6 +135,22 @@ OBSYoutubeActions::OBSYoutubeActions(QWidget *parent, Auth *auth)
 	qDeleteAll(ui->scrollAreaWidgetContents->findChildren<QWidget *>(
 		QString(), Qt::FindDirectChildrenOnly));
 
+	// Add label indicating loading state
+	QLabel *loadingLabel = new QLabel();
+	loadingLabel->setTextFormat(Qt::RichText);
+	loadingLabel->setAlignment(Qt::AlignHCenter);
+	loadingLabel->setText(
+		QString("<big>%1</big>")
+			.arg(QTStr("YouTube.Actions.EventsLoading")));
+	ui->scrollAreaWidgetContents->layout()->addWidget(loadingLabel);
+
+	// Delete "loading..." label on completion
+	connect(workerThread, &WorkerThread::finished, this, [&] {
+		QLayoutItem *item =
+			ui->scrollAreaWidgetContents->layout()->takeAt(0);
+		item->widget()->deleteLater();
+	});
+
 	connect(workerThread, &WorkerThread::failed, this, [&]() {
 		auto last_error = apiYouTube->GetLastError();
 		if (last_error.isEmpty())

--- a/UI/window-youtube-actions.hpp
+++ b/UI/window-youtube-actions.hpp
@@ -23,7 +23,8 @@ public slots:
 signals:
 	void ready();
 	void new_item(const QString &title, const QString &dateTimeString,
-		      const QString &broadcast, bool astart, bool astop);
+		      const QString &broadcast, const QString &status,
+		      bool astart, bool astop);
 	void failed();
 };
 
@@ -43,7 +44,7 @@ protected:
 			     StreamDescription &stream);
 	bool StreamLaterAction(YoutubeApiWrappers *api);
 	bool ChooseAnEventAction(YoutubeApiWrappers *api,
-				 StreamDescription &stream, bool start);
+				 StreamDescription &stream);
 
 	void ShowErrorDialog(QWidget *parent, QString text);
 

--- a/UI/youtube-api-wrappers.cpp
+++ b/UI/youtube-api-wrappers.cpp
@@ -29,7 +29,7 @@ using namespace json11;
 #define YOUTUBE_LIVE_VIDEOS_URL YOUTUBE_LIVE_API_URL "/videos"
 
 #define DEFAULT_BROADCASTS_PER_QUERY \
-	"7" // acceptable values are 0 to 50, inclusive
+	"50" // acceptable values are 0 to 50, inclusive
 /* ------------------------------------------------------------------------- */
 
 bool IsYouTubeService(const std::string &service)
@@ -284,14 +284,20 @@ bool YoutubeApiWrappers::BindStream(const QString broadcast_id,
 			     data.dump().c_str(), json_out);
 }
 
-bool YoutubeApiWrappers::GetBroadcastsList(Json &json_out, QString page)
+bool YoutubeApiWrappers::GetBroadcastsList(Json &json_out, const QString &page,
+					   const QString &status)
 {
 	lastErrorMessage.clear();
 	lastErrorReason.clear();
 	QByteArray url = YOUTUBE_LIVE_BROADCAST_URL
 		"?part=snippet,contentDetails,status"
-		"&broadcastType=all&maxResults=" DEFAULT_BROADCASTS_PER_QUERY
-		"&mine=true";
+		"&broadcastType=all&maxResults=" DEFAULT_BROADCASTS_PER_QUERY;
+
+	if (status.isEmpty())
+		url += "&mine=true";
+	else
+		url += "&broadcastStatus=" + status.toUtf8();
+
 	if (!page.isEmpty())
 		url += "&pageToken=" + page.toUtf8();
 	return InsertCommand(url, "application/json", "", nullptr, json_out);
@@ -390,6 +396,11 @@ bool YoutubeApiWrappers::StopBroadcast(const QString &broadcast_id)
 bool YoutubeApiWrappers::StopLatestBroadcast()
 {
 	return StopBroadcast(this->broadcast_id);
+}
+
+void YoutubeApiWrappers::SetBroadcastId(QString &broadcast_id)
+{
+	this->broadcast_id = broadcast_id;
 }
 
 bool YoutubeApiWrappers::ResetBroadcast(const QString &broadcast_id)

--- a/UI/youtube-api-wrappers.cpp
+++ b/UI/youtube-api-wrappers.cpp
@@ -156,6 +156,13 @@ bool YoutubeApiWrappers::GetChannelDescription(
 	if (!InsertCommand(url, "application/json", "", nullptr, json_out)) {
 		return false;
 	}
+
+	if (json_out["pageInfo"]["totalResults"].int_value() == 0) {
+		lastErrorMessage =
+			"No channel(s) available on selected account";
+		return false;
+	}
+
 	channel_description.id =
 		QString(json_out["items"][0]["id"].string_value().c_str());
 	channel_description.country =

--- a/UI/youtube-api-wrappers.hpp
+++ b/UI/youtube-api-wrappers.hpp
@@ -65,7 +65,8 @@ public:
 	bool InsertBroadcast(BroadcastDescription &broadcast);
 	bool InsertStream(StreamDescription &stream);
 	bool BindStream(const QString broadcast_id, const QString stream_id);
-	bool GetBroadcastsList(json11::Json &json_out, QString page);
+	bool GetBroadcastsList(json11::Json &json_out, const QString &page,
+			       const QString &status);
 	bool
 	GetVideoCategoriesList(const QString &country, const QString &language,
 			       QVector<CategoryDescription> &category_list_out);
@@ -78,6 +79,8 @@ public:
 	bool ResetBroadcast(const QString &broadcast_id);
 	bool StartLatestBroadcast();
 	bool StopLatestBroadcast();
+
+	void SetBroadcastId(QString &broadcast_id);
 
 	bool FindBroadcast(const QString &id, json11::Json &json_out);
 	bool FindStream(const QString &id, json11::Json &json_out);

--- a/UI/youtube-api-wrappers.hpp
+++ b/UI/youtube-api-wrappers.hpp
@@ -83,10 +83,12 @@ public:
 	bool FindStream(const QString &id, json11::Json &json_out);
 
 	QString GetLastError() { return lastErrorMessage; };
+	bool GetTranslatedError(QString &error_message);
 
 private:
 	QString broadcast_id;
 
 	int lastError;
 	QString lastErrorMessage;
+	QString lastErrorReason;
 };


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
These changes are intended to improve how YouTube API errors are exposed to the user and fix a few issues found during debugging/testing.

### Motivation and Context
Several issues such as live streaming not being enabled on a channel or a Google account without YouTube channel being used during the OAuth process are currently not properly explained to the user.

The API to retrieve existing broadcasts was used poorly, leading to potentially hundreds of requests made only to throw their results away since *every single broadcast* on a channel was fetched, rather than only those we care about (live, scheduled). This PR also adds an indicator to the list informing the user that data is still being fetched from the API.

Additionally resuming a stream that was interrupted (e.g. due to OBS crashing) was not possible, and the code for using an already attached `liveStream` didn't work.

### How Has This Been Tested?
Tested with YouTube channel without livestreaming and with Google account without YouTube channel.

Tested various live streams in different configurations (scheduled, autostart on/off, etc.)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
