### PR TITLE
linux-capture: proper DMA-BUF capability negotiation via PipeWire

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -238,6 +238,32 @@
       ]
     },
     {
+      "name": "pipewire",
+      "buildsystem": "meson",
+      "config-opts": [
+        "-Daudiotestsrc=disabled",
+        "-Droc=disabled",
+        "-Dvideotestsrc=disabled",
+        "-Dvolume=disabled",
+        "-Dvulkan=disabled",
+        "-Ddocs=disabled",
+        "-Dman=disabled",
+        "-Dbluez5-codec-ldac=disabled",
+        "-Dbluez5-codec-aptx=disabled",
+        "-Dlibcamera=disabled",
+        "-Dudevrulesdir=/app/lib/udev/rules.d/",
+        "-Dsession-managers=[]"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://gitlab.freedesktop.org/pipewire/pipewire.git",
+          "tag": "0.3.40",
+          "commit": "7afd80052b7c49754a13c9ab49c368f95b60e0a7"
+        }
+      ]
+    },
+    {
       "name": "cef",
       "buildsystem": "cmake-ninja",
       "no-make-install": true,

--- a/docs/sphinx/reference-libobs-graphics-graphics.rst
+++ b/docs/sphinx/reference-libobs-graphics-graphics.rst
@@ -1005,6 +1005,50 @@ Texture Functions
 
 ---------------------
 
+.. type:: enum gs_dmabuf_flags
+
+   DMA-BUF capabilities:
+
+   - GS_DMABUF_FLAG_NONE
+   - GS_DMABUF_FLAG_SUPPORTS_IMPLICIT_MODIFIERS  - Renderer supports implicit modifiers
+
+---------------------
+
+.. function:: bool *gs_query_dmabuf_capabilities(enum gs_dmabuf_flags *dmabuf_flags, uint32_t **drm_formats, size_t *n_formats)
+
+   **Linux only:** Queries the capabilities for DMA-BUFs.
+
+   Graphics cards can optimize frame buffers by storing them in custom layouts,
+   depending on their hardware features. These layouts can make these frame
+   buffers unsuitable for linear processing. This function allows querying whether
+   the graphics card in use supports implicit modifiers, and the supported texture
+   formats.
+
+   The caller must free the `drm_formats` array with `bfree()` after use.
+
+   :param dmabuf_flags: Pointer to receive a capability bitmap
+   :param drm_formats:  Pointer to receive an array of DRM formats
+   :param n_formats:    Pointer to receive the number of formats
+   :rtype:              bool
+
+---------------------
+
+.. function:: bool *gs_query_dmabuf_modifiers_for_format(uint32_t drm_format, uint64_t **modifiers, size_t *n_modifiers)
+
+   **Linux only:** Queries the supported DMA-BUF modifiers for a given format.
+
+   This function queries all supported explicit modifiers for a format,
+   stores them as an array and returns the number of supported modifiers.
+
+   The caller must free the `modifiers` array with `bfree()` after use.
+
+   :param drm_format:   DRM format of the DMA-BUF buffer
+   :param modifiers:    Pointer to receive an array of modifiers
+   :param n_modifiers:  Pointer to receive the number of modifiers
+   :rtype:              bool
+
+---------------------
+
 .. function:: gs_texture_t *gs_texture_create_from_iosurface(void *iosurf)
 
    **Mac only:** Creates a texture from an IOSurface.

--- a/libobs-opengl/gl-egl-common.h
+++ b/libobs-opengl/gl-egl-common.h
@@ -12,3 +12,12 @@ gl_egl_create_dmabuf_image(EGLDisplay egl_display, unsigned int width,
 			   enum gs_color_format color_format, uint32_t n_planes,
 			   const int *fds, const uint32_t *strides,
 			   const uint32_t *offsets, const uint64_t *modifiers);
+
+bool gl_egl_query_dmabuf_capabilities(EGLDisplay egl_display,
+				      enum gs_dmabuf_flags *dmabuf_flags,
+				      uint32_t **drm_format, size_t *n_formats);
+
+bool gl_egl_query_dmabuf_modifiers_for_format(EGLDisplay egl_display,
+					      uint32_t drm_format,
+					      uint64_t **modifiers,
+					      size_t *n_modifiers);

--- a/libobs-opengl/gl-nix.c
+++ b/libobs-opengl/gl-nix.c
@@ -134,3 +134,21 @@ extern struct gs_texture *device_texture_create_from_dmabuf(
 		device, width, height, drm_format, color_format, n_planes, fds,
 		strides, offsets, modifiers);
 }
+
+extern bool device_query_dmabuf_capabilities(gs_device_t *device,
+					     enum gs_dmabuf_flags *dmabuf_flags,
+					     uint32_t **drm_formats,
+					     size_t *n_formats)
+{
+	return gl_vtable->device_query_dmabuf_capabilities(
+		device, dmabuf_flags, drm_formats, n_formats);
+}
+
+extern bool device_query_dmabuf_modifiers_for_format(gs_device_t *device,
+						     uint32_t drm_format,
+						     uint64_t **modifiers,
+						     size_t *n_modifiers)
+{
+	return gl_vtable->device_query_dmabuf_modifiers_for_format(
+		device, drm_format, modifiers, n_modifiers);
+}

--- a/libobs-opengl/gl-nix.h
+++ b/libobs-opengl/gl-nix.h
@@ -59,4 +59,13 @@ struct gl_winsys_vtable {
 		uint32_t drm_format, enum gs_color_format color_format,
 		uint32_t n_planes, const int *fds, const uint32_t *strides,
 		const uint32_t *offsets, const uint64_t *modifiers);
+
+	bool (*device_query_dmabuf_capabilities)(
+		gs_device_t *device, enum gs_dmabuf_flags *dmabuf_flags,
+		uint32_t **drm_formats, size_t *n_formats);
+
+	bool (*device_query_dmabuf_modifiers_for_format)(gs_device_t *device,
+							 uint32_t drm_format,
+							 uint64_t **modifiers,
+							 size_t *n_modifiers);
 };

--- a/libobs-opengl/gl-wayland-egl.c
+++ b/libobs-opengl/gl-wayland-egl.c
@@ -363,6 +363,30 @@ static struct gs_texture *gl_wayland_egl_device_texture_create_from_dmabuf(
 					  fds, strides, offsets, modifiers);
 }
 
+static bool gl_wayland_egl_device_query_dmabuf_capabilities(
+	gs_device_t *device, enum gs_dmabuf_flags *dmabuf_flags,
+	uint32_t **drm_formats, size_t *n_formats)
+{
+	UNUSED_PARAMETER(device);
+	UNUSED_PARAMETER(dmabuf_flags);
+	UNUSED_PARAMETER(drm_formats);
+	UNUSED_PARAMETER(n_formats);
+
+	return false;
+}
+
+static bool gl_wayland_egl_device_query_dmabuf_modifiers_for_format(
+	gs_device_t *device, uint32_t drm_format, uint64_t **modifiers,
+	size_t *n_modifiers)
+{
+	UNUSED_PARAMETER(device);
+	UNUSED_PARAMETER(drm_format);
+	UNUSED_PARAMETER(modifiers);
+	UNUSED_PARAMETER(n_modifiers);
+
+	return false;
+}
+
 static const struct gl_winsys_vtable egl_wayland_winsys_vtable = {
 	.windowinfo_create = gl_wayland_egl_windowinfo_create,
 	.windowinfo_destroy = gl_wayland_egl_windowinfo_destroy,
@@ -380,6 +404,10 @@ static const struct gl_winsys_vtable egl_wayland_winsys_vtable = {
 	.device_present = gl_wayland_egl_device_present,
 	.device_texture_create_from_dmabuf =
 		gl_wayland_egl_device_texture_create_from_dmabuf,
+	.device_query_dmabuf_capabilities =
+		gl_wayland_egl_device_query_dmabuf_capabilities,
+	.device_query_dmabuf_modifiers_for_format =
+		gl_wayland_egl_device_query_dmabuf_modifiers_for_format,
 };
 
 const struct gl_winsys_vtable *gl_wayland_egl_get_winsys_vtable(void)

--- a/libobs-opengl/gl-wayland-egl.c
+++ b/libobs-opengl/gl-wayland-egl.c
@@ -367,24 +367,20 @@ static bool gl_wayland_egl_device_query_dmabuf_capabilities(
 	gs_device_t *device, enum gs_dmabuf_flags *dmabuf_flags,
 	uint32_t **drm_formats, size_t *n_formats)
 {
-	UNUSED_PARAMETER(device);
-	UNUSED_PARAMETER(dmabuf_flags);
-	UNUSED_PARAMETER(drm_formats);
-	UNUSED_PARAMETER(n_formats);
+	struct gl_platform *plat = device->plat;
 
-	return false;
+	return gl_egl_query_dmabuf_capabilities(plat->display, dmabuf_flags,
+						drm_formats, n_formats);
 }
 
 static bool gl_wayland_egl_device_query_dmabuf_modifiers_for_format(
 	gs_device_t *device, uint32_t drm_format, uint64_t **modifiers,
 	size_t *n_modifiers)
 {
-	UNUSED_PARAMETER(device);
-	UNUSED_PARAMETER(drm_format);
-	UNUSED_PARAMETER(modifiers);
-	UNUSED_PARAMETER(n_modifiers);
+	struct gl_platform *plat = device->plat;
 
-	return false;
+	return gl_egl_query_dmabuf_modifiers_for_format(
+		plat->display, drm_format, modifiers, n_modifiers);
 }
 
 static const struct gl_winsys_vtable egl_wayland_winsys_vtable = {

--- a/libobs-opengl/gl-x11-egl.c
+++ b/libobs-opengl/gl-x11-egl.c
@@ -649,6 +649,30 @@ static struct gs_texture *gl_x11_egl_device_texture_create_from_dmabuf(
 					  fds, strides, offsets, modifiers);
 }
 
+static bool gl_x11_egl_device_query_dmabuf_capabilities(
+	gs_device_t *device, enum gs_dmabuf_flags *dmabuf_flags,
+	uint32_t **drm_formats, size_t *n_formats)
+{
+	UNUSED_PARAMETER(device);
+	UNUSED_PARAMETER(dmabuf_flags);
+	UNUSED_PARAMETER(drm_formats);
+	UNUSED_PARAMETER(n_formats);
+
+	return false;
+}
+
+static bool gl_x11_egl_device_query_dmabuf_modifiers_for_format(
+	gs_device_t *device, uint32_t drm_format, uint64_t **modifiers,
+	size_t *n_modifiers)
+{
+	UNUSED_PARAMETER(device);
+	UNUSED_PARAMETER(drm_format);
+	UNUSED_PARAMETER(modifiers);
+	UNUSED_PARAMETER(n_modifiers);
+
+	return false;
+}
+
 static const struct gl_winsys_vtable egl_x11_winsys_vtable = {
 	.windowinfo_create = gl_x11_egl_windowinfo_create,
 	.windowinfo_destroy = gl_x11_egl_windowinfo_destroy,
@@ -666,6 +690,10 @@ static const struct gl_winsys_vtable egl_x11_winsys_vtable = {
 	.device_present = gl_x11_egl_device_present,
 	.device_texture_create_from_dmabuf =
 		gl_x11_egl_device_texture_create_from_dmabuf,
+	.device_query_dmabuf_capabilities =
+		gl_x11_egl_device_query_dmabuf_capabilities,
+	.device_query_dmabuf_modifiers_for_format =
+		gl_x11_egl_device_query_dmabuf_modifiers_for_format,
 };
 
 const struct gl_winsys_vtable *gl_x11_egl_get_winsys_vtable(void)

--- a/libobs-opengl/gl-x11-egl.c
+++ b/libobs-opengl/gl-x11-egl.c
@@ -653,24 +653,20 @@ static bool gl_x11_egl_device_query_dmabuf_capabilities(
 	gs_device_t *device, enum gs_dmabuf_flags *dmabuf_flags,
 	uint32_t **drm_formats, size_t *n_formats)
 {
-	UNUSED_PARAMETER(device);
-	UNUSED_PARAMETER(dmabuf_flags);
-	UNUSED_PARAMETER(drm_formats);
-	UNUSED_PARAMETER(n_formats);
+	struct gl_platform *plat = device->plat;
 
-	return false;
+	return gl_egl_query_dmabuf_capabilities(plat->xdisplay, dmabuf_flags,
+						drm_formats, n_formats);
 }
 
 static bool gl_x11_egl_device_query_dmabuf_modifiers_for_format(
 	gs_device_t *device, uint32_t drm_format, uint64_t **modifiers,
 	size_t *n_modifiers)
 {
-	UNUSED_PARAMETER(device);
-	UNUSED_PARAMETER(drm_format);
-	UNUSED_PARAMETER(modifiers);
-	UNUSED_PARAMETER(n_modifiers);
+	struct gl_platform *plat = device->plat;
 
-	return false;
+	return gl_egl_query_dmabuf_modifiers_for_format(
+		plat->xdisplay, drm_format, modifiers, n_modifiers);
 }
 
 static const struct gl_winsys_vtable egl_x11_winsys_vtable = {

--- a/libobs-opengl/gl-x11-glx.c
+++ b/libobs-opengl/gl-x11-glx.c
@@ -599,6 +599,30 @@ static struct gs_texture *gl_x11_glx_device_texture_create_from_dmabuf(
 	return NULL;
 }
 
+static bool gl_x11_glx_device_query_dmabuf_capabilities(
+	gs_device_t *device, enum gs_dmabuf_flags *dmabuf_flags,
+	uint32_t **drm_formats, size_t *n_formats)
+{
+	UNUSED_PARAMETER(device);
+	UNUSED_PARAMETER(dmabuf_flags);
+	UNUSED_PARAMETER(drm_formats);
+	UNUSED_PARAMETER(n_formats);
+
+	return false;
+}
+
+static bool gl_x11_glx_device_query_dmabuf_modifiers_for_format(
+	gs_device_t *device, uint32_t drm_format, uint64_t **modifiers,
+	size_t *n_modifiers)
+{
+	UNUSED_PARAMETER(device);
+	UNUSED_PARAMETER(drm_format);
+	UNUSED_PARAMETER(modifiers);
+	UNUSED_PARAMETER(n_modifiers);
+
+	return false;
+}
+
 static const struct gl_winsys_vtable glx_winsys_vtable = {
 	.windowinfo_create = gl_x11_glx_windowinfo_create,
 	.windowinfo_destroy = gl_x11_glx_windowinfo_destroy,
@@ -616,6 +640,10 @@ static const struct gl_winsys_vtable glx_winsys_vtable = {
 	.device_present = gl_x11_glx_device_present,
 	.device_texture_create_from_dmabuf =
 		gl_x11_glx_device_texture_create_from_dmabuf,
+	.device_query_dmabuf_capabilities =
+		gl_x11_glx_device_query_dmabuf_capabilities,
+	.device_query_dmabuf_modifiers_for_format =
+		gl_x11_glx_device_query_dmabuf_modifiers_for_format,
 };
 
 const struct gl_winsys_vtable *gl_x11_glx_get_winsys_vtable(void)

--- a/libobs/graphics/device-exports.h
+++ b/libobs/graphics/device-exports.h
@@ -180,6 +180,16 @@ EXPORT gs_texture_t *device_texture_create_from_dmabuf(
 	uint32_t n_planes, const int *fds, const uint32_t *strides,
 	const uint32_t *offsets, const uint64_t *modifiers);
 
+EXPORT bool
+device_query_dmabuf_capabilities(gs_device_t *device,
+				 enum gs_dmabuf_flags *gs_dmabuf_flags,
+				 uint32_t **drm_formats, size_t *n_formats);
+
+EXPORT bool device_query_dmabuf_modifiers_for_format(gs_device_t *device,
+						     uint32_t drm_format,
+						     uint64_t **modifiers,
+						     size_t *n_modifiers);
+
 #endif
 
 #ifdef __cplusplus

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -227,6 +227,8 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT_OPTIONAL(device_unregister_loss_callbacks);
 #elif __linux__
 	GRAPHICS_IMPORT(device_texture_create_from_dmabuf);
+	GRAPHICS_IMPORT(device_query_dmabuf_capabilities);
+	GRAPHICS_IMPORT(device_query_dmabuf_modifiers_for_format);
 #endif
 
 	return success;

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -337,6 +337,13 @@ struct gs_exports {
 		uint32_t drm_format, enum gs_color_format color_format,
 		uint32_t n_planes, const int *fds, const uint32_t *strides,
 		const uint32_t *offsets, const uint64_t *modifiers);
+	bool (*device_query_dmabuf_capabilities)(
+		gs_device_t *device, enum gs_dmabuf_flags *dmabuf_flags,
+		uint32_t **drm_formats, size_t *n_formats);
+	bool (*device_query_dmabuf_modifiers_for_format)(gs_device_t *device,
+							 uint32_t drm_format,
+							 uint64_t **modifiers,
+							 size_t *n_modifiers);
 #endif
 };
 

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -1392,6 +1392,25 @@ gs_texture_t *gs_texture_create_from_dmabuf(
 		n_planes, fds, strides, offsets, modifiers);
 }
 
+bool gs_query_dmabuf_capabilities(enum gs_dmabuf_flags *dmabuf_flags,
+				  uint32_t **drm_formats, size_t *n_formats)
+{
+	graphics_t *graphics = thread_graphics;
+
+	return graphics->exports.device_query_dmabuf_capabilities(
+		graphics->device, dmabuf_flags, drm_formats, n_formats);
+}
+
+bool gs_query_dmabuf_modifiers_for_format(uint32_t drm_format,
+					  uint64_t **modifiers,
+					  size_t *n_modifiers)
+{
+	graphics_t *graphics = thread_graphics;
+
+	return graphics->exports.device_query_dmabuf_modifiers_for_format(
+		graphics->device, drm_format, modifiers, n_modifiers);
+}
+
 #endif
 
 gs_texture_t *gs_cubetexture_create(uint32_t size,

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -943,6 +943,19 @@ EXPORT gs_texture_t *gs_texture_create_from_dmabuf(
 	const uint32_t *strides, const uint32_t *offsets,
 	const uint64_t *modifiers);
 
+enum gs_dmabuf_flags {
+	GS_DMABUF_FLAG_NONE = 0,
+	GS_DMABUF_FLAG_IMPLICIT_MODIFIERS_SUPPORTED = (1 << 0),
+};
+
+EXPORT bool gs_query_dmabuf_capabilities(enum gs_dmabuf_flags *dmabuf_flags,
+					 uint32_t **drm_formats,
+					 size_t *n_formats);
+
+EXPORT bool gs_query_dmabuf_modifiers_for_format(uint32_t drm_format,
+						 uint64_t **modifiers,
+						 size_t *n_modifiers);
+
 #endif
 
 /* inline functions used by modules */

--- a/plugins/linux-capture/CMakeLists.txt
+++ b/plugins/linux-capture/CMakeLists.txt
@@ -46,7 +46,7 @@ set(linux-capture_LIBRARIES
 
 option(ENABLE_PIPEWIRE "Enable PipeWire support" ON)
 if(ENABLE_PIPEWIRE)
-	find_package(PipeWire 0.3.33 QUIET)
+	find_package(PipeWire 0.3.32 QUIET)
 	find_package(Libdrm QUIET) # we require libdrm/drm_fourcc.h to build
 	find_package(Gio QUIET)
 

--- a/plugins/linux-capture/CMakeLists.txt
+++ b/plugins/linux-capture/CMakeLists.txt
@@ -46,7 +46,7 @@ set(linux-capture_LIBRARIES
 
 option(ENABLE_PIPEWIRE "Enable PipeWire support" ON)
 if(ENABLE_PIPEWIRE)
-	find_package(PipeWire QUIET)
+	find_package(PipeWire 0.3.33 QUIET)
 	find_package(Libdrm QUIET) # we require libdrm/drm_fourcc.h to build
 	find_package(Gio QUIET)
 

--- a/plugins/linux-capture/pipewire.c
+++ b/plugins/linux-capture/pipewire.c
@@ -38,6 +38,10 @@
 #include <spa/param/video/type-info.h>
 #include <spa/utils/result.h>
 
+#ifndef SPA_POD_PROP_FLAG_DONT_FIXATE
+#define SPA_POD_PROP_FLAG_DONT_FIXATE (1 << 4)
+#endif
+
 #define REQUEST_PATH "/org/freedesktop/portal/desktop/request/%s/obs%u"
 #define SESSION_PATH "/org/freedesktop/portal/desktop/session/%s/obs%u"
 

--- a/plugins/linux-capture/pipewire.c
+++ b/plugins/linux-capture/pipewire.c
@@ -44,23 +44,6 @@
 	(sizeof(struct spa_meta_cursor) + sizeof(struct spa_meta_bitmap) + \
 	 width * height * 4)
 
-#define fourcc_code(a, b, c, d)                                \
-	((__u32)(a) | ((__u32)(b) << 8) | ((__u32)(c) << 16) | \
-	 ((__u32)(d) << 24))
-
-#define DRM_FORMAT_XRGB8888        \
-	fourcc_code('X', 'R', '2', \
-		    '4') /* [31:0] x:R:G:B 8:8:8:8 little endian */
-#define DRM_FORMAT_XBGR8888        \
-	fourcc_code('X', 'B', '2', \
-		    '4') /* [31:0] x:B:G:R 8:8:8:8 little endian */
-#define DRM_FORMAT_ARGB8888        \
-	fourcc_code('A', 'R', '2', \
-		    '4') /* [31:0] A:R:G:B 8:8:8:8 little endian */
-#define DRM_FORMAT_ABGR8888        \
-	fourcc_code('A', 'B', '2', \
-		    '4') /* [31:0] A:B:G:R 8:8:8:8 little endian */
-
 struct obs_pw_version {
 	int major;
 	int minor;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This MR implements the negotiation for sharing of DMA-BUFs via PipeWire as described in https://docs.pipewire.org/page_dma_buf.html.
This MR follows up on #5221 by adding capabilities to query all modifiers supported by the renderer.
This query was implemented for EGL based renderers. 


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
For proper DMA-BUF capability negotiation it is important, that both clients announce there capabilities by the means of a list of supported modifiers for a given format. Since PipeWire 0.3.33 we have the possibility to announce such a list per format and assure that it will not be mixed up with the capabilities of SHM buffer transport, which is distinguished by not announcing the modifier key.
This MR is required for obs to be able to use DMA-BUF transport via PipeWire with Wayland compositors after the mentioned MRs in the tested section have been merged. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This can/will (be able to) be tested with: 
* the next kwin release containing https://invent.kde.org/plasma/kwin/-/merge_requests/1210
* a mutter build containing https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1939
* a build of xdg-desktop-portal-wlr containing https://github.com/emersion/xdg-desktop-portal-wlr/pull/159



### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

Requires: #5221 
Requires: #5585 
Requires: PipeWire 0.3.33
Split into 3 Feature sets wrt. PipeWire version:
- x < 0.3.24: SHM only
- 0.3.24 <= x < 0.3.40: Old style Dma-Buf negotiation
- x >= 0.3.40: Proper modifier negotiation