### PR TITLE
UI: Force minimum reconnect delay of 1 second

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -5285,6 +5285,9 @@
                        <property name="suffix">
                         <string> s</string>
                        </property>
+                       <property name="minimum">
+                        <number>1</number>
+                       </property>
                        <property name="maximum">
                         <number>30</number>
                        </property>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1373,6 +1373,17 @@ bool OBSBasic::InitBasicConfigDefaults()
 	}
 
 	/* ----------------------------------------------------- */
+	/* enforce minimum retry delay of 1 second prior to 27.1 */
+	if (config_has_user_value(basicConfig, "Output", "RetryDelay")) {
+		int retryDelay =
+			config_get_uint(basicConfig, "Output", "RetryDelay");
+		if (retryDelay < 1) {
+			config_set_uint(basicConfig, "Output", "RetryDelay", 1);
+			changed = true;
+		}
+	}
+
+	/* ----------------------------------------------------- */
 
 	if (changed)
 		config_save_safe(basicConfig, "tmp", nullptr);


### PR DESCRIPTION
### Description
Sets the minimum reconnect delay to 1 second and migrate existing configs with 0 seconds.

### Motivation and Context
Fixes OBS breaking when using a 0 second reconnect delay due to various components not expecting zero values. Example user issue: https://obsproject.com/forum/threads/cant-reconnect-after-internet-going-down-then-coming-back-online.148269/

### How Has This Been Tested?
Ran OBS, ensured UI capped the value and configs with 0 seconds were migrated.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
