### PR TITLE
UI: Add undo/redo for resetting filters properties

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -192,6 +192,68 @@ inline OBSSource OBSBasicFilters::GetFilter(int row, bool async)
 	return v.value<OBSSource>();
 }
 
+void FilterChangeUndoRedo(void *vp, obs_data_t *nd_old_settings,
+			  obs_data_t *new_settings)
+{
+	obs_source_t *source = reinterpret_cast<obs_source_t *>(vp);
+	obs_source_t *parent = obs_filter_get_parent(source);
+	const char *source_name = obs_source_get_name(source);
+	OBSBasic *main = OBSBasic::Get();
+
+	obs_data_t *redo_wrapper = obs_data_create();
+	obs_data_set_string(redo_wrapper, "name", source_name);
+	obs_data_set_string(redo_wrapper, "settings",
+			    obs_data_get_json(new_settings));
+	obs_data_set_string(redo_wrapper, "parent",
+			    obs_source_get_name(parent));
+
+	obs_data_t *filter_settings = obs_source_get_settings(source);
+
+	obs_data_t *undo_wrapper = obs_data_create();
+	obs_data_set_string(undo_wrapper, "name", source_name);
+	obs_data_set_string(undo_wrapper, "settings",
+			    obs_data_get_json(nd_old_settings));
+	obs_data_set_string(undo_wrapper, "parent",
+			    obs_source_get_name(parent));
+
+	auto undo_redo = [](const std::string &data) {
+		obs_data_t *dat = obs_data_create_from_json(data.c_str());
+		obs_source_t *parent_source = obs_get_source_by_name(
+			obs_data_get_string(dat, "parent"));
+		const char *filter_name = obs_data_get_string(dat, "name");
+		obs_source_t *filter = obs_source_get_filter_by_name(
+			parent_source, filter_name);
+		obs_data_t *new_settings = obs_data_create_from_json(
+			obs_data_get_string(dat, "settings"));
+
+		obs_data_t *current_settings = obs_source_get_settings(filter);
+		obs_data_clear(current_settings);
+		obs_data_release(current_settings);
+
+		obs_source_update(filter, new_settings);
+		obs_source_update_properties(filter);
+
+		obs_data_release(dat);
+		obs_data_release(new_settings);
+		obs_source_release(filter);
+		obs_source_release(parent_source);
+	};
+
+	main->undo_s.enable();
+
+	std::string name = std::string(obs_source_get_name(source));
+	std::string undo_data = obs_data_get_json(undo_wrapper);
+	std::string redo_data = obs_data_get_json(redo_wrapper);
+	main->undo_s.add_action(QTStr("Undo.Filters").arg(name.c_str()),
+				undo_redo, undo_redo, undo_data, redo_data);
+
+	obs_data_release(redo_wrapper);
+	obs_data_release(undo_wrapper);
+	obs_data_release(filter_settings);
+
+	obs_source_update(source, new_settings);
+}
+
 void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 {
 	if (view) {
@@ -207,70 +269,6 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 
 	obs_data_t *settings = obs_source_get_settings(filter);
 
-	auto filter_change = [](void *vp, obs_data_t *nd_old_settings,
-				obs_data_t *new_settings) {
-		obs_source_t *source = reinterpret_cast<obs_source_t *>(vp);
-		obs_source_t *parent = obs_filter_get_parent(source);
-		const char *source_name = obs_source_get_name(source);
-		OBSBasic *main = OBSBasic::Get();
-
-		obs_data_t *redo_wrapper = obs_data_create();
-		obs_data_set_string(redo_wrapper, "name", source_name);
-		obs_data_set_string(redo_wrapper, "settings",
-				    obs_data_get_json(new_settings));
-		obs_data_set_string(redo_wrapper, "parent",
-				    obs_source_get_name(parent));
-
-		obs_data_t *filter_settings = obs_source_get_settings(source);
-		obs_data_t *old_settings =
-			obs_data_get_defaults(filter_settings);
-		obs_data_apply(old_settings, nd_old_settings);
-
-		obs_data_t *undo_wrapper = obs_data_create();
-		obs_data_set_string(undo_wrapper, "name", source_name);
-		obs_data_set_string(undo_wrapper, "settings",
-				    obs_data_get_json(old_settings));
-		obs_data_set_string(undo_wrapper, "parent",
-				    obs_source_get_name(parent));
-
-		auto undo_redo = [](const std::string &data) {
-			obs_data_t *dat =
-				obs_data_create_from_json(data.c_str());
-			obs_source_t *parent_source = obs_get_source_by_name(
-				obs_data_get_string(dat, "parent"));
-			const char *filter_name =
-				obs_data_get_string(dat, "name");
-			obs_source_t *filter = obs_source_get_filter_by_name(
-				parent_source, filter_name);
-			obs_data_t *settings = obs_data_create_from_json(
-				obs_data_get_string(dat, "settings"));
-
-			obs_source_update(filter, settings);
-			obs_source_update_properties(filter);
-
-			obs_data_release(dat);
-			obs_data_release(settings);
-			obs_source_release(filter);
-			obs_source_release(parent_source);
-		};
-
-		main->undo_s.enable();
-
-		std::string name = std::string(obs_source_get_name(source));
-		std::string undo_data = obs_data_get_json(undo_wrapper);
-		std::string redo_data = obs_data_get_json(redo_wrapper);
-		main->undo_s.add_action(QTStr("Undo.Filters").arg(name.c_str()),
-					undo_redo, undo_redo, undo_data,
-					redo_data);
-
-		obs_data_release(redo_wrapper);
-		obs_data_release(undo_wrapper);
-		obs_data_release(old_settings);
-		obs_data_release(filter_settings);
-
-		obs_source_update(source, new_settings);
-	};
-
 	auto disabled_undo = [](void *vp, obs_data_t *settings) {
 		OBSBasic *main =
 			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
@@ -282,7 +280,7 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 	view = new OBSPropertiesView(
 		settings, filter,
 		(PropertiesReloadCallback)obs_source_properties,
-		(PropertiesUpdateCallback)filter_change,
+		(PropertiesUpdateCallback)FilterChangeUndoRedo,
 		(PropertiesVisualUpdateCb)disabled_undo);
 
 	updatePropertiesSignal.Connect(obs_source_get_signal_handler(filter),
@@ -1136,6 +1134,11 @@ void OBSBasicFilters::ResetFilters()
 		return;
 
 	obs_data_t *settings = obs_source_get_settings(filter);
+
+	obs_data_t *empty_settings = obs_data_create();
+	FilterChangeUndoRedo((void *)filter, settings, empty_settings);
+	obs_data_release(empty_settings);
+
 	obs_data_clear(settings);
 	obs_data_release(settings);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds an undo/redo action when you click "Defaults" in the filters properties window.

The callback (or whatever you'd call that) `filter_change` was moved into a function so that it could be called from outside without code being duplicated for no reason (this is the majority of the lines added/removed).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Pressing "Defaults" on the filter properties would previously not create an undo action, resulting in bad UX and unpredictable behaviour when you first changed a filter, then pressed "Defaults" and did an undo.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0 beta 6, compiled and run

Pressing "Defaults" will add an `Undo Filter Changes on 'FILTER_NAME'` undo action.
Undo/Redo for normal changes to filters still works as before.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
