### PR TITLE
UI: Fix disabled auto-start/stop checkboxes

### DIFF
--- a/UI/window-youtube-actions.cpp
+++ b/UI/window-youtube-actions.cpp
@@ -35,9 +35,6 @@ OBSYoutubeActions::OBSYoutubeActions(QWidget *parent, Auth *auth)
 	ui->latencyBox->addItem(QTStr("YouTube.Actions.Latency.UltraLow"),
 				"ultraLow");
 
-	ui->checkAutoStart->setEnabled(false);
-	ui->checkAutoStop->setEnabled(false);
-
 	UpdateOkButtonStatus();
 
 	connect(ui->title, &QLineEdit::textChanged, this,


### PR DESCRIPTION
### Description
The YouTube integration auto-start and auto-stop checkboxes are only
made visible when scheduling an event. However, they are disabled by
default so users can't change them when they're visible.

I suspect these checkboxes used to always be visible and were on an
enable/disable flip which got changed to a visibility flip.

### Motivation and Context
We have the code for these checkboxes so we should use them :)

### How Has This Been Tested?
Changed the auto-start/auto-stop values when scheduling an event.

Went live with a non-scheduled event to ensure it auto-started and stopped.

Went live with scheduled events with the values changed and made sure it behaved as selected

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
