### PR TITLE
UI: Minimize context bar when too small

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -205,7 +205,7 @@
       </property>
       <property name="minimumSize">
        <size>
-        <width>740</width>
+        <width>0</width>
         <height>30</height>
        </size>
       </property>

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -195,6 +195,12 @@ class OBSBasic : public OBSMainWindow {
 		DropType_Url,
 	};
 
+	enum ContextBarSize {
+		ContextBarSize_Minimized,
+		ContextBarSize_Reduced,
+		ContextBarSize_Normal
+	};
+
 private:
 	obs_frontend_callbacks *api = nullptr;
 
@@ -210,6 +216,7 @@ private:
 	long disableSaving = 1;
 	bool projectChanged = false;
 	bool previewEnabled = true;
+	ContextBarSize contextBarSize = ContextBarSize_Normal;
 
 	std::deque<SourceCopyInfo> clipboard;
 	OBSWeakSource copyFiltersSource;
@@ -1118,6 +1125,7 @@ public slots:
 	void ClearContextBar();
 	void UpdateContextBar(bool force = false);
 	void UpdateContextBarDeferred(bool force = false);
+	void UpdateContextBarVisibility();
 
 public:
 	explicit OBSBasic(QWidget *parent = 0);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change removes the minimum total size from the context bar, instead
removing certain elements when the size is too small. This means that
users will still be able to make OBS smaller in width while keeping the
context bar enabled.

First, the properties, filter and interact buttons will get reduced to
just the symbols, if it gets even smaller the source specific menus are
hidden.

This is how it looks:

https://user-images.githubusercontent.com/59806498/137125517-df9f4abc-b267-49ae-bea4-33ab8b782d7b.mp4

This is a draft for two (three/four) reasons:
- ~~It doesn't yet refresh when docks are popped out.~~
- The first threshold (740) is the current minimum size of the toolbar. However, the second threshold (600) was chosen arbitrarily. I'm not a UX expert, feedback or suggestions on that number would be appreciated.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
27.1 introduced a minimum size for the context bar / toolbar, which meant that
users with smaller widths had to disable it.
I think this is a more elegant approach to the problem of small toolbars.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0 beta 6, compiled and run.

For the result, see the video above.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
