### PR TITLE
win-capture: Fix UI block caused by game title

### DIFF
--- a/plugins/win-capture/window-helpers.c
+++ b/plugins/win-capture/window-helpers.c
@@ -106,17 +106,13 @@ fail:
 
 void get_window_title(struct dstr *name, HWND hwnd)
 {
-	wchar_t *temp;
-	int len;
-
-	len = GetWindowTextLengthW(hwnd);
-	if (!len)
-		return;
-
-	temp = malloc(sizeof(wchar_t) * (len + 1));
-	if (GetWindowTextW(hwnd, temp, len + 1))
-		dstr_from_wcs(name, temp);
-	free(temp);
+	wchar_t name_temp[MAX_PATH] = {0};
+	ULONG_PTR copy_count = 0;
+	LRESULT res = SendMessageTimeoutW(hwnd, WM_GETTEXT, MAX_PATH, name_temp,
+					  SMTO_ABORTIFHUNG, 2000, &copy_count);
+	if (0 != res && copy_count > 0) {
+		dstr_from_wcs(name, name_temp);
+	}
 }
 
 void get_window_class(struct dstr *class, HWND hwnd)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
get_window_title(...) is called from game_capture_tick(...) which is not in UI thread.
That will make GetWindowTextLengthW blocked sometimes.
GetWindowTextLengthW should be called from UI thread.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When this function is blocked in video-tick, some critial locks can't be released which can cause UI frozen.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I am using another worker thread to reproduce this issue.
In worker thread, enum all windows frequently and call GetWindowTextLengthW for every HWND.
Then, GetWindowTextLengthW  will be blocked soon.

### Types of changes
Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
