### PR TITLE
rtmp-services: add "Jio Games"

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 182,
+	"version": 183,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 182
+			"version": 183
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2332,6 +2332,24 @@
                     "url":  "rtmp://rtmp.disciplemedia.com/b-fme"
                 }
             ]
+        },
+        {
+            "name": "Jio Games",
+            "servers": [
+                {
+                    "name": "Primary",
+                    "url": "rtmp://livepub1.api.engageapps.jio/live"
+                },
+                {
+                    "name": "Secondary",
+                    "url": "rtmp://livepub2.api.engageapps.jio/live"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 32000,
+                "max audio bitrate": 256
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
Add Jio Games to rtmp services list.

### Motivation and Context
Supporting users of 'Jio Games', a live streaming platform for gamers in India.

### How Has This Been Tested?
Local build

### Types of changes
New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ x] My code is not on the master branch.
- [ x] The code has been tested.
- [ x] All commit messages are properly formatted and commits squashed where appropriate.
- [ x] I have included updates to all appropriate documentation.
