### PR TITLE
Fix Qt6 compatibility issues

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -820,8 +820,8 @@ bool OBSApp::InitLocale()
 
 	// set basic default application locale
 	if (!locale.empty())
-		QLocale::setDefault(
-			QString::fromStdString(locale).replace('-', '_'));
+		QLocale::setDefault(QLocale(
+			QString::fromStdString(locale).replace('-', '_')));
 
 	string englishPath;
 	if (!GetDataFilePath("locale/" DEFAULT_LANG ".ini", englishPath)) {
@@ -864,9 +864,9 @@ bool OBSApp::InitLocale()
 
 			// set application default locale to the new choosen one
 			if (!locale.empty())
-				QLocale::setDefault(
+				QLocale::setDefault(QLocale(
 					QString::fromStdString(locale).replace(
-						'-', '_'));
+						'-', '_')));
 
 			return true;
 		}

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -386,7 +386,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	// Register shortcuts for Undo/Redo
 	ui->actionMainUndo->setShortcut(Qt::CTRL + Qt::Key_Z);
 	QList<QKeySequence> shrt;
-	shrt << QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Z)
+	shrt << QKeySequence(Qt::CTRL | Qt::SHIFT + Qt::Key_Z)
 	     << QKeySequence(Qt::CTRL + Qt::Key_Y);
 	ui->actionMainRedo->setShortcuts(shrt);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

There are two commits in this PR.  One commit fixes a Qt6-incompatible call to QLocale::setDefault.  The other commit fixes a Qt6-incompatible operator usage with two Qt::Modifier instances.

----

UI: Fix Qt6-incompatible call to QLocale::setDefault 

The YouTube integration changes introduced code that does not build on Qt6. The errors were:

 * void QLocale::setDefault(const QLocale &)': cannot convert argument 1 from 'QString' to 'const QLocale &'

 * no suitable user-defined conversion from "QString" to "const QLocale" exists

This commit creates a new QLocale in place from a QString using the `QLocale(const QString &name)` constructor, and passing that QLocale to QLocale::setDefault.

----

UI: Fix Qt6-incompatible operator usage

Commit 60d95cb5 introduced some code that used the + operator on two Qt::Modifier items. Using a pipe operator instead fixes the compilation error on Qt5 and Qt6.

----

QLocale Docs:
* https://doc.qt.io/qt-5/qlocale.html
* https://doc.qt.io/qt-6/qlocale.html

The only docs regarding the Qt::Modifier operator I could find were in QKeySequence:
* https://doc.qt.io/qt-5/qkeysequence.html#details
* https://doc.qt.io/qt-6/qkeysequence.html#details

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Maintain compatibility with both Qt5 and Qt6 to make switching between the two easier in the future.

Not an urgent fix since we still only support Qt5, so this does not need to be merged during the 27.1.0 RC phase.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Clang-format CI check passed on my fork.

Built and tested Undo/Redo on Windows 10 against Qt 5.15.2 and Qt 6.2.0-beta3 to make sure the change to the modifier operator works with both Qt5 and Qt6.

May need testing for the change to the QLocale invocation.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
