### PR TITLE
UI: Move OBS finished loading event

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2078,13 +2078,13 @@ void OBSBasic::OBSInit()
 	QMetaObject::invokeMethod(this, "DeferredSysTrayLoad",
 				  Qt::QueuedConnection, Q_ARG(int, 10));
 #endif
+
+	if (api)
+		api->on_event(OBS_FRONTEND_EVENT_FINISHED_LOADING);
 }
 
 void OBSBasic::OnFirstLoad()
 {
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_FINISHED_LOADING);
-
 #if defined(BROWSER_AVAILABLE) && defined(_WIN32)
 	/* Attempt to load init screen if available */
 	if (cef) {


### PR DESCRIPTION
### Description
Before when the event was called, CEF, Auth and the log viewer were
still needing to be loaded. This moves it, so it is the last thing
called when OBS is loading.

### Motivation and Context
It just makes sense to be the last thing called when loading OBS.

### How Has This Been Tested?
Tested with a script, and it still worked just fine.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
