### PR TITLE
Add info (text label) property as text sub-type in properties API

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -310,6 +310,50 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
 		connect(edit, SIGNAL(textEdited(const QString &)), info,
 			SLOT(ControlChanged()));
 		return nullptr;
+	} else if (type == OBS_TEXT_INFO) {
+		QString desc = QT_UTF8(obs_property_description(prop));
+		const char *long_desc = obs_property_long_description(prop);
+		obs_text_info_type info_type =
+			obs_property_text_info_type(prop);
+
+		QLabel *info_label = new QLabel(QT_UTF8(val));
+
+		if (info_label->text().isEmpty() && long_desc == NULL) {
+			label = nullptr;
+			info_label->setText(desc);
+		} else
+			label = new QLabel(desc);
+
+		if (long_desc != NULL && !info_label->text().isEmpty()) {
+			QString file = !App()->IsThemeDark()
+					       ? ":/res/images/help.svg"
+					       : ":/res/images/help_light.svg";
+			QString lStr = "<html>%1 <img src='%2' style=' \
+				vertical-align: bottom; ' /></html>";
+
+			info_label->setText(lStr.arg(info_label->text(), file));
+			info_label->setToolTip(QT_UTF8(long_desc));
+		} else if (long_desc != NULL) {
+			info_label->setText(QT_UTF8(long_desc));
+		}
+
+		info_label->setOpenExternalLinks(true);
+		info_label->setWordWrap(obs_property_text_info_word_wrap(prop));
+
+		if (info_type == OBS_TEXT_INFO_WARNING)
+			info_label->setObjectName("warningLabel");
+		else if (info_type == OBS_TEXT_INFO_ERROR)
+			info_label->setObjectName("errorLabel");
+
+		if (label)
+			label->setObjectName(info_label->objectName());
+
+		WidgetInfo *info = new WidgetInfo(this, prop, info_label);
+		children.emplace_back(info);
+
+		layout->addRow(label, info_label);
+
+		return nullptr;
 	}
 
 	QLineEdit *edit = new QLineEdit();

--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -144,8 +144,16 @@ Property Object Functions
                           - **OBS_TEXT_DEFAULT** - Single line of text
                           - **OBS_TEXT_PASSWORD** - Single line of text (passworded)
                           - **OBS_TEXT_MULTILINE** - Multi-line text
+                          - **OBS_TEXT_INFO** - Read-only informative text, behaves differently
+                            depending on wether description, string value and long description
+                            are set
 
    :return:               The property
+
+   Important Related Functions:
+
+   - :c:func:`obs_property_text_set_info_type`
+   - :c:func:`obs_property_text_set_info_word_wrap`
 
 ---------------------
 
@@ -437,6 +445,20 @@ Property Enumeration Functions
 
 ---------------------
 
+.. function:: enum obs_text_info_type     obs_property_text_info_type(obs_property_t *p)
+
+   :return: One of the following values:
+
+             - OBS_TEXT_INFO_NORMAL
+             - OBS_TEXT_INFO_WARNING
+             - OBS_TEXT_INFO_ERROR
+
+---------------------
+
+.. function:: bool     obs_property_text_info_word_wrap(obs_property_t *p)
+
+---------------------
+
 .. function:: enum obs_path_type     obs_property_path_type(obs_property_t *p)
 
 ---------------------
@@ -600,6 +622,20 @@ Property Modification Functions
 ---------------------
 
 .. function:: void obs_property_float_set_limits(obs_property_t *p, double min, double max, double step)
+
+---------------------
+
+.. function:: void     obs_property_text_set_info_type(obs_property_t *p, enum obs_text_info_type type)
+
+   :param   type: Can be one of the following values:
+
+                  - **OBS_TEXT_INFO_NORMAL** - To show a basic message
+                  - **OBS_TEXT_INFO_WARNING** - To show a warning
+                  - **OBS_TEXT_INFO_ERROR** - To show an error
+
+---------------------
+
+.. function:: void     obs_property_text_set_info_word_wrap(obs_property_t *p, bool word_wrap)
 
 ---------------------
 

--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -56,6 +56,8 @@ struct path_data {
 struct text_data {
 	enum obs_text_type type;
 	bool monospace;
+	enum obs_text_info_type info_type;
+	bool info_word_wrap;
 };
 
 struct list_data {
@@ -600,6 +602,8 @@ obs_property_t *obs_properties_add_text(obs_properties_t *props,
 	struct obs_property *p = new_prop(props, name, desc, OBS_PROPERTY_TEXT);
 	struct text_data *data = get_property_data(p);
 	data->type = type;
+	data->info_type = OBS_TEXT_INFO_NORMAL;
+	data->info_word_wrap = true;
 	return p;
 }
 
@@ -1022,6 +1026,18 @@ bool obs_property_text_monospace(obs_property_t *p)
 	return data ? data->monospace : false;
 }
 
+enum obs_text_info_type obs_property_text_info_type(obs_property_t *p)
+{
+	struct text_data *data = get_type_data(p, OBS_PROPERTY_TEXT);
+	return data ? data->info_type : OBS_TEXT_INFO_NORMAL;
+}
+
+bool obs_property_text_info_word_wrap(obs_property_t *p)
+{
+	struct text_data *data = get_type_data(p, OBS_PROPERTY_TEXT);
+	return data ? data->info_word_wrap : true;
+}
+
 enum obs_path_type obs_property_path_type(obs_property_t *p)
 {
 	struct path_data *data = get_type_data(p, OBS_PROPERTY_PATH);
@@ -1102,6 +1118,25 @@ void obs_property_text_set_monospace(obs_property_t *p, bool monospace)
 		return;
 
 	data->monospace = monospace;
+}
+
+void obs_property_text_set_info_type(obs_property_t *p,
+				     enum obs_text_info_type type)
+{
+	struct text_data *data = get_type_data(p, OBS_PROPERTY_TEXT);
+	if (!data)
+		return;
+
+	data->info_type = type;
+}
+
+void obs_property_text_set_info_word_wrap(obs_property_t *p, bool word_wrap)
+{
+	struct text_data *data = get_type_data(p, OBS_PROPERTY_TEXT);
+	if (!data)
+		return;
+
+	data->info_word_wrap = word_wrap;
 }
 
 void obs_property_button_set_type(obs_property_t *p, enum obs_button_type type)

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -88,6 +88,13 @@ enum obs_text_type {
 	OBS_TEXT_DEFAULT,
 	OBS_TEXT_PASSWORD,
 	OBS_TEXT_MULTILINE,
+	OBS_TEXT_INFO,
+};
+
+enum obs_text_info_type {
+	OBS_TEXT_INFO_NORMAL,
+	OBS_TEXT_INFO_WARNING,
+	OBS_TEXT_INFO_ERROR,
 };
 
 enum obs_number_type {
@@ -324,6 +331,8 @@ EXPORT enum obs_number_type obs_property_float_type(obs_property_t *p);
 EXPORT const char *obs_property_float_suffix(obs_property_t *p);
 EXPORT enum obs_text_type obs_property_text_type(obs_property_t *p);
 EXPORT bool obs_property_text_monospace(obs_property_t *p);
+EXPORT enum obs_text_info_type obs_property_text_info_type(obs_property_t *p);
+EXPORT bool obs_property_text_info_word_wrap(obs_property_t *p);
 EXPORT enum obs_path_type obs_property_path_type(obs_property_t *p);
 EXPORT const char *obs_property_path_filter(obs_property_t *p);
 EXPORT const char *obs_property_path_default_path(obs_property_t *p);
@@ -338,6 +347,10 @@ EXPORT void obs_property_int_set_suffix(obs_property_t *p, const char *suffix);
 EXPORT void obs_property_float_set_suffix(obs_property_t *p,
 					  const char *suffix);
 EXPORT void obs_property_text_set_monospace(obs_property_t *p, bool monospace);
+EXPORT void obs_property_text_set_info_type(obs_property_t *p,
+					    enum obs_text_info_type type);
+EXPORT void obs_property_text_set_info_word_wrap(obs_property_t *p,
+						 bool word_wrap);
 
 EXPORT void obs_property_button_set_type(obs_property_t *p,
 					 enum obs_button_type type);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
It adds a property which adds a text label to the properties view. This label can be a simple info, a warning or an error.

This new type of property is a sub-type of text property.

On UI side, Rich Text, clickable links and word wrap are enabled.
Depending on if the description, the string value and the long description are set, the property will be shown differently.

<!--- If this change includes UI elements, please include screenshots. -->
<!-- ![OBS-Info-prop](https://user-images.githubusercontent.com/17492366/130086427-6279d97d-d48e-4ea2-9759-34d2ecd0163c.png)
![OBS-Info-prop-plus](https://user-images.githubusercontent.com/17492366/130120675-d2a585b1-f0d5-4003-8359-e5d94ac379d6.png) -->
![Add_text_info_examples](https://user-images.githubusercontent.com/17492366/149313664-42171c79-7f0c-43b2-81bd-a9aea0edc0de.png)
Forgot a "with" in a string value.

My screenshot tool does not let the cursor appear.
![Add_text_info_examples_tooltip](https://user-images.githubusercontent.com/17492366/149315222-e5b3b029-4bac-4075-aa4c-99726f1e880f.png)

- A text info with only a description will only show the the info without the label in the first column.
- A text info with a description and a string value or a long description will fill the first column with the description and the second with the string value or the long description.
  - If an empty description is set, the first column will be empty.
 - If the three strings are provided, the long description become a tooltip.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
A while ago, someone asked on Discord for a property in the properties API which just only add a text label.

I had something from my service overhaul draft 😅  but it needed a revision, and I did it today.

@paulh-aja suggested to make my `add_info` a sub-type of `add_text`, so I also made the change.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I added the property in FFmpeg VAAPI properties function and set some defaults value to the default function to test it on Linux any property view would work.
Default:
```C
obs_data_set_default_string(settings, "test_value", "This a string value with an empty description");
obs_data_set_default_string(settings, "test_value2", "This a string value a description");
obs_data_set_default_string( settings, "test_tooltip", "This a string value with a description and a long description");
```
Properties:
```C
p = obs_properties_add_text(props, "test_normal", "Placeholder desc", OBS_TEXT_INFO);
obs_property_set_long_description(p, "This is a simple normal info label created with properties API,<br> we seriously need to really test Qt rich text");
p = obs_properties_add_text(props, "test_warning", NULL, OBS_TEXT_INFO);
obs_property_text_set_info_type(p, OBS_TEXT_INFO_WARNING);
obs_property_set_long_description(p, "This is a simple warning info label created with properties API");
p = obs_properties_add_text(props, "test_error", "ERROR", OBS_TEXT_INFO);
obs_property_text_set_info_type(p, OBS_TEXT_INFO_ERROR);
obs_property_set_long_description(p, "This is a simple error info label created with properties API, we seriously need to really test word wrapping");

p = obs_properties_add_text(props, "test_desc_only", "This is a info label created with only a description", OBS_TEXT_INFO);
//obs_property_text_set_info_word_wrap(p, false);

obs_properties_add_text(props, "test_value", NULL, OBS_TEXT_INFO);
obs_properties_add_text(props, "test_value2", "Description", OBS_TEXT_INFO);

p = obs_properties_add_text(props, "test_tooltip", "Test tooltip description", OBS_TEXT_INFO);
obs_property_set_long_description(p, "This is a tooltip");
```
Sometimes, word wrap do strange things, disabling it on the property can fix it.
```C
obs_property_text_set_info_word_wrap(p, false); // on "test_desc_only" property
```
![Add_text_info_examples2](https://user-images.githubusercontent.com/17492366/149313796-4295be1f-87c4-4fab-8797-fed77aac0534.png)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
  - Except if you want me to separate it into various commits
- [x] I have included updates to all appropriate documentation.
