### PR TITLE
libobs: Add CSPRNG functions

### DIFF
--- a/docs/sphinx/reference-libobs-util-platform.rst
+++ b/docs/sphinx/reference-libobs-util-platform.rst
@@ -471,3 +471,9 @@ Other Functions
 .. function:: uint64_t os_get_proc_virtual_size(void)
 
    Returns the virtual memory size of the current process.
+
+---------------------
+
+.. function:: void os_random_bytes(void *buffer, uint32_t length)
+
+   Generates cryptographically-secure random bytes.

--- a/docs/sphinx/reference-libobs-util-rng.rst
+++ b/docs/sphinx/reference-libobs-util-rng.rst
@@ -1,0 +1,28 @@
+Random Number Generation
+========================
+
+Helper functions to turn raw random bytes into random numbers.
+
+.. code:: cpp
+
+   #include <util/rng.h>
+
+RNG Functions
+-------------
+
+.. function:: uint64_t random_uint64_bounded(uint64_t min, uint64_t max)
+
+   Generates an unbiased 64 bit unsigned integer in the range min - max
+   (inclusive).
+
+   :param min: Minimum bound
+   :param max: Maximum bound, must be >= min
+   :return:           The generated number
+
+---------------------
+
+.. function:: uint64_t random_uint64(void)
+
+   Generates a 64 bit unsigned integer in the range 0 - UINT64_MAX.
+   
+   :return:           The generated number

--- a/docs/sphinx/reference-libobs-util.rst
+++ b/docs/sphinx/reference-libobs-util.rst
@@ -12,6 +12,7 @@ Platform/Utility API Reference (libobs/util)
    reference-libobs-util-dstr
    reference-libobs-util-platform
    reference-libobs-util-profiler
+   reference-libobs-util-rng
    reference-libobs-util-serializers
    reference-libobs-util-text-lookup
    reference-libobs-util-threading

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -381,7 +381,8 @@ set(libobs_util_SOURCES
 	util/text-lookup.c
 	util/cf-parser.c
 	util/profiler.c
-	util/bitstream.c)
+	util/bitstream.c
+	util/rng.c)
 set(libobs_util_HEADERS
 	util/curl/curl-helper.h
 	util/sse-intrin.h
@@ -409,6 +410,7 @@ set(libobs_util_HEADERS
 	util/profiler.h
 	util/profiler.hpp
 	util/bitstream.h
+	util/rng.h
 	util/util.hpp)
 
 set(libobs_libobs_SOURCES

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -20,6 +20,7 @@
 #include <shlobj.h>
 #include <intrin.h>
 #include <psapi.h>
+#include <ntsecapi.h>
 
 #include "base.h"
 #include "platform.h"
@@ -1311,4 +1312,10 @@ uint64_t os_get_free_disk_space(const char *dir)
 	bfree(wdir);
 
 	return success ? free.QuadPart : 0;
+}
+
+void os_random_bytes(void *buffer, uint32_t length)
+{
+	if (!RtlGenRandom(buffer, length))
+		bcrash("System RNG failure");
 }

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -197,6 +197,8 @@ EXPORT bool os_get_proc_memory_usage(os_proc_memory_usage_t *usage);
 EXPORT uint64_t os_get_proc_resident_size(void);
 EXPORT uint64_t os_get_proc_virtual_size(void);
 
+EXPORT void os_random_bytes(void *buffer, uint32_t length);
+
 /* clang-format off */
 #ifdef __APPLE__
 # define ARCH_BITS 64

--- a/libobs/util/rng.c
+++ b/libobs/util/rng.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2013 Hugh Bailey <obs.jim@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "c99defs.h"
+#include "rng.h"
+#include "platform.h"
+
+/* generates a cryptographically secure random uint64 in the range
+   min-max (inclusive) */
+uint64_t random_uint64_bounded(uint64_t min, uint64_t max)
+{
+	uint64_t num;
+	uint64_t range;
+
+	assert(min <= max);
+
+	if (min == max)
+		return min;
+
+	// take first sample
+	os_random_bytes(&num, sizeof(num));
+
+	range = max - min;
+
+	if (range == UINT64_MAX)
+		return num;
+
+	// make it inclusive of max
+	range++;
+
+	// powers of 2 are bias-free
+	if (range & (range - 1)) {
+		uint64_t max_bias_limit = UINT64_MAX - (UINT64_MAX % range) - 1;
+
+		// avoid bias by re-sampling if necessary
+		while (num > max_bias_limit) {
+			os_random_bytes(&num, sizeof(num));
+		}
+	}
+
+	num %= range;
+	num += min;
+
+	return num;
+}
+
+/* cryptographically secure random int between 0 and UINT64_MAX (inclusive) */
+uint64_t random_uint64(void)
+{
+	uint64_t num;
+	os_random_bytes(&num, sizeof(num));
+	return num;
+}

--- a/libobs/util/rng.h
+++ b/libobs/util/rng.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2013 Hugh Bailey <obs.jim@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include "c99defs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+EXPORT uint64_t random_uint64_bounded(uint64_t min, uint64_t max);
+EXPORT uint64_t random_uint64(void);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
### Description
Adds three new functions to libobs, backed by the operating system's cryptographically secure pseudo-random number generator (RtlGenRandom on Windows, getrandom(2) on *nix, /dev/urandom on macOS. The output of these functions should be suitable for using in secrets such as encryption keys, tokens, etc.

`os_random_bytes` is added as part of the platform files and covers platform-specific generation of random numbers. A new `libobs/util/rng.{c,h}` file contains helper functions to turn the random bytes into more useful things such as a bounded `uint64_t`.

#### New Functions
`void os_random_bytes(void *buffer, uint32_t length)`
Generate raw random bytes into a buffer.

`uint64_t random_uint64(void)`
Generate a random uint64_t.

`uint64_t random_uint64_bounded(uint64_t min, uint64_t max)` 
Generate a bounded random uint64_t, avoiding modulo bias.

### Motivation and Context
We need a secure random number generator to generate things like state parameters for OAuth flows. Ideally this would be `QRandomGenerator` where needed, but that requires Qt >= 5.10 which is not available for all our supported platforms.

### How Has This Been Tested?
Only tested on Windows. Very basic statistical tests on the output of various ranges to check for bias. Needs testing on other platforms.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
