### PR TITLE
UI: Add UUID to Twitch panel URLs

### DIFF
--- a/UI/auth-twitch.hpp
+++ b/UI/auth-twitch.hpp
@@ -26,6 +26,7 @@ class TwitchAuth : public OAuthStreamKey {
 	bool uiLoaded = false;
 
 	std::string name;
+	std::string uuid;
 
 	virtual bool RetryLogin() override;
 


### PR DESCRIPTION
### Description
Some Twitch dashboard panels now require a UUID, it is not used for
anything but local storage right now, and according to Twitch we can
generate it ourselves (or even use a static string). To be safe we can
just use QUuid to generate a "real" UUID and then store it locally until
the user disconnects the account.

### Motivation and Context

Twitch break, I fix.

### How Has This Been Tested?
Logged into panel on new profile, verified it works and UUID is saved/loaded.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
