### PR TITLE
obs-ffmpeg: Fix unwritten audio-only output

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -913,7 +913,7 @@ static void receive_audio(void *param, size_t mix_idx, struct audio_data *frame)
 
 	AVCodecContext *context = data->audio_infos[track_order].ctx;
 
-	if (!data->start_timestamp)
+	if (!data->start_timestamp && data->video)
 		return;
 
 	if (!output->audio_start_ts)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Prior to this change, all audio was discarded until the first video packet arrives. This change limits to discard audio only if video is available.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When video is disabled, no audio was sent to the container so that the audio was not saved.
The bug was discussed on discord thread starting from this message.
https://discord.com/channels/348973006581923840/374636084883095554/897411306154504223

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: Tested on Fedora 34 and CentOS 8.
Step to test:
1. Set recording type to `Custom Output (FFmpeg)`
   Set container format to `matroska (Audio)` (or anything else)
   Set video encoder to `Disable Encoder`
2. Start recording, wait ~10 seconds, and stop recording.
3. Check the file with `ffprobe`
Without this fix:
```
[matroska,webm @ 0x556583cef680] Duplicate element
[matroska,webm @ 0x556583cef680] 0x00 at pos 110 (0x6e) invalid as first byte of an EBML number
[matroska,webm @ 0x556583cef680] Duplicate element
[matroska,webm @ 0x556583cef680] 0x00 at pos 204 (0xcc) invalid as first byte of an EBML number
[matroska,webm @ 0x556583cef680] Element at 0x67 ending at 0x242ec6d exceeds containing master element ending at 0x1413
2021-10-16_12-54.mka: End of file
```
With this fix:
```
Input #0, matroska,webm, from '2021-10-16_12-48.mka':
  Metadata:
    ENCODER         : Lavf58.76.100
  Duration: 00:00:17.59, start: 0.000000, bitrate: 4 kb/s
  Stream #0:0: Audio: vorbis, 48000 Hz, stereo, fltp (default)
    Metadata:
      DURATION        : 00:00:17.593000000
```


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
