### PR TITLE
libobs-opengl: Load required EGL extensions

### DIFF
--- a/libobs-opengl/gl-wayland-egl.c
+++ b/libobs-opengl/gl-wayland-egl.c
@@ -209,8 +209,14 @@ static struct gl_platform *gl_wayland_egl_platform_create(gs_device_t *device,
 		goto fail_load_gl;
 	}
 
+	if (!gladLoadEGL()) {
+		blog(LOG_ERROR, "Unable to load EGL entry functions.");
+		goto fail_load_egl;
+	}
+
 	goto success;
 
+fail_load_egl:
 fail_load_gl:
 	egl_context_destroy(plat);
 fail_context_create:


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Check if the required EGL extensions to import DMA-BUFs are available before importing buffers.
The two required extensions are EGL_EXT_image_dma_buf_import and
EGL_EXT_image_dma_buf_import_modifiers.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We need those extensions to be present  to import DMA-BUFs.

*  EGL_EXT_image_dma_buf_import: This extension is required to import
DMA-BUFs with the modifier-less path. It is limited to buffers with 3
planes. [1]
* EGL_EXT_image_dma_buf_import_modifiers: This extension is required to
import DMA-BUFs with an explicit modifier. It raises the limit of buffer
planes to 4, which is the maximum planecount for DMA-BUFs. [2]

[1] https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_image_dma_buf_import.txt
[2] https://www.khronos.org/registry/EGL/extensions/EXT/EGL_EXT_image_dma_buf_import_modifiers.txt

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

This requires a linux systems with and without the mentioned extensions above. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
