### PR TITLE
UI: Add ability to reuse previous broadcast settings

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -101,6 +101,7 @@ LogViewer="Log Viewer"
 ShowOnStartup="Show on startup"
 OpenFile="Open file"
 AddValue="Add %1"
+RememberSettings="Remember these settings"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"
@@ -1196,6 +1197,8 @@ YouTube.Actions.Privacy.Private="Private"
 YouTube.Actions.Privacy.Public="Public"
 YouTube.Actions.Privacy.Unlisted="Unlisted"
 YouTube.Actions.Category="Category"
+YouTube.Actions.ReuseSettings.Title="Reuse Settings"
+YouTube.Actions.ReuseSettings.Description="Do you want to reuse the settings from the previous broadcast?"
 
 YouTube.Actions.MadeForKids="Is this video made for kids?*"
 YouTube.Actions.MadeForKids.Yes="Yes, it's made for kids"

--- a/UI/forms/OBSYoutubeActions.ui
+++ b/UI/forms/OBSYoutubeActions.ui
@@ -48,14 +48,14 @@
        <property name="labelAlignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
-       <item row="0" column="0">
+       <item row="1" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
           <string>YouTube.Actions.Title</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
+       <item row="1" column="1">
         <widget class="QLineEdit" name="title">
          <property name="text">
           <string>YouTube.Actions.MyBroadcast</string>
@@ -65,28 +65,28 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
+       <item row="2" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
           <string>YouTube.Actions.Description</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="2" column="1">
         <widget class="QPlainTextEdit" name="description">
          <property name="tabChangesFocus">
           <bool>true</bool>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>YouTube.Actions.Privacy</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <widget class="QComboBox" name="privacyBox">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -99,14 +99,14 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
           <string>YouTube.Actions.Category</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <widget class="QComboBox" name="categoryBox">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -116,14 +116,14 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>YouTube.Actions.MadeForKids</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
           <widget class="QRadioButton" name="notMakeForKids">
@@ -150,7 +150,7 @@
          </item>
         </layout>
        </item>
-       <item row="5" column="0">
+       <item row="6" column="0">
         <spacer name="horizontalSpacer_5">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -163,7 +163,7 @@
          </property>
         </spacer>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_8">
          <item>
           <widget class="QRadioButton" name="yesMakeForKids">
@@ -174,14 +174,14 @@
          </item>
         </layout>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>YouTube.Actions.AdditionalSettings</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="7" column="1">
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -194,7 +194,7 @@
          </property>
         </spacer>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <spacer name="horizontalSpacer_7">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -207,7 +207,7 @@
          </property>
         </spacer>
        </item>
-       <item row="7" column="1">
+       <item row="8" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QLabel" name="label_3">
@@ -228,7 +228,7 @@
          </item>
         </layout>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <spacer name="horizontalSpacer_6">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -241,7 +241,7 @@
          </property>
         </spacer>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_6">
          <item>
           <widget class="QCheckBox" name="checkAutoStart">
@@ -290,7 +290,7 @@
          </item>
         </layout>
        </item>
-       <item row="12" column="0">
+       <item row="13" column="0">
         <spacer name="horizontalSpacer_3">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -303,7 +303,7 @@
          </property>
         </spacer>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <widget class="QCheckBox" name="checkAutoStop">
@@ -320,7 +320,7 @@
          </item>
         </layout>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_9">
          <item>
           <widget class="QCheckBox" name="checkScheduledLater">
@@ -334,7 +334,7 @@
          </item>
         </layout>
        </item>
-       <item row="10" column="0">
+       <item row="11" column="0">
         <spacer name="horizontalSpacer_12">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -347,7 +347,7 @@
          </property>
         </spacer>
        </item>
-       <item row="13" column="0">
+       <item row="14" column="0">
         <spacer name="horizontalSpacer_13">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -360,7 +360,7 @@
          </property>
         </spacer>
        </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_10">
          <item>
           <widget class="QDateTimeEdit" name="scheduledTime">
@@ -380,7 +380,7 @@
          </item>
         </layout>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QCheckBox" name="checkDVR">
@@ -394,7 +394,7 @@
          </item>
         </layout>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <spacer name="horizontalSpacer_14">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -407,7 +407,7 @@
          </property>
         </spacer>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <spacer name="horizontalSpacer_8">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -420,7 +420,7 @@
          </property>
         </spacer>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_7">
          <item>
           <widget class="QCheckBox" name="check360Video">
@@ -459,6 +459,13 @@
           </spacer>
          </item>
         </layout>
+       </item>
+       <item row="0" column="1">
+        <widget class="QCheckBox" name="saveSettings">
+         <property name="text">
+          <string>RememberSettings</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -170,6 +170,7 @@ class OBSBasic : public OBSMainWindow {
 	friend class DeviceCaptureToolbar;
 	friend class DeviceToolbarPropertiesThread;
 	friend class OBSBasicSourceSelect;
+	friend class OBSYoutubeActions;
 	friend struct BasicOutputHandler;
 	friend struct OBSStudioAPI;
 

--- a/UI/window-youtube-actions.cpp
+++ b/UI/window-youtube-actions.cpp
@@ -235,6 +235,13 @@ OBSYoutubeActions::OBSYoutubeActions(QWidget *parent, Auth *auth)
 	this->resize(this->width() + 200, this->height() + 120);
 #endif
 	valid = true;
+
+	OBSBasic *main = OBSBasic::Get();
+	bool settingsSaved =
+		config_get_bool(main->basicConfig, "YouTube", "SettingsSaved");
+
+	if (settingsSaved)
+		LoadSettings();
 }
 
 OBSYoutubeActions::~OBSYoutubeActions()
@@ -594,6 +601,91 @@ void OBSYoutubeActions::UiToBroadcast(BroadcastDescription &broadcast)
 	// Current time by default.
 	broadcast.schedul_date_time = QDateTime::currentDateTimeUtc().toString(
 		SchedulDateAndTimeFormat);
+
+	SaveSettings(broadcast);
+}
+
+void OBSYoutubeActions::SaveSettings(BroadcastDescription &broadcast)
+{
+	OBSBasic *main = OBSBasic::Get();
+
+	config_set_string(main->basicConfig, "YouTube", "Title",
+			  QT_TO_UTF8(broadcast.title));
+	config_set_string(main->basicConfig, "YouTube", "Description",
+			  QT_TO_UTF8(broadcast.description));
+	config_set_string(main->basicConfig, "YouTube", "Privacy",
+			  QT_TO_UTF8(broadcast.privacy));
+	config_set_string(main->basicConfig, "YouTube", "CategoryID",
+			  QT_TO_UTF8(broadcast.category.id));
+	config_set_string(main->basicConfig, "YouTube", "Latency",
+			  QT_TO_UTF8(broadcast.latency));
+	config_set_bool(main->basicConfig, "YouTube", "AutoStart",
+			broadcast.auto_start);
+	config_set_bool(main->basicConfig, "YouTube", "AutoStop",
+			broadcast.auto_start);
+	config_set_bool(main->basicConfig, "YouTube", "DVR", broadcast.dvr);
+	config_set_bool(main->basicConfig, "YouTube", "ScheduleForLater",
+			broadcast.schedul_for_later);
+	config_set_string(main->basicConfig, "YouTube", "Projection",
+			  QT_TO_UTF8(broadcast.projection));
+	config_set_bool(main->basicConfig, "YouTube", "SettingsSaved",
+			ui->saveSettings->isChecked());
+}
+
+void OBSYoutubeActions::LoadSettings()
+{
+	OBSBasic *main = OBSBasic::Get();
+
+	bool saveSettings =
+		config_get_bool(main->basicConfig, "YouTube", "SettingsSaved");
+	ui->saveSettings->setChecked(saveSettings);
+
+	const char *title =
+		config_get_string(main->basicConfig, "YouTube", "Title");
+	ui->title->setText(QT_UTF8(title));
+
+	const char *desc =
+		config_get_string(main->basicConfig, "YouTube", "Description");
+	ui->description->setPlainText(QT_UTF8(desc));
+
+	const char *priv =
+		config_get_string(main->basicConfig, "YouTube", "Privacy");
+	int index = ui->privacyBox->findData(priv);
+	ui->privacyBox->setCurrentIndex(index);
+
+	const char *catID =
+		config_get_string(main->basicConfig, "YouTube", "CategoryID");
+	index = ui->categoryBox->findData(catID);
+	ui->categoryBox->setCurrentIndex(index);
+
+	const char *latency =
+		config_get_string(main->basicConfig, "YouTube", "Latency");
+	index = ui->latencyBox->findData(latency);
+	ui->latencyBox->setCurrentIndex(index);
+
+	bool autoStart =
+		config_get_bool(main->basicConfig, "YouTube", "AutoStart");
+	ui->checkAutoStart->setChecked(autoStart);
+
+	bool autoStop =
+		config_get_bool(main->basicConfig, "YouTube", "AutoStop");
+	ui->checkAutoStop->setChecked(autoStop);
+
+	bool dvr = config_get_bool(main->basicConfig, "YouTube", "DVR");
+	ui->checkDVR->setChecked(dvr);
+
+	bool schedLater = config_get_bool(main->basicConfig, "YouTube",
+					  "ScheduleForLater");
+	ui->checkScheduledLater->setChecked(schedLater);
+
+	const char *projection =
+		config_get_string(main->basicConfig, "YouTube", "Projection");
+	if (projection && *projection) {
+		if (strcmp(projection, "360") == 0)
+			ui->check360Video->setChecked(true);
+		else
+			ui->check360Video->setChecked(false);
+	}
 }
 
 void OBSYoutubeActions::OpenYouTubeDashboard()

--- a/UI/window-youtube-actions.hpp
+++ b/UI/window-youtube-actions.hpp
@@ -66,4 +66,7 @@ private:
 	bool valid = false;
 	YoutubeApiWrappers *apiYouTube;
 	WorkerThread *workerThread;
+
+	void SaveSettings(BroadcastDescription &broadcast);
+	void LoadSettings();
 };


### PR DESCRIPTION
### Description
This adds an option to save the YouTube settings.

### Motivation and Context
It is a pain to reenter the settings each time when streaming to YouTube.

### How Has This Been Tested?
Created broadcast, closed dialog and made sure when clicking yes on the dialog, the settings were the same as before.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
