### PR TITLE
UI: Add accessible text messages for YT actions

### DIFF
--- a/UI/forms/OBSYoutubeActions.ui
+++ b/UI/forms/OBSYoutubeActions.ui
@@ -57,6 +57,9 @@
        </item>
        <item row="0" column="1">
         <widget class="QLineEdit" name="title">
+         <property name="accessibleName">
+          <string>Youtube.Actions.Title</string>
+         </property>
          <property name="text">
           <string>YouTube.Actions.MyBroadcast</string>
          </property>
@@ -74,6 +77,9 @@
        </item>
        <item row="1" column="1">
         <widget class="QPlainTextEdit" name="description">
+         <property name="accessibleName">
+          <string>Youtube.Actions.Description</string>
+         </property>
          <property name="tabChangesFocus">
           <bool>true</bool>
          </property>
@@ -94,6 +100,9 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="accessibleName">
+          <string>Youtube.Actions.Privacy</string>
+         </property>
          <property name="sizeAdjustPolicy">
           <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
          </property>
@@ -113,6 +122,9 @@
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
+         </property>
+         <property name="accessibleName">
+          <string>Youtube.Actions.Category</string>
          </property>
         </widget>
        </item>
@@ -223,6 +235,9 @@
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="accessibleName">
+            <string>Youtube.Actions.Latency</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
### Description
I have added accessibleText data to the Youtube Actions window.
As it stood it's far too lacking of any good narrations of data, labels that were associated with input fields were not linked at all to their appropriate input fields.
There's still some things that need work on, but I am not sure how to tackle them without adding new text strings to the application.
 - The time/date selection for Auto Stop does not have any description,
 - Made For Kids lacks a associated label, but it will otherwise tell you "No, it's not made for kids" or "Yes, it's for kids"


### Motivation and Context
This helps to improve accessibility for OBS studio with users that require assistive technologies.

### How Has This Been Tested?
Tests have been done on a Windows 10 PC running Microsoft Narrator.
Elements within the interface were tabbed through to have their contents spoken back through the system

### Types of changes
 - Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
