### PR TITLE
Fix some unused parameter warnings

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1245,7 +1245,7 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 		obs_data_release(oldTransitionData);
 	};
 	if (visible) {
-		auto setDuration = [this](int duration) {
+		auto setDuration = [](int duration) {
 			OBSBasic *main = reinterpret_cast<OBSBasic *>(
 				App()->GetMainWindow());
 
@@ -1257,7 +1257,7 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 			(void (QSpinBox::*)(int)) & QSpinBox::valueChanged,
 			setDuration);
 	} else {
-		auto setDuration = [this](int duration) {
+		auto setDuration = [](int duration) {
 			OBSBasic *main = reinterpret_cast<OBSBasic *>(
 				App()->GetMainWindow());
 

--- a/plugins/obs-filters/noise-suppress-filter.c
+++ b/plugins/obs-filters/noise-suppress-filter.c
@@ -149,8 +149,10 @@ pthread_mutex_t nvafx_initializer_mutex;
 #define SUP_MIN -60
 #define SUP_MAX 0
 
+#ifdef LIBSPEEXDSP_ENABLED
 static const float c_32_to_16 = (float)INT16_MAX;
 static const float c_16_to_32 = ((float)INT16_MAX + 1.0f);
+#endif
 
 /* -------------------------------------------------------- */
 
@@ -338,6 +340,8 @@ static inline void alloc_channel(struct noise_suppress_data *ng,
 #ifdef LIBSPEEXDSP_ENABLED
 	ng->spx_states[channel] =
 		speex_preprocess_state_init((int)frames, sample_rate);
+#else
+	UNUSED_PARAMETER(sample_rate);
 #endif
 #ifdef LIBRNNOISE_ENABLED
 	ng->rnn_states[channel] = rnnoise_create(NULL);
@@ -656,6 +660,8 @@ static inline void process_speexdsp(struct noise_suppress_data *ng)
 			ng->copy_buffers[i][j] =
 				(float)ng->spx_segment_buffers[i][j] /
 				c_16_to_32;
+#else
+	UNUSED_PARAMETER(ng);
 #endif
 }
 

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -525,6 +525,8 @@ static void *ft2_source_create(obs_data_t *settings, obs_source_t *source)
 
 	obs_source_update(source, NULL);
 
+	UNUSED_PARAMETER(settings);
+
 	return srcdata;
 }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes some unused parameter warnings.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
XCode (`Apple clang version 13.0.0 (clang-1300.0.29.3)`) yelled at me.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0.1, still compiles and warnings are gone.
Also still compiles on Windows and Linux CI.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.