### PR TITLE
UI: Fix vertical stretching in audio settings pane

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -151,8 +151,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>803</width>
-              <height>1026</height>
+              <width>806</width>
+              <height>1181</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -1361,8 +1361,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>601</width>
-              <height>602</height>
+              <width>820</width>
+              <height>679</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -3870,8 +3870,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>555</width>
-              <height>469</height>
+              <width>820</width>
+              <height>641</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_50">
@@ -4291,6 +4291,19 @@
                    </property>
                   </layout>
                  </widget>
+                </item>
+                <item>
+                 <spacer name="verticalSpacer_4">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                 </spacer>
                 </item>
                </layout>
               </widget>
@@ -4726,8 +4739,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>602</width>
-              <height>781</height>
+              <width>609</width>
+              <height>870</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_23">


### PR DESCRIPTION
### Description
The fixes in #5143 caused the audio pane in settings to stretch out to fit the available space.

Add a spacer so the pane only uses the space it needs.

## Before
![image](https://user-images.githubusercontent.com/1554753/132081871-f0d5264e-1bb5-4642-83ed-f93d3e58916d.png)

## After
![image](https://user-images.githubusercontent.com/1554753/132081878-45bbf88e-8f05-416b-b73c-cab43edcc61b.png)


### Motivation and Context
These group boxes shouldn't stretch

### How Has This Been Tested?
Checked the audio pane of Settings

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
