### PR TITLE
libobs: Free async cache when sources output NULL frames

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2940,7 +2940,11 @@ obs_source_output_video_internal(obs_source_t *source,
 		return;
 
 	if (!frame) {
+		pthread_mutex_lock(&source->async_mutex);
 		source->async_active = false;
+		source->last_frame_ts = 0;
+		free_async_cache(source);
+		pthread_mutex_unlock(&source->async_mutex);
 		return;
 	}
 


### PR DESCRIPTION
### Description
This PR fixes an issue where old frames, potentially hours old, can be redisplayed for a short period of time when an inactive async source begins outputting video again. The two sources that are known to have this bug are the ffmpeg source and VLC source.

### Motivation and Context
When sources output NULL frames, it is generally used to disable the source and prevent the last frame from being left on screen. However, when the source begins outputting video again, the last frame is still in the async cache.

Depending on the stability of the source's frame output, this still frame can end up being shown for 5+ output frames.

By freeing the async cache when a NULL frame is submitted, we avoid the issue of old frames being re-displayed.

### How Has This Been Tested?
OS: Ubuntu 20.04

This was especially apparent in a custom source I was developing, but can be observed in FFmpeg and VLC sources too.

Before:

https://user-images.githubusercontent.com/28720189/143187924-16338ec1-a665-486e-a33a-9298b9df07a4.mp4

After:

https://user-images.githubusercontent.com/28720189/143187981-0482905a-2873-4ae4-b2ca-f43e5c7f9d3f.mp4

### Types of change
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
