### PR TITLE
UI/importers: Automatically detect SL Collections on macOS

### DIFF
--- a/UI/importers/sl.cpp
+++ b/UI/importers/sl.cpp
@@ -503,11 +503,12 @@ bool SLImporter::Check(const string &path)
 OBSImporterFiles SLImporter::FindFiles()
 {
 	OBSImporterFiles res;
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 	char dst[512];
 
-	int found = os_get_config_path(dst, 512,
-				       "slobs-client\\SceneCollections\\");
+	int found =
+		os_get_config_path(dst, 512, "slobs-client/SceneCollections/");
+
 	if (found == -1)
 		return res;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Enables the FindFiles function for the Streamlabs importer on macOS, which previously was
windows-only.
This is not needed for OBS Classic or XSplit, since neither exist(ed) on Mac.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
`Search known locations for scene collections when importing` would do nothing on macOS (so this is something in between a tweak and a bug fix).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0.1, compiled and run.
Installed Streamlabs (a big pain, no idea why they would make the process so damn annoying) and created a collection.
It shows up in the importer window and is correctly identified as Streamlabs.
<img width="1186" alt="image" src="https://user-images.githubusercontent.com/59806498/143768975-d46a86eb-5b3a-4f55-9f92-2c918491d1cf.png">

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
