### PR TITLE
aja: Fix crash in output settings when no card present

### DIFF
--- a/plugins/aja/aja-common.cpp
+++ b/plugins/aja/aja-common.cpp
@@ -226,6 +226,23 @@ bool aja_video_format_changed(obs_properties_t *props, obs_property_t *list,
 	auto vid_fmt = static_cast<NTV2VideoFormat>(
 		obs_data_get_int(settings, kUIPropVideoFormatSelect.id));
 
+	size_t itemCount = obs_property_list_item_count(list);
+	bool itemFound = false;
+
+	for (size_t i = 0; i < itemCount; i++) {
+		int itemFormat = obs_property_list_item_int(list, i);
+		if (itemFormat == vid_fmt) {
+			itemFound = true;
+			break;
+		}
+	}
+
+	if (!itemFound) {
+		obs_property_list_insert_int(list, 0, "", vid_fmt);
+		obs_property_list_item_disable(list, 0, true);
+		return true;
+	}
+
 	obs_property_t *sdi_4k_trx =
 		obs_properties_get(props, kUIPropSDI4KTransport.id);
 

--- a/plugins/aja/aja-output.cpp
+++ b/plugins/aja/aja-output.cpp
@@ -782,6 +782,24 @@ bool aja_output_device_changed(void *data, obs_properties_t *props,
 	populate_output_device_list(list);
 
 	const char *cardID = obs_data_get_string(settings, kUIPropDevice.id);
+
+	size_t itemCount = obs_property_list_item_count(list);
+	bool itemFound = false;
+
+	for (size_t i = 0; i < itemCount; i++) {
+		const char *itemCardID = obs_property_list_item_string(list, i);
+		if (strcmp(cardID, itemCardID) == 0) {
+			itemFound = true;
+			break;
+		}
+	}
+
+	if (!itemFound) {
+		obs_property_list_insert_string(list, 0, cardID, cardID);
+		obs_property_list_item_disable(list, 0, true);
+		return true;
+	}
+
 	if (!cardID) {
 		blog(LOG_ERROR, "aja_output_device_changed: Card ID is null!");
 		return false;
@@ -847,14 +865,33 @@ bool aja_output_dest_changed(obs_properties_t *props, obs_property_t *list,
 
 	blog(LOG_DEBUG, "AJA Output Dest Changed");
 
-	auto &cardManager = aja::CardManager::Instance();
-	cardManager.EnumerateCards();
+	int dest = obs_data_get_int(settings, kUIPropOutput.id);
+
+	size_t itemCount = obs_property_list_item_count(list);
+	bool itemFound = false;
+
+	for (size_t i = 0; i < itemCount; i++) {
+		int itemDest = obs_property_list_item_int(list, i);
+		if (dest == itemDest) {
+			itemFound = true;
+			break;
+		}
+	}
+
+	if (!itemFound) {
+		obs_property_list_insert_int(list, 0, "", dest);
+		obs_property_list_item_disable(list, 0, true);
+		return true;
+	}
+
 	const char *cardID = obs_data_get_string(settings, kUIPropDevice.id);
 	if (!cardID) {
 		blog(LOG_ERROR, "aja_output_dest_changed: Card ID is null!");
 		return false;
 	}
 
+	auto &cardManager = aja::CardManager::Instance();
+	cardManager.EnumerateCards();
 	auto cardEntry = cardManager.GetCardEntry(cardID);
 	if (!cardEntry) {
 		blog(LOG_ERROR,
@@ -915,7 +952,7 @@ static void *aja_output_create(obs_data_t *settings, obs_output_t *output)
 	const char *cardID = obs_data_get_string(settings, kUIPropDevice.id);
 	if (!cardID) {
 		blog(LOG_ERROR, "aja_output_create: Card ID is null!");
-		return false;
+		return nullptr;
 	}
 	const char *outputID =
 		obs_data_get_string(settings, kUIPropAJAOutputID.id);

--- a/plugins/aja/aja-source.cpp
+++ b/plugins/aja/aja-source.cpp
@@ -854,8 +854,6 @@ static void aja_source_deactivate(void *data)
 
 static void aja_source_update(void *data, obs_data_t *settings)
 {
-	blog(LOG_INFO, "aja_source_update: Begin callback...");
-
 	static bool initialized = false;
 
 	auto ajaSource = (AJASource *)data;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR adds the current property value in the Aja output properties if it doesn't exist. This stops the properties callback from calling an infinite number of time and eventually crashing.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

AJA output ui would crash

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
