### PR TITLE
libobs-d3d11: Fix present skip comment

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -2037,10 +2037,10 @@ void device_present(gs_device_t *device)
 {
 	gs_swap_chain *const curSwapChain = device->curSwapChain;
 	if (curSwapChain) {
-		/* Skip Present because full queue may cause a stall */
-		const HANDLE hWaitiable = curSwapChain->hWaitable;
-		if ((hWaitiable == NULL) ||
-		    WaitForSingleObject(hWaitiable, 0) == WAIT_OBJECT_0) {
+		/* Skip Present at frame limit to avoid stall */
+		const HANDLE hWaitable = curSwapChain->hWaitable;
+		if ((hWaitable == NULL) ||
+		    WaitForSingleObject(hWaitable, 0) == WAIT_OBJECT_0) {
 			const HRESULT hr = curSwapChain->swap->Present(
 				0, curSwapChain->presentFlags);
 			if (hr == DXGI_ERROR_DEVICE_REMOVED ||


### PR DESCRIPTION
### Description
It's about the CPU being ahead of the GPU, not flip queue being full.

EDIT: Also fixed variable typo.

### Motivation and Context
Don't want to mislead people.

### How Has This Been Tested?
It's a comment. I compiled it.

EDIT: Debugger inspection for variable typo fix.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.