### PR TITLE
Add kudos to AppData file

### DIFF
--- a/UI/xdg-data/com.obsproject.Studio.appdata.xml.in
+++ b/UI/xdg-data/com.obsproject.Studio.appdata.xml.in
@@ -17,6 +17,10 @@
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"/>
+  <kudos>
+    <kudo>ModernToolkit</kudo>
+    <kudo>HiDpiIcon</kudo>
+  </kudos>
   <releases>
     <release version="@OBS_VERSION@" date="@APPDATA_RELEASE_DATE@"/>
   </releases>


### PR DESCRIPTION
### Description

Add the "hi-dpi icon" and "modern toolkit" kudos to the AppData file, and let app centers tell the world how awesome OBS Studio is :slightly_smiling_face: 

### Motivation and Context

Kudos are read by app centers such as GNOME Software and Discover to calculate the "awesomeness" level of the application. OBS Studio qualifies for two of these kudos: the "hi-dpi icon" kudo, since we have 128x128 and bigger icons; and the "modern toolkit" icon, since we use Qt5.

### How Has This Been Tested?

 - Build this branch, and observe that app centers add these kudos to OBS Studio

### Types of changes

 - Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
