### PR TITLE
Screencast session restore for Wayland / PipeWire

### DIFF
--- a/plugins/linux-capture/pipewire-capture.c
+++ b/plugins/linux-capture/pipewire-capture.c
@@ -51,6 +51,11 @@ static void pipewire_capture_destroy(void *data)
 	obs_pipewire_destroy(data);
 }
 
+static void pipewire_capture_save(void *data, obs_data_t *settings)
+{
+	obs_pipewire_save(data, settings);
+}
+
 static void pipewire_capture_get_defaults(obs_data_t *settings)
 {
 	obs_pipewire_get_defaults(settings);
@@ -132,6 +137,7 @@ void pipewire_capture_load(void)
 		.get_name = pipewire_desktop_capture_get_name,
 		.create = pipewire_desktop_capture_create,
 		.destroy = pipewire_capture_destroy,
+		.save = pipewire_capture_save,
 		.get_defaults = pipewire_capture_get_defaults,
 		.get_properties = pipewire_capture_get_properties,
 		.update = pipewire_capture_update,

--- a/plugins/linux-capture/pipewire.h
+++ b/plugins/linux-capture/pipewire.h
@@ -35,6 +35,7 @@ void *obs_pipewire_create(enum obs_pw_capture_type capture_type,
 
 void obs_pipewire_destroy(obs_pipewire_data *obs_pw);
 
+void obs_pipewire_save(obs_pipewire_data *obs_pw, obs_data_t *settings);
 void obs_pipewire_get_defaults(obs_data_t *settings);
 
 obs_properties_t *obs_pipewire_get_properties(obs_pipewire_data *obs_pw,

--- a/plugins/linux-capture/portal.c
+++ b/plugins/linux-capture/portal.c
@@ -73,6 +73,22 @@ uint32_t portal_get_available_capture_types(void)
 	return available_source_types;
 }
 
+uint32_t portal_get_screencast_version(void)
+{
+	g_autoptr(GVariant) cached_version = NULL;
+	uint32_t version;
+
+	ensure_proxy();
+
+	if (!proxy)
+		return 0;
+
+	cached_version = g_dbus_proxy_get_cached_property(proxy, "version");
+	version = cached_version ? g_variant_get_uint32(cached_version) : 0;
+
+	return version;
+}
+
 GDBusConnection *portal_get_dbus_connection(void)
 {
 	ensure_proxy();

--- a/plugins/linux-capture/portal.h
+++ b/plugins/linux-capture/portal.h
@@ -24,6 +24,7 @@
 #include <gio/gio.h>
 
 uint32_t portal_get_available_capture_types(void);
+uint32_t portal_get_screencast_version(void);
 
 GDBusConnection *portal_get_dbus_connection(void);
 GDBusProxy *portal_get_dbus_proxy(void);


### PR DESCRIPTION
### Description

Implement restoring screencast sessions using portals. Do so by storing the restore token received by the portal in the source data, and using it next time the source is loaded. This feature is only available in the v4 version of the ScreenCast portal [1] - if an older version is running in the host system, the current behavior is preserved.

### Motivation and Context

Currently OBS Studio has to recreate screencast sessions from scratch each time a PipeWire source is loaded. This can be annoying,

Use the new screencast restore options provided by xdg-desktop-portal to restore previous sessions.

### How Has This Been Tested?

 - Have xdg-desktop-portal and xdg-desktop-portal-gnome  installed from the master/main branches [2]
 - Run this branch of OBS Studio on Wayland, or X11 with `OBS_USE_EGL=1`
 - Add a PipeWire source, and select a window or a monitor
 - Close OBS Studio
 - Open it again
 - Notice that the sources were restored automatically

### Types of changes

 - Tweak (non-breaking change to improve existing functionality) 

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

---

[1] https://github.com/flatpak/xdg-desktop-portal/pull/638
[2] This is **not** a GNOME-specific feature; it's just the only implementation available at this point. KDE folks reviewed and approved this new feature, and might be working on their implementation.