### PR TITLE
Unassorted Flatpak updates and extensions

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -19,6 +19,16 @@
     "--own-name=org.kde.StatusNotifierItem-2-2",
     "--system-talk-name=org.freedesktop.Avahi"
   ],
+  "add-extensions": {
+    "com.obsproject.Studio.Plugin": {
+      "directory": "plugins",
+      "subdirectories": true,
+      "add-ld-path": "lib",
+      "merge-dirs": "lib/obs-plugins;share/obs/obs-plugins",
+      "no-autodownload": true,
+      "autodelete": true
+    }
+  },
   "cleanup": [
     "/lib/pkgconfig",
     "/share/man",
@@ -268,6 +278,9 @@
         "-DYOUTUBE_CLIENTID_HASH=$YOUTUBE_CLIENTID_HASH",
         "-DYOUTUBE_SECRET=$YOUTUBE_SECRET",
         "-DYOUTUBE_SECRET_HASH=$YOUTUBE_SECRET_HASH"
+      ],
+      "post-install": [
+        "install -d /app/plugins"
       ],
       "sources": [
         {

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -58,8 +58,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.20.0.tar.bz2",
-          "sha256": "956118713f7ccb405c55c7088a6a2490c32d54300dd9a30d8d5008c28d3726f7"
+          "url": "https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.22.0.tar.bz2",
+          "sha256": "1069e5d7909bcc563baeaadc3a5c496f0e658524c413cf7818816e37bfcea344"
         }
       ]
     },

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -17,7 +17,8 @@
     "--talk-name=org.freedesktop.Flatpak",
     "--talk-name=org.freedesktop.Notifications",
     "--own-name=org.kde.StatusNotifierItem-2-2",
-    "--system-talk-name=org.freedesktop.Avahi"
+    "--system-talk-name=org.freedesktop.Avahi",
+    "--env=VST_PATH=/app/extensions/Plugins/lxvst"
   ],
   "add-extensions": {
     "com.obsproject.Studio.Plugin": {
@@ -27,6 +28,14 @@
       "merge-dirs": "lib/obs-plugins;share/obs/obs-plugins",
       "no-autodownload": true,
       "autodelete": true
+    },
+    "org.freedesktop.LinuxAudio.Plugins": {
+      "directory": "extensions/Plugins",
+      "version": "21.08",
+      "add-ld-path": "lib",
+      "merge-dirs": "lxvst",
+      "subdirectories": true,
+      "no-autodownload": true
     }
   },
   "cleanup": [
@@ -280,7 +289,8 @@
         "-DYOUTUBE_SECRET_HASH=$YOUTUBE_SECRET_HASH"
       ],
       "post-install": [
-        "install -d /app/plugins"
+        "install -d /app/plugins",
+        "install -d /app/extensions/Plugins"
       ],
       "sources": [
         {

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -38,7 +38,7 @@
         {
           "type": "git",
           "url": "https://code.videolan.org/videolan/x264.git",
-          "commit": "b86ae3c66f51ac9eab5ab7ad09a9d62e67961b8a"
+          "commit": "66a5bc1bd1563d8227d5d18440b525a09bcf17ca"
         }
       ]
     },


### PR DESCRIPTION
### Description

Basically, synchronize this Flatpak manifest with what's in Flathub. This includes a couple of dependency updates, and extension points.

### Motivation and Context

We've been using a simplified version of the Flatpak manifest because it's main purpose was CI support. Now that this manifest is what will be used to publish Flathub updates, we need to bring in all the features it had.

### How Has This Been Tested?

 - Download the Flatpak generated from the CI
 - Open the bundle with an app store (e.g. GNOME Software, or KDE's Discover)
 - Observe that plugins are listed there

### Types of changes

 - New feature (non-breaking change which adds functionality) 

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
