### PR TITLE
UI: Use std::gcd for aspect ratio

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -294,14 +294,9 @@ static void PopulateAACBitrates(initializer_list<QComboBox *> boxes)
 	}
 }
 
-static int gcd(int a, int b)
-{
-	return b == 0 ? a : gcd(b, a % b);
-}
-
 static std::tuple<int, int> aspect_ratio(int cx, int cy)
 {
-	int common = gcd(cx, cy);
+	int common = std::gcd(cx, cy);
 	int newCX = cx / common;
 	int newCY = cy / common;
 


### PR DESCRIPTION
### Description
This removes our own code for gcd, as it is already built into cpp.

### Motivation and Context
Code cleanup.

### How Has This Been Tested?
Open settings to see if the aspect ratio still worked.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
