### PR TITLE
libobs: Add obs_get_transition_by_name

### DIFF
--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -262,6 +262,15 @@ Libobs Objects
 
 ---------------------
 
+.. function:: obs_source_t *obs_get_transition_by_name(const char *name)
+
+   Gets a transition by its name.
+  
+   Increments the source reference counter, use
+   :c:func:`obs_source_release()` to release it when complete.
+
+---------------------
+
 .. function:: obs_output_t *obs_get_output_by_name(const char *name)
 
    Gets an output by its name.

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1593,6 +1593,27 @@ obs_source_t *obs_get_source_by_name(const char *name)
 				   obs_source_addref_safe_);
 }
 
+obs_source_t *obs_get_transition_by_name(const char *name)
+{
+	struct obs_source **first = &obs->data.first_source;
+	struct obs_source *source;
+
+	pthread_mutex_lock(&obs->data.sources_mutex);
+
+	source = *first;
+	while (source) {
+		if (source->info.type == OBS_SOURCE_TYPE_TRANSITION &&
+		    strcmp(source->context.name, name) == 0) {
+			source = obs_source_addref_safe_(source);
+			break;
+		}
+		source = (void *)source->context.next;
+	}
+
+	pthread_mutex_unlock(&obs->data.sources_mutex);
+	return source;
+}
+
 obs_output_t *obs_get_output_by_name(const char *name)
 {
 	return get_context_by_name(&obs->data.first_output, name,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -636,6 +636,9 @@ EXPORT void obs_enum_services(bool (*enum_proc)(void *, obs_service_t *),
  */
 EXPORT obs_source_t *obs_get_source_by_name(const char *name);
 
+/** Get a transition source by its name. */
+EXPORT obs_source_t *obs_get_transition_by_name(const char *name);
+
 /** Gets an output by its name. */
 EXPORT obs_output_t *obs_get_output_by_name(const char *name);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a function that gets a transition by its name. Like `obs_get_source_by_name`, but for transitions.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
`obs_get_source_by_name` has the limitation that it doesn't get private sources.
This new method makes obsproject/obs-browser#312 much cleaner.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0.1, compiled and run.
Tested with obsproject/obs-browser#312.
If a transition exists, it will get returned, otherwise it will return null (like `obs_get_source_by_name`).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
