### PR TITLE
Relative path import

### DIFF
--- a/UI/importers/classic.cpp
+++ b/UI/importers/classic.cpp
@@ -530,6 +530,11 @@ int ClassicImporter::ImportScenes(const string &path, string &name, Json &res)
 	Json sc = data;
 	translate_sc(sc, res);
 
+	QDir dir(path.c_str());
+
+	TranslateOSStudio(res);
+	TranslatePaths(res, QDir::cleanPath(dir.filePath("..")).toStdString());
+
 	return IMPORTER_SUCCESS;
 }
 

--- a/UI/importers/importers.hpp
+++ b/UI/importers/importers.hpp
@@ -23,6 +23,7 @@
 #include <util/util.hpp>
 #include <string>
 #include <vector>
+#include <QDir>
 
 enum obs_importer_responses {
 	IMPORTER_SUCCESS,
@@ -106,6 +107,7 @@ int ImportSC(const std::string &path, std::string &name, json11::Json &res);
 OBSImporterFiles ImportersFindFiles();
 
 void TranslateOSStudio(json11::Json &data);
+void TranslatePaths(json11::Json &data, const std::string &rootDir);
 
 static inline std::string GetFilenameFromPath(const std::string &path)
 {

--- a/UI/importers/sl.cpp
+++ b/UI/importers/sl.cpp
@@ -439,7 +439,10 @@ int SLImporter::ImportScenes(const string &path, string &name, Json &res)
 		}
 	}
 
+	QDir dir(path.c_str());
+
 	TranslateOSStudio(res);
+	TranslatePaths(res, QDir::cleanPath(dir.filePath("..")).toStdString());
 
 	return result;
 }

--- a/UI/importers/xsplit.cpp
+++ b/UI/importers/xsplit.cpp
@@ -477,6 +477,11 @@ int XSplitImporter::ImportScenes(const string &path, string &name,
 
 	res = r;
 
+	QDir dir(path.c_str());
+
+	TranslateOSStudio(res);
+	TranslatePaths(res, QDir::cleanPath(dir.filePath("..")).toStdString());
+
 	return IMPORTER_SUCCESS;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change makes it so any strings in a scene collection that start with "./" are checked as being a relative path. As long as the resulting absolute path is contained within the same directory as the collection being imported, it will be replaced with an absolute path.

This change also corrects an issue where scene collections that were translated from third-party programs would only produce valid Windows collections, but did not translate the source types to the types for the current OS, if running on macOS or *nix. This adds the missing calls to do those translations.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This allows scene collections to be effectively "packaged" with assets, so long as the assets are contained somewhere within the folder the collection is being imported from.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This code was tested by running the importer on manually edited scene collections to include relative paths starting with "./". Some collections pointed to files located within the current directory, and others pointing to files in the parent directory. The former correctly had their paths translated and swapped into the resulting import, while the latter cases were ignored.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
