### PR TITLE
UI: Set replay buffer checkbox to true

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1409,7 +1409,7 @@ bool OBSBasic::InitBasicConfigDefaults()
 				  "hq");
 	config_set_default_string(basicConfig, "SimpleOutput", "RecQuality",
 				  "Stream");
-	config_set_default_bool(basicConfig, "SimpleOutput", "RecRB", false);
+	config_set_default_bool(basicConfig, "SimpleOutput", "RecRB", true);
 	config_set_default_int(basicConfig, "SimpleOutput", "RecRBTime", 20);
 	config_set_default_int(basicConfig, "SimpleOutput", "RecRBSize", 512);
 	config_set_default_string(basicConfig, "SimpleOutput", "RecRBPrefix",
@@ -1450,7 +1450,7 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_uint(basicConfig, "AdvOut", "Track5Bitrate", 160);
 	config_set_default_uint(basicConfig, "AdvOut", "Track6Bitrate", 160);
 
-	config_set_default_bool(basicConfig, "AdvOut", "RecRB", false);
+	config_set_default_bool(basicConfig, "AdvOut", "RecRB", true);
 	config_set_default_uint(basicConfig, "AdvOut", "RecRBTime", 20);
 	config_set_default_int(basicConfig, "AdvOut", "RecRBSize", 512);
 


### PR DESCRIPTION
### Description
This sets the replay buffer checkbox to be true, by default,
in the settings.

### Motivation and Context
As this is one of the main features, its checkbox should be enabled in the settings by default. Currently if the user wants to enable the feature, they have to go to the output settings, enable the replay buffer, and to set a hotkey, they have to apply the settings and go to the hotkeys section to enable it. This can be cumbersome for new users.

### How Has This Been Tested?
Ran OBS to make sure the replay buffer button shows up on new install.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
