### PR TITLE
obs-ffmpeg, UI: Allow passing muxer and protocol options for the ffmpeg-mpegts-muxer output.

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -829,6 +829,11 @@ Basic.Settings.Stream.Recommended.MaxVideoBitrate="Maximum Video Bitrate: %1 kbp
 Basic.Settings.Stream.Recommended.MaxAudioBitrate="Maximum Audio Bitrate: %1 kbps"
 Basic.Settings.Stream.Recommended.MaxResolution="Maximum Resolution: %1"
 Basic.Settings.Stream.Recommended.MaxFPS="Maximum FPS: %1"
+Basic.Settings.Stream.Custom.MpegtsOptions="Use options for mpegts streams (srt, rist, udp)"
+Basic.Settings.Stream.Custom.MpegtsMuxerOptions="Mpeg-ts options"
+Basic.Settings.Stream.Custom.MpegtsMuxerOptions.TT="Syntax: option1=value1 option2=value2; refer to https://ffmpeg.org/ffmpeg-formats.html#toc-mpegts-1 for a list of options"
+Basic.Settings.Stream.Custom.MpegtsProtocolOptions="Protocol options"
+Basic.Settings.Stream.Custom.MpegtsProtocolOptions.TT="Syntax: option1=value1 option2=value2; refer to https://ffmpeg.org/ffmpeg-protocols.html for a list of options"
 
 # basic mode 'output' settings
 Basic.Settings.Output="Output"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -1325,6 +1325,45 @@
                </item>
               </layout>
              </item>
+             <item row="13" column="1">
+              <widget class="QCheckBox" name="mpegtsOpts">
+               <property name="text">
+                <string>Basic.Settings.Stream.Custom.MpegtsOptions</string>
+               </property>
+              </widget>
+             </item>
+             <item row="14" column="0">
+              <widget class="QLabel" name="mpegtsMuxerOptionsLabel">
+               <property name="text">
+                <string>Basic.Settings.Stream.Custom.MpegtsMuxerOptions</string>
+               </property>
+               <property name="buddy">
+                <cstring>mpegtsMuxerOpts</cstring>
+               </property>
+               <property name="toolTip">
+                <string>Basic.Settings.Stream.Custom.MpegtsMuxerOptions.TT</string>
+               </property>
+              </widget>
+             </item>
+             <item row="14" column="1">
+              <widget class="QLineEdit" name="mpegtsMuxerOpts"/>
+             </item>
+             <item row="15" column="0">
+              <widget class="QLabel" name="mpegtsProtocolOptionsLabel">
+               <property name="text">
+                <string>Basic.Settings.Stream.Custom.MpegtsProtocolOptions</string>
+               </property>
+               <property name="buddy">
+                <cstring>mpegtsProtoOpts</cstring>
+               </property>
+               <property name="toolTip">
+                <string>Basic.Settings.Stream.Custom.MpegtsProtocolOptions.TT</string>
+               </property>
+              </widget>
+             </item>
+             <item row="15" column="1">
+              <widget class="QLineEdit" name="mpegtsProtoOpts"/>
+             </item>
             </layout>
            </widget>
           </widget>
@@ -5619,6 +5658,9 @@
   <tabstop>authUsername</tabstop>
   <tabstop>authPw</tabstop>
   <tabstop>authPwShow</tabstop>
+  <tabstop>mpegtsOpts</tabstop>
+  <tabstop>mpegtsMuxerOpts</tabstop>
+  <tabstop>mpegtsProtoOpts</tabstop>
   <tabstop>scrollArea_3</tabstop>
   <tabstop>outputMode</tabstop>
   <tabstop>simpleOutputVBitrate</tabstop>

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -914,6 +914,15 @@ bool SimpleOutput::StartStreaming(obs_service_t *service)
 	bool enableDynBitrate =
 		config_get_bool(main->Config(), "Output", "DynamicBitrate");
 
+	obs_service_t *service_obj = main->GetService();
+	obs_data_t *serv_settings = obs_service_get_settings(service_obj);
+	bool mpegtsOpts = obs_data_get_bool(serv_settings, "mpegts_opts");
+	const char *muxer_settings =
+		obs_data_get_string(serv_settings, "mpegts_muxer_settings");
+	const char *proto_settings =
+		obs_data_get_string(serv_settings, "mpegts_proto_settings");
+	obs_data_release(serv_settings);
+
 	obs_data_t *settings = obs_data_create();
 	obs_data_set_string(settings, "bind_ip", bindIP);
 	obs_data_set_bool(settings, "new_socket_loop_enabled",
@@ -921,6 +930,11 @@ bool SimpleOutput::StartStreaming(obs_service_t *service)
 	obs_data_set_bool(settings, "low_latency_mode_enabled",
 			  enableLowLatencyMode);
 	obs_data_set_bool(settings, "dyn_bitrate", enableDynBitrate);
+	if (mpegtsOpts) {
+		obs_data_set_string(settings, "muxer_settings", muxer_settings);
+		obs_data_set_string(settings, "protocol_settings",
+				    proto_settings);
+	}
 	obs_output_update(streamOutput, settings);
 	obs_data_release(settings);
 
@@ -1813,6 +1827,15 @@ bool AdvancedOutput::StartStreaming(obs_service_t *service)
 	bool enableDynBitrate =
 		config_get_bool(main->Config(), "Output", "DynamicBitrate");
 
+	obs_service_t *service_obj = main->GetService();
+	obs_data_t *serv_settings = obs_service_get_settings(service_obj);
+	bool mpegtsOpts = obs_data_get_bool(serv_settings, "mpegts_opts");
+	const char *muxer_settings =
+		obs_data_get_string(serv_settings, "mpegts_muxer_opts");
+	const char *proto_settings =
+		obs_data_get_string(serv_settings, "mpegts_proto_opts");
+	obs_data_release(serv_settings);
+
 	obs_data_t *settings = obs_data_create();
 	obs_data_set_string(settings, "bind_ip", bindIP);
 	obs_data_set_bool(settings, "new_socket_loop_enabled",
@@ -1820,6 +1843,11 @@ bool AdvancedOutput::StartStreaming(obs_service_t *service)
 	obs_data_set_bool(settings, "low_latency_mode_enabled",
 			  enableLowLatencyMode);
 	obs_data_set_bool(settings, "dyn_bitrate", enableDynBitrate);
+	if (mpegtsOpts) {
+		obs_data_set_string(settings, "muxer_settings", muxer_settings);
+		obs_data_set_string(settings, "protocol_settings",
+				    proto_settings);
+	}
 	obs_output_update(streamOutput, settings);
 	obs_data_release(settings);
 

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -128,6 +128,15 @@ void OBSBasicSettings::LoadStream1Settings()
 		ui->authUsername->setText(QT_UTF8(username));
 		ui->authPw->setText(QT_UTF8(password));
 		ui->useAuth->setChecked(use_auth);
+
+		bool mpegts_opts = obs_data_get_bool(settings, "mpegts_opts");
+		const char *muxer_settings =
+			obs_data_get_string(settings, "mpegts_muxer_opts");
+		const char *proto_settings =
+			obs_data_get_string(settings, "mpegts_proto_opts");
+		ui->mpegtsMuxerOpts->setText(QT_UTF8(muxer_settings));
+		ui->mpegtsProtoOpts->setText(QT_UTF8(proto_settings));
+		ui->mpegtsOpts->setChecked(mpegts_opts);
 	} else {
 		int idx = ui->service->findText(service);
 		if (idx == -1) {
@@ -209,6 +218,16 @@ void OBSBasicSettings::SaveStream1Settings()
 				QT_TO_UTF8(ui->authUsername->text()));
 			obs_data_set_string(settings, "password",
 					    QT_TO_UTF8(ui->authPw->text()));
+		}
+		obs_data_set_bool(settings, "mpegts_opts",
+				  ui->mpegtsOpts->isChecked());
+		if (ui->mpegtsOpts->isChecked()) {
+			obs_data_set_string(
+				settings, "mpegts_muxer_opts",
+				QT_TO_UTF8(ui->mpegtsMuxerOpts->text()));
+			obs_data_set_string(
+				settings, "mpegts_proto_opts",
+				QT_TO_UTF8(ui->mpegtsProtoOpts->text()));
 		}
 	}
 
@@ -470,6 +489,7 @@ void OBSBasicSettings::on_service_currentIndexChanged(int)
 		ui->serverStackedWidget->setVisible(true);
 		ui->serverLabel->setVisible(true);
 		on_useAuth_toggled();
+		on_mpegtsOpts_toggled();
 	} else {
 		ui->serverStackedWidget->setCurrentIndex(0);
 	}
@@ -712,6 +732,18 @@ void OBSBasicSettings::on_useAuth_toggled()
 	ui->authPwWidget->setVisible(use_auth);
 }
 
+void OBSBasicSettings::on_mpegtsOpts_toggled()
+{
+	if (!IsCustomService())
+		return;
+
+	bool mpegts_opts = ui->mpegtsOpts->isChecked();
+
+	ui->mpegtsMuxerOpts->setVisible(mpegts_opts);
+	ui->mpegtsProtoOpts->setVisible(mpegts_opts);
+	ui->mpegtsMuxerOptionsLabel->setVisible(mpegts_opts);
+	ui->mpegtsProtocolOptionsLabel->setVisible(mpegts_opts);
+}
 void OBSBasicSettings::UpdateVodTrackSetting()
 {
 	bool enableForCustomServer = config_get_bool(

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -428,6 +428,9 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->authUsername,         EDIT_CHANGED,   STREAM1_CHANGED);
 	HookWidget(ui->authPw,               EDIT_CHANGED,   STREAM1_CHANGED);
 	HookWidget(ui->ignoreRecommended,    CHECK_CHANGED,  STREAM1_CHANGED);
+	HookWidget(ui->mpegtsOpts,           CHECK_CHANGED,  STREAM1_CHANGED);
+	HookWidget(ui->mpegtsMuxerOpts,      EDIT_CHANGED,   STREAM1_CHANGED);
+	HookWidget(ui->mpegtsProtoOpts,      EDIT_CHANGED,   STREAM1_CHANGED);
 	HookWidget(ui->outputMode,           COMBO_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->simpleOutputPath,     EDIT_CHANGED,   OUTPUTS_CHANGED);
 	HookWidget(ui->simpleNoSpace,        CHECK_CHANGED,  OUTPUTS_CHANGED);

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -267,6 +267,7 @@ private slots:
 	void on_disconnectAccount_clicked();
 	void on_useStreamKey_clicked();
 	void on_useAuth_toggled();
+	void on_mpegtsOpts_toggled();
 
 private:
 	/* output */

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
@@ -22,6 +22,7 @@ struct ffmpeg_muxer {
 	struct dstr path;
 	struct dstr printable_path;
 	struct dstr muxer_settings;
+	struct dstr proto_settings;
 	struct dstr stream_key;
 
 	/* replay buffer */


### PR DESCRIPTION
### Description
For the rist or srt protocols, most protocol options can be passed through URL ( proto://IP:port?option1=val1&option2=val2 ).
But some can't and have to be passed programmatically through the private_data of an URLContext.
In addition muxer options can't be specified at the moment due to lack of UI.
This PR allows setting both muxer options and protocol options from Settings > Stream > Custom .
The syntax is the usual one:
ex: `option1=val1 option2=val2`
The options available are listed here:   
- mpegts muxer options : https://ffmpeg.org/ffmpeg-formats.html#toc-mpegts-1
- rist options : https://ffmpeg.org/ffmpeg-protocols.html#rist
- srt options : https://ffmpeg.org/ffmpeg-protocols.html#srt

For the UI, the choice has been made to put the new option text fields in the Stream Settings rather than in the Ouput Settings because the fields are meaningful only for the Custom stream service and only with mpegts streams (srt or rist in practice).
![obs64_2021-11-04_13-15-44](https://user-images.githubusercontent.com/9283407/140314292-7ef565ec-4456-4180-886d-a77e0e561188.png)
These new fields are ignored for the rtmp protocol. 
![obs64_2021-11-04_13-15-39](https://user-images.githubusercontent.com/9283407/140314306-46278d29-c36e-4cf3-a239-2c39a1057236.png)
Tooltips explain the syntax for the options.
![obs64_2021-11-04_13-41-07](https://user-images.githubusercontent.com/9283407/140315146-4d9ddcbd-89b8-4be5-a6c1-025394407c5e.png)

### Motivation and Context
The motivation is that it can sometimes be necessary to specify some of these muxer or protocol options.
An example is that it is impossible otherwise to stream to Amazon Elemental Media Connect with rist.
Media Connect allows only rist simple profile while the default profile is main in avformat for rist.
With the enhancements brought by this PR, rist streaming from obs to Media Connect works though.


### How Has This Been Tested?
Tested by streaming with rist and srt to Elemental Media Connect, to vlc (in simple profile for rist).
(build done on vs2019 on win 10)

### Types of changes
 - New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
