### PR TITLE
libobs/audio-monitoring: Fix PulseAudio monitoring volume for s32 format and u8 format

### DIFF
--- a/libobs/audio-monitoring/pulse/pulseaudio-output.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-output.c
@@ -126,11 +126,11 @@ static pa_channel_map pulseaudio_channel_map(enum speaker_layout layout)
 
 static void process_byte(void *p, size_t frames, size_t channels, float vol)
 {
-	register char *cur = (char *)p;
-	register char *end = cur + frames * channels;
+	register uint8_t *cur = (uint8_t *)p;
+	register uint8_t *end = cur + frames * channels;
 
-	while (cur < end)
-		*(cur++) *= vol;
+	for (; cur < end; cur++)
+		*cur = ((int)*cur - 128) * vol + 128;
 }
 
 static void process_s16(void *p, size_t frames, size_t channels, float vol)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When pulseaudio-output chose signed 32-bit audio as the output format and volume was lowered, audio data was broken. In the function `process_volume`, the type of the data is switched by `bytes_per_channel`. However the size of signed 32-bit integer and the size of float are same so that the signed 32-bit integer is processed as float.
This commit changes these items.
- Use `format` instead of `bytes_per_channel` so that all the sample types can be differentiated.
  This fix the bug.
- Change `char` to `uint8_t` in `process_byte` because the type is expected unsigned 8-bit.
  This also change behavior but I don't think there is a use case for unsigned 8-bit audio.
- Change `short` to `int16_t` and renames existing function `process_short` to `process_s16` to clarify the function is processing signed 16-bit.
  This is just a coding change. It should not affect anything.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The bug was reported on another PR and turned out it  is an existing bug in master branch.
https://github.com/obsproject/obs-studio/pull/4908#issuecomment-864454692
https://github.com/obsproject/obs-studio/pull/4908#issuecomment-939666132

This bug was revealed when using PulseAudio with PipeWire.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: Fedora 34
Tested with a `ffmpeg_source` that has [a mp4 video](https://download.blender.org/demo/movies/BBB/bbb_sunflower_1080p_30fps_normal.mp4), set the audio to monitor and output, and lower the volume.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
