### PR TITLE
UI: Fix vertical/horizontal scene item alignment

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -8093,15 +8093,8 @@ static bool center_to_scene(obs_scene_t *, obs_sceneitem_t *item, void *param)
 	obs_get_video_info(&ovi);
 	obs_sceneitem_get_info(item, &oti);
 
-	if (centerType == CenterType::Scene)
-		vec3_set(&screenCenter, float(ovi.base_width),
-			 float(ovi.base_height), 0.0f);
-	else if (centerType == CenterType::Vertical)
-		vec3_set(&screenCenter, float(oti.bounds.x),
-			 float(ovi.base_height), 0.0f);
-	else if (centerType == CenterType::Horizontal)
-		vec3_set(&screenCenter, float(ovi.base_width),
-			 float(oti.bounds.y), 0.0f);
+	vec3_set(&screenCenter, float(ovi.base_width), float(ovi.base_height),
+		 0.0f);
 
 	vec3_mulf(&screenCenter, &screenCenter, 0.5f);
 
@@ -8114,10 +8107,12 @@ static bool center_to_scene(obs_scene_t *, obs_sceneitem_t *item, void *param)
 	vec3_sub(&offset, &screenCenter, &itemCenter);
 	vec3_add(&tl, &tl, &offset);
 
+	vec3 itemTL = GetItemTL(item);
+
 	if (centerType == CenterType::Vertical)
-		tl.x = oti.pos.x;
+		tl.x = itemTL.x;
 	else if (centerType == CenterType::Horizontal)
-		tl.y = oti.pos.y;
+		tl.y = itemTL.y;
 
 	SetItemTL(item, tl);
 	return true;


### PR DESCRIPTION
### Description
If the transform position alignment was set to anything but
top left, or the item was flipped, the item would be moved to
the the wrong position when centering vertically or horizontally.

### Motivation and Context
Fixes bug that I have noticed.

### How Has This Been Tested?
Set transform position alignment to bottom center, and centered vertically/horizontally 

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
