### PR TITLE
UI: Adjust minimum size of source toolbar smaller

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -205,7 +205,7 @@
       </property>
       <property name="minimumSize">
        <size>
-        <width>800</width>
+        <width>740</width>
         <height>30</height>
        </size>
       </property>

--- a/UI/forms/source-toolbar/game-capture-toolbar.ui
+++ b/UI/forms/source-toolbar/game-capture-toolbar.ui
@@ -70,7 +70,7 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>150</width>
+       <width>120</width>
        <height>22</height>
       </size>
      </property>
@@ -117,7 +117,7 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>150</width>
+       <width>120</width>
        <height>22</height>
       </size>
      </property>


### PR DESCRIPTION
### Description
#5187 added a minimum size enforcement on the source toolbar to ensure it remains functional at lower window sizes.

That minimum size was set to 800 pixels, which causes issues for users on 1366x768 monitors in a vertical orientation.

This is still a rather common resolution, so this reduces the minimum size below 768

![image](https://user-images.githubusercontent.com/1554753/135205664-1d096af8-00b6-41c4-ae2c-e417546eac22.png)
_740px wide plus border width_

### Motivation and Context
Fixes OBS not fitting on 768px wide screens with the source toolbar enabled

### How Has This Been Tested?
Checked all source types to ensure toolbar controls were at least mildly useable at minimum width.

Checked all themes displayed correctly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
