### PR TITLE
CI: Increase Crowdin Sync Checkout Fetch Depth

### DIFF
--- a/.github/workflows/crowdin-sync-download.yml
+++ b/.github/workflows/crowdin-sync-download.yml
@@ -1,7 +1,7 @@
 name: "Crowdin Sync: Import latest translations"
 on: workflow_dispatch
 jobs:
-  download:
+  crowdin-sync-download:
     name: Import latest translations
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/crowdin-sync-upload.yml
+++ b/.github/workflows/crowdin-sync-upload.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - "**/en-US.ini"
 jobs:
-  upload:
+  crowdin-sync-upload:
     name: Upload English strings
     runs-on: ubuntu-latest
     env:
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-          fetch-depth: 2
+          fetch-depth: 100
       - uses: actions/setup-node@v2
         with:
           node-version: 16


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This fixes an issue with the Crowdin Sync Upload action when more than 1 commit gets pushed where one of the commits contains an updated language file. By increasing the fetch depth I make sure all pushed commits get covered by the checkout.
This also updates the job names for both actions to clarify what they are in the global scope.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
A failing action is bad.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
In a fork and a private Crowdin project.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
