### PR TITLE
rtmp-services: update CamSoda domains

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 182,
+	"version": 183,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 182
+			"version": 183
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -990,23 +990,23 @@
             "servers": [
                 {
                     "name": "North America",
-                    "url": "rtmp://obs-ingest-na.camsoda.com/cam_obs"
+                    "url": "rtmp://obs-ingest-na.livemediahost.com/cam_obs"
                 },
                 {
                     "name": "South America",
-                    "url": "rtmp://obs-ingest-sa.camsoda.com/cam_obs"
+                    "url": "rtmp://obs-ingest-sa.livemediahost.com/cam_obs"
                 },
                 {
                     "name": "Asia",
-                    "url": "rtmp://obs-ingest-as.camsoda.com/cam_obs"
+                    "url": "rtmp://obs-ingest-as.livemediahost.com/cam_obs"
                 },
                 {
                     "name": "Europe",
-                    "url": "rtmp://obs-ingest-eu.camsoda.com/cam_obs"
+                    "url": "rtmp://obs-ingest-eu.livemediahost.com/cam_obs"
                 },
                 {
                     "name": "Oceania",
-                    "url": "rtmp://obs-ingest-oc.camsoda.com/cam_obs"
+                    "url": "rtmp://obs-ingest-oc.livemediahost.com/cam_obs"
                 }
             ],
             "recommended": {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

This PR updates the CamSoda servers in the rtmp-services plugin list  to match the ones that we currently are using.

### Motivation and Context

We changed changed the dns names of our ingest points and while the old  still work for the foreseeable future we  would like to have the new ones in OBS.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 - Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
