### PR TITLE
UI: Update volume controls by callback

### DIFF
--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -4,7 +4,6 @@
 #include <QWidget>
 #include <QPaintEvent>
 #include <QSharedPointer>
-#include <QTimer>
 #include <QMutex>
 #include <QList>
 #include <QMenu>
@@ -186,18 +185,20 @@ protected:
 	void paintEvent(QPaintEvent *event) override;
 };
 
-class VolumeMeterTimer : public QTimer {
+class VolumeMeterTimer : public QObject {
 	Q_OBJECT
 
 public:
-	inline VolumeMeterTimer() : QTimer() {}
-
 	void AddVolControl(VolumeMeter *meter);
 	void RemoveVolControl(VolumeMeter *meter);
+	void SignalUpdate();
+
+protected slots:
+	void UpdateMeters();
 
 protected:
-	void timerEvent(QTimerEvent *event) override;
 	QList<VolumeMeter *> volumeMeters;
+	std::atomic<uint64_t> lastUpdate = 0;
 };
 
 class QLabel;


### PR DESCRIPTION
### Description
Get rid of the time-critical timeSetEvent thread on Windows.

### Motivation and Context
Trying to reduce CPU usage/contention. Doesn't solve the stalls on Windows 11, but it shouldn't hurt.

### How Has This Been Tested?
Volume meters still appear to update.

CPU% in status bar looks the same, but getting rid of a thread should be a positive.

Verified updates still amortize to 60 FPS with temporary timing code. Audio updates were actually firing at 100 Hz on my PC.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.