### PR TITLE
libobs: Add AutoRelease OBSRef wrappers for OBS types

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -445,9 +445,9 @@ void OBSAdvAudioCtrl::volumeChanged(double db)
 	obs_source_set_volume(source, val);
 
 	auto undo_redo = [](const std::string &name, float val) {
-		obs_source_t *source = obs_get_source_by_name(name.c_str());
+		OBSSourceAutoRelease source =
+			obs_get_source_by_name(name.c_str());
 		obs_source_set_volume(source, val);
-		obs_source_release(source);
 	};
 
 	const char *name = obs_source_get_name(source);
@@ -468,9 +468,9 @@ void OBSAdvAudioCtrl::percentChanged(int percent)
 	obs_source_set_volume(source, val);
 
 	auto undo_redo = [](const std::string &name, float val) {
-		obs_source_t *source = obs_get_source_by_name(name.c_str());
+		OBSSourceAutoRelease source =
+			obs_get_source_by_name(name.c_str());
 		obs_source_set_volume(source, val);
-		obs_source_release(source);
 	};
 
 	const char *name = obs_source_get_name(source);
@@ -507,9 +507,9 @@ void OBSAdvAudioCtrl::downmixMonoChanged(bool val)
 	obs_source_set_flags(source, flags);
 
 	auto undo_redo = [](const std::string &name, bool val) {
-		obs_source_t *source = obs_get_source_by_name(name.c_str());
+		OBSSourceAutoRelease source =
+			obs_get_source_by_name(name.c_str());
 		set_mono(source, val);
-		obs_source_release(source);
 	};
 
 	QString text = QTStr(val ? "Undo.ForceMono.On" : "Undo.ForceMono.Off");
@@ -536,9 +536,9 @@ void OBSAdvAudioCtrl::balanceChanged(int val)
 	obs_source_set_balance_value(source, bal);
 
 	auto undo_redo = [](const std::string &name, float val) {
-		obs_source_t *source = obs_get_source_by_name(name.c_str());
+		OBSSourceAutoRelease source =
+			obs_get_source_by_name(name.c_str());
 		obs_source_set_balance_value(source, val);
-		obs_source_release(source);
 	};
 
 	const char *name = obs_source_get_name(source);
@@ -565,9 +565,9 @@ void OBSAdvAudioCtrl::syncOffsetChanged(int milliseconds)
 	obs_source_set_sync_offset(source, val);
 
 	auto undo_redo = [](const std::string &name, int64_t val) {
-		obs_source_t *source = obs_get_source_by_name(name.c_str());
+		OBSSourceAutoRelease source =
+			obs_get_source_by_name(name.c_str());
 		obs_source_set_sync_offset(source, val);
-		obs_source_release(source);
 	};
 
 	const char *name = obs_source_get_name(source);
@@ -605,9 +605,9 @@ void OBSAdvAudioCtrl::monitoringTypeChanged(int index)
 	     name ? name : "(null)", type);
 
 	auto undo_redo = [](const std::string &name, obs_monitoring_type val) {
-		obs_source_t *source = obs_get_source_by_name(name.c_str());
+		OBSSourceAutoRelease source =
+			obs_get_source_by_name(name.c_str());
 		obs_source_set_monitoring_type(source, val);
-		obs_source_release(source);
 	};
 
 	OBSBasic::Get()->undo_s.add_action(
@@ -630,9 +630,9 @@ static inline void setMixer(obs_source_t *source, const int mixerIdx,
 	obs_source_set_audio_mixers(source, new_mixers);
 
 	auto undo_redo = [](const std::string &name, uint32_t mixers) {
-		obs_source_t *source = obs_get_source_by_name(name.c_str());
+		OBSSourceAutoRelease source =
+			obs_get_source_by_name(name.c_str());
 		obs_source_set_audio_mixers(source, mixers);
-		obs_source_release(source);
 	};
 
 	const char *name = obs_source_get_name(source);

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -390,21 +390,21 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 
 	obs_output_t *obs_frontend_get_streaming_output(void) override
 	{
-		OBSOutput output = main->outputHandler->streamOutput;
+		OBSOutput output = main->outputHandler->streamOutput.Get();
 		obs_output_addref(output);
 		return output;
 	}
 
 	obs_output_t *obs_frontend_get_recording_output(void) override
 	{
-		OBSOutput out = main->outputHandler->fileOutput;
+		OBSOutput out = main->outputHandler->fileOutput.Get();
 		obs_output_addref(out);
 		return out;
 	}
 
 	obs_output_t *obs_frontend_get_replay_buffer_output(void) override
 	{
-		OBSOutput out = main->outputHandler->replayBuffer;
+		OBSOutput out = main->outputHandler->replayBuffer.Get();
 		obs_output_addref(out);
 		return out;
 	}
@@ -584,7 +584,7 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 
 	obs_output_t *obs_frontend_get_virtualcam_output(void) override
 	{
-		OBSOutput output = main->outputHandler->virtualCam;
+		OBSOutput output = main->outputHandler->virtualCam.Get();
 		obs_output_addref(output);
 		return output;
 	}

--- a/UI/auth-oauth.cpp
+++ b/UI/auth-oauth.cpp
@@ -314,7 +314,7 @@ void OAuthStreamKey::OnStreamConfig()
 	OBSBasic *main = OBSBasic::Get();
 	obs_service_t *service = main->GetService();
 
-	obs_data_t *settings = obs_service_get_settings(service);
+	OBSDataAutoRelease settings = obs_service_get_settings(service);
 
 	bool bwtest = obs_data_get_bool(settings, "bwtest");
 
@@ -325,6 +325,4 @@ void OAuthStreamKey::OnStreamConfig()
 		obs_data_set_string(settings, "key", key_.c_str());
 
 	obs_service_update(service, settings);
-
-	obs_data_release(settings);
 }

--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -37,12 +37,10 @@ SourceToolbar::SourceToolbar(QWidget *parent, OBSSource source)
 void SourceToolbar::SaveOldProperties(obs_source_t *source)
 {
 	oldData = obs_data_create();
-	obs_data_release(oldData);
 
-	obs_data_t *oldSettings = obs_source_get_settings(source);
+	OBSDataAutoRelease oldSettings = obs_source_get_settings(source);
 	obs_data_apply(oldData, oldSettings);
 	obs_data_set_string(oldData, "undo_sname", obs_source_get_name(source));
-	obs_data_release(oldSettings);
 }
 
 void SourceToolbar::SetUndoProperties(obs_source_t *source, bool repeatable)
@@ -60,24 +58,21 @@ void SourceToolbar::SetUndoProperties(obs_source_t *source, bool repeatable)
 	std::string scene_name = obs_source_get_name(currentSceneSource);
 	auto undo_redo = [scene_name,
 			  main = std::move(main)](const std::string &data) {
-		obs_data_t *settings = obs_data_create_from_json(data.c_str());
-		obs_source_t *source = obs_get_source_by_name(
+		OBSDataAutoRelease settings =
+			obs_data_create_from_json(data.c_str());
+		OBSSourceAutoRelease source = obs_get_source_by_name(
 			obs_data_get_string(settings, "undo_sname"));
 		obs_source_reset_settings(source, settings);
 
-		obs_source_t *scene_source =
+		OBSSourceAutoRelease scene_source =
 			obs_get_source_by_name(scene_name.c_str());
-		main->SetCurrentScene(scene_source, true);
-		obs_source_release(scene_source);
-
-		obs_data_release(settings);
-		obs_source_release(source);
+		main->SetCurrentScene(scene_source.Get(), true);
 
 		main->UpdateContextBar();
 	};
 
-	OBSData new_settings = obs_data_create();
-	OBSData curr_settings = obs_source_get_settings(source);
+	OBSDataAutoRelease new_settings = obs_data_create();
+	OBSDataAutoRelease curr_settings = obs_source_get_settings(source);
 	obs_data_apply(new_settings, curr_settings);
 	obs_data_set_string(new_settings, "undo_sname",
 			    obs_source_get_name(source));
@@ -91,8 +86,6 @@ void SourceToolbar::SetUndoProperties(obs_source_t *source, bool repeatable)
 				.arg(obs_source_get_name(source)),
 			undo_redo, undo_redo, undo_data, redo_data, repeatable);
 
-	obs_data_release(new_settings);
-	obs_data_release(curr_settings);
 	oldData = nullptr;
 }
 
@@ -165,13 +158,12 @@ void UpdateSourceComboToolbarProperties(QComboBox *combo, OBSSource source,
 {
 	std::string cur_id;
 
-	obs_data_t *settings = obs_source_get_settings(source);
+	OBSDataAutoRelease settings = obs_source_get_settings(source);
 	if (is_int) {
 		cur_id = std::to_string(obs_data_get_int(settings, prop_name));
 	} else {
 		cur_id = obs_data_get_string(settings, prop_name);
 	}
-	obs_data_release(settings);
 
 	combo->blockSignals(true);
 
@@ -209,14 +201,13 @@ void UpdateSourceComboToolbarValue(QComboBox *combo, OBSSource source, int idx,
 {
 	QString id = combo->itemData(idx).toString();
 
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 	if (is_int) {
 		obs_data_set_int(settings, prop_name, id.toInt());
 	} else {
 		obs_data_set_string(settings, prop_name, QT_TO_UTF8(id));
 	}
 	obs_source_update(source, settings);
-	obs_data_release(settings);
 }
 
 void ComboSelectToolbar::on_device_currentIndexChanged(int idx)
@@ -328,9 +319,8 @@ DeviceCaptureToolbar::DeviceCaptureToolbar(QWidget *parent, OBSSource source)
 	ui->deviceLabel = nullptr;
 	ui->device = nullptr;
 
-	obs_data_t *settings = obs_source_get_settings(source);
+	OBSDataAutoRelease settings = obs_source_get_settings(source);
 	active = obs_data_get_bool(settings, "active");
-	obs_data_release(settings);
 
 	obs_module_t *mod = obs_get_module("win-dshow");
 	activateText = obs_module_get_locale_text(mod, "Activate");
@@ -351,9 +341,8 @@ void DeviceCaptureToolbar::on_activateButton_clicked()
 		return;
 	}
 
-	obs_data_t *settings = obs_source_get_settings(source);
+	OBSDataAutoRelease settings = obs_source_get_settings(source);
 	bool now_active = obs_data_get_bool(settings, "active");
-	obs_data_release(settings);
 
 	bool desyncedSetting = now_active != active;
 
@@ -388,10 +377,9 @@ GameCaptureToolbar::GameCaptureToolbar(QWidget *parent, OBSSource source)
 	ui->windowLabel->setText(
 		obs_module_get_locale_text(mod, "WindowCapture.Window"));
 
-	obs_data_t *settings = obs_source_get_settings(source);
+	OBSDataAutoRelease settings = obs_source_get_settings(source);
 	std::string cur_mode = obs_data_get_string(settings, "capture_mode");
 	std::string cur_window = obs_data_get_string(settings, "window");
-	obs_data_release(settings);
 
 	ui->mode->blockSignals(true);
 	p = obs_properties_get(props.get(), "capture_mode");
@@ -435,10 +423,9 @@ void GameCaptureToolbar::on_mode_currentIndexChanged(int idx)
 	QString id = ui->mode->itemData(idx).toString();
 
 	SaveOldProperties(source);
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 	obs_data_set_string(settings, "capture_mode", QT_TO_UTF8(id));
 	obs_source_update(source, settings);
-	obs_data_release(settings);
 	SetUndoProperties(source);
 
 	UpdateWindowVisibility();
@@ -454,10 +441,9 @@ void GameCaptureToolbar::on_window_currentIndexChanged(int idx)
 	QString id = ui->window->itemData(idx).toString();
 
 	SaveOldProperties(source);
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 	obs_data_set_string(settings, "window", QT_TO_UTF8(id));
 	obs_source_update(source, settings);
-	obs_data_release(settings);
 	SetUndoProperties(source);
 }
 
@@ -471,9 +457,8 @@ ImageSourceToolbar::ImageSourceToolbar(QWidget *parent, OBSSource source)
 	obs_module_t *mod = obs_get_module("image-source");
 	ui->pathLabel->setText(obs_module_get_locale_text(mod, "File"));
 
-	obs_data_t *settings = obs_source_get_settings(source);
+	OBSDataAutoRelease settings = obs_source_get_settings(source);
 	std::string file = obs_data_get_string(settings, "file");
-	obs_data_release(settings);
 
 	ui->path->setText(file.c_str());
 }
@@ -503,10 +488,9 @@ void ImageSourceToolbar::on_browse_clicked()
 	ui->path->setText(path);
 
 	SaveOldProperties(source);
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 	obs_data_set_string(settings, "file", QT_TO_UTF8(path));
 	obs_source_update(source, settings);
-	obs_data_release(settings);
 	SetUndoProperties(source);
 }
 
@@ -533,9 +517,8 @@ ColorSourceToolbar::ColorSourceToolbar(QWidget *parent, OBSSource source)
 {
 	ui->setupUi(this);
 
-	obs_data_t *settings = obs_source_get_settings(source);
+	OBSDataAutoRelease settings = obs_source_get_settings(source);
 	unsigned int val = (unsigned int)obs_data_get_int(settings, "color");
-	obs_data_release(settings);
 
 	color = color_from_int(val);
 	UpdateColor();
@@ -589,10 +572,9 @@ void ColorSourceToolbar::on_choose_clicked()
 
 	SaveOldProperties(source);
 
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 	obs_data_set_int(settings, "color", color_to_int(color));
 	obs_source_update(source, settings);
-	obs_data_release(settings);
 
 	SetUndoProperties(source);
 }
@@ -606,16 +588,15 @@ TextSourceToolbar::TextSourceToolbar(QWidget *parent, OBSSource source)
 {
 	ui->setupUi(this);
 
-	obs_data_t *settings = obs_source_get_settings(source);
+	OBSDataAutoRelease settings = obs_source_get_settings(source);
 
 	const char *id = obs_source_get_unversioned_id(source);
 	bool ft2 = strcmp(id, "text_ft2_source") == 0;
 	bool read_from_file = obs_data_get_bool(
 		settings, ft2 ? "from_file" : "read_from_file");
 
-	obs_data_t *font_obj = obs_data_get_obj(settings, "font");
+	OBSDataAutoRelease font_obj = obs_data_get_obj(settings, "font");
 	MakeQFont(font_obj, font);
-	obs_data_release(font_obj);
 
 	// Use "color1" if it's a freetype source and "color" elsewise
 	unsigned int val = (unsigned int)obs_data_get_int(
@@ -634,8 +615,6 @@ TextSourceToolbar::TextSourceToolbar(QWidget *parent, OBSSource source)
 	ui->text->setVisible(single_line);
 	if (single_line)
 		ui->text->setText(text);
-
-	obs_data_release(settings);
 }
 
 TextSourceToolbar::~TextSourceToolbar()
@@ -664,7 +643,7 @@ void TextSourceToolbar::on_selectFont_clicked()
 		return;
 	}
 
-	obs_data_t *font_obj = obs_data_create();
+	OBSDataAutoRelease font_obj = obs_data_create();
 
 	obs_data_set_string(font_obj, "face", QT_TO_UTF8(font.family()));
 	obs_data_set_string(font_obj, "style", QT_TO_UTF8(font.styleName()));
@@ -677,13 +656,11 @@ void TextSourceToolbar::on_selectFont_clicked()
 
 	SaveOldProperties(source);
 
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 
 	obs_data_set_obj(settings, "font", font_obj);
-	obs_data_release(font_obj);
 
 	obs_source_update(source, settings);
-	obs_data_release(settings);
 
 	SetUndoProperties(source);
 }
@@ -719,7 +696,7 @@ void TextSourceToolbar::on_selectColor_clicked()
 
 	SaveOldProperties(source);
 
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 	if (freetype) {
 		obs_data_set_int(settings, "color1", color_to_int(color));
 		obs_data_set_int(settings, "color2", color_to_int(color));
@@ -727,7 +704,6 @@ void TextSourceToolbar::on_selectColor_clicked()
 		obs_data_set_int(settings, "color", color_to_int(color));
 	}
 	obs_source_update(source, settings);
-	obs_data_release(settings);
 
 	SetUndoProperties(source);
 }
@@ -741,10 +717,9 @@ void TextSourceToolbar::on_text_textChanged()
 
 	SaveOldProperties(source);
 
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 	obs_data_set_string(settings, "text", QT_TO_UTF8(ui->text->text()));
 	obs_source_update(source, settings);
-	obs_data_release(settings);
 
 	SetUndoProperties(source, true);
 }

--- a/UI/context-bar-controls.hpp
+++ b/UI/context-bar-controls.hpp
@@ -22,7 +22,7 @@ protected:
 		std::unique_ptr<obs_properties_t, properties_delete_t>;
 
 	properties_t props;
-	OBSData oldData;
+	OBSDataAutoRelease oldData;
 
 	void SaveOldProperties(obs_source_t *source);
 	void SetUndoProperties(obs_source_t *source, bool repeatable = false);

--- a/UI/frontend-plugins/frontend-tools/captions.cpp
+++ b/UI/frontend-plugins/frontend-tools/captions.cpp
@@ -226,10 +226,9 @@ void CaptionsDialog::on_provider_currentIndexChanged(int idx)
 
 static void caption_text(const std::string &text)
 {
-	obs_output *output = obs_frontend_get_streaming_output();
+	OBSOutputAutoRelease output = obs_frontend_get_streaming_output();
 	if (output) {
 		obs_output_output_caption_text1(output, text.c_str());
-		obs_output_release(output);
 	}
 }
 
@@ -396,7 +395,7 @@ static void obs_event(enum obs_frontend_event event, void *)
 static void save_caption_data(obs_data_t *save_data, bool saving, void *)
 {
 	if (saving) {
-		obs_data_t *obj = obs_data_create();
+		OBSDataAutoRelease obj = obs_data_create();
 
 		obs_data_set_string(obj, "source",
 				    captions->source_name.c_str());
@@ -406,11 +405,11 @@ static void save_caption_data(obs_data_t *save_data, bool saving, void *)
 				    captions->handler_id.c_str());
 
 		obs_data_set_obj(save_data, "captions", obj);
-		obs_data_release(obj);
 	} else {
 		captions->stop();
 
-		obs_data_t *obj = obs_data_get_obj(save_data, "captions");
+		OBSDataAutoRelease obj =
+			obs_data_get_obj(save_data, "captions");
 		if (!obj)
 			obj = obs_data_create();
 
@@ -424,7 +423,6 @@ static void save_caption_data(obs_data_t *save_data, bool saving, void *)
 		captions->handler_id = obs_data_get_string(obj, "provider");
 		captions->source =
 			GetWeakSourceByName(captions->source_name.c_str());
-		obs_data_release(obj);
 
 		if (enabled)
 			captions->start();

--- a/UI/frontend-plugins/frontend-tools/output-timer.cpp
+++ b/UI/frontend-plugins/frontend-tools/output-timer.cpp
@@ -250,7 +250,7 @@ void OutputTimer::EventStopRecording()
 static void SaveOutputTimer(obs_data_t *save_data, bool saving, void *)
 {
 	if (saving) {
-		obs_data_t *obj = obs_data_create();
+		OBSDataAutoRelease obj = obs_data_create();
 
 		obs_data_set_int(obj, "streamTimerHours",
 				 ot->ui->streamingTimerHours->value());
@@ -275,10 +275,9 @@ static void SaveOutputTimer(obs_data_t *save_data, bool saving, void *)
 				  ot->ui->pauseRecordTimer->isChecked());
 
 		obs_data_set_obj(save_data, "output-timer", obj);
-
-		obs_data_release(obj);
 	} else {
-		obs_data_t *obj = obs_data_get_obj(save_data, "output-timer");
+		OBSDataAutoRelease obj =
+			obs_data_get_obj(save_data, "output-timer");
 
 		if (!obj)
 			obj = obs_data_create();
@@ -304,8 +303,6 @@ static void SaveOutputTimer(obs_data_t *save_data, bool saving, void *)
 
 		ot->ui->pauseRecordTimer->setChecked(
 			obs_data_get_bool(obj, "pauseRecordTimer"));
-
-		obs_data_release(obj);
 	}
 }
 

--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -243,8 +243,7 @@ void ScriptsTool::ReloadScript(const char *path)
 		if (strcmp(script_path, path) == 0) {
 			obs_script_reload(script);
 
-			OBSData settings = obs_data_create();
-			obs_data_release(settings);
+			OBSDataAutoRelease settings = obs_data_create();
 
 			obs_properties_t *prop =
 				obs_script_get_properties(script);
@@ -275,9 +274,9 @@ void ScriptsTool::SetScriptDefaults(const char *path)
 	for (OBSScript &script : scriptData->scripts) {
 		const char *script_path = obs_script_get_path(script);
 		if (strcmp(script_path, path) == 0) {
-			obs_data_t *settings = obs_script_get_settings(script);
+			OBSDataAutoRelease settings =
+				obs_script_get_settings(script);
 			obs_data_clear(settings);
-			obs_data_release(settings);
 
 			obs_script_update(script, nullptr);
 			on_reloadScripts_clicked();
@@ -353,8 +352,7 @@ void ScriptsTool::on_addScripts_clicked()
 			item->setData(Qt::UserRole, QString(file));
 			ui->scripts->addItem(item);
 
-			OBSData settings = obs_data_create();
-			obs_data_release(settings);
+			OBSDataAutoRelease settings = obs_data_create();
 
 			obs_properties_t *prop =
 				obs_script_get_properties(script);
@@ -499,11 +497,10 @@ void ScriptsTool::on_scripts_currentRowChanged(int row)
 		return;
 	}
 
-	OBSData settings = obs_script_get_settings(script);
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_script_get_settings(script);
 
 	propertiesView = new OBSPropertiesView(
-		settings, script,
+		settings.Get(), script,
 		(PropertiesReloadCallback)obs_script_get_properties, nullptr,
 		(PropertiesVisualUpdateCb)obs_script_update);
 	ui->propertiesLayout->addWidget(propertiesView);
@@ -585,30 +582,26 @@ static void obs_event(enum obs_frontend_event event, void *)
 
 static void load_script_data(obs_data_t *load_data, bool, void *)
 {
-	obs_data_array_t *array = obs_data_get_array(load_data, "scripts-tool");
+	OBSDataArrayAutoRelease array =
+		obs_data_get_array(load_data, "scripts-tool");
 
 	delete scriptData;
 	scriptData = new ScriptData;
 
 	size_t size = obs_data_array_count(array);
 	for (size_t i = 0; i < size; i++) {
-		obs_data_t *obj = obs_data_array_item(array, i);
+		OBSDataAutoRelease obj = obs_data_array_item(array, i);
 		const char *path = obs_data_get_string(obj, "path");
-		obs_data_t *settings = obs_data_get_obj(obj, "settings");
+		OBSDataAutoRelease settings = obs_data_get_obj(obj, "settings");
 
 		obs_script_t *script = obs_script_create(path, settings);
 		if (script) {
 			scriptData->scripts.emplace_back(script);
 		}
-
-		obs_data_release(settings);
-		obs_data_release(obj);
 	}
 
 	if (scriptsWindow)
 		scriptsWindow->RefreshLists();
-
-	obs_data_array_release(array);
 }
 
 static void save_script_data(obs_data_t *save_data, bool saving, void *)
@@ -616,23 +609,19 @@ static void save_script_data(obs_data_t *save_data, bool saving, void *)
 	if (!saving)
 		return;
 
-	obs_data_array_t *array = obs_data_array_create();
+	OBSDataArrayAutoRelease array = obs_data_array_create();
 
 	for (OBSScript &script : scriptData->scripts) {
 		const char *script_path = obs_script_get_path(script);
-		obs_data_t *settings = obs_script_save(script);
+		OBSDataAutoRelease settings = obs_script_save(script);
 
-		obs_data_t *obj = obs_data_create();
+		OBSDataAutoRelease obj = obs_data_create();
 		obs_data_set_string(obj, "path", script_path);
 		obs_data_set_obj(obj, "settings", settings);
 		obs_data_array_push_back(array, obj);
-		obs_data_release(obj);
-
-		obs_data_release(settings);
 	}
 
 	obs_data_set_array(save_data, "scripts-tool", array);
-	obs_data_array_release(array);
 }
 
 static void script_log(void *, obs_script_t *script, int log_level,

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -643,17 +643,14 @@ static string GetSceneCollectionFileFromName(const char *name)
 		if (ent.directory)
 			continue;
 
-		obs_data_t *data =
+		OBSDataAutoRelease data =
 			obs_data_create_from_json_file_safe(ent.path, "bak");
 		const char *curName = obs_data_get_string(data, "name");
 
 		if (astrcmpi(name, curName) == 0) {
 			outputPath = ent.path;
-			obs_data_release(data);
 			break;
 		}
-
-		obs_data_release(data);
 	}
 
 	os_globfree(glob);
@@ -1446,10 +1443,9 @@ bool OBSApp::OBSInit()
 	bool browserHWAccel =
 		config_get_bool(globalConfig, "General", "BrowserHWAccel");
 
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 	obs_data_set_bool(settings, "BrowserHWAccel", browserHWAccel);
 	obs_apply_private_data(settings);
-	obs_data_release(settings);
 
 	blog(LOG_INFO, "Current Date/Time: %s",
 	     CurrentDateTimeString().c_str());
@@ -2556,7 +2552,8 @@ static void convert_x264_settings(obs_data_t *data)
 
 static void convert_14_2_encoder_setting(const char *encoder, const char *file)
 {
-	obs_data_t *data = obs_data_create_from_json_file_safe(file, "bak");
+	OBSDataAutoRelease data =
+		obs_data_create_from_json_file_safe(file, "bak");
 	obs_data_item_t *cbr_item = obs_data_item_byname(data, "cbr");
 	obs_data_item_t *rc_item = obs_data_item_byname(data, "rate_control");
 	bool modified = false;
@@ -2585,7 +2582,6 @@ static void convert_14_2_encoder_setting(const char *encoder, const char *file)
 
 	obs_data_item_release(&rc_item);
 	obs_data_item_release(&cbr_item);
-	obs_data_release(data);
 }
 
 static void upgrade_settings(void)

--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -190,9 +190,9 @@ QDataStream &operator>>(QDataStream &in, OBSScene &scene)
 
 	in >> sceneName;
 
-	obs_source_t *source = obs_get_source_by_name(QT_TO_UTF8(sceneName));
+	OBSSourceAutoRelease source =
+		obs_get_source_by_name(QT_TO_UTF8(sceneName));
 	scene = obs_scene_from_source(source);
-	obs_source_release(source);
 
 	return in;
 }
@@ -212,13 +212,11 @@ QDataStream &operator>>(QDataStream &in, OBSSceneItem &si)
 
 	in >> sceneName >> sourceName;
 
-	obs_source_t *sceneSource =
+	OBSSourceAutoRelease sceneSource =
 		obs_get_source_by_name(QT_TO_UTF8(sceneName));
 
 	obs_scene_t *scene = obs_scene_from_source(sceneSource);
 	si = obs_scene_find_source(scene, QT_TO_UTF8(sourceName));
-
-	obs_source_release(sceneSource);
 
 	return in;
 }

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -68,9 +68,9 @@ void VolControl::SetMuted(bool checked)
 	obs_source_set_muted(source, checked);
 
 	auto undo_redo = [](const std::string &name, bool val) {
-		obs_source_t *source = obs_get_source_by_name(name.c_str());
+		OBSSourceAutoRelease source =
+			obs_get_source_by_name(name.c_str());
 		obs_source_set_muted(source, val);
-		obs_source_release(source);
 	};
 
 	QString text =
@@ -92,9 +92,9 @@ void VolControl::SliderChanged(int vol)
 	updateText();
 
 	auto undo_redo = [](const std::string &name, float val) {
-		obs_source_t *source = obs_get_source_by_name(name.c_str());
+		OBSSourceAutoRelease source =
+			obs_get_source_by_name(name.c_str());
 		obs_source_set_volume(source, val);
-		obs_source_release(source);
 	};
 
 	float val = obs_source_get_volume(source);

--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -119,8 +119,7 @@ void AutoConfigTestPage::StartRecordingEncoderStage()
 
 void AutoConfigTestPage::GetServers(std::vector<ServerInfo> &servers)
 {
-	OBSData settings = obs_data_create();
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_create();
 	obs_data_set_string(settings, "service", wiz->serviceName.c_str());
 
 	obs_properties_t *ppts = obs_get_service_properties("rtmp_common");
@@ -182,15 +181,12 @@ void AutoConfigTestPage::TestBandwidthThread()
 	const char *serverType = wiz->customServer ? "rtmp_custom"
 						   : "rtmp_common";
 
-	OBSEncoder vencoder = obs_video_encoder_create("obs_x264", "test_x264",
-						       nullptr, nullptr);
-	OBSEncoder aencoder = obs_audio_encoder_create("ffmpeg_aac", "test_aac",
-						       nullptr, 0, nullptr);
-	OBSService service = obs_service_create(serverType, "test_service",
-						nullptr, nullptr);
-	obs_encoder_release(vencoder);
-	obs_encoder_release(aencoder);
-	obs_service_release(service);
+	OBSEncoderAutoRelease vencoder = obs_video_encoder_create(
+		"obs_x264", "test_x264", nullptr, nullptr);
+	OBSEncoderAutoRelease aencoder = obs_audio_encoder_create(
+		"ffmpeg_aac", "test_aac", nullptr, 0, nullptr);
+	OBSServiceAutoRelease service = obs_service_create(
+		serverType, "test_service", nullptr, nullptr);
 
 	/* -----------------------------------*/
 	/* configure settings                 */
@@ -202,14 +198,10 @@ void AutoConfigTestPage::TestBandwidthThread()
 	// output: "bind_ip" via main config -> "Output", "BindIP"
 	//         obs_output_set_service
 
-	OBSData service_settings = obs_data_create();
-	OBSData vencoder_settings = obs_data_create();
-	OBSData aencoder_settings = obs_data_create();
-	OBSData output_settings = obs_data_create();
-	obs_data_release(service_settings);
-	obs_data_release(vencoder_settings);
-	obs_data_release(aencoder_settings);
-	obs_data_release(output_settings);
+	OBSDataAutoRelease service_settings = obs_data_create();
+	OBSDataAutoRelease vencoder_settings = obs_data_create();
+	OBSDataAutoRelease aencoder_settings = obs_data_create();
+	OBSDataAutoRelease output_settings = obs_data_create();
 
 	std::string key = wiz->key;
 	if (wiz->service == AutoConfig::Service::Twitch) {
@@ -281,9 +273,8 @@ void AutoConfigTestPage::TestBandwidthThread()
 	if (!output_type)
 		output_type = "rtmp_output";
 
-	OBSOutput output =
+	OBSOutputAutoRelease output =
 		obs_output_create(output_type, "test_stream", nullptr, nullptr);
-	obs_output_release(output);
 	obs_output_update(output, output_settings);
 
 	const char *audio_codec = obs_output_get_supported_audio_codecs(output);
@@ -292,7 +283,6 @@ void AutoConfigTestPage::TestBandwidthThread()
 		const char *id = FindAudioEncoderFromCodec(audio_codec);
 		aencoder = obs_audio_encoder_create(id, "test_audio", nullptr,
 						    0, nullptr);
-		obs_encoder_release(aencoder);
 	}
 
 	/* -----------------------------------*/
@@ -531,23 +521,18 @@ bool AutoConfigTestPage::TestSoftwareEncoding()
 	/* -----------------------------------*/
 	/* create obs objects                 */
 
-	OBSEncoder vencoder = obs_video_encoder_create("obs_x264", "test_x264",
-						       nullptr, nullptr);
-	OBSEncoder aencoder = obs_audio_encoder_create("ffmpeg_aac", "test_aac",
-						       nullptr, 0, nullptr);
-	OBSOutput output =
+	OBSEncoderAutoRelease vencoder = obs_video_encoder_create(
+		"obs_x264", "test_x264", nullptr, nullptr);
+	OBSEncoderAutoRelease aencoder = obs_audio_encoder_create(
+		"ffmpeg_aac", "test_aac", nullptr, 0, nullptr);
+	OBSOutputAutoRelease output =
 		obs_output_create("null_output", "null", nullptr, nullptr);
-	obs_output_release(output);
-	obs_encoder_release(vencoder);
-	obs_encoder_release(aencoder);
 
 	/* -----------------------------------*/
 	/* configure settings                 */
 
-	OBSData aencoder_settings = obs_data_create();
-	OBSData vencoder_settings = obs_data_create();
-	obs_data_release(aencoder_settings);
-	obs_data_release(vencoder_settings);
+	OBSDataAutoRelease aencoder_settings = obs_data_create();
+	OBSDataAutoRelease vencoder_settings = obs_data_create();
 	obs_data_set_int(aencoder_settings, "bitrate", 32);
 
 	if (wiz->type != AutoConfig::Type::Recording) {
@@ -1020,14 +1005,11 @@ void AutoConfigTestPage::FinalizeResults()
 		const char *serverType = wiz->customServer ? "rtmp_custom"
 							   : "rtmp_common";
 
-		OBSService service = obs_service_create(
+		OBSServiceAutoRelease service = obs_service_create(
 			serverType, "temp_service", nullptr, nullptr);
-		obs_service_release(service);
 
-		OBSData service_settings = obs_data_create();
-		OBSData vencoder_settings = obs_data_create();
-		obs_data_release(service_settings);
-		obs_data_release(vencoder_settings);
+		OBSDataAutoRelease service_settings = obs_data_create();
+		OBSDataAutoRelease vencoder_settings = obs_data_create();
 
 		obs_data_set_int(vencoder_settings, "bitrate",
 				 wiz->idealBitrate);

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -43,17 +43,15 @@ static OBSData OpenServiceSettings(std::string &type)
 	if (ret <= 0)
 		return OBSData();
 
-	OBSData data =
+	OBSDataAutoRelease data =
 		obs_data_create_from_json_file_safe(serviceJsonPath, "bak");
-	obs_data_release(data);
 
 	obs_data_set_default_string(data, "type", "rtmp_common");
 	type = obs_data_get_string(data, "type");
 
-	OBSData settings = obs_data_get_obj(data, "settings");
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_get_obj(data, "settings");
 
-	return settings;
+	return settings.Get();
 }
 
 static void GetServiceInfo(std::string &type, std::string &service,
@@ -340,8 +338,7 @@ inline bool AutoConfigStreamPage::IsCustomService() const
 
 bool AutoConfigStreamPage::validatePage()
 {
-	OBSData service_settings = obs_data_create();
-	obs_data_release(service_settings);
+	OBSDataAutoRelease service_settings = obs_data_create();
 
 	wiz->customServer = IsCustomService();
 
@@ -353,9 +350,8 @@ bool AutoConfigStreamPage::validatePage()
 				    QT_TO_UTF8(ui->service->currentText()));
 	}
 
-	OBSService service = obs_service_create(serverType, "temp_service",
-						service_settings, nullptr);
-	obs_service_release(service);
+	OBSServiceAutoRelease service = obs_service_create(
+		serverType, "temp_service", service_settings, nullptr);
 
 	int bitrate;
 	if (!ui->doBandwidthTest->isChecked()) {
@@ -376,8 +372,7 @@ bool AutoConfigStreamPage::validatePage()
 #endif
 	}
 
-	OBSData settings = obs_data_create();
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_create();
 	obs_data_set_int(settings, "bitrate", bitrate);
 	obs_service_apply_encoder_settings(service, settings, nullptr);
 
@@ -697,8 +692,7 @@ void AutoConfigStreamPage::UpdateMoreInfoLink()
 	obs_properties_t *props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
-	OBSData settings = obs_data_create();
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_create();
 
 	obs_data_set_string(settings, "service", QT_TO_UTF8(serviceName));
 	obs_property_modified(services, settings);
@@ -724,8 +718,7 @@ void AutoConfigStreamPage::UpdateKeyLink()
 	obs_properties_t *props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
-	OBSData settings = obs_data_create();
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_create();
 
 	obs_data_set_string(settings, "service", QT_TO_UTF8(serviceName));
 	obs_property_modified(services, settings);
@@ -759,8 +752,7 @@ void AutoConfigStreamPage::LoadServices(bool showAll)
 {
 	obs_properties_t *props = obs_get_service_properties("rtmp_common");
 
-	OBSData settings = obs_data_create();
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_create();
 
 	obs_data_set_bool(settings, "show_all", showAll);
 
@@ -823,8 +815,7 @@ void AutoConfigStreamPage::UpdateServerList()
 	obs_properties_t *props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
-	OBSData settings = obs_data_create();
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_create();
 
 	obs_data_set_string(settings, "service", QT_TO_UTF8(serviceName));
 	obs_property_modified(services, settings);
@@ -904,8 +895,7 @@ AutoConfig::AutoConfig(QWidget *parent) : QWizard(parent)
 	/* ----------------------------------------- */
 	/* check to see if Twitch's "auto" available */
 
-	OBSData twitchSettings = obs_data_create();
-	obs_data_release(twitchSettings);
+	OBSDataAutoRelease twitchSettings = obs_data_create();
 
 	obs_data_set_string(twitchSettings, "service", "Twitch");
 
@@ -1077,11 +1067,9 @@ void AutoConfig::SaveStreamSettings()
 	const char *service_id = customServer ? "rtmp_custom" : "rtmp_common";
 
 	obs_service_t *oldService = main->GetService();
-	OBSData hotkeyData = obs_hotkeys_save_service(oldService);
-	obs_data_release(hotkeyData);
+	OBSDataAutoRelease hotkeyData = obs_hotkeys_save_service(oldService);
 
-	OBSData settings = obs_data_create();
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_create();
 
 	if (!customServer)
 		obs_data_set_string(settings, "service", serviceName.c_str());
@@ -1093,9 +1081,8 @@ void AutoConfig::SaveStreamSettings()
 	obs_data_set_string(settings, "key", key.c_str());
 #endif
 
-	OBSService newService = obs_service_create(
+	OBSServiceAutoRelease newService = obs_service_create(
 		service_id, "default_service", settings, hotkeyData);
-	obs_service_release(newService);
 
 	if (!newService)
 		return;

--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -50,12 +50,11 @@ static string GenerateSourceName(const char *base)
 			name += ")";
 		}
 
-		obs_source_t *source = obs_get_source_by_name(name.c_str());
+		OBSSourceAutoRelease source =
+			obs_get_source_by_name(name.c_str());
 
 		if (!source)
 			return name;
-		else
-			obs_source_release(source);
 	}
 }
 
@@ -106,8 +105,8 @@ void OBSBasic::AddDropURL(const char *url, QString &name, obs_data_t *settings,
 void OBSBasic::AddDropSource(const char *data, DropType image)
 {
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
-	obs_data_t *settings = obs_data_create();
-	obs_source_t *source = nullptr;
+	OBSDataAutoRelease settings = obs_data_create();
+	OBSSourceAutoRelease source = nullptr;
 	const char *type = nullptr;
 	std::vector<const char *> types;
 	QString name;
@@ -167,7 +166,6 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 		}
 	}
 	if (type == nullptr || !obs_source_get_display_name(type)) {
-		obs_data_release(settings);
 		return;
 	}
 
@@ -179,10 +177,7 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 	if (source) {
 		OBSScene scene = main->GetCurrentScene();
 		obs_scene_add(scene, source);
-		obs_source_release(source);
 	}
-
-	obs_data_release(settings);
 }
 
 void OBSBasic::dragEnterEvent(QDragEnterEvent *event)

--- a/UI/window-basic-main-outputs.hpp
+++ b/UI/window-basic-main-outputs.hpp
@@ -5,10 +5,10 @@
 class OBSBasic;
 
 struct BasicOutputHandler {
-	OBSOutput fileOutput;
-	OBSOutput streamOutput;
-	OBSOutput replayBuffer;
-	OBSOutput virtualCam;
+	OBSOutputAutoRelease fileOutput;
+	OBSOutputAutoRelease streamOutput;
+	OBSOutputAutoRelease replayBuffer;
+	OBSOutputAutoRelease virtualCam;
 	bool streamingActive = false;
 	bool recordingActive = false;
 	bool delayActive = false;

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -53,7 +53,7 @@ void EnumSceneCollections(std::function<bool(const char *, const char *)> &&cb)
 		if (glob->gl_pathv[i].directory)
 			continue;
 
-		obs_data_t *data =
+		OBSDataAutoRelease data =
 			obs_data_create_from_json_file_safe(filePath, "bak");
 		std::string name = obs_data_get_string(data, "name");
 
@@ -63,8 +63,6 @@ void EnumSceneCollections(std::function<bool(const char *, const char *)> &&cb)
 			name = strrchr(filePath, '/') + 1;
 			name.resize(name.size() - 5);
 		}
-
-		obs_data_release(data);
 
 		if (!cb(name.c_str(), filePath))
 			break;

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -68,7 +68,7 @@ void OBSBasic::InitDefaultTransitions()
 		const char *name = obs_source_get_display_name(id);
 
 		if (!obs_is_source_configurable(id)) {
-			obs_source_t *tr =
+			OBSSourceAutoRelease tr =
 				obs_source_create_private(id, name, NULL);
 			InitTransition(tr);
 			transitions.emplace_back(tr);
@@ -77,8 +77,6 @@ void OBSBasic::InitDefaultTransitions()
 				fadeTransition = tr;
 			else if (strcmp(id, "cut_transition") == 0)
 				cutTransition = tr;
-
-			obs_source_release(tr);
 		} else {
 			AddTransitionVal val;
 			val.name = QTStr("Add") + QStringLiteral(": ") +
@@ -239,8 +237,9 @@ void OBSBasic::LoadQuickTransitions(obs_data_array_t *array)
 	quickTransitionIdCounter = 1;
 
 	for (size_t i = 0; i < count; i++) {
-		obs_data_t *data = obs_data_array_item(array, i);
-		obs_data_array_t *hotkeys = obs_data_get_array(data, "hotkeys");
+		OBSDataAutoRelease data = obs_data_array_item(array, i);
+		OBSDataArrayAutoRelease hotkeys =
+			obs_data_get_array(data, "hotkeys");
 		const char *name = obs_data_get_string(data, "name");
 		int duration = obs_data_get_int(data, "duration");
 		int id = obs_data_get_int(data, "id");
@@ -262,9 +261,6 @@ void OBSBasic::LoadQuickTransitions(obs_data_array_t *array)
 						hotkeys);
 			}
 		}
-
-		obs_data_release(data);
-		obs_data_array_release(hotkeys);
 	}
 }
 
@@ -273,8 +269,8 @@ obs_data_array_t *OBSBasic::SaveQuickTransitions()
 	obs_data_array_t *array = obs_data_array_create();
 
 	for (QuickTransition &qt : quickTransitions) {
-		obs_data_t *data = obs_data_create();
-		obs_data_array_t *hotkeys = obs_hotkey_save(qt.hotkey);
+		OBSDataAutoRelease data = obs_data_create();
+		OBSDataArrayAutoRelease hotkeys = obs_hotkey_save(qt.hotkey);
 
 		obs_data_set_string(data, "name",
 				    obs_source_get_name(qt.source));
@@ -284,9 +280,6 @@ obs_data_array_t *OBSBasic::SaveQuickTransitions()
 		obs_data_set_bool(data, "fade_to_black", qt.fadeToBlack);
 
 		obs_data_array_push_back(array, data);
-
-		obs_data_release(data);
-		obs_data_array_release(hotkeys);
 	}
 
 	return array;
@@ -333,15 +326,13 @@ void OBSBasic::TransitionStopped()
 
 void OBSBasic::OverrideTransition(OBSSource transition)
 {
-	obs_source_t *oldTransition = obs_get_output_source(0);
+	OBSSourceAutoRelease oldTransition = obs_get_output_source(0);
 
 	if (transition != oldTransition) {
 		obs_transition_swap_begin(transition, oldTransition);
 		obs_set_output_source(0, transition);
 		obs_transition_swap_end(transition, oldTransition);
 	}
-
-	obs_source_release(oldTransition);
 }
 
 void OBSBasic::TransitionFullyStopped()
@@ -387,13 +378,12 @@ void OBSBasic::TransitionToScene(OBSSource source, bool force,
 		source = obs_scene_get_source(scene);
 	}
 
-	OBSSource transition = obs_get_output_source(0);
+	OBSSourceAutoRelease transition = obs_get_output_source(0);
 	if (!transition) {
 		if (usingPreviewProgram && sceneDuplicationMode)
 			obs_scene_release(scene);
 		return;
 	}
-	obs_source_release(transition);
 
 	float t = obs_transition_get_time(transition);
 	bool stillTransitioning = t < 1.0f && t > 0.0f;
@@ -462,8 +452,7 @@ static inline void SetComboTransition(QComboBox *combo, obs_source_t *tr)
 
 void OBSBasic::SetTransition(OBSSource transition)
 {
-	obs_source_t *oldTransition = obs_get_output_source(0);
-	obs_source_release(oldTransition);
+	OBSSourceAutoRelease oldTransition = obs_get_output_source(0);
 
 	if (transition == oldTransition)
 		return;
@@ -561,9 +550,8 @@ void OBSBasic::AddTransition(QString id)
 		ClearQuickTransitionWidgets();
 		RefreshQuickTransitions();
 	} else {
-		obs_source_t *transition = obs_get_output_source(0);
+		OBSSourceAutoRelease transition = obs_get_output_source(0);
 		SetComboTransition(ui->transitions, transition);
-		obs_source_release(transition);
 	}
 }
 
@@ -929,8 +917,7 @@ void OBSBasic::TBarReleased()
 {
 	int val = tBar->value();
 
-	OBSSource transition = obs_get_output_source(0);
-	obs_source_release(transition);
+	OBSSourceAutoRelease transition = obs_get_output_source(0);
 
 	if ((tBar->maximum() - val) <= T_BAR_CLAMP) {
 		obs_transition_set_manual_time(transition, 1.0f);
@@ -968,8 +955,7 @@ static bool ValidTBarTransition(OBSSource transition)
 
 void OBSBasic::TBarChanged(int value)
 {
-	OBSSource transition = obs_get_output_source(0);
-	obs_source_release(transition);
+	OBSSourceAutoRelease transition = obs_get_output_source(0);
 
 	tBar->setValue(value);
 
@@ -1029,8 +1015,7 @@ QMenu *OBSBasic::CreatePerSceneTransitionMenu()
 	QMenu *menu = new QMenu(QTStr("TransitionOverride"));
 	QAction *action;
 
-	OBSData data = obs_source_get_private_settings(scene);
-	obs_data_release(data);
+	OBSDataAutoRelease data = obs_source_get_private_settings(scene);
 
 	obs_data_set_default_int(data, "transition_duration", 300);
 
@@ -1047,8 +1032,8 @@ QMenu *OBSBasic::CreatePerSceneTransitionMenu()
 	auto setTransition = [this](QAction *action) {
 		int idx = action->property("transition_index").toInt();
 		OBSSource scene = GetCurrentSceneSource();
-		OBSData data = obs_source_get_private_settings(scene);
-		obs_data_release(data);
+		OBSDataAutoRelease data =
+			obs_source_get_private_settings(scene);
 
 		if (idx == -1) {
 			obs_data_set_string(data, "transition", "");
@@ -1065,8 +1050,8 @@ QMenu *OBSBasic::CreatePerSceneTransitionMenu()
 
 	auto setDuration = [this](int duration) {
 		OBSSource scene = GetCurrentSceneSource();
-		OBSData data = obs_source_get_private_settings(scene);
-		obs_data_release(data);
+		OBSDataAutoRelease data =
+			obs_source_get_private_settings(scene);
 
 		obs_data_set_int(data, "transition_duration", duration);
 	};
@@ -1163,20 +1148,18 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 
 		auto undo_redo = [sceneName, sceneItemId,
 				  visible](const std::string &data) {
-			obs_source_t *source =
+			OBSSourceAutoRelease source =
 				obs_get_source_by_name(sceneName.c_str());
 			obs_scene_t *scene = obs_scene_from_source(source);
 			obs_sceneitem_t *i = obs_scene_find_sceneitem_by_id(
 				scene, sceneItemId);
 			if (i) {
-				obs_data_t *dat =
+				OBSDataAutoRelease dat =
 					obs_data_create_from_json(data.c_str());
 				obs_sceneitem_transition_load(i, dat, visible);
-				obs_data_release(dat);
 			}
-			obs_source_release(source);
 		};
-		obs_data_t *oldTransitionData =
+		OBSDataAutoRelease oldTransitionData =
 			obs_sceneitem_transition_save(sceneItem, visible);
 		if (id.isNull() || id.isEmpty()) {
 			if (visible)
@@ -1229,7 +1212,7 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 			if (obs_source_configurable(tr))
 				CreatePropertiesWindow(tr);
 		}
-		obs_data_t *newTransitionData =
+		OBSDataAutoRelease newTransitionData =
 			obs_sceneitem_transition_save(sceneItem, visible);
 		std::string undo_data(obs_data_get_json(oldTransitionData));
 		std::string redo_data(obs_data_get_json(newTransitionData));
@@ -1241,8 +1224,6 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 						obs_sceneitem_get_source(
 							sceneItem))),
 				undo_redo, undo_redo, undo_data, redo_data);
-		obs_data_release(newTransitionData);
-		obs_data_release(oldTransitionData);
 	};
 	if (visible) {
 		auto setDuration = [this](int duration) {
@@ -1612,7 +1593,7 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 		OBSScene curScene = GetCurrentScene();
 
-		obs_scene_t *dup;
+		OBSSceneAutoRelease dup;
 		if (sceneDuplicationMode) {
 			dup = obs_scene_duplicate(
 				curScene,
@@ -1626,11 +1607,9 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 			obs_scene_addref(dup);
 		}
 
-		obs_source_t *transition = obs_get_output_source(0);
+		OBSSourceAutoRelease transition = obs_get_output_source(0);
 		obs_source_t *dup_source = obs_scene_get_source(dup);
 		obs_transition_set(transition, dup_source);
-		obs_source_release(transition);
-		obs_scene_release(dup);
 
 		if (curScene) {
 			obs_source_t *source = obs_scene_get_source(curScene);
@@ -1779,8 +1758,8 @@ obs_data_array_t *OBSBasic::SaveTransitions()
 		if (!tr || !obs_source_configurable(tr))
 			continue;
 
-		obs_data_t *sourceData = obs_data_create();
-		obs_data_t *settings = obs_source_get_settings(tr);
+		OBSDataAutoRelease sourceData = obs_data_create();
+		OBSDataAutoRelease settings = obs_source_get_settings(tr);
 
 		obs_data_set_string(sourceData, "name",
 				    obs_source_get_name(tr));
@@ -1788,9 +1767,6 @@ obs_data_array_t *OBSBasic::SaveTransitions()
 		obs_data_set_obj(sourceData, "settings", settings);
 
 		obs_data_array_push_back(transitions, sourceData);
-
-		obs_data_release(settings);
-		obs_data_release(sourceData);
 	}
 
 	return transitions;
@@ -1802,12 +1778,13 @@ void OBSBasic::LoadTransitions(obs_data_array_t *transitions,
 	size_t count = obs_data_array_count(transitions);
 
 	for (size_t i = 0; i < count; i++) {
-		obs_data_t *item = obs_data_array_item(transitions, i);
+		OBSDataAutoRelease item = obs_data_array_item(transitions, i);
 		const char *name = obs_data_get_string(item, "name");
 		const char *id = obs_data_get_string(item, "id");
-		obs_data_t *settings = obs_data_get_obj(item, "settings");
+		OBSDataAutoRelease settings =
+			obs_data_get_obj(item, "settings");
 
-		obs_source_t *source =
+		OBSSourceAutoRelease source =
 			obs_source_create_private(id, name, settings);
 		if (!obs_obj_invalid(source)) {
 			InitTransition(source);
@@ -1815,10 +1792,6 @@ void OBSBasic::LoadTransitions(obs_data_array_t *transitions,
 			if (cb)
 				cb(private_data, source);
 		}
-
-		obs_data_release(settings);
-		obs_data_release(item);
-		obs_source_release(source);
 	}
 }
 
@@ -1827,8 +1800,7 @@ OBSSource OBSBasic::GetOverrideTransition(OBSSource source)
 	if (!source)
 		return nullptr;
 
-	OBSData data = obs_source_get_private_settings(source);
-	obs_data_release(data);
+	OBSDataAutoRelease data = obs_source_get_private_settings(source);
 
 	const char *trOverrideName = obs_data_get_string(data, "transition");
 
@@ -1845,8 +1817,7 @@ int OBSBasic::GetOverrideTransitionDuration(OBSSource source)
 	if (!source)
 		return 300;
 
-	OBSData data = obs_source_get_private_settings(source);
-	obs_data_release(data);
+	OBSDataAutoRelease data = obs_source_get_private_settings(source);
 	obs_data_set_default_int(data, "transition_duration", 300);
 
 	return (int)obs_data_get_int(data, "transition_duration");

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -467,18 +467,15 @@ OBSBasic::OBSBasic(QWidget *parent)
 static void SaveAudioDevice(const char *name, int channel, obs_data_t *parent,
 			    vector<OBSSource> &audioSources)
 {
-	obs_source_t *source = obs_get_output_source(channel);
+	OBSSourceAutoRelease source = obs_get_output_source(channel);
 	if (!source)
 		return;
 
-	audioSources.push_back(source);
+	audioSources.push_back(source.Get());
 
-	obs_data_t *data = obs_save_source(source);
+	OBSDataAutoRelease data = obs_save_source(source);
 
 	obs_data_set_obj(parent, name, data);
-
-	obs_data_release(data);
-	obs_source_release(source);
 }
 
 static obs_data_t *GenerateSaveData(obs_data_array_t *sceneOrder,
@@ -531,7 +528,7 @@ static obs_data_t *GenerateSaveData(obs_data_array_t *sceneOrder,
 
 	/* -------------------------------- */
 
-	obs_source_t *transition = obs_get_output_source(0);
+	OBSSourceAutoRelease transition = obs_get_output_source(0);
 	obs_source_t *currentScene = obs_scene_get_source(scene);
 	const char *sceneName = obs_source_get_name(currentScene);
 	const char *programName = obs_source_get_name(curProgramScene);
@@ -554,7 +551,6 @@ static obs_data_t *GenerateSaveData(obs_data_array_t *sceneOrder,
 	obs_data_set_string(saveData, "current_transition",
 			    obs_source_get_name(transition));
 	obs_data_set_int(saveData, "transition_duration", transitionDuration);
-	obs_source_release(transition);
 
 	return saveData;
 }
@@ -625,11 +621,10 @@ obs_data_array_t *OBSBasic::SaveSceneListOrder()
 	obs_data_array_t *sceneOrder = obs_data_array_create();
 
 	for (int i = 0; i < ui->scenes->count(); i++) {
-		obs_data_t *data = obs_data_create();
+		OBSDataAutoRelease data = obs_data_create();
 		obs_data_set_string(data, "name",
 				    QT_TO_UTF8(ui->scenes->item(i)->text()));
 		obs_data_array_push_back(sceneOrder, data);
-		obs_data_release(data);
 	}
 
 	return sceneOrder;
@@ -643,7 +638,7 @@ obs_data_array_t *OBSBasic::SaveProjectors()
 		if (!projector)
 			return;
 
-		obs_data_t *data = obs_data_create();
+		OBSDataAutoRelease data = obs_data_create();
 		ProjectorType type = projector->GetProjectorType();
 
 		switch (type) {
@@ -672,7 +667,6 @@ obs_data_array_t *OBSBasic::SaveProjectors()
 				  projector->IsAlwaysOnTopOverridden());
 
 		obs_data_array_push_back(savedProjectors, data);
-		obs_data_release(data);
 	};
 
 	for (size_t i = 0; i < projectors.size(); i++)
@@ -688,11 +682,11 @@ void OBSBasic::Save(const char *file)
 	if (!curProgramScene)
 		curProgramScene = obs_scene_get_source(scene);
 
-	obs_data_array_t *sceneOrder = SaveSceneListOrder();
-	obs_data_array_t *transitions = SaveTransitions();
-	obs_data_array_t *quickTrData = SaveQuickTransitions();
-	obs_data_array_t *savedProjectorList = SaveProjectors();
-	obs_data_t *saveData = GenerateSaveData(
+	OBSDataArrayAutoRelease sceneOrder = SaveSceneListOrder();
+	OBSDataArrayAutoRelease transitions = SaveTransitions();
+	OBSDataArrayAutoRelease quickTrData = SaveQuickTransitions();
+	OBSDataArrayAutoRelease savedProjectorList = SaveProjectors();
+	OBSDataAutoRelease saveData = GenerateSaveData(
 		sceneOrder, quickTrData, ui->transitionDuration->value(),
 		transitions, scene, curProgramScene, savedProjectorList);
 
@@ -707,20 +701,13 @@ void OBSBasic::Save(const char *file)
 			    ui->preview->GetScrollY());
 
 	if (api) {
-		obs_data_t *moduleObj = obs_data_create();
+		OBSDataAutoRelease moduleObj = obs_data_create();
 		api->on_save(moduleObj);
 		obs_data_set_obj(saveData, "modules", moduleObj);
-		obs_data_release(moduleObj);
 	}
 
 	if (!obs_data_save_json_safe(saveData, file, "tmp", "bak"))
 		blog(LOG_ERROR, "Could not save scene data to %s", file);
-
-	obs_data_release(saveData);
-	obs_data_array_release(sceneOrder);
-	obs_data_array_release(quickTrData);
-	obs_data_array_release(transitions);
-	obs_data_array_release(savedProjectorList);
 }
 
 void OBSBasic::DeferSaveBegin()
@@ -740,31 +727,29 @@ static void LogFilter(obs_source_t *, obs_source_t *filter, void *v_val);
 
 static void LoadAudioDevice(const char *name, int channel, obs_data_t *parent)
 {
-	obs_data_t *data = obs_data_get_obj(parent, name);
+	OBSDataAutoRelease data = obs_data_get_obj(parent, name);
 	if (!data)
 		return;
 
-	obs_source_t *source = obs_load_source(data);
-	if (source) {
-		obs_set_output_source(channel, source);
+	OBSSourceAutoRelease source = obs_load_source(data);
+	if (!source)
+		return;
 
-		const char *name = obs_source_get_name(source);
-		blog(LOG_INFO, "[Loaded global audio device]: '%s'", name);
-		obs_source_enum_filters(source, LogFilter, (void *)(intptr_t)1);
-		obs_monitoring_type monitoring_type =
-			obs_source_get_monitoring_type(source);
-		if (monitoring_type != OBS_MONITORING_TYPE_NONE) {
-			const char *type = (monitoring_type ==
-					    OBS_MONITORING_TYPE_MONITOR_ONLY)
-						   ? "monitor only"
-						   : "monitor and output";
+	obs_set_output_source(channel, source);
 
-			blog(LOG_INFO, "    - monitoring: %s", type);
-		}
-		obs_source_release(source);
+	const char *source_name = obs_source_get_name(source);
+	blog(LOG_INFO, "[Loaded global audio device]: '%s'", source_name);
+	obs_source_enum_filters(source, LogFilter, (void *)(intptr_t)1);
+	obs_monitoring_type monitoring_type =
+		obs_source_get_monitoring_type(source);
+	if (monitoring_type != OBS_MONITORING_TYPE_NONE) {
+		const char *type =
+			(monitoring_type == OBS_MONITORING_TYPE_MONITOR_ONLY)
+				? "monitor only"
+				: "monitor and output";
+
+		blog(LOG_INFO, "    - monitoring: %s", type);
 	}
-
-	obs_data_release(data);
 }
 
 static inline bool HasAudioDevices(const char *source_id)
@@ -808,13 +793,12 @@ void OBSBasic::CreateDefaultScene(bool firstStart)
 	ui->transitionDuration->setValue(300);
 	SetTransition(fadeTransition);
 
-	obs_scene_t *scene = obs_scene_create(Str("Basic.Scene"));
+	OBSSceneAutoRelease scene = obs_scene_create(Str("Basic.Scene"));
 
 	if (firstStart)
 		CreateFirstRunSources();
 
 	SetCurrentScene(scene, true);
-	obs_scene_release(scene);
 
 	disableSaving--;
 }
@@ -839,12 +823,10 @@ void OBSBasic::LoadSceneListOrder(obs_data_array_t *array)
 	size_t num = obs_data_array_count(array);
 
 	for (size_t i = 0; i < num; i++) {
-		obs_data_t *data = obs_data_array_item(array, i);
+		OBSDataAutoRelease data = obs_data_array_item(array, i);
 		const char *name = obs_data_get_string(data, "name");
 
 		ReorderItemByName(ui->scenes, name, (int)i);
-
-		obs_data_release(data);
 	}
 }
 
@@ -858,7 +840,7 @@ void OBSBasic::LoadSavedProjectors(obs_data_array_t *array)
 	size_t num = obs_data_array_count(array);
 
 	for (size_t i = 0; i < num; i++) {
-		obs_data_t *data = obs_data_array_item(array, i);
+		OBSDataAutoRelease data = obs_data_array_item(array, i);
 
 		SavedProjectorInfo *info = new SavedProjectorInfo();
 		info->monitor = obs_data_get_int(data, "monitor");
@@ -872,8 +854,6 @@ void OBSBasic::LoadSavedProjectors(obs_data_array_t *array)
 			obs_data_get_bool(data, "alwaysOnTopOverridden");
 
 		savedProjectorsArray.emplace_back(info);
-
-		obs_data_release(data);
 	}
 }
 
@@ -982,14 +962,16 @@ void OBSBasic::LoadData(obs_data_t *data, const char *file)
 
 	QApplication::sendPostedEvents(this);
 
-	obs_data_t *modulesObj = obs_data_get_obj(data, "modules");
+	OBSDataAutoRelease modulesObj = obs_data_get_obj(data, "modules");
 	if (api)
 		api->on_preload(modulesObj);
 
-	obs_data_array_t *sceneOrder = obs_data_get_array(data, "scene_order");
-	obs_data_array_t *sources = obs_data_get_array(data, "sources");
-	obs_data_array_t *groups = obs_data_get_array(data, "groups");
-	obs_data_array_t *transitions = obs_data_get_array(data, "transitions");
+	OBSDataArrayAutoRelease sceneOrder =
+		obs_data_get_array(data, "scene_order");
+	OBSDataArrayAutoRelease sources = obs_data_get_array(data, "sources");
+	OBSDataArrayAutoRelease groups = obs_data_get_array(data, "groups");
+	OBSDataArrayAutoRelease transitions =
+		obs_data_get_array(data, "transitions");
 	const char *sceneName = obs_data_get_string(data, "current_scene");
 	const char *programSceneName =
 		obs_data_get_string(data, "current_program_scene");
@@ -1015,8 +997,8 @@ void OBSBasic::LoadData(obs_data_t *data, const char *file)
 	obs_data_set_default_string(data, "name", curSceneCollection);
 
 	const char *name = obs_data_get_string(data, "name");
-	obs_source_t *curScene;
-	obs_source_t *curProgramScene;
+	OBSSourceAutoRelease curScene;
+	OBSSourceAutoRelease curProgramScene;
 	obs_source_t *curTransition;
 
 	if (!name || !*name)
@@ -1031,6 +1013,7 @@ void OBSBasic::LoadData(obs_data_t *data, const char *file)
 
 	if (!sources) {
 		sources = groups;
+		obs_data_array_addref(groups);
 		groups = nullptr;
 	} else {
 		obs_data_array_push_back_array(sources, groups);
@@ -1055,8 +1038,6 @@ void OBSBasic::LoadData(obs_data_t *data, const char *file)
 	if (sceneOrder)
 		LoadSceneListOrder(sceneOrder);
 
-	obs_data_array_release(transitions);
-
 	curTransition = FindTransition(transitionName);
 	if (!curTransition)
 		curTransition = fadeTransition;
@@ -1074,8 +1055,6 @@ retryScene:
 		sceneName = obs_data_get_string(data, "current_scene");
 		programSceneName =
 			obs_data_get_string(data, "current_program_scene");
-		obs_source_release(curScene);
-		obs_source_release(curProgramScene);
 		opt_starting_scene.clear();
 		goto retryScene;
 	}
@@ -1085,15 +1064,9 @@ retryScene:
 		obs_source_addref(curScene);
 	}
 
-	SetCurrentScene(curScene, true);
+	SetCurrentScene(curScene.Get(), true);
 	if (IsPreviewProgramMode())
-		TransitionToScene(curProgramScene, true);
-	obs_source_release(curScene);
-	obs_source_release(curProgramScene);
-
-	obs_data_array_release(sources);
-	obs_data_array_release(groups);
-	obs_data_array_release(sceneOrder);
+		TransitionToScene(curProgramScene.Get(), true);
 
 	/* ------------------- */
 
@@ -1101,7 +1074,7 @@ retryScene:
 					     "SaveProjectors");
 
 	if (projectorSave) {
-		obs_data_array_t *savedProjectors =
+		OBSDataArrayAutoRelease savedProjectors =
 			obs_data_get_array(data, "saved_projectors");
 
 		if (savedProjectors) {
@@ -1109,8 +1082,6 @@ retryScene:
 			OpenSavedProjectors();
 			activateWindow();
 		}
-
-		obs_data_array_release(savedProjectors);
 	}
 
 	/* ------------------- */
@@ -1123,10 +1094,9 @@ retryScene:
 	config_set_string(App()->GlobalConfig(), "Basic", "SceneCollectionFile",
 			  file_base.c_str());
 
-	obs_data_array_t *quickTransitionData =
+	OBSDataArrayAutoRelease quickTransitionData =
 		obs_data_get_array(data, "quick_transitions");
 	LoadQuickTransitions(quickTransitionData);
-	obs_data_array_release(quickTransitionData);
 
 	RefreshQuickTransitions();
 
@@ -1153,7 +1123,6 @@ retryScene:
 	if (api)
 		api->on_load(modulesObj);
 
-	obs_data_release(modulesObj);
 	obs_data_release(data);
 
 	if (!opt_starting_scene.empty())
@@ -1224,17 +1193,14 @@ void OBSBasic::SaveService()
 	if (ret <= 0)
 		return;
 
-	obs_data_t *data = obs_data_create();
-	obs_data_t *settings = obs_service_get_settings(service);
+	OBSDataAutoRelease data = obs_data_create();
+	OBSDataAutoRelease settings = obs_service_get_settings(service);
 
 	obs_data_set_string(data, "type", obs_service_get_type(service));
 	obs_data_set_obj(data, "settings", settings);
 
 	if (!obs_data_save_json_safe(data, serviceJsonPath, "tmp", "bak"))
 		blog(LOG_WARNING, "Failed to save service");
-
-	obs_data_release(settings);
-	obs_data_release(data);
 }
 
 bool OBSBasic::LoadService()
@@ -1247,7 +1213,7 @@ bool OBSBasic::LoadService()
 	if (ret <= 0)
 		return false;
 
-	obs_data_t *data =
+	OBSDataAutoRelease data =
 		obs_data_create_from_json_file_safe(serviceJsonPath, "bak");
 
 	if (!data)
@@ -1256,16 +1222,12 @@ bool OBSBasic::LoadService()
 	obs_data_set_default_string(data, "type", "rtmp_common");
 	type = obs_data_get_string(data, "type");
 
-	obs_data_t *settings = obs_data_get_obj(data, "settings");
-	obs_data_t *hotkey_data = obs_data_get_obj(data, "hotkeys");
+	OBSDataAutoRelease settings = obs_data_get_obj(data, "settings");
+	OBSDataAutoRelease hotkey_data = obs_data_get_obj(data, "hotkeys");
 
 	service = obs_service_create(type, "default_service", settings,
 				     hotkey_data);
 	obs_service_release(service);
-
-	obs_data_release(hotkey_data);
-	obs_data_release(settings);
-	obs_data_release(data);
 
 	return !!service;
 }
@@ -1824,12 +1786,11 @@ void OBSBasic::OBSInit()
 	cef = obs_browser_init_panel();
 #endif
 
-	obs_data_t *obsData = obs_get_private_data();
+	OBSDataAutoRelease obsData = obs_get_private_data();
 	vcamEnabled = obs_data_get_bool(obsData, "vcamEnabled");
 	if (vcamEnabled) {
 		AddVCamButton();
 	}
-	obs_data_release(obsData);
 
 	InitBasicConfigDefaults2();
 
@@ -2370,33 +2331,28 @@ void OBSBasic::CreateHotkeys()
 		if (!info)
 			return {};
 
-		obs_data_t *data = obs_data_create_from_json(info);
+		OBSDataAutoRelease data = obs_data_create_from_json(info);
 		if (!data)
 			return {};
 
-		OBSData res = data;
-		obs_data_release(data);
-		return res;
+		return data.Get();
 	};
 
 	auto LoadHotkey = [&](obs_hotkey_id id, const char *name) {
-		obs_data_array_t *array =
+		OBSDataArrayAutoRelease array =
 			obs_data_get_array(LoadHotkeyData(name), "bindings");
 
 		obs_hotkey_load(id, array);
-		obs_data_array_release(array);
 	};
 
 	auto LoadHotkeyPair = [&](obs_hotkey_pair_id id, const char *name0,
 				  const char *name1) {
-		obs_data_array_t *array0 =
+		OBSDataArrayAutoRelease array0 =
 			obs_data_get_array(LoadHotkeyData(name0), "bindings");
-		obs_data_array_t *array1 =
+		OBSDataArrayAutoRelease array1 =
 			obs_data_get_array(LoadHotkeyData(name1), "bindings");
 
 		obs_hotkey_pair_load(id, array0, array1);
-		obs_data_array_release(array0);
-		obs_data_array_release(array1);
 	};
 
 #define MAKE_CALLBACK(pred, method, log_action)                            \
@@ -2880,10 +2836,10 @@ void OBSBasic::AddScene(OBSSource source)
 
 			auto potential_source =
 				static_cast<obs_source_t *>(data);
-			auto source = obs_source_get_ref(potential_source);
+			OBSSourceAutoRelease source =
+				obs_source_get_ref(potential_source);
 			if (source && pressed)
-				main->SetCurrentScene(source);
-			obs_source_release(source);
+				main->SetCurrentScene(source.Get());
 		},
 		static_cast<obs_source_t *>(source));
 
@@ -3073,9 +3029,8 @@ static bool is_network_media_source(obs_source_t *source, const char *id)
 	if (strcmp(id, "ffmpeg_source") != 0)
 		return false;
 
-	obs_data_t *s = obs_source_get_settings(source);
+	OBSDataAutoRelease s = obs_source_get_settings(source);
 	bool is_local_file = obs_data_get_bool(s, "is_local_file");
-	obs_data_release(s);
 
 	return !is_local_file;
 }
@@ -3243,18 +3198,18 @@ void OBSBasic::UpdateContextBar(bool force)
 
 static inline bool SourceMixerHidden(obs_source_t *source)
 {
-	obs_data_t *priv_settings = obs_source_get_private_settings(source);
+	OBSDataAutoRelease priv_settings =
+		obs_source_get_private_settings(source);
 	bool hidden = obs_data_get_bool(priv_settings, "mixer_hidden");
-	obs_data_release(priv_settings);
 
 	return hidden;
 }
 
 static inline void SetSourceMixerHidden(obs_source_t *source, bool hidden)
 {
-	obs_data_t *priv_settings = obs_source_get_private_settings(source);
+	OBSDataAutoRelease priv_settings =
+		obs_source_get_private_settings(source);
 	obs_data_set_bool(priv_settings, "mixer_hidden", hidden);
-	obs_data_release(priv_settings);
 }
 
 void OBSBasic::GetAudioSourceFilters()
@@ -3347,8 +3302,8 @@ void OBSBasic::MixerRenameSource()
 			continue;
 		}
 
-		OBSSource sourceTest = obs_get_source_by_name(name.c_str());
-		obs_source_release(sourceTest);
+		OBSSourceAutoRelease sourceTest =
+			obs_get_source_by_name(name.c_str());
 
 		if (sourceTest) {
 			OBSMessageBox::warning(this, QTStr("NameExists.Title"),
@@ -3363,9 +3318,9 @@ void OBSBasic::MixerRenameSource()
 
 static inline bool SourceVolumeLocked(obs_source_t *source)
 {
-	obs_data_t *priv_settings = obs_source_get_private_settings(source);
+	OBSDataAutoRelease priv_settings =
+		obs_source_get_private_settings(source);
 	bool lock = obs_data_get_bool(priv_settings, "volume_locked");
-	obs_data_release(priv_settings);
 
 	return lock;
 }
@@ -3376,9 +3331,9 @@ void OBSBasic::LockVolumeControl(bool lock)
 	VolControl *vol = action->property("volControl").value<VolControl *>();
 	obs_source_t *source = vol->GetSource();
 
-	obs_data_t *priv_settings = obs_source_get_private_settings(source);
+	OBSDataAutoRelease priv_settings =
+		obs_source_get_private_settings(source);
 	obs_data_set_bool(priv_settings, "volume_locked", lock);
-	obs_data_release(priv_settings);
 
 	vol->EnableSlider(!lock);
 }
@@ -3462,10 +3417,10 @@ void OBSBasic::VolControlContextMenu()
 	copyFiltersAction.setEnabled(obs_source_filter_count(vol->GetSource()) >
 				     0);
 
-	obs_source_t *source = obs_weak_source_get_source(copyFiltersSource);
+	OBSSourceAutoRelease source =
+		obs_weak_source_get_source(copyFiltersSource);
 	if (source) {
 		pasteFiltersAction.setEnabled(true);
-		obs_source_release(source);
 	} else {
 		pasteFiltersAction.setEnabled(false);
 	}
@@ -3735,9 +3690,8 @@ void OBSBasic::DuplicateSelectedScene()
 
 	int i = 2;
 	QString placeHolderText = format.arg(i);
-	obs_source_t *source = nullptr;
+	OBSSourceAutoRelease source = nullptr;
 	while ((source = obs_get_source_by_name(QT_TO_UTF8(placeHolderText)))) {
-		obs_source_release(source);
 		placeHolderText = format.arg(++i);
 	}
 
@@ -3766,28 +3720,25 @@ void OBSBasic::DuplicateSelectedScene()
 			continue;
 		}
 
-		obs_scene_t *scene = obs_scene_duplicate(curScene, name.c_str(),
-							 OBS_SCENE_DUP_REFS);
+		OBSSceneAutoRelease scene = obs_scene_duplicate(
+			curScene, name.c_str(), OBS_SCENE_DUP_REFS);
 		source = obs_scene_get_source(scene);
 		SetCurrentScene(source, true);
 
 		auto undo = [](const std::string &data) {
-			obs_source_t *source =
+			OBSSourceAutoRelease source =
 				obs_get_source_by_name(data.c_str());
 			obs_source_remove(source);
-			obs_source_release(source);
 		};
 
 		auto redo = [this, name](const std::string &data) {
-			obs_source_t *source =
+			OBSSourceAutoRelease source =
 				obs_get_source_by_name(data.c_str());
 			obs_scene_t *scene = obs_scene_from_source(source);
-			obs_source_release(source);
 			scene = obs_scene_duplicate(scene, name.c_str(),
 						    OBS_SCENE_DUP_REFS);
 			source = obs_scene_get_source(scene);
-			SetCurrentScene(source, true);
-			obs_scene_release(scene);
+			SetCurrentScene(source.Get(), true);
 		};
 
 		undo_s.add_action(
@@ -3795,8 +3746,6 @@ void OBSBasic::DuplicateSelectedScene()
 				.arg(obs_source_get_name(source)),
 			undo, redo, obs_source_get_name(source),
 			obs_source_get_name(obs_scene_get_source(curScene)));
-
-		obs_scene_release(scene);
 
 		break;
 	}
@@ -3817,22 +3766,17 @@ static bool save_undo_source_enum(obs_scene_t *scene, obs_sceneitem_t *item,
 	const char *name = obs_source_get_name(source);
 	const size_t count = obs_data_array_count(array);
 	for (size_t i = 0; i < count; i++) {
-		obs_data_t *sourceData = obs_data_array_item(array, i);
-		if (strcmp(name, obs_data_get_string(sourceData, "name")) ==
-		    0) {
-			obs_data_release(sourceData);
+		OBSDataAutoRelease sourceData = obs_data_array_item(array, i);
+		if (strcmp(name, obs_data_get_string(sourceData, "name")) == 0)
 			return true;
-		}
-		obs_data_release(sourceData);
 	}
 
 	if (obs_source_is_group(source))
 		obs_scene_enum_items(obs_group_from_source(source),
 				     save_undo_source_enum, p);
 
-	obs_data_t *source_data = obs_save_source(source);
+	OBSDataAutoRelease source_data = obs_save_source(source);
 	obs_data_array_push_back(array, source_data);
-	obs_data_release(source_data);
 	return true;
 }
 
@@ -3862,19 +3806,20 @@ void OBSBasic::RemoveSelectedScene()
 	/* ------------------------------ */
 	/* save all sources in scene      */
 
-	obs_data_array_t *sources_in_deleted_scene = obs_data_array_create();
+	OBSDataArrayAutoRelease sources_in_deleted_scene =
+		obs_data_array_create();
 
 	obs_scene_enum_items(scene, save_undo_source_enum,
 			     sources_in_deleted_scene);
 
-	obs_data_t *scene_data = obs_save_source(source);
+	OBSDataAutoRelease scene_data = obs_save_source(source);
 	obs_data_array_push_back(sources_in_deleted_scene, scene_data);
-	obs_data_release(scene_data);
 
 	/* ----------------------------------------------- */
 	/* save all scenes and groups the scene is used in */
 
-	obs_data_array_t *scene_used_in_other_scenes = obs_data_array_create();
+	OBSDataArrayAutoRelease scene_used_in_other_scenes =
+		obs_data_array_create();
 
 	struct other_scenes_cb_data {
 		obs_source_t *oldScene;
@@ -3894,12 +3839,11 @@ void OBSBasic::RemoveSelectedScene()
 			obs_group_or_scene_from_source(scene),
 			obs_source_get_name(data->oldScene));
 		if (item) {
-			obs_data_t *scene_data =
+			OBSDataAutoRelease scene_data =
 				obs_save_source(obs_scene_get_source(
 					obs_sceneitem_get_scene(item)));
 			obs_data_array_push_back(
 				data->scene_used_in_other_scenes, scene_data);
-			obs_data_release(scene_data);
 		}
 		return true;
 	};
@@ -3909,32 +3853,30 @@ void OBSBasic::RemoveSelectedScene()
 	/* undo/redo                   */
 
 	auto undo = [this](const std::string &json) {
-		obs_data_t *base = obs_data_create_from_json(json.c_str());
-		obs_data_array_t *sources_in_deleted_scene =
+		OBSDataAutoRelease base =
+			obs_data_create_from_json(json.c_str());
+		OBSDataArrayAutoRelease sources_in_deleted_scene =
 			obs_data_get_array(base, "sources_in_deleted_scene");
-		obs_data_array_t *scene_used_in_other_scenes =
+		OBSDataArrayAutoRelease scene_used_in_other_scenes =
 			obs_data_get_array(base, "scene_used_in_other_scenes");
 		int savedIndex = (int)obs_data_get_int(base, "index");
-		std::vector<obs_source_t *> sources;
+		std::vector<OBSSource> sources;
 
 		/* create missing sources */
 		size_t count = obs_data_array_count(sources_in_deleted_scene);
 		sources.reserve(count);
 
 		for (size_t i = 0; i < count; i++) {
-			obs_data_t *data = obs_data_array_item(
+			OBSDataAutoRelease data = obs_data_array_item(
 				sources_in_deleted_scene, i);
 			const char *name = obs_data_get_string(data, "name");
 
-			obs_source_t *source = obs_get_source_by_name(name);
+			OBSSourceAutoRelease source =
+				obs_get_source_by_name(name);
 			if (!source) {
 				source = obs_load_source(data);
-				sources.push_back(source);
-			} else {
-				obs_source_release(source);
+				sources.push_back(source.Get());
 			}
-
-			obs_data_release(data);
 		}
 
 		/* actually load sources now */
@@ -3945,26 +3887,26 @@ void OBSBasic::RemoveSelectedScene()
 		for (size_t i = 0;
 		     i < obs_data_array_count(scene_used_in_other_scenes);
 		     i++) {
-			obs_data_t *data = obs_data_array_item(
+			OBSDataAutoRelease data = obs_data_array_item(
 				scene_used_in_other_scenes, i);
 			const char *name = obs_data_get_string(data, "name");
-			obs_source_t *source = obs_get_source_by_name(name);
+			OBSSourceAutoRelease source =
+				obs_get_source_by_name(name);
 
-			obs_data_t *settings =
+			OBSDataAutoRelease settings =
 				obs_data_get_obj(data, "settings");
-			obs_data_array_t *items =
+			OBSDataArrayAutoRelease items =
 				obs_data_get_array(settings, "items");
 
 			/* Clear scene, but keep a reference to all sources in the scene to make sure they don't get destroyed */
-			std::vector<obs_source_t *> existing_sources;
+			std::vector<OBSSource> existing_sources;
 			auto cb = [](obs_scene_t *scene, obs_sceneitem_t *item,
 				     void *data) {
 				UNUSED_PARAMETER(scene);
 				std::vector<obs_source_t *> *existing =
 					(std::vector<obs_source_t *> *)data;
-				obs_source_t *source =
+				OBSSource source =
 					obs_sceneitem_get_source(item);
-				obs_source_addref(source);
 				obs_sceneitem_remove(item);
 				existing->push_back(source);
 				return true;
@@ -3976,15 +3918,6 @@ void OBSBasic::RemoveSelectedScene()
 			/* Re-add sources to the scene */
 			obs_sceneitems_add(
 				obs_group_or_scene_from_source(source), items);
-
-			/* Release source references */
-			for (obs_source_t *source : existing_sources)
-				obs_source_release(source);
-
-			obs_data_array_release(items);
-			obs_data_release(settings);
-			obs_source_release(source);
-			obs_data_release(data);
 		}
 
 		obs_source_t *scene_source = sources.back();
@@ -3998,23 +3931,15 @@ void OBSBasic::RemoveSelectedScene()
 		ui->scenes->insertItem(savedIndex, item);
 		ui->scenes->setCurrentRow(savedIndex);
 		ui->scenes->blockSignals(false);
-
-		/* release sources */
-		for (obs_source_t *source : sources)
-			obs_source_release(source);
-
-		obs_data_array_release(sources_in_deleted_scene);
-		obs_data_array_release(scene_used_in_other_scenes);
-		obs_data_release(base);
 	};
 
 	auto redo = [](const std::string &name) {
-		obs_source_t *source = obs_get_source_by_name(name.c_str());
+		OBSSourceAutoRelease source =
+			obs_get_source_by_name(name.c_str());
 		RemoveSceneAndReleaseNested(source);
-		obs_source_release(source);
 	};
 
-	obs_data_t *data = obs_data_create();
+	OBSDataAutoRelease data = obs_data_create();
 	obs_data_set_array(data, "sources_in_deleted_scene",
 			   sources_in_deleted_scene);
 	obs_data_set_array(data, "scene_used_in_other_scenes",
@@ -4024,10 +3949,6 @@ void OBSBasic::RemoveSelectedScene()
 	const char *scene_name = obs_source_get_name(source);
 	undo_s.add_action(QTStr("Undo.Delete").arg(scene_name), undo, redo,
 			  obs_data_get_json(data), scene_name);
-
-	obs_data_array_release(sources_in_deleted_scene);
-	obs_data_array_release(scene_used_in_other_scenes);
-	obs_data_release(data);
 
 	/* --------------------------- */
 	/* remove                      */
@@ -4287,8 +4208,9 @@ obs_service_t *OBSBasic::GetService()
 
 void OBSBasic::SetService(obs_service_t *newService)
 {
-	if (newService)
+	if (newService) {
 		service = newService;
+	}
 }
 
 int OBSBasic::GetTransitionDuration()
@@ -4491,8 +4413,8 @@ void OBSBasic::ResetAudioDevice(const char *sourceId, const char *deviceId,
 				const char *deviceDesc, int channel)
 {
 	bool disable = deviceId && strcmp(deviceId, "disabled") == 0;
-	obs_source_t *source;
-	obs_data_t *settings;
+	OBSSourceAutoRelease source;
+	OBSDataAutoRelease settings;
 
 	source = obs_get_output_source(channel);
 	if (source) {
@@ -4507,20 +4429,15 @@ void OBSBasic::ResetAudioDevice(const char *sourceId, const char *deviceId,
 						    deviceId);
 				obs_source_update(source, settings);
 			}
-			obs_data_release(settings);
 		}
-
-		obs_source_release(source);
 
 	} else if (!disable) {
 		settings = obs_data_create();
 		obs_data_set_string(settings, "device_id", deviceId);
 		source = obs_source_create(sourceId, deviceDesc, settings,
 					   nullptr);
-		obs_data_release(settings);
 
 		obs_set_output_source(channel, source);
-		obs_source_release(source);
 	}
 }
 
@@ -4891,11 +4808,11 @@ void OBSBasic::on_actionShowMissingFiles_triggered()
 
 void save_audio_source(int channel, obs_data_t *save)
 {
-	obs_source_t *source = obs_get_output_source(channel);
+	OBSSourceAutoRelease source = obs_get_output_source(channel);
 	if (!source)
 		return;
 
-	obs_data_t *obj = obs_data_create();
+	OBSDataAutoRelease obj = obs_data_create();
 
 	obs_data_set_double(obj, "vol", obs_source_get_volume(source));
 	obs_data_set_double(obj, "balance",
@@ -4905,17 +4822,15 @@ void save_audio_source(int channel, obs_data_t *save)
 	obs_data_set_double(obj, "flags", obs_source_get_flags(source));
 
 	obs_data_set_obj(save, std::to_string(channel).c_str(), obj);
-	obs_data_release(obj);
-	obs_source_release(source);
 }
 
 void load_audio_source(int channel, obs_data_t *data)
 {
-	obs_source_t *source = obs_get_output_source(channel);
+	OBSSourceAutoRelease source = obs_get_output_source(channel);
 	if (!source)
 		return;
 
-	obs_data_t *save =
+	OBSDataAutoRelease save =
 		obs_data_get_obj(data, std::to_string(channel).c_str());
 
 	obs_source_set_volume(source, obs_data_get_double(save, "vol"));
@@ -4925,9 +4840,6 @@ void load_audio_source(int channel, obs_data_t *data)
 				    obs_data_get_double(save, "mixers"));
 	obs_source_set_sync_offset(source, obs_data_get_double(save, "sync"));
 	obs_source_set_flags(source, obs_data_get_double(save, "flags"));
-
-	obs_data_release(save);
-	obs_source_release(source);
 }
 
 void OBSBasic::on_actionAdvAudioProperties_triggered()
@@ -5099,8 +5011,8 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 			popup.addAction(QTStr("ShowInMultiview"));
 
 		OBSSource source = GetCurrentSceneSource();
-		OBSData data = obs_source_get_private_settings(source);
-		obs_data_release(data);
+		OBSDataAutoRelease data =
+			obs_source_get_private_settings(source);
 
 		obs_data_set_default_bool(data, "show_in_multiview", true);
 		bool show = obs_data_get_bool(data, "show_in_multiview");
@@ -5116,7 +5028,7 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 		};
 
 		connect(multiviewAction, &QAction::triggered,
-			std::bind(showInMultiview, data));
+			std::bind(showInMultiview, data.Get()));
 
 		copyFilters->setEnabled(obs_source_filter_count(source) > 0);
 	}
@@ -5148,9 +5060,8 @@ void OBSBasic::on_actionAddScene_triggered()
 
 	int i = 2;
 	QString placeHolderText = format.arg(i);
-	obs_source_t *source = nullptr;
+	OBSSourceAutoRelease source = nullptr;
 	while ((source = obs_get_source_by_name(QT_TO_UTF8(placeHolderText)))) {
-		obs_source_release(source);
 		placeHolderText = format.arg(++i);
 	}
 
@@ -5167,12 +5078,12 @@ void OBSBasic::on_actionAddScene_triggered()
 			return;
 		}
 
-		obs_source_t *source = obs_get_source_by_name(name.c_str());
+		OBSSourceAutoRelease source =
+			obs_get_source_by_name(name.c_str());
 		if (source) {
 			OBSMessageBox::warning(this, QTStr("NameExists.Title"),
 					       QTStr("NameExists.Text"));
 
-			obs_source_release(source);
 			on_actionAddScene_triggered();
 			return;
 		}
@@ -5186,18 +5097,18 @@ void OBSBasic::on_actionAddScene_triggered()
 		};
 
 		auto redo_fn = [this](const std::string &data) {
-			obs_scene_t *scene = obs_scene_create(data.c_str());
+			OBSSceneAutoRelease scene =
+				obs_scene_create(data.c_str());
 			obs_source_t *source = obs_scene_get_source(scene);
 			SetCurrentScene(source, true);
-			obs_scene_release(scene);
 		};
 		undo_s.add_action(QTStr("Undo.Add").arg(QString(name.c_str())),
 				  undo_fn, redo_fn, name, name);
 
-		obs_scene_t *scene = obs_scene_create(name.c_str());
+		OBSSceneAutoRelease scene = obs_scene_create(name.c_str());
 		source = obs_scene_get_source(scene);
-		SetCurrentScene(source);
-		obs_scene_release(scene);
+		obs_source_addref(source);
+		SetCurrentScene(source.Get());
 	}
 }
 
@@ -5741,7 +5652,7 @@ static bool remove_items(obs_scene_t *, obs_sceneitem_t *item, void *param)
 OBSData OBSBasic::BackupScene(obs_scene_t *scene,
 			      std::vector<obs_source_t *> *sources)
 {
-	obs_data_array_t *undo_array = obs_data_array_create();
+	OBSDataArrayAutoRelease undo_array = obs_data_array_create();
 
 	if (!sources) {
 		obs_scene_enum_items(scene, save_undo_source_enum, undo_array);
@@ -5753,17 +5664,15 @@ OBSData OBSBasic::BackupScene(obs_scene_t *scene,
 		}
 	}
 
-	obs_data_t *scene_data = obs_save_source(obs_scene_get_source(scene));
+	OBSDataAutoRelease scene_data =
+		obs_save_source(obs_scene_get_source(scene));
 	obs_data_array_push_back(undo_array, scene_data);
-	obs_data_release(scene_data);
 
-	OBSData data = obs_data_create();
-	obs_data_release(data);
+	OBSDataAutoRelease data = obs_data_create();
 
 	obs_data_set_array(data, "array", undo_array);
 	obs_data_get_json(data);
-	obs_data_array_release(undo_array);
-	return data;
+	return data.Get();
 }
 
 static bool add_source_enum(obs_scene_t *, obs_sceneitem_t *item, void *p)
@@ -5777,24 +5686,27 @@ void OBSBasic::CreateSceneUndoRedoAction(const QString &action_name,
 					 OBSData undo_data, OBSData redo_data)
 {
 	auto undo_redo = [this](const std::string &json) {
-		obs_data_t *base = obs_data_create_from_json(json.c_str());
-		obs_data_array_t *array = obs_data_get_array(base, "array");
-		std::vector<obs_source_t *> sources;
-		std::vector<obs_source_t *> old_sources;
+		OBSDataAutoRelease base =
+			obs_data_create_from_json(json.c_str());
+		OBSDataArrayAutoRelease array =
+			obs_data_get_array(base, "array");
+		std::vector<OBSSource> sources;
+		std::vector<OBSSource> old_sources;
 
 		/* create missing sources */
 		const size_t count = obs_data_array_count(array);
 		sources.reserve(count);
 
 		for (size_t i = 0; i < count; i++) {
-			obs_data_t *data = obs_data_array_item(array, i);
+			OBSDataAutoRelease data = obs_data_array_item(array, i);
 			const char *name = obs_data_get_string(data, "name");
 
-			obs_source_t *source = obs_get_source_by_name(name);
+			OBSSourceAutoRelease source =
+				obs_get_source_by_name(name);
 			if (!source)
 				source = obs_load_source(data);
 
-			sources.push_back(source);
+			sources.push_back(source.Get());
 
 			/* update scene/group settings to restore their
 			* contents to their saved settings */
@@ -5803,29 +5715,15 @@ void OBSBasic::CreateSceneUndoRedoAction(const QString &action_name,
 			if (scene) {
 				obs_scene_enum_items(scene, add_source_enum,
 						     &old_sources);
-				obs_data_t *scene_settings =
+				OBSDataAutoRelease scene_settings =
 					obs_data_get_obj(data, "settings");
 				obs_source_update(source, scene_settings);
-				obs_data_release(scene_settings);
 			}
-
-			obs_data_release(data);
 		}
-		for (obs_source_t *source : old_sources)
-			obs_source_addref(source);
 
 		/* actually load sources now */
 		for (obs_source_t *source : sources)
 			obs_source_load2(source);
-
-		/* release sources */
-		for (obs_source_t *source : sources)
-			obs_source_release(source);
-		for (obs_source_t *source : old_sources)
-			obs_source_release(source);
-
-		obs_data_array_release(array);
-		obs_data_release(base);
 
 		ui->sources->RefreshItems();
 	};
@@ -6129,10 +6027,10 @@ void OBSBasic::crashUploadFinished(const QString &text, const QString &error)
 void OBSBasic::openLogDialog(const QString &text, const bool crash)
 {
 
-	obs_data_t *returnData = obs_data_create_from_json(QT_TO_UTF8(text));
+	OBSDataAutoRelease returnData =
+		obs_data_create_from_json(QT_TO_UTF8(text));
 	string resURL = obs_data_get_string(returnData, "url");
 	QString logURL = resURL.c_str();
-	obs_data_release(returnData);
 
 	OBSLogReply logDialog(this, logURL, crash);
 	logDialog.exec();
@@ -6145,7 +6043,7 @@ static void RenameListItem(OBSBasic *parent, QListWidget *listWidget,
 	if (name == prevName)
 		return;
 
-	obs_source_t *foundSource = obs_get_source_by_name(name.c_str());
+	OBSSourceAutoRelease foundSource = obs_get_source_by_name(name.c_str());
 	QListWidgetItem *listItem = listWidget->currentItem();
 
 	if (foundSource || name.empty()) {
@@ -6160,22 +6058,18 @@ static void RenameListItem(OBSBasic *parent, QListWidget *listWidget,
 					       QTStr("NoNameEntered.Title"),
 					       QTStr("NoNameEntered.Text"));
 		}
-
-		obs_source_release(foundSource);
 	} else {
 		auto undo = [prev = std::string(prevName)](
 				    const std::string &data) {
-			obs_source_t *source =
+			OBSSourceAutoRelease source =
 				obs_get_source_by_name(data.c_str());
 			obs_source_set_name(source, prev.c_str());
-			obs_source_release(source);
 		};
 
 		auto redo = [name](const std::string &data) {
-			obs_source_t *source =
+			OBSSourceAutoRelease source =
 				obs_get_source_by_name(data.c_str());
 			obs_source_set_name(source, name.c_str());
-			obs_source_release(source);
 		};
 
 		std::string undo_data(name);
@@ -6277,7 +6171,7 @@ void OBSBasic::YouTubeActionDialogOk(const QString &id, const QString &key,
 {
 	//blog(LOG_DEBUG, "Stream key: %s", QT_TO_UTF8(key));
 	obs_service_t *service_obj = GetService();
-	obs_data_t *settings = obs_service_get_settings(service_obj);
+	OBSDataAutoRelease settings = obs_service_get_settings(service_obj);
 
 	const std::string a_key = QT_TO_UTF8(key);
 	obs_data_set_string(settings, "key", a_key.c_str());
@@ -6289,8 +6183,6 @@ void OBSBasic::YouTubeActionDialogOk(const QString &id, const QString &key,
 	autoStartBroadcast = autostart;
 	autoStopBroadcast = autostop;
 	broadcastReady = true;
-
-	obs_data_release(settings);
 
 	if (start_now)
 		QMetaObject::invokeMethod(this, "StartStreaming");
@@ -6866,7 +6758,8 @@ void OBSBasic::StreamingStart()
 	if (!autoStartBroadcast) {
 		// get a current stream key
 		obs_service_t *service_obj = GetService();
-		obs_data_t *settings = obs_service_get_settings(service_obj);
+		OBSDataAutoRelease settings =
+			obs_service_get_settings(service_obj);
 		std::string key = obs_data_get_string(settings, "stream_id");
 		if (!key.empty() && !youtubeStreamCheckThread) {
 			youtubeStreamCheckThread = CreateQThread(
@@ -7504,10 +7397,9 @@ void OBSBasic::on_streamButton_clicked()
 		bool bwtest = false;
 
 		if (this->auth) {
-			obs_data_t *settings =
+			OBSDataAutoRelease settings =
 				obs_service_get_settings(service);
 			bwtest = obs_data_get_bool(settings, "bwtest");
-			obs_data_release(settings);
 			// Disable confirmation if this is going to open broadcast setup
 			if (auth && auth->broadcastFlow() && !broadcastReady &&
 			    !broadcastActive)
@@ -7872,13 +7764,11 @@ void OBSBasic::on_actionCopyTransform_triggered()
 
 void undo_redo(const std::string &data)
 {
-	obs_data_t *dat = obs_data_create_from_json(data.c_str());
-	obs_source_t *source =
+	OBSDataAutoRelease dat = obs_data_create_from_json(data.c_str());
+	OBSSourceAutoRelease source =
 		obs_get_source_by_name(obs_data_get_string(dat, "scene_name"));
 	reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-		->SetCurrentScene(source, true);
-	obs_source_release(source);
-	obs_data_release(dat);
+		->SetCurrentScene(source.Get(), true);
 
 	obs_scene_load_transform_states(data.c_str());
 }
@@ -7918,9 +7808,11 @@ void OBSBasic::on_actionResetTransform_triggered()
 {
 	obs_scene_t *scene = GetCurrentScene();
 
-	obs_data_t *wrapper = obs_scene_save_transform_states(scene, false);
+	OBSDataAutoRelease wrapper =
+		obs_scene_save_transform_states(scene, false);
 	obs_scene_enum_items(scene, reset_tr, nullptr);
-	obs_data_t *rwrapper = obs_scene_save_transform_states(scene, false);
+	OBSDataAutoRelease rwrapper =
+		obs_scene_save_transform_states(scene, false);
 
 	std::string undo_data(obs_data_get_json(wrapper));
 	std::string redo_data(obs_data_get_json(rwrapper));
@@ -7928,9 +7820,6 @@ void OBSBasic::on_actionResetTransform_triggered()
 		QTStr("Undo.Transform.Reset")
 			.arg(obs_source_get_name(obs_scene_get_source(scene))),
 		undo_redo, undo_redo, undo_data, redo_data);
-
-	obs_data_release(wrapper);
-	obs_data_release(rwrapper);
 
 	obs_scene_enum_items(GetCurrentScene(), reset_tr, nullptr);
 }
@@ -8009,10 +7898,10 @@ static bool RotateSelectedSources(obs_scene_t *scene, obs_sceneitem_t *item,
 void OBSBasic::on_actionRotate90CW_triggered()
 {
 	float f90CW = 90.0f;
-	obs_data_t *wrapper =
+	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 	obs_scene_enum_items(GetCurrentScene(), RotateSelectedSources, &f90CW);
-	obs_data_t *rwrapper =
+	OBSDataAutoRelease rwrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 
 	std::string undo_data(obs_data_get_json(wrapper));
@@ -8021,18 +7910,15 @@ void OBSBasic::on_actionRotate90CW_triggered()
 				  .arg(obs_source_get_name(obs_scene_get_source(
 					  GetCurrentScene()))),
 			  undo_redo, undo_redo, undo_data, redo_data);
-
-	obs_data_release(wrapper);
-	obs_data_release(rwrapper);
 }
 
 void OBSBasic::on_actionRotate90CCW_triggered()
 {
 	float f90CCW = -90.0f;
-	obs_data_t *wrapper =
+	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 	obs_scene_enum_items(GetCurrentScene(), RotateSelectedSources, &f90CCW);
-	obs_data_t *rwrapper =
+	OBSDataAutoRelease rwrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 
 	std::string undo_data(obs_data_get_json(wrapper));
@@ -8041,18 +7927,15 @@ void OBSBasic::on_actionRotate90CCW_triggered()
 				  .arg(obs_source_get_name(obs_scene_get_source(
 					  GetCurrentScene()))),
 			  undo_redo, undo_redo, undo_data, redo_data);
-
-	obs_data_release(wrapper);
-	obs_data_release(rwrapper);
 }
 
 void OBSBasic::on_actionRotate180_triggered()
 {
 	float f180 = 180.0f;
-	obs_data_t *wrapper =
+	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 	obs_scene_enum_items(GetCurrentScene(), RotateSelectedSources, &f180);
-	obs_data_t *rwrapper =
+	OBSDataAutoRelease rwrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 
 	std::string undo_data(obs_data_get_json(wrapper));
@@ -8061,9 +7944,6 @@ void OBSBasic::on_actionRotate180_triggered()
 				  .arg(obs_source_get_name(obs_scene_get_source(
 					  GetCurrentScene()))),
 			  undo_redo, undo_redo, undo_data, redo_data);
-
-	obs_data_release(wrapper);
-	obs_data_release(rwrapper);
 }
 
 static bool MultiplySelectedItemScale(obs_scene_t *scene, obs_sceneitem_t *item,
@@ -8098,11 +7978,11 @@ void OBSBasic::on_actionFlipHorizontal_triggered()
 {
 	vec2 scale;
 	vec2_set(&scale, -1.0f, 1.0f);
-	obs_data_t *wrapper =
+	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 	obs_scene_enum_items(GetCurrentScene(), MultiplySelectedItemScale,
 			     &scale);
-	obs_data_t *rwrapper =
+	OBSDataAutoRelease rwrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 
 	std::string undo_data(obs_data_get_json(wrapper));
@@ -8111,20 +7991,17 @@ void OBSBasic::on_actionFlipHorizontal_triggered()
 				  .arg(obs_source_get_name(obs_scene_get_source(
 					  GetCurrentScene()))),
 			  undo_redo, undo_redo, undo_data, redo_data);
-
-	obs_data_release(wrapper);
-	obs_data_release(rwrapper);
 }
 
 void OBSBasic::on_actionFlipVertical_triggered()
 {
 	vec2 scale;
 	vec2_set(&scale, 1.0f, -1.0f);
-	obs_data_t *wrapper =
+	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 	obs_scene_enum_items(GetCurrentScene(), MultiplySelectedItemScale,
 			     &scale);
-	obs_data_t *rwrapper =
+	OBSDataAutoRelease rwrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 
 	std::string undo_data(obs_data_get_json(wrapper));
@@ -8133,9 +8010,6 @@ void OBSBasic::on_actionFlipVertical_triggered()
 				  .arg(obs_source_get_name(obs_scene_get_source(
 					  GetCurrentScene()))),
 			  undo_redo, undo_redo, undo_data, redo_data);
-
-	obs_data_release(wrapper);
-	obs_data_release(rwrapper);
 }
 
 static bool CenterAlignSelectedItems(obs_scene_t *scene, obs_sceneitem_t *item,
@@ -8175,11 +8049,11 @@ static bool CenterAlignSelectedItems(obs_scene_t *scene, obs_sceneitem_t *item,
 void OBSBasic::on_actionFitToScreen_triggered()
 {
 	obs_bounds_type boundsType = OBS_BOUNDS_SCALE_INNER;
-	obs_data_t *wrapper =
+	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 	obs_scene_enum_items(GetCurrentScene(), CenterAlignSelectedItems,
 			     &boundsType);
-	obs_data_t *rwrapper =
+	OBSDataAutoRelease rwrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 
 	std::string undo_data(obs_data_get_json(wrapper));
@@ -8188,19 +8062,16 @@ void OBSBasic::on_actionFitToScreen_triggered()
 				  .arg(obs_source_get_name(obs_scene_get_source(
 					  GetCurrentScene()))),
 			  undo_redo, undo_redo, undo_data, redo_data);
-
-	obs_data_release(wrapper);
-	obs_data_release(rwrapper);
 }
 
 void OBSBasic::on_actionStretchToScreen_triggered()
 {
 	obs_bounds_type boundsType = OBS_BOUNDS_STRETCH;
-	obs_data_t *wrapper =
+	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 	obs_scene_enum_items(GetCurrentScene(), CenterAlignSelectedItems,
 			     &boundsType);
-	obs_data_t *rwrapper =
+	OBSDataAutoRelease rwrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 
 	std::string undo_data(obs_data_get_json(wrapper));
@@ -8209,9 +8080,6 @@ void OBSBasic::on_actionStretchToScreen_triggered()
 				  .arg(obs_source_get_name(obs_scene_get_source(
 					  GetCurrentScene()))),
 			  undo_redo, undo_redo, undo_data, redo_data);
-
-	obs_data_release(wrapper);
-	obs_data_release(rwrapper);
 }
 
 enum class CenterType {
@@ -8267,10 +8135,10 @@ static bool center_to_scene(obs_scene_t *, obs_sceneitem_t *item, void *param)
 void OBSBasic::on_actionCenterToScreen_triggered()
 {
 	CenterType centerType = CenterType::Scene;
-	obs_data_t *wrapper =
+	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 	obs_scene_enum_items(GetCurrentScene(), center_to_scene, &centerType);
-	obs_data_t *rwrapper =
+	OBSDataAutoRelease rwrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 
 	std::string undo_data(obs_data_get_json(wrapper));
@@ -8279,18 +8147,15 @@ void OBSBasic::on_actionCenterToScreen_triggered()
 				  .arg(obs_source_get_name(obs_scene_get_source(
 					  GetCurrentScene()))),
 			  undo_redo, undo_redo, undo_data, redo_data);
-
-	obs_data_release(wrapper);
-	obs_data_release(rwrapper);
 }
 
 void OBSBasic::on_actionVerticalCenter_triggered()
 {
 	CenterType centerType = CenterType::Vertical;
-	obs_data_t *wrapper =
+	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 	obs_scene_enum_items(GetCurrentScene(), center_to_scene, &centerType);
-	obs_data_t *rwrapper =
+	OBSDataAutoRelease rwrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 
 	std::string undo_data(obs_data_get_json(wrapper));
@@ -8299,18 +8164,15 @@ void OBSBasic::on_actionVerticalCenter_triggered()
 				  .arg(obs_source_get_name(obs_scene_get_source(
 					  GetCurrentScene()))),
 			  undo_redo, undo_redo, undo_data, redo_data);
-
-	obs_data_release(wrapper);
-	obs_data_release(rwrapper);
 }
 
 void OBSBasic::on_actionHorizontalCenter_triggered()
 {
 	CenterType centerType = CenterType::Horizontal;
-	obs_data_t *wrapper =
+	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 	obs_scene_enum_items(GetCurrentScene(), center_to_scene, &centerType);
-	obs_data_t *rwrapper =
+	OBSDataAutoRelease rwrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 
 	std::string undo_data(obs_data_get_json(wrapper));
@@ -8319,9 +8181,6 @@ void OBSBasic::on_actionHorizontalCenter_triggered()
 				  .arg(obs_source_get_name(obs_scene_get_source(
 					  GetCurrentScene()))),
 			  undo_redo, undo_redo, undo_data, redo_data);
-
-	obs_data_release(wrapper);
-	obs_data_release(rwrapper);
 }
 
 void OBSBasic::EnablePreviewDisplay(bool enable)
@@ -8414,7 +8273,7 @@ void OBSBasic::Nudge(int dist, MoveDir dir)
 
 	if (!recent_nudge) {
 		recent_nudge = true;
-		obs_data_t *wrapper = obs_scene_save_transform_states(
+		OBSDataAutoRelease wrapper = obs_scene_save_transform_states(
 			GetCurrentScene(), true);
 		std::string undo_data(obs_data_get_json(wrapper));
 
@@ -8422,7 +8281,7 @@ void OBSBasic::Nudge(int dist, MoveDir dir)
 		QObject::connect(
 			nudge_timer, &QTimer::timeout,
 			[this, &recent_nudge = recent_nudge, undo_data]() {
-				obs_data_t *rwrapper =
+				OBSDataAutoRelease rwrapper =
 					obs_scene_save_transform_states(
 						GetCurrentScene(), true);
 				std::string redo_data(
@@ -8436,13 +8295,10 @@ void OBSBasic::Nudge(int dist, MoveDir dir)
 					redo_data);
 
 				recent_nudge = false;
-				obs_data_release(rwrapper);
 			});
 		connect(nudge_timer, &QTimer::timeout, nudge_timer,
 			&QTimer::deleteLater);
 		nudge_timer->setSingleShot(true);
-
-		obs_data_release(wrapper);
 	}
 
 	if (nudge_timer) {
@@ -8601,15 +8457,13 @@ void OBSBasic::OpenSavedProjector(SavedProjectorInfo *info)
 		switch (info->type) {
 		case ProjectorType::Source:
 		case ProjectorType::Scene: {
-			OBSSource source =
+			OBSSourceAutoRelease source =
 				obs_get_source_by_name(info->name.c_str());
 			if (!source)
 				return;
 
 			projector = OpenProjector(source, info->monitor,
 						  info->type);
-
-			obs_source_release(source);
 			break;
 		}
 		default: {
@@ -9211,7 +9065,6 @@ void OBSBasic::AudioMixerCopyFilters()
 	obs_source_t *source = vol->GetSource();
 
 	copyFiltersSource = obs_source_get_weak_source(source);
-	obs_weak_source_release(copyFiltersSource);
 }
 
 void OBSBasic::AudioMixerPasteFilters()
@@ -9220,8 +9073,8 @@ void OBSBasic::AudioMixerPasteFilters()
 	VolControl *vol = action->property("volControl").value<VolControl *>();
 	obs_source_t *dstSource = vol->GetSource();
 
-	OBSSource source = obs_weak_source_get_source(copyFiltersSource);
-	obs_source_release(source);
+	OBSSourceAutoRelease source =
+		obs_weak_source_get_source(copyFiltersSource);
 
 	if (source == dstSource)
 		return;
@@ -9232,13 +9085,12 @@ void OBSBasic::AudioMixerPasteFilters()
 void OBSBasic::SceneCopyFilters()
 {
 	copyFiltersSource = obs_source_get_weak_source(GetCurrentSceneSource());
-	obs_weak_source_release(copyFiltersSource);
 }
 
 void OBSBasic::ScenePasteFilters()
 {
-	OBSSource source = obs_weak_source_get_source(copyFiltersSource);
-	obs_source_release(source);
+	OBSSourceAutoRelease source =
+		obs_weak_source_get_source(copyFiltersSource);
 
 	OBSSource dstSource = GetCurrentSceneSource();
 
@@ -9258,7 +9110,6 @@ void OBSBasic::on_actionCopyFilters_triggered()
 	OBSSource source = obs_sceneitem_get_source(item);
 
 	copyFiltersSource = obs_source_get_weak_source(source);
-	obs_weak_source_release(copyFiltersSource);
 
 	ui->actionPasteFilters->setEnabled(true);
 }
@@ -9269,16 +9120,14 @@ void OBSBasic::CreateFilterPasteUndoRedoAction(const QString &text,
 					       obs_data_array_t *redo_array)
 {
 	auto undo_redo = [this](const std::string &json) {
-		obs_data_t *data = obs_data_create_from_json(json.c_str());
-		obs_data_array_t *array = obs_data_get_array(data, "array");
+		OBSDataAutoRelease data =
+			obs_data_create_from_json(json.c_str());
+		OBSDataArrayAutoRelease array =
+			obs_data_get_array(data, "array");
 		const char *name = obs_data_get_string(data, "name");
-		obs_source_t *source = obs_get_source_by_name(name);
+		OBSSourceAutoRelease source = obs_get_source_by_name(name);
 
 		obs_source_restore_filters(source, array);
-		obs_source_release(source);
-
-		obs_data_array_release(array);
-		obs_data_release(data);
 
 		if (filters)
 			filters->UpdateSource(source);
@@ -9286,8 +9135,8 @@ void OBSBasic::CreateFilterPasteUndoRedoAction(const QString &text,
 
 	const char *name = obs_source_get_name(source);
 
-	obs_data_t *undo_data = obs_data_create();
-	obs_data_t *redo_data = obs_data_create();
+	OBSDataAutoRelease undo_data = obs_data_create();
+	OBSDataAutoRelease redo_data = obs_data_create();
 	obs_data_set_array(undo_data, "array", undo_array);
 	obs_data_set_array(redo_data, "array", redo_array);
 	obs_data_set_string(undo_data, "name", name);
@@ -9296,15 +9145,12 @@ void OBSBasic::CreateFilterPasteUndoRedoAction(const QString &text,
 	undo_s.add_action(text, undo_redo, undo_redo,
 			  obs_data_get_json(undo_data),
 			  obs_data_get_json(redo_data));
-
-	obs_data_release(undo_data);
-	obs_data_release(redo_data);
 }
 
 void OBSBasic::on_actionPasteFilters_triggered()
 {
-	OBSSource source = obs_weak_source_get_source(copyFiltersSource);
-	obs_source_release(source);
+	OBSSourceAutoRelease source =
+		obs_weak_source_get_source(copyFiltersSource);
 
 	OBSSceneItem sceneItem = GetCurrentSceneItem();
 	OBSSource dstSource = obs_sceneitem_get_source(sceneItem);
@@ -9312,9 +9158,11 @@ void OBSBasic::on_actionPasteFilters_triggered()
 	if (source == dstSource)
 		return;
 
-	obs_data_array_t *undo_array = obs_source_backup_filters(dstSource);
+	OBSDataArrayAutoRelease undo_array =
+		obs_source_backup_filters(dstSource);
 	obs_source_copy_filters(dstSource, source);
-	obs_data_array_t *redo_array = obs_source_backup_filters(dstSource);
+	OBSDataArrayAutoRelease redo_array =
+		obs_source_backup_filters(dstSource);
 
 	const char *srcName = obs_source_get_name(source);
 	const char *dstName = obs_source_get_name(dstSource);
@@ -9323,9 +9171,6 @@ void OBSBasic::on_actionPasteFilters_triggered()
 
 	CreateFilterPasteUndoRedoAction(text, dstSource, undo_array,
 					redo_array);
-
-	obs_data_array_release(undo_array);
-	obs_data_array_release(redo_array);
 }
 
 static void ConfirmColor(SourceTree *sources, const QColor &color,
@@ -9340,12 +9185,11 @@ static void ConfirmColor(SourceTree *sources, const QColor &color,
 		treeItem->style()->polish(treeItem);
 
 		OBSSceneItem sceneItem = sources->Get(selectedItems[x].row());
-		obs_data_t *privData =
+		OBSDataAutoRelease privData =
 			obs_sceneitem_get_private_settings(sceneItem);
 		obs_data_set_int(privData, "color-preset", 1);
 		obs_data_set_string(privData, "color",
 				    QT_TO_UTF8(color.name(QColor::HexArgb)));
-		obs_data_release(privData);
 	}
 }
 
@@ -9372,11 +9216,10 @@ void OBSBasic::ColorChange()
 
 			OBSSceneItem sceneItem =
 				ui->sources->Get(selectedItems[x].row());
-			obs_data_t *privData =
+			OBSDataAutoRelease privData =
 				obs_sceneitem_get_private_settings(sceneItem);
 			obs_data_set_int(privData, "color-preset", preset + 1);
 			obs_data_set_string(privData, "color", "");
-			obs_data_release(privData);
 		}
 
 		for (int i = 1; i < 9; i++) {
@@ -9397,7 +9240,7 @@ void OBSBasic::ColorChange()
 			OBSSceneItem curSceneItem = GetCurrentSceneItem();
 			SourceTreeItem *curTreeItem =
 				GetItemWidgetFromSceneItem(curSceneItem);
-			obs_data_t *curPrivData =
+			OBSDataAutoRelease curPrivData =
 				obs_sceneitem_get_private_settings(
 					curSceneItem);
 
@@ -9458,8 +9301,6 @@ void OBSBasic::ColorChange()
 				changedColor);
 			connect(colorDialog, &QColorDialog::rejected, rejected);
 			colorDialog->open();
-
-			obs_data_release(curPrivData);
 		} else {
 			for (int x = 0; x < selectedItems.count(); x++) {
 				SourceTreeItem *treeItem =
@@ -9472,13 +9313,12 @@ void OBSBasic::ColorChange()
 
 				OBSSceneItem sceneItem = ui->sources->Get(
 					selectedItems[x].row());
-				obs_data_t *privData =
+				OBSDataAutoRelease privData =
 					obs_sceneitem_get_private_settings(
 						sceneItem);
 				obs_data_set_int(privData, "color-preset",
 						 preset);
 				obs_data_set_string(privData, "color", "");
-				obs_data_release(privData);
 			}
 		}
 	}
@@ -9964,11 +9804,10 @@ void OBSBasic::UpdateProjectorAlwaysOnTop(bool top)
 
 void OBSBasic::ResetProjectors()
 {
-	obs_data_array_t *savedProjectorList = SaveProjectors();
+	OBSDataArrayAutoRelease savedProjectorList = SaveProjectors();
 	ClearProjectors();
 	LoadSavedProjectors(savedProjectorList);
 	OpenSavedProjectors();
-	obs_data_array_release(savedProjectorList);
 }
 
 void OBSBasic::on_sourcePropertiesButton_clicked()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -219,7 +219,7 @@ private:
 	ContextBarSize contextBarSize = ContextBarSize_Normal;
 
 	std::deque<SourceCopyInfo> clipboard;
-	OBSWeakSource copyFiltersSource;
+	OBSWeakSourceAutoRelease copyFiltersSource;
 	bool copyVisible = true;
 
 	bool closing = false;

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -32,9 +32,6 @@ OBSBasicPreview::~OBSBasicPreview()
 		gs_vertexbuffer_destroy(rectFill);
 
 	obs_leave_graphics();
-
-	if (wrapper)
-		obs_data_release(wrapper);
 }
 
 vec2 OBSBasicPreview::GetMouseEventPos(QMouseEvent *event)
@@ -568,8 +565,6 @@ void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 	vec2_zero(&lastMoveOffset);
 
 	mousePos = startPos;
-	if (wrapper)
-		obs_data_release(wrapper);
 	wrapper =
 		obs_scene_save_transform_states(main->GetCurrentScene(), true);
 	changed = false;
@@ -706,17 +701,16 @@ void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 		selectedItems.clear();
 	}
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
-	obs_data_t *rwrapper =
+	OBSDataAutoRelease rwrapper =
 		obs_scene_save_transform_states(main->GetCurrentScene(), true);
 
 	auto undo_redo = [](const std::string &data) {
-		obs_data_t *dat = obs_data_create_from_json(data.c_str());
-		obs_source_t *source = obs_get_source_by_name(
+		OBSDataAutoRelease dat =
+			obs_data_create_from_json(data.c_str());
+		OBSSourceAutoRelease source = obs_get_source_by_name(
 			obs_data_get_string(dat, "scene_name"));
 		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(source, true);
-		obs_source_release(source);
-		obs_data_release(dat);
+			->SetCurrentScene(source.Get(), true);
 
 		obs_scene_load_transform_states(data.c_str());
 	};
@@ -732,13 +726,7 @@ void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 				undo_redo, undo_redo, undo_data, redo_data);
 	}
 
-	if (wrapper)
-		obs_data_release(wrapper);
-
-	if (rwrapper)
-		obs_data_release(rwrapper);
-
-	wrapper = NULL;
+	wrapper = nullptr;
 }
 
 struct SelectedItemBounds {

--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -106,7 +106,7 @@ private:
 
 	void ProcessClick(const vec2 &pos);
 
-	obs_data_t *wrapper = NULL;
+	OBSDataAutoRelease wrapper = nullptr;
 	bool changed;
 
 public:

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -78,9 +78,8 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 	/* The OBSData constructor increments the reference once */
 	obs_data_release(oldSettings);
 
-	OBSData nd_settings = obs_source_get_settings(source);
+	OBSDataAutoRelease nd_settings = obs_source_get_settings(source);
 	obs_data_apply(oldSettings, nd_settings);
-	obs_data_release(nd_settings);
 
 	auto handle_memory = [](void *vp, obs_data_t *old_settings,
 				obs_data_t *new_settings) {
@@ -93,7 +92,7 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 	};
 
 	view = new OBSPropertiesView(
-		nd_settings, source,
+		nd_settings.Get(), source,
 		(PropertiesReloadCallback)obs_source_properties,
 		(PropertiesUpdateCallback)handle_memory,
 		(PropertiesVisualUpdateCb)obs_source_update);
@@ -163,14 +162,11 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 		sourceB =
 			obs_source_create_private("scene", "sourceB", nullptr);
 
-		obs_source_release(sourceA);
-		obs_source_release(sourceB);
-
 		uint32_t colorA = 0xFFB26F52;
 		uint32_t colorB = 0xFF6FB252;
 
-		CreateTransitionScene(sourceA, "A", colorA);
-		CreateTransitionScene(sourceB, "B", colorB);
+		CreateTransitionScene(sourceA.Get(), "A", colorA);
+		CreateTransitionScene(sourceB.Get(), "B", colorB);
 
 		/**
 		 * The cloned source is made from scratch, rather than using
@@ -178,26 +174,22 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 		 * play correctly otherwise.
 		 */
 
-		obs_data_t *settings = obs_source_get_settings(source);
+		OBSDataAutoRelease settings = obs_source_get_settings(source);
 
 		sourceClone = obs_source_create_private(
 			obs_source_get_id(source), "clone", settings);
-		obs_source_release(sourceClone);
 
 		obs_source_inc_active(sourceClone);
 		obs_transition_set(sourceClone, sourceA);
 
-		obs_data_release(settings);
-
 		auto updateCallback = [=]() {
-			obs_data_t *settings = obs_source_get_settings(source);
+			OBSDataAutoRelease settings =
+				obs_source_get_settings(source);
 			obs_source_update(sourceClone, settings);
 
 			obs_transition_clear(sourceClone);
 			obs_transition_set(sourceClone, sourceA);
 			obs_transition_force_stop(sourceClone);
-
-			obs_data_release(settings);
 
 			direction = true;
 		};
@@ -258,8 +250,8 @@ void OBSBasicProperties::AddPreviewButton()
 
 static obs_source_t *CreateLabel(const char *name, size_t h)
 {
-	obs_data_t *settings = obs_data_create();
-	obs_data_t *font = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
+	OBSDataAutoRelease font = obs_data_create();
 
 	std::string text;
 	text += " ";
@@ -289,26 +281,24 @@ static obs_source_t *CreateLabel(const char *name, size_t h)
 	obs_source_t *txtSource =
 		obs_source_create_private(text_source_id, name, settings);
 
-	obs_data_release(font);
-	obs_data_release(settings);
-
 	return txtSource;
 }
 
 static void CreateTransitionScene(OBSSource scene, const char *text,
 				  uint32_t color)
 {
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 	obs_data_set_int(settings, "width", obs_source_get_width(scene));
 	obs_data_set_int(settings, "height", obs_source_get_height(scene));
 	obs_data_set_int(settings, "color", color);
 
-	obs_source_t *colorBG = obs_source_create_private(
+	OBSSourceAutoRelease colorBG = obs_source_create_private(
 		"color_source", "background", settings);
 
 	obs_scene_add(obs_scene_from_source(scene), colorBG);
 
-	obs_source_t *label = CreateLabel(text, obs_source_get_height(scene));
+	OBSSourceAutoRelease label =
+		CreateLabel(text, obs_source_get_height(scene));
 	obs_sceneitem_t *item =
 		obs_scene_add(obs_scene_from_source(scene), label);
 
@@ -322,10 +312,6 @@ static void CreateTransitionScene(OBSSource scene, const char *text,
 
 	obs_sceneitem_set_bounds(item, &size);
 	obs_sceneitem_set_bounds_type(item, OBS_BOUNDS_SCALE_INNER);
-
-	obs_data_release(settings);
-	obs_source_release(colorBG);
-	obs_source_release(label);
 }
 
 void OBSBasicProperties::SourceRemoved(void *data, calldata_t *params)
@@ -361,27 +347,24 @@ void OBSBasicProperties::on_buttonBox_clicked(QAbstractButton *button)
 			obs_source_get_name(main->GetCurrentSceneSource());
 
 		auto undo_redo = [scene_name](const std::string &data) {
-			obs_data_t *settings =
+			OBSDataAutoRelease settings =
 				obs_data_create_from_json(data.c_str());
-			obs_source_t *source = obs_get_source_by_name(
+			OBSSourceAutoRelease source = obs_get_source_by_name(
 				obs_data_get_string(settings, "undo_sname"));
 			obs_source_reset_settings(source, settings);
 
 			obs_source_update_properties(source);
 
-			obs_source_t *scene_source =
+			OBSSourceAutoRelease scene_source =
 				obs_get_source_by_name(scene_name.c_str());
 
-			OBSBasic::Get()->SetCurrentScene(scene_source, true);
-
-			obs_source_release(scene_source);
-
-			obs_data_release(settings);
-			obs_source_release(source);
+			OBSBasic::Get()->SetCurrentScene(scene_source.Get(),
+							 true);
 		};
 
-		obs_data_t *new_settings = obs_data_create();
-		obs_data_t *curr_settings = obs_source_get_settings(source);
+		OBSDataAutoRelease new_settings = obs_data_create();
+		OBSDataAutoRelease curr_settings =
+			obs_source_get_settings(source);
 		obs_data_apply(new_settings, curr_settings);
 		obs_data_set_string(new_settings, "undo_sname",
 				    obs_source_get_name(source));
@@ -397,9 +380,6 @@ void OBSBasicProperties::on_buttonBox_clicked(QAbstractButton *button)
 					.arg(obs_source_get_name(source)),
 				undo_redo, undo_redo, undo_data, redo_data);
 
-		obs_data_release(new_settings);
-		obs_data_release(curr_settings);
-
 		acceptClicked = true;
 		close();
 
@@ -407,9 +387,8 @@ void OBSBasicProperties::on_buttonBox_clicked(QAbstractButton *button)
 			view->UpdateSettings();
 
 	} else if (val == QDialogButtonBox::RejectRole) {
-		obs_data_t *settings = obs_source_get_settings(source);
+		OBSDataAutoRelease settings = obs_source_get_settings(source);
 		obs_data_clear(settings);
-		obs_data_release(settings);
 
 		if (view->DeferUpdate())
 			obs_data_apply(settings, oldSettings);
@@ -419,9 +398,8 @@ void OBSBasicProperties::on_buttonBox_clicked(QAbstractButton *button)
 		close();
 
 	} else if (val == QDialogButtonBox::ResetRole) {
-		obs_data_t *settings = obs_source_get_settings(source);
+		OBSDataAutoRelease settings = obs_source_get_settings(source);
 		obs_data_clear(settings);
-		obs_data_release(settings);
 
 		if (!view->DeferUpdate())
 			obs_source_update(source, nullptr);
@@ -542,14 +520,11 @@ void OBSBasicProperties::Init()
 
 int OBSBasicProperties::CheckSettings()
 {
-	OBSData currentSettings = obs_source_get_settings(source);
+	OBSDataAutoRelease currentSettings = obs_source_get_settings(source);
 	const char *oldSettingsJson = obs_data_get_json(oldSettings);
 	const char *currentSettingsJson = obs_data_get_json(currentSettings);
 
-	int ret = strcmp(currentSettingsJson, oldSettingsJson);
-
-	obs_data_release(currentSettings);
-	return ret;
+	return strcmp(currentSettingsJson, oldSettingsJson);
 }
 
 bool OBSBasicProperties::ConfirmQuit()

--- a/UI/window-basic-properties.hpp
+++ b/UI/window-basic-properties.hpp
@@ -45,9 +45,9 @@ private:
 	QDialogButtonBox *buttonBox;
 	QSplitter *windowSplitter;
 
-	OBSSource sourceA;
-	OBSSource sourceB;
-	OBSSource sourceClone;
+	OBSSourceAutoRelease sourceA;
+	OBSSourceAutoRelease sourceB;
+	OBSSourceAutoRelease sourceClone;
 	bool direction = true;
 
 	static void SourceRemoved(void *data, calldata_t *params);

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -108,7 +108,7 @@ void OBSBasicSettings::LoadStream1Settings()
 
 	loading = true;
 
-	obs_data_t *settings = obs_service_get_settings(service_obj);
+	OBSDataAutoRelease settings = obs_service_get_settings(service_obj);
 
 	const char *service = obs_data_get_string(settings, "service");
 	const char *server = obs_data_get_string(settings, "server");
@@ -159,8 +159,6 @@ void OBSBasicSettings::LoadStream1Settings()
 	lastService.clear();
 	on_service_currentIndexChanged(0);
 
-	obs_data_release(settings);
-
 	UpdateKeyLink();
 	UpdateMoreInfoLink();
 	UpdateVodTrackSetting();
@@ -183,11 +181,9 @@ void OBSBasicSettings::SaveStream1Settings()
 	const char *service_id = customServer ? "rtmp_custom" : "rtmp_common";
 
 	obs_service_t *oldService = main->GetService();
-	OBSData hotkeyData = obs_hotkeys_save_service(oldService);
-	obs_data_release(hotkeyData);
+	OBSDataAutoRelease hotkeyData = obs_hotkeys_save_service(oldService);
 
-	OBSData settings = obs_data_create();
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_create();
 
 	if (!customServer) {
 		obs_data_set_string(settings, "service",
@@ -231,9 +227,8 @@ void OBSBasicSettings::SaveStream1Settings()
 
 	obs_data_set_string(settings, "key", QT_TO_UTF8(ui->key->text()));
 
-	OBSService newService = obs_service_create(
+	OBSServiceAutoRelease newService = obs_service_create(
 		service_id, "default_service", settings, hotkeyData);
-	obs_service_release(newService);
 
 	if (!newService)
 		return;
@@ -262,8 +257,7 @@ void OBSBasicSettings::UpdateMoreInfoLink()
 	obs_properties_t *props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
-	OBSData settings = obs_data_create();
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_create();
 
 	obs_data_set_string(settings, "service", QT_TO_UTF8(serviceName));
 	obs_property_modified(services, settings);
@@ -289,8 +283,7 @@ void OBSBasicSettings::UpdateKeyLink()
 	obs_properties_t *props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
-	OBSData settings = obs_data_create();
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_create();
 
 	obs_data_set_string(settings, "service", QT_TO_UTF8(serviceName));
 	obs_property_modified(services, settings);
@@ -324,8 +317,7 @@ void OBSBasicSettings::LoadServices(bool showAll)
 {
 	obs_properties_t *props = obs_get_service_properties("rtmp_common");
 
-	OBSData settings = obs_data_create();
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_create();
 
 	obs_data_set_bool(settings, "show_all", showAll);
 
@@ -509,8 +501,7 @@ void OBSBasicSettings::UpdateServerList()
 	obs_properties_t *props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
-	OBSData settings = obs_data_create();
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_create();
 
 	obs_data_set_string(settings, "service", QT_TO_UTF8(serviceName));
 	obs_property_modified(services, settings);
@@ -556,8 +547,7 @@ OBSService OBSBasicSettings::SpawnTempService()
 	bool custom = IsCustomService();
 	const char *service_id = custom ? "rtmp_custom" : "rtmp_common";
 
-	OBSData settings = obs_data_create();
-	obs_data_release(settings);
+	OBSDataAutoRelease settings = obs_data_create();
 
 	if (!custom) {
 		obs_data_set_string(settings, "service",
@@ -572,11 +562,9 @@ OBSService OBSBasicSettings::SpawnTempService()
 	}
 	obs_data_set_string(settings, "key", QT_TO_UTF8(ui->key->text()));
 
-	OBSService newService = obs_service_create(service_id, "temp_service",
-						   settings, nullptr);
-	obs_service_release(newService);
-
-	return newService;
+	OBSServiceAutoRelease newService = obs_service_create(
+		service_id, "temp_service", settings, nullptr);
+	return newService.Get();
 }
 
 void OBSBasicSettings::OnOAuthStreamKeyConnected()

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1828,7 +1828,7 @@ OBSPropertiesView *
 OBSBasicSettings::CreateEncoderPropertyView(const char *encoder,
 					    const char *path, bool changed)
 {
-	obs_data_t *settings = obs_encoder_defaults(encoder);
+	OBSDataAutoRelease settings = obs_encoder_defaults(encoder);
 	OBSPropertiesView *view;
 
 	if (path) {
@@ -1844,13 +1844,12 @@ OBSBasicSettings::CreateEncoderPropertyView(const char *encoder,
 	}
 
 	view = new OBSPropertiesView(
-		settings, encoder,
+		settings.Get(), encoder,
 		(PropertiesReloadCallback)obs_get_encoder_properties, 170);
 	view->setFrameShape(QFrame::StyledPanel);
 	view->setProperty("changed", QVariant(changed));
 	QObject::connect(view, SIGNAL(Changed()), this, SLOT(OutputsChanged()));
 
-	obs_data_release(settings);
 	return view;
 }
 
@@ -2210,9 +2209,9 @@ void OBSBasicSettings::LoadListValues(QComboBox *widget, obs_property_t *prop,
 {
 	size_t count = obs_property_list_item_count(prop);
 
-	obs_source_t *source = obs_get_output_source(index);
+	OBSSourceAutoRelease source = obs_get_output_source(index);
 	const char *deviceId = nullptr;
-	obs_data_t *settings = nullptr;
+	OBSDataAutoRelease settings = nullptr;
 
 	if (source) {
 		settings = obs_source_get_settings(source);
@@ -2243,11 +2242,6 @@ void OBSBasicSettings::LoadListValues(QComboBox *widget, obs_property_t *prop,
 					       "errorLabel");
 		}
 	}
-
-	if (settings)
-		obs_data_release(settings);
-	if (source)
-		obs_source_release(source);
 }
 
 void OBSBasicSettings::LoadAudioDevices()
@@ -3715,13 +3709,11 @@ void OBSBasicSettings::SaveHotkeySettings()
 		if (!hotkey.first)
 			continue;
 
-		obs_data_array_t *array = obs_hotkey_save(hw.id);
-		obs_data_t *data = obs_data_create();
+		OBSDataArrayAutoRelease array = obs_hotkey_save(hw.id);
+		OBSDataAutoRelease data = obs_data_create();
 		obs_data_set_array(data, "bindings", array);
 		const char *json = obs_data_get_json(data);
 		config_set_string(config, "Hotkeys", hw.name.c_str(), json);
-		obs_data_release(data);
-		obs_data_array_release(array);
 	}
 
 	if (!main->outputHandler || !main->outputHandler->replayBuffer)
@@ -3729,11 +3721,10 @@ void OBSBasicSettings::SaveHotkeySettings()
 
 	const char *id = obs_obj_get_id(main->outputHandler->replayBuffer);
 	if (strcmp(id, "replay_buffer") == 0) {
-		obs_data_t *hotkeys = obs_hotkeys_save_output(
+		OBSDataAutoRelease hotkeys = obs_hotkeys_save_output(
 			main->outputHandler->replayBuffer);
 		config_set_string(config, "Hotkeys", "ReplayBuffer",
 				  obs_data_get_json(hotkeys));
-		obs_data_release(hotkeys);
 	}
 }
 
@@ -4785,10 +4776,10 @@ void OBSBasicSettings::AdvReplayBufferChanged()
 					 sizeof(encoderJsonPath),
 					 "recordEncoder.json");
 		if (ret > 0) {
-			obs_data_t *data = obs_data_create_from_json_file_safe(
-				encoderJsonPath, "bak");
+			OBSDataAutoRelease data =
+				obs_data_create_from_json_file_safe(
+					encoderJsonPath, "bak");
 			obs_data_apply(settings, data);
-			obs_data_release(data);
 		}
 	}
 
@@ -4858,8 +4849,8 @@ void OBSBasicSettings::SimpleRecordingEncoderChanged()
 	delete simpleOutRecWarning;
 
 	if (enforceBitrate && service) {
-		obs_data_t *videoSettings = obs_data_create();
-		obs_data_t *audioSettings = obs_data_create();
+		OBSDataAutoRelease videoSettings = obs_data_create();
+		OBSDataAutoRelease audioSettings = obs_data_create();
 		int oldVBitrate = ui->simpleOutputVBitrate->value();
 		int oldABitrate =
 			ui->simpleOutputABitrate->currentText().toInt();
@@ -4881,9 +4872,6 @@ void OBSBasicSettings::SimpleRecordingEncoderChanged()
 			warning += SIMPLE_OUTPUT_WARNING("AudioBitrate")
 					   .arg(newABitrate);
 		}
-
-		obs_data_release(videoSettings);
-		obs_data_release(audioSettings);
 	}
 
 	if (qual == "Lossless") {

--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -287,10 +287,8 @@ void OBSBasicStats::Update()
 	struct obs_video_info ovi = {};
 	obs_get_video_info(&ovi);
 
-	OBSOutput strOutput = obs_frontend_get_streaming_output();
-	OBSOutput recOutput = obs_frontend_get_recording_output();
-	obs_output_release(strOutput);
-	obs_output_release(recOutput);
+	OBSOutputAutoRelease strOutput = obs_frontend_get_streaming_output();
+	OBSOutputAutoRelease recOutput = obs_frontend_get_recording_output();
 
 	if (!strOutput && !recOutput)
 		return;
@@ -487,10 +485,8 @@ void OBSBasicStats::Reset()
 	first_rendered = 0xFFFFFFFF;
 	first_lagged = 0xFFFFFFFF;
 
-	OBSOutput strOutput = obs_frontend_get_streaming_output();
-	OBSOutput recOutput = obs_frontend_get_recording_output();
-	obs_output_release(strOutput);
-	obs_output_release(recOutput);
+	OBSOutputAutoRelease strOutput = obs_frontend_get_streaming_output();
+	OBSOutputAutoRelease recOutput = obs_frontend_get_recording_output();
 
 	outputLabels[0].Reset(strOutput);
 	outputLabels[1].Reset(recOutput);

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -77,11 +77,9 @@ OBSBasicTransform::OBSBasicTransform(OBSBasic *parent)
 	std::string name = obs_source_get_name(obs_sceneitem_get_source(item));
 	setWindowTitle(QTStr("Basic.TransformWindow.Title").arg(name.c_str()));
 
-	obs_data_t *wrapper =
+	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(main->GetCurrentScene(), false);
 	undo_data = std::string(obs_data_get_json(wrapper));
-
-	obs_data_release(wrapper);
 
 	channelChangedSignal.Connect(obs_get_signal_handler(), "channel_change",
 				     OBSChannelChanged, this);
@@ -89,17 +87,16 @@ OBSBasicTransform::OBSBasicTransform(OBSBasic *parent)
 
 OBSBasicTransform::~OBSBasicTransform()
 {
-	obs_data_t *wrapper =
+	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(main->GetCurrentScene(), false);
 
 	auto undo_redo = [](const std::string &data) {
-		obs_data_t *dat = obs_data_create_from_json(data.c_str());
-		obs_source_t *source = obs_get_source_by_name(
+		OBSDataAutoRelease dat =
+			obs_data_create_from_json(data.c_str());
+		OBSSourceAutoRelease source = obs_get_source_by_name(
 			obs_data_get_string(dat, "scene_name"));
 		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(source, true);
-		obs_source_release(source);
-		obs_data_release(dat);
+			->SetCurrentScene(source.Get(), true);
 		obs_scene_load_transform_states(data.c_str());
 	};
 
@@ -110,8 +107,6 @@ OBSBasicTransform::~OBSBasicTransform()
 				.arg(obs_source_get_name(obs_scene_get_source(
 					main->GetCurrentScene()))),
 			undo_redo, undo_redo, undo_data, redo_data);
-
-	obs_data_release(wrapper);
 }
 
 void OBSBasicTransform::SetScene(OBSScene scene)

--- a/UI/window-missing-files.cpp
+++ b/UI/window-missing-files.cpp
@@ -265,13 +265,11 @@ QVariant MissingFilesModel::data(const QModelIndex &index, int role) const
 		   index.column() == MissingFilesColumn::Source) {
 		OBSBasic *main =
 			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
-		obs_source_t *source = obs_get_source_by_name(
+		OBSSourceAutoRelease source = obs_get_source_by_name(
 			files[index.row()].source.toStdString().c_str());
 
 		if (source) {
 			result = main->GetSourceIcon(obs_source_get_id(source));
-
-			obs_source_release(source);
 		}
 	} else if (role == Qt::FontRole &&
 		   index.column() == MissingFilesColumn::State) {

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -153,8 +153,8 @@ void OBSProjector::SetHideCursor()
 
 static OBSSource CreateLabel(const char *name, size_t h)
 {
-	obs_data_t *settings = obs_data_create();
-	obs_data_t *font = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
+	OBSDataAutoRelease font = obs_data_create();
 
 	std::string text;
 	text += " ";
@@ -181,14 +181,10 @@ static OBSSource CreateLabel(const char *name, size_t h)
 	const char *text_source_id = "text_ft2_source";
 #endif
 
-	OBSSource txtSource =
+	OBSSourceAutoRelease txtSource =
 		obs_source_create_private(text_source_id, name, settings);
-	obs_source_release(txtSource);
 
-	obs_data_release(font);
-	obs_data_release(settings);
-
-	return txtSource;
+	return txtSource.Get();
 }
 
 static inline uint32_t labelOffset(obs_source_t *label, uint32_t cx)
@@ -931,8 +927,7 @@ void OBSProjector::UpdateMultiview()
 	size_t i = 0;
 	while (i < scenes.sources.num && numSrcs < maxSrcs) {
 		obs_source_t *src = scenes.sources.array[i++];
-		OBSData data = obs_source_get_private_settings(src);
-		obs_data_release(data);
+		OBSDataAutoRelease data = obs_source_get_private_settings(src);
 
 		obs_data_set_default_bool(data, "show_in_multiview", true);
 		if (!obs_data_get_bool(data, "show_in_multiview"))

--- a/libobs/obs.hpp
+++ b/libobs/obs.hpp
@@ -47,6 +47,52 @@ using OBSWeakEncoder = OBSRef<obs_weak_encoder_t *, obs_weak_encoder_addref,
 using OBSWeakService = OBSRef<obs_weak_service_t *, obs_weak_service_addref,
 			      obs_weak_service_release>;
 
+inline void ___source_dummy_addref(obs_source_t *){};
+inline void ___scene_dummy_addref(obs_scene_t *){};
+inline void ___sceneitem_dummy_addref(obs_sceneitem_t *){};
+inline void ___data_dummy_addref(obs_data_t *){};
+inline void ___data_array_dummy_addref(obs_data_array_t *){};
+inline void ___output_dummy_addref(obs_output_t *){};
+inline void ___encoder_dummy_addref(obs_encoder_t *){};
+inline void ___service_dummy_addref(obs_service_t *){};
+
+inline void ___weak_source_dummy_addref(obs_weak_source_t *){};
+inline void ___weak_output_dummy_addref(obs_weak_output_t *){};
+inline void ___weak_encoder_dummy_addref(obs_weak_encoder_t *){};
+inline void ___weak_service_dummy_addref(obs_weak_service_t *){};
+
+using OBSSourceAutoRelease =
+	OBSRef<obs_source_t *, ___source_dummy_addref, obs_source_release>;
+using OBSSceneAutoRelease =
+	OBSRef<obs_scene_t *, ___scene_dummy_addref, obs_scene_release>;
+using OBSSceneItemAutoRelease =
+	OBSRef<obs_sceneitem_t *, ___sceneitem_dummy_addref,
+	       obs_sceneitem_release>;
+using OBSDataAutoRelease =
+	OBSRef<obs_data_t *, ___data_dummy_addref, obs_data_release>;
+using OBSDataArrayAutoRelease =
+	OBSRef<obs_data_array_t *, ___data_array_dummy_addref,
+	       obs_data_array_release>;
+using OBSOutputAutoRelease =
+	OBSRef<obs_output_t *, ___output_dummy_addref, obs_output_release>;
+using OBSEncoderAutoRelease =
+	OBSRef<obs_encoder_t *, ___encoder_dummy_addref, obs_encoder_release>;
+using OBSServiceAutoRelease =
+	OBSRef<obs_service_t *, ___service_dummy_addref, obs_service_release>;
+
+using OBSWeakSourceAutoRelease =
+	OBSRef<obs_weak_source_t *, ___weak_source_dummy_addref,
+	       obs_weak_source_release>;
+using OBSWeakOutputAutoRelease =
+	OBSRef<obs_weak_output_t *, ___weak_output_dummy_addref,
+	       obs_weak_output_release>;
+using OBSWeakEncoderAutoRelease =
+	OBSRef<obs_weak_encoder_t *, ___weak_encoder_dummy_addref,
+	       obs_weak_encoder_release>;
+using OBSWeakServiceAutoRelease =
+	OBSRef<obs_weak_service_t *, ___weak_service_dummy_addref,
+	       obs_weak_service_release>;
+
 template<typename T, void addref(T), void release(T)> class OBSRef {
 	T val;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
These AutoRelease versions of the C++ OBSRef types do not add a ref on
construction, which is useful when accepting the result of a function
that turns a raw C pointer type that has had a reference added.

The AutoRelease types and names are taken from obs-websocket.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Not having these types has resulted in multiple awkward anti-patterns.
Such as immediately releasing after construction to account for the
extra addref, or avoiding using the C++ type entirely and manually
releasing it later.

Example:
```
OBSSource source = obs_get_source_by_name(name.c_str());
obs_source_release(source);
```

The whole point of these types is to avoid the need for manual releases,
and rely on the RAII mechanisms inside of C++. Additionally, the
immediate release isn't commented anywhere, resulting in confusion for
other developers looking at the code as to why things are being
immediately released.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Using aspects of the UI and the frontend tools that these changes affect, observing memory leaks not going up, and observing no crashes being introduced.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
