### PR TITLE
UI: Apply transforms/crops correctly to sources on paste

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -89,6 +89,13 @@ struct SavedProjectorInfo {
 	bool alwaysOnTopOverridden;
 };
 
+struct SourceCopyInfo {
+	OBSWeakSource weak_source;
+	bool visible;
+	std::shared_ptr<obs_sceneitem_crop> crop;
+	std::shared_ptr<obs_transform_info> transform;
+};
+
 struct QuickTransition {
 	QPushButton *button = nullptr;
 	OBSSource source;
@@ -204,7 +211,7 @@ private:
 	bool projectChanged = false;
 	bool previewEnabled = true;
 
-	std::deque<OBSWeakSource> copySources;
+	std::deque<SourceCopyInfo> clipboard;
 	OBSWeakSource copyFiltersSource;
 	bool copyVisible = true;
 
@@ -946,7 +953,6 @@ private slots:
 
 	void on_actionEditTransform_triggered();
 	void on_actionCopyTransform_triggered();
-	void on_actionPasteTransform_triggered();
 	void on_actionRotate90CW_triggered();
 	void on_actionRotate90CCW_triggered();
 	void on_actionRotate180_triggered();

--- a/UI/window-basic-source-select.hpp
+++ b/UI/window-basic-source-select.hpp
@@ -22,6 +22,7 @@
 
 #include "ui_OBSBasicSourceSelect.h"
 #include "undo-stack-obs.hpp"
+#include "window-basic-main.hpp"
 
 class OBSBasic;
 
@@ -52,5 +53,5 @@ public:
 
 	OBSSource newSource;
 
-	static void SourcePaste(const char *name, bool visible, bool duplicate);
+	static void SourcePaste(SourceCopyInfo &info, bool duplicate);
 };


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fixes #3632
Applies transformations correctly to copy/pasted sources when copy and pasting multiple. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Previous behavior was unintuitive and not how users would expect copy + paste to function.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Verified functionality running on Windows 10 with latest code from master + this commit

![ws - u3oqpHhFH4](https://user-images.githubusercontent.com/17508706/135175195-ab876e0a-e2b8-4a7c-9219-a0da5c0c8621.gif)

Also verified undo/redo still function as expected
![wu - GLdqptD5wQ](https://user-images.githubusercontent.com/17508706/135175557-a4ba3c01-6b0e-4800-bee6-adc260aafb21.gif)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)  
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
