### PR TITLE
UI: Add undo/redo for context bar text changes

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -45,7 +45,7 @@ void SourceToolbar::SaveOldProperties(obs_source_t *source)
 	obs_data_release(oldSettings);
 }
 
-void SourceToolbar::SetUndoProperties(obs_source_t *source)
+void SourceToolbar::SetUndoProperties(obs_source_t *source, bool repeatable)
 {
 	if (!oldData) {
 		blog(LOG_ERROR, "%s: somehow oldData was null.", __FUNCTION__);
@@ -87,7 +87,7 @@ void SourceToolbar::SetUndoProperties(obs_source_t *source)
 		main->undo_s.add_action(
 			QTStr("Undo.Properties")
 				.arg(obs_source_get_name(source)),
-			undo_redo, undo_redo, undo_data, redo_data);
+			undo_redo, undo_redo, undo_data, redo_data, repeatable);
 
 	obs_data_release(new_settings);
 	obs_data_release(curr_settings);
@@ -737,8 +737,12 @@ void TextSourceToolbar::on_text_textChanged()
 		return;
 	}
 
+	SaveOldProperties(source);
+
 	obs_data_t *settings = obs_data_create();
 	obs_data_set_string(settings, "text", QT_TO_UTF8(ui->text->text()));
 	obs_source_update(source, settings);
 	obs_data_release(settings);
+
+	SetUndoProperties(source, true);
 }

--- a/UI/context-bar-controls.hpp
+++ b/UI/context-bar-controls.hpp
@@ -25,7 +25,7 @@ protected:
 	OBSData oldData;
 
 	void SaveOldProperties(obs_source_t *source);
-	void SetUndoProperties(obs_source_t *source);
+	void SetUndoProperties(obs_source_t *source, bool repeatable = false);
 
 public:
 	SourceToolbar(QWidget *parent, OBSSource source);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds undo/redo for when users change the text of a text source in the context bar.
Makes use of the `repeatable` undo/redo function (I really love that function!); making
sure that there aren't 10 new entries in the undo stack after typing 10 letters.
(Delay needed to create a new action should be three seconds according to `ae5ac8fa8`)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This doesn't have undo/redo as of right now, but it should.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0.1, compiled and run

Undo and redo correctly get added. If multiple letters are typed/removed, those changes will get undone/redone all at once unless a lot of time has passed between typing those letters.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
