### PR TITLE
UI: Change YouTube description input to QPlainTextEdit

### DIFF
--- a/UI/forms/OBSYoutubeActions.ui
+++ b/UI/forms/OBSYoutubeActions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>583</width>
-    <height>452</height>
+    <height>510</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -73,9 +73,9 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QLineEdit" name="description">
-         <property name="maxLength">
-          <number>5000</number>
+        <widget class="QPlainTextEdit" name="description">
+         <property name="tabChangesFocus">
+          <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/UI/window-youtube-actions.cpp
+++ b/UI/window-youtube-actions.cpp
@@ -579,7 +579,8 @@ void OBSYoutubeActions::InitBroadcast()
 void OBSYoutubeActions::UiToBroadcast(BroadcastDescription &broadcast)
 {
 	broadcast.title = ui->title->text();
-	broadcast.description = ui->description->text();
+	// ToDo: UI warning rather than silent truncation
+	broadcast.description = ui->description->toPlainText().left(5000);
 	broadcast.privacy = ui->privacyBox->currentData().toString();
 	broadcast.category.title = ui->categoryBox->currentText();
 	broadcast.category.id = ui->categoryBox->currentData().toString();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Changes description from `QLineEdit` to `QPlainTextEdit` to allow for multi-line descriptions

Result:
![2021-08-30_02-27-42_e6zhtq](https://user-images.githubusercontent.com/3123295/131270547-3202d24e-8296-499b-b1e6-3ecf2af3000d.png)

### Motivation and Context
Descriptions can have newlines.

### How Has This Been Tested?
Created broadcast with multi-line description.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)

<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
