### PR TITLE
More YouTube cleanup and fixes

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -470,6 +470,8 @@ void OBSBasicSettings::on_service_currentIndexChanged(int)
 		ui->serverStackedWidget->setCurrentIndex(0);
 	}
 
+	auth.reset();
+
 	if (!main->auth) {
 		return;
 	}
@@ -482,7 +484,6 @@ void OBSBasicSettings::on_service_currentIndexChanged(int)
 						IsYouTubeService(service);
 #endif
 	if (service_check) {
-		auth.reset();
 		auth = main->auth;
 		OnAuthConnected();
 	}

--- a/UI/window-youtube-actions.cpp
+++ b/UI/window-youtube-actions.cpp
@@ -110,8 +110,6 @@ OBSYoutubeActions::OBSYoutubeActions(QWidget *parent, Auth *auth)
 
 	QVector<CategoryDescription> category_list;
 	if (!apiYouTube->GetVideoCategoriesList(category_list)) {
-		blog(LOG_DEBUG, "Could not get video category for country; %s.",
-		     channel.country.toStdString().c_str());
 		ShowErrorDialog(
 			parent,
 			apiYouTube->GetLastError().isEmpty()
@@ -383,7 +381,7 @@ bool OBSYoutubeActions::StreamNowAction(YoutubeApiWrappers *api,
 		blog(LOG_DEBUG, "No broadcast created.");
 		return false;
 	}
-	stream = {"", "", "OBS Studio Video Stream", ""};
+	stream = {"", "", "OBS Studio Video Stream"};
 	if (!apiYouTube->InsertStream(stream)) {
 		blog(LOG_DEBUG, "No stream created.");
 		return false;
@@ -465,15 +463,12 @@ bool OBSYoutubeActions::ChooseAnEventAction(YoutubeApiWrappers *api,
 		auto streamName = item["cdn"]["ingestionInfo"]["streamName"]
 					  .string_value();
 		auto title = item["snippet"]["title"].string_value();
-		auto description =
-			item["snippet"]["description"].string_value();
 
 		stream.name = streamName.c_str();
 		stream.title = title.c_str();
-		stream.description = description.c_str();
 		api->SetBroadcastId(selectedBroadcast);
 	} else {
-		stream = {"", "", "OBS Studio Video Stream", ""};
+		stream = {"", "", "OBS Studio Video Stream"};
 		if (!apiYouTube->InsertStream(stream)) {
 			blog(LOG_DEBUG, "No stream created.");
 			return false;

--- a/UI/youtube-api-wrappers.cpp
+++ b/UI/youtube-api-wrappers.cpp
@@ -180,14 +180,6 @@ bool YoutubeApiWrappers::GetChannelDescription(
 
 	channel_description.id =
 		QString(json_out["items"][0]["id"].string_value().c_str());
-	channel_description.country =
-		QString(json_out["items"][0]["snippet"]["country"]
-				.string_value()
-				.c_str());
-	channel_description.language =
-		QString(json_out["items"][0]["snippet"]["defaultLanguage"]
-				.string_value()
-				.c_str());
 	channel_description.title = QString(
 		json_out["items"][0]["snippet"]["title"].string_value().c_str());
 	return channel_description.id.isEmpty() ? false : true;

--- a/UI/youtube-api-wrappers.hpp
+++ b/UI/youtube-api-wrappers.hpp
@@ -40,11 +40,6 @@ struct BroadcastDescription {
 	QString projection;
 };
 
-struct BindDescription {
-	const QString id;
-	const QString stream_name;
-};
-
 bool IsYouTubeService(const std::string &service);
 
 class YoutubeApiWrappers : public YoutubeAuth {

--- a/UI/youtube-api-wrappers.hpp
+++ b/UI/youtube-api-wrappers.hpp
@@ -8,15 +8,12 @@
 struct ChannelDescription {
 	QString id;
 	QString title;
-	QString country;
-	QString language;
 };
 
 struct StreamDescription {
 	QString id;
 	QString name;
 	QString title;
-	QString description;
 };
 
 struct CategoryDescription {


### PR DESCRIPTION
### Description
- Cleanup
  + Remove unused `BindDescription` struct from `youtube-api-wrappers.hpp `
  + Remove unused members of `ChannelDescription` and `StreamDescription` structs as well as related code
- Fixes
  + Restore `auth.reset()` on service switch (Fixes #5236)

### Motivation and Context
Obsolete code makes us unhappy. So do bugs.

### How Has This Been Tested?

Compiled on Windows, verified that #5236 is no longer happening.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
