### PR TITLE
UI: Don't load existing sources for scene removal undo

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3835,9 +3835,12 @@ void OBSBasic::RemoveSelectedScene()
 			const char *name = obs_data_get_string(data, "name");
 
 			obs_source_t *source = obs_get_source_by_name(name);
-			if (!source)
+			if (!source) {
 				source = obs_load_source(data);
-			sources.push_back(source);
+				sources.push_back(source);
+			} else {
+				obs_source_release(source);
+			}
 
 			obs_data_release(data);
 		}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When undoing a scene removal, `obs_source_load` would get called on all sources, not just those had to get recreated since they no longer existed.
If I understand [the docs](https://obsproject.com/docs/reference-sources.html?highlight=.load#c.obs_source_info.load), that method should only be called when a source has been freshly created, and not at any random point in its lifetime (which it would be for existing sources. This could be potentially dangerous for source types other than `scene` as well if they didn't "expect" the call). This change makes only the sources get `.load`ed that were recreated.
In case I misunderstood the docs in that regard and the call to `.load` was intentional for all sources, this PR would be the wrong solution. In that case, `.load` for scenes would need to be changed to make them not lose references to their sources and let them get destroyed.
(Or perhaps both should get fixed? If you have opinions please tell me :p )

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #5489 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0.1, compiled and run
Bug no longer appears.
Normal sources, groups (also with items) and scenes correctly get re-created when undoing a scene deletion.
This applies to both those that get re-loaded and those that still existed in other scenes and with this change won't get re-loaded.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
