### PR TITLE
UI: Prevent Restream OAuth disconnection

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -686,7 +686,8 @@ void AutoConfigStreamPage::ServiceChanged()
 
 	if (main->auth) {
 		auto system_auth_service = main->auth->service();
-		bool service_check = service == system_auth_service;
+		bool service_check = service.find(system_auth_service) !=
+				     std::string::npos;
 #if YOUTUBE_ENABLED
 		service_check =
 			service_check ? service_check

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -481,7 +481,8 @@ void OBSBasicSettings::on_service_currentIndexChanged(int)
 	}
 
 	auto system_auth_service = main->auth->service();
-	bool service_check = service == system_auth_service;
+	bool service_check = service.find(system_auth_service) !=
+			     std::string::npos;
 #if YOUTUBE_ENABLED
 	service_check = service_check ? service_check
 				      : IsYouTubeService(system_auth_service) &&


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix the service check for services where its name in the UI does not match its Auth::Def service string.

In Restream's case, the service name in the UI and rtmp-services is "Restream.io" while the service name in its Auth::Def is "Restream".  This mismatch causes the `service_check` bool to be false, whereas the previous condition (`!!main->auth && service.find(main->auth->service()) != std::string::npos`) would have evaluated to true.

This was broken in commit e6f1daab8c64aa4cd57c7615647ad80362d72d72.

Fixes #5290.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We want service integrations to work.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled and tested on Windows 10.  Connected to accounts for Twitch, YouTube, and Restream and checked against the STR in #5290.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
