### PR TITLE
UI: Fix bug with audio balance slider not updating

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -63,6 +63,8 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 			    this);
 	mixersSignal.Connect(handler, "audio_mixers", OBSSourceMixersChanged,
 			     this);
+	balChangedSignal.Connect(handler, "audio_balance",
+				 OBSSourceBalanceChanged, this);
 
 	hlayout = new QHBoxLayout();
 	hlayout->setContentsMargins(0, 0, 0, 0);
@@ -338,6 +340,13 @@ void OBSAdvAudioCtrl::OBSSourceMixersChanged(void *param, calldata_t *calldata)
 				  Q_ARG(uint32_t, mixers));
 }
 
+void OBSAdvAudioCtrl::OBSSourceBalanceChanged(void *param, calldata_t *calldata)
+{
+	int balance = (float)calldata_float(calldata, "balance") * 100.0f;
+	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param),
+				  "SourceBalanceChanged", Q_ARG(int, balance));
+}
+
 /* ------------------------------------------------------------------------- */
 /* Qt event queue source callbacks */
 
@@ -373,6 +382,13 @@ void OBSAdvAudioCtrl::SourceVolumeChanged(float value)
 	percent->setValue((int)std::round(value * 100.0f));
 	percent->blockSignals(false);
 	volume->blockSignals(false);
+}
+
+void OBSAdvAudioCtrl::SourceBalanceChanged(int value)
+{
+	balance->blockSignals(true);
+	balance->setValue(value);
+	balance->blockSignals(false);
 }
 
 void OBSAdvAudioCtrl::SourceSyncChanged(int64_t offset)

--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -54,6 +54,7 @@ private:
 	OBSSignal mixersSignal;
 	OBSSignal activateSignal;
 	OBSSignal deactivateSignal;
+	OBSSignal balChangedSignal;
 
 	static void OBSSourceActivated(void *param, calldata_t *calldata);
 	static void OBSSourceDeactivated(void *param, calldata_t *calldata);
@@ -61,6 +62,7 @@ private:
 	static void OBSSourceVolumeChanged(void *param, calldata_t *calldata);
 	static void OBSSourceSyncChanged(void *param, calldata_t *calldata);
 	static void OBSSourceMixersChanged(void *param, calldata_t *calldata);
+	static void OBSSourceBalanceChanged(void *param, calldata_t *calldata);
 
 public:
 	OBSAdvAudioCtrl(QGridLayout *layout, obs_source_t *source_);
@@ -78,6 +80,7 @@ public slots:
 	void SourceVolumeChanged(float volume);
 	void SourceSyncChanged(int64_t offset);
 	void SourceMixersChanged(uint32_t mixers);
+	void SourceBalanceChanged(int balance);
 
 	void volumeChanged(double db);
 	void percentChanged(int percent);

--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -578,6 +578,10 @@ Source Signals
 
    Called when the audio sync offset has changed.
 
+**audio_balance** (ptr source, in out float balance)
+
+   Called when the audio balance has changed.
+
 **audio_mixers** (ptr source, in out int mixers)
 
    Called when the audio mixers have changed.

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -87,6 +87,7 @@ static const char *source_signals[] = {
 	"void update_properties(ptr source)",
 	"void update_flags(ptr source, int flags)",
 	"void audio_sync(ptr source, int out int offset)",
+	"void audio_balance(ptr source, in out float balance)",
 	"void audio_mixers(ptr source, in out int mixers)",
 	"void audio_activate(ptr source)",
 	"void audio_deactivate(ptr source)",
@@ -5102,10 +5103,19 @@ enum speaker_layout obs_source_get_speaker_layout(obs_source_t *source)
 
 void obs_source_set_balance_value(obs_source_t *source, float balance)
 {
-	if (!obs_source_valid(source, "obs_source_set_balance_value"))
-		return;
+	if (obs_source_valid(source, "obs_source_set_balance_value")) {
+		struct calldata data;
+		uint8_t stack[128];
 
-	source->balance = balance;
+		calldata_init_fixed(&data, stack, sizeof(stack));
+		calldata_set_ptr(&data, "source", source);
+		calldata_set_float(&data, "balance", balance);
+
+		signal_handler_signal(source->context.signals, "audio_balance",
+				      &data);
+
+		source->balance = (float)calldata_float(&data, "balance");
+	}
 }
 
 float obs_source_get_balance_value(const obs_source_t *source)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
In the advanced audio properties, the balance slider does not update after undo/redo actions. To fix this bug, I adding a source_signal and a value change listener for the audio balance widget. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #4763 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Testing environment (Arch Linux, i3 Desktop)

Test steps:
1) Open advanced audio properties
2) Move balance slider
3) Undo/redo the action


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
