### PR TITLE
win-dshow: Don't buffer Elgato Facecam by default

### DIFF
--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -839,7 +839,8 @@ static long long GetOBSFPS();
 static inline bool IsDelayedDevice(const VideoConfig &config)
 {
 	return config.format > VideoFormat::MJPEG ||
-	       wstrstri(config.name.c_str(), L"elgato") != NULL ||
+	       (wstrstri(config.name.c_str(), L"elgato") != NULL &&
+		wstrstri(config.name.c_str(), L"facecam") == NULL) ||
 	       wstrstri(config.name.c_str(), L"stream engine") != NULL;
 }
 


### PR DESCRIPTION
win-dshow: Buffering should be disabled for Elgato Facecam in "Auto-detect" mode to prevent latency changes over time

### Description
When "Buffering" is set to "Auto-detect" it was always enabled for all Elgato devices. I added "Facecam" as an exception to that rule.

### Motivation and Context
We found that buffering causes latency changes over time for Facecam in OBS and audio from other devices does not stay in sync with the webcam video.

### How Has This Been Tested?
Tested with Elgato Facecam on Windows 10.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
