### PR TITLE
image-source: Use mutex when accessing slideshow

### DIFF
--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -730,8 +730,10 @@ static void ss_video_tick(void *data, float seconds)
 {
 	struct slideshow *ss = data;
 
+	pthread_mutex_lock(&ss->mutex);
+
 	if (!ss->transition || !ss->slide_time)
-		return;
+		goto finish;
 
 	if (ss->restart_on_activate && ss->use_cut) {
 		ss->elapsed = 0.0f;
@@ -740,11 +742,11 @@ static void ss_video_tick(void *data, float seconds)
 		ss->restart_on_activate = false;
 		ss->use_cut = false;
 		ss->stop = false;
-		return;
+		goto finish;
 	}
 
 	if (ss->pause_on_deactivate || ss->manual || ss->stop || ss->paused)
-		return;
+		goto finish;
 
 	/* ----------------------------------------------------- */
 	/* fade to transparency when the file list becomes empty */
@@ -771,11 +773,14 @@ static void ss_video_tick(void *data, float seconds)
 			else
 				do_transition(ss, false);
 
-			return;
+			goto finish;
 		}
 
 		obs_source_media_next(ss->source);
 	}
+
+finish:
+	pthread_mutex_unlock(&ss->mutex);
 }
 
 static inline bool ss_audio_render_(obs_source_t *transition, uint64_t *ts_out,


### PR DESCRIPTION
### Description
While `ss_update` used the mutex, `ss_video_tick` did not, so concurrent access was not well protected. This could cause crashes if an update modified the files as the tick function was running concurrently.

### Motivation and Context
Hopefully fixes random slideshow crashes such as #5260.

### How Has This Been Tested?
Was not able to reproduce the race condition to actually test this, but I think the change is good.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
