### PR TITLE
Remove dependency on psapi.lib

### DIFF
--- a/UI/win-update/updater/CMakeLists.txt
+++ b/UI/win-update/updater/CMakeLists.txt
@@ -45,7 +45,6 @@ target_link_libraries(updater
 	${STATIC_ZLIB_PATH}
 	lzma
 	blake2
-	psapi
 	comctl32
 	shell32
 	winhttp

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -120,7 +120,7 @@ if(WIN32)
 	set(libobs_audio_monitoring_HEADERS
 		audio-monitoring/win32/wasapi-output.h
 		)
-	set(libobs_PLATFORM_DEPS winmm psapi)
+	set(libobs_PLATFORM_DEPS winmm)
 	if(MSVC)
 		set(libobs_PLATFORM_DEPS
 		${libobs_PLATFORM_DEPS}

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -14,7 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#define PSAPI_VERSION 1
 #include <windows.h>
 #include <mmsystem.h>
 #include <shellapi.h>

--- a/plugins/win-capture/CMakeLists.txt
+++ b/plugins/win-capture/CMakeLists.txt
@@ -40,8 +40,7 @@ target_link_libraries(win-capture
 	${win-capture_PLATFORM_DEPS}
 	libobs
 	Dwmapi
-	ipc-util
-	psapi)
+	ipc-util)
 set_target_properties(win-capture PROPERTIES FOLDER "plugins/win-capture")
 
 install_obs_plugin_with_data(win-capture data)

--- a/plugins/win-capture/graphics-hook/CMakeLists.txt
+++ b/plugins/win-capture/graphics-hook/CMakeLists.txt
@@ -55,7 +55,6 @@ target_include_directories(graphics-hook PUBLIC
 target_link_libraries(graphics-hook
 	dxguid
 	ipc-util
-	psapi
 	${DETOURS_LIBRARIES})
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/plugins/win-capture/window-helpers.c
+++ b/plugins/win-capture/window-helpers.c
@@ -1,4 +1,3 @@
-#define PSAPI_VERSION 1
 #include <obs.h>
 #include <util/dstr.h>
 


### PR DESCRIPTION
### Description
Only need psapi.lib for XP/Vista, which we aren't compiling for anymore.

### Motivation and Context
Get rid of PSAPI_VERSION macro fragility.

### How Has This Been Tested?
Debugger inspection for GetProcessMemoryInfo and GetProcessImageFileNameW.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.