### PR TITLE
UI: Fix crash when output source 0 is null

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -388,6 +388,11 @@ void OBSBasic::TransitionToScene(OBSSource source, bool force,
 	}
 
 	OBSSource transition = obs_get_output_source(0);
+	if (!transition) {
+		if (usingPreviewProgram && sceneDuplicationMode)
+			obs_scene_release(scene);
+		return;
+	}
 	obs_source_release(transition);
 
 	float t = obs_transition_get_time(transition);


### PR DESCRIPTION
### Description
Fix crash when output source 0 is null

### Motivation and Context
When trying to switch scenes while output source 0 is null obs will crash on obs_transition_get_time

### How Has This Been Tested?
On windows 64 bit by starting OBS with loads of plugins multiple times. ±1 out of 5 times obs will start without setting output source 0 on startup

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
