### PR TITLE
UI: Enable AutoConfig bandwidth test for YT integration

### DIFF
--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -262,6 +262,9 @@ void AutoConfigTestPage::TestBandwidthThread()
 		 * server */
 		servers.erase(servers.begin() + 1);
 		servers.resize(3);
+	} else if (wiz->service == AutoConfig::Service::YouTube) {
+		/* Only test first set of primary + backup servers */
+		servers.resize(2);
 	}
 
 	/* -----------------------------------*/

--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -305,6 +305,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 
 	obs_output_set_video_encoder(output, vencoder);
 	obs_output_set_audio_encoder(output, aencoder, 0);
+	obs_output_set_reconnect_settings(output, 0, 0);
 
 	obs_output_set_service(output, service);
 

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -38,6 +38,7 @@ class AutoConfig : public QWizard {
 
 	enum class Service {
 		Twitch,
+		YouTube,
 		Other,
 	};
 


### PR DESCRIPTION
### Description

Enables bandwdith testing for YouTube if service integration is used. Also sets target bandwidth to YouTube maximum of 51 Mbps rather than using default of 10.

### Motivation and Context
Bandwidth testing for YouTube was originally disabled due to the created video resulting in temporary strikes due to YouTube's content filters determining the content to be spam.

With the YouTube integration we can instead simply create a throwaway stream key without any attached broadcast, meaning that no video will be created, and nothing we send will be saved. That way we can safely test the bandwidth to the YouTube servers.

### How Has This Been Tested?
- Ran bandwidth test
- Made sure UI properly resets and locks out bandwidth test if account is disconnected

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
