### PR TITLE
obs-transitions: Fix stinger transition looping

### DIFF
--- a/plugins/obs-transitions/transition-stinger.c
+++ b/plugins/obs-transitions/transition-stinger.c
@@ -73,6 +73,7 @@ static void stinger_update(void *data, obs_data_t *settings)
 	obs_data_t *media_settings = obs_data_create();
 	obs_data_set_string(media_settings, "local_file", path);
 	obs_data_set_bool(media_settings, "hw_decode", hw_decode);
+	obs_data_set_bool(media_settings, "looping", false);
 
 	obs_source_release(s->media_source);
 	struct dstr name;
@@ -119,6 +120,7 @@ static void stinger_update(void *data, obs_data_t *settings)
 
 		obs_data_t *tm_media_settings = obs_data_create();
 		obs_data_set_string(tm_media_settings, "local_file", tm_path);
+		obs_data_set_bool(tm_media_settings, "looping", false);
 
 		s->matte_source = obs_source_create_private(
 			"ffmpeg_source", NULL, tm_media_settings);


### PR DESCRIPTION
### Description
Fix showing the first part of the stinger again at the end of the transition

### Motivation and Context
sometimes a stinger transition flashes the first frames at the end of the track matte stinger transition

### How Has This Been Tested?
On windows 64bit by breaking the process during the track matte stinger transition

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
