### PR TITLE
rtmp-services: Add "Disciple Media"

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 181,
+	"version": 182,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 181
+			"version": 182
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2323,6 +2323,15 @@
                     "url":  "rtmp://rtmp.boxcast.com/live"
                 }
             ]
+        },
+        {
+            "name": "Disciple Media",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url":  "rtmp://rtmp.disciplemedia.com/b-fme"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
### Description
Adds [Disciple Media](https://www.disicplemedia.com) to the rtmp services list.
Disciple is a community platform with live streaming capabilities.

### Motivation and Context
Add support for Disciple Media for OBS users

### How Has This Been Tested?
Local / CI build

### Types of changes
New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
