### PR TITLE
UI: Add obs_frontend_get_current_record_output_path()

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -618,6 +618,13 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 					  Q_ARG(OBSSource, OBSSource(source)));
 	}
 
+	char *obs_frontend_get_current_record_output_path(void) override
+	{
+		const char *recordOutputPath = main->GetCurrentOutputPath();
+
+		return bstrdup(recordOutputPath);
+	}
+
 	void on_load(obs_data_t *settings) override
 	{
 		for (size_t i = saveCallbacks.size(); i > 0; i--) {

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -546,3 +546,10 @@ void obs_frontend_open_source_filters(obs_source_t *source)
 	if (callbacks_valid())
 		c->obs_frontend_open_source_filters(source);
 }
+
+char *obs_frontend_get_current_record_output_path(void)
+{
+	return !!callbacks_valid()
+		       ? c->obs_frontend_get_current_record_output_path()
+		       : nullptr;
+}

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -220,6 +220,8 @@ EXPORT void obs_frontend_reset_video(void);
 EXPORT void obs_frontend_open_source_properties(obs_source_t *source);
 EXPORT void obs_frontend_open_source_filters(obs_source_t *source);
 
+EXPORT char *obs_frontend_get_current_record_output_path(void);
+
 /* ------------------------------------------------------------------------- */
 
 #ifdef __cplusplus

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -138,6 +138,8 @@ struct obs_frontend_callbacks {
 	virtual void
 	obs_frontend_open_source_properties(obs_source_t *source) = 0;
 	virtual void obs_frontend_open_source_filters(obs_source_t *source) = 0;
+
+	virtual char *obs_frontend_get_current_record_output_path(void) = 0;
 };
 
 EXPORT void

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -680,3 +680,10 @@ Functions
    Opens the filters window of the specified source.
 
    :param source: The source to open the filters window of.
+
+---------------------------------------
+
+.. function:: char *obs_frontend_get_current_record_output_path(void)
+
+   :return: A new pointer to the current record output path. Free
+            with :c:func:`bfree()`.


### PR DESCRIPTION
### Description
Returns the current path of the record output.

### Motivation and Context
obs-websocket currently reimplements the `GetCurrentOutputPath()` function. To avoid future breakages (we have already had to update our side once), this allows us to fetch it directly from OBS.

### How Has This Been Tested?
Same tests as #4525 

### Types of changes
- New feature (non-breaking change which adds functionality)
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
