### PR TITLE
UI: Detect cpp memory leaks

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -70,6 +70,29 @@
 
 using namespace std;
 
+#ifdef _DEBUG
+void *operator new(size_t size)
+{
+	if (size == 0)
+		size++;
+
+	if (void *ptr = bzalloc(size))
+		return ptr;
+
+	throw bad_alloc{};
+}
+
+void operator delete(void *p) noexcept
+{
+	bfree(p);
+}
+
+void operator delete(void *p, size_t) noexcept
+{
+	bfree(p);
+}
+#endif
+
 static log_handler_t def_log_handler;
 
 static string currentLogFile;


### PR DESCRIPTION
### Description
This overloads the cpp new/delete operators, to add an alloc counter
to detect memory leaks. This number is printed when using OBS in debug
mode when exiting.

### Motivation and Context
Makes it easier to find memory leaks in QT or cpp.

### How Has This Been Tested?
Ran the program and checked if the memory leak number was printed when exiting.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
