### PR TITLE
libobs: Remove sources before deleting the last scene item

### DIFF
--- a/docs/sphinx/reference-scenes.rst
+++ b/docs/sphinx/reference-scenes.rst
@@ -205,6 +205,20 @@ General Scene Functions
 
 .. function:: obs_sceneitem_t *obs_scene_add(obs_scene_t *scene, obs_source_t *source)
 
+   Creates a new scene item for a source within the scene. Created
+   with `tracked` being true, where the source will be removed once
+   the last tracked scene item for that source is removed.
+
+   :return: A new scene item for a source within a scene.  Does not
+            increment the reference
+
+---------------------
+
+.. function:: obs_sceneitem_t *obs_scene_add2(obs_scene_t *scene, obs_source_t *source, bool tracked)
+
+   Similar to :c:func:`obs_scene_add()`, with the difference being the
+   ability to set the `tracked` value.
+
    :return: A new scene item for a source within a scene.  Does not
             increment the reference
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -616,6 +616,9 @@ struct obs_source {
 	/* ensures activate/deactivate are only called once */
 	volatile long activate_refs;
 
+	/* the number of scene items tied to this source, if any */
+	volatile long scene_item_refs;
+
 	/* used to indicate that the source has been removed and all
 	 * references to it should be released (not exactly how I would prefer
 	 * to handle things but it's the best option) */

--- a/libobs/obs-scene.h
+++ b/libobs/obs-scene.h
@@ -46,6 +46,7 @@ struct obs_scene_item {
 	bool visible;
 	bool selected;
 	bool locked;
+	bool tracked;
 
 	gs_texrender_t *item_render;
 	struct obs_sceneitem_crop crop;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1617,6 +1617,12 @@ EXPORT bool obs_source_is_scene(const obs_source_t *source);
 /** Adds/creates a new scene item for a source */
 EXPORT obs_sceneitem_t *obs_scene_add(obs_scene_t *scene, obs_source_t *source);
 
+/** Adds/creates a new scene item for a source, with the option of tracking the
+ * scene item in the source's scene item refcount
+ */
+EXPORT obs_sceneitem_t *obs_scene_add2(obs_scene_t *scene, obs_source_t *source,
+				       bool tracked);
+
 typedef void (*obs_scene_atomic_update_func)(void *, obs_scene_t *scene);
 EXPORT void obs_scene_atomic_update(obs_scene_t *scene,
 				    obs_scene_atomic_update_func func,


### PR DESCRIPTION
### Description
- "Tracks" all created scene items by default. When the last tracked scene item for a source is removed, `obs_source_remove()` will be called on the source itself to provide strong reference holders notice to release their references.
- Adds `obs_scene_add2()` which allows the ability to create untracked scene items.

Note: This change only applies to sources which have associated scene items. Functionality for sources without scene items is completely unchanged.

### Motivation and Context
**Current behavior - two possible scenarios:**
- The last scene item for a source is removed. The source has no references left and gets destroyed during `obs_source_release()`, without signalling `source_remove`.
  - This requires plugins like obs-websocket to handle inputs slightly differently to compensate for the incomplete behavior.
- The last scene item for a source is removed. Another plugin holds a strong reference to the source, but does not know that the last scene item for the source has been removed, so instead of the source being cleaned up, it stays active only for the specific reference holder.

**New behavior:**
With this change, both of these issues are solved. When the last scene item is removed, `obs_source_remove()` is invoked automatically, emitting the signal to all subscribers. For plugin authors who use scenes and scene items in unconventional ways, `obs_scene_add2()` provides the ability to control this functionality manually.

### How Has This Been Tested?
As always, all implementations of the changed API functions have been thoroughly inspected and tested in order to validate that only the intended behavior happens. All implementations act the same, with the exception of the source being removed as it should.

Written and tested on Ubuntu 20.04 Desktop

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
