### PR TITLE
libobs: Add filter visibility hotkeys

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1101,6 +1101,10 @@ Push-to-talk="Push-to-talk"
 SceneItemShow="Show '%1'"
 SceneItemHide="Hide '%1'"
 
+# filter visibility hotkeys
+FilterEnable="Enable Filter '%1'"
+FilterDisable="Disable Filter '%1'"
+
 # Output warnings
 OutputWarnings.NoTracksSelected="You must select at least one track"
 OutputWarnings.MP4Recording="Warning: Recordings saved to MP4/MOV will be unrecoverable if the file cannot be finalized (e.g. as a result of BSODs, power losses, etc.). If you want to record multiple audio tracks consider using MKV and remux the recording to MP4/MOV after it is finished (File → Remux Recordings)"

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2321,6 +2321,9 @@ void OBSBasic::InitHotkeys()
 	obs_hotkeys_set_sceneitem_hotkeys_translations(Str("SceneItemShow"),
 						       Str("SceneItemHide"));
 
+	obs_hotkeys_set_source_filter_hotkeys_translations(
+		Str("FilterEnable"), Str("FilterDisable"));
+
 	obs_hotkey_enable_callback_rerouting(true);
 	obs_hotkey_set_callback_routing_func(OBSBasic::HotkeyTriggered, this);
 }

--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -1617,3 +1617,14 @@ void obs_hotkeys_set_sceneitem_hotkeys_translations(const char *show,
 	SET_T(hide);
 #undef SET_T
 }
+
+void obs_hotkeys_set_source_filter_hotkeys_translations(const char *enable,
+							const char *disable)
+{
+#define SET_T(n)                        \
+	bfree(obs->hotkeys.filter_##n); \
+	obs->hotkeys.filter_##n = bstrdup(n)
+	SET_T(enable);
+	SET_T(disable);
+#undef SET_T
+}

--- a/libobs/obs-hotkey.h
+++ b/libobs/obs-hotkey.h
@@ -151,6 +151,10 @@ obs_hotkeys_set_audio_hotkeys_translations(const char *mute, const char *unmute,
 EXPORT void obs_hotkeys_set_sceneitem_hotkeys_translations(const char *show,
 							   const char *hide);
 
+EXPORT void
+obs_hotkeys_set_source_filter_hotkeys_translations(const char *enable,
+						   const char *disable);
+
 /* registering hotkeys (giving hotkeys a name and a function) */
 
 typedef void (*obs_hotkey_func)(void *data, obs_hotkey_id id,

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -402,6 +402,8 @@ struct obs_core_hotkeys {
 	char *push_to_talk;
 	char *sceneitem_show;
 	char *sceneitem_hide;
+	char *filter_enable;
+	char *filter_disable;
 };
 
 struct obs_core {
@@ -727,6 +729,7 @@ struct obs_source {
 	gs_texrender_t *filter_texrender;
 	enum obs_allow_direct_render allow_direct;
 	bool rendering_filter;
+	obs_hotkey_pair_id filter_toggle_visibility_key;
 
 	/* sources specific hotkeys */
 	obs_hotkey_pair_id mute_unmute_key;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -778,6 +778,8 @@ static inline bool obs_init_hotkeys(void)
 	hotkeys->push_to_talk = bstrdup("Push-to-talk");
 	hotkeys->sceneitem_show = bstrdup("Show '%1'");
 	hotkeys->sceneitem_hide = bstrdup("Hide '%1'");
+	hotkeys->filter_enable = bstrdup("Enable Filter '%1'");
+	hotkeys->filter_disable = bstrdup("Disable Filter '%1'");
 
 	if (!obs_hotkeys_platform_init(hotkeys))
 		return false;
@@ -829,6 +831,8 @@ static inline void obs_free_hotkeys(void)
 	bfree(hotkeys->push_to_talk);
 	bfree(hotkeys->sceneitem_show);
 	bfree(hotkeys->sceneitem_hide);
+	bfree(hotkeys->filter_enable);
+	bfree(hotkeys->filter_disable);
 
 	obs_hotkey_name_map_free();
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds the ability to enable and disable filters via hotkeys.
Since filters are part of and bound to sources (not scenes), that is where they appear (elsewhere doesn't make sense imo).

<img width="860" alt="Bildschirmfoto 2021-08-25 um 17 41 48" src="https://user-images.githubusercontent.com/59806498/130832053-8ad7d00b-f51e-43f2-9b90-c5b6147a294b.png">


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->


Given that this is possible for sceneitems, it should also be possible to enable filters via hotkeys.

Asked on the Discord as well as [Fider](https://ideas.obsproject.com/posts/636/enable-hotkey-toggling-source-filters-on-off)

There also is a [scripting workaround](https://github.com/upgradeQ/obs-filter-hotkeys) for this, but given the limitations of scripts it is a litte janky (and doesn't have a great UI).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0 beta 5, compiled and run

Setting a hotkey correctly enables / disables the filter. Toggles also work.
Both effect filters and AV Filters work.

Filters with the same name do not interfere with each other.
Hotkeys are kept after OBS restart.

No memory leaks detected.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
