### PR TITLE
UI,libobs,obs-filters: Add missing files check to filters

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4861,14 +4861,15 @@ void OBSBasic::on_actionShowMissingFiles_triggered()
 	};
 	obs_enum_sources(cb_sources, files);
 
-	auto cb_transitions = [](void *data, obs_source_t *source) {
-		if (obs_source_get_type(source) != OBS_SOURCE_TYPE_TRANSITION)
-			return true;
+	auto cb_transitions_filters = [](void *data, obs_source_t *source) {
+		enum obs_source_type type = obs_source_get_type(source);
+		if (type == OBS_SOURCE_TYPE_TRANSITION ||
+		    type == OBS_SOURCE_TYPE_FILTER)
+			AddMissingFiles(data, source);
 
-		AddMissingFiles(data, source);
 		return true;
 	};
-	obs_enum_all_sources(cb_transitions, files);
+	obs_enum_all_sources(cb_transitions_filters, files);
 
 	if (obs_missing_files_count(files) > 0) {
 		/* When loading the missing files dialog on launch, the

--- a/libobs/obs-missing-files.c
+++ b/libobs/obs-missing-files.c
@@ -95,7 +95,16 @@ obs_missing_file_t *obs_missing_file_create(const char *path,
 
 	switch (src_type) {
 	case OBS_MISSING_FILE_SOURCE:
-		file->src_name = bstrdup(obs_source_get_name(src));
+		if (obs_source_get_type(src) == OBS_SOURCE_TYPE_FILTER) {
+			obs_source_t *parent = obs_filter_get_parent(src);
+			struct dstr name = {0};
+			dstr_printf(&name, "%s (%s)", obs_source_get_name(src),
+				    obs_source_get_name(parent));
+			file->src_name = bstrdup(name.array);
+			dstr_free(&name);
+		} else {
+			file->src_name = bstrdup(obs_source_get_name(src));
+		}
 		break;
 	case OBS_MISSING_FILE_SCRIPT:
 		break;

--- a/plugins/obs-filters/color-grade-filter.c
+++ b/plugins/obs-filters/color-grade-filter.c
@@ -488,6 +488,36 @@ static void color_grade_filter_render(void *data, gs_effect_t *effect)
 	UNUSED_PARAMETER(effect);
 }
 
+static void missing_files_callback(void *src, const char *new_path, void *data)
+{
+	struct lut_filter_data *filter_data = src;
+
+	obs_source_t *source = filter_data->context;
+	obs_data_t *settings = obs_source_get_settings(source);
+	obs_data_set_string(settings, SETTING_IMAGE_PATH, new_path);
+	obs_source_update(source, settings);
+	obs_data_release(settings);
+
+	UNUSED_PARAMETER(data);
+}
+
+static obs_missing_files_t *color_grade_filter_missingfiles(void *data)
+{
+	struct lut_filter_data *filter_data = data;
+	obs_missing_files_t *files = obs_missing_files_create();
+
+	if (filter_data->file && strcmp(filter_data->file, "") != 0) {
+		if (!os_file_exists(filter_data->file)) {
+			obs_missing_file_t *file = obs_missing_file_create(
+				filter_data->file, missing_files_callback,
+				OBS_MISSING_FILE_SOURCE, filter_data->context,
+				NULL);
+			obs_missing_files_add_file(files, file);
+		}
+	}
+	return files;
+}
+
 struct obs_source_info color_grade_filter = {
 	.id = "clut_filter",
 	.type = OBS_SOURCE_TYPE_FILTER,
@@ -499,4 +529,5 @@ struct obs_source_info color_grade_filter = {
 	.get_defaults = color_grade_filter_defaults,
 	.get_properties = color_grade_filter_properties,
 	.video_render = color_grade_filter_render,
+	.missing_files = color_grade_filter_missingfiles,
 };


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
- Filters are not respected by the missing files dialog, even though they are sources (which makes this comparitibly easy to implement).
This adds the missing files check for filters. The libobs change is needed since filter names aren't unique on a global context, so having the parent source name is needed so that the user is be able to identify which filter is meant.

- Having a source with a LUT filter and an image mask filter where the files are missing would look like this in the missing files dialog:
<img width="687" alt="image" src="https://user-images.githubusercontent.com/59806498/136798189-39e7d4ba-e204-4fce-a862-bebdb5a94ed9.png">

- From what I've seen, only the "Apply LUT" and "Image Mask/Blend" filters have files, so those have been included. Please comment in case I've missed one.

- Depends on #5148 (Well, doesn't strickly depend on it, but makes that PR makes this one way cleaner). *Draft until that is merged.*

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
- Fixes #5182


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0 beta 6, compiled and run.
For both filter types, the check shows that the file is missing (see above).
Clicking apply replaces it (if a new one has been selected) in the source properties and refreshes the source.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
