### PR TITLE
Incorporate DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT

### DIFF
--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -471,10 +471,10 @@ try {
 	context->ClearState();
 	context->Flush();
 
-	context.Release();
-	device.Release();
-	adapter.Release();
-	factory.Release();
+	context.Clear();
+	device.Clear();
+	adapter.Clear();
+	factory.Clear();
 
 	/* ----------------------------------------------------------------- */
 

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -801,6 +801,7 @@ struct gs_swap_chain : gs_obj {
 	gs_texture_2d target;
 	gs_zstencil_buffer zs;
 	ComPtr<IDXGISwapChain> swap;
+	HANDLE hWaitable = NULL;
 
 	void InitTarget(uint32_t cx, uint32_t cy);
 	void InitZStencilBuffer(uint32_t cx, uint32_t cy);
@@ -813,10 +814,15 @@ struct gs_swap_chain : gs_obj {
 	{
 		target.Release();
 		zs.Release();
-		swap.Release();
+		if (hWaitable) {
+			CloseHandle(hWaitable);
+			hWaitable = NULL;
+		}
+		swap.Clear();
 	}
 
 	gs_swap_chain(gs_device *device, const gs_init_data *data);
+	virtual ~gs_swap_chain();
 };
 
 struct BlendState {

--- a/libobs/util/windows/ComPtr.hpp
+++ b/libobs/util/windows/ComPtr.hpp
@@ -58,6 +58,10 @@ public:
 			ptr->AddRef();
 	}
 	inline ComPtr(ComPtr<T> &&c) noexcept : ptr(c.ptr) { c.ptr = nullptr; }
+	template<class U>
+	inline ComPtr(ComPtr<U> &&c) noexcept : ptr(c.Detach())
+	{
+	}
 	inline ~ComPtr() { Kill(); }
 
 	inline void Clear()
@@ -87,6 +91,14 @@ public:
 			ptr = c.ptr;
 			c.ptr = nullptr;
 		}
+
+		return *this;
+	}
+
+	template<class U> inline ComPtr<T> &operator=(ComPtr<U> &&c) noexcept
+	{
+		Kill();
+		ptr = c.Detach();
 
 		return *this;
 	}


### PR DESCRIPTION
### Description
Use DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT to determine if the swap chain is full, and skip Present if it is to avoid stalling the graphics thread.

This is the flip model swap chain version of #2259, which for OBS will only apply to Windows 11.

### Motivation and Context
Don't want to stall the graphics thread.

### How Has This Been Tested?
Debugger inspection of diffs on Windows 11, Windows 10, and with modifications to test waitable object on Windows 10.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.