### PR TITLE
CI: Don't publish betas to Flathub stable

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: "Publish to Flathub"
         uses: bilelmoussaoui/flatpak-github-actions/flat-manager@v4
-        if: "!contains(github.ref, '-rc')"
+        if: "!contains(github.ref, '-beta') && !contains(github.ref, '-rc')"
         with:
           flat-manager-url: https://hub.flathub.org/
           repository: stable


### PR DESCRIPTION
### Description

Don't publish beta releases to Flathub stable.

### Motivation and Context

Beta releases are being considered, in which case the tag name will contain '-beta' instead of '-rc'. Adapt the CI workflow to take '-beta' into account too.

### How Has This Been Tested?

Observe that this [fake beta release](https://github.com/GeorgesStavracas/obs-studio/runs/4419285226?check_suite_focus=true) skips the `Publish to Flathub` step.

### Types of changes

- Enhancement (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
