### PR TITLE
obs-qsv11: Remove Intel discrete device ID checking

### DIFF
--- a/plugins/obs-qsv11/QSV_Encoder.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder.cpp
@@ -79,7 +79,6 @@ bool prefer_igpu_enc(int *iGPUIndex)
 	int adapterIndex = 0;
 	bool hasIGPU = false;
 	bool hasDGPU = false;
-	bool isDG1Primary = false;
 
 	HMODULE hDXGI = LoadLibrary(L"dxgi.dll");
 	if (hDXGI == NULL) {
@@ -109,6 +108,7 @@ bool prefer_igpu_enc(int *iGPUIndex)
 		return false;
 	}
 
+	// Check for i+I cases (Intel discrete + Intel integrated graphics on the same system). Default will be integrated.
 	while (SUCCEEDED(pFactory->EnumAdapters(adapterIndex, &pAdapter))) {
 		DXGI_ADAPTER_DESC AdapterDesc = {};
 		if (SUCCEEDED(pAdapter->GetDesc(&AdapterDesc))) {
@@ -122,13 +122,6 @@ bool prefer_igpu_enc(int *iGPUIndex)
 				} else {
 					hasDGPU = true;
 				}
-				if ((AdapterDesc.DeviceId == 0x4905) ||
-				    (AdapterDesc.DeviceId == 0x4906) ||
-				    (AdapterDesc.DeviceId == 0x4907)) {
-					if (adapterIndex == 0) {
-						isDG1Primary = true;
-					}
-				}
 			}
 		}
 		adapterIndex++;
@@ -138,7 +131,7 @@ bool prefer_igpu_enc(int *iGPUIndex)
 	pFactory->Release();
 	FreeLibrary(hDXGI);
 
-	return hasIGPU && hasDGPU && isDG1Primary;
+	return hasIGPU && hasDGPU;
 }
 
 void qsv_encoder_version(unsigned short *major, unsigned short *minor)

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -752,12 +752,6 @@ static void *obs_qsv_create_tex(obs_data_t *settings, obs_encoder_t *encoder)
 		return obs_encoder_create_rerouted(encoder, "obs_qsv11_soft");
 	}
 
-	if (prefer_igpu_enc(NULL)) {
-		blog(LOG_INFO,
-		     ">>> prefer iGPU encoding, fall back to old qsv encoder");
-		return obs_encoder_create_rerouted(encoder, "obs_qsv11_soft");
-	}
-
 	blog(LOG_INFO, ">>> new qsv encoder");
 	return obs_qsv_create(settings, encoder);
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This commit removes the old checking of Intel discrete device IDs and sets the default to integrated when Intel discrete and integrated graphics (i+I) are co-existing on the platform. 

### Motivation and Context
As Intel continues to add discrete graphics cards, maintaining a long list of discrete device IDs to check against isn't wise. When i+I platforms are detected, default to integrated graphics. 

### How Has This Been Tested?
Tested with the following scenarios:
- i+I: RKL+DG2, TGL+DG2, ADL+DG2
- DG2 only: TGL
- Monitor connected to iGPU in i+I cases and user selection of OBS on iGPU/dGPU (Low Power/High Performance Graphics Settings)
- Monitor connected to dGPU in i+I cases and user selection of OBS on iGPU/dGPU (Low Power/High Performance Graphics Settings)
- DG2 A0 128 EU, DG2 A0 512 EU and DG2 B0 512 EU cards

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
