### PR TITLE
UI,libobs: Fix delete scene undo problems

### DIFF
--- a/docs/sphinx/reference-scenes.rst
+++ b/docs/sphinx/reference-scenes.rst
@@ -265,6 +265,12 @@ General Scene Functions
 
 ---------------------
 
+.. function:: void obs_scene_prune_sources(obs_scene_t *scene)
+
+   Releases all sources from a scene that have been marked as removed by obs_source_remove.
+
+---------------------
+
 
 .. _scene_item_reference:
 

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -3608,3 +3608,18 @@ obs_data_t *obs_sceneitem_transition_save(struct obs_scene_item *item,
 			      : item->hide_transition_duration);
 	return data;
 }
+
+void obs_scene_prune_sources(obs_scene_t *scene)
+{
+	DARRAY(struct obs_scene_item *) remove_items;
+	da_init(remove_items);
+
+	video_lock(scene);
+	update_transforms_and_prune_sources(scene, &remove_items.da, NULL);
+	video_unlock(scene);
+
+	for (size_t i = 0; i < remove_items.num; i++)
+		obs_sceneitem_release(remove_items.array[i]);
+
+	da_free(remove_items);
+}

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1819,6 +1819,7 @@ EXPORT void obs_sceneitem_transition_load(struct obs_scene_item *item,
 					  obs_data_t *data, bool show);
 EXPORT obs_data_t *obs_sceneitem_transition_save(struct obs_scene_item *item,
 						 bool show);
+EXPORT void obs_scene_prune_sources(obs_scene_t *scene);
 
 /* ------------------------------------------------------------------------- */
 /* Outputs */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR consists of three commits, hopefully fixing all undo shenanigans when deleting sources:

Commit 1 makes scenes listen to the removed signal of their source. When that signal is called, all
other scenes will check if they have removed sources, thus removing nested instances of the
scene that got deleted. This makes them release their references to that scene, letting it get destroyed
properly.
Previously, scenes would check for removed sources when they were rendered (and still do, that doesn't
change). However, this would mean that they had to be selected once in the scene list or get rendered 
otherwise to release their references. Without undo/redo, this wasn't a big problem (it only showed in
for example the name of the source still being in use), however undo/redo expects to have to re-create
the scene, causing issues when it wasn't deleted before.

Commit 2 overhauls what gets stored in the undo data when deleting sources, and fixes the deleted
scene not getting added back to scenes it was nested in when undoing the deletion.
Firstly, the undo data json now differentiates between the deleted scene itself (including the sources in
it) and the scenes/groups it was nested in. #4916 relied on sceneitems of the scene still existing in other
scenes when the source got re-added. This lead to the scene only getting re-added when the the scene
it was nested in wasn't rendered in the meantime (see description of 1), leading to weird and sometimes
unpredictable-seeming behaviour.
The differentiation between the scene itself and scenes/groups it's nested in leads to more controllable
behaviour that should be less prone to bugs.
I added a few comments in my code explaining the individual steps, I hope they are understandable.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
"Follow-up" from #5495, after #5515 revealed some more problems.
I also discovered more weirdness along the way, that should all be fixed with this PR.

Fixes #5515

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0.1, compiled and run

I tried quite a few configurations of scenes being nested in other scenes, including in groups. These
include the configurations of #5515 and #5495.
Most of them would break on undo in 27.1.3, but there wasn't a single one that would be
re-created incorrectly with this PR.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
