### PR TITLE
libobs: Fix gs_texture_2d::BackupTexture with GS_TEXTURE_CUBE

### DIFF
--- a/libobs-d3d11/d3d11-texture2d.cpp
+++ b/libobs-d3d11/d3d11-texture2d.cpp
@@ -50,26 +50,31 @@ void gs_texture_2d::InitSRD(vector<D3D11_SUBRESOURCE_DATA> &srd)
 
 void gs_texture_2d::BackupTexture(const uint8_t *const *data)
 {
-	this->data.resize(levels);
-
-	uint32_t w = width;
-	uint32_t h = height;
+	uint32_t textures = type == GS_TEXTURE_CUBE ? 6 : 1;
 	uint32_t bbp = gs_get_format_bpp(format);
 
-	for (uint32_t i = 0; i < levels; i++) {
-		if (!data[i])
-			break;
+	this->data.resize(levels * textures);
 
-		uint32_t texSize = bbp * w * h / 8;
-		this->data[i].resize(texSize);
+	for (uint32_t t = 0; t < textures; t++) {
+		uint32_t w = width;
+		uint32_t h = height;
 
-		vector<uint8_t> &subData = this->data[i];
-		memcpy(&subData[0], data[i], texSize);
+		for (uint32_t lv = 0; lv < levels; lv++) {
+			uint32_t i = levels * t + lv;
+			if (!data[i])
+				break;
 
-		if (w > 1)
-			w /= 2;
-		if (h > 1)
-			h /= 2;
+			uint32_t texSize = bbp * w * h / 8;
+
+			vector<uint8_t> &subData = this->data[i];
+			subData.resize(texSize);
+			memcpy(&subData[0], data[i], texSize);
+
+			if (w > 1)
+				w /= 2;
+			if (h > 1)
+				h /= 2;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Cubemaps weren't even working properly before this. The gs_texture_2d::data vector did not take cubemaps into account. This code fixes that issue. -Jim

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Would be nice to have cubemaps working I suppose. -Jim

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested by Jim -Jim

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
