### PR TITLE
Windows SDK 10.0.20348.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 if(WIN32)
 	cmake_minimum_required(VERSION 3.16)
 
-	# Check for Win SDK version 10.0.19041 or above
-	if(MSVC AND MSVC_VERSION LESS 1920)
+	# Check for Win SDK version 10.0.20348 or above
+	if(MSVC)
 		message(STATUS "Windows API version is ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
 		string(REPLACE "." ";" WINAPI_VER "${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
 
@@ -26,7 +26,7 @@ if(WIN32)
 		set(WINAPI_COMPATIBLE FALSE)
 		if(WINAPI_VER_MAJOR EQUAL 10)
 			if (WINAPI_VER_MINOR EQUAL 0)
-				if (WINAPI_VER_BUILD GREATER_EQUAL 19041)
+				if (WINAPI_VER_BUILD GREATER_EQUAL 20348)
 					set(WINAPI_COMPATIBLE TRUE)
 				endif()
 			else()
@@ -37,7 +37,7 @@ if(WIN32)
 		endif()
 
 		if(NOT WINAPI_COMPATIBLE)
-			message(FATAL_ERROR "OBS requires Windows 10 SDK version 10.0.19041.0 and above to compile.\nPlease download the most recent Windows 10 SDK in order to compile (or update to Visual Studio 2019).")
+			message(FATAL_ERROR "OBS requires Windows 10 SDK version 10.0.20348.0 and above to compile.\nPlease download the most recent Windows 10 SDK in order to compile.")
 		endif()
 	endif()
 

--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -262,7 +262,6 @@ static void winrt_capture_device_loss_release(void *data)
 	capture->item = nullptr;
 }
 
-#if WINDOWS_FOUNDATION_UNIVERSALAPICONTRACT_VERSION >= 0xc0000
 static bool winrt_capture_border_toggle_supported()
 try {
 	return winrt::Windows::Foundation::Metadata::ApiInformation::
@@ -278,7 +277,6 @@ try {
 	     winrt::to_hresult().value);
 	return false;
 }
-#endif
 
 static winrt::Windows::Graphics::Capture::GraphicsCaptureItem
 winrt_capture_create_item(IGraphicsCaptureItemInterop *const interop_factory,
@@ -362,7 +360,6 @@ static void winrt_capture_device_loss_rebuild(void *device_void, void *data)
 	const winrt::Windows::Graphics::Capture::GraphicsCaptureSession session =
 		frame_pool.CreateCaptureSession(item);
 
-#if WINDOWS_FOUNDATION_UNIVERSALAPICONTRACT_VERSION >= 0xc0000
 	if (winrt_capture_border_toggle_supported()) {
 		winrt::Windows::Graphics::Capture::GraphicsCaptureAccess::
 			RequestAccessAsync(
@@ -371,7 +368,6 @@ static void winrt_capture_device_loss_rebuild(void *device_void, void *data)
 				.get();
 		session.IsBorderRequired(false);
 	}
-#endif
 
 	if (winrt_capture_cursor_toggle_supported())
 		session.IsCursorCaptureEnabled(capture->capture_cursor &&
@@ -444,7 +440,6 @@ try {
 	const winrt::Windows::Graphics::Capture::GraphicsCaptureSession session =
 		frame_pool.CreateCaptureSession(item);
 
-#if WINDOWS_FOUNDATION_UNIVERSALAPICONTRACT_VERSION >= 0xc0000
 	if (winrt_capture_border_toggle_supported()) {
 		winrt::Windows::Graphics::Capture::GraphicsCaptureAccess::
 			RequestAccessAsync(
@@ -453,7 +448,6 @@ try {
 				.get();
 		session.IsBorderRequired(false);
 	}
-#endif
 
 	/* disable cursor capture if possible since ours performs better */
 	const BOOL cursor_toggle_supported =


### PR DESCRIPTION
### Description
Update minimum Windows SDK version to 10.0.20348.0.

### Motivation and Context
Necessary for borderless WGC support to be compiled in. Also for future support of per-process audio capture.

### How Has This Been Tested?
Borderless WGC works on Windows 11 preview build.

Verified build does not compile on 19041, and reports error message.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.