### PR TITLE
UI: Generate unique identifiers for Custom Browser Docks

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -9571,6 +9571,7 @@ void OBSBasic::ResizeOutputSizeOfSource()
 QAction *OBSBasic::AddDockWidget(QDockWidget *dock)
 {
 	QAction *action = ui->menuDocks->addAction(dock->windowTitle());
+	action->setProperty("uuid", dock->property("uuid").toString());
 	action->setCheckable(true);
 	assignDockToggle(dock, action);
 	extraDocks.push_back(dock);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -538,7 +538,7 @@ private:
 	void SaveExtraBrowserDocks();
 	void ManageExtraBrowserDocks();
 	void AddExtraBrowserDock(const QString &title, const QString &url,
-				 bool firstCreate);
+				 const QString &uuid, bool firstCreate);
 #endif
 
 	QIcon imageIcon;

--- a/UI/window-extra-browsers.hpp
+++ b/UI/window-extra-browsers.hpp
@@ -49,6 +49,7 @@ public:
 		int prevIdx;
 		QString title;
 		QString url;
+		QString uuid;
 	};
 
 	void TabSelection(bool forward);


### PR DESCRIPTION
### Description

Adds a persistent `uuid` property to Custom Browser Docks in the Docks menu and internally. This allows for the ability to uniquely identify custom browser docks.

This UUID is accessible from the `global.ini` configuration, the dock widget itself, and the menu item representing the dock.

```ini
[BasicWindow]
ExtraBrowserDocks=[{"title": "Google", "url": "https://google.com", "uuid": "f081624cc81f49b0848470e8d16d8e46"}]
```

### Motivation and Context

There are certain future enhancements that would be entirely impossible without a way to uniquely identify docks.

### How Has This Been Tested?

* Create a custom browser dock (or already have one configured)
* Close OBS
* Check `global.ini`

### Types of changes

 - New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
