### PR TITLE
Fix Windows 11 responsiveness using FLIP_DISCARD

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -794,7 +794,6 @@ struct gs_pixel_shader : gs_shader {
 };
 
 struct gs_swap_chain : gs_obj {
-	uint32_t numBuffers;
 	HWND hwnd;
 	gs_init_data initData;
 	DXGI_SWAP_CHAIN_DESC swapDesc = {};

--- a/libobs/util/windows/win-version.h
+++ b/libobs/util/windows/win-version.h
@@ -29,8 +29,8 @@ struct win_version_info {
 	int revis;
 };
 
-static inline int win_version_compare(struct win_version_info *dst,
-				      struct win_version_info *src)
+static inline int win_version_compare(const struct win_version_info *dst,
+				      const struct win_version_info *src)
 {
 	if (dst->major > src->major)
 		return 1;


### PR DESCRIPTION
### Description
Windows 11 support for DISCARD swap effect seems to be buggy and slow.
Use FLIP_DISCARD instead. Staying with DISCARD on Windows 10 because of
reports of flickering that hopefully won't happen on Windows 11.

We're also not using ALLOW_TEARING because it seems to break after an
OBS cycle of minimize/restore on both Windows 10 and 11. The swap chain
displays a stale image. Not sure if ALLOW_TEARING would be beneficial
even if it was working.

Fixes #4807.
Fixes #5097.

### Motivation and Context
Don't want OBS to run terrible on Windows 11.

### How Has This Been Tested?
Verified responsiveness fixed on Windows 11 insider build by moving mouse back and forth to check button hover response in bottom-right of OBS. Windows 10 21H1 continues to work fine.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.