### PR TITLE
UI: React to `source_remove` correctly and update UI accordingly

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -311,6 +311,7 @@ void SourceTreeItem::ReconnectSignals()
 			reinterpret_cast<SourceTreeItem *>(data);
 		this_->DisconnectSignals();
 		this_->sceneitem = nullptr;
+		QMetaObject::invokeMethod(this_->tree, "RefreshItems");
 	};
 
 	obs_source_t *source = obs_sceneitem_get_source(sceneitem);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5047,7 +5047,6 @@ void OBSBasic::on_actionAddScene_triggered()
 		obs_scene_t *scene = obs_scene_create(name.c_str());
 		source = obs_scene_get_source(scene);
 		SetCurrentScene(source);
-		RefreshSources(scene);
 		obs_scene_release(scene);
 	}
 }

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -254,8 +254,6 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 				obs_get_source_by_name(scene_name.c_str());
 			main->SetCurrentScene(scene_source, true);
 			obs_source_release(scene_source);
-
-			main->RefreshSources(main->GetCurrentScene());
 		};
 		obs_data_t *wrapper = obs_data_create();
 		obs_data_set_string(wrapper, "id", id);
@@ -285,7 +283,6 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 			obs_sceneitem_set_id(item, (int64_t)obs_data_get_int(
 							   dat, "item_id"));
 
-			main->RefreshSources(main->GetCurrentScene());
 			obs_data_release(dat);
 			obs_sceneitem_release(item);
 		};


### PR DESCRIPTION
### Description
- Makes the UI react properly to the `source_remove` signal and only when relevant
- Removes calls to `RefreshSources()` that are no longer necessary with this PR

### Motivation and Context
Calling `obs_source_remove()` on an input from obs-websocket was not updating the UI if there was a scene item of the input in the current scene. This is because the source tree was not being refreshed, leaving one last reference to the source.

### How Has This Been Tested?
- Tested removing inputs via unreleased `RemoveScene` request in obs-websocket: Works great
- Tested all functions where `RefreshSources()` was removed by the second commit: Works exactly as before, with `RefreshSources()` still being called when necessary.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
