### PR TITLE
Improve scaling of audio meter (issue 3915)

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -707,6 +707,13 @@ VolumeMeter {
 	qproperty-majorTickColor: rgb(239,240,241); /* White */
 	qproperty-minorTickColor: rgb(118,121,124); /* Light Gray */
 	qproperty-peakDecayRate: 23.4; /* Override of the standard PPM Type I rate. */
+	qproperty-meterThickness: 3;
+
+	/* The meter scale numbers normally use your QWidget font, with size    */
+	/* multiplied by meterFontScaling to get a proportionally smaller font. */
+	/* To use a unique font for the numbers, specify font-family and/or     */
+	/* font-size here, and set meterFontScaling to 1.0.                     */
+	qproperty-meterFontScaling: 0.7;
 }
 
 
@@ -1260,7 +1267,7 @@ QCalendarWidget QToolButton:pressed {
 
 /* Month Dropdown Menu */
 QCalendarWidget QMenu {
-    
+
 }
 /* Year spinbox */
 QCalendarWidget QSpinBox {

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -583,6 +583,13 @@ VolumeMeter {
     qproperty-magnitudeColor: rgb(0,0,0);
     qproperty-majorTickColor: palette(window-text);
     qproperty-minorTickColor: rgb(122,121,122); /* light */
+    qproperty-meterThickness: 3;
+
+    /* The meter scale numbers normally use your QWidget font, with size    */
+    /* multiplied by meterFontScaling to get a proportionally smaller font. */
+    /* To use a unique font for the numbers, specify font-family and/or     */
+    /* font-size here, and set meterFontScaling to 1.0.                     */
+    qproperty-meterFontScaling: 0.7;
 }
 
 
@@ -978,7 +985,7 @@ QCalendarWidget QToolButton:pressed {
 
 /* Month Dropdown Menu */
 QCalendarWidget QMenu {
-    
+
 }
 /* Year spinbox */
 QCalendarWidget QSpinBox {

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -831,6 +831,13 @@ VolumeMeter {
 	qproperty-magnitudeColor: palette(window);
 	qproperty-majorTickColor: palette(window-text);
 	qproperty-minorTickColor: palette(mid);
+	qproperty-meterThickness: 3;
+
+	/* The meter scale numbers normally use your QWidget font, with size    */
+	/* multiplied by meterFontScaling to get a proportionally smaller font. */
+	/* To use a unique font for the numbers, specify font-family and/or     */
+	/* font-size here, and set meterFontScaling to 1.0.                     */
+	qproperty-meterFontScaling: 0.7;
 }
 
 /*******************/

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -90,6 +90,13 @@ VolumeMeter {
     qproperty-magnitudeColor: rgb(0, 0, 0);
     qproperty-majorTickColor: rgb(0, 0, 0);
     qproperty-minorTickColor: rgb(50, 50, 50);
+    qproperty-meterThickness: 3;
+
+    /* The meter scale numbers normally use your QWidget font, with size    */
+    /* multiplied by meterFontScaling to get a proportionally smaller font. */
+    /* To use a unique font for the numbers, specify font-family and/or     */
+    /* font-size here, and set meterFontScaling to 1.0.                     */
+    qproperty-meterFontScaling: 0.7;
 }
 
 

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -60,6 +60,10 @@ class VolumeMeter : public QWidget {
 			   setMajorTickColor DESIGNABLE true)
 	Q_PROPERTY(QColor minorTickColor READ getMinorTickColor WRITE
 			   setMinorTickColor DESIGNABLE true)
+	Q_PROPERTY(int meterThickness READ getMeterThickness WRITE
+			   setMeterThickness DESIGNABLE true)
+	Q_PROPERTY(qreal meterFontScaling READ getMeterFontScaling WRITE
+			   setMeterFontScaling DESIGNABLE true)
 
 	// Levels are denoted in dBFS.
 	Q_PROPERTY(qreal minimumLevel READ getMinimumLevel WRITE setMinimumLevel
@@ -99,7 +103,7 @@ private:
 	QSharedPointer<VolumeMeterTimer> updateTimerRef;
 
 	inline void resetLevels();
-	inline void handleChannelCofigurationChange();
+	inline void doLayout();
 	inline bool detectIdle(uint64_t ts);
 	inline void calculateBallistics(uint64_t ts,
 					qreal timeSinceLastRedraw = 0.0);
@@ -110,14 +114,14 @@ private:
 			     int height, float peakHold);
 	void paintHMeter(QPainter &painter, int x, int y, int width, int height,
 			 float magnitude, float peak, float peakHold);
-	void paintHTicks(QPainter &painter, int x, int y, int width,
-			 int height);
+	void paintHTicks(QPainter &painter, int x, int y, int width);
 	void paintVMeter(QPainter &painter, int x, int y, int width, int height,
 			 float magnitude, float peak, float peakHold);
 	void paintVTicks(QPainter &painter, int x, int y, int height);
 
 	QMutex dataMutex;
 
+	bool recalculateLayout = true;
 	uint64_t currentLastUpdateTime = 0;
 	float currentMagnitude[MAX_AUDIO_CHANNELS];
 	float currentPeak[MAX_AUDIO_CHANNELS];
@@ -150,6 +154,10 @@ private:
 	QColor magnitudeColor;
 	QColor majorTickColor;
 	QColor minorTickColor;
+
+	int meterThickness;
+	qreal meterFontScaling;
+
 	qreal minimumLevel;
 	qreal warningLevel;
 	qreal errorLevel;
@@ -175,7 +183,8 @@ public:
 	void setLevels(const float magnitude[MAX_AUDIO_CHANNELS],
 		       const float peak[MAX_AUDIO_CHANNELS],
 		       const float inputPeak[MAX_AUDIO_CHANNELS]);
-	QRect getBarRect();
+	QRect getBarRect() const;
+	bool needLayoutChange();
 
 	QColor getBackgroundNominalColor() const;
 	void setBackgroundNominalColor(QColor c);
@@ -211,6 +220,10 @@ public:
 	void setMajorTickColor(QColor c);
 	QColor getMinorTickColor() const;
 	void setMinorTickColor(QColor c);
+	int getMeterThickness() const;
+	void setMeterThickness(int v);
+	qreal getMeterFontScaling() const;
+	void setMeterFontScaling(qreal v);
 	qreal getMinimumLevel() const;
 	void setMinimumLevel(qreal v);
 	qreal getWarningLevel() const;
@@ -235,6 +248,7 @@ public:
 
 protected:
 	void paintEvent(QPaintEvent *event) override;
+	void changeEvent(QEvent *e) override;
 };
 
 class VolumeMeterTimer : public QTimer {

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -123,7 +123,6 @@ private:
 	float currentPeak[MAX_AUDIO_CHANNELS];
 	float currentInputPeak[MAX_AUDIO_CHANNELS];
 
-	QPixmap *tickPaintCache = nullptr;
 	int displayNrAudioChannels = 0;
 	float displayMagnitude[MAX_AUDIO_CHANNELS];
 	float displayPeak[MAX_AUDIO_CHANNELS];
@@ -176,6 +175,7 @@ public:
 	void setLevels(const float magnitude[MAX_AUDIO_CHANNELS],
 		       const float peak[MAX_AUDIO_CHANNELS],
 		       const float inputPeak[MAX_AUDIO_CHANNELS]);
+	QRect getBarRect();
 
 	QColor getBackgroundNominalColor() const;
 	void setBackgroundNominalColor(QColor c);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
My branch has two commits, as recommended by the fine folks on OBS Discord.

The first addresses issue 3915 by replacing a cached bitmap with selective repaint. This helps with legibility at scaled DPI, and also eliminates unnecessary repainting of the scale area.

V27.0.1 (using cached bitmap). Left 100%, right 125% scaling
![Q V27](https://user-images.githubusercontent.com/31324355/131730604-5b72290f-6ebc-4614-b617-07cab96a97ae.png)

First commit. Left 100%, right 125% scaling
![Q fix1](https://user-images.githubusercontent.com/31324355/131730644-9b13ced7-19b7-45da-a226-1f9530f549db.png)

The second commit allows the appearance of the meter to be adjusted via the stylesheet. This permits the appearance to be optimized by the user to deal with scaling or other needs and preferences.

Second commit. Left 100%, right 125% scaling
![Q fix2](https://user-images.githubusercontent.com/31324355/131730695-c41c3328-b581-4c10-a89c-1ebc21376c00.png)

Second commit, vertical orientation. Left 100%, right 125% scaling
![Q fix2 vertical](https://user-images.githubusercontent.com/31324355/131730737-5f1b81b7-9ca5-4367-986a-0f9ccd865bc0.png)

Second commit, stylesheet specifies meter bar 9 pixels wide, silly font at 150%
![Q fix2 silly at 100](https://user-images.githubusercontent.com/31324355/131730765-77e23c4d-2477-416e-a6e5-0cf4696ed4db.png)

Minor changes
- A horizontal meter has lots of space for the label, so the default label font is used (V27 used 1px smaller). A vertical meter has less space for a label, so the font size is reduced to 80% of the default.
- For vertical meters, the number showing the fader setting was centered on the meter/fader pair;  which made it somewhat ambiguous whether it represented fader or audio level.  Changed to be right-justified, putting the number over the fader.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Eliminating the bitmap cache improves the appearance of the meter when scaled, fixes #3915

But in my opinion, the underlying problem is that the font used for the volume meter scale is just too small and is not adjustable. My second commit draws the scale numbers using the font settings for VolumeMeter, or its base class QWidget. It adds a qproperty to the stylesheet to adjust the size of the font by a percentage (80% default). It also adds a qproperty to specify the thickness of the meter bar in pixels, which might be used to match the width of the volume fader, etc.

<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
[https://github.com/obsproject/obs-studio/issues/3915](url)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows 10 version 21H1 plus updates
- tested at 100% and 125% scaling, horizontal and vertical meters
- tested with existing stylesheets without added properties
- tested with updated stylesheets with added properties

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality) second commit adding stylesheet properties
- (minor) Performance enhancement (non-breaking change which improves efficiency) elimination of copying cached bitmap may offer a small performance improvement
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
