### PR TITLE
UI: Remove unused RemoveSelectedSceneItem slot

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3874,16 +3874,6 @@ void OBSBasic::RemoveSelectedScene()
 		api->on_event(OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED);
 }
 
-void OBSBasic::RemoveSelectedSceneItem()
-{
-	OBSSceneItem item = GetCurrentSceneItem();
-	if (item) {
-		obs_source_t *source = obs_sceneitem_get_source(item);
-		if (QueryRemoveSource(source))
-			obs_sceneitem_remove(item);
-	}
-}
-
 void OBSBasic::ReorderSources(OBSScene scene)
 {
 	if (scene != GetCurrentScene() || ui->sources->IgnoreReorder())

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -660,7 +660,6 @@ private slots:
 
 	void DuplicateSelectedScene();
 	void RemoveSelectedScene();
-	void RemoveSelectedSceneItem();
 
 	void ToggleAlwaysOnTop();
 


### PR DESCRIPTION
### Description
Removes unused `OBSBasic::RemoveSelectedSceneItem` slot.

### Motivation and Context
Appears to be a remnant left by the undo/redo system changes, not used at all by any parts of the UI. This slot does not have undo/redo system functionality, so it is not useful in its current form.

### How Has This Been Tested?
Built fine on Ubuntu 20.04

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
