### PR TITLE
libobs/UI: Signal when monitoring type is changed and update UI accordingly

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -41,9 +41,8 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	percent = new QSpinBox();
 	forceMono = new QCheckBox();
 	balance = new BalanceSlider();
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	monitoringType = new QComboBox();
-#endif
+	if (obs_audio_monitoring_supported())
+		monitoringType = new QComboBox();
 	syncOffset = new QSpinBox();
 	mixer1 = new QCheckBox();
 	mixer2 = new QCheckBox();
@@ -170,19 +169,22 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 		QTStr("Basic.AdvAudio.SyncOffsetSource").arg(sourceName));
 
 	int idx;
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	monitoringType->addItem(QTStr("Basic.AdvAudio.Monitoring.None"),
-				(int)OBS_MONITORING_TYPE_NONE);
-	monitoringType->addItem(QTStr("Basic.AdvAudio.Monitoring.MonitorOnly"),
-				(int)OBS_MONITORING_TYPE_MONITOR_ONLY);
-	monitoringType->addItem(QTStr("Basic.AdvAudio.Monitoring.Both"),
-				(int)OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT);
-	int mt = (int)obs_source_get_monitoring_type(source);
-	idx = monitoringType->findData(mt);
-	monitoringType->setCurrentIndex(idx);
-	monitoringType->setAccessibleName(
-		QTStr("Basic.AdvAudio.MonitoringSource").arg(sourceName));
-#endif
+	if (obs_audio_monitoring_supported()) {
+		monitoringType->addItem(QTStr("Basic.AdvAudio.Monitoring.None"),
+					(int)OBS_MONITORING_TYPE_NONE);
+		monitoringType->addItem(
+			QTStr("Basic.AdvAudio.Monitoring.MonitorOnly"),
+			(int)OBS_MONITORING_TYPE_MONITOR_ONLY);
+		monitoringType->addItem(
+			QTStr("Basic.AdvAudio.Monitoring.Both"),
+			(int)OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT);
+		int mt = (int)obs_source_get_monitoring_type(source);
+		idx = monitoringType->findData(mt);
+		monitoringType->setCurrentIndex(idx);
+		monitoringType->setAccessibleName(
+			QTStr("Basic.AdvAudio.MonitoringSource")
+				.arg(sourceName));
+	}
 
 	mixer1->setText("1");
 	mixer1->setChecked(mixers & (1 << 0));
@@ -237,10 +239,10 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 			 SLOT(ResetBalance()));
 	QWidget::connect(syncOffset, SIGNAL(valueChanged(int)), this,
 			 SLOT(syncOffsetChanged(int)));
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	QWidget::connect(monitoringType, SIGNAL(currentIndexChanged(int)), this,
-			 SLOT(monitoringTypeChanged(int)));
-#endif
+	if (obs_audio_monitoring_supported())
+		QWidget::connect(monitoringType,
+				 SIGNAL(currentIndexChanged(int)), this,
+				 SLOT(monitoringTypeChanged(int)));
 	QWidget::connect(mixer1, SIGNAL(clicked(bool)), this,
 			 SLOT(mixer1Changed(bool)));
 	QWidget::connect(mixer2, SIGNAL(clicked(bool)), this,
@@ -266,9 +268,8 @@ OBSAdvAudioCtrl::~OBSAdvAudioCtrl()
 	forceMonoContainer->deleteLater();
 	balanceContainer->deleteLater();
 	syncOffset->deleteLater();
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	monitoringType->deleteLater();
-#endif
+	if (obs_audio_monitoring_supported())
+		monitoringType->deleteLater();
 	mixerContainer->deleteLater();
 }
 
@@ -284,9 +285,8 @@ void OBSAdvAudioCtrl::ShowAudioControl(QGridLayout *layout)
 	layout->addWidget(forceMonoContainer, lastRow, idx++);
 	layout->addWidget(balanceContainer, lastRow, idx++);
 	layout->addWidget(syncOffset, lastRow, idx++);
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	layout->addWidget(monitoringType, lastRow, idx++);
-#endif
+	if (obs_audio_monitoring_supported())
+		layout->addWidget(monitoringType, lastRow, idx++);
 	layout->addWidget(mixerContainer, lastRow, idx++);
 	layout->layout()->setAlignment(mixerContainer, Qt::AlignVCenter);
 	layout->setHorizontalSpacing(15);

--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -60,6 +60,10 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 				 this);
 	flagsSignal.Connect(handler, "update_flags", OBSSourceFlagsChanged,
 			    this);
+	if (obs_audio_monitoring_supported())
+		monitoringTypeSignal.Connect(handler, "audio_monitoring",
+					     OBSSourceMonitoringTypeChanged,
+					     this);
 	mixersSignal.Connect(handler, "audio_mixers", OBSSourceMixersChanged,
 			     this);
 
@@ -330,6 +334,15 @@ void OBSAdvAudioCtrl::OBSSourceSyncChanged(void *param, calldata_t *calldata)
 				  "SourceSyncChanged", Q_ARG(int64_t, offset));
 }
 
+void OBSAdvAudioCtrl::OBSSourceMonitoringTypeChanged(void *param,
+						     calldata_t *calldata)
+{
+	int type = calldata_int(calldata, "type");
+	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param),
+				  "SourceMonitoringTypeChanged",
+				  Q_ARG(int, type));
+}
+
 void OBSAdvAudioCtrl::OBSSourceMixersChanged(void *param, calldata_t *calldata)
 {
 	uint32_t mixers = (uint32_t)calldata_int(calldata, "mixers");
@@ -380,6 +393,14 @@ void OBSAdvAudioCtrl::SourceSyncChanged(int64_t offset)
 	syncOffset->blockSignals(true);
 	syncOffset->setValue(offset / NSEC_PER_MSEC);
 	syncOffset->blockSignals(false);
+}
+
+void OBSAdvAudioCtrl::SourceMonitoringTypeChanged(int type)
+{
+	int idx = monitoringType->findData(type);
+	monitoringType->blockSignals(true);
+	monitoringType->setCurrentIndex(idx);
+	monitoringType->blockSignals(false);
 }
 
 void OBSAdvAudioCtrl::SourceMixersChanged(uint32_t mixers)

--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -51,6 +51,7 @@ private:
 	OBSSignal volChangedSignal;
 	OBSSignal syncOffsetSignal;
 	OBSSignal flagsSignal;
+	OBSSignal monitoringTypeSignal;
 	OBSSignal mixersSignal;
 	OBSSignal activateSignal;
 	OBSSignal deactivateSignal;
@@ -60,6 +61,8 @@ private:
 	static void OBSSourceFlagsChanged(void *param, calldata_t *calldata);
 	static void OBSSourceVolumeChanged(void *param, calldata_t *calldata);
 	static void OBSSourceSyncChanged(void *param, calldata_t *calldata);
+	static void OBSSourceMonitoringTypeChanged(void *param,
+						   calldata_t *calldata);
 	static void OBSSourceMixersChanged(void *param, calldata_t *calldata);
 
 public:
@@ -77,6 +80,7 @@ public slots:
 	void SourceFlagsChanged(uint32_t flags);
 	void SourceVolumeChanged(float volume);
 	void SourceSyncChanged(int64_t offset);
+	void SourceMonitoringTypeChanged(int type);
 	void SourceMixersChanged(uint32_t mixers);
 
 	void volumeChanged(double db);

--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -69,11 +69,11 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 	label = new QLabel(QTStr("Basic.AdvAudio.SyncOffset"));
 	label->setStyleSheet("font-weight: bold;");
 	mainLayout->addWidget(label, 0, idx++);
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	label = new QLabel(QTStr("Basic.AdvAudio.Monitoring"));
-	label->setStyleSheet("font-weight: bold;");
-	mainLayout->addWidget(label, 0, idx++);
-#endif
+	if (obs_audio_monitoring_supported()) {
+		label = new QLabel(QTStr("Basic.AdvAudio.Monitoring"));
+		label->setStyleSheet("font-weight: bold;");
+		mainLayout->addWidget(label, 0, idx++);
+	}
 	label = new QLabel(QTStr("Basic.AdvAudio.AudioTracks"));
 	label->setStyleSheet("font-weight: bold;");
 	mainLayout->addWidget(label, 0, idx++);

--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -457,17 +457,17 @@ void OBSBasic::ResetProfileData()
 	CreateHotkeys();
 
 	/* load audio monitoring */
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	const char *device_name =
-		config_get_string(basicConfig, "Audio", "MonitoringDeviceName");
-	const char *device_id =
-		config_get_string(basicConfig, "Audio", "MonitoringDeviceId");
+	if (obs_audio_monitoring_supported()) {
+		const char *device_name = config_get_string(
+			basicConfig, "Audio", "MonitoringDeviceName");
+		const char *device_id = config_get_string(basicConfig, "Audio",
+							  "MonitoringDeviceId");
 
-	obs_set_audio_monitoring_device(device_name, device_id);
+		obs_set_audio_monitoring_device(device_name, device_id);
 
-	blog(LOG_INFO, "Audio monitoring device:\n\tname: %s\n\tid: %s",
-	     device_name, device_id);
-#endif
+		blog(LOG_INFO, "Audio monitoring device:\n\tname: %s\n\tid: %s",
+		     device_name, device_id);
+	}
 }
 
 void OBSBasic::on_actionNewProfile_triggered()

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1774,17 +1774,17 @@ void OBSBasic::OBSInit()
 	}
 
 	/* load audio monitoring */
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	const char *device_name =
-		config_get_string(basicConfig, "Audio", "MonitoringDeviceName");
-	const char *device_id =
-		config_get_string(basicConfig, "Audio", "MonitoringDeviceId");
+	if (obs_audio_monitoring_supported()) {
+		const char *device_name = config_get_string(
+			basicConfig, "Audio", "MonitoringDeviceName");
+		const char *device_id = config_get_string(basicConfig, "Audio",
+							  "MonitoringDeviceId");
 
-	obs_set_audio_monitoring_device(device_name, device_id);
+		obs_set_audio_monitoring_device(device_name, device_id);
 
-	blog(LOG_INFO, "Audio monitoring device:\n\tname: %s\n\tid: %s",
-	     device_name, device_id);
-#endif
+		blog(LOG_INFO, "Audio monitoring device:\n\tname: %s\n\tid: %s",
+		     device_name, device_id);
+	}
 
 	InitOBSCallbacks();
 	InitHotkeys();

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -534,9 +534,8 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->colorRange,           COMBO_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->disableOSXVSync,      CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->resetOSXVSync,        CHECK_CHANGED,  ADV_CHANGED);
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	HookWidget(ui->monitoringDevice,     COMBO_CHANGED,  ADV_CHANGED);
-#endif
+	if (obs_audio_monitoring_supported())
+		HookWidget(ui->monitoringDevice,     COMBO_CHANGED,  ADV_CHANGED);
 #ifdef _WIN32
 	HookWidget(ui->disableAudioDucking,  CHECK_CHANGED,  ADV_CHANGED);
 #endif
@@ -583,10 +582,11 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	ui->enableAutoUpdates = nullptr;
 #endif
 
-#if !defined(_WIN32) && !defined(__APPLE__) && !HAVE_PULSEAUDIO
-	delete ui->audioAdvGroupBox;
-	ui->audioAdvGroupBox = nullptr;
-#endif
+	// Remove the Advanced Audio section if monitoring is not supported, as the monitoring device selection is the only item in the group box.
+	if (!obs_audio_monitoring_supported()) {
+		delete ui->audioAdvGroupBox;
+		ui->audioAdvGroupBox = nullptr;
+	}
 
 #ifdef _WIN32
 	uint32_t winVer = GetWindowsVersion();
@@ -735,9 +735,8 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 
 	FillSimpleRecordingValues();
 	FillSimpleStreamingValues();
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	FillAudioMonitoringDevices();
-#endif
+	if (obs_audio_monitoring_supported())
+		FillAudioMonitoringDevices();
 
 	connect(ui->channelSetup, SIGNAL(currentIndexChanged(int)), this,
 		SLOT(SurroundWarning(int)));
@@ -2479,12 +2478,15 @@ void OBSBasicSettings::LoadAdvancedSettings()
 		config_get_string(main->Config(), "Video", "ColorSpace");
 	const char *videoColorRange =
 		config_get_string(main->Config(), "Video", "ColorRange");
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	const char *monDevName = config_get_string(main->Config(), "Audio",
-						   "MonitoringDeviceName");
-	const char *monDevId = config_get_string(main->Config(), "Audio",
-						 "MonitoringDeviceId");
-#endif
+
+	QString monDevName;
+	QString monDevId;
+	if (obs_audio_monitoring_supported()) {
+		monDevName = config_get_string(main->Config(), "Audio",
+					       "MonitoringDeviceName");
+		monDevId = config_get_string(main->Config(), "Audio",
+					     "MonitoringDeviceId");
+	}
 	bool enableDelay =
 		config_get_bool(main->Config(), "Output", "DelayEnable");
 	int delaySec = config_get_int(main->Config(), "Output", "DelaySec");
@@ -2516,10 +2518,10 @@ void OBSBasicSettings::LoadAdvancedSettings()
 
 	LoadRendererList();
 
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	if (!SetComboByValue(ui->monitoringDevice, monDevId))
-		SetInvalidValue(ui->monitoringDevice, monDevName, monDevId);
-#endif
+	if (obs_audio_monitoring_supported() &&
+	    !SetComboByValue(ui->monitoringDevice, monDevId.toUtf8()))
+		SetInvalidValue(ui->monitoringDevice, monDevName.toUtf8(),
+				monDevId.toUtf8());
 
 	ui->filenameFormatting->setText(filename);
 	ui->overwriteIfExists->setChecked(overwriteIfExists);
@@ -3243,10 +3245,12 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	SaveCombo(ui->colorFormat, "Video", "ColorFormat");
 	SaveCombo(ui->colorSpace, "Video", "ColorSpace");
 	SaveComboData(ui->colorRange, "Video", "ColorRange");
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	SaveCombo(ui->monitoringDevice, "Audio", "MonitoringDeviceName");
-	SaveComboData(ui->monitoringDevice, "Audio", "MonitoringDeviceId");
-#endif
+	if (obs_audio_monitoring_supported()) {
+		SaveCombo(ui->monitoringDevice, "Audio",
+			  "MonitoringDeviceName");
+		SaveComboData(ui->monitoringDevice, "Audio",
+			      "MonitoringDeviceId");
+	}
 
 #ifdef _WIN32
 	if (WidgetChanged(ui->disableAudioDucking)) {
@@ -3271,19 +3275,21 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	SaveCheckBox(ui->autoRemux, "Video", "AutoRemux");
 	SaveCheckBox(ui->dynBitrate, "Output", "DynamicBitrate");
 
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
-	QString newDevice = ui->monitoringDevice->currentData().toString();
+	if (obs_audio_monitoring_supported()) {
+		QString newDevice =
+			ui->monitoringDevice->currentData().toString();
 
-	if (lastMonitoringDevice != newDevice) {
-		obs_set_audio_monitoring_device(
-			QT_TO_UTF8(ui->monitoringDevice->currentText()),
-			QT_TO_UTF8(newDevice));
+		if (lastMonitoringDevice != newDevice) {
+			obs_set_audio_monitoring_device(
+				QT_TO_UTF8(ui->monitoringDevice->currentText()),
+				QT_TO_UTF8(newDevice));
 
-		blog(LOG_INFO, "Audio monitoring device:\n\tname: %s\n\tid: %s",
-		     QT_TO_UTF8(ui->monitoringDevice->currentText()),
-		     QT_TO_UTF8(newDevice));
+			blog(LOG_INFO,
+			     "Audio monitoring device:\n\tname: %s\n\tid: %s",
+			     QT_TO_UTF8(ui->monitoringDevice->currentText()),
+			     QT_TO_UTF8(newDevice));
+		}
 	}
-#endif
 }
 
 static inline const char *OutputModeFromIdx(int idx)

--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -416,6 +416,12 @@ Video, Audio, and Graphics
 
 ---------------------
 
+.. function:: bool obs_audio_monitoring_supported(void)
+
+   :return: Whether audio monitoring is supported on the current platform
+
+---------------------
+
 .. function:: void obs_enum_audio_monitoring_devices(obs_enum_audio_device_cb cb, void *data)
 
    Enumerates audio devices which can be used for audio monitoring.

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -114,8 +114,9 @@ if(WIN32)
 		util/windows/HRError.hpp
 		util/windows/WinHandle.hpp)
 	set(libobs_audio_monitoring_SOURCES
-		audio-monitoring/win32/wasapi-output.c
 		audio-monitoring/win32/wasapi-enum-devices.c
+		audio-monitoring/win32/wasapi-monitoring-supported.c
+		audio-monitoring/win32/wasapi-output.c
 		)
 	set(libobs_audio_monitoring_HEADERS
 		audio-monitoring/win32/wasapi-output.h
@@ -138,6 +139,7 @@ elseif(APPLE)
 		util/apple/cfstring-utils.h)
 	set(libobs_audio_monitoring_SOURCES
 		audio-monitoring/osx/coreaudio-enum-devices.c
+		audio-monitoring/osx/coreaudio-monitoring-supported.c
 		audio-monitoring/osx/coreaudio-output.c
 		)
 	set(libobs_audio_monitoring_HEADERS
@@ -219,6 +221,7 @@ elseif(UNIX)
 		set(libobs_audio_monitoring_SOURCES
 			audio-monitoring/pulse/pulseaudio-wrapper.c
 			audio-monitoring/pulse/pulseaudio-enum-devices.c
+			audio-monitoring/pulse/pulseaudio-monitoring-supported.c
 			audio-monitoring/pulse/pulseaudio-output.c)
 	else()
 		set(libobs_audio_monitoring_SOURCES

--- a/libobs/audio-monitoring/null/null-audio-monitoring.c
+++ b/libobs/audio-monitoring/null/null-audio-monitoring.c
@@ -1,5 +1,10 @@
 #include <obs-internal.h>
 
+bool obs_audio_monitoring_supported(void)
+{
+	return false;
+}
+
 void obs_enum_audio_monitoring_devices(obs_enum_audio_device_cb cb, void *data)
 {
 	UNUSED_PARAMETER(cb);

--- a/libobs/audio-monitoring/osx/coreaudio-monitoring-supported.c
+++ b/libobs/audio-monitoring/osx/coreaudio-monitoring-supported.c
@@ -1,0 +1,6 @@
+#include "../../obs-internal.h"
+
+bool obs_audio_monitoring_supported(void)
+{
+	return true;
+}

--- a/libobs/audio-monitoring/pulse/pulseaudio-monitoring-supported.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-monitoring-supported.c
@@ -1,0 +1,6 @@
+#include <obs-internal.h>
+
+bool obs_audio_monitoring_supported(void)
+{
+	return true;
+}

--- a/libobs/audio-monitoring/win32/wasapi-monitoring-supported.c
+++ b/libobs/audio-monitoring/win32/wasapi-monitoring-supported.c
@@ -1,0 +1,6 @@
+#include "../../obs-internal.h"
+
+bool obs_audio_monitoring_supported(void)
+{
+	return true;
+}

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -88,6 +88,7 @@ static const char *source_signals[] = {
 	"void update_flags(ptr source, int flags)",
 	"void audio_sync(ptr source, int out int offset)",
 	"void audio_mixers(ptr source, in out int mixers)",
+	"void audio_monitoring(ptr source, int type)",
 	"void audio_activate(ptr source)",
 	"void audio_deactivate(ptr source)",
 	"void filter_add(ptr source, ptr filter)",
@@ -5003,6 +5004,8 @@ void obs_source_remove_audio_capture_callback(
 void obs_source_set_monitoring_type(obs_source_t *source,
 				    enum obs_monitoring_type type)
 {
+	struct calldata data;
+	uint8_t stack[128];
 	bool was_on;
 	bool now_on;
 
@@ -5010,6 +5013,13 @@ void obs_source_set_monitoring_type(obs_source_t *source,
 		return;
 	if (source->monitoring_type == type)
 		return;
+
+	calldata_init_fixed(&data, stack, sizeof(stack));
+	calldata_set_ptr(&data, "source", source);
+	calldata_set_int(&data, "type", type);
+
+	signal_handler_signal(source->context.signals, "audio_monitoring",
+			      &data);
 
 	was_on = source->monitoring_type != OBS_MONITORING_TYPE_NONE;
 	now_on = type != OBS_MONITORING_TYPE_NONE;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2248,7 +2248,9 @@ bool obs_set_audio_monitoring_device(const char *name, const char *id)
 	if (!name || !id || !*name || !*id)
 		return false;
 
-#if defined(_WIN32) || HAVE_PULSEAUDIO || defined(__APPLE__)
+	if (!obs_audio_monitoring_supported())
+		return false;
+
 	pthread_mutex_lock(&obs->audio.monitoring_mutex);
 
 	if (strcmp(id, obs->audio.monitoring_device_id) == 0) {
@@ -2269,9 +2271,6 @@ bool obs_set_audio_monitoring_device(const char *name, const char *id)
 
 	pthread_mutex_unlock(&obs->audio.monitoring_mutex);
 	return true;
-#else
-	return false;
-#endif
 }
 
 void obs_get_audio_monitoring_device(const char **name, const char **id)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -740,6 +740,8 @@ EXPORT bool obs_obj_is_private(void *obj);
 typedef bool (*obs_enum_audio_device_cb)(void *data, const char *name,
 					 const char *id);
 
+EXPORT bool obs_audio_monitoring_supported(void);
+
 EXPORT void obs_enum_audio_monitoring_devices(obs_enum_audio_device_cb cb,
 					      void *data);
 


### PR DESCRIPTION
### Description
- Adds `obs_audio_monitoring_supported()`
- Adds `audio_monitoring` source signal for monitoring type changes
- Updates the Advanced Audio Properties dialog when an input's audio monitoring type changes

### Motivation and Context
We allow users to change the monitoring type through obs-websocket, and it wasn't updating the UI when someone would perform a request. I also hate incomplete functionality.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: Ubuntu 20.04
Build: Latest git commit as of posting

- `obs_audio_monitoring_supported()` related changes were only tested on Ubuntu, but *should* work the same on all platforms.
- `audio_monitoring` signal was tested via obs-websocket
- Advanced Audio Properties update when `SetInputAudioMonitorType` obs-websocket request is performed

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
