### PR TITLE
UI: Close source projector when all sceneitems of the source are deleted

### DIFF
--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -28,10 +28,12 @@ class OBSProjector : public OBSQTDisplay {
 private:
 	OBSSource source;
 	OBSSignal removedSignal;
+	OBSSignal savedSignal;
 
 	static void OBSRenderMultiview(void *data, uint32_t cx, uint32_t cy);
 	static void OBSRender(void *data, uint32_t cx, uint32_t cy);
 	static void OBSSourceRemoved(void *data, calldata_t *params);
+	static void OBSSourceSaved(void *data, calldata_t *params);
 
 	void mousePressEvent(QMouseEvent *event) override;
 	void mouseDoubleClickEvent(QMouseEvent *event) override;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Makes a source projector close when its source gets deleted.

Implementation wise, this listens to the `source_save` signal, since that is the only signal getting triggered when a sceneitem gets removed, but the source doesn't, which here is the case, since the projector will keep the source from getting destroyed. As such, signals like `source_destroy` would be a chicken and egg problem - the projector wouldn't be closed until `destroy` is sent, while being the reason for it not getting sent.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This is already the current behaviour for scene projectors (though a little buggy, see #5171).
It should also work for source projectors.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0 beta 6, compiled and run

If a source has only one sceneitem and gets removed, the projector closes (and after that `destroy` gets sent). When removing a sceneitem of a source that exists multiple times (in the same or different scene) the projector will stay open.
When removing a sceneitem of a 'scene' source which still exists as a source, but not scene, the projector will also stay open until the scene gets deleted.

If you run into crashes with this, for example while testing scene projectors, there's a very good chance those are also happening in the current release and would be fixed by #5171.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
