### PR TITLE
libobs: Simplify util_mul_div64 for x64 on Windows

### DIFF
--- a/libobs/util/util_uint64.h
+++ b/libobs/util/util_uint64.h
@@ -16,9 +16,19 @@
 
 #pragma once
 
+#if defined(_MSC_VER) && defined(_M_X64)
+#include <intrin.h>
+#endif
+
 static inline uint64_t util_mul_div64(uint64_t num, uint64_t mul, uint64_t div)
 {
+#if defined(_MSC_VER) && defined(_M_X64)
+	unsigned __int64 high;
+	const unsigned __int64 low = _umul128(num, mul, &high);
+	unsigned __int64 rem;
+	return _udiv128(high, low, div, &rem);
+#else
 	const uint64_t rem = num % div;
-
 	return (num / div) * mul + (rem * mul) / div;
+#endif
 }


### PR DESCRIPTION
### Description
Use intrinsics to perform 128-bit math directly.

### Motivation and Context
Noticed the function was doing extra math that x86-64 processors can handle without shenanigans.

### How Has This Been Tested?
Disassembly inspection in RelWithDebInfo. New instruction sequence is trivial (mul, div).

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.