### PR TITLE
aja-output.cpp return false

### DIFF
--- a/plugins/aja/aja-output.cpp
+++ b/plugins/aja/aja-output.cpp
@@ -915,7 +915,7 @@ static void *aja_output_create(obs_data_t *settings, obs_output_t *output)
 	const char *cardID = obs_data_get_string(settings, kUIPropDevice.id);
 	if (!cardID) {
 		blog(LOG_ERROR, "aja_output_create: Card ID is null!");
-		return false;
+		return nullptr;
 	}
 	const char *outputID =
 		obs_data_get_string(settings, kUIPropAJAOutputID.id);


### PR DESCRIPTION
### Description

obs-studio/plugins/aja/aja-output.cpp:918:10: error: cannot initialize return object of type 'void *' with an rvalue of type 'bool'