### PR TITLE
libobs: Remove DrawSrgbDecompressPremultiplied

### DIFF
--- a/libobs/data/default.effect
+++ b/libobs/data/default.effect
@@ -69,14 +69,6 @@ float4 PSDrawSrgbDecompress(VertInOut vert_in) : TARGET
 	return rgba;
 }
 
-float4 PSDrawSrgbDecompressPremultiplied(VertInOut vert_in) : TARGET
-{
-	float4 rgba = image.Sample(def_sampler, vert_in.uv);
-	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
-	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
-	return rgba;
-}
-
 technique Draw
 {
 	pass
@@ -110,14 +102,5 @@ technique DrawSrgbDecompress
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawSrgbDecompress(vert_in);
-	}
-}
-
-technique DrawSrgbDecompressPremultiplied
-{
-	pass
-	{
-		vertex_shader = VSDefault(vert_in);
-		pixel_shader  = PSDrawSrgbDecompressPremultiplied(vert_in);
 	}
 }

--- a/libobs/data/default_rect.effect
+++ b/libobs/data/default_rect.effect
@@ -47,14 +47,6 @@ float4 PSDrawSrgbDecompress(VertInOut vert_in) : TARGET
 	return rgba;
 }
 
-float4 PSDrawSrgbDecompressPremultiplied(VertInOut vert_in) : TARGET
-{
-	float4 rgba = image.Sample(def_sampler, vert_in.uv);
-	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
-	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
-	return rgba;
-}
-
 technique Draw
 {
 	pass
@@ -79,14 +71,5 @@ technique DrawSrgbDecompress
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawSrgbDecompress(vert_in);
-	}
-}
-
-technique DrawSrgbDecompressPremultiplied
-{
-	pass
-	{
-		vertex_shader = VSDefault(vert_in);
-		pixel_shader  = PSDrawSrgbDecompressPremultiplied(vert_in);
 	}
 }


### PR DESCRIPTION
### Description
Technique is no longer referenced, and doesn't seem useful.

### Motivation and Context
Don't want people to use this technique.

### How Has This Been Tested?
OBS still load default and default_rect effects without errors.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.