### PR TITLE
CI: Use manifest hash as Flatpak cache key

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           bundle: obs-studio-${{ steps.setup.outputs.commitHash }}.flatpak
           manifest-path: CI/flatpak/com.obsproject.Studio.json
-          cache-key: flatpak-builder-${{ github.sha }}
+          cache-key: flatpak-builder-${{ hashFiles('CI/flatpak/com.obsproject.Studio.json') }}
           mirror-screenshots-url: https://dl.flathub.org/repo/screenshots
           branch: ${{ matrix.branch }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -399,7 +399,7 @@ jobs:
         with:
           bundle: obs-studio-flatpak-${{ env.OBS_GIT_HASH }}.flatpak
           manifest-path: CI/flatpak/com.obsproject.Studio.json
-          cache-key: flatpak-builder-${{ github.sha }}
+          cache-key: flatpak-builder-${{ hashFiles('CI/flatpak/com.obsproject.Studio.json') }}
 
   windows_package:
     name: '03 - Windows Installer'


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

#### Better caching
The action repo recommends using the checksum of the manifest as cache key. The hash of the last commit is actually used.

<!-- I think the best is making a checksum of the dependencies part of the manifest. The cache apparently does not contain the build cache of the obs module so it really contains only dependencies.

```sh
cat CI/flatpak/com.obsproject.Studio.json \ # Print the manifest to use it with jq
| jq '. | {runtime, "runtime-version", sdk, modules} | del(.modules[] | select(.name == "obs")) | del(.modules[].cleanup)' \
| sha256sum \ # Make a sha256 sum with jq output
| cut -f1 -d' ' # Remove filename from sha256sum output
```
The `jq` command do this:
- Get `runtime`, `runtime-version`, `sdk` and `modules` JSON objects
- Remove the OBS module from `modules` since it's not a dependency
- Remove `cleanup` objects from `modules` since they do not affect dependencies but how the bundle is made

So only a change in those deps make the cache key change.-->

Note: This error `Error: Failed to save cache: ReserveCacheError: Unable to reserve cache with key flatpak-builder-7d9a9401dcf04743a57b8f438d60bc4a2e3767630734d301da849c9de8c14668, another job may be creating this cache.` will always appear because the cache with those deps already exist. **But it will not fail the job.**

<!--#### Cleanup PipeWire module
This module as no cleanup stage and let many unused file so I try to remove most of them.-->

<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
- Create a cache with a better key to reduce build time on flatpak CI.
<!--- Remove uneeded PipeWire files from the bundle.-->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- The command to generate the hash was tested in a terminal inside an OBS repo.
- After many forced push on a test PR on my repo, I confirm that the new cache key can speed up the CI compilation time since it only compile OBS except if the manifest is changed.
<!-- - Set PipeWire screen capture with the flatpak.-->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- CI improvements

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
