### PR TITLE
Fixes for YouTube integration when delay is enabled

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6544,6 +6544,18 @@ void OBSBasic::ForceStopStreaming()
 	if (outputHandler->StreamingActive())
 		outputHandler->StopStreaming(true);
 
+	// special case: force reset broadcast state if
+	// no autostart and no autostop selected
+	if (!autoStartBroadcast && !broadcastActive) {
+		broadcastActive = false;
+		autoStartBroadcast = true;
+		autoStopBroadcast = true;
+		ui->broadcastButton->setVisible(false);
+	}
+
+	if (autoStopBroadcast)
+		broadcastActive = false;
+
 	OnDeactivate();
 
 	bool recordWhenStreaming = config_get_bool(


### PR DESCRIPTION
### Description
Fixes #5199 and an additional bug where the UI and internal state of the broadcast configuration isn't reset when force-stopping (e.g. when discarding remaining delayed stream data).

### Motivation and Context
Bugs are bad.

### How Has This Been Tested?
- Tested delayed stream without autostart to make sure the check thread still works
- Tested stopping a delayed stream (forced/unforced)
- Tested force-stopping a delayed stream before it starts (to verify thread gets cleaned up)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
