### PR TITLE
UI, libobs, obs-plugins: Fix compiler warnings

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -386,7 +386,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	// Register shortcuts for Undo/Redo
 	ui->actionMainUndo->setShortcut(Qt::CTRL + Qt::Key_Z);
 	QList<QKeySequence> shrt;
-	shrt << QKeySequence(Qt::CTRL | Qt::SHIFT + Qt::Key_Z)
+	shrt << QKeySequence((Qt::CTRL | Qt::SHIFT) + Qt::Key_Z)
 	     << QKeySequence(Qt::CTRL + Qt::Key_Y);
 	ui->actionMainRedo->setShortcuts(shrt);
 
@@ -6329,7 +6329,7 @@ void OBSBasic::StartStreaming()
 void OBSBasic::BroadcastButtonClicked()
 {
 	if (!broadcastReady ||
-	    !broadcastActive && !outputHandler->StreamingActive()) {
+	    (!broadcastActive && !outputHandler->StreamingActive())) {
 		SetupBroadcast();
 		if (broadcastReady)
 			ui->broadcastButton->setChecked(true);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4382,10 +4382,10 @@ bool OBSBasicSettings::ScanDuplicateHotkeys(QFormLayout *layout)
 			edit->hasDuplicate = false;
 	}
 
-	for (int i = 0; i < items.size(); i++) {
+	for (size_t i = 0; i < items.size(); i++) {
 		OBSHotkeyLabel *item1 = items[i];
 
-		for (int j = i + 1; j < items.size(); j++)
+		for (size_t j = i + 1; j < items.size(); j++)
 			hasDupes |= MarkHotkeyConflicts(item1, items[j]);
 	}
 

--- a/UI/window-youtube-actions.hpp
+++ b/UI/window-youtube-actions.hpp
@@ -74,9 +74,9 @@ private:
 	QString selectedBroadcast;
 	bool autostart, autostop;
 	bool valid = false;
-	bool broadcastReady = false;
 	YoutubeApiWrappers *apiYouTube;
-	WorkerThread *workerThread;
+	WorkerThread *workerThread = nullptr;
+	bool broadcastReady = false;
 	QString thumbnailFile;
 	QIcon thumbPlaceholder;
 };

--- a/UI/youtube-api-wrappers.cpp
+++ b/UI/youtube-api-wrappers.cpp
@@ -152,7 +152,7 @@ bool YoutubeApiWrappers::InsertCommand(const char *url,
 	if (json_out.object_items().find("error") !=
 	    json_out.object_items().end()) {
 		blog(LOG_ERROR,
-		     "YouTube API error:\n\tHTTP status: %d\n\tURL: %s\n\tJSON: %s",
+		     "YouTube API error:\n\tHTTP status: %ld\n\tURL: %s\n\tJSON: %s",
 		     error_code, url, json_out.dump().c_str());
 
 		lastError = json_out["error"]["code"].int_value();

--- a/libobs/obs-audio-controls.c
+++ b/libobs/obs-audio-controls.c
@@ -783,8 +783,6 @@ obs_volmeter_t *obs_volmeter_create(enum obs_fader_type type)
 
 	volmeter->type = type;
 
-	obs_volmeter_set_update_interval(volmeter, 50);
-
 	return volmeter;
 fail:
 	obs_volmeter_destroy(volmeter);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-av1.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-av1.c
@@ -333,7 +333,7 @@ static inline void copy_data(AVFrame *pic, const struct encoder_frame *frame,
 	}
 }
 
-#define SEC_TO_NSEC 1000000000ULL
+#define SEC_TO_NSEC 1000000000LL
 #define TIMEOUT_MAX_SEC 5
 #define TIMEOUT_MAX_NSEC (TIMEOUT_MAX_SEC * SEC_TO_NSEC)
 static const AVRational nsec_timebase = {1, 1000000000};
@@ -374,7 +374,7 @@ static bool av1_encode(void *data, struct encoder_frame *frame,
 					      enc->context->extradata,
 					      enc->context->extradata_size);
 			} else {
-				for (size_t i = 0; i < av_pkt.side_data_elems;
+				for (int i = 0; i < av_pkt.side_data_elems;
 				     i++) {
 					AVPacketSideData *side_data =
 						av_pkt.side_data + i;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -92,6 +92,8 @@ static void set_psycho_aq(struct nvenc_encoder *enc, bool psycho_aq)
 
 static bool nvenc_init_codec(struct nvenc_encoder *enc, bool psycho_aq)
 {
+	UNUSED_PARAMETER(psycho_aq);
+
 	int ret;
 
 	// avcodec_open2 will overwrite priv_data, we call this to get a


### PR DESCRIPTION
### Description
Found warnings when compiling OBS.

### Motivation and Context
Warnings are annoying.

### How Has This Been Tested?
Compiled to see if warnings went away.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
