### PR TITLE
UI: Fix Twitch bandwidth test checkbox

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -604,6 +604,8 @@ void OBSBasicSettings::OnOAuthStreamKeyConnected()
 			ui->bandwidthTestEnable->setVisible(true);
 			ui->twitchAddonLabel->setVisible(true);
 			ui->twitchAddonDropdown->setVisible(true);
+		} else {
+			ui->bandwidthTestEnable->setChecked(false);
 		}
 #if YOUTUBE_ENABLED
 		if (IsYouTubeService(a->service())) {
@@ -618,7 +620,6 @@ void OBSBasicSettings::OnOAuthStreamKeyConnected()
 			get_yt_ch_title(ui.get());
 		}
 #endif
-		ui->bandwidthTestEnable->setChecked(false);
 	}
 
 	ui->streamStackWidget->setCurrentIndex((int)Section::StreamKey);


### PR DESCRIPTION
### Description
One line was erroneously moved outside of an `else` when the YouTube integration was merged in e6f1daab8c64aa4cd57c7615647ad80362d72d72.

### Motivation and Context
Users complained, I listened with an open ear.

### How Has This Been Tested?
Confirmed that box is no longer getting unchecked when opening settings.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
