### PR TITLE
UI: Fix redo recreating sources in the wrong scene

### DIFF
--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -269,6 +269,11 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 		obs_data_set_bool(wrapper, "visible", visible);
 
 		auto redo = [scene_name, main](const std::string &data) {
+			obs_source_t *scene_source =
+				obs_get_source_by_name(scene_name.c_str());
+			main->SetCurrentScene(scene_source, true);
+			obs_source_release(scene_source);
+
 			obs_data_t *dat =
 				obs_data_create_from_json(data.c_str());
 			OBSSource source;
@@ -279,11 +284,6 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 				main->GetCurrentScene(), source);
 			obs_sceneitem_set_id(item, (int64_t)obs_data_get_int(
 							   dat, "item_id"));
-
-			obs_source_t *scene_source =
-				obs_get_source_by_name(scene_name.c_str());
-			main->SetCurrentScene(scene_source, true);
-			obs_source_release(scene_source);
 
 			main->RefreshSources(main->GetCurrentScene());
 			obs_data_release(dat);


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes an issue where if creating a new source was re-done from a
different scene, the source would be created first in that scene and
then OBS would switch to the scene where the source originally was
created.
Changes the order of these two operations, which makes OBS create the
source in the correct scene.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed this bug while doing another PR.

To reproduce (100% reproducible on every try):
- Have any scene collection with at least 2 scenes
- Create a new source - when prompted with the properties dialog, either press cancel, or change properties and press OK, but keep in mind you'll create 2 undo/redo actions
- Undo
- If you previously pressed "OK" instead of "Cancel", Undo again
- Switch to a different scene
- Redo

You will get thrown back into the scene where you created the source, but it won't be there.
Instead, switch back to the you did the Redo in and notice the source.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0 beta 5, compiled and run.

The source will now get recreated in the scene it got created in originally.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
