### PR TITLE
UI: Show name of scene item in Transform window title

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -615,6 +615,9 @@ Basic.TransformWindow.BoundsType.ScaleToWidth="Scale to width of bounds"
 Basic.TransformWindow.BoundsType.ScaleToHeight="Scale to height of bounds"
 Basic.TransformWindow.BoundsType.Stretch="Stretch to bounds"
 
+Basic.TransformWindow.Title="Edit Transform for '%1'"
+Basic.TransformWindow.NoSelectedSource="No source selected"
+
 # no scene warning
 Basic.Main.AddSourceHelp.Title="Cannot Add Source"
 Basic.Main.AddSourceHelp.Text="You need to have at least 1 scene to add a source."

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -73,6 +73,9 @@ OBSBasicTransform::OBSBasicTransform(OBSBasic *parent)
 	SetScene(scene);
 	SetItem(item);
 
+	std::string name = obs_source_get_name(obs_sceneitem_get_source(item));
+	setWindowTitle(QTStr("Basic.TransformWindow.Title").arg(name.c_str()));
+
 	obs_data_t *wrapper =
 		obs_scene_save_transform_states(main->GetCurrentScene(), false);
 	undo_data = std::string(obs_data_get_json(wrapper));
@@ -204,8 +207,11 @@ void OBSBasicTransform::OBSSceneItemDeselect(void *param, calldata_t *data)
 	OBSScene scene = (obs_scene_t *)calldata_ptr(data, "scene");
 	OBSSceneItem item = (obs_sceneitem_t *)calldata_ptr(data, "item");
 
-	if (item == window->item)
+	if (item == window->item) {
+		window->setWindowTitle(
+			QTStr("Basic.TransformWindow.NoSelectedSource"));
 		window->SetItem(FindASelectedItem(scene));
+	}
 }
 
 static const uint32_t listToAlign[] = {OBS_ALIGN_TOP | OBS_ALIGN_LEFT,
@@ -266,6 +272,9 @@ void OBSBasicTransform::RefreshControls()
 	ui->cropTop->setValue(int(crop.top));
 	ui->cropBottom->setValue(int(crop.bottom));
 	ignoreItemChange = false;
+
+	std::string name = obs_source_get_name(source);
+	setWindowTitle(QTStr("Basic.TransformWindow.Title").arg(name.c_str()));
 }
 
 void OBSBasicTransform::OnBoundsType(int index)


### PR DESCRIPTION
### Description
This updates the Edit Transform window title to include the name of the scene item being edited.

# Before
![image](https://user-images.githubusercontent.com/1554753/129721705-a44cb939-48ea-4a94-85f8-202f752fb3c7.png)

# After
![image](https://user-images.githubusercontent.com/1554753/129722121-5ac499bf-82ec-4df9-a8c8-fda709b4c4cf.png)


### Motivation and Context
Consistency with the Properties and Filters windows.

This is also a helpful stopgap until someone can make other UX improvements to the Edit Transform window with how it handles multiple selected sources.

### How Has This Been Tested?
Ensured the window title updates correctly when switching sources, deselecting sources, and selecting multiple sources.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
