### PR TITLE
Updated Info.plist with new bool syntax

### DIFF
--- a/CI/scripts/macos/app/Info.plist
+++ b/CI/scripts/macos/app/Info.plist
@@ -17,9 +17,9 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>10.13.0</string>
 	<key>NSHighResolutionCapable</key>
-	<true/>
+	<string>True</string>
 	<key>LSAppNapIsDisabled</key>
-	<true/>
+	<string>True</string>
 	<key>NSCameraUsageDescription</key>
  	<string>OBS needs to access the camera to enable camera sources to work.</string>
  	<key>NSMicrophoneUsageDescription</key>


### PR DESCRIPTION
I'm not sure if I missread this, or if it's simply wrong, but I've lookedup the defaults man page (https://ss64.com/osx/defaults.html) and also found this:
https://stackoverflow.com/questions/1832157/setting-a-boolean-property-in-info-plist-from-a-user-defined-setting (maybe just on iOS?)
And some other materials saying the <true/> <false/> tags are no longer valid, and <string></string> with either TRUE/FALSE or YES/NO, should be used.
