### PR TITLE
win-capture: Clear stale pointers for game capture

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -336,12 +336,12 @@ static void stop_capture(struct game_capture *gc)
 
 	obs_enter_graphics();
 	gs_texrender_destroy(gc->extra_texrender);
-	gs_texture_destroy(gc->extra_texture);
-	gs_texture_destroy(gc->texture);
-	obs_leave_graphics();
 	gc->extra_texrender = NULL;
+	gs_texture_destroy(gc->extra_texture);
 	gc->extra_texture = NULL;
+	gs_texture_destroy(gc->texture);
 	gc->texture = NULL;
+	obs_leave_graphics();
 
 	if (gc->active)
 		info("capture stopped");
@@ -1563,8 +1563,11 @@ static inline bool init_shmem_capture(struct game_capture *gc)
 
 	obs_enter_graphics();
 	gs_texrender_destroy(gc->extra_texrender);
+	gc->extra_texrender = NULL;
 	gs_texture_destroy(gc->extra_texture);
+	gc->extra_texture = NULL;
 	gs_texture_destroy(gc->texture);
+	gc->texture = NULL;
 	gs_texture_t *const texture =
 		gs_texture_create(gc->cx, gc->cy, format, 1, NULL, GS_DYNAMIC);
 	obs_leave_graphics();
@@ -1608,8 +1611,11 @@ static inline bool init_shtex_capture(struct game_capture *gc)
 {
 	obs_enter_graphics();
 	gs_texrender_destroy(gc->extra_texrender);
+	gc->extra_texrender = NULL;
 	gs_texture_destroy(gc->extra_texture);
+	gc->extra_texture = NULL;
 	gs_texture_destroy(gc->texture);
+	gc->texture = NULL;
 	gs_texture_t *const texture =
 		gs_texture_open_shared(gc->shtex_data->tex_handle);
 	bool success = texture != NULL;


### PR DESCRIPTION
### Description
Fixes shmem crashes when using Alt+Tab.

Fixes #5208

### Motivation and Context
Crashes are bad.

### How Has This Been Tested?
No longer crashes. Game feed comes back.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.