### PR TITLE
Implement non-default blending modes

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -474,6 +474,16 @@ ScaleFiltering.Bicubic="Bicubic"
 ScaleFiltering.Lanczos="Lanczos"
 ScaleFiltering.Area="Area"
 
+# blending modes
+BlendingMode="Blending Mode"
+BlendingMode.Normal="Normal"
+BlendingMode.Additive="Additive"
+BlendingMode.Subtract="Subtract"
+BlendingMode.Screen="Screen"
+BlendingMode.Multiply="Multiply"
+BlendingMode.Lighten="Lighten"
+BlendingMode.Darken="Darken"
+
 # deinterlacing
 Deinterlacing="Deinterlacing"
 Deinterlacing.Discard="Discard"

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2607,6 +2607,7 @@ OBSBasic::~OBSBasic()
 	delete sourceProjector;
 	delete sceneProjectorMenu;
 	delete scaleFilteringMenu;
+	delete blendingModeMenu;
 	delete colorMenu;
 	delete colorWidgetAction;
 	delete colorSelect;
@@ -5204,6 +5205,40 @@ QMenu *OBSBasic::AddScaleFilteringMenu(QMenu *menu, obs_sceneitem_t *item)
 	return menu;
 }
 
+void OBSBasic::SetBlendingMode()
+{
+	QAction *action = reinterpret_cast<QAction *>(sender());
+	obs_blending_type mode =
+		(obs_blending_type)action->property("mode").toInt();
+	OBSSceneItem sceneItem = GetCurrentSceneItem();
+
+	obs_sceneitem_set_blending_mode(sceneItem, mode);
+}
+
+QMenu *OBSBasic::AddBlendingModeMenu(QMenu *menu, obs_sceneitem_t *item)
+{
+	obs_blending_type blendingMode = obs_sceneitem_get_blending_mode(item);
+	QAction *action;
+
+#define ADD_MODE(name, mode)                               \
+	action = menu->addAction(QTStr("" name), this,     \
+				 SLOT(SetBlendingMode())); \
+	action->setProperty("mode", (int)mode);            \
+	action->setCheckable(true);                        \
+	action->setChecked(blendingMode == mode);
+
+	ADD_MODE("BlendingMode.Normal", OBS_BLEND_NORMAL);
+	ADD_MODE("BlendingMode.Additive", OBS_BLEND_ADDITIVE);
+	ADD_MODE("BlendingMode.Subtract", OBS_BLEND_SUBTRACT);
+	ADD_MODE("BlendingMode.Screen", OBS_BLEND_SCREEN);
+	ADD_MODE("BlendingMode.Multiply", OBS_BLEND_MULTIPLY);
+	ADD_MODE("BlendingMode.Lighten", OBS_BLEND_LIGHTEN);
+	ADD_MODE("BlendingMode.Darken", OBS_BLEND_DARKEN);
+#undef ADD_MODE
+
+	return menu;
+}
+
 QMenu *OBSBasic::AddBackgroundColorMenu(QMenu *menu,
 					QWidgetAction *widgetAction,
 					ColorSelect *select,
@@ -5274,6 +5309,7 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 	delete previewProjectorSource;
 	delete sourceProjector;
 	delete scaleFilteringMenu;
+	delete blendingModeMenu;
 	delete colorMenu;
 	delete colorWidgetAction;
 	delete colorSelect;
@@ -5403,6 +5439,10 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		scaleFilteringMenu = new QMenu(QTStr("ScaleFiltering"));
 		popup.addMenu(
 			AddScaleFilteringMenu(scaleFilteringMenu, sceneItem));
+		popup.addSeparator();
+
+		blendingModeMenu = new QMenu(QTStr("BlendingMode"));
+		popup.addMenu(AddBlendingModeMenu(blendingModeMenu, sceneItem));
 		popup.addSeparator();
 
 		popup.addMenu(sourceProjector);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -291,6 +291,7 @@ private:
 	QPointer<QMenu> sceneProjectorMenu;
 	QPointer<QMenu> sourceProjector;
 	QPointer<QMenu> scaleFilteringMenu;
+	QPointer<QMenu> blendingModeMenu;
 	QPointer<QMenu> colorMenu;
 	QPointer<QWidgetAction> colorWidgetAction;
 	QPointer<ColorSelect> colorSelect;
@@ -686,6 +687,8 @@ private slots:
 
 	void SetScaleFilter();
 
+	void SetBlendingMode();
+
 	void IconActivated(QSystemTrayIcon::ActivationReason reason);
 	void SetShowing(bool showing);
 
@@ -860,6 +863,7 @@ public:
 
 	QMenu *AddDeinterlacingMenu(QMenu *menu, obs_source_t *source);
 	QMenu *AddScaleFilteringMenu(QMenu *menu, obs_sceneitem_t *item);
+	QMenu *AddBlendingModeMenu(QMenu *menu, obs_sceneitem_t *item);
 	QMenu *AddBackgroundColorMenu(QMenu *menu, QWidgetAction *widgetAction,
 				      ColorSelect *select,
 				      obs_sceneitem_t *item);

--- a/docs/sphinx/reference-libobs-graphics-graphics.rst
+++ b/docs/sphinx/reference-libobs-graphics-graphics.rst
@@ -768,21 +768,29 @@ Draw Functions
 
 .. function:: void gs_blend_function(enum gs_blend_type src, enum gs_blend_type dest)
 
-   Sets the blend function
+   Sets the blend function's source and destination factors
 
-   :param src:  Blend type for the source
-   :param dest: Blend type for the destination
+   :param src:  Blend type for the blending equation's source factors
+   :param dest: Blend type for the blending equation's destination factors
 
 ---------------------
 
 .. function:: void gs_blend_function_separate(enum gs_blend_type src_c, enum gs_blend_type dest_c, enum gs_blend_type src_a, enum gs_blend_type dest_a)
 
-   Sets the blend function for RGB and alpha separately
+   Sets the blend function's source and destination factors for RGB and alpha separately
 
-   :param src_c:  Blend type for the source RGB
-   :param dest_c: Blend type for the destination RGB
-   :param src_a:  Blend type for the source alpha
-   :param dest_a: Blend type for the destination alpha
+   :param src_c:  Blend type for the blending equation's source RGB factor
+   :param dest_c: Blend type for the blending equation's destination RGB factor
+   :param src_a:  Blend type for the blending equation's source alpha factor
+   :param dest_a: Blend type for the blending equation's destination alpha factor
+
+---------------------
+
+.. function:: void gs_blend_op(enum gs_blend_op_type op)
+
+   Sets the blend function's operation type
+
+   :param op: Operation type for the blending equation
 
 ---------------------
 
@@ -881,7 +889,7 @@ Texture Functions
    :param data:         Pointer to array of texture data pointers
    :param flags:        Can be 0 or a bitwise-OR combination of one or
                         more of the following value:
-                        
+
                         - GS_BUILD_MIPMAPS - Automatically builds
                           mipmaps (Note: not fully tested)
                         - GS_DYNAMIC - Dynamic
@@ -1080,7 +1088,7 @@ Cube Texture Functions
    :param data:         Pointer to array of texture data pointers
    :param flags:        Can be 0 or a bitwise-OR combination of one or
                         more of the following value:
-                        
+
                         - GS_BUILD_MIPMAPS - Automatically builds
                           mipmaps (Note: not fully tested)
                         - GS_DYNAMIC - Dynamic

--- a/docs/sphinx/reference-scenes.rst
+++ b/docs/sphinx/reference-scenes.rst
@@ -487,6 +487,22 @@ Scene Item Functions
 
 ---------------------
 
+.. function:: void obs_sceneitem_set_blending_mode(obs_sceneitem_t *item, enum obs_blending_type type)
+              enum obs_blending_type obs_sceneitem_get_blending_mode(obs_sceneitem_t *item)
+
+   Sets/gets the blending mode used for the scene item.
+
+   :param type: | Can be one of the following values:
+                | OBS_BLEND_NORMAL
+                | OBS_BLEND_ADDITIVE
+                | OBS_BLEND_SUBTRACT
+                | OBS_BLEND_SCREEN
+                | OBS_BLEND_MULTIPLY
+                | OBS_BLEND_LIGHTEN
+                | OBS_BLEND_DARKEN
+
+---------------------
+
 .. function:: void obs_sceneitem_defer_update_begin(obs_sceneitem_t *item)
               void obs_sceneitem_defer_update_end(obs_sceneitem_t *item)
 

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -705,8 +705,10 @@ ID3D11BlendState *gs_device::AddBlendState()
 	memset(&bd, 0, sizeof(bd));
 	for (int i = 0; i < 8; i++) {
 		bd.RenderTarget[i].BlendEnable = blendState.blendEnabled;
-		bd.RenderTarget[i].BlendOp = D3D11_BLEND_OP_ADD;
-		bd.RenderTarget[i].BlendOpAlpha = D3D11_BLEND_OP_ADD;
+		bd.RenderTarget[i].BlendOp =
+			ConvertGSBlendOpType(blendState.op);
+		bd.RenderTarget[i].BlendOpAlpha =
+			ConvertGSBlendOpType(blendState.op);
 		bd.RenderTarget[i].SrcBlend =
 			ConvertGSBlendType(blendState.srcFactorC);
 		bd.RenderTarget[i].DestBlend =
@@ -2156,6 +2158,15 @@ void device_blend_function_separate(gs_device_t *device,
 	device->blendState.destFactorC = dest_c;
 	device->blendState.srcFactorA = src_a;
 	device->blendState.destFactorA = dest_a;
+	device->blendStateChanged = true;
+}
+
+void device_blend_op(gs_device_t *device, enum gs_blend_op_type op)
+{
+	if (device->blendState.op == op)
+		return;
+
+	device->blendState.op = op;
 	device->blendStateChanged = true;
 }
 

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -281,6 +281,24 @@ static inline D3D11_BLEND ConvertGSBlendType(gs_blend_type type)
 	return D3D11_BLEND_ONE;
 }
 
+static inline D3D11_BLEND_OP ConvertGSBlendOpType(gs_blend_op_type type)
+{
+	switch (type) {
+	case GS_BLEND_OP_ADD:
+		return D3D11_BLEND_OP_ADD;
+	case GS_BLEND_OP_SUBTRACT:
+		return D3D11_BLEND_OP_SUBTRACT;
+	case GS_BLEND_OP_REVERSE_SUBTRACT:
+		return D3D11_BLEND_OP_REV_SUBTRACT;
+	case GS_BLEND_OP_MIN:
+		return D3D11_BLEND_OP_MIN;
+	case GS_BLEND_OP_MAX:
+		return D3D11_BLEND_OP_MAX;
+	}
+
+	return D3D11_BLEND_OP_ADD;
+}
+
 static inline D3D11_CULL_MODE ConvertGSCullMode(gs_cull_mode mode)
 {
 	switch (mode) {
@@ -831,6 +849,7 @@ struct BlendState {
 	gs_blend_type destFactorC;
 	gs_blend_type srcFactorA;
 	gs_blend_type destFactorA;
+	gs_blend_op_type op;
 
 	bool redEnabled;
 	bool greenEnabled;
@@ -843,6 +862,7 @@ struct BlendState {
 		  destFactorC(GS_BLEND_INVSRCALPHA),
 		  srcFactorA(GS_BLEND_ONE),
 		  destFactorA(GS_BLEND_INVSRCALPHA),
+		  op(GS_BLEND_OP_ADD),
 		  redEnabled(true),
 		  greenEnabled(true),
 		  blueEnabled(true),

--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -1262,6 +1262,17 @@ void device_blend_function_separate(gs_device_t *device,
 	UNUSED_PARAMETER(device);
 }
 
+void device_blend_op(gs_device_t *device, enum gs_blend_op_type op)
+{
+	GLenum gl_blend_op = convert_gs_blend_op_type(op);
+
+	glBlendEquation(gl_blend_op);
+	if (!gl_success("glBlendEquation"))
+		blog(LOG_ERROR, "device_blend_op (GL) failed");
+
+	UNUSED_PARAMETER(device);
+}
+
 void device_depth_function(gs_device_t *device, enum gs_depth_test test)
 {
 	GLenum gl_test = convert_gs_depth_test(test);

--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -294,6 +294,24 @@ static inline GLenum convert_gs_blend_type(enum gs_blend_type type)
 	return GL_ONE;
 }
 
+static inline GLenum convert_gs_blend_op_type(enum gs_blend_op_type type)
+{
+	switch (type) {
+	case GS_BLEND_OP_ADD:
+		return GL_FUNC_ADD;
+	case GS_BLEND_OP_SUBTRACT:
+		return GL_FUNC_SUBTRACT;
+	case GS_BLEND_OP_REVERSE_SUBTRACT:
+		return GL_FUNC_REVERSE_SUBTRACT;
+	case GS_BLEND_OP_MIN:
+		return GL_MIN;
+	case GS_BLEND_OP_MAX:
+		return GL_MAX;
+	}
+
+	return GL_FUNC_ADD;
+}
+
 static inline GLenum convert_shader_type(enum gs_shader_type type)
 {
 	switch (type) {

--- a/libobs/graphics/device-exports.h
+++ b/libobs/graphics/device-exports.h
@@ -145,6 +145,8 @@ EXPORT void device_blend_function_separate(gs_device_t *device,
 					   enum gs_blend_type dest_c,
 					   enum gs_blend_type src_a,
 					   enum gs_blend_type dest_a);
+EXPORT void device_blend_op(gs_device_t *device, enum gs_blend_op_type op);
+
 EXPORT void device_depth_function(gs_device_t *device, enum gs_depth_test test);
 EXPORT void device_stencil_function(gs_device_t *device,
 				    enum gs_stencil_side side,

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -104,6 +104,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT(device_enable_color);
 	GRAPHICS_IMPORT(device_blend_function);
 	GRAPHICS_IMPORT(device_blend_function_separate);
+	GRAPHICS_IMPORT(device_blend_op);
 	GRAPHICS_IMPORT(device_depth_function);
 	GRAPHICS_IMPORT(device_stencil_function);
 	GRAPHICS_IMPORT(device_stencil_op);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -147,6 +147,8 @@ struct gs_exports {
 					       enum gs_blend_type dest_c,
 					       enum gs_blend_type src_a,
 					       enum gs_blend_type dest_a);
+	void (*device_blend_op)(gs_device_t *device, enum gs_blend_op_type op);
+
 	void (*device_depth_function)(gs_device_t *device,
 				      enum gs_depth_test test);
 	void (*device_stencil_function)(gs_device_t *device,
@@ -342,6 +344,7 @@ struct blend_state {
 	enum gs_blend_type dest_c;
 	enum gs_blend_type src_a;
 	enum gs_blend_type dest_a;
+	enum gs_blend_op_type op;
 };
 
 struct graphics_subsystem {

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -111,6 +111,14 @@ enum gs_blend_type {
 	GS_BLEND_SRCALPHASAT,
 };
 
+enum gs_blend_op_type {
+	GS_BLEND_OP_ADD,
+	GS_BLEND_OP_SUBTRACT,
+	GS_BLEND_OP_REVERSE_SUBTRACT,
+	GS_BLEND_OP_MIN,
+	GS_BLEND_OP_MAX
+};
+
 enum gs_depth_test {
 	GS_NEVER,
 	GS_LESS,
@@ -728,6 +736,8 @@ EXPORT void gs_blend_function_separate(enum gs_blend_type src_c,
 				       enum gs_blend_type dest_c,
 				       enum gs_blend_type src_a,
 				       enum gs_blend_type dest_a);
+EXPORT void gs_blend_op(enum gs_blend_op_type op);
+
 EXPORT void gs_depth_function(enum gs_depth_test test);
 
 EXPORT void gs_stencil_function(enum gs_stencil_side side,

--- a/libobs/obs-scene.h
+++ b/libobs/obs-scene.h
@@ -63,6 +63,8 @@ struct obs_scene_item {
 	struct vec2 output_scale;
 	enum obs_scale_type scale_filter;
 
+	enum obs_blending_type blend_type;
+
 	struct matrix4 box_transform;
 	struct vec2 box_scale;
 	struct matrix4 draw_transform;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -121,6 +121,16 @@ enum obs_scale_type {
 	OBS_SCALE_AREA,
 };
 
+enum obs_blending_type {
+	OBS_BLEND_NORMAL,
+	OBS_BLEND_ADDITIVE,
+	OBS_BLEND_SUBTRACT,
+	OBS_BLEND_SCREEN,
+	OBS_BLEND_MULTIPLY,
+	OBS_BLEND_LIGHTEN,
+	OBS_BLEND_DARKEN,
+};
+
 /**
  * Used with scene items to indicate the type of bounds to use for scene items.
  * Mostly determines how the image will be scaled within those bounds, or
@@ -1730,6 +1740,11 @@ EXPORT void obs_sceneitem_set_scale_filter(obs_sceneitem_t *item,
 					   enum obs_scale_type filter);
 EXPORT enum obs_scale_type
 obs_sceneitem_get_scale_filter(obs_sceneitem_t *item);
+
+EXPORT void obs_sceneitem_set_blending_mode(obs_sceneitem_t *item,
+					    enum obs_blending_type type);
+EXPORT enum obs_blending_type
+obs_sceneitem_get_blending_mode(obs_sceneitem_t *item);
 
 EXPORT void obs_sceneitem_force_update_transform(obs_sceneitem_t *item);
 


### PR DESCRIPTION
### Description
Implements non-default blending modes for sources, allowing for compositing functionality similar to Photoshop/Nuke etc.
![image](https://user-images.githubusercontent.com/25467950/138602562-6f9fabd5-8fa4-43a8-9cb2-ec302211a9fb.png)
The implemented blending modes are:
- Normal
- Additive
- Subtractive
- Screen
- Multiply
- Lighten
- Darken 

Screenshots of each mode's behaviour are available [here](https://obsproject.com/forum/threads/source-blending-modes.148443/).

Blending modes have been implemented to leverage the existing blend state functionality, so changes to allow the blending equation's operation type to be modified have been added. Each blending mode is a preset combination of the blending equation's source/destination factors and operation, so the number of modes implemented is somewhat limited. Non-default blending modes require scene items to be rendered to a texture (using the same render pipeline for non-default scale filtering modes), but are otherwise 'free' from a performance point of view.

### Motivation and Context
- Allows for compositing techniques where chroma/luma keying does not provide the desired effect.
- This has been requested [here](https://ideas.obsproject.com/posts/317/add-blend-modes-for-dynamic-sources) and [here](https://ideas.obsproject.com/posts/1575/)

### How Has This Been Tested?
I've only tested these changes on macOS, cherry-picked onto [this branch](https://github.com/PatTheMav/obs-studio/tree/universal-build) to allow me to build on my device. As such, the d3d11 changes are untested.

Blending mode settings have been tested in scene loading/saving.
Tested with image sources, media sources, window capture sources, and display capture sources.

### Types of changes
- New feature (non-breaking change which adds functionality) -->
- Documentation (a change to documentation pages)

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [x] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
