### PR TITLE
rtmp-services: Add Autistici.org

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2378,6 +2378,20 @@
                 "max video bitrate": 5000,
                 "max audio bitrate": 160
             }
+        },
+        {
+            "name": "Autistici.org Live",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url":  "rtmp://live.autistici.org/ingest"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 2500,
+                "max audio bitrate": 128
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
Add [Autistici.org](https://live.autistici.org) to rtmp services list.

### Motivation and Context
Autistici/Inventati is a no-profit association from Italy which provides various services. Starting in 2020, it is running a free streaming service at https://live.autistici.org.

Adding Autistici.org to the list of rtmp services was [suggested by one user](https://ideas.obsproject.com/posts/1497/add-autistici-live-preset-in-streaming-services-list), as per OBS policy we are now submitting the request first-hand. 

### How Has This Been Tested?
Local Build

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
