### PR TITLE
win-virtualcam: Make placeholder fit to virtualcam resolution

### DIFF
--- a/plugins/win-dshow/virtualcam-module/virtualcam-filter.cpp
+++ b/plugins/win-dshow/virtualcam-module/virtualcam-filter.cpp
@@ -7,7 +7,7 @@
 
 using namespace DShow;
 
-extern bool initialize_placeholder();
+extern bool initialize_placeholder(int dest_cx, int dest_cy);
 extern const uint8_t *get_placeholder_ptr();
 extern const bool get_placeholder_size(int *out_cx, int *out_cy);
 
@@ -167,7 +167,7 @@ void VCamFilter::Thread()
 	/* ---------------------------------------- */
 	/* load placeholder image                   */
 
-	if (initialize_placeholder()) {
+	if (initialize_placeholder(cx, cy)) {
 		placeholder.source_data = get_placeholder_ptr();
 		get_placeholder_size(&placeholder.cx, &placeholder.cy);
 	} else {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This commit makes placeholer for win-virtualcam fit to virtualcam resolution instead of stretching.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Currently, the placeholder is stretched to resolution of virtualcam, looks like this:

![1636621826](https://user-images.githubusercontent.com/13063763/141747897-fda1e4b4-210b-4bb8-b499-3158d3764757.png)

I think fitting to the virtualcam resolution might looks better, just like this:

![1636621890](https://user-images.githubusercontent.com/13063763/141748125-401a61ad-b06c-4c4d-99b7-392870093fd5.png)


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows 10 64bit

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality) 
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
