### PR TITLE
inject-helper: Remove UNUSED_PARAMETER macro

### DIFF
--- a/plugins/win-capture/inject-helper/inject-helper.c
+++ b/plugins/win-capture/inject-helper/inject-helper.c
@@ -92,12 +92,11 @@ static int inject_helper(wchar_t *argv[], const wchar_t *dll)
 			       : inject_library_full(id, dll);
 }
 
-#define UNUSED_PARAMETER(x) ((void)(x))
-
-int main(int argc, char *argv_ansi[])
+int main(void)
 {
 	wchar_t dll_path[MAX_PATH];
 	LPWSTR pCommandLineW;
+	int argc;
 	LPWSTR *argv;
 	int ret = INJECT_ERROR_INVALID_PARAMS;
 
@@ -106,14 +105,14 @@ int main(int argc, char *argv_ansi[])
 
 	pCommandLineW = GetCommandLineW();
 	argv = CommandLineToArgvW(pCommandLineW, &argc);
-	if (argv && argc == 4) {
-		DWORD size = GetModuleFileNameW(NULL, dll_path, MAX_PATH);
-		if (size) {
-			ret = inject_helper(argv, argv[1]);
+	if (argv) {
+		if (argc == 4) {
+			if (GetModuleFileNameW(NULL, dll_path, MAX_PATH))
+				ret = inject_helper(argv, argv[1]);
 		}
-	}
-	LocalFree(argv);
 
-	UNUSED_PARAMETER(argv_ansi);
+		LocalFree(argv);
+	}
+
 	return ret;
 }


### PR DESCRIPTION
### Description
Potential definition clash with c99defs.h. Not needed anyway.

### Motivation and Context
Seeing warning in a branch where the symbols clash.

### How Has This Been Tested?
Verified injection still works for game capture.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.