### PR TITLE
UI: Fetch YouTube channel information in separate thread

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -3744,6 +3744,12 @@ void OBSBasicSettings::closeEvent(QCloseEvent *event)
 {
 	if (!AskIfCanCloseSettings())
 		event->ignore();
+#if YOUTUBE_ENABLED
+	if (fetchInfoThread) {
+		fetchInfoThread->terminate();
+		fetchInfoThread->wait();
+	}
+#endif
 }
 
 void OBSBasicSettings::reject()

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -29,6 +29,7 @@
 #include <obs.hpp>
 
 #include "auth-base.hpp"
+#include "ui-config.h"
 
 class OBSBasic;
 class QAbstractButton;
@@ -250,6 +251,12 @@ private:
 	QString lastService;
 	int prevLangIndex;
 	bool prevBrowserAccel;
+#if YOUTUBE_ENABLED
+	void FetchUserInfo();
+	void FetchUserInfoFinished();
+	QScopedPointer<QThread> fetchInfoThread;
+	QString fetchInfoResult;
+#endif
 private slots:
 	void UpdateServerList();
 	void UpdateKeyLink();


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Make fetching user information actually not block the UI.

Since on_service_currentIndexChanged() gets called twice for some reason every time the settings dialog is opened this would previously send not one but two blocking web requests, one of which would be redundant since they fetch the same data.

### Motivation and Context
Using a thread is a good idea if you don't want to block the UI, but then immediately blocking the UI by using `wait()` completely defeats its purpose.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiles and runs.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
