### PR TITLE
libobs/media-io: Register audio thread with MMCSS

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -120,7 +120,7 @@ if(WIN32)
 	set(libobs_audio_monitoring_HEADERS
 		audio-monitoring/win32/wasapi-output.h
 		)
-	set(libobs_PLATFORM_DEPS winmm)
+	set(libobs_PLATFORM_DEPS Avrt winmm)
 	if(MSVC)
 		set(libobs_PLATFORM_DEPS
 		${libobs_PLATFORM_DEPS}

--- a/libobs/media-io/audio-io.c
+++ b/libobs/media-io/audio-io.c
@@ -28,6 +28,12 @@
 #include "audio-io.h"
 #include "audio-resampler.h"
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <avrt.h>
+#endif
+
 extern profiler_name_store_t *obs_get_profiler_name_store(void);
 
 /* #define DEBUG_AUDIO */
@@ -197,6 +203,11 @@ static void input_and_output(struct audio_output *audio, uint64_t audio_time,
 
 static void *audio_thread(void *param)
 {
+#ifdef _WIN32
+	DWORD unused = 0;
+	const HANDLE handle = AvSetMmThreadCharacteristics(L"Audio", &unused);
+#endif
+
 	struct audio_output *audio = param;
 	size_t rate = audio->info.samples_per_sec;
 	uint64_t samples = 0;
@@ -233,6 +244,11 @@ static void *audio_thread(void *param)
 
 		profile_reenable_thread();
 	}
+
+#ifdef _WIN32
+	if (handle)
+		AvRevertMmThreadCharacteristics(handle);
+#endif
 
 	return NULL;
 }


### PR DESCRIPTION
### Description
Ensure audio gets more priority to help prevent glitching.

### Motivation and Context
MS samples old and new seem to be using MMCSS, so we probably should too. Also someone reported glitching with the new process loopback audio capture, so let's try to make sure we meet audio deadlines as best we can.

### How Has This Been Tested?
Audio has been verified to work in recording, thread priority was increased in Process Explorer, and the API calls were inspected in debugger to return success. I don't have any glitch/load tests though.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.