### PR TITLE
UI: Expose cURL error if Remote Text error text is empty

### DIFF
--- a/UI/remote-text.cpp
+++ b/UI/remote-text.cpp
@@ -91,7 +91,7 @@ void RemoteTextThread::run()
 		if (code != CURLE_OK) {
 			blog(LOG_WARNING,
 			     "RemoteTextThread: HTTP request failed. %s",
-			     error);
+			     strlen(error) ? error : curl_easy_strerror(code));
 			emit Result(QString(), QT_UTF8(error));
 		} else {
 			emit Result(QT_UTF8(str.c_str()), QString());
@@ -212,7 +212,8 @@ bool GetRemoteFile(const char *url, std::string &str, std::string &error,
 					  responseCode);
 
 		if (code != CURLE_OK) {
-			error = error_in;
+			error = strlen(error_in) ? error_in
+						 : curl_easy_strerror(code);
 		} else if (signature) {
 			for (string &h : header_in_list) {
 				string name = h.substr(0, 13);


### PR DESCRIPTION
### Description

Rather than returning an empty error alongside a `false` success response, this populates the error field with the string version of the cURL error.

**Before:**
![image](https://user-images.githubusercontent.com/941350/143407026-3c3aebe5-b1da-43e2-887c-4f1de5595d65.png)

> ```
> 19:41:22.314: AutoUpdateThread::run: Failed to fetch manifest file: 
> 16:02:22.238: TwitchAuth::GetChannelInfo: Failed to get text from remote: 
> ```

**After:**
![image](https://user-images.githubusercontent.com/941350/143407012-383ac4b9-7f74-437a-9afb-568a70b7b36e.png)

> ```
> 19:41:22.314: AutoUpdateThread::run: Failed to fetch manifest file: Couldn't connect to server
> 16:27:57.040: TwitchAuth::GetChannelInfo: Failed to get text from remote: Couldn't connect to server
> ```

### Motivation and Context

Empty errors tell the user or support volunteer nothing about what went wrong. Providing at least the cURL error provides some context.


### How Has This Been Tested?

Enable Twitch integration and restart OBS. Sometimes, an error dialog with zero error information appears. (In this case, while fetching stream key)

### Types of changes
 Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
