### PR TITLE
UI: Update python linkage for older compilers

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -160,15 +160,6 @@ elseif(UNIX)
 		Qt5::Gui
 		Qt5::GuiPrivate)
 
-	# python symbols must be in the global symbol table
-	# so we link the main executable to python if we expect
-	# obs-scripting python support to be enabled.
-	# see: https://github.com/obsproject/obs-studio/issues/2222 and https://bugs.python.org/issue36721
-	if(NOT DISABLE_PYTHON AND PYTHONLIBS_FOUND)
-		set(obs_PLATFORM_LIBRARIES
-			${obs_PLATFORM_LIBRARIES}
-			${PYTHON_LIBRARIES})
-	endif()
 
 	if("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
 		list(APPEND obs_PLATFORM_LIBRARIES
@@ -487,6 +478,19 @@ install_obs_data_file(obs ../AUTHORS obs-studio/authors)
 
 if (UNIX AND UNIX_STRUCTURE AND NOT APPLE)
 	add_subdirectory(xdg-data)
+endif()
+
+if (UNIX AND NOT APPLE)
+	# python symbols must be in the global symbol table
+	# so we link the main executable to python if we expect
+	# obs-scripting python support to be enabled.
+	# see: https://github.com/obsproject/obs-studio/issues/2222 and https://bugs.python.org/issue36721
+	if(NOT DISABLE_PYTHON AND PYTHONLIBS_FOUND)
+		target_link_libraries(obs ${PYTHON_LIBRARIES})
+		set_target_properties(obs PROPERTIES LINK_FLAGS "-Wl,--no-as-needed")
+		# Use this after cmake 3.13 aka we drop ubuntu 18.04.
+		# target_link_options(obs PRIVATE "LINKER:-no-as-needed")
+	endif()
 endif()
 
 add_subdirectory(frontend-plugins)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Move the python linkage after the obs target is defined so that we can
also add linker flags to preserve the unused python linkage. This is
required before GCC 11.

Pat suggested `target_link_options` but this is only available on cmake 3.13 which is not available in ubuntu 18.04 so I switched it to the deprecated LINKER_FLAGS property.  I left this in a comment in case.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Previous fix would not work on our PPAs.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on ubuntu 18/20 and this works there as well now.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
