### PR TITLE
frontend: Apply process mitigation policies for Windows

### DIFF
--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -781,6 +781,42 @@ static void load_debug_privilege(void)
 
 	CloseHandle(token);
 }
+
+static void set_process_mitigations(void)
+{
+	// SetProcessMitigationPolicy is Windows 8+
+	typedef BOOL(WINAPI * PFN_SetProcessMitigationPolicy)(PROCESS_MITIGATION_POLICY, PVOID, SIZE_T);
+	PFN_SetProcessMitigationPolicy pSetProcessMitigationPolicy;
+
+	pSetProcessMitigationPolicy = (PFN_SetProcessMitigationPolicy)GetProcAddress(GetModuleHandle(L"KERNEL32"),
+										     "SetProcessMitigationPolicy");
+
+	if (pSetProcessMitigationPolicy) {
+		PROCESS_MITIGATION_DEP_POLICY dep = {0};
+		dep.DisableAtlThunkEmulation = 1;
+		dep.Enable = 1;
+		dep.Permanent = TRUE;
+		pSetProcessMitigationPolicy(ProcessDEPPolicy, &dep, sizeof(dep));
+
+		PROCESS_MITIGATION_ASLR_POLICY aslr = {0};
+		aslr.EnableBottomUpRandomization = 1;
+		aslr.EnableHighEntropy = 1;
+		aslr.EnableForceRelocateImages = 1;
+		aslr.DisallowStrippedImages = 1;
+		pSetProcessMitigationPolicy(ProcessASLRPolicy, &aslr, sizeof(aslr));
+
+		PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY xpoints = {0};
+		xpoints.DisableExtensionPoints = 1;
+		pSetProcessMitigationPolicy(ProcessExtensionPointDisablePolicy, &xpoints, sizeof(xpoints));
+
+#ifdef _DEBUG
+		PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY hcheck = {0};
+		hcheck.RaiseExceptionOnInvalidHandleReference = 1;
+		hcheck.HandleExceptionsPermanentlyEnabled = 1;
+		pSetProcessMitigationPolicy(ProcessStrictHandleCheckPolicy, &hcheck, sizeof(hcheck));
+#endif
+	}
+}
 #endif
 
 static inline bool arg_is(const char *arg, const char *long_form, const char *short_form)
@@ -872,6 +908,7 @@ int main(int argc, char *argv[])
 	SetErrorMode(SEM_FAILCRITICALERRORS);
 	load_debug_privilege();
 	base_set_crash_handler(main_crash_handler, nullptr);
+	set_process_mitigations();
 
 	/* Shutdown priority value is a range from 0 - 4FF with higher values getting first priority.
 	 * 000 - 0FF and 400 - 4FF are reserved system ranges.


### PR DESCRIPTION
### Description
This PR enables some process mitigation flags on startup to help reduce risk of exploits.

- Enable DEP as it's still opt-in even on Windows 10. No OBS code or plugins should be executing data as code and this is an important mitigation against stack-based buffer overflows.
- Enable and force ASLR. This makes it harder for any potential exploits to use fixed offsets into OBS or Windows DLLs to run gadgets.
- Disable extension points. These are typically used for system-wide code injection, and we have generally had trouble with various things injecting into OBS and causing issues.
- Enable strict handle checks when running debug builds. This will raise an exception if we operate on an invalid handle, something that should hopefully not ever happen in the current code.

Note that the dynamic code mitigation was intentionally omitted due to our use of Lua JIT.

### Motivation and Context
Makes it harder to exploit any bugs in OBS. Might help improve stability by blocking random hooking DLLs. Helps catch invalid handle use during development.

### How Has This Been Tested?
Ran OBS with the standard set of plugins, observed no broken behavior.

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
