### PR TITLE
ipc-util: Fix potential ready_event hang

### DIFF
--- a/deps/ipc-util/ipc-util/pipe-windows.h
+++ b/deps/ipc-util/ipc-util/pipe-windows.h
@@ -22,6 +22,7 @@ struct ipc_pipe_server {
 	OVERLAPPED overlap;
 	HANDLE handle;
 	HANDLE ready_event;
+	HANDLE stop_event;
 	HANDLE thread;
 
 	uint8_t *read_data;


### PR DESCRIPTION
### Description
There is an expectation that ready_event will signal/wake 1:1, so the
stray teardown signal may get lost. Add new stop_event for safety.

### Motivation and Context
OBS hang is bad.

This may not be common in practice because I can only repro the hang by altering timing using a debugger. Still better to be safe.

### How Has This Been Tested?
Manipulated timing to repro hang, and hang no longer occurs with new setup.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.