### PR TITLE
UI: Use qrand() on Qt < 5.10.0

### DIFF
--- a/UI/auth-youtube.cpp
+++ b/UI/auth-youtube.cpp
@@ -7,7 +7,10 @@
 #include <QDesktopServices>
 #include <QHBoxLayout>
 #include <QUrl>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 #include <QRandomGenerator>
+#endif
 
 #ifdef WIN32
 #include <windows.h>
@@ -193,13 +196,17 @@ void YoutubeAuth::ResetChat()
 
 QString YoutubeAuth::GenerateState()
 {
-	char state[YOUTUBE_API_STATE_LENGTH + 1];
-	QRandomGenerator *rng = QRandomGenerator::system();
-	int i;
+	QByteArray state;
 
-	for (i = 0; i < YOUTUBE_API_STATE_LENGTH; i++)
-		state[i] = allowedChars[rng->bounded(0, allowedCount)];
-	state[i] = 0;
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+	// Qt < 5.10.0 does not include QRandomGenerator, so we use qrand()
+	for (size_t i = 0; i < YOUTUBE_API_STATE_LENGTH; i++)
+		state += allowedChars[qrand() % allowedCount];
+#else
+	QRandomGenerator *rng = QRandomGenerator::system();
+	for (size_t i = 0; i < YOUTUBE_API_STATE_LENGTH; i++)
+		state.append(allowedChars[rng->bounded(0, allowedCount)]);
+#endif
 
 	return state;
 }

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -38,6 +38,10 @@
 #include <QProcess>
 #include <QAccessible>
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+#include <QTime>
+#endif
+
 #include "qt-wrappers.hpp"
 #include "obs-app.hpp"
 #include "log-viewer.hpp"
@@ -2019,6 +2023,11 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 	const char *session_type = getenv("XDG_SESSION_TYPE");
 	if (session_type && strcmp(session_type, "wayland") == 0)
 		setenv("QT_QPA_PLATFORM", "wayland", false);
+#endif
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+	// Initialize the Qt random generator using the current time
+	qsrand(QTime::currentTime().msec());
 #endif
 
 	OBSApp program(argc, argv, profilerNameStore.get());


### PR DESCRIPTION
### Description
Uses obsolete qrand() if QRandomGenerator is not available.

### Motivation and Context
QRandomGenerator is not available on Qt < 5.10.0, so we must fall back to the obsolete qrand() as a random generator if on an incorrect version.

### How Has This Been Tested?
.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
