### PR TITLE
decklink: Fix deactivate when not showing

### DIFF
--- a/plugins/decklink/decklink-source.cpp
+++ b/plugins/decklink/decklink-source.cpp
@@ -102,7 +102,7 @@ static void decklink_hide(void *data)
 	DeckLinkInput *decklink = (DeckLinkInput *)data;
 	obs_source_t *source = decklink->GetSource();
 	bool showing = obs_source_showing(source);
-	if (decklink->dwns && showing)
+	if (decklink->dwns && !showing && decklink->Capturing())
 		decklink->Deactivate();
 }
 

--- a/plugins/decklink/decklink-source.cpp
+++ b/plugins/decklink/decklink-source.cpp
@@ -87,9 +87,8 @@ static void decklink_update(void *data, obs_data_t *settings)
 static void decklink_show(void *data)
 {
 	DeckLinkInput *decklink = (DeckLinkInput *)data;
-	obs_source_t *source = decklink->GetSource();
-	bool showing = obs_source_showing(source);
-	if (decklink->dwns && showing && !decklink->Capturing()) {
+
+	if (decklink->dwns && !decklink->Capturing()) {
 		ComPtr<DeckLinkDevice> device;
 		device.Set(deviceEnum->FindByHash(decklink->hash.c_str()));
 		decklink->Activate(device, decklink->id,
@@ -100,9 +99,8 @@ static void decklink_show(void *data)
 static void decklink_hide(void *data)
 {
 	DeckLinkInput *decklink = (DeckLinkInput *)data;
-	obs_source_t *source = decklink->GetSource();
-	bool showing = obs_source_showing(source);
-	if (decklink->dwns && !showing && decklink->Capturing())
+
+	if (decklink->dwns && decklink->Capturing())
 		decklink->Deactivate();
 }
 


### PR DESCRIPTION
### Description
If the option to deactivate when not showing was on, the Decklink
input device wouldn't deactivate/activate when hiding/showing.

### Motivation and Context
Noticed when testing with Decklink devices.

### How Has This Been Tested?
Toggled the visibility of the Decklink source, to make sure it deactivated/activated properly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
