### PR TITLE
libobs: Block sceneitem creation if item source is removed

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1829,6 +1829,11 @@ static obs_sceneitem_t *obs_scene_add_internal(obs_scene_t *scene,
 		return NULL;
 	}
 
+	if (source->removed) {
+		blog(LOG_WARNING, "Tried to add a removed source to a scene");
+		return NULL;
+	}
+
 	if (pthread_mutex_init(&mutex, NULL) != 0) {
 		blog(LOG_WARNING, "Failed to create scene item mutex");
 		return NULL;


### PR DESCRIPTION
### Description
Prevents scene items from being created from removed sources.

### Motivation and Context
There are some cases where an item may attempt to be created for a removed (but not destroyed) source.

Previously, items created from removed sources would lead to the item itself being saved, but the underlying source not being saved. While this does not break OBS immediately, it means that the source along with all associated items will disappear on OBS reload.

This prevents the item from being created in the first place, reducing the chances of user work being lost.


### How Has This Been Tested?
1. Create an input in OBS
2. Using a plugin, fetch the input
3. Increment the reference for the input
4. Call `obs_source_remove()` on the input
5. Attempt to add the input as a scene item to a scene in the UI
6. The scene item will not appear and a warning will be logged

As an extra precaution, I went through all instances where `obs_scene_add_internal()` is called and verified that the new check's result is handled.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
