### PR TITLE
pipewire: only deinit if we init'ed

### DIFF
--- a/plugins/linux-capture/pipewire-capture.c
+++ b/plugins/linux-capture/pipewire-capture.c
@@ -105,6 +105,8 @@ static void pipewire_capture_video_render(void *data, gs_effect_t *effect)
 	obs_pipewire_video_render(data, effect);
 }
 
+static bool initialized = false;
+
 void pipewire_capture_load(void)
 {
 	uint32_t available_capture_types = portal_get_available_capture_types();
@@ -167,9 +169,11 @@ void pipewire_capture_load(void)
 		obs_register_source(&pipewire_window_capture_info);
 
 	pw_init(NULL, NULL);
+	initialized = true;
 }
 
 void pipewire_capture_unload(void)
 {
-	pw_deinit();
+	if (initialized)
+		pw_deinit();
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
If you don't have a xdg-desktop-portal backend then pipewire wont init,
however on exit we unconditionally deinit which can crash in pipewire
which does not handle this gracefully.

Its not the most graceful solution, but I didn't think we should be querying dbus
again just to figure out if pipewire can be safely deinit'ed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Crashing on exit is bad.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Running obs in a wayland session without a portal backend crashes on exit, with this it doesnt.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
