### PR TITLE
UI: Theme fixes for Dark and Acri

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -428,6 +428,11 @@ QComboBox {
 	padding-left: 10px;
 }
 
+QDateTimeEdit:hover,
+QComboBox:hover {
+    background-color: rgb(61,61,63);
+}
+
 QDateTimeEdit::drop-down,
 QComboBox::drop-down {
 	border:none;
@@ -563,8 +568,18 @@ QPushButton:hover {
 	border: 1px solid rgb(54,70,131);
 }
 
+QPushButton:checked:hover {
+	background-color: rgb(116,32,49);
+	border-color: rgb(176,12,47);
+}
+
 QPushButton:pressed {
 	background-color: rgb(22,31,65);
+}
+
+QPushButton:checked:pressed {
+	background-color: rgb(63,21,30);
+	border-color: rgb(132,22,45);
 }
 
 QPushButton:disabled {

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -478,6 +478,10 @@ QPushButton::flat {
     background-color: palette(window);
 }
 
+QPushButton:checked {
+    background-color: palette(base);
+}
+
 QPushButton:hover {
     background-color: rgb(122,121,122); /* light */
 }
@@ -486,8 +490,8 @@ QPushButton:pressed {
     background-color: palette(base);
 }
 
-QPushButton:checked {
-    background-color: rgb(122,121,122); /* light */
+QPushButton:disabled {
+    background-color: rgb(46,45,46);
 }
 
 QPushButton::menu-indicator {


### PR DESCRIPTION
### Description
Reorder styling on Dark so that checked buttons can still get hover styling. Also adds a distinct background color for disabled buttons. Fixes the text being the same color as the button when disabled.

## Dark
### QPushButton Checked
![image](https://user-images.githubusercontent.com/1554753/132960969-f813ca87-0090-4f37-a8b7-bace3dd4ad39.png)
Before

![image](https://user-images.githubusercontent.com/1554753/132960965-4040a003-2894-4431-8417-f4894198013e.png)
After

### QPushButton Checked + Disabled
![image](https://user-images.githubusercontent.com/1554753/132961063-51b55f4e-895a-45af-b013-63a41e7d9d5d.png)
Before

![image](https://user-images.githubusercontent.com/1554753/132960984-2883e2af-9704-4e44-a3ee-7a28a44dc329.png)
After

## Acri
### Dropdown Hover
![image](https://user-images.githubusercontent.com/1554753/132960954-3506aceb-68b7-4fc5-8c16-389a4090d20c.png)
Before

![image](https://user-images.githubusercontent.com/1554753/132960959-e6bbdbee-2b62-4b63-813d-91d2c9335d29.png)
After

### QPushButton Checked + Hovered
![image](https://user-images.githubusercontent.com/1554753/132960950-75680389-604c-41da-829c-6f665fdce346.png)
Before

![image](https://user-images.githubusercontent.com/1554753/132960934-9cf173ac-e73d-42a7-a889-fdc00c2d402f.png)
After

### QPushButton Checked + Pressed
![image](https://user-images.githubusercontent.com/1554753/132960951-117043cf-abe3-4b40-8a67-c7819b6b6612.png)
Before

![image](https://user-images.githubusercontent.com/1554753/132960927-8769f156-4cc8-4036-accf-76d34c948472.png)
After

### Motivation and Context
These changes are all general improvements to the themes but they're mainly targeted at elements and states that are more prevalent now with the YouTube integration.

### How Has This Been Tested?
Checked both themes

### Types of changes
- New feature (non-breaking change which adds functionality)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
