### PR TITLE
libobs: DrawSrgbDecompress for default_rect.effect

### DIFF
--- a/libobs/data/default_rect.effect
+++ b/libobs/data/default_rect.effect
@@ -40,6 +40,13 @@ float3 srgb_nonlinear_to_linear(float3 v)
 	return float3(srgb_nonlinear_to_linear_channel(v.r), srgb_nonlinear_to_linear_channel(v.g), srgb_nonlinear_to_linear_channel(v.b));
 }
 
+float4 PSDrawSrgbDecompress(VertInOut vert_in) : TARGET
+{
+	float4 rgba = image.Sample(def_sampler, vert_in.uv);
+	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
+	return rgba;
+}
+
 float4 PSDrawSrgbDecompressPremultiplied(VertInOut vert_in) : TARGET
 {
 	float4 rgba = image.Sample(def_sampler, vert_in.uv);
@@ -63,6 +70,15 @@ technique DrawOpaque
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawOpaque(vert_in);
+	}
+}
+
+technique DrawSrgbDecompress
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawSrgbDecompress(vert_in);
 	}
 }
 


### PR DESCRIPTION
### Description
Necessary for upcoming fix to browser source alpha.

### Motivation and Context
People want semi-transparency to work as expected.

### How Has This Been Tested?
WebM video supplied by #5347 seems to look like Chrome in browser source with or without default custom CSS.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.