### PR TITLE
UI: Fix source toolbar shifting when nothing is selected

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -309,6 +309,31 @@
            </widget>
           </item>
           <item>
+           <widget class="QLabel" name="contextSourceIconSpacer">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>22</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>22</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="Line" name="line_3">
             <property name="orientation">
              <enum>Qt::Vertical</enum>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3140,6 +3140,7 @@ void OBSBasic::UpdateContextBar(bool force)
 
 		QPixmap pixmap = icon.pixmap(QSize(16, 16));
 		ui->contextSourceIcon->setPixmap(pixmap);
+		ui->contextSourceIconSpacer->hide();
 		ui->contextSourceIcon->show();
 
 		const char *name = obs_source_get_name(source);
@@ -3150,6 +3151,7 @@ void OBSBasic::UpdateContextBar(bool force)
 			obs_source_configurable(source));
 	} else {
 		ui->contextSourceIcon->hide();
+		ui->contextSourceIconSpacer->show();
 		ui->contextSourceLabel->setText(
 			QTStr("ContextBar.NoSelectedSource"));
 


### PR DESCRIPTION
### Description
#5125 added icons to the source toolbar but no icon is displayed when nothing is selected.

This adds a spacer on the right side of the label that gets toggled inversely to the source icon, to maintain the same width

## Before
https://user-images.githubusercontent.com/1554753/130439699-33b9181f-2be5-4bad-9da0-4d1475c1bf1d.mp4


## After
https://user-images.githubusercontent.com/1554753/130439590-aac3d563-3b8a-4d39-a2ab-1637c2453286.mp4


### Motivation and Context
Small adjustment to avoid visual shifting on the source toolbar

### How Has This Been Tested?
Selected and unselected sources

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
