### PR TITLE
CI: Update XML/clang-format validation job names

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -3,7 +3,7 @@ name: Clang Format Check
 on: [push, pull_request]
 
 jobs:
-  ubuntu64:
+  clang-format-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/qt-xml.yml
+++ b/.github/workflows/qt-xml.yml
@@ -9,7 +9,7 @@ on:
       - "UI/forms/**"
 
 jobs:
-  ubuntu64:
+  qt-xml-validator:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description
Give XML and clang-format validator more descriptive job names.

### Motivation and Context
When setting up restrictions for PR merges to require checks to have passed GitHub only allows to specify individual jobs rather than an entire check suite. The clang-format and Qt XML actions previously had identical generic job names which breaks that specific UI.

### How Has This Been Tested?
Made sure jobs still run

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
