### PR TITLE
UI: Move Docks into top level menu

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -112,7 +112,7 @@ ChromeOS.Text="OBS appears to be running inside a ChromeOS container. This platf
 
 # warning when closing docks. it's frustrating that we actually need this.
 DockCloseWarning.Title="Closing Dockable Window"
-DockCloseWarning.Text="You just closed a dockable window. If you'd like to show it again, use the View → Docks menu on the menu bar."
+DockCloseWarning.Text="You just closed a dockable window. If you'd like to show it again, use the Docks menu on the menu bar."
 
 # extra browser panels dialog
 ExtraBrowsers="Custom Browser Docks"
@@ -235,7 +235,7 @@ Basic.Stats.DiskFullIn="Disk full in (approx.)"
 Basic.Stats.ResetStats="Reset Stats"
 
 ResetUIWarning.Title="Are you sure you want to reset the UI?"
-ResetUIWarning.Text="Resetting the UI will hide additional docks. You will need to unhide these docks from the view menu if you want them to be visible.\n\nAre you sure you want to reset the UI?"
+ResetUIWarning.Text="Resetting the UI will hide additional docks. You will need to unhide these docks from the Docks menu if you want them to be visible.\n\nAre you sure you want to reset the UI?"
 
 # updater
 Updater.Title="New update available"
@@ -714,16 +714,18 @@ Basic.MainMenu.Edit.AdvAudio="&Advanced Audio Properties"
 # basic mode view menu
 Basic.MainMenu.View="&View"
 Basic.MainMenu.View.Toolbars="&Toolbars"
-Basic.MainMenu.View.Docks="Docks"
-Basic.MainMenu.View.Docks.ResetUI="Reset UI"
-Basic.MainMenu.View.Docks.LockUI="Lock UI"
-Basic.MainMenu.View.Docks.CustomBrowserDocks="Custom Browser Docks..."
 Basic.MainMenu.View.ListboxToolbars="Scene/Source List Buttons"
 Basic.MainMenu.View.ContextBar="Source Toolbar"
 Basic.MainMenu.View.SceneTransitions="S&cene Transitions"
 Basic.MainMenu.View.SourceIcons="Source &Icons"
 Basic.MainMenu.View.StatusBar="&Status Bar"
 Basic.MainMenu.View.Fullscreen.Interface="Fullscreen Interface"
+
+#basic mode docks menu
+Basic.MainMenu.Docks="Docks"
+Basic.MainMenu.Docks.ResetUI="Reset UI"
+Basic.MainMenu.Docks.LockUI="Lock UI"
+Basic.MainMenu.Docks.CustomBrowserDocks="Custom Browser Docks..."
 
 # basic mode profile/scene collection menus
 Basic.MainMenu.SceneCollection="&Scene Collection"

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -654,20 +654,6 @@
     <property name="title">
      <string>Basic.MainMenu.View</string>
     </property>
-    <widget class="QMenu" name="viewMenuDocks">
-     <property name="title">
-      <string>Basic.MainMenu.View.Docks</string>
-     </property>
-     <addaction name="resetUI"/>
-     <addaction name="lockUI"/>
-     <addaction name="separator"/>
-     <addaction name="toggleScenes"/>
-     <addaction name="toggleSources"/>
-     <addaction name="toggleMixer"/>
-     <addaction name="toggleTransitions"/>
-     <addaction name="toggleControls"/>
-     <addaction name="toggleStats"/>
-    </widget>
     <action name="actionFullscreenInterface">
      <property name="text">
       <string>Basic.MainMenu.View.Fullscreen.Interface</string>
@@ -678,7 +664,6 @@
     </action>
     <addaction name="actionFullscreenInterface"/>
     <addaction name="separator"/>
-    <addaction name="viewMenuDocks"/>
     <addaction name="toggleListboxToolbars"/>
     <addaction name="toggleContextBar"/>
     <addaction name="toggleSourceIcons"/>
@@ -693,9 +678,24 @@
     <addaction name="autoConfigure"/>
     <addaction name="separator"/>
    </widget>
+   <widget class="QMenu" name="menuDocks">
+    <property name="title">
+     <string>Basic.MainMenu.Docks</string>
+    </property>
+    <addaction name="lockUI"/>
+    <addaction name="resetUI"/>
+    <addaction name="separator"/>
+    <addaction name="toggleScenes"/>
+    <addaction name="toggleSources"/>
+    <addaction name="toggleMixer"/>
+    <addaction name="toggleTransitions"/>
+    <addaction name="toggleControls"/>
+    <addaction name="toggleStats"/>
+   </widget>
    <addaction name="menu_File"/>
    <addaction name="menuBasic_MainMenu_Edit"/>
    <addaction name="viewMenu"/>
+   <addaction name="menuDocks"/>
    <addaction name="profileMenu"/>
    <addaction name="sceneCollectionMenu"/>
    <addaction name="menuTools"/>
@@ -1959,7 +1959,7 @@
   </action>
   <action name="resetUI">
    <property name="text">
-    <string>Basic.MainMenu.View.Docks.ResetUI</string>
+    <string>Basic.MainMenu.Docks.ResetUI</string>
    </property>
   </action>
   <action name="lockUI">
@@ -1970,7 +1970,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Basic.MainMenu.View.Docks.LockUI</string>
+    <string>Basic.MainMenu.Docks.LockUI</string>
    </property>
   </action>
   <action name="toggleScenes">

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1964,14 +1964,13 @@ void OBSBasic::OBSInit()
 
 #ifdef BROWSER_AVAILABLE
 	if (cef) {
-		QAction *action = new QAction(QTStr("Basic.MainMenu."
-						    "View.Docks."
+		QAction *action = new QAction(QTStr("Basic.MainMenu.Docks."
 						    "CustomBrowserDocks"),
 					      this);
-		ui->viewMenuDocks->insertAction(ui->toggleScenes, action);
+		ui->menuDocks->insertAction(ui->toggleScenes, action);
 		connect(action, &QAction::triggered, this,
 			&OBSBasic::ManageExtraBrowserDocks);
-		ui->viewMenuDocks->insertSeparator(ui->toggleScenes);
+		ui->menuDocks->insertSeparator(ui->toggleScenes);
 
 		LoadExtraBrowserDocks();
 	}
@@ -9417,7 +9416,7 @@ void OBSBasic::ResizeOutputSizeOfSource()
 
 QAction *OBSBasic::AddDockWidget(QDockWidget *dock)
 {
-	QAction *action = ui->viewMenuDocks->addAction(dock->windowTitle());
+	QAction *action = ui->menuDocks->addAction(dock->windowTitle());
 	action->setCheckable(true);
 	assignDockToggle(dock, action);
 	extraDocks.push_back(dock);
@@ -9794,7 +9793,7 @@ void OBSBasic::on_customContextMenuRequested(const QPoint &pos)
 		className = widget->metaObject()->className();
 
 	if (!className || strstr(className, "Dock") != nullptr)
-		ui->viewMenuDocks->exec(mapToGlobal(pos));
+		ui->menuDocks->exec(mapToGlobal(pos));
 }
 
 void OBSBasic::UpdateProjectorHideCursor()


### PR DESCRIPTION
### Description
Moves the Docks menu out of the View menu and on to the top level

![image](https://user-images.githubusercontent.com/1554753/142558577-699f9dd3-88ff-4a5d-9043-2bfde10b321c.png)

### Motivation and Context
OBS UI docks are a core feature and as such should be at the top level of the menu

### How Has This Been Tested?
Ensured all dock menu entries still function as intended, including custom browser docks and service integration docks

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
