### PR TITLE
obs-ffmpeg-mux: Add support for rist protocol

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -617,13 +617,15 @@ static inline int open_output_file(struct ffmpeg_mux *ffm)
 #define UDP_PROTO "udp"
 #define TCP_PROTO "tcp"
 #define HTTP_PROTO "http"
+#define RIST_PROTO "rist"
 
 static bool ffmpeg_mux_is_network(struct ffmpeg_mux *ffm)
 {
 	return !strncmp(ffm->params.file, SRT_PROTO, sizeof(SRT_PROTO) - 1) ||
 	       !strncmp(ffm->params.file, UDP_PROTO, sizeof(UDP_PROTO) - 1) ||
 	       !strncmp(ffm->params.file, TCP_PROTO, sizeof(TCP_PROTO) - 1) ||
-	       !strncmp(ffm->params.file, HTTP_PROTO, sizeof(HTTP_PROTO) - 1);
+	       !strncmp(ffm->params.file, HTTP_PROTO, sizeof(HTTP_PROTO) - 1) ||
+	       !strncmp(ffm->params.file, RIST_PROTO, sizeof(RIST_PROTO) - 1);
 }
 
 static int ffmpeg_mux_init_context(struct ffmpeg_mux *ffm)


### PR DESCRIPTION
### Description
This adds RIST to the list of protocols supported by the obs ffmpeg_mpegts_muxer.
RIST is container and codec agnostic. But this implementation relies on ffmpeg avformat integration and uses mpeg-ts container.

### Motivation and Context
Obs-studio supports srt & ftl among the new protocols.
Rist is gaining traction. It relies on rtp frames rather than udt.
But it's quite similar to srt in terms of capabilities : 
- ARQ (Automatic Repeat reQuests, or packet resend if there's packet loss),
- low latency,
- FEC correction,
- bonding.   
The advanced profile (in development) will have dynamic bitrate capability.
According to rist users/devs, a rist stream can be recovered with up to 50% packet loss
against 10% with srt. (I haven't checked the claim.)

It's standards based and there's an open source implementation
librist, [https://code.videolan.org/rist/librist](https://code.videolan.org/rist/librist) .
In terms of obs-studio support, most of the work was done already for srt.
So we can leverage the code written for srt and it's then a matter of adding **two lines of code.**

Requirements: 
- compile FFmpeg with librist support (--enable-librist flag).
- compile librist : 
`meson setup build --backend vs2019`
`meson compile -C build`


### How Has This Been Tested?
This was tested locally to an IP: rist://192.168.xx.xx:port?cname=SEND&bandwidth=5000
The stream was received in vlc 4: rist://@192.168.xx.xx:port?cname=RECEIVER&bandwidth=5000
[https://nightlies.videolan.org/](https://nightlies.videolan.org/)
It would be desirable to test against streaming servers accepting rist ingest.
(I'm aware of nimble-server supporting rist but no open source server.
FFmpeg or ristreceiver can be used though; ristreceiver is a demo tool provided by librist).

For testing, this page is quite useful : 
[https://code.videolan.org/rist/librist/-/wikis/rist-sender-and-receiver-Command-Line-Examples-as-of-v.-0.2.0](https://code.videolan.org/rist/librist/-/wikis/rist-sender-and-receiver-Command-Line-Examples-as-of-v.-0.2.0)

Edit: tested on sipradius RistGatway (much thanks to Sergio Ammirata from [sipradius](https://www.sipradius.com/) for providing the access; Sergio is the main author of librist.) I'm not observing any ARQ though atm, but the testing is very preliminary.
Edit 2: the bandwidth is in kbps ; it was before in Mbps but the docs had not been updated. With a proper bandwidth setting, I see the ARQ setting in. I was able to have as much as 50% packet drops with a very good stream for a transatlantic stream between Europe and the US. This protocol is very impressive. I add Gijs Peskens to my thanks for his help with Srgio Ammirata during my testing of sipradius rist server (ristgateway).

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
