### PR TITLE
UI: Clean up other UI form file markup

### DIFF
--- a/UI/forms/AutoConfigStreamPage.ui
+++ b/UI/forms/AutoConfigStreamPage.ui
@@ -30,7 +30,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QWidget" name="widget">
+    <widget class="QFrame" name="widget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
        <horstretch>0</horstretch>
@@ -74,7 +74,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QWidget" name="serviceWidget">
+       <widget class="QFrame" name="serviceWidget">
         <layout class="QHBoxLayout" name="serviceWidgetLayout">
          <property name="leftMargin">
           <number>0</number>
@@ -286,7 +286,7 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QWidget" name="streamKeyWidget">
+        <widget class="QFrame" name="streamKeyWidget">
          <layout class="QHBoxLayout" name="horizontalLayout_4">
           <property name="leftMargin">
            <number>0</number>

--- a/UI/forms/OBSAbout.ui
+++ b/UI/forms/OBSAbout.ui
@@ -149,7 +149,7 @@
     </layout>
    </item>
    <item>
-    <widget class="QWidget" name="widget">
+    <widget class="QFrame" name="widget">
      <property name="minimumSize">
       <size>
        <width>0</width>

--- a/UI/forms/OBSBasicFilters.ui
+++ b/UI/forms/OBSBasicFilters.ui
@@ -15,19 +15,25 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,10">
      <property name="sizeConstraint">
       <enum>QLayout::SetMinimumSize</enum>
      </property>
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QWidget" name="asyncWidget">
+        <widget class="QFrame" name="asyncWidget">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>255</width>
+           <height>0</height>
+          </size>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_3">
           <property name="leftMargin">
@@ -62,8 +68,8 @@
             </property>
            </widget>
           </item>
-          <item alignment="Qt::AlignLeft">
-           <widget class="QWidget" name="widget">
+          <item>
+           <widget class="QFrame" name="widget">
             <layout class="QHBoxLayout" name="horizontalLayout_4">
              <property name="spacing">
               <number>4</number>
@@ -88,11 +94,14 @@
                  <height>22</height>
                 </size>
                </property>
+               <property name="accessibleName">
+                <string>Add</string>
+               </property>
                <property name="text">
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset resource="obs.qrc">
+                <iconset>
                  <normaloff>:/res/images/add.png</normaloff>:/res/images/add.png</iconset>
                </property>
                <property name="autoDefault">
@@ -104,9 +113,6 @@
                <property name="themeID" stdset="0">
                 <string>addIconSmall</string>
                </property>
-               <property name="accessibleName">
-                <string>Add</string>
-               </property>
               </widget>
              </item>
              <item>
@@ -117,11 +123,14 @@
                  <height>22</height>
                 </size>
                </property>
+               <property name="accessibleName">
+                <string>Remove</string>
+               </property>
                <property name="text">
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset resource="obs.qrc">
+                <iconset>
                  <normaloff>:/res/images/list_remove.png</normaloff>:/res/images/list_remove.png</iconset>
                </property>
                <property name="autoDefault">
@@ -133,9 +142,6 @@
                <property name="themeID" stdset="0">
                 <string>removeIconSmall</string>
                </property>
-               <property name="accessibleName">
-                <string>Remove</string>
-               </property>
               </widget>
              </item>
              <item>
@@ -146,11 +152,14 @@
                  <height>22</height>
                 </size>
                </property>
+               <property name="accessibleName">
+                <string>MoveUp</string>
+               </property>
                <property name="text">
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset resource="obs.qrc">
+                <iconset>
                  <normaloff>:/res/images/up.png</normaloff>:/res/images/up.png</iconset>
                </property>
                <property name="autoDefault">
@@ -162,9 +171,6 @@
                <property name="themeID" stdset="0">
                 <string>upArrowIconSmall</string>
                </property>
-               <property name="accessibleName">
-                <string>MoveUp</string>
-               </property>
               </widget>
              </item>
              <item>
@@ -175,11 +181,14 @@
                  <height>22</height>
                 </size>
                </property>
+               <property name="accessibleName">
+                <string>MoveDown</string>
+               </property>
                <property name="text">
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset resource="obs.qrc">
+                <iconset>
                  <normaloff>:/res/images/down.png</normaloff>:/res/images/down.png</iconset>
                </property>
                <property name="autoDefault">
@@ -191,10 +200,23 @@
                <property name="themeID" stdset="0">
                 <string>downArrowIconSmall</string>
                </property>
-               <property name="accessibleName">
-                <string>MoveDown</string>
-               </property>
               </widget>
+             </item>
+             <item>
+              <spacer name="asyncToolbarSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Expanding</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </spacer>
              </item>
             </layout>
            </widget>
@@ -210,12 +232,18 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="effectWidget">
+        <widget class="QFrame" name="effectWidget">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>255</width>
+           <height>0</height>
+          </size>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <property name="leftMargin">
@@ -250,8 +278,8 @@
             </property>
            </widget>
           </item>
-          <item alignment="Qt::AlignLeft">
-           <widget class="QWidget" name="widget_2">
+          <item>
+           <widget class="QFrame" name="widget_2">
             <layout class="QHBoxLayout" name="horizontalLayout_6">
              <property name="spacing">
               <number>4</number>
@@ -276,11 +304,14 @@
                  <height>22</height>
                 </size>
                </property>
+               <property name="accessibleName">
+                <string>Add</string>
+               </property>
                <property name="text">
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset resource="obs.qrc">
+                <iconset>
                  <normaloff>:/res/images/add.png</normaloff>:/res/images/add.png</iconset>
                </property>
                <property name="autoDefault">
@@ -292,9 +323,6 @@
                <property name="themeID" stdset="0">
                 <string>addIconSmall</string>
                </property>
-               <property name="accessibleName">
-                <string>Add</string>
-               </property>
               </widget>
              </item>
              <item>
@@ -305,11 +333,14 @@
                  <height>22</height>
                 </size>
                </property>
+               <property name="accessibleName">
+                <string>Remove</string>
+               </property>
                <property name="text">
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset resource="obs.qrc">
+                <iconset>
                  <normaloff>:/res/images/list_remove.png</normaloff>:/res/images/list_remove.png</iconset>
                </property>
                <property name="autoDefault">
@@ -321,9 +352,6 @@
                <property name="themeID" stdset="0">
                 <string>removeIconSmall</string>
                </property>
-               <property name="accessibleName">
-                <string>Remove</string>
-               </property>
               </widget>
              </item>
              <item>
@@ -334,11 +362,14 @@
                  <height>22</height>
                 </size>
                </property>
+               <property name="accessibleName">
+                <string>MoveUp</string>
+               </property>
                <property name="text">
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset resource="obs.qrc">
+                <iconset>
                  <normaloff>:/res/images/up.png</normaloff>:/res/images/up.png</iconset>
                </property>
                <property name="autoDefault">
@@ -350,9 +381,6 @@
                <property name="themeID" stdset="0">
                 <string>upArrowIconSmall</string>
                </property>
-               <property name="accessibleName">
-                <string>MoveUp</string>
-               </property>
               </widget>
              </item>
              <item>
@@ -363,11 +391,14 @@
                  <height>22</height>
                 </size>
                </property>
+               <property name="accessibleName">
+                <string>MoveDown</string>
+               </property>
                <property name="text">
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset resource="obs.qrc">
+                <iconset>
                  <normaloff>:/res/images/down.png</normaloff>:/res/images/down.png</iconset>
                </property>
                <property name="autoDefault">
@@ -379,10 +410,23 @@
                <property name="themeID" stdset="0">
                 <string>downArrowIconSmall</string>
                </property>
-               <property name="accessibleName">
-                <string>MoveDown</string>
-               </property>
               </widget>
+             </item>
+             <item>
+              <spacer name="effectToolbarSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Expanding</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </spacer>
              </item>
             </layout>
            </widget>
@@ -397,7 +441,7 @@
        <item>
         <layout class="QVBoxLayout" name="rightLayout">
          <item>
-          <widget class="OBSQTDisplay" name="preview">
+          <widget class="OBSQTDisplay" name="preview" native="true">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
@@ -438,7 +482,7 @@
          <item>
           <widget class="QDialogButtonBox" name="buttonBox">
            <property name="standardButtons">
-            <set>QDialogButtonBox::Reset|QDialogButtonBox::Close</set>
+            <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
            </property>
           </widget>
          </item>
@@ -451,7 +495,7 @@
   </layout>
   <action name="actionRemoveFilter">
    <property name="icon">
-    <iconset resource="obs.qrc">
+    <iconset>
      <normaloff>:/res/images/list_remove.png</normaloff>:/res/images/list_remove.png</iconset>
    </property>
    <property name="text">
@@ -463,7 +507,7 @@
   </action>
   <action name="actionMoveUp">
    <property name="icon">
-    <iconset resource="obs.qrc">
+    <iconset>
      <normaloff>:/res/images/up.png</normaloff>:/res/images/up.png</iconset>
    </property>
    <property name="text">
@@ -475,7 +519,7 @@
   </action>
   <action name="actionMoveDown">
    <property name="icon">
-    <iconset resource="obs.qrc">
+    <iconset>
      <normaloff>:/res/images/down.png</normaloff>:/res/images/down.png</iconset>
    </property>
    <property name="text">
@@ -502,6 +546,5 @@
  <resources>
   <include location="obs.qrc"/>
  </resources>
- <connections>
- </connections>
+ <connections/>
 </ui>

--- a/UI/forms/OBSBasicInteraction.ui
+++ b/UI/forms/OBSBasicInteraction.ui
@@ -18,7 +18,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="OBSQTDisplay" name="preview">
+    <widget class="OBSQTDisplay" name="preview" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -168,8 +168,8 @@
              <property name="bottomMargin">
               <number>9</number>
              </property>
-             <item alignment="Qt::AlignTop">
-              <widget class="QWidget" name="widget_2">
+             <item>
+              <widget class="QFrame" name="widget_2">
                <layout class="QVBoxLayout" name="verticalLayout_20">
                 <item>
                  <widget class="QGroupBox" name="groupBox_15">
@@ -799,7 +799,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QWidget" name="widget_5">
+          <widget class="QFrame" name="widget_5">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
              <horstretch>0</horstretch>
@@ -824,7 +824,7 @@
              </widget>
             </item>
             <item row="3" column="1">
-             <widget class="QWidget" name="serviceWidget">
+             <widget class="QFrame" name="serviceWidget">
               <layout class="QHBoxLayout" name="serviceWidgetLayout" stretch="0,0">
                <property name="leftMargin">
                 <number>0</number>
@@ -1052,7 +1052,7 @@
               </widget>
              </item>
              <item row="1" column="1">
-              <widget class="QWidget" name="streamKeyWidget">
+              <widget class="QFrame" name="streamKeyWidget">
                <layout class="QHBoxLayout" name="horizontalLayout_11">
                 <property name="leftMargin">
                  <number>0</number>
@@ -1196,7 +1196,7 @@
               </widget>
              </item>
              <item row="10" column="1">
-              <widget class="QWidget" name="authPwWidget">
+              <widget class="QFrame" name="authPwWidget">
                <layout class="QHBoxLayout" name="horizontalLayout_25">
                 <property name="leftMargin">
                  <number>0</number>
@@ -1365,8 +1365,8 @@
              <property name="bottomMargin">
               <number>9</number>
              </property>
-             <item alignment="Qt::AlignTop">
-              <widget class="QWidget" name="widget">
+             <item>
+              <widget class="QFrame" name="widget">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                  <horstretch>0</horstretch>
@@ -1882,8 +1882,8 @@
                    </property>
                   </spacer>
                  </item>
-                 <item alignment="Qt::AlignTop">
-                  <widget class="QWidget" name="simpleOutputContainer">
+                 <item>
+                  <widget class="QFrame" name="simpleOutputContainer">
                    <layout class="QVBoxLayout" name="verticalLayout_4">
                     <property name="leftMargin">
                      <number>0</number>
@@ -1941,8 +1941,8 @@
                      <property name="bottomMargin">
                       <number>9</number>
                      </property>
-                     <item alignment="Qt::AlignTop">
-                      <widget class="QWidget" name="widget_4">
+                     <item>
+                      <widget class="QFrame" name="widget_4">
                        <layout class="QVBoxLayout" name="verticalLayout_14">
                         <property name="spacing">
                          <number>0</number>
@@ -1960,7 +1960,7 @@
                          <number>0</number>
                         </property>
                         <item>
-                         <widget class="QWidget" name="advOutTopContainer">
+                         <widget class="QFrame" name="advOutTopContainer">
                           <property name="sizePolicy">
                            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
                             <horstretch>0</horstretch>
@@ -1991,7 +1991,7 @@
                             </widget>
                            </item>
                            <item row="1" column="1">
-                            <widget class="QWidget" name="widget_8">
+                            <widget class="QFrame" name="widget_8">
                              <property name="sizePolicy">
                               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                                <horstretch>0</horstretch>
@@ -2124,7 +2124,7 @@
                       <number>9</number>
                      </property>
                      <item>
-                      <widget class="QWidget" name="advOutRecTypeContainer">
+                      <widget class="QFrame" name="advOutRecTypeContainer">
                        <layout class="QFormLayout" name="formLayout_9">
                         <property name="fieldGrowthPolicy">
                          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -2194,7 +2194,7 @@
                           <number>0</number>
                          </property>
                          <item>
-                          <widget class="QWidget" name="advOutRecTopContainer">
+                          <widget class="QFrame" name="advOutRecTopContainer">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
                              <horstretch>0</horstretch>
@@ -2348,7 +2348,7 @@
                              </widget>
                             </item>
                             <item row="5" column="1">
-                             <widget class="QWidget" name="advOutRecRescaleContainer">
+                             <widget class="QFrame" name="advOutRecRescaleContainer">
                               <layout class="QHBoxLayout" name="horizontalLayout_4">
                                <property name="leftMargin">
                                 <number>0</number>
@@ -2518,8 +2518,8 @@
                            </layout>
                           </widget>
                          </item>
-                         <item alignment="Qt::AlignTop">
-                          <widget class="QWidget" name="widget_7">
+                         <item>
+                          <widget class="QFrame" name="widget_7">
                            <layout class="QVBoxLayout" name="verticalLayout_15">
                             <property name="leftMargin">
                              <number>0</number>
@@ -2873,7 +2873,7 @@
                           </widget>
                          </item>
                          <item row="13" column="1">
-                          <widget class="QWidget" name="widget_10">
+                          <widget class="QFrame" name="widget_10">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                              <horstretch>0</horstretch>
@@ -3010,8 +3010,8 @@
                      <property name="bottomMargin">
                       <number>0</number>
                      </property>
-                     <item alignment="Qt::AlignTop">
-                      <widget class="QWidget" name="widget_3">
+                     <item>
+                      <widget class="QFrame" name="widget_3">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                          <horstretch>0</horstretch>
@@ -3874,8 +3874,8 @@
              <property name="bottomMargin">
               <number>9</number>
              </property>
-             <item alignment="Qt::AlignTop">
-              <widget class="QWidget" name="widget_50">
+             <item>
+              <widget class="QFrame" name="widget_50">
                <layout class="QVBoxLayout" name="verticalLayout_51">
                 <item>
                  <widget class="QGroupBox" name="audioGeneralGroupBox">
@@ -4731,7 +4731,7 @@
               <number>9</number>
              </property>
              <item>
-              <widget class="QWidget" name="widget_11">
+              <widget class="QFrame" name="widget_11">
                <layout class="QVBoxLayout" name="verticalLayout_24">
                 <item>
                  <widget class="QGroupBox" name="advancedGeneralGroupBox">
@@ -5124,7 +5124,7 @@
                     </widget>
                    </item>
                    <item row="1" column="1">
-                    <widget class="QWidget" name="widget_12">
+                    <widget class="QFrame" name="widget_12">
                      <property name="enabled">
                       <bool>true</bool>
                      </property>

--- a/UI/forms/OBSBasicTransform.ui
+++ b/UI/forms/OBSBasicTransform.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>564</width>
-    <height>241</height>
+    <height>313</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Basic.TransformWindow</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,5,0">
    <item>
     <layout class="QFormLayout" name="formLayout">
      <property name="fieldGrowthPolicy">
@@ -36,10 +36,10 @@
          <height>0</height>
         </size>
        </property>
-       <property name="text">
+       <property name="accessibleName">
         <string>Basic.TransformWindow.Position</string>
        </property>
-       <property name="accessibleName">
+       <property name="text">
         <string>Basic.TransformWindow.Position</string>
        </property>
        <property name="alignment">
@@ -48,7 +48,7 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QWidget" name="widget">
+      <widget class="QFrame" name="widget">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -76,6 +76,9 @@
             <height>0</height>
            </size>
           </property>
+          <property name="accessibleName">
+           <string>Basic.TransformWindow.PositionX</string>
+          </property>
           <property name="decimals">
            <number>4</number>
           </property>
@@ -84,9 +87,6 @@
           </property>
           <property name="maximum">
            <double>90001.000000000000000</double>
-          </property>
-          <property name="accessibleName">
-           <string>Basic.TransformWindow.PositionX</string>
           </property>
          </widget>
         </item>
@@ -98,6 +98,9 @@
             <height>0</height>
            </size>
           </property>
+          <property name="accessibleName">
+           <string>Basic.TransformWindow.PositionY</string>
+          </property>
           <property name="decimals">
            <number>4</number>
           </property>
@@ -107,9 +110,6 @@
           <property name="maximum">
            <double>90001.000000000000000</double>
           </property>
-          <property name="accessibleName">
-           <string>Basic.TransformWindow.PositionY</string>
-          </property>
          </widget>
         </item>
        </layout>
@@ -117,10 +117,10 @@
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_2">
-       <property name="text">
+       <property name="accessibleName">
         <string>Basic.TransformWindow.Rotation</string>
        </property>
-       <property name="accessibleName">
+       <property name="text">
         <string>Basic.TransformWindow.Rotation</string>
        </property>
       </widget>
@@ -139,6 +139,9 @@
          <height>0</height>
         </size>
        </property>
+       <property name="accessibleName">
+        <string>Basic.TransformWindow.Rotation</string>
+       </property>
        <property name="minimum">
         <double>-360.000000000000000</double>
        </property>
@@ -148,23 +151,20 @@
        <property name="singleStep">
         <double>0.100000000000000</double>
        </property>
-       <property name="accessibleName">
-        <string>Basic.TransformWindow.Rotation</string>
-       </property>
       </widget>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_3">
-       <property name="text">
+       <property name="accessibleName">
         <string>Basic.TransformWindow.Size</string>
        </property>
-       <property name="accessibleName">
+       <property name="text">
         <string>Basic.TransformWindow.Size</string>
        </property>
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QWidget" name="widget_2">
+      <widget class="QFrame" name="widget_2">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -192,6 +192,9 @@
             <height>0</height>
            </size>
           </property>
+          <property name="accessibleName">
+           <string>Basic.TransformWindow.Width</string>
+          </property>
           <property name="decimals">
            <number>4</number>
           </property>
@@ -203,9 +206,6 @@
           </property>
           <property name="singleStep">
            <double>1.000000000000000</double>
-          </property>
-          <property name="accessibleName">
-           <string>Basic.TransformWindow.Width</string>
           </property>
          </widget>
         </item>
@@ -217,6 +217,9 @@
             <height>0</height>
            </size>
           </property>
+          <property name="accessibleName">
+           <string>Basic.TransformWindow.Height</string>
+          </property>
           <property name="decimals">
            <number>4</number>
           </property>
@@ -229,9 +232,6 @@
           <property name="singleStep">
            <double>1.000000000000000</double>
           </property>
-          <property name="accessibleName">
-           <string>Basic.TransformWindow.Height</string>
-          </property>
          </widget>
         </item>
        </layout>
@@ -239,21 +239,21 @@
      </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_4">
-       <property name="text">
+       <property name="accessibleName">
         <string>Basic.TransformWindow.Alignment</string>
        </property>
-       <property name="accessibleName">
+       <property name="text">
         <string>Basic.TransformWindow.Alignment</string>
        </property>
       </widget>
      </item>
      <item row="3" column="1">
       <widget class="QComboBox" name="align">
-       <property name="currentText">
-        <string>Basic.TransformWindow.Alignment.TopLeft</string>
-       </property>
        <property name="accessibleName">
         <string>Basic.TransformWindow.Alignment</string>
+       </property>
+       <property name="currentText">
+        <string>Basic.TransformWindow.Alignment.TopLeft</string>
        </property>
        <item>
         <property name="text">
@@ -317,10 +317,10 @@
      </item>
      <item row="5" column="0">
       <widget class="QLabel" name="label_5">
-       <property name="text">
+       <property name="accessibleName">
         <string>Basic.TransformWindow.BoundsType</string>
        </property>
-       <property name="accessibleName">
+       <property name="text">
         <string>Basic.TransformWindow.BoundsType</string>
        </property>
       </widget>
@@ -369,10 +369,10 @@
      </item>
      <item row="6" column="0">
       <widget class="QLabel" name="label_6">
-       <property name="text">
+       <property name="accessibleName">
         <string>Basic.TransformWindow.BoundsAlignment</string>
        </property>
-       <property name="accessibleName">
+       <property name="text">
         <string>Basic.TransformWindow.BoundsAlignment</string>
        </property>
       </widget>
@@ -382,11 +382,11 @@
        <property name="enabled">
         <bool>false</bool>
        </property>
-       <property name="currentText">
-        <string>Basic.TransformWindow.Alignment.TopLeft</string>
-       </property>
        <property name="accessibleName">
         <string>Basic.TransformWindow.BoundsAlignment</string>
+       </property>
+       <property name="currentText">
+        <string>Basic.TransformWindow.Alignment.TopLeft</string>
        </property>
        <item>
         <property name="text">
@@ -437,16 +437,16 @@
      </item>
      <item row="7" column="0">
       <widget class="QLabel" name="label_7">
-       <property name="text">
+       <property name="accessibleName">
         <string>Basic.TransformWindow.Bounds</string>
        </property>
-       <property name="accessibleName">
+       <property name="text">
         <string>Basic.TransformWindow.Bounds</string>
        </property>
       </widget>
      </item>
      <item row="7" column="1">
-      <widget class="QWidget" name="widget_3">
+      <widget class="QFrame" name="widget_3">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -477,6 +477,9 @@
             <height>0</height>
            </size>
           </property>
+          <property name="accessibleName">
+           <string>Basic.TransformWindow.BoundsWidth</string>
+          </property>
           <property name="decimals">
            <number>4</number>
           </property>
@@ -485,9 +488,6 @@
           </property>
           <property name="maximum">
            <double>90001.000000000000000</double>
-          </property>
-          <property name="accessibleName">
-           <string>Basic.TransformWindow.BoundsWidth</string>
           </property>
          </widget>
         </item>
@@ -502,6 +502,9 @@
             <height>0</height>
            </size>
           </property>
+          <property name="accessibleName">
+           <string>Basic.TransformWindow.BoundsHeight</string>
+          </property>
           <property name="decimals">
            <number>4</number>
           </property>
@@ -510,9 +513,6 @@
           </property>
           <property name="maximum">
            <double>90001.000000000000000</double>
-          </property>
-          <property name="accessibleName">
-           <string>Basic.TransformWindow.BoundsHeight</string>
           </property>
          </widget>
         </item>
@@ -534,10 +534,10 @@
      </item>
      <item row="9" column="0">
       <widget class="QLabel" name="label_8">
-       <property name="text">
+       <property name="accessibleName">
         <string>Basic.TransformWindow.Crop</string>
        </property>
-       <property name="accessibleName">
+       <property name="text">
         <string>Basic.TransformWindow.Crop</string>
        </property>
       </widget>
@@ -558,11 +558,11 @@
            <height>0</height>
           </size>
          </property>
-         <property name="maximum">
-          <number>100000</number>
-         </property>
          <property name="accessibleName">
           <string>Basic.TransformWindow.CropLeft</string>
+         </property>
+         <property name="maximum">
+          <number>100000</number>
          </property>
         </widget>
        </item>
@@ -580,11 +580,11 @@
            <height>0</height>
           </size>
          </property>
-         <property name="maximum">
-          <number>100000</number>
-         </property>
          <property name="accessibleName">
           <string>Basic.TransformWindow.CropRight</string>
+         </property>
+         <property name="maximum">
+          <number>100000</number>
          </property>
         </widget>
        </item>
@@ -628,11 +628,11 @@
            <height>0</height>
           </size>
          </property>
-         <property name="maximum">
-          <number>100000</number>
-         </property>
          <property name="accessibleName">
           <string>Basic.TransformWindow.CropTop</string>
+         </property>
+         <property name="maximum">
+          <number>100000</number>
          </property>
         </widget>
        </item>
@@ -650,11 +650,11 @@
            <height>0</height>
           </size>
          </property>
-         <property name="maximum">
-          <number>100000</number>
-         </property>
          <property name="accessibleName">
           <string>Basic.TransformWindow.CropBottom</string>
+         </property>
+         <property name="maximum">
+          <number>100000</number>
          </property>
         </widget>
        </item>
@@ -702,9 +702,22 @@
     </layout>
    </item>
    <item>
+    <spacer name="transformSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Reset|QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
      </property>
     </widget>
    </item>
@@ -717,6 +730,16 @@
    <signal>rejected()</signal>
    <receiver>OBSBasicTransform</receiver>
    <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
  </connections>
 </ui>

--- a/UI/forms/OBSExtraBrowsers.ui
+++ b/UI/forms/OBSExtraBrowsers.ui
@@ -29,10 +29,10 @@
      <property name="selectionMode">
       <enum>QAbstractItemView::NoSelection</enum>
      </property>
-     <attribute name="horizontalHeaderDefaultSectionSize">
+     <attribute name="horizontalHeaderMinimumSectionSize">
       <number>23</number>
      </attribute>
-     <attribute name="horizontalHeaderMinimumSectionSize">
+     <attribute name="horizontalHeaderDefaultSectionSize">
       <number>23</number>
      </attribute>
      <attribute name="verticalHeaderVisible">

--- a/UI/forms/OBSImporter.ui
+++ b/UI/forms/OBSImporter.ui
@@ -29,7 +29,7 @@
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="standardButtons">
-        <set>QDialogButtonBox::Close|QDialogButtonBox::Open|QDialogButtonBox::Ok</set>
+        <set>QDialogButtonBox::Close|QDialogButtonBox::Ok|QDialogButtonBox::Open</set>
        </property>
       </widget>
      </item>
@@ -40,10 +40,10 @@
      <property name="selectionMode">
       <enum>QAbstractItemView::NoSelection</enum>
      </property>
-     <attribute name="horizontalHeaderDefaultSectionSize">
+     <attribute name="horizontalHeaderMinimumSectionSize">
       <number>23</number>
      </attribute>
-     <attribute name="horizontalHeaderMinimumSectionSize">
+     <attribute name="horizontalHeaderDefaultSectionSize">
       <number>23</number>
      </attribute>
      <attribute name="verticalHeaderVisible">

--- a/UI/forms/OBSMissingFiles.ui
+++ b/UI/forms/OBSMissingFiles.ui
@@ -20,6 +20,7 @@
       <widget class="QLabel" name="warningIcon">
        <property name="minimumSize">
         <size>
+         <width>0</width>
          <height>20</height>
         </size>
        </property>
@@ -45,10 +46,10 @@
      <property name="selectionMode">
       <enum>QAbstractItemView::NoSelection</enum>
      </property>
-     <attribute name="horizontalHeaderDefaultSectionSize">
+     <attribute name="horizontalHeaderMinimumSectionSize">
       <number>23</number>
      </attribute>
-     <attribute name="horizontalHeaderMinimumSectionSize">
+     <attribute name="horizontalHeaderDefaultSectionSize">
       <number>23</number>
      </attribute>
      <attribute name="verticalHeaderVisible">
@@ -108,8 +109,8 @@
          </item>
         </layout>
        </item>
-       </layout>
-      </item>
+      </layout>
+     </item>
     </layout>
    </item>
   </layout>

--- a/UI/forms/OBSRemux.ui
+++ b/UI/forms/OBSRemux.ui
@@ -40,10 +40,10 @@
      <property name="selectionMode">
       <enum>QAbstractItemView::NoSelection</enum>
      </property>
-     <attribute name="horizontalHeaderDefaultSectionSize">
+     <attribute name="horizontalHeaderMinimumSectionSize">
       <number>23</number>
      </attribute>
-     <attribute name="horizontalHeaderMinimumSectionSize">
+     <attribute name="horizontalHeaderDefaultSectionSize">
       <number>23</number>
      </attribute>
      <attribute name="verticalHeaderVisible">

--- a/UI/forms/OBSUpdate.ui
+++ b/UI/forms/OBSUpdate.ui
@@ -34,7 +34,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="openExternalLinks">
-        <bool>true</bool>
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/UI/forms/source-toolbar/game-capture-toolbar.ui
+++ b/UI/forms/source-toolbar/game-capture-toolbar.ui
@@ -148,7 +148,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="empty">
+    <widget class="QFrame" name="empty">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>

--- a/UI/forms/source-toolbar/text-source-toolbar.ui
+++ b/UI/forms/source-toolbar/text-source-toolbar.ui
@@ -83,7 +83,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="emptySpace">
+    <widget class="QFrame" name="emptySpace">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>


### PR DESCRIPTION
### Description
This applies similar fixes to those in #5133 to the rest of the UI forms

After #5133 and this PR are merged, all UI forms in the project should now open in Qt Creator/Designer and resave without any entries being shuffled around or clobbered

Before this change, the changed QWidgets in the form files are not properly shown in Qt Creator, only their associated layouts are displayed and their QWidget properties are not accessible or shown. These widgets will also get completely removed upon saving.

After these changes, the items are properly listed in the Qt Creator hierarchy.

### Motivation and Context
Qt Creator/Designer is the primary method for building UI forms and all our form files should open and save without creating unnecessary history changes

### How Has This Been Tested?
All forms have been compared against v27.0.1 to ensure they still get laid out the same at various sizes

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
