### PR TITLE
UI: Change QWidgets to QFrame so Qt Creator doesn't hide these entries

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -61,7 +61,7 @@
          <number>2</number>
         </property>
         <item>
-         <widget class="QWidget" name="previewDisabledWidget">
+         <widget class="QFrame" name="previewDisabledWidget">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
             <horstretch>0</horstretch>
@@ -196,7 +196,7 @@
      </layout>
     </item>
     <item>
-     <widget class="QWidget" name="contextContainer">
+     <widget class="QFrame" name="contextContainer">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
         <horstretch>0</horstretch>
@@ -235,7 +235,7 @@
         <number>4</number>
        </property>
        <item>
-        <widget class="QWidget" name="contextSubContainer">
+        <widget class="QFrame" name="contextSubContainer">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -406,7 +406,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="emptySpace">
+        <widget class="QFrame" name="emptySpace">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -1116,7 +1116,7 @@
       <number>4</number>
      </property>
      <item>
-      <widget class="QWidget" name="transitionsContainer">
+      <widget class="QFrame" name="transitionsContainer">
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="spacing">
          <number>2</number>


### PR DESCRIPTION
QWidgets that contain property definitions as well as a layout child item do not properly show up in the Qt Creator hierarchy. The properties on these QWidgets are still invisibly applied to the UI layout but not shown in Qt Creator.

These entries will also get removed from the file after saving the file in Qt Creator even without any changes.

### Description
Before this change, the changed QWidgets in OBSBasic.ui are not properly shown in Qt Creator, they are only listed as layouts and their QWidget properties are not accessible or shown.
![image](https://user-images.githubusercontent.com/1554753/129507563-b745ac21-720f-4e98-8640-6d09e3792cb8.png)

These widgets will also get completely removed upon saving.

![image](https://user-images.githubusercontent.com/1554753/129507599-fa08d7f3-f675-4840-bef9-69bad8e5ff7b.png)
After this change, the items are properly listed in the Qt Creator hierarchy

### Motivation and Context
I wanna fix UI stuff and broken UI files are a blocker

### How Has This Been Tested?
Updated the UI file and ensured the UI still looked and behaved as usual

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
