### PR TITLE
linux-pipewire: check pipewire buffers for corruption

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -454,11 +454,12 @@ static void on_process_cb(void *user_data)
 	obs_pipewire_data *obs_pw = user_data;
 	struct spa_meta_cursor *cursor;
 	uint32_t drm_format;
+	struct spa_meta_header *header;
 	struct spa_meta_region *region;
 	struct spa_buffer *buffer;
 	struct pw_buffer *b;
 	bool swap_red_blue = false;
-	bool has_buffer;
+	bool has_buffer = true;
 
 	/* Find the most recent buffer */
 	b = NULL;
@@ -478,10 +479,19 @@ static void on_process_cb(void *user_data)
 	}
 
 	buffer = b->buffer;
-	has_buffer = buffer->datas[0].chunk->size != 0;
+	header = spa_buffer_find_meta_data(buffer, SPA_META_Header,
+					   sizeof(*header));
+	if (header && (header->flags & SPA_META_HEADER_FLAG_CORRUPTED) > 0) {
+		blog(LOG_ERROR, "[pipewire] buffer is corrupt");
+		pw_stream_queue_buffer(obs_pw->stream, b);
+		return;
+	} else if (!header) {
+		has_buffer = buffer->datas[0].chunk->size != 0;
+	}
 
 	obs_enter_graphics();
 
+	// Workaround for mutter behaviour pre GNOME 43
 	if (!has_buffer)
 		goto read_metadata;
 
@@ -492,6 +502,7 @@ static void on_process_cb(void *user_data)
 		uint64_t modifiers[planes];
 		int fds[planes];
 		bool use_modifiers;
+		bool corrupt = false;
 
 		blog(LOG_DEBUG,
 		     "[pipewire] DMA-BUF info: fd:%ld, stride:%d, offset:%u, size:%dx%d",
@@ -514,6 +525,14 @@ static void on_process_cb(void *user_data)
 			offsets[plane] = buffer->datas[plane].chunk->offset;
 			strides[plane] = buffer->datas[plane].chunk->stride;
 			modifiers[plane] = obs_pw->format.info.raw.modifier;
+			corrupt |= (buffer->datas[plane].chunk->flags &
+				    SPA_CHUNK_FLAG_CORRUPTED) > 0;
+		}
+
+		if (corrupt) {
+			blog(LOG_ERROR,
+			     "[pipewire] buffer contains corrupted data");
+			goto read_metadata;
 		}
 
 		g_clear_pointer(&obs_pw->texture, gs_texture_destroy);
@@ -544,6 +563,19 @@ static void on_process_cb(void *user_data)
 			blog(LOG_ERROR,
 			     "[pipewire] unsupported DMA buffer format: %d",
 			     obs_pw->format.info.raw.format);
+			goto read_metadata;
+		}
+
+		if ((buffer->datas[0].chunk->flags & SPA_CHUNK_FLAG_CORRUPTED) >
+		    0) {
+			blog(LOG_ERROR,
+			     "[pipewire] buffer contains corrupted data");
+			goto read_metadata;
+		}
+
+		if (buffer->datas[0].chunk->size == 0) {
+			blog(LOG_ERROR,
+			     "[pipewire] buffer contains empty data");
 			goto read_metadata;
 		}
 
@@ -626,7 +658,7 @@ static void on_param_changed_cb(void *user_data, uint32_t id,
 {
 	obs_pipewire_data *obs_pw = user_data;
 	struct spa_pod_builder pod_builder;
-	const struct spa_pod *params[3];
+	const struct spa_pod *params[4];
 	uint32_t buffer_types;
 	uint8_t params_buffer[1024];
 	int result;
@@ -695,7 +727,14 @@ static void on_param_changed_cb(void *user_data, uint32_t id,
 		&pod_builder, SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
 		SPA_PARAM_BUFFERS_dataType, SPA_POD_Int(buffer_types));
 
-	pw_stream_update_params(obs_pw->stream, params, 3);
+	/* Meta header */
+	params[3] = spa_pod_builder_add_object(
+		&pod_builder, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta,
+		SPA_PARAM_META_type, SPA_POD_Id(SPA_META_Header),
+		SPA_PARAM_META_size,
+		SPA_POD_Int(sizeof(struct spa_meta_header)));
+
+	pw_stream_update_params(obs_pw->stream, params, 4);
 
 	obs_pw->negotiated = true;
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This patch checks the buffer received from PipeWire for flags indicating that the buffer is corrupt.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Portals can set a buffer as corrupted via flags. This allows obs to skip those frames and avoid trying to import them.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Modified version of [xdg-desktop-portal-wlr](https://github.com/emersion/xdg-desktop-portal-wlr) to alternate between those flags for a given time duration. With this patch your screencast will freeze until a new frame without a flag arrives. Mouse pointer should still be updated when it is not embedded. 


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
