### PR TITLE
UI: Add missing properties to ResetBroadcast

### DIFF
--- a/UI/youtube-api-wrappers.cpp
+++ b/UI/youtube-api-wrappers.cpp
@@ -431,7 +431,9 @@ bool YoutubeApiWrappers::ResetBroadcast(const QString &broadcast_id)
 		{"snippet",
 		 Json::object{
 			 {"title", snippet["title"]},
+			 {"description", snippet["description"]},
 			 {"scheduledStartTime", snippet["scheduledStartTime"]},
+			 {"scheduledEndTime", snippet["scheduledEndTime"]},
 		 }},
 		{"status",
 		 Json::object{
@@ -450,6 +452,10 @@ bool YoutubeApiWrappers::ResetBroadcast(const QString &broadcast_id)
 					  monitorStream["broadcastStreamDelayMs"]},
 				 },
 			 },
+			 {"enableAutoStart", contentDetails["enableAutoStart"]},
+			 {"enableAutoStop", contentDetails["enableAutoStop"]},
+			 {"enableClosedCaptions",
+			  contentDetails["enableClosedCaptions"]},
 			 {"enableDvr", contentDetails["enableDvr"]},
 			 {"enableContentEncryption",
 			  contentDetails["enableContentEncryption"]},


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Ensures description and other options are carried over when `ResetBroadcast` is called.

A better way to fix this problem (and avoid calling `ResetBroadcast` alltogether) would be to transition a broadcast that has monitoring enabled to `testing` before going `live`, but that would require waiting for several seconds and should probably have UI feedback as well.

### Motivation and Context
Users complained about description being reset when starting scheduled broadcast.

### How Has This Been Tested?
Scheduled broadcast, ensured description isn't lost when starting.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
