### PR TITLE
UI: Set correct text in system tray on startup

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6485,9 +6485,9 @@ static inline void ClearProcessPriority()
 	} while (false)
 #endif
 
-inline void OBSBasic::OnActivate()
+inline void OBSBasic::OnActivate(bool force)
 {
-	if (ui->profileMenu->isEnabled()) {
+	if (ui->profileMenu->isEnabled() || force) {
 		ui->profileMenu->setEnabled(false);
 		ui->autoConfigure->setEnabled(false);
 		App()->IncrementSleepInhibition();
@@ -8869,14 +8869,22 @@ void OBSBasic::SystemTrayInit()
 	trayIcon->setToolTip("OBS Studio");
 
 	showHide = new QAction(QTStr("Basic.SystemTray.Show"), trayIcon.data());
-	sysTrayStream = new QAction(QTStr("Basic.Main.StartStreaming"),
-				    trayIcon.data());
-	sysTrayRecord = new QAction(QTStr("Basic.Main.StartRecording"),
-				    trayIcon.data());
-	sysTrayReplayBuffer = new QAction(QTStr("Basic.Main.StartReplayBuffer"),
-					  trayIcon.data());
-	sysTrayVirtualCam = new QAction(QTStr("Basic.Main.StartVirtualCam"),
-					trayIcon.data());
+	sysTrayStream = new QAction(
+		StreamingActive() ? QTStr("Basic.Main.StopStreaming")
+				  : QTStr("Basic.Main.StartStreaming"),
+		trayIcon.data());
+	sysTrayRecord = new QAction(
+		RecordingActive() ? QTStr("Basic.Main.StopRecording")
+				  : QTStr("Basic.Main.StartRecording"),
+		trayIcon.data());
+	sysTrayReplayBuffer = new QAction(
+		ReplayBufferActive() ? QTStr("Basic.Main.StopReplayBuffer")
+				     : QTStr("Basic.Main.StartReplayBuffer"),
+		trayIcon.data());
+	sysTrayVirtualCam = new QAction(
+		VirtualCamActive() ? QTStr("Basic.Main.StopVirtualCam")
+				   : QTStr("Basic.Main.StartVirtualCam"),
+		trayIcon.data());
 	exit = new QAction(QTStr("Exit"), trayIcon.data());
 
 	trayMenu = new QMenu;
@@ -8901,6 +8909,9 @@ void OBSBasic::SystemTrayInit()
 		sysTrayReplayBuffer->setEnabled(false);
 
 	sysTrayVirtualCam->setEnabled(vcamEnabled);
+
+	if (Active())
+		OnActivate(true);
 
 	connect(trayIcon.data(),
 		SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this,
@@ -9505,6 +9516,13 @@ bool OBSBasic::ReplayBufferActive()
 	if (!outputHandler)
 		return false;
 	return outputHandler->ReplayBufferActive();
+}
+
+bool OBSBasic::VirtualCamActive()
+{
+	if (!outputHandler)
+		return false;
+	return outputHandler->VirtualCamActive();
 }
 
 SceneRenameDelegate::SceneRenameDelegate(QObject *parent)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -482,7 +482,7 @@ private:
 
 	int disableOutputsRef = 0;
 
-	inline void OnActivate();
+	inline void OnActivate(bool force = false);
 	inline void OnDeactivate();
 
 	void AddDropSource(const char *file, DropType image);
@@ -1108,6 +1108,7 @@ public slots:
 	bool StreamingActive();
 	bool RecordingActive();
 	bool ReplayBufferActive();
+	bool VirtualCamActive();
 
 	void ClearContextBar();
 	void UpdateContextBar(bool force = false);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The system tray assumed all outputs are inactive when it's initiated,
however outputs can be active if started via command line options. This
caused the wrong (only) text to be set if the output was in fact active.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #5484

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0.1, compiled and run
When using launch parameters, the system try will now show the correct texts for "Start/Stop Streaming/Recording/Replay Buffer/Virtual Camera" and also have the active icon (with the little dot).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
