### PR TITLE
UI: Fix build with Clang and libc++

### DIFF
--- a/UI/platform-x11.cpp
+++ b/UI/platform-x11.cpp
@@ -48,7 +48,9 @@
 #include <thread>
 #endif
 
-using namespace std;
+using std::string;
+using std::vector;
+using std::ostringstream;
 
 #ifdef __linux__
 void RunningInstanceCheck(bool &already_running)


### PR DESCRIPTION
Signed-off-by: James Beddek <telans@posteo.de>

### Description
This change removes `using namespace std;` which introduces build errors when compiling obs-studio with Clang and libc++.
Instead only use specific `std` members that are required.

The build issue encountered is:

```
/var/tmp/portage/media-video/obs-studio-26.1.2/work/obs-studio-26.1.2/UI/platform-x11.cpp:75:6: error: no viable conversion from '__bind<int &, sockaddr *, unsigned long>' to 'int'
        int bindErr = bind(uniq, (struct sockaddr *)&bindInfo,
            ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning and 1 error generated.
```

### Motivation and Context
This change fixes building with Clang & libc++, a (somewhat) common Clang combination on Gentoo.
Myself and other users have encountered this issue. See https://bugs.gentoo.org/768246

### How Has This Been Tested?
This has been tested by building and running the resulting program with both GCC and Clang.
Gentoo 64-bit ~amd64
`gcc version 11.2.0 (Gentoo 11.2.0 p1)`
`clang version 13.0.0`

### Types of changes
_Bug fix (non-breaking change which fixes an issue)_
Fixes building with Clang with `-stdlib=libc++`

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
