### PR TITLE
UI: Source toolbar color selector fixes

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -546,8 +546,6 @@ ColorSourceToolbar::~ColorSourceToolbar()
 
 void ColorSourceToolbar::UpdateColor()
 {
-	color.setAlpha(255);
-
 	QPalette palette = QPalette(color);
 	ui->color->setFrameStyle(QFrame::Sunken | QFrame::Panel);
 	ui->color->setText(color.name(QColor::HexRgb));
@@ -574,6 +572,7 @@ void ColorSourceToolbar::on_choose_clicked()
 
 	QColorDialog::ColorDialogOptions options;
 
+	options |= QColorDialog::ShowAlphaChannel;
 #ifndef _WIN32
 	options |= QColorDialog::DontUseNativeDialog;
 #endif
@@ -693,6 +692,7 @@ void TextSourceToolbar::on_selectColor_clicked()
 
 	QColorDialog::ColorDialogOptions options;
 
+	options |= QColorDialog::ShowAlphaChannel;
 #ifndef _WIN32
 	options |= QColorDialog::DontUseNativeDialog;
 #endif

--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -615,7 +615,13 @@ TextSourceToolbar::TextSourceToolbar(QWidget *parent, OBSSource source)
 	MakeQFont(font_obj, font);
 	obs_data_release(font_obj);
 
-	unsigned int val = (unsigned int)obs_data_get_int(settings, "color");
+	// Use "color1" if it's a freetype source and "color" elsewise
+	unsigned int val = (unsigned int)obs_data_get_int(
+		settings,
+		(strncmp(obs_source_get_id(source), "text_ft2_source", 15) == 0)
+			? "color1"
+			: "color");
+
 	color = color_from_int(val);
 
 	const char *text = obs_data_get_string(settings, "text");
@@ -687,7 +693,12 @@ void TextSourceToolbar::on_selectColor_clicked()
 		return;
 	}
 
-	obs_property_t *p = obs_properties_get(props.get(), "color");
+	bool freetype =
+		strncmp(obs_source_get_id(source), "text_ft2_source", 15) == 0;
+
+	obs_property_t *p =
+		obs_properties_get(props.get(), freetype ? "color1" : "color");
+
 	const char *desc = obs_property_description(p);
 
 	QColorDialog::ColorDialogOptions options;
@@ -707,7 +718,7 @@ void TextSourceToolbar::on_selectColor_clicked()
 	SaveOldProperties(source);
 
 	obs_data_t *settings = obs_data_create();
-	if (!strncmp(obs_source_get_id(source), "text_ft2_source", 15)) {
+	if (freetype) {
 		obs_data_set_int(settings, "color1", color_to_int(color));
 		obs_data_set_int(settings, "color2", color_to_int(color));
 	} else {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Commit 1 makes it possible for the toolbar color selectors for the text and color sources to have the alpha channel changed. Before, it would always set it to 255. This also made sources that originally had a non-default alpha value change when "Ok" was clicked change that value to the default 255, without the user interacting with any part of the actual dialog (Except clicking OK).
Unlike with the normal properties, a check whether the source supports alpha is not needed since the color source and all text sources do support it.
I left the color preview without alpha since looking at the code, this seemed intentional. If requested, this could easily be changed (like 3 lines I think). This is how it looks (same as before):
<img width="462" alt="image" src="https://user-images.githubusercontent.com/59806498/133941179-9cd6d5fa-462c-4afc-b335-899025b49065.png">


Commit 2 is a fix for the freetype text source, where the toolbar color selector QColorDialog would default to having every all properties set to 0, due to the supplied `color` variable being null. This is because the property for the freetype source isn't called `color`, but `color1` and `color2` respectively. The values set when opening the dialog will no longer all be 0, but rather have the values of `color1`.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Stumbled across these bug. Fixing seemed like a good idea.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0 beta 6, compiled and run.

Changes from commit 1 (Using the color source as an example):
*Before*
<img width="605" alt="image" src="https://user-images.githubusercontent.com/59806498/133941329-c68402bb-a022-49b8-be29-9207c4ed301f.png">
*After*
<img width="605" alt="image" src="https://user-images.githubusercontent.com/59806498/133941307-48c1a86c-f513-42d7-b9d8-d061c5f098f8.png">
Note that the alpha channel now is available.

Changes from commit 2, just opening the dialog:
*Before*
<img width="605" alt="image" src="https://user-images.githubusercontent.com/59806498/133941257-0d5ebaf3-a55a-4906-a2bf-252b3932c5a2.png">
*After*
<img width="605" alt="image" src="https://user-images.githubusercontent.com/59806498/133941282-6e01291f-aee2-4ec5-82b8-b3fd7a94b9ea.png">

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
