### PR TITLE
UI: Remove duplicated StreamingActive() function

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4150,13 +4150,6 @@ int OBSBasic::GetTransitionDuration()
 	return ui->transitionDuration->value();
 }
 
-bool OBSBasic::StreamingActive() const
-{
-	if (!outputHandler)
-		return false;
-	return outputHandler->StreamingActive();
-}
-
 bool OBSBasic::Active() const
 {
 	if (!outputHandler)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -819,7 +819,6 @@ public:
 
 	inline bool VCamEnabled() const { return vcamEnabled; }
 
-	bool StreamingActive() const;
 	bool Active() const;
 
 	void ResetUI();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes the `bool OBSBasic::StreamingActive() const` since `bool OBSBasic::StreamingActive()` exists further down (exactly the same code), along with `RecordingActive` etc.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
No need for it to exist twice.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0.1
Still compiles and runs

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
