### PR TITLE
libobs: Fix thread-safe issue for audio monitor

### DIFF
--- a/libobs/audio-monitoring/win32/wasapi-output.c
+++ b/libobs/audio-monitoring/win32/wasapi-output.c
@@ -219,15 +219,18 @@ static inline void audio_monitor_free(struct audio_monitor *monitor)
 			monitor->source, on_audio_playback, monitor);
 	}
 
+	pthread_mutex_lock(&monitor->playback_mutex);
 	if (monitor->client)
 		monitor->client->lpVtbl->Stop(monitor->client);
-
 	safe_release(monitor->device);
 	safe_release(monitor->client);
 	safe_release(monitor->render);
 	audio_resampler_destroy(monitor->resampler);
 	circlebuf_free(&monitor->delay_buffer);
 	da_free(monitor->buf);
+	pthread_mutex_unlock(&monitor->playback_mutex);
+
+	pthread_mutex_destroy(&monitor->playback_mutex);
 }
 
 static enum speaker_layout convert_speaker_layout(DWORD layout, WORD channels)

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -5014,8 +5014,11 @@ void obs_source_set_monitoring_type(obs_source_t *source,
 
 	if (!obs_source_valid(source, "obs_source_set_monitoring_type"))
 		return;
+
+	pthread_mutex_lock(&obs->audio.monitoring_mutex);
+
 	if (source->monitoring_type == type)
-		return;
+		goto unlock;
 
 	was_on = source->monitoring_type != OBS_MONITORING_TYPE_NONE;
 	now_on = type != OBS_MONITORING_TYPE_NONE;
@@ -5030,6 +5033,9 @@ void obs_source_set_monitoring_type(obs_source_t *source,
 	}
 
 	source->monitoring_type = type;
+
+unlock:
+	pthread_mutex_unlock(&obs->audio.monitoring_mutex);
 }
 
 enum obs_monitoring_type


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Modify tips:
1. _obs_source_set_monitoring_type_ may be called from different threads， such as UI thread and _WASAPISource::ReconnectThread_;
![1630031255](https://user-images.githubusercontent.com/18413354/131062191-c88c8555-892b-4e71-bbc2-943680e48170.png)

2. _audio_monitor::playback_mutex_ lost destroy logic;

3. it is better to request "_playback_mutex_" in _audio_monitor_free_.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
for thread-safe

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Switch audio monitor (on & off) from UI frequently.
At the same time, disconnect and connect audio device frequently to make sure WASAPISource::ReconnectThread can be called.

### Types of changes
Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
