### PR TITLE
UI: Fix used source for SetCurrentScene during undo

### DIFF
--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -378,7 +378,7 @@ void OBSBasicProperties::on_buttonBox_clicked(QAbstractButton *button)
 			obs_source_t *scene_source =
 				obs_get_source_by_name(scene_name.c_str());
 
-			OBSBasic::Get()->SetCurrentScene(source, true);
+			OBSBasic::Get()->SetCurrentScene(scene_source, true);
 
 			obs_source_release(scene_source);
 


### PR DESCRIPTION
### Description
Use the correct source when setting the current scene during undo callback execution.

### Motivation and Context
Bugs are bad. It was doing this:
![image](https://user-images.githubusercontent.com/28720189/133056214-34f9f6fe-135a-4491-8894-17481a0409c7.png)


### How Has This Been Tested?
- Create an input (source)
- Click OK on the properties dialog
- Press CTRL + Z

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
