### PR TITLE
Various code cleanup items

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -102,8 +102,6 @@ include_directories(${LIBCURL_INCLUDE_DIRS})
 add_definitions(${LIBCURL_DEFINITIONS})
 
 if(WIN32)
-	add_definitions(-DNOMINMAX)
-
 	include_directories(${BLAKE2_INCLUDE_DIR})
 
 	set(obs_PLATFORM_SOURCES

--- a/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
@@ -42,7 +42,6 @@ set(decklink-ouput-ui_UI
 	)
 
 if(WIN32)
-	add_definitions(-DNOMINMAX)
 	set(MODULE_DESCRIPTION "OBS DeckLink Output UI")
 	configure_file(${CMAKE_SOURCE_DIR}/cmake/winrc/obs-module.rc.in decklink-ouput-ui.rc)
 	list(APPEND decklink-ouput-ui_SOURCES

--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -73,7 +73,6 @@ if(SCRIPTING_ENABLED)
 endif()
 
 if(WIN32)
-	add_definitions(-DNOMINMAX)
 	set(MODULE_DESCRIPTION "OBS Frontend Tools")
 	configure_file(${CMAKE_SOURCE_DIR}/cmake/winrc/obs-module.rc.in frontend-tools.rc)
 	set(frontend-tools_PLATFORM_SOURCES

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -396,9 +396,9 @@ void OBSPropertiesView::AddFloat(obs_property_t *prop, QFormLayout *layout,
 	const char *suffix = obs_property_float_suffix(prop);
 
 	if (stepVal < 1.0) {
-		int decimals = (int)(log10(1.0 / stepVal) + 0.99);
 		constexpr int sane_limit = 8;
-		decimals = std::min(decimals, sane_limit);
+		const int decimals =
+			std::min<int>(log10(1.0 / stepVal) + 0.99, sane_limit);
 		if (decimals > spin->decimals())
 			spin->setDecimals(decimals);
 	}

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6431,8 +6431,8 @@ void OBSBasic::SetBroadcastFlowEnabled(bool enabled)
 
 void OBSBasic::SetupBroadcast()
 {
-	Auth *auth = GetAuth();
 #if YOUTUBE_ENABLED
+	Auth *const auth = GetAuth();
 	if (IsYouTubeService(auth->service())) {
 		OBSYoutubeActions *dialog;
 		dialog = new OBSYoutubeActions(this, auth, broadcastReady);

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -1,7 +1,6 @@
 #include <QGuiApplication>
 #include <QMouseEvent>
 
-#include <algorithm>
 #include <cmath>
 #include <string>
 #include <graphics/vec4.h>
@@ -1049,10 +1048,14 @@ static bool FindItemsInBox(obs_scene_t *scene, obs_sceneitem_t *item,
 	vec3 pos3;
 	vec3 pos3_;
 
-	float x1 = std::min(data->startPos.x, data->pos.x);
-	float x2 = std::max(data->startPos.x, data->pos.x);
-	float y1 = std::min(data->startPos.y, data->pos.y);
-	float y2 = std::max(data->startPos.y, data->pos.y);
+	vec2 pos_min, pos_max;
+	vec2_min(&pos_min, &data->startPos, &data->pos);
+	vec2_max(&pos_max, &data->startPos, &data->pos);
+
+	const float x1 = pos_min.x;
+	const float x2 = pos_max.x;
+	const float y1 = pos_min.y;
+	const float y2 = pos_max.y;
 
 	if (!SceneItemHasVideo(item))
 		return true;

--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -20,8 +20,12 @@
 #include "gl-subsystem.h"
 
 /* Goofy Windows.h macros need to be removed */
-#undef far
+#ifdef near
 #undef near
+#endif
+#ifdef far
+#undef far
+#endif
 
 /* #define SHOW_ALL_GL_MESSAGES */
 

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -28,8 +28,10 @@
 #include "effect-parser.h"
 #include "effect.h"
 
-#ifdef _MSC_VER
+#ifdef near
 #undef near
+#endif
+#ifdef far
 #undef far
 #endif
 

--- a/libobs/graphics/vec2.h
+++ b/libobs/graphics/vec2.h
@@ -119,36 +119,28 @@ static inline float vec2_dist(const struct vec2 *v1, const struct vec2 *v2)
 
 static inline void vec2_minf(struct vec2 *dst, const struct vec2 *v, float val)
 {
-	if (v->x < val)
-		dst->x = val;
-	if (v->y < val)
-		dst->y = val;
+	dst->x = (v->x < val) ? v->x : val;
+	dst->y = (v->y < val) ? v->y : val;
 }
 
 static inline void vec2_min(struct vec2 *dst, const struct vec2 *v,
 			    const struct vec2 *min_v)
 {
-	if (v->x < min_v->x)
-		dst->x = min_v->x;
-	if (v->y < min_v->y)
-		dst->y = min_v->y;
+	dst->x = (v->x < min_v->x) ? v->x : min_v->x;
+	dst->y = (v->y < min_v->y) ? v->y : min_v->y;
 }
 
 static inline void vec2_maxf(struct vec2 *dst, const struct vec2 *v, float val)
 {
-	if (v->x > val)
-		dst->x = val;
-	if (v->y > val)
-		dst->y = val;
+	dst->x = (v->x > val) ? v->x : val;
+	dst->y = (v->y > val) ? v->y : val;
 }
 
 static inline void vec2_max(struct vec2 *dst, const struct vec2 *v,
 			    const struct vec2 *max_v)
 {
-	if (v->x > max_v->x)
-		dst->x = max_v->x;
-	if (v->y > max_v->y)
-		dst->y = max_v->y;
+	dst->x = (v->x > max_v->x) ? v->x : max_v->x;
+	dst->y = (v->y > max_v->y) ? v->y : max_v->y;
 }
 
 EXPORT void vec2_abs(struct vec2 *dst, const struct vec2 *v);

--- a/libobs/obs-hotkey-name-map.c
+++ b/libobs/obs-hotkey-name-map.c
@@ -15,10 +15,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifdef _MSC_VER
-#define WIN32_LEAN_AND_MEAN
-#endif
-
 #include <string.h>
 #include <assert.h>
 

--- a/libobs/util/sse-intrin.h
+++ b/libobs/util/sse-intrin.h
@@ -17,11 +17,13 @@
 
 #pragma once
 
-#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86)) && \
-	!(defined(_M_ARM64) || defined(_M_ARM64EC))
-
+#if defined(_MSC_VER) && \
+	((defined(_M_X64) && !defined(_M_ARM64EC)) || defined(_M_IX86))
 #include <emmintrin.h>
 #else
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #define SIMDE_ENABLE_NATIVE_ALIASES
 #include "simde/x86/sse2.h"
 #endif

--- a/plugins/coreaudio-encoder/windows-imports.h
+++ b/plugins/coreaudio-encoder/windows-imports.h
@@ -1,4 +1,3 @@
-#define NO_MIN_MAX 1
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <ShlObj.h>

--- a/plugins/decklink/platform.hpp
+++ b/plugins/decklink/platform.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #if defined(_WIN32)
+#include <combaseapi.h>
 #include <DeckLinkAPI.h>
 #include "win/decklink-sdk/DeckLinkAPIVersion.h"
 typedef BOOL decklink_bool_t;

--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -15,10 +15,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifdef _MSC_VER
-#define WIN32_LEAN_AND_MEAN
-#endif
-
 #include <obs.h>
 #include <stdio.h>
 #include <util/dstr.h>

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -15,10 +15,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifdef _MSC_VER
-#define WIN32_LEAN_AND_MEAN
-#endif
-
 #include <obs-module.h>
 #include <obs-avc.h>
 #include <util/platform.h>

--- a/plugins/obs-outputs/obs-outputs.c
+++ b/plugins/obs-outputs/obs-outputs.c
@@ -1,13 +1,8 @@
-#ifdef _MSC_VER
-#define WIN32_LEAN_AND_MEAN
-#endif
-
 #include <obs-module.h>
 
 #include "obs-outputs-config.h"
 
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <mbedtls/threading.h>
 #endif

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -15,10 +15,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifdef _MSC_VER
-#define WIN32_LEAN_AND_MEAN
-#endif
-
 #include "rtmp-stream.h"
 
 #ifndef SEC_TO_NSEC

--- a/plugins/obs-outputs/rtmp-windows.c
+++ b/plugins/obs-outputs/rtmp-windows.c
@@ -1,6 +1,5 @@
 #ifdef _WIN32
 #include "rtmp-stream.h"
-#include <winsock2.h>
 
 static void fatal_sock_shutdown(struct rtmp_stream *stream)
 {

--- a/plugins/obs-outputs/rtmp-windows.c
+++ b/plugins/obs-outputs/rtmp-windows.c
@@ -1,7 +1,3 @@
-#ifdef _MSC_VER
-#define WIN32_LEAN_AND_MEAN
-#endif
-
 #ifdef _WIN32
 #include "rtmp-stream.h"
 #include <winsock2.h>

--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -3,7 +3,7 @@
 #include <util/util.hpp>
 #include <obs-module.h>
 #include <sys/stat.h>
-#include <windows.h>
+#include <combaseapi.h>
 #include <gdiplus.h>
 #include <algorithm>
 #include <string>


### PR DESCRIPTION
### Description
Address a diverse set of code health items.

### Motivation and Context
Saw WIN32_LEAN_AND_MEAN sprinkled around, and decided to consolidate and tidy up nearby areas.

### How Has This Been Tested?
Compiled on x64 and ARM64. Debugger inspection for altered code paths.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.