### PR TITLE
UI: Display grayscale volume meter if muted

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -338,9 +338,19 @@ QColor VolumeMeter::getBackgroundNominalColor() const
 	return backgroundNominalColor;
 }
 
+QColor VolumeMeter::getBackgroundNominalColorDisabled() const
+{
+	return backgroundNominalColorDisabled;
+}
+
 void VolumeMeter::setBackgroundNominalColor(QColor c)
 {
 	backgroundNominalColor = std::move(c);
+}
+
+void VolumeMeter::setBackgroundNominalColorDisabled(QColor c)
+{
+	backgroundNominalColorDisabled = std::move(c);
 }
 
 QColor VolumeMeter::getBackgroundWarningColor() const
@@ -348,9 +358,19 @@ QColor VolumeMeter::getBackgroundWarningColor() const
 	return backgroundWarningColor;
 }
 
+QColor VolumeMeter::getBackgroundWarningColorDisabled() const
+{
+	return backgroundWarningColorDisabled;
+}
+
 void VolumeMeter::setBackgroundWarningColor(QColor c)
 {
 	backgroundWarningColor = std::move(c);
+}
+
+void VolumeMeter::setBackgroundWarningColorDisabled(QColor c)
+{
+	backgroundWarningColorDisabled = std::move(c);
 }
 
 QColor VolumeMeter::getBackgroundErrorColor() const
@@ -358,9 +378,19 @@ QColor VolumeMeter::getBackgroundErrorColor() const
 	return backgroundErrorColor;
 }
 
+QColor VolumeMeter::getBackgroundErrorColorDisabled() const
+{
+	return backgroundErrorColorDisabled;
+}
+
 void VolumeMeter::setBackgroundErrorColor(QColor c)
 {
 	backgroundErrorColor = std::move(c);
+}
+
+void VolumeMeter::setBackgroundErrorColorDisabled(QColor c)
+{
+	backgroundErrorColorDisabled = std::move(c);
 }
 
 QColor VolumeMeter::getForegroundNominalColor() const
@@ -368,9 +398,19 @@ QColor VolumeMeter::getForegroundNominalColor() const
 	return foregroundNominalColor;
 }
 
+QColor VolumeMeter::getForegroundNominalColorDisabled() const
+{
+	return foregroundNominalColorDisabled;
+}
+
 void VolumeMeter::setForegroundNominalColor(QColor c)
 {
 	foregroundNominalColor = std::move(c);
+}
+
+void VolumeMeter::setForegroundNominalColorDisabled(QColor c)
+{
+	foregroundNominalColorDisabled = std::move(c);
 }
 
 QColor VolumeMeter::getForegroundWarningColor() const
@@ -378,9 +418,19 @@ QColor VolumeMeter::getForegroundWarningColor() const
 	return foregroundWarningColor;
 }
 
+QColor VolumeMeter::getForegroundWarningColorDisabled() const
+{
+	return foregroundWarningColorDisabled;
+}
+
 void VolumeMeter::setForegroundWarningColor(QColor c)
 {
 	foregroundWarningColor = std::move(c);
+}
+
+void VolumeMeter::setForegroundWarningColorDisabled(QColor c)
+{
+	foregroundWarningColorDisabled = std::move(c);
 }
 
 QColor VolumeMeter::getForegroundErrorColor() const
@@ -388,9 +438,19 @@ QColor VolumeMeter::getForegroundErrorColor() const
 	return foregroundErrorColor;
 }
 
+QColor VolumeMeter::getForegroundErrorColorDisabled() const
+{
+	return foregroundErrorColorDisabled;
+}
+
 void VolumeMeter::setForegroundErrorColor(QColor c)
 {
 	foregroundErrorColor = std::move(c);
+}
+
+void VolumeMeter::setForegroundErrorColorDisabled(QColor c)
+{
+	foregroundErrorColorDisabled = std::move(c);
 }
 
 QColor VolumeMeter::getClipColor() const
@@ -584,19 +644,27 @@ VolumeMeter::VolumeMeter(QWidget *parent, obs_volmeter_t *obs_volmeter,
 	foregroundNominalColor.setRgb(0x4c, 0xff, 0x4c); // Bright green
 	foregroundWarningColor.setRgb(0xff, 0xff, 0x4c); // Bright yellow
 	foregroundErrorColor.setRgb(0xff, 0x4c, 0x4c);   // Bright red
-	clipColor.setRgb(0xff, 0xff, 0xff);              // Bright white
-	magnitudeColor.setRgb(0x00, 0x00, 0x00);         // Black
-	majorTickColor.setRgb(0xff, 0xff, 0xff);         // Black
-	minorTickColor.setRgb(0xcc, 0xcc, 0xcc);         // Black
-	minimumLevel = -60.0;                            // -60 dB
-	warningLevel = -20.0;                            // -20 dB
-	errorLevel = -9.0;                               //  -9 dB
-	clipLevel = -0.5;                                //  -0.5 dB
-	minimumInputLevel = -50.0;                       // -50 dB
-	peakDecayRate = 11.76;                           //  20 dB / 1.7 sec
-	magnitudeIntegrationTime = 0.3;                  //  99% in 300 ms
-	peakHoldDuration = 20.0;                         //  20 seconds
-	inputPeakHoldDuration = 1.0;                     //  1 second
+
+	backgroundNominalColorDisabled.setRgb(90, 90, 90);
+	backgroundWarningColorDisabled.setRgb(117, 117, 117);
+	backgroundErrorColorDisabled.setRgb(65, 65, 65);
+	foregroundNominalColorDisabled.setRgb(163, 163, 163);
+	foregroundWarningColorDisabled.setRgb(217, 217, 217);
+	foregroundErrorColorDisabled.setRgb(113, 113, 113);
+
+	clipColor.setRgb(0xff, 0xff, 0xff);      // Bright white
+	magnitudeColor.setRgb(0x00, 0x00, 0x00); // Black
+	majorTickColor.setRgb(0xff, 0xff, 0xff); // Black
+	minorTickColor.setRgb(0xcc, 0xcc, 0xcc); // Black
+	minimumLevel = -60.0;                    // -60 dB
+	warningLevel = -20.0;                    // -20 dB
+	errorLevel = -9.0;                       //  -9 dB
+	clipLevel = -0.5;                        //  -0.5 dB
+	minimumInputLevel = -50.0;               // -50 dB
+	peakDecayRate = 11.76;                   //  20 dB / 1.7 sec
+	magnitudeIntegrationTime = 0.3;          //  99% in 300 ms
+	peakHoldDuration = 20.0;                 //  20 seconds
+	inputPeakHoldDuration = 1.0;             //  1 second
 
 	channels = (int)audio_output_get_channels(obs_get_audio());
 
@@ -855,15 +923,6 @@ void VolumeMeter::ClipEnding()
 	clipping = false;
 }
 
-QColor VolumeMeter::ConvertToGrayscale(const QColor &color) const
-{
-	if (!muted)
-		return color;
-
-	int gray = qGray(color.rgb());
-	return QColor(gray, gray, gray);
-}
-
 void VolumeMeter::paintHMeter(QPainter &painter, int x, int y, int width,
 			      int height, float magnitude, float peak,
 			      float peakHold)
@@ -888,56 +947,61 @@ void VolumeMeter::paintHMeter(QPainter &painter, int x, int y, int width,
 		peakPosition = maximumPosition;
 	}
 
-	QColor backgroundNominalColor_ =
-		ConvertToGrayscale(backgroundNominalColor);
-	QColor backgroundWarningColor_ =
-		ConvertToGrayscale(backgroundWarningColor);
-	QColor backgroundErrorColor_ = ConvertToGrayscale(backgroundErrorColor);
-	QColor foregroundNominalColor_ =
-		ConvertToGrayscale(foregroundNominalColor);
-	QColor foregroundWarningColor_ =
-		ConvertToGrayscale(foregroundWarningColor);
-	QColor foregroundErrorColor_ = ConvertToGrayscale(foregroundErrorColor);
-	QColor magnitudeColor_ = ConvertToGrayscale(magnitudeColor);
-
 	if (peakPosition < minimumPosition) {
 		painter.fillRect(minimumPosition, y, nominalLength, height,
-				 backgroundNominalColor_);
+				 muted ? backgroundNominalColorDisabled
+				       : backgroundNominalColor);
 		painter.fillRect(warningPosition, y, warningLength, height,
-				 backgroundWarningColor_);
+				 muted ? backgroundWarningColorDisabled
+				       : backgroundWarningColor);
 		painter.fillRect(errorPosition, y, errorLength, height,
-				 backgroundErrorColor_);
+				 muted ? backgroundErrorColorDisabled
+				       : backgroundErrorColor);
 	} else if (peakPosition < warningPosition) {
 		painter.fillRect(minimumPosition, y,
 				 peakPosition - minimumPosition, height,
-				 foregroundNominalColor_);
+				 muted ? foregroundNominalColorDisabled
+				       : foregroundNominalColor);
 		painter.fillRect(peakPosition, y,
 				 warningPosition - peakPosition, height,
-				 backgroundNominalColor_);
+				 muted ? backgroundNominalColorDisabled
+				       : backgroundNominalColor);
 		painter.fillRect(warningPosition, y, warningLength, height,
-				 backgroundWarningColor_);
+				 muted ? backgroundWarningColorDisabled
+				       : backgroundWarningColor);
 		painter.fillRect(errorPosition, y, errorLength, height,
-				 backgroundErrorColor_);
+				 muted ? backgroundErrorColorDisabled
+				       : backgroundErrorColor);
 	} else if (peakPosition < errorPosition) {
 		painter.fillRect(minimumPosition, y, nominalLength, height,
-				 foregroundNominalColor_);
+				 muted ? foregroundNominalColorDisabled
+				       : foregroundNominalColor);
 		painter.fillRect(warningPosition, y,
 				 peakPosition - warningPosition, height,
-				 foregroundWarningColor_);
+				 muted ? foregroundWarningColorDisabled
+				       : foregroundWarningColor);
 		painter.fillRect(peakPosition, y, errorPosition - peakPosition,
-				 height, backgroundWarningColor_);
+				 height,
+				 muted ? backgroundWarningColorDisabled
+				       : backgroundWarningColor);
 		painter.fillRect(errorPosition, y, errorLength, height,
-				 backgroundErrorColor_);
+				 muted ? backgroundErrorColorDisabled
+				       : backgroundErrorColor);
 	} else if (peakPosition < maximumPosition) {
 		painter.fillRect(minimumPosition, y, nominalLength, height,
-				 foregroundNominalColor_);
+				 muted ? foregroundNominalColorDisabled
+				       : foregroundNominalColor);
 		painter.fillRect(warningPosition, y, warningLength, height,
-				 foregroundWarningColor_);
+				 muted ? foregroundWarningColorDisabled
+				       : foregroundWarningColor);
 		painter.fillRect(errorPosition, y, peakPosition - errorPosition,
-				 height, foregroundErrorColor_);
+				 height,
+				 muted ? foregroundErrorColorDisabled
+				       : foregroundErrorColor);
 		painter.fillRect(peakPosition, y,
 				 maximumPosition - peakPosition, height,
-				 backgroundErrorColor_);
+				 muted ? backgroundErrorColorDisabled
+				       : backgroundErrorColor);
 	} else if (int(magnitude) != 0) {
 		if (!clipping) {
 			QTimer::singleShot(CLIP_FLASH_DURATION_MS, this,
@@ -947,24 +1011,28 @@ void VolumeMeter::paintHMeter(QPainter &painter, int x, int y, int width,
 
 		int end = errorLength + warningLength + nominalLength;
 		painter.fillRect(minimumPosition, y, end, height,
-				 QBrush(foregroundErrorColor_));
+				 QBrush(muted ? foregroundErrorColorDisabled
+					      : foregroundErrorColor));
 	}
 
 	if (peakHoldPosition - 3 < minimumPosition)
 		; // Peak-hold below minimum, no drawing.
 	else if (peakHoldPosition < warningPosition)
 		painter.fillRect(peakHoldPosition - 3, y, 3, height,
-				 foregroundNominalColor_);
+				 muted ? foregroundNominalColorDisabled
+				       : foregroundNominalColor);
 	else if (peakHoldPosition < errorPosition)
 		painter.fillRect(peakHoldPosition - 3, y, 3, height,
-				 foregroundWarningColor_);
+				 muted ? foregroundWarningColorDisabled
+				       : foregroundWarningColor);
 	else
 		painter.fillRect(peakHoldPosition - 3, y, 3, height,
-				 foregroundErrorColor_);
+				 muted ? foregroundErrorColorDisabled
+				       : foregroundErrorColor);
 
 	if (magnitudePosition - 3 >= minimumPosition)
 		painter.fillRect(magnitudePosition - 3, y, 3, height,
-				 magnitudeColor_);
+				 magnitudeColor);
 }
 
 void VolumeMeter::paintVMeter(QPainter &painter, int x, int y, int width,

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -26,6 +26,32 @@ class VolumeMeter : public QWidget {
 			   WRITE setForegroundWarningColor DESIGNABLE true)
 	Q_PROPERTY(QColor foregroundErrorColor READ getForegroundErrorColor
 			   WRITE setForegroundErrorColor DESIGNABLE true)
+
+	Q_PROPERTY(QColor backgroundNominalColorDisabled READ
+			   getBackgroundNominalColorDisabled WRITE
+				   setBackgroundNominalColorDisabled
+					   DESIGNABLE true)
+	Q_PROPERTY(QColor backgroundWarningColorDisabled READ
+			   getBackgroundWarningColorDisabled WRITE
+				   setBackgroundWarningColorDisabled
+					   DESIGNABLE true)
+	Q_PROPERTY(
+		QColor backgroundErrorColorDisabled READ
+			getBackgroundErrorColorDisabled WRITE
+				setBackgroundErrorColorDisabled DESIGNABLE true)
+	Q_PROPERTY(QColor foregroundNominalColorDisabled READ
+			   getForegroundNominalColorDisabled WRITE
+				   setForegroundNominalColorDisabled
+					   DESIGNABLE true)
+	Q_PROPERTY(QColor foregroundWarningColorDisabled READ
+			   getForegroundWarningColorDisabled WRITE
+				   setForegroundWarningColorDisabled
+					   DESIGNABLE true)
+	Q_PROPERTY(
+		QColor foregroundErrorColorDisabled READ
+			getForegroundErrorColorDisabled WRITE
+				setForegroundErrorColorDisabled DESIGNABLE true)
+
 	Q_PROPERTY(QColor clipColor READ getClipColor WRITE setClipColor
 			   DESIGNABLE true)
 	Q_PROPERTY(QColor magnitudeColor READ getMagnitudeColor WRITE
@@ -90,8 +116,6 @@ private:
 			 float magnitude, float peak, float peakHold);
 	void paintVTicks(QPainter &painter, int x, int y, int height);
 
-	QColor ConvertToGrayscale(const QColor &color) const;
-
 	QMutex dataMutex;
 
 	uint64_t currentLastUpdateTime = 0;
@@ -115,6 +139,14 @@ private:
 	QColor foregroundNominalColor;
 	QColor foregroundWarningColor;
 	QColor foregroundErrorColor;
+
+	QColor backgroundNominalColorDisabled;
+	QColor backgroundWarningColorDisabled;
+	QColor backgroundErrorColorDisabled;
+	QColor foregroundNominalColorDisabled;
+	QColor foregroundWarningColorDisabled;
+	QColor foregroundErrorColorDisabled;
+
 	QColor clipColor;
 	QColor magnitudeColor;
 	QColor majorTickColor;
@@ -157,6 +189,20 @@ public:
 	void setForegroundWarningColor(QColor c);
 	QColor getForegroundErrorColor() const;
 	void setForegroundErrorColor(QColor c);
+
+	QColor getBackgroundNominalColorDisabled() const;
+	void setBackgroundNominalColorDisabled(QColor c);
+	QColor getBackgroundWarningColorDisabled() const;
+	void setBackgroundWarningColorDisabled(QColor c);
+	QColor getBackgroundErrorColorDisabled() const;
+	void setBackgroundErrorColorDisabled(QColor c);
+	QColor getForegroundNominalColorDisabled() const;
+	void setForegroundNominalColorDisabled(QColor c);
+	QColor getForegroundWarningColorDisabled() const;
+	void setForegroundWarningColorDisabled(QColor c);
+	QColor getForegroundErrorColorDisabled() const;
+	void setForegroundErrorColorDisabled(QColor c);
+
 	QColor getClipColor() const;
 	void setClipColor(QColor c);
 	QColor getMagnitudeColor() const;

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -62,6 +62,8 @@ class VolumeMeter : public QWidget {
 	Q_PROPERTY(qreal inputPeakHoldDuration READ getInputPeakHoldDuration
 			   WRITE setInputPeakHoldDuration DESIGNABLE true)
 
+	friend class VolControl;
+
 private slots:
 	void ClipEnding();
 
@@ -87,6 +89,8 @@ private:
 	void paintVMeter(QPainter &painter, int x, int y, int width, int height,
 			 float magnitude, float peak, float peakHold);
 	void paintVTicks(QPainter &painter, int x, int y, int height);
+
+	QColor ConvertToGrayscale(const QColor &color) const;
 
 	QMutex dataMutex;
 
@@ -129,6 +133,7 @@ private:
 	int channels = 0;
 	bool clipping = false;
 	bool vertical;
+	bool muted = false;
 
 public:
 	explicit VolumeMeter(QWidget *parent = nullptr,

--- a/libobs/obs-audio-controls.c
+++ b/libobs/obs-audio-controls.c
@@ -535,7 +535,7 @@ static void volmeter_source_data_received(void *vptr, obs_source_t *source,
 
 	// Adjust magnitude/peak based on the volume level set by the user.
 	// And convert to dB.
-	mul = muted ? 0.0f : db_to_mul(volmeter->cur_db);
+	mul = db_to_mul(volmeter->cur_db);
 	for (int channel_nr = 0; channel_nr < MAX_AUDIO_CHANNELS;
 	     channel_nr++) {
 		magnitude[channel_nr] =
@@ -552,6 +552,7 @@ static void volmeter_source_data_received(void *vptr, obs_source_t *source,
 	signal_levels_updated(volmeter, magnitude, peak, input_peak);
 
 	UNUSED_PARAMETER(source);
+	UNUSED_PARAMETER(muted);
 }
 
 obs_fader_t *obs_fader_create(enum obs_fader_type type)


### PR DESCRIPTION
### Description
Currently, the volume meters don't show volume levels when
muted. This shows the levels and makes it grayscale when
the source is muted.

Muted:
![Screenshot from 2021-08-24 01-10-37](https://user-images.githubusercontent.com/19962531/130565942-ffc77fd5-ab41-48eb-ac4e-46c929573802.png)

Not muted:
![Screenshot from 2021-08-24 01-11-14](https://user-images.githubusercontent.com/19962531/130565965-379178fb-f22b-41ba-99f0-10c226c9ffde.png)

### Motivation and Context
Give indication to users of volume levels, even if muted.

### How Has This Been Tested?
Muted/unmuted audio sources, to make sure volume meters updated properly.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
