### PR TITLE
UI: Pass parent QWidget to Browser Docks

### DIFF
--- a/UI/auth-restream.cpp
+++ b/UI/auth-restream.cpp
@@ -142,7 +142,7 @@ void RestreamAuth::LoadUI()
 	chat->setWindowTitle(QTStr("Auth.Chat"));
 	chat->setAllowedAreas(Qt::AllDockWidgetAreas);
 
-	browser = cef->create_widget(nullptr, url, panel_cookies);
+	browser = cef->create_widget(chat.get(), url, panel_cookies);
 	chat->SetWidget(browser);
 
 	main->addDockWidget(Qt::RightDockWidgetArea, chat.data());
@@ -159,7 +159,7 @@ void RestreamAuth::LoadUI()
 	info->setWindowTitle(QTStr("Auth.StreamInfo"));
 	info->setAllowedAreas(Qt::AllDockWidgetAreas);
 
-	browser = cef->create_widget(nullptr, url, panel_cookies);
+	browser = cef->create_widget(info.get(), url, panel_cookies);
 	info->SetWidget(browser);
 
 	main->addDockWidget(Qt::LeftDockWidgetArea, info.data());
@@ -176,7 +176,7 @@ void RestreamAuth::LoadUI()
 	channels->setWindowTitle(QTStr("RestreamAuth.Channels"));
 	channels->setAllowedAreas(Qt::AllDockWidgetAreas);
 
-	browser = cef->create_widget(nullptr, url, panel_cookies);
+	browser = cef->create_widget(channels.get(), url, panel_cookies);
 	channels->SetWidget(browser);
 
 	main->addDockWidget(Qt::LeftDockWidgetArea, channels.data());

--- a/UI/auth-twitch.cpp
+++ b/UI/auth-twitch.cpp
@@ -225,7 +225,7 @@ void TwitchAuth::LoadUI()
 	chat->setWindowTitle(QTStr("Auth.Chat"));
 	chat->setAllowedAreas(Qt::AllDockWidgetAreas);
 
-	browser = cef->create_widget(nullptr, url, panel_cookies);
+	browser = cef->create_widget(chat.get(), url, panel_cookies);
 	chat->SetWidget(browser);
 	cef->add_force_popup_url(moderation_tools_url, chat.data());
 
@@ -313,7 +313,7 @@ void TwitchAuth::LoadSecondaryUIPanes()
 	info->setWindowTitle(QTStr("Auth.StreamInfo"));
 	info->setAllowedAreas(Qt::AllDockWidgetAreas);
 
-	browser = cef->create_widget(nullptr, url, panel_cookies);
+	browser = cef->create_widget(info.get(), url, panel_cookies);
 	info->SetWidget(browser);
 	browser->setStartupScript(script);
 
@@ -333,7 +333,7 @@ void TwitchAuth::LoadSecondaryUIPanes()
 	stat->setWindowTitle(QTStr("TwitchAuth.Stats"));
 	stat->setAllowedAreas(Qt::AllDockWidgetAreas);
 
-	browser = cef->create_widget(nullptr, url, panel_cookies);
+	browser = cef->create_widget(stat.get(), url, panel_cookies);
 	stat->SetWidget(browser);
 	browser->setStartupScript(script);
 
@@ -353,7 +353,7 @@ void TwitchAuth::LoadSecondaryUIPanes()
 	feed->setWindowTitle(QTStr("TwitchAuth.Feed"));
 	feed->setAllowedAreas(Qt::AllDockWidgetAreas);
 
-	browser = cef->create_widget(nullptr, url, panel_cookies);
+	browser = cef->create_widget(feed.get(), url, panel_cookies);
 	feed->SetWidget(browser);
 	browser->setStartupScript(script);
 

--- a/UI/auth-youtube.cpp
+++ b/UI/auth-youtube.cpp
@@ -148,7 +148,7 @@ void YoutubeAuth::LoadUI()
 	chat->setWindowTitle(QTStr("Auth.Chat"));
 	chat->setAllowedAreas(Qt::AllDockWidgetAreas);
 
-	browser = cef->create_widget(nullptr, YOUTUBE_CHAT_PLACEHOLDER_URL,
+	browser = cef->create_widget(chat.get(), YOUTUBE_CHAT_PLACEHOLDER_URL,
 				     panel_cookies);
 	browser->setStartupScript(ytchat_script);
 

--- a/UI/window-extra-browsers.cpp
+++ b/UI/window-extra-browsers.cpp
@@ -530,7 +530,7 @@ void OBSBasic::AddExtraBrowserDock(const QString &title, const QString &url,
 	dock->setAllowedAreas(Qt::AllDockWidgetAreas);
 
 	QCefWidget *browser =
-		cef->create_widget(nullptr, QT_TO_UTF8(url), nullptr);
+		cef->create_widget(dock, QT_TO_UTF8(url), nullptr);
 	if (browser && panel_version >= 1)
 		browser->allowAllPopups(true);
 


### PR DESCRIPTION
### Description

The `create_widget()` function supports QWidget as the first parameter, this makes use of that.

### Motivation and Context

This provides browser docks with the ability to receive additional information from their parent QWidget. For example, acquiring the title of the dock using `widget->parentWidget()->windowTitle()`, or in future being able to get/set information about a dock via the context menu.

### How Has This Been Tested?

* [ ] https://github.com/obsproject/obs-browser/pull/331

Tested on Windows 10.

Tested in both Custom Browser Docks and the Twitch Chat dock using BTTV "Font size"

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
