### PR TITLE
win-virtualcam: Make sure virtualcam output thread safe

### DIFF
--- a/plugins/win-dshow/virtualcam.c
+++ b/plugins/win-dshow/virtualcam.c
@@ -1,10 +1,13 @@
 #include <obs-module.h>
 #include <util/platform.h>
+#include "util/threading.h"
 #include "shared-memory-queue.h"
 
 struct virtualcam_data {
 	obs_output_t *output;
 	video_queue_t *vq;
+	volatile bool active;
+	volatile bool stopping;
 };
 
 static const char *virtualcam_name(void *unused)
@@ -62,19 +65,31 @@ static bool virtualcam_start(void *data)
 	vsi.height = height;
 	obs_output_set_video_conversion(vcam->output, &vsi);
 
+	os_atomic_set_bool(&vcam->active, true);
+	os_atomic_set_bool(&vcam->stopping, false);
 	blog(LOG_INFO, "Virtual output started");
 	obs_output_begin_data_capture(vcam->output, 0);
 	return true;
 }
 
-static void virtualcam_stop(void *data, uint64_t ts)
+static void virtualcam_deactive(struct virtualcam_data *vcam)
 {
-	struct virtualcam_data *vcam = (struct virtualcam_data *)data;
 	obs_output_end_data_capture(vcam->output);
 	video_queue_close(vcam->vq);
 	vcam->vq = NULL;
 
+	os_atomic_set_bool(&vcam->active, false);
+	os_atomic_set_bool(&vcam->stopping, false);
+
 	blog(LOG_INFO, "Virtual output stopped");
+}
+
+static void virtualcam_stop(void *data, uint64_t ts)
+{
+	struct virtualcam_data *vcam = (struct virtualcam_data *)data;
+	os_atomic_set_bool(&vcam->stopping, true);
+
+	blog(LOG_INFO, "Virtual output stopping");
 
 	UNUSED_PARAMETER(ts);
 }
@@ -85,6 +100,14 @@ static void virtual_video(void *param, struct video_data *frame)
 
 	if (!vcam->vq)
 		return;
+
+	if (!os_atomic_load_bool(&vcam->active))
+		return;
+
+	if (os_atomic_load_bool(&vcam->stopping)) {
+		virtualcam_deactive(vcam);
+		return;
+	}
 
 	video_queue_write(vcam->vq, frame->data, frame->linesize,
 			  frame->timestamp);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Modify Windows virtualcam output to make sure it's thread safe. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The virtualcam output for Windows is not thread safe.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows 10.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
