### PR TITLE
win-wasapi: Reset audio monitor if defaut device is changed

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2293,6 +2293,24 @@ bool obs_obj_is_private(void *obj)
 	return context->private;
 }
 
+void obs_default_audio_output_device_changed()
+{
+	pthread_mutex_lock(&obs->audio.monitoring_mutex);
+
+	if (strcmp(obs->audio.monitoring_device_id, "default") == 0) {
+		blog(LOG_INFO,
+		     "Default audio output device has changed. Reset monitor if needed.");
+
+		for (size_t i = 0; i < obs->audio.monitors.num; i++) {
+			struct audio_monitor *monitor =
+				obs->audio.monitors.array[i];
+			audio_monitor_reset(monitor);
+		}
+	}
+
+	pthread_mutex_unlock(&obs->audio.monitoring_mutex);
+}
+
 bool obs_set_audio_monitoring_device(const char *name, const char *id)
 {
 	if (!name || !id || !*name || !*id)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -758,6 +758,8 @@ EXPORT bool obs_audio_monitoring_available(void);
 EXPORT void obs_enum_audio_monitoring_devices(obs_enum_audio_device_cb cb,
 					      void *data);
 
+EXPORT void obs_default_audio_output_device_changed();
+
 EXPORT bool obs_set_audio_monitoring_device(const char *name, const char *id);
 EXPORT void obs_get_audio_monitoring_device(const char **name, const char **id);
 

--- a/plugins/win-wasapi/CMakeLists.txt
+++ b/plugins/win-wasapi/CMakeLists.txt
@@ -1,22 +1,33 @@
 project(win-wasapi)
 
-set(win-wasapi_HEADERS
-	enum-wasapi.hpp)
+set(CMAKE_AUTOMOC TRUE)
+find_package(Qt5Widgets REQUIRED)
 
+set(win-wasapi_HEADERS
+	enum-wasapi.hpp
+	audio-notify-client.h
+	detect-default-device.h)
+	
 set(MODULE_DESCRIPTION "OBS WASAPI module")
 configure_file(${CMAKE_SOURCE_DIR}/cmake/winrc/obs-module.rc.in win-wasapi.rc)
+
 set(win-wasapi_SOURCES
 	win-wasapi.cpp
 	enum-wasapi.cpp
 	plugin-main.cpp
+	audio-notify-client.cpp
+	detect-default-device.cpp
 	win-wasapi.rc)
 
 add_library(win-wasapi MODULE
 	${win-wasapi_SOURCES}
 	${win-wasapi_HEADERS})
+
 target_link_libraries(win-wasapi
 	Avrt
-	libobs)
+	libobs
+	Qt5::Widgets)
+
 set_target_properties(win-wasapi PROPERTIES FOLDER "plugins")
 
 install_obs_plugin_with_data(win-wasapi data)

--- a/plugins/win-wasapi/audio-notify-client.cpp
+++ b/plugins/win-wasapi/audio-notify-client.cpp
@@ -1,0 +1,66 @@
+#include "audio-notify-client.h"
+#include <windows.h>
+#include <assert.h>
+
+WASAPINotify::WASAPINotify(IWASNotifyCallback *cb_) : cb(cb_)
+{
+	assert(cb);
+}
+
+STDMETHODIMP_(ULONG) WASAPINotify::AddRef()
+{
+	return InterlockedIncrement(&refs);
+}
+
+STDMETHODIMP_(ULONG) STDMETHODCALLTYPE WASAPINotify::Release()
+{
+	long temp = InterlockedDecrement(&refs);
+	if (temp == 0)
+		delete this;
+
+	return temp;
+}
+
+STDMETHODIMP WASAPINotify::QueryInterface(REFIID riid, void **ptr)
+{
+	if (riid == IID_IUnknown) {
+		*ptr = (IUnknown *)this;
+	} else if (riid == __uuidof(IMMNotificationClient)) {
+		*ptr = (IMMNotificationClient *)this;
+	} else {
+		*ptr = nullptr;
+		return E_NOINTERFACE;
+	}
+
+	InterlockedIncrement(&refs);
+	return S_OK;
+}
+
+STDMETHODIMP WASAPINotify::OnDeviceAdded(LPCWSTR)
+{
+	return S_OK;
+}
+
+STDMETHODIMP WASAPINotify::OnDeviceRemoved(LPCWSTR)
+{
+	return S_OK;
+}
+
+STDMETHODIMP WASAPINotify::OnDeviceStateChanged(LPCWSTR, DWORD)
+{
+	return S_OK;
+}
+
+STDMETHODIMP WASAPINotify::OnPropertyValueChanged(LPCWSTR, const PROPERTYKEY)
+{
+	return S_OK;
+}
+
+STDMETHODIMP WASAPINotify::OnDefaultDeviceChanged(EDataFlow flow, ERole role,
+						  LPCWSTR pwstrDeviceId)
+{
+	if (pwstrDeviceId)
+		cb->NotifyDefaultDeviceChanged(flow, role, pwstrDeviceId);
+
+	return S_OK;
+}

--- a/plugins/win-wasapi/audio-notify-client.h
+++ b/plugins/win-wasapi/audio-notify-client.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <Mmdeviceapi.h>
+
+class IWASNotifyCallback {
+public:
+	virtual ~IWASNotifyCallback() {}
+	virtual void NotifyDefaultDeviceChanged(EDataFlow flow, ERole role,
+						LPCWSTR id) = 0;
+};
+
+class WASAPINotify : public IMMNotificationClient {
+	long refs = 1;
+	IWASNotifyCallback *cb = nullptr;
+
+public:
+	WASAPINotify(IWASNotifyCallback *cb_);
+
+	STDMETHODIMP_(ULONG) AddRef();
+	STDMETHODIMP_(ULONG) STDMETHODCALLTYPE Release();
+	STDMETHODIMP QueryInterface(REFIID riid, void **ptr);
+
+	STDMETHODIMP OnDeviceAdded(LPCWSTR);
+	STDMETHODIMP OnDeviceRemoved(LPCWSTR);
+	STDMETHODIMP OnDeviceStateChanged(LPCWSTR, DWORD);
+	STDMETHODIMP OnPropertyValueChanged(LPCWSTR, const PROPERTYKEY);
+	STDMETHODIMP OnDefaultDeviceChanged(EDataFlow flow, ERole role,
+					    LPCWSTR pwstrDeviceId);
+};

--- a/plugins/win-wasapi/detect-default-device.cpp
+++ b/plugins/win-wasapi/detect-default-device.cpp
@@ -1,0 +1,81 @@
+#include "detect-default-device.h"
+#include <obs.h>
+#include <mutex>
+
+std::mutex lockDetect;
+DetectDefaultDevice *detectDevice = nullptr;
+
+void DetectDefaultDevice::Create()
+{
+	if (!detectDevice) {
+		std::lock_guard<std::mutex> auto_lock(lockDetect);
+		if (!detectDevice)
+			detectDevice = new DetectDefaultDevice();
+	}
+}
+
+DetectDefaultDevice *DetectDefaultDevice::Instance()
+{
+	Create();
+	return detectDevice;
+}
+
+void DetectDefaultDevice::Destroy()
+{
+	std::lock_guard<std::mutex> auto_lock(lockDetect);
+	if (detectDevice) {
+		delete detectDevice;
+		detectDevice = nullptr;
+	}
+}
+
+DetectDefaultDevice::DetectDefaultDevice() {}
+
+DetectDefaultDevice::~DetectDefaultDevice()
+{
+	Stop();
+}
+
+void DetectDefaultDevice::Start()
+{
+	HRESULT res = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr,
+				       CLSCTX_ALL,
+				       __uuidof(IMMDeviceEnumerator),
+				       (LPVOID *)enumerator.Assign());
+	if (SUCCEEDED(res)) {
+		notify = new WASAPINotify(this);
+		notify->Release(); /* Default ref is 1, but ComPtr will call AddRef() */
+		enumerator->RegisterEndpointNotificationCallback(notify);
+	} else {
+		enumerator.Clear();
+		assert(false);
+	}
+}
+
+void DetectDefaultDevice::Stop()
+{
+	if (enumerator) {
+		enumerator->UnregisterEndpointNotificationCallback(notify);
+		enumerator.Clear();
+	}
+
+	notify.Clear();
+}
+
+void DetectDefaultDevice::NotifyDefaultDeviceChanged(EDataFlow flow, ERole role,
+						     LPCWSTR id)
+{
+	if (flow == eRender && role == eConsole) // output device
+	{
+		// Post event into UI thread for resetting audio monitor
+		QMetaObject::invokeMethod(this, "OnDefaultOutputChanged",
+					  Qt::QueuedConnection);
+	}
+
+	UNUSED_PARAMETER(id);
+}
+
+void DetectDefaultDevice::OnDefaultOutputChanged()
+{
+	obs_default_audio_output_device_changed();
+}

--- a/plugins/win-wasapi/detect-default-device.h
+++ b/plugins/win-wasapi/detect-default-device.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "audio-notify-client.h"
+#include <util/windows/ComPtr.hpp>
+#include <qobject.h>
+
+class DetectDefaultDevice : public QObject, public IWASNotifyCallback {
+	Q_OBJECT
+
+public:
+	~DetectDefaultDevice();
+
+	static void Create();
+	static DetectDefaultDevice *Instance();
+	static void Destroy();
+
+	void Start();
+	void Stop();
+
+protected:
+	DetectDefaultDevice();
+
+	// IWASNotifyCallback
+	virtual void NotifyDefaultDeviceChanged(EDataFlow flow, ERole role,
+						LPCWSTR id);
+private slots:
+	void OnDefaultOutputChanged();
+
+private:
+	ComPtr<IMMDeviceEnumerator> enumerator;
+	ComPtr<WASAPINotify> notify;
+};

--- a/plugins/win-wasapi/plugin-main.cpp
+++ b/plugins/win-wasapi/plugin-main.cpp
@@ -1,4 +1,5 @@
 #include <obs-module.h>
+#include "detect-default-device.h"
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("win-wasapi", "en-US")
@@ -14,5 +15,15 @@ bool obs_module_load(void)
 {
 	RegisterWASAPIInput();
 	RegisterWASAPIOutput();
+
+	DetectDefaultDevice::Create();
+	DetectDefaultDevice::Instance()->Start();
+
 	return true;
+}
+
+void obs_module_unload(void)
+{
+	DetectDefaultDevice::Instance()->Stop();
+	DetectDefaultDevice::Destroy();
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
fix #4463 on Windows platform

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
while using "default" for audio monitor, when the default output device is changed, audio monitor should be reset.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
as steps in #4463

### Types of changes
Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
