### PR TITLE
UI: Use OBS locale for YouTube categories API

### DIFF
--- a/UI/window-youtube-actions.cpp
+++ b/UI/window-youtube-actions.cpp
@@ -109,8 +109,7 @@ OBSYoutubeActions::OBSYoutubeActions(QWidget *parent, Auth *auth)
 	this->setWindowTitle(channel.title);
 
 	QVector<CategoryDescription> category_list;
-	if (!apiYouTube->GetVideoCategoriesList(
-		    channel.country, channel.language, category_list)) {
+	if (!apiYouTube->GetVideoCategoriesList(category_list)) {
 		blog(LOG_DEBUG, "Could not get video category for country; %s.",
 		     channel.country.toStdString().c_str());
 		ShowErrorDialog(

--- a/UI/youtube-api-wrappers.hpp
+++ b/UI/youtube-api-wrappers.hpp
@@ -68,8 +68,7 @@ public:
 	bool GetBroadcastsList(json11::Json &json_out, const QString &page,
 			       const QString &status);
 	bool
-	GetVideoCategoriesList(const QString &country, const QString &language,
-			       QVector<CategoryDescription> &category_list_out);
+	GetVideoCategoriesList(QVector<CategoryDescription> &category_list_out);
 	bool SetVideoCategory(const QString &video_id,
 			      const QString &video_title,
 			      const QString &video_description,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

If a language or country is not set in the YouTube channel data, we should fall back to the OBS locale rather than `en-US`.

### Motivation and Context

YouTube Category names were not locallised unless the channel had a default language assigned (apparently automatically by YouTube). Furthermore the country or region requires manual configuration by the user otherwise it will also be unset.

### How Has This Been Tested?

Set OBS language to something other than `en-XX` and verified that the categories now are in that locale's langauge.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
