### PR TITLE
UI: Cleanup advanced audio functions

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4750,19 +4750,6 @@ void OBSBasic::on_actionAdvAudioProperties_triggered()
 	advAudioWindow->show();
 	advAudioWindow->setAttribute(Qt::WA_DeleteOnClose, true);
 	advAudioWindow->SetIconsVisible(iconsVisible);
-
-	connect(advAudioWindow, SIGNAL(destroyed()), this,
-		SLOT(AdvAudioPropsDestroyed()));
-}
-
-void OBSBasic::AdvAudioPropsClicked()
-{
-	on_actionAdvAudioProperties_triggered();
-}
-
-void OBSBasic::AdvAudioPropsDestroyed()
-{
-	advAudioWindow = nullptr;
 }
 
 void OBSBasic::on_scenes_currentItemChanged(QListWidgetItem *current,

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -911,8 +911,6 @@ private slots:
 	void on_action_Settings_triggered();
 	void on_actionShowMissingFiles_triggered();
 	void on_actionAdvAudioProperties_triggered();
-	void AdvAudioPropsClicked();
-	void AdvAudioPropsDestroyed();
 	void on_actionShowLogs_triggered();
 	void on_actionUploadCurrentLog_triggered();
 	void on_actionUploadLastLog_triggered();


### PR DESCRIPTION
### Description
This removes the AdvAudioPropsClicked and AdvAudioPropsDestroyed
functions. The click function was not being used anywhere and the
destroy function was redundant because the dialog is set
to be deleted on close.

### Motivation and Context
Makes code cleaner.

### How Has This Been Tested?
Tested the advanced audio dialog to make sure everything still worked.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
