### PR TITLE
obs-frontend-api: Add scripting shutdown event

### DIFF
--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -57,6 +57,7 @@ enum obs_frontend_event {
 	OBS_FRONTEND_EVENT_TBAR_VALUE_CHANGED,
 	OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGING,
 	OBS_FRONTEND_EVENT_PROFILE_CHANGING,
+	OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN,
 };
 
 /* ------------------------------------------------------------------------- */

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4590,6 +4590,9 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 	ClearExtraBrowserDocks();
 #endif
 
+	if (api)
+		api->on_event(OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN);
+
 	disableSaving++;
 
 	/* Clear all scene data (dialogs, widgets, widget sub-items, scenes,

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -93,6 +93,10 @@ Structures/Enumerations
 
      Triggered when a profile has been added/removed/renamed.
 
+   - **OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN**
+
+     Triggered when scripts are unloaded when exiting OBS.
+
    - **OBS_FRONTEND_EVENT_EXIT**
 
      Triggered when the program is about to exit.


### PR DESCRIPTION
### Description
For example: this event is for when scripts need to know when
OBS is exiting. Currently scripts are destroyed before the current
exit event.

### Motivation and Context
Since https://github.com/obsproject/obs-studio/commit/228ca556611e77d9be6926dbdad59acf37321813, scripts don't know when OBS is exiting.

### How Has This Been Tested?
Tested with a script.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
