### PR TITLE
linux-v4l2: Support for H264 codec

### DIFF
--- a/plugins/linux-v4l2/CMakeLists.txt
+++ b/plugins/linux-v4l2/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(linux-v4l2 MODULE)
 add_library(OBS::v4l2 ALIAS linux-v4l2)
 
 target_sources(linux-v4l2 PRIVATE linux-v4l2.c v4l2-controls.c v4l2-input.c
-                                  v4l2-helpers.c v4l2-output.c v4l2-mjpeg.c)
+                                  v4l2-helpers.c v4l2-output.c v4l2-decoder.c)
 
 target_link_libraries(
   linux-v4l2 PRIVATE OBS::libobs LIB4L2::LIB4L2 FFmpeg::avcodec

--- a/plugins/linux-v4l2/v4l2-decoder.h
+++ b/plugins/linux-v4l2/v4l2-decoder.h
@@ -26,42 +26,43 @@ extern "C" {
 #include <libavutil/pixfmt.h>
 
 /**
- * Data structure for mjpeg decoding
+ * Data structure for decoder
  */
-struct v4l2_mjpeg_decoder {
-	const AVCodec *codec;
+struct v4l2_decoder {
+	AVCodec *codec;
 	AVCodecContext *context;
 	AVPacket *packet;
 	AVFrame *frame;
 };
 
 /**
- * Initialize the mjpeg decoder.
+ * Initialize the decoder.
  * The decoder must be destroyed on failure.
  *
- * @param props the decoder structure
+ * @param decoder the decoder structure
+ * @param pixfmt which codec is used
  * @return non-zero on failure
  */
-int v4l2_init_mjpeg(struct v4l2_mjpeg_decoder *decoder);
+int v4l2_init_decoder(struct v4l2_decoder *decoder, int pixfmt);
 
 /**
  * Free any data associated with the decoder.
  *
  * @param decoder the decoder structure
  */
-void v4l2_destroy_mjpeg(struct v4l2_mjpeg_decoder *decoder);
+void v4l2_destroy_decoder(struct v4l2_decoder *decoder);
 
 /**
- * Decode a jpeg into an obs frame
+ * Decode a jpeg or h264 frame into an obs frame
  *
  * @param out the obs frame to decode into
- * @param data the jpeg data
+ * @param data the codec data
  * @param length length of the data
- * @param decoder the decoder as initialized by v4l2_init_mjpeg
+ * @param decoder the decoder as initialized by v4l2_init_decoder
  * @return non-zero on failure
  */
-int v4l2_decode_mjpeg(struct obs_source_frame *out, uint8_t *data,
-		      size_t length, struct v4l2_mjpeg_decoder *decoder);
+int v4l2_decode_frame(struct obs_source_frame *out, uint8_t *data,
+		      size_t length, struct v4l2_decoder *decoder);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description
Added support for format "H264" to capture from the linux-v4l2 plugin.
Build on top of kosmisk-dk PR to also support MJPEG https://github.com/obsproject/obs-studio/pull/3046

### Motivation and Context
H264 tends to have less noise than MJPEG
It also can use less USB bandwidth which might be important if you're using more than 1 webcam on save USB bus.

### How Has This Been Tested?
I've selected "Moition-JPEG" from the "Video Format" drop down.
I've switch to "H264" from the "Video Format" drop down.
I've switch back and forth multiple times with different framerates and resolution.

MJPEG was tested with Logitech c920 and Microdia Digital microscope
H264 was tested with Logitech c920

### Types of changes
Enhanced if conditions to support 1 more codec.
Renamed files.

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
