### PR TITLE
UI: Use inline const for shared vector

### DIFF
--- a/UI/auth-youtube.hpp
+++ b/UI/auth-youtube.hpp
@@ -7,7 +7,7 @@
 
 #include "auth-oauth.hpp"
 
-const std::vector<Auth::Def> youtubeServices = {
+inline const std::vector<Auth::Def> youtubeServices = {
 	{"YouTube - RTMP", Auth::Type::OAuth_LinkedAccount, true},
 	{"YouTube - RTMPS", Auth::Type::OAuth_LinkedAccount, true},
 	{"YouTube - HLS", Auth::Type::OAuth_LinkedAccount, true}};


### PR DESCRIPTION
### Description
Avoiding duplicating the vector in every file that includes this header. Mostly making this as a PR to check `inline const` is available in all our CI builds (C++17).

### Motivation and Context
Sharing constants is better.

### How Has This Been Tested?
OBS still compiles.

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
