### PR TITLE
rtmp-services: Add Fantasy.Club

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 187,
+	"version": 188,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 187
+			"version": 188
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2437,6 +2437,70 @@
                 "max video bitrate": 4000,
                 "max fps": 30
             }
+        },
+        {
+            "name": "Fantasy.Club",
+            "stream_key_link": "https://fantasy.club/app/create-content/stream-now",
+            "more_info_link": "https://help.fantasy.club/",
+            "servers": [
+                {
+                    "name": "US: East",
+                    "url": "rtmp://live-east.fantasy.club/live"
+                },
+                {
+                    "name": "US: West",
+                    "url": "rtmp://live-west.fantasy.club/live"
+                },
+                {
+                    "name": "Europe",
+                    "url": "rtmp://live-eu.fantasy.club/live"
+                },
+                {
+                    "name": "South America",
+                    "url": "rtmp://live-sa.fantasy.club/live"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "profile": "high",
+                "bframes": 0,
+                "x264opts": "scenecut=0",
+                "supported resolutions": [
+                    "1920x1080",
+                    "1280x720",
+                    "852x480"
+                ],
+                "bitrate matrix": [
+                    {
+                        "res": "852x480",
+                        "fps": 30,
+                        "max bitrate": 1200
+                    },
+                    {
+                        "res": "1280x720",
+                        "fps": 30,
+                        "max bitrate": 3600
+                    },
+                    {
+                        "res": "1280x720",
+                        "fps": 60,
+                        "max bitrate": 4200
+                    },
+                    {
+                        "res": "1920x1080",
+                        "fps": 30,
+                        "max bitrate": 5000
+                    },
+                    {
+                        "res": "1920x1080",
+                        "fps": 60,
+                        "max bitrate": 7200
+                    }
+                ],
+                "max fps": 60,
+                "max video bitrate": 7200,
+                "max audio bitrate": 196
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
Add Fantasy.Club to rtmp services list.

### Motivation and Context
Simplify life for streamers using the Fantasy.Club platform

### How Has This Been Tested?
Dev team updates to local services.json instances

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.