### PR TITLE
UI: Remove thread from YouTube auto config

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -470,40 +470,33 @@ void AutoConfigStreamPage::OnOAuthStreamKeyConnected()
 			ui->connectedAccountText->setText(
 				QTStr("Auth.LoadingChannel.Title"));
 
-			QScopedPointer<QThread> thread(CreateQThread([&]() {
-				std::shared_ptr<YoutubeApiWrappers> ytAuth =
-					std::dynamic_pointer_cast<
-						YoutubeApiWrappers>(auth);
-				if (ytAuth.get()) {
-					ChannelDescription cd;
-					if (ytAuth->GetChannelDescription(cd)) {
-						ui->connectedAccountText
-							->setText(cd.title);
-					}
-					StreamDescription stream = {
-						"", "",
-						"OBS Studio Test Stream"};
-					if (ytAuth->InsertStream(stream)) {
-						ui->key->setText(stream.name);
-						/* Re-enable BW test if creating throwaway
+			std::shared_ptr<YoutubeApiWrappers> ytAuth =
+				std::dynamic_pointer_cast<YoutubeApiWrappers>(
+					auth);
+			if (ytAuth.get()) {
+				ChannelDescription cd;
+				if (ytAuth->GetChannelDescription(cd)) {
+					ui->connectedAccountText->setText(
+						cd.title);
+				}
+				StreamDescription stream = {
+					"", "", "OBS Studio Test Stream"};
+				if (ytAuth->InsertStream(stream)) {
+					ui->key->setText(stream.name);
+					/* Re-enable BW test if creating throwaway
 						 * stream key succeeded. Also check it if
 						 * it was previously disabled */
-						if (!ui->doBandwidthTest
-							     ->isEnabled())
-							QMetaObject::invokeMethod(
-								ui->doBandwidthTest,
-								"setChecked",
-								Q_ARG(bool,
-								      true));
+					if (!ui->doBandwidthTest->isEnabled())
 						QMetaObject::invokeMethod(
 							ui->doBandwidthTest,
-							"setEnabled",
+							"setChecked",
 							Q_ARG(bool, true));
-					}
+					QMetaObject::invokeMethod(
+						ui->doBandwidthTest,
+						"setEnabled",
+						Q_ARG(bool, true));
 				}
-			}));
-			thread->start();
-			thread->wait();
+			}
 		}
 #endif
 	}


### PR DESCRIPTION
### Description
Removes thread from auto configuration code that was accessing UI objects and causing crashing. Given we immediately start and wait on the thread, it seemed largely pointless anyway.

### Motivation and Context
Fixes illegal Qt behavior that caused a crash. Fixes https://github.com/obsproject/obs-studio/issues/5364.

### How Has This Been Tested?
Ran OBS, auto config loaded when it crashed before.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
