### PR TITLE
Update to FFmpeg 4.4.1 on Flatpak

### DIFF
--- a/CI/flatpak/avcode-vaapi-encode-fix-segfault-upon-closing.patch
+++ b/CI/flatpak/avcode-vaapi-encode-fix-segfault-upon-closing.patch
@@ -1,0 +1,52 @@
+From d1b47f3bfcc625ca1cae210fc198dcbd54381a88 Mon Sep 17 00:00:00 2001
+From: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
+Date: Mon, 29 Nov 2021 15:29:11 +0100
+Subject: [PATCH] avcodec/vaapi_encode: Fix segfault upon closing uninitialized
+ encoder
+
+Fixes ticket #9537.
+Probably a regression since 2b3206891649f317c20993411efef4bee39ae784.
+
+Signed-off-by: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
+---
+ libavcodec/vaapi_encode.c | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/vaapi_encode.c b/libavcodec/vaapi_encode.c
+index ec054ae70152..3bf379b1a0bd 100644
+--- a/libavcodec/vaapi_encode.c
++++ b/libavcodec/vaapi_encode.c
+@@ -2366,6 +2366,11 @@ av_cold int ff_vaapi_encode_init(AVCodecContext *avctx)
+     VAStatus vas;
+     int err;
+ 
++    ctx->va_config  = VA_INVALID_ID;
++    ctx->va_context = VA_INVALID_ID;
++
++    /* If you add something that can fail above this av_frame_alloc(),
++     * modify ff_vaapi_encode_close() accordingly. */
+     ctx->frame = av_frame_alloc();
+     if (!ctx->frame) {
+         return AVERROR(ENOMEM);
+@@ -2377,9 +2382,6 @@ av_cold int ff_vaapi_encode_init(AVCodecContext *avctx)
+         return AVERROR(EINVAL);
+     }
+ 
+-    ctx->va_config  = VA_INVALID_ID;
+-    ctx->va_context = VA_INVALID_ID;
+-
+     ctx->input_frames_ref = av_buffer_ref(avctx->hw_frames_ctx);
+     if (!ctx->input_frames_ref) {
+         err = AVERROR(ENOMEM);
+@@ -2531,6 +2533,11 @@ av_cold int ff_vaapi_encode_close(AVCodecContext *avctx)
+     VAAPIEncodeContext *ctx = avctx->priv_data;
+     VAAPIEncodePicture *pic, *next;
+ 
++    /* We check ctx->frame to know whether ff_vaapi_encode_init()
++     * has been called and va_config/va_context initialized. */
++    if (!ctx->frame)
++        return 0;
++
+     for (pic = ctx->pic_start; pic; pic = next) {
+         next = pic->next;
+         vaapi_encode_free(avctx, pic);

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -145,8 +145,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://www.ffmpeg.org/releases/ffmpeg-4.3.2.tar.xz",
-          "sha256": "46e4e64f1dd0233cbc0934b9f1c0da676008cad34725113fb7f802cfa84ccddb"
+          "url": "https://www.ffmpeg.org/releases/ffmpeg-4.4.1.tar.xz",
+          "sha256": "eadbad9e9ab30b25f5520fbfde99fae4a92a1ae3c0257a8d68569a4651e30e02"
         }
       ]
     },

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -147,6 +147,10 @@
           "type": "archive",
           "url": "https://www.ffmpeg.org/releases/ffmpeg-4.4.1.tar.xz",
           "sha256": "eadbad9e9ab30b25f5520fbfde99fae4a92a1ae3c0257a8d68569a4651e30e02"
+        },
+        {
+          "type": "patch",
+          "path": "avcode-vaapi-encode-fix-segfault-upon-closing.patch"
         }
       ]
     },


### PR DESCRIPTION
### Description

Update to FFmpeg 4.4.1 on Flatpak.

### Motivation and Context

Some people are reporting that VAAPI is not working with some AMD cards on Flatpak, whereas it's working on their host system. The only meaningful difference in these cases is the FFmpeg version used.

### How Has This Been Tested?

TBD

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
