### PR TITLE
UI: Fix YouTube remember settings issues

### DIFF
--- a/UI/window-youtube-actions.cpp
+++ b/UI/window-youtube-actions.cpp
@@ -704,13 +704,19 @@ void OBSYoutubeActions::UiToBroadcast(BroadcastDescription &broadcast)
 	broadcast.projection = ui->check360Video->isChecked() ? "360"
 							      : "rectangular";
 
-	if (ui->checkRememberSettings->isChecked())
-		SaveSettings(broadcast);
+	SaveSettings(broadcast);
 }
 
 void OBSYoutubeActions::SaveSettings(BroadcastDescription &broadcast)
 {
 	OBSBasic *main = OBSBasic::Get();
+
+	bool remember = ui->checkRememberSettings->isChecked();
+	config_set_bool(main->basicConfig, "YouTube", "RememberSettings",
+			remember);
+
+	if (!remember)
+		return;
 
 	config_set_string(main->basicConfig, "YouTube", "Title",
 			  QT_TO_UTF8(broadcast.title));
@@ -735,7 +741,6 @@ void OBSYoutubeActions::SaveSettings(BroadcastDescription &broadcast)
 			  QT_TO_UTF8(broadcast.projection));
 	config_set_string(main->basicConfig, "YouTube", "ThumbnailFile",
 			  QT_TO_UTF8(thumbnailFile));
-	config_set_bool(main->basicConfig, "YouTube", "RememberSettings", true);
 }
 
 void OBSYoutubeActions::LoadSettings()
@@ -815,6 +820,10 @@ void OBSYoutubeActions::LoadSettings()
 					160, 90, Qt::KeepAspectRatio));
 		}
 	}
+
+	bool rememberSettings = config_get_bool(main->basicConfig, "YouTube",
+						"RememberSettings");
+	ui->checkRememberSettings->setChecked(rememberSettings);
 }
 
 void OBSYoutubeActions::OpenYouTubeDashboard()


### PR DESCRIPTION
### Description
-The remember checkbox wouldn't be checked if remember settings
was enabled when loading the YouTube broadcast dialog

-If the user would click remember settings one time and not
the next, the dialog would still load the remembered settings
from the first time, instead of defaults

### Motivation and Context
Fixes bugs that I have noticed.

### How Has This Been Tested?
Created broadcast with saved settings enabled/disabled, to make sure everything worked as expected.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
