### PR TITLE
libobs: Fix minor static analysis warnings

### DIFF
--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -1010,17 +1010,14 @@ gs_generalize_format(enum gs_color_format format)
 {
 	switch (format) {
 	case GS_RGBA_UNORM:
-		format = GS_RGBA;
-		break;
+		return GS_RGBA;
 	case GS_BGRX_UNORM:
-		format = GS_BGRX;
-		break;
+		return GS_BGRX;
 	case GS_BGRA_UNORM:
-		format = GS_BGRA;
-	default:;
+		return GS_BGRA;
+	default:
+		return format;
 	}
-
-	return format;
 }
 
 static inline uint32_t gs_get_total_levels(uint32_t width, uint32_t height,

--- a/libobs/util/windows/ComPtr.hpp
+++ b/libobs/util/windows/ComPtr.hpp
@@ -57,7 +57,7 @@ public:
 		if (ptr)
 			ptr->AddRef();
 	}
-	inline ComPtr(ComPtr<T> &&c) : ptr(c.ptr) { c.ptr = nullptr; }
+	inline ComPtr(ComPtr<T> &&c) noexcept : ptr(c.ptr) { c.ptr = nullptr; }
 	inline ~ComPtr() { Kill(); }
 
 	inline void Clear()
@@ -80,7 +80,7 @@ public:
 		return *this;
 	}
 
-	inline ComPtr<T> &operator=(ComPtr<T> &&c)
+	inline ComPtr<T> &operator=(ComPtr<T> &&c) noexcept
 	{
 		if (&ptr != &c.ptr) {
 			Kill();


### PR DESCRIPTION
### Description
Fix minor static analysis warnings.

### Motivation and Context
Don't like warning spam.

### How Has This Been Tested?
Breakpoint inspection.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.