### PR TITLE
aja: Disable plugin if no devices are found

### DIFF
--- a/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
@@ -83,27 +83,59 @@ add_library(aja-output-ui MODULE
 	${aja-output-ui_SOURCES}
 	${aja-output-ui_UI_HEADERS})
 
-if (APPLE)
-	target_compile_definitions(aja-output-ui PUBLIC
-		AJAMac
-		AJA_MAC)
+set(aja_LIBRARIES
+		$<IF:$<CONFIG:Debug>,${LIBAJANTV2_DEBUG_LIBRARIES},${LIBAJANTV2_LIBRARIES}>
+		libobs)
+
+# macOS
+if(APPLE)
+	set(aja_COMPILE_DEFS
+			AJAMac
+			AJA_MAC)
+
+	find_library(IOKIT_FRAMEWORK Iokit)
+	find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+	find_library(APPKIT_FRAMEWORK AppKit)
+
+	list(APPEND aja_LIBRARIES
+			${IOKIT_FRAMEWORK}
+			${COREFOUNDATION_LIBRARY}
+			${APPKIT_FRAMEWORK})
+	# Windows
 elseif(WIN32)
-	target_compile_definitions(aja-output-ui PUBLIC
-		AJA_WINDOWS
-		_WINDOWS
-		WIN32
-		MSWindows)
+	set(aja_COMPILE_DEFS
+			AJA_WINDOWS
+			_WINDOWS
+			WIN32
+			MSWindows)
+
+	if(CMAKE_BUILD_TYPE STREQUAL Debug)
+		list(APPEND aja_COMPILE_DEFS
+				_DEBUG)
+	else()
+		list(APPEND aja_COMPILE_DEFS
+				NDEBUG)
+	endif()
+
+	list(APPEND aja_LIBRARIES
+			ws2_32.lib
+			setupapi.lib
+			Winmm.lib
+			netapi32.lib
+			Shlwapi.lib)
+	# Linux
 elseif(UNIX AND NOT APPLE)
-	target_compile_definitions(aja-output-ui PUBLIC
-		AJA_LINUX
-		AJALinux)
+	set(aja_COMPILE_DEFS
+			AJA_LINUX
+			AJALinux)
 endif()
 
 target_include_directories(aja-output-ui PUBLIC
 	${LIBAJANTV2_INCLUDE_DIRS})
-
+target_compile_definitions(aja-output-ui PUBLIC ${aja_COMPILE_DEFS})
 target_link_libraries(aja-output-ui
 	${frontend-tools_PLATFORM_LIBS}
+	${aja_LIBRARIES}
 	obs-frontend-api
 	Qt5::Widgets
 	libobs)

--- a/UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp
+++ b/UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp
@@ -11,6 +11,7 @@
 #include <util/platform.h>
 #include <media-io/video-io.h>
 #include <media-io/video-frame.h>
+#include <ajantv2/includes/ntv2devicescanner.h>
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("aja-output-ui", "en-US")
@@ -310,6 +311,13 @@ static void OBSEvent(enum obs_frontend_event event, void *)
 
 bool obs_module_load(void)
 {
+	CNTV2DeviceScanner scanner;
+	auto numDevices = scanner.GetNumDevices();
+
+	if (numDevices == 0) {
+		return false;
+	}
+
 	addOutputUI();
 
 	obs_frontend_add_event_callback(OBSEvent, nullptr);

--- a/plugins/aja/main.cpp
+++ b/plugins/aja/main.cpp
@@ -1,5 +1,6 @@
 #include "aja-card-manager.hpp"
 #include <obs-module.h>
+#include <ajantv2/includes/ntv2devicescanner.h>
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("aja", "en-US")
@@ -17,6 +18,13 @@ struct obs_output_info aja_output_info;
 
 bool obs_module_load(void)
 {
+	CNTV2DeviceScanner scanner;
+	auto numDevices = scanner.GetNumDevices();
+
+	if (numDevices == 0) {
+		return false;
+	}
+
 	aja::CardManager::Instance().EnumerateCards();
 
 	aja_source_info = create_aja_source_info();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

When the AJA plugin loads we check if any devices are present, if they are not we tell OBS to not load the AJA plugin.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

This should cut down on user confusion and reduce clutter.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Ran locally with no devices and the plugin doesn't load.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
