### PR TITLE
Test darray type during CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,11 @@ if(APPLE)
 elseif(UNIX)
 	option(USE_XDG "Utilize XDG Base Directory Specification" ON)
 	option(ENABLE_WAYLAND "Build support for Wayland" ON)
+	if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
+		option(ENABLE_DARRAY_TYPE_TEST "Test types of darray argument" ON)
+	else()
+		option(ENABLE_DARRAY_TYPE_TEST "Test types of darray argument" OFF)
+	endif()
 
 	if(USE_XDG)
 		add_definitions(-DUSE_XDG)
@@ -214,6 +219,10 @@ elseif(UNIX)
 
 	if(NOT UNIX_STRUCTURE)
 		list(APPEND CMAKE_INSTALL_RPATH "$ORIGIN")
+	endif()
+
+	if(ENABLE_DARRAY_TYPE_TEST)
+		add_definitions(-DENABLE_DARRAY_TYPE_TEST)
 	endif()
 endif()
 

--- a/libobs/graphics/effect-parser.c
+++ b/libobs/graphics/effect-parser.c
@@ -1017,12 +1017,14 @@ static inline int ep_parse_param_assign_intfloat(struct effect_parser *ep,
 		float f = (float)os_strtod(ep->cfp.cur_token->str.array);
 		if (is_negative)
 			f = -f;
-		da_push_back_array(param->default_val, &f, sizeof(float));
+		da_push_back_array(param->default_val, (uint8_t *)&f,
+				   sizeof(float));
 	} else {
 		long l = strtol(ep->cfp.cur_token->str.array, NULL, 10);
 		if (is_negative)
 			l = -l;
-		da_push_back_array(param->default_val, &l, sizeof(long));
+		da_push_back_array(param->default_val, (uint8_t *)&l,
+				   sizeof(long));
 	}
 
 	return PARSE_SUCCESS;
@@ -1036,11 +1038,13 @@ static inline int ep_parse_param_assign_bool(struct effect_parser *ep,
 
 	if (cf_token_is(&ep->cfp, "true")) {
 		long l = 1;
-		da_push_back_array(param->default_val, &l, sizeof(long));
+		da_push_back_array(param->default_val, (uint8_t *)&l,
+				   sizeof(long));
 		return PARSE_SUCCESS;
 	} else if (cf_token_is(&ep->cfp, "false")) {
 		long l = 0;
-		da_push_back_array(param->default_val, &l, sizeof(long));
+		da_push_back_array(param->default_val, (uint8_t *)&l,
+				   sizeof(long));
 		return PARSE_SUCCESS;
 	}
 

--- a/libobs/graphics/effect-parser.h
+++ b/libobs/graphics/effect-parser.h
@@ -223,10 +223,10 @@ struct ep_func {
 	char *name, *ret_type, *mapping;
 	struct dstr contents;
 	DARRAY(struct ep_var) param_vars;
-	DARRAY(const char *) func_deps;
-	DARRAY(const char *) struct_deps;
-	DARRAY(const char *) param_deps;
-	DARRAY(const char *) sampler_deps;
+	DARRAY(char *) func_deps;
+	DARRAY(char *) struct_deps;
+	DARRAY(char *) param_deps;
+	DARRAY(char *) sampler_deps;
 	bool written;
 };
 

--- a/libobs/graphics/shader-parser.c
+++ b/libobs/graphics/shader-parser.c
@@ -541,12 +541,14 @@ static inline int sp_parse_param_assign_intfloat(struct shader_parser *sp,
 		float f = (float)os_strtod(sp->cfp.cur_token->str.array);
 		if (is_negative)
 			f = -f;
-		da_push_back_array(param->default_val, &f, sizeof(float));
+		da_push_back_array(param->default_val, (uint8_t *)&f,
+				   sizeof(float));
 	} else {
 		long l = strtol(sp->cfp.cur_token->str.array, NULL, 10);
 		if (is_negative)
 			l = -l;
-		da_push_back_array(param->default_val, &l, sizeof(long));
+		da_push_back_array(param->default_val, (uint8_t *)&l,
+				   sizeof(long));
 	}
 
 	return PARSE_SUCCESS;

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -1222,7 +1222,7 @@ static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 	sei_init(&sei, 0.0);
 
 	da_init(out_data);
-	da_push_back_array(out_data, &ref, sizeof(ref));
+	da_push_back_array(out_data, (uint8_t *)&ref, sizeof(ref));
 	da_push_back_array(out_data, out->data, out->size);
 
 	if (output->caption_data.size > 0) {

--- a/libobs/util/array-serializer.c
+++ b/libobs/util/array-serializer.c
@@ -20,7 +20,7 @@
 static size_t array_output_write(void *param, const void *data, size_t size)
 {
 	struct array_output_data *output = param;
-	da_push_back_array(output->bytes, data, size);
+	da_push_back_array(output->bytes, (uint8_t *)data, size);
 	return size;
 }
 

--- a/libobs/util/darray.h
+++ b/libobs/util/darray.h
@@ -494,33 +494,124 @@ static inline void darray_swap(const size_t element_size, struct darray *dst,
 
 #define da_move(dst, src) darray_move(&dst.da, &src.da)
 
-#define da_find(v, item, idx) darray_find(sizeof(*v.array), &v.da, item, idx)
+#ifdef ENABLE_DARRAY_TYPE_TEST
+#ifdef __cplusplus
+#define da_type_test(v, item)                 \
+	({                                    \
+		if (false) {                  \
+			auto _t = v.array;    \
+			_t = (item);          \
+			(void)_t;             \
+			*(v).array = *(item); \
+		}                             \
+	})
+#else
+#define da_type_test(v, item)                       \
+	({                                          \
+		if (false) {                        \
+			const typeof(*v.array) *_t; \
+			_t = (item);                \
+			(void)_t;                   \
+			*(v).array = *(item);       \
+		}                                   \
+	})
+#endif
+#endif // ENABLE_DARRAY_TYPE_TEST
 
+#ifdef ENABLE_DARRAY_TYPE_TEST
+#define da_find(v, item, idx)                                    \
+	({                                                       \
+		da_type_test(v, item);                           \
+		darray_find(sizeof(*v.array), &v.da, item, idx); \
+	})
+#else
+#define da_find(v, item, idx) darray_find(sizeof(*v.array), &v.da, item, idx)
+#endif
+
+#ifdef ENABLE_DARRAY_TYPE_TEST
+#define da_push_back(v, item)                                    \
+	({                                                       \
+		da_type_test(v, item);                           \
+		darray_push_back(sizeof(*v.array), &v.da, item); \
+	})
+#else
 #define da_push_back(v, item) darray_push_back(sizeof(*v.array), &v.da, item)
+#endif
 
 #define da_push_back_new(v) darray_push_back_new(sizeof(*v.array), &v.da)
 
+#ifdef ENABLE_DARRAY_TYPE_TEST
+#define da_push_back_array(dst, src_array, n)                                  \
+	({                                                                     \
+		da_type_test(dst, src_array);                                  \
+		darray_push_back_array(sizeof(*dst.array), &dst.da, src_array, \
+				       n);                                     \
+	})
+#else
 #define da_push_back_array(dst, src_array, n) \
 	darray_push_back_array(sizeof(*dst.array), &dst.da, src_array, n)
+#endif
 
+#ifdef ENABLE_DARRAY_TYPE_TEST
+#define da_push_back_da(dst, src)                                              \
+	({                                                                     \
+		da_type_test(dst, src.array);                                  \
+		darray_push_back_darray(sizeof(*dst.array), &dst.da, &src.da); \
+	})
+#else
 #define da_push_back_da(dst, src) \
 	darray_push_back_darray(sizeof(*dst.array), &dst.da, &src.da)
+#endif
 
+#ifdef ENABLE_DARRAY_TYPE_TEST
+#define da_insert(v, idx, item)                                    \
+	({                                                         \
+		da_type_test(v, item);                             \
+		darray_insert(sizeof(*v.array), &v.da, idx, item); \
+	})
+#else
 #define da_insert(v, idx, item) \
 	darray_insert(sizeof(*v.array), &v.da, idx, item)
+#endif
 
 #define da_insert_new(v, idx) darray_insert_new(sizeof(*v.array), &v.da, idx)
 
+#ifdef ENABLE_DARRAY_TYPE_TEST
+#define da_insert_array(dst, idx, src_array, n)                       \
+	({                                                            \
+		da_type_test(dst, src_array);                         \
+		darray_insert_array(sizeof(*dst.array), &dst.da, idx, \
+				    src_array, n);                    \
+	})
+#else
 #define da_insert_array(dst, idx, src_array, n) \
 	darray_insert_array(sizeof(*dst.array), &dst.da, idx, src_array, n)
+#endif
 
+#ifdef ENABLE_DARRAY_TYPE_TEST
+#define da_insert_da(dst, idx, src)                                    \
+	({                                                             \
+		da_type_test(dst, src.array);                          \
+		darray_insert_darray(sizeof(*dst.array), &dst.da, idx, \
+				     &src.da);                         \
+	})
+#else
 #define da_insert_da(dst, idx, src) \
 	darray_insert_darray(sizeof(*dst.array), &dst.da, idx, &src.da)
+#endif
 
 #define da_erase(dst, idx) darray_erase(sizeof(*dst.array), &dst.da, idx)
 
+#ifdef ENABLE_DARRAY_TYPE_TEST
+#define da_erase_item(dst, item)                                      \
+	({                                                            \
+		da_type_test(dst, item);                              \
+		darray_erase_item(sizeof(*dst.array), &dst.da, item); \
+	})
+#else
 #define da_erase_item(dst, item) \
 	darray_erase_item(sizeof(*dst.array), &dst.da, item)
+#endif
 
 #define da_erase_range(dst, from, to) \
 	darray_erase_range(sizeof(*dst.array), &dst.da, from, to)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR adds a test of argument types for darray macros. If type mismatch is found, an error or an warning will be raised. The test is enabled in the flow `CI Multiplatform Build` / `Linux/Ubuntu 64-bit`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This test was requested by R1CH. https://discord.com/channels/348973006581923840/374636084883095554/867388478194581545
Some mismatches are found such as #5009, #5016. We want to avoid similar mistakes.
Some implementations are falsely detected by the test, type casts are added.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
These commits are checked on my local machine (Fedora 34).
| commit | message | result |
|---|---|---|
| d6c77964 | libobs: Fix stack buffer overflow in build_current_order_info | Error | 
| 7b4ae861 | libobs: Fix da_push_back taking a wrong type of item | Error |
| 04b0d632 | UI: Fix da_push_back taking a wrong type of item | Error |
| d65ca911 | libobs: Add type-cast to uint8_t* to da_push_back_array | Warning |
| 52dd5ec6 | libobs: Fix const qualifier mismatch on DARRAY | Warning |
| ef5e04a6 | libobs/util: Add type cast for da_push_back_array type-check | Error |

<!--- and the tests you ran, including how it may affect other areas of code. -->
The test is enabled iff a macro `ENABLE_DARRAY_TYPE_TEST` is defined. Hence, it won't affect plugins which include `darray.h`.
In the implementation, I introduced a macro `da_type_test`, which will cause compile-error if the type does not match but do nothing for actual behavior since the test is inside `if (false)` statement.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

(Please correct me if above type selection is wrong.)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
