### PR TITLE
obs-ffmpeg: Set DRI devices and their name persistently

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -422,7 +422,8 @@ jobs:
            qtbase5-private-dev \
            libqt5svg5-dev \
            swig \
-           libcmocka-dev
+           libcmocka-dev \
+           libpci-dev
       - name: 'Restore Chromium Embedded Framework from cache'
         id: cef-cache
         uses: actions/cache@v2.1.2

--- a/cmake/Modules/FindLibpci.cmake
+++ b/cmake/Modules/FindLibpci.cmake
@@ -1,0 +1,49 @@
+# * Try to find Libpci
+# Once done this will define
+#
+# LIBPCI_FOUND - system has Libpci
+# LIBPCI_INCLUDE_DIRS - the Libpci include directory
+# LIBPCI_LIBRARIES - the libraries needed to use Libpci
+# LIBPCI_DEFINITIONS - Compiler switches required for using Libpci
+
+# Use pkg-config to get the directories and then use these values in the
+# find_path() and find_library() calls
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(_LIBPCI libpci)
+endif()
+
+find_path(
+  LIBPCI_INCLUDE_DIR
+  NAMES pci.h
+  HINTS ${_LIBPCI_INCLUDE_DIRS}
+  PATHS /usr/include /usr/local/include /opt/local/include
+  PATH_SUFFIXES pci/)
+
+find_library(
+  LIBPCI_LIB
+  NAMES ${_LIBPCI_LIBRARIES} libpci
+  HINTS ${_LIBPCI_LIBRARY_DIRS}
+  PATHS /usr/lib /usr/local/lib /opt/local/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libpci REQUIRED_VARS LIBPCI_LIB LIBPCI_INCLUDE_DIR)
+mark_as_advanced(LIBPCI_INCLUDE_DIR LIBPCI_LIB)
+
+if(LIBPCI_FOUND)
+  set(LIBPCI_INCLUDE_DIRS ${LIBPCI_INCLUDE_DIR})
+  set(LIBPCI_LIBRARIES ${LIBPCI_LIB})
+
+  if(NOT TARGET LIBPCI::LIBPCI)
+    if(IS_ABSOLUTE "${LIBPCI_LIBRARIES}")
+      add_library(LIBPCI::LIBPCI UNKNOWN IMPORTED)
+      set_target_properties(LIBPCI::LIBPCI PROPERTIES IMPORTED_LOCATION
+                                                "${LIBPCI_LIBRARIES}")
+    else()
+      add_library(LIBPCI::LIBPCI INTERFACE IMPORTED)
+      set_target_properties(LIBPCI::LIBPCI PROPERTIES IMPORTED_LIBNAME
+                                                "${LIBPCI_LIBRARIES}")
+    endif()
+  endif()
+endif()

--- a/plugins/obs-ffmpeg/CMakeLists.txt
+++ b/plugins/obs-ffmpeg/CMakeLists.txt
@@ -11,6 +11,11 @@ find_package(FFmpeg REQUIRED
 	COMPONENTS avcodec avfilter avdevice avutil swscale avformat swresample)
 include_directories(${FFMPEG_INCLUDE_DIRS})
 
+if(UNIX AND NOT APPLE)
+        find_package(Libpci REQUIRED)
+        include_directories(${LIBPCI_INCLUDE_DIRS})
+endif()
+
 configure_file(
 	"${CMAKE_CURRENT_SOURCE_DIR}/obs-ffmpeg-config.h.in"
 	"${CMAKE_CURRENT_BINARY_DIR}/obs-ffmpeg-config.h")
@@ -37,7 +42,8 @@ if(UNIX AND NOT APPLE)
 	list(APPEND obs-ffmpeg_SOURCES
 		obs-ffmpeg-vaapi.c)
 	LIST(APPEND obs-ffmpeg_PLATFORM_DEPS
-		${LIBVA_LBRARIES})
+		${LIBVA_LBRARIES}
+		${LIBPCI_LIBRARIES})
 endif()
 
 if(ENABLE_FFMPEG_LOGGING)


### PR DESCRIPTION

### Description
As discussed in the issue, I retrieve the DRI devices from `/dev/dri/by-path/` instead of `/dev/dri/renderDXXX` (e.g. `/dev/dri/by-path/pci-0000:00:02.0-render`). This enable us to use [`lspci`](https://github.com/pciutils/pciutils/) to get the device name as well.
If `/dev/dri/by-path/` does not exist, I fall back to the old implementation

![immagine](https://user-images.githubusercontent.com/34198340/134891263-ac9d1798-8a41-4b4f-88c2-eb0bcae57a43.png)

This is the first time contributing here: I am not sure it is correct to add the `-lpci` flag where I did in `CMakeLists.txt`. Additionally I don't work often in C, but I hope this works out as intended since it's a small contribution.

### Motivation and Context
Fixes #2936

### How Has This Been Tested?
I tested it in a clean environment on my desktop with two vaapi devices. It appears to work as intended

specs:
```
OS: Manjaro Linux x86_64 
Kernel: 5.14.7-2-MANJARO 
Resolution: 1920x1080, 1920x1080 
DE: Plasma 5.22.5 
WM: KWin 

CPU: Intel i5-6400 (4) @ 3.300GHz 
GPU: AMD ATI Radeon R9 285/380 
GPU: Intel HD Graphics 530 
Memory: 7176MiB / 15867MiB 
```

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch. (as in "it's not in **my** master branch)
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
