### PR TITLE
UI: Change the Source Toolbar to not be fixed size

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -209,12 +209,6 @@
         <height>30</height>
        </size>
       </property>
-      <property name="maximumSize">
-       <size>
-        <width>16777215</width>
-        <height>30</height>
-       </size>
-      </property>
       <layout class="QHBoxLayout" name="horizontalLayout9">
        <property name="spacing">
         <number>6</number>
@@ -310,12 +304,6 @@
               <height>22</height>
              </size>
             </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>22</height>
-             </size>
-            </property>
             <property name="toolTip">
              <string>Properties</string>
             </property>
@@ -342,12 +330,6 @@
               <height>22</height>
              </size>
             </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>22</height>
-             </size>
-            </property>
             <property name="toolTip">
              <string>Filters</string>
             </property>
@@ -371,12 +353,6 @@
             <property name="minimumSize">
              <size>
               <width>0</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
               <height>22</height>
              </size>
             </property>
@@ -408,7 +384,7 @@
        <item>
         <widget class="QFrame" name="emptySpace">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -416,12 +392,6 @@
          <property name="minimumSize">
           <size>
            <width>0</width>
-           <height>22</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
            <height>22</height>
           </size>
          </property>

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -61,7 +61,7 @@
          <number>2</number>
         </property>
         <item>
-         <widget class="QWidget" name="previewDisabledWidget">
+         <widget class="QFrame" name="previewDisabledWidget">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
             <horstretch>0</horstretch>
@@ -196,7 +196,7 @@
      </layout>
     </item>
     <item>
-     <widget class="QWidget" name="contextContainer">
+     <widget class="QFrame" name="contextContainer">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
         <horstretch>0</horstretch>
@@ -235,7 +235,7 @@
         <number>4</number>
        </property>
        <item>
-        <widget class="QWidget" name="contextSubContainer">
+        <widget class="QFrame" name="contextSubContainer">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -406,7 +406,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="emptySpace">
+        <widget class="QFrame" name="emptySpace">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -1116,7 +1116,7 @@
       <number>4</number>
      </property>
      <item>
-      <widget class="QWidget" name="transitionsContainer">
+      <widget class="QFrame" name="transitionsContainer">
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="spacing">
          <number>2</number>

--- a/UI/forms/source-toolbar/browser-source-toolbar.ui
+++ b/UI/forms/source-toolbar/browser-source-toolbar.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -19,12 +19,6 @@
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>22</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>16777215</width>
     <height>22</height>
    </size>
   </property>
@@ -49,12 +43,6 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>22</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
        <height>22</height>
       </size>
      </property>

--- a/UI/forms/source-toolbar/color-source-toolbar.ui
+++ b/UI/forms/source-toolbar/color-source-toolbar.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -19,12 +19,6 @@
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>22</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>16777215</width>
     <height>22</height>
    </size>
   </property>
@@ -58,12 +52,6 @@
        <height>22</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>22</height>
-      </size>
-     </property>
      <property name="text">
       <string notr="true">color here</string>
      </property>
@@ -77,12 +65,6 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>22</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
        <height>22</height>
       </size>
      </property>

--- a/UI/forms/source-toolbar/device-select-toolbar.ui
+++ b/UI/forms/source-toolbar/device-select-toolbar.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -19,12 +19,6 @@
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>22</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>16777215</width>
     <height>22</height>
    </size>
   </property>
@@ -61,12 +55,6 @@
        <height>22</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>22</height>
-      </size>
-     </property>
      <property name="text">
       <string notr="true">Device</string>
      </property>
@@ -89,12 +77,6 @@
        <height>22</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>22</height>
-      </size>
-     </property>
      <property name="currentText">
       <string notr="true"/>
      </property>
@@ -108,12 +90,6 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>22</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
        <height>22</height>
       </size>
      </property>

--- a/UI/forms/source-toolbar/game-capture-toolbar.ui
+++ b/UI/forms/source-toolbar/game-capture-toolbar.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -20,12 +20,6 @@
    <size>
     <width>0</width>
     <height>22</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>16777215</width>
-    <height>24</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -58,12 +52,6 @@
        <height>22</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>22</height>
-      </size>
-     </property>
      <property name="text">
       <string notr="true">Mode</string>
      </property>
@@ -77,12 +65,6 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>22</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
        <height>22</height>
       </size>
      </property>
@@ -105,12 +87,6 @@
        <height>22</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>22</height>
-      </size>
-     </property>
      <property name="text">
       <string notr="true">Window</string>
      </property>
@@ -130,12 +106,6 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>22</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
        <height>22</height>
       </size>
      </property>

--- a/UI/forms/source-toolbar/image-source-toolbar.ui
+++ b/UI/forms/source-toolbar/image-source-toolbar.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -19,12 +19,6 @@
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>22</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>16777215</width>
     <height>22</height>
    </size>
   </property>
@@ -58,12 +52,6 @@
        <height>22</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>22</height>
-      </size>
-     </property>
      <property name="text">
       <string notr="true">Image File</string>
      </property>
@@ -77,12 +65,6 @@
      <property name="minimumSize">
       <size>
        <width>100</width>
-       <height>22</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
        <height>22</height>
       </size>
      </property>
@@ -105,12 +87,6 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>22</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
        <height>22</height>
       </size>
      </property>

--- a/UI/forms/source-toolbar/media-controls.ui
+++ b/UI/forms/source-toolbar/media-controls.ui
@@ -77,6 +77,9 @@
      <property name="flat">
       <bool>true</bool>
      </property>
+     <property name="themeID2" stdset="0">
+      <string notr="true">contextBarButton</string>
+     </property>
     </widget>
    </item>
    <item>
@@ -131,6 +134,9 @@
      <property name="flat">
       <bool>true</bool>
      </property>
+     <property name="themeID2" stdset="0">
+      <string notr="true">contextBarButton</string>
+     </property>
     </widget>
    </item>
    <item>
@@ -169,6 +175,9 @@
      <property name="flat">
       <bool>true</bool>
      </property>
+     <property name="themeID2" stdset="0">
+      <string notr="true">contextBarButton</string>
+     </property>
     </widget>
    </item>
    <item>
@@ -206,6 +215,9 @@
      </property>
      <property name="flat">
       <bool>true</bool>
+     </property>
+     <property name="themeID2" stdset="0">
+      <string notr="true">contextBarButton</string>
      </property>
     </widget>
    </item>
@@ -337,9 +349,9 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="emptySpaceAgain">
+    <widget class="QFrame" name="emptySpaceAgain">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>

--- a/UI/forms/source-toolbar/media-controls.ui
+++ b/UI/forms/source-toolbar/media-controls.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -19,12 +19,6 @@
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>22</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>16777215</width>
     <height>22</height>
    </size>
   </property>
@@ -56,12 +50,6 @@
       </sizepolicy>
      </property>
      <property name="minimumSize">
-      <size>
-       <width>22</width>
-       <height>22</height>
-      </size>
-     </property>
-     <property name="maximumSize">
       <size>
        <width>22</width>
        <height>22</height>
@@ -121,12 +109,6 @@
        <height>22</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>22</width>
-       <height>22</height>
-      </size>
-     </property>
      <property name="toolTip">
       <string>ContextBar.MediaControls.PlaylistPrevious</string>
      </property>
@@ -160,12 +142,6 @@
       </sizepolicy>
      </property>
      <property name="minimumSize">
-      <size>
-       <width>22</width>
-       <height>22</height>
-      </size>
-     </property>
-     <property name="maximumSize">
       <size>
        <width>22</width>
        <height>22</height>
@@ -209,12 +185,6 @@
        <height>22</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>22</width>
-       <height>22</height>
-      </size>
-     </property>
      <property name="toolTip">
       <string>ContextBar.MediaControls.PlaylistNext</string>
      </property>
@@ -244,12 +214,6 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>22</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
        <height>22</height>
       </size>
      </property>
@@ -297,12 +261,6 @@
        <height>22</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>22</height>
-      </size>
-     </property>
      <property name="text">
       <string>--:--:--</string>
      </property>
@@ -338,12 +296,6 @@
        <height>22</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>22</height>
-      </size>
-     </property>
      <property name="text">
       <string>/</string>
      </property>
@@ -376,12 +328,6 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>22</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
        <height>22</height>
       </size>
      </property>

--- a/UI/forms/source-toolbar/text-source-toolbar.ui
+++ b/UI/forms/source-toolbar/text-source-toolbar.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -19,12 +19,6 @@
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>22</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>16777215</width>
     <height>22</height>
    </size>
   </property>
@@ -52,12 +46,6 @@
        <height>22</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>22</height>
-      </size>
-     </property>
      <property name="text">
       <string>Basic.PropertiesWindow.SelectFont</string>
      </property>
@@ -68,12 +56,6 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>22</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
        <height>22</height>
       </size>
      </property>
@@ -97,12 +79,6 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>22</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
        <height>22</height>
       </size>
      </property>


### PR DESCRIPTION
### Description
This is dependent on the fixes in #5133 

The Source Toolbar previously had a fixed height that made styling it difficult. It now takes up the minimum amount of space it needs, but can grow to accommodate larger buttons, padding, etc.

This is part of a larger pass I'll be making over the UI to make it behave better with qss

# Before
![T0q32Lcs09](https://user-images.githubusercontent.com/1554753/129516232-fc7efb0a-5853-4e61-a609-9b0e32ca5157.png)
Increased font size and/or padding on the toolbar widgets would cause them to get squished within the container widget

# After
![3E7B9Lwgyh](https://user-images.githubusercontent.com/1554753/129516628-08cc884f-bc98-41dd-86b4-09dfda950a76.png)
Existing themes still look (mostly*) the same as they used to

![2YQGktLQ6Z](https://user-images.githubusercontent.com/1554753/129516646-9434fa4e-53ae-4aa6-b002-cb2b612600f2.png)
Themes are now able to properly apply padding and size increases and the context bar will adjust to fit them

![Code_PNsvEzofMK](https://user-images.githubusercontent.com/1554753/129516683-5ab3e92b-dc51-41a8-a09a-dd9f062c9532.png)
Example of excessive padding set in qss


## *Side Effects
![obs64_2mwfgBUmy0](https://user-images.githubusercontent.com/1554753/129516766-bfc32ef5-b5ae-440b-85d1-bcc22fbb97f7.png)

The Properties, Filters and Interact buttons have `themeID2=contextBarButton` applied to them, which in Dark.qss applies a smaller horizontal padding. The media controls do not have this themeId, and so they currently get the default QPushButton padding in Dark.qss which is 20px

This is now fixed in 15c2081

### Motivation and Context
The UI should allow qss to control things like margin, padding and sizes without hard restrictions in place to force it into it's layouts.

### How Has This Been Tested?
Tested all existing themes and custom changes to the padding and size of the buttons in the context bar to ensure it resized but only as much as needed

### Types of changes
- Bug fix (non-breaking change which fixes an issue)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
