### PR TITLE
UI: Simplify OBSRef QDataStreams

### DIFF
--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -179,47 +179,23 @@ QDataStream &operator>>(QDataStream &in,
 	return in;
 }
 
-QDataStream &operator<<(QDataStream &out, const OBSScene &scene)
+QDataStream &operator<<(QDataStream &out, const OBSScene &)
 {
-	return out << QString(obs_source_get_name(obs_scene_get_source(scene)));
+	return out;
 }
 
-QDataStream &operator>>(QDataStream &in, OBSScene &scene)
+QDataStream &operator>>(QDataStream &in, OBSScene &)
 {
-	QString sceneName;
-
-	in >> sceneName;
-
-	obs_source_t *source = obs_get_source_by_name(QT_TO_UTF8(sceneName));
-	scene = obs_scene_from_source(source);
-	obs_source_release(source);
-
 	return in;
 }
 
-QDataStream &operator<<(QDataStream &out, const OBSSceneItem &si)
+QDataStream &operator<<(QDataStream &out, const OBSSceneItem &)
 {
-	obs_scene_t *scene = obs_sceneitem_get_scene(si);
-	obs_source_t *source = obs_sceneitem_get_source(si);
-	return out << QString(obs_source_get_name(obs_scene_get_source(scene)))
-		   << QString(obs_source_get_name(source));
+	return out;
 }
 
-QDataStream &operator>>(QDataStream &in, OBSSceneItem &si)
+QDataStream &operator>>(QDataStream &in, OBSSceneItem &)
 {
-	QString sceneName;
-	QString sourceName;
-
-	in >> sceneName >> sourceName;
-
-	obs_source_t *sceneSource =
-		obs_get_source_by_name(QT_TO_UTF8(sceneName));
-
-	obs_scene_t *scene = obs_scene_from_source(sceneSource);
-	si = obs_scene_find_source(scene, QT_TO_UTF8(sourceName));
-
-	obs_source_release(sceneSource);
-
 	return in;
 }
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -121,15 +121,13 @@ Q_DECLARE_METATYPE(OBSSource);
 Q_DECLARE_METATYPE(obs_order_movement);
 Q_DECLARE_METATYPE(SignalContainer<OBSScene>);
 
-QDataStream &operator<<(QDataStream &out, const SignalContainer<OBSScene> &v)
+QDataStream &operator<<(QDataStream &out, const SignalContainer<OBSScene> &)
 {
-	out << v.ref;
 	return out;
 }
 
-QDataStream &operator>>(QDataStream &in, SignalContainer<OBSScene> &v)
+QDataStream &operator>>(QDataStream &in, SignalContainer<OBSScene> &)
 {
-	in >> v.ref;
 	return in;
 }
 


### PR DESCRIPTION
### Description
The QDataStream can use the OBSRef pointers themselves, instead
of relying on QStrings. The OBSSignal container data stream
is used this way and works just fine.

### Motivation and Context
Code simplification, and it should also prevent any more potential crashes, like the one fixed with https://github.com/obsproject/obs-studio/commit/642dff054de1f7bfea28a9dfbf3209a83ca0bef8

### How Has This Been Tested?
Ran many operations with scenes/sources in the list widgets (drag, drop, reorder, rename, etc.)
Nothing at all seemed to break.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
