### PR TITLE
UI: Don't save defaults in oldSettings in properties

### DIFF
--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -79,10 +79,7 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 	obs_data_release(oldSettings);
 
 	OBSData nd_settings = obs_source_get_settings(source);
-	OBSData settings = obs_data_get_defaults(nd_settings);
-	obs_data_apply(settings, nd_settings);
-	obs_data_apply(oldSettings, settings);
-	obs_data_release(settings);
+	obs_data_apply(oldSettings, nd_settings);
 	obs_data_release(nd_settings);
 
 	auto handle_memory = [](void *vp, obs_data_t *old_settings,


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The default settings were saved in the oldSettings variable of the
properties dialog in `86eb7ae` to be able to restore default settings in
undo/redo. This doesn't seem to actually do anything, since it works the same as before.
There probably have been changes to undo/redo making it unnecessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Storing the defaults in oldSettings introduced a bug where clicking "Cancel" in the
properties dialog would save all settings, including default ones, as
well as a bug where not changing anything in the properties dialog would
still add an undo action.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0 beta 6, compiled and run

Clicking "Cancel" in the properties dialog no longer saves all settings to the collection.
Clicking "Ok" will no longer add an undo action to the stack, as expected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
