### PR TITLE
UI: Add Rosetta Detection

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2116,6 +2116,12 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		}
 #endif
 
+#ifdef __APPLE__
+		bool rosettaTranslated = ProcessIsRosettaTranslated();
+		blog(LOG_INFO, "Rosetta translation used: %s",
+		     rosettaTranslated ? "true" : "false");
+#endif
+
 		if (!created_log) {
 			create_log_file(logFile);
 			created_log = true;

--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -23,6 +23,7 @@
 #include "obs-app.hpp"
 
 #include <unistd.h>
+#include <sys/sysctl.h>
 
 #import <AppKit/AppKit.h>
 
@@ -233,6 +234,19 @@ void EnableOSXDockIcon(bool enable)
 	else
 		[NSApp setActivationPolicy:
 				NSApplicationActivationPolicyProhibited];
+}
+
+bool ProcessIsRosettaTranslated()
+{
+#ifdef __aarch64__
+	return false;
+#else
+	int ret = 0;
+	size_t size = sizeof(ret);
+	if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1)
+		return false;
+	return ret == 1;
+#endif
 }
 
 /*

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -69,6 +69,7 @@ void EnableOSXDockIcon(bool enable);
 void InstallNSApplicationSubclass();
 void disableColorSpaceConversion(QWidget *window);
 void CheckAppWithSameBundleID(bool &already_running);
+bool ProcessIsRosettaTranslated();
 #endif
 #ifdef __linux__
 void RunningInstanceCheck(bool &already_running);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a check that detects if OBS is running on Rosetta on macOS and logs
the result.
~~Also adds a popup window that asks the user wether OBS is intended to
run on Rosetta. This window is currently disabled, and should get
get enabled once we officially support ARM natively.~~

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
With OBS most likely being compilable natively with the next release, it
will be good to know which version users are using when they face
issues (for example with third party plugins not working).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

macOS 12.0.1, Intel: 
- Compiled and Run
- Log correctly confirms that it's not translated.

A friends Mac mini (using a CI build of this branch), macOS 12.0.1, M1:
- Log correctly reports translation via Rosetta.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
