### PR TITLE
Fix FFmpeg deprecations up to FFmpeg 4.4 and current FFmpeg git

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -608,7 +608,11 @@ static int interrupt_callback(void *data)
 
 static bool init_avformat(mp_media_t *m)
 {
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(59, 0, 100)
 	AVInputFormat *format = NULL;
+#else
+	const AVInputFormat *format = NULL;
+#endif
 
 	if (m->format_name && *m->format_name) {
 		format = av_find_input_format(m->format_name);

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -452,10 +452,10 @@ static void create_audio_stream(struct ffmpeg_mux *ffm, int idx)
 	context->extradata_size = ffm->audio_header[idx].size;
 	context->channel_layout =
 		av_get_default_channel_layout(context->channels);
-	//AVlib default channel layout for 4 channels is 4.0 ; fix for quad
+	//avutil default channel layout for 4 channels is 4.0 ; fix for quad
 	if (context->channels == 4)
 		context->channel_layout = av_get_channel_layout("quad");
-	//AVlib default channel layout for 5 channels is 5.0 ; fix for 4.1
+	//avutil default channel layout for 5 channels is 5.0 ; fix for 4.1
 	if (context->channels == 5)
 		context->channel_layout = av_get_channel_layout("4.1");
 	if (ffm->output->oformat->flags & AVFMT_GLOBALHEADER)

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -27,6 +27,7 @@
 #include "ffmpeg-mux.h"
 
 #include <util/dstr.h>
+#include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 
 #define ANSI_COLOR_RED "\x1b[0;91m"

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -565,7 +565,11 @@ static inline bool ffmpeg_mux_get_extra_data(struct ffmpeg_mux *ffm)
 
 static inline int open_output_file(struct ffmpeg_mux *ffm)
 {
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(59, 0, 100)
 	AVOutputFormat *format = ffm->output->oformat;
+#else
+	const AVOutputFormat *format = ffm->output->oformat;
+#endif
 	int ret;
 
 	if ((format->flags & AVFMT_NOFILE) == 0) {
@@ -631,7 +635,11 @@ static bool ffmpeg_mux_is_network(struct ffmpeg_mux *ffm)
 
 static int ffmpeg_mux_init_context(struct ffmpeg_mux *ffm)
 {
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(59, 0, 100)
 	AVOutputFormat *output_format;
+#else
+	const AVOutputFormat *output_format;
+#endif
 	int ret;
 	bool is_http = false;
 	is_http = (strncmp(ffm->params.file, HTTP_PROTO,
@@ -665,8 +673,10 @@ static int ffmpeg_mux_init_context(struct ffmpeg_mux *ffm)
 		return FFM_ERROR;
 	}
 
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(59, 0, 100)
 	ffm->output->oformat->video_codec = AV_CODEC_ID_NONE;
 	ffm->output->oformat->audio_codec = AV_CODEC_ID_NONE;
+#endif
 
 	if (!init_streams(ffm)) {
 		free_avformat(ffm);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
@@ -21,6 +21,7 @@
 #include <util/dstr.h>
 #include <obs-module.h>
 
+#include <libavutil/channel_layout.h>
 #include <libavutil/opt.h>
 #include <libavformat/avformat.h>
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-formats.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-formats.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <libavcodec/avcodec.h>
+
 static inline int64_t rescale_ts(int64_t val, AVCodecContext *context,
 				 AVRational new_base)
 {

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -24,6 +24,7 @@
 
 #include <libavutil/opt.h>
 #include <libavutil/pixdesc.h>
+#include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 
 #include "obs-ffmpeg-formats.h"

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -345,7 +345,7 @@ static bool create_audio_stream(struct ffmpeg_data *data, int idx)
 	context->channel_layout =
 		av_get_default_channel_layout(context->channels);
 
-	//AVlib default channel layout for 5 channels is 5.0 ; fix for 4.1
+	//avutil default channel layout for 5 channels is 5.0 ; fix for 4.1
 	if (aoi.speakers == SPEAKERS_4POINT1)
 		context->channel_layout = av_get_channel_layout("4.1");
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.h
@@ -2,6 +2,7 @@
 
 #include <libavutil/opt.h>
 #include <libavutil/pixdesc.h>
+#include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -180,7 +180,9 @@ static bool nvenc_supported(void)
 	bool success = false;
 
 	if (!nvenc) {
-		goto cleanup;
+		nvenc = avcodec_find_encoder_by_name("h264_nvenc");
+		if (!nvenc)
+			goto cleanup;
 	}
 
 #if defined(_WIN32)

--- a/plugins/win-dshow/ffmpeg-decode.c
+++ b/plugins/win-dshow/ffmpeg-decode.c
@@ -377,7 +377,7 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode, uint8_t *data,
 
 	frame->range = range;
 
-	*ts = decode->frame->pkt_pts;
+	*ts = decode->frame->pts;
 
 	frame->width = decode->frame->width;
 	frame->height = decode->frame->height;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
These commits address various FFmpeg changes, and deprecations.  They also address removals of deprecated code post FFmpeg 4.x.

Details about the changes and why they are needed are in each commit message.  As far as I can tell, these changes are compatible for the entire FFmpeg 4.x series, and _should_ be fine for FFmpeg 3.2+ releases.

Big thanks to @pkviet who helped me with this!


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

These changes allow us to use FFmpeg 4.4+ up to FFmpeg to FFmpeg/FFmpeg@9d4989f2e17c11d4ee9daa489b6e4f5195d80b99.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

On Windows 10 with FFmpeg 4.2.4, FFmpeg 4.4.1, and FFmpeg git (ffmpeg-N-104473-g9d4989f2e1, FFmpeg/FFmpeg@9d4989f2e17c11d4ee9daa489b6e4f5195d80b99), I successfully tested:
* streaming to Twitch with NVENC and x264
* recording to MKV and MP4 with NVENC, x264, and QSV
* Color Source with Color Correction filter
* Media Source with local files (MP4; WEBM with transparency)
* Media Source with Chroma Key filter
* Image Source with JPG and animated GIF
* Text Source (both GDI+ and FreeType2)
* Video Capture Device
* VLC Source with multiple files selected

Resulting recordings seems fine in VLC.

Needs additional testing on macOS and Linux, for which assistance would be appreciated.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
