### PR TITLE
UI: Adjust minimum size of source toolbars

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -421,7 +421,6 @@ void GameCaptureToolbar::UpdateWindowVisibility()
 	bool is_window = (mode == "window");
 	ui->windowLabel->setVisible(is_window);
 	ui->window->setVisible(is_window);
-	ui->empty->setVisible(!is_window);
 }
 
 void GameCaptureToolbar::on_mode_currentIndexChanged(int idx)

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -205,7 +205,7 @@
       </property>
       <property name="minimumSize">
        <size>
-        <width>0</width>
+        <width>800</width>
         <height>30</height>
        </size>
       </property>
@@ -293,13 +293,13 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>250</width>
+              <width>160</width>
               <height>22</height>
              </size>
             </property>
             <property name="maximumSize">
              <size>
-              <width>250</width>
+              <width>160</width>
               <height>22</height>
              </size>
             </property>
@@ -1001,7 +1001,7 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>94</width>
+           <width>67</width>
            <height>16</height>
           </rect>
          </property>

--- a/UI/forms/source-toolbar/device-select-toolbar.ui
+++ b/UI/forms/source-toolbar/device-select-toolbar.ui
@@ -25,7 +25,7 @@
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_2">
+  <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1,0,0">
    <property name="sizeConstraint">
     <enum>QLayout::SetNoConstraint</enum>
    </property>
@@ -44,7 +44,7 @@
    <item>
     <widget class="QLabel" name="deviceLabel">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -77,6 +77,12 @@
        <height>22</height>
       </size>
      </property>
+     <property name="maximumSize">
+      <size>
+       <width>600</width>
+       <height>16777215</height>
+      </size>
+     </property>
      <property name="currentText">
       <string notr="true"/>
      </property>
@@ -87,6 +93,12 @@
    </item>
    <item>
     <widget class="QPushButton" name="activateButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -103,9 +115,12 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>40</width>
+       <width>0</width>
        <height>20</height>
       </size>
      </property>

--- a/UI/forms/source-toolbar/game-capture-toolbar.ui
+++ b/UI/forms/source-toolbar/game-capture-toolbar.ui
@@ -25,7 +25,7 @@
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,4,0,5,0">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -62,10 +62,22 @@
    </item>
    <item>
     <widget class="QComboBox" name="mode">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
-       <width>0</width>
+       <width>150</width>
        <height>22</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>400</width>
+       <height>16777215</height>
       </size>
      </property>
      <property name="currentText">
@@ -105,8 +117,14 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>0</width>
+       <width>150</width>
        <height>22</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>600</width>
+       <height>16777215</height>
       </size>
      </property>
      <property name="currentText">
@@ -118,14 +136,17 @@
     </widget>
    </item>
    <item>
-    <widget class="QFrame" name="empty">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <spacer name="empty">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-    </widget>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/UI/forms/source-toolbar/image-source-toolbar.ui
+++ b/UI/forms/source-toolbar/image-source-toolbar.ui
@@ -25,7 +25,7 @@
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1,0,0">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -68,6 +68,12 @@
        <height>22</height>
       </size>
      </property>
+     <property name="maximumSize">
+      <size>
+       <width>400</width>
+       <height>16777215</height>
+      </size>
+     </property>
      <property name="text">
       <string notr="true"/>
      </property>
@@ -94,6 +100,19 @@
       <string>Browse</string>
      </property>
     </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
### Description
Sets a minimum size on the source toolbar itself to prevent shrinking the main window too small for it to be useable in some cases.

Also sets some sane limits on the toolbars with dropdown menus and the image source toolbar filepath

### Motivation and Context
Previously the window could be shrunk below a useable width for the source toolbar. This minimum width was also dependent on what source type you had selected, if any. Selecting a source type that needed more space would cause the window to change size.

## Before
![image](https://user-images.githubusercontent.com/1554753/130722028-a89c6693-c044-42d5-970e-006497ea73d1.png)
_No source selected_

![image](https://user-images.githubusercontent.com/1554753/130722076-a0588e34-fb0c-4c2d-9018-a6f9c8369264.png)
_Game capture selected, window is forced to a new size and toolbar is barely useable_

## After
![image](https://user-images.githubusercontent.com/1554753/130722006-6536b5cd-bbea-4d62-93e3-32de9c6e8f86.png)
_Minimum window size enforced, game capture dropdowns get available space evenly_

![image](https://user-images.githubusercontent.com/1554753/130722143-bf5717f8-ae1b-42d0-a0f5-efe508b70113.png)
_Window can still be made smaller if the source toolbar is turned off_


### How Has This Been Tested?
Checked the window and toolbar widget sizes for all source types.

Checked source toolbar on all default themes.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
