### PR TITLE
linux-capture: Lookup session handle without typechecks

### DIFF
--- a/plugins/linux-capture/pipewire.c
+++ b/plugins/linux-capture/pipewire.c
@@ -958,6 +958,7 @@ static void on_create_session_response_received_cb(
 	UNUSED_PARAMETER(interface_name);
 	UNUSED_PARAMETER(signal_name);
 
+	g_autoptr(GVariant) session_handle_variant = NULL;
 	g_autoptr(GVariant) result = NULL;
 	struct dbus_call_data *call = user_data;
 	obs_pipewire_data *obs_pw = call->obs_pw;
@@ -975,8 +976,10 @@ static void on_create_session_response_received_cb(
 
 	blog(LOG_INFO, "[pipewire] screencast session created");
 
-	g_variant_lookup(result, "session_handle", "s",
-			 &obs_pw->session_handle);
+	session_handle_variant =
+		g_variant_lookup_value(result, "session_handle", NULL);
+	obs_pw->session_handle =
+		g_variant_dup_string(session_handle_variant, NULL);
 
 	select_source(obs_pw);
 }


### PR DESCRIPTION

### Description

Retrieve the session handle for the PipeWire screencast without performing strict type checks.

### Motivation and Context

g_variant_lookup() obligatorily receives the type of the variant to lookup. This function is used when retrieving the session handle from the portal's response, and the variant type passed is "s" (a string).

However, xdg-desktop-portal had a bug: the documentation explicitly mentions that the session handle is an object path (of variant type "o"), but it passed a string (of variant type "s"). This mismatch [was fixed](https://github.com/flatpak/xdg-desktop-portal/pull/609) in the xdg-desktop-portal release 1.10, but that broke the PipeWire capture code, which was passing specifically the "s" value to the variant lookup.

Fix this by not checking the variant type at all. Object paths ("o") are simply strings with a few extra checks, and we don't actually need to perform these checks.

This change probably broke other apps, and that makes me extremely sad :(

### How Has This Been Tested?

 - Run OBS Studio with xdg-desktop-portal >= 1.10
 - PipeWire screencast still works
 - Run OBS Studio with xdg-desktop-portal < 1.10
 - PipeWire screencast still works too

### Types of changes

 - Bug fix (non-breaking change which fixes an issue) 

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
