### PR TITLE
Fix some compillation warnings that appear on Linux

### DIFF
--- a/UI/auth-oauth.cpp
+++ b/UI/auth-oauth.cpp
@@ -64,6 +64,8 @@ OAuthLogin::OAuthLogin(QWidget *parent, const std::string &url, bool token)
 	QVBoxLayout *topLayout = new QVBoxLayout(this);
 	topLayout->addWidget(cefWidget);
 	topLayout->addLayout(bottomLayout);
+#else
+	UNUSED_PARAMETER(url);
 #endif
 }
 

--- a/UI/auth-youtube.cpp
+++ b/UI/auth-youtube.cpp
@@ -181,6 +181,8 @@ void YoutubeAuth::SetChatId(QString &chat_id)
 	if (chat && chat->cefWidget) {
 		chat->cefWidget->setURL(chat_url.toStdString());
 	}
+#else
+	UNUSED_PARAMETER(chat_id);
 #endif
 }
 

--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -97,6 +97,8 @@ static int mp_open_codec(struct mp_decode *d, bool hw)
 #ifdef USE_NEW_HARDWARE_CODEC_METHOD
 	if (hw)
 		init_hw_decoder(d, c);
+#else
+	UNUSED_PARAMETER(hw);
 #endif
 
 	if (c->thread_count == 1 && c->codec_id != AV_CODEC_ID_PNG &&

--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -1644,9 +1644,11 @@ bool obs_scripting_load_python(const char *python_path)
 	dstr_free(&old_path);
 #endif
 
+#if PY_VERSION_HEX < 0x03070000
 	PyEval_InitThreads();
 	if (!PyEval_ThreadsInitialized())
 		return false;
+#endif
 
 	/* ---------------------------------------------- */
 	/* Must set arguments for guis to work            */

--- a/deps/obs-scripting/obspython/obspython.i
+++ b/deps/obs-scripting/obspython/obspython.i
@@ -30,6 +30,15 @@
 #include "obs-frontend-api.h"
 #endif
 
+/* Redefine SWIG_PYTHON_INITIALIZE_THREADS if:
+ * - Python version is 3.7 or later because PyEval_InitThreads() became deprecated and unnecessary
+ * - SWIG version is not 4.1 or later because SWIG_PYTHON_INITIALIZE_THREADS will be define correctly
+ *   with Python 3.7 and later */
+#if PY_VERSION_HEX >= 0x03070000 && SWIGVERSION < 0x040100
+#undef SWIG_PYTHON_INITIALIZE_THREADS
+#define SWIG_PYTHON_INITIALIZE_THREADS
+#endif
+
 %}
 
 #define DEPRECATED_START
@@ -81,6 +90,17 @@ static inline void wrap_blog(int log_level, const char *message)
 %ignore obs_hotkey_pair_register_output;
 %ignore obs_hotkey_pair_register_service;
 %ignore obs_hotkey_pair_register_source;
+
+/* The function gs_debug_marker_begin_format has a va_args.
+ * By default, SWIG just drop it and replace it with a single NULL pointer.
+ * Source: http://swig.org/Doc4.0/Varargs.html#Varargs_nn4
+ *
+ * But the generated wrapper will make the compiler emit a warning
+ * because varargs is an unused parameter.
+ * So in the check step, varargs will be treated like any unused parameter. */
+%typemap(check) (const float color[4], const char *format, ...) {
+	(void)varargs;
+}
 
 %include "graphics/graphics.h"
 %include "graphics/vec4.h"

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -790,8 +790,9 @@ static inline void video_sleep(struct obs_core_video *video, bool raw_active,
 		const uint64_t udiff = os_gettime_ns() - cur_time;
 		int64_t diff;
 		memcpy(&diff, &udiff, sizeof(diff));
-		const uint64_t clamped_diff =
-			(diff > (int64_t)interval_ns) ? diff : interval_ns;
+		const uint64_t clamped_diff = (diff > (int64_t)interval_ns)
+						      ? (uint64_t)diff
+						      : interval_ns;
 		count = (int)(clamped_diff / interval_ns);
 		*p_time = cur_time + interval_ns * count;
 	}

--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -197,9 +197,14 @@ static bool virtualcam_start(void *data)
 		return false;
 
 	for (int i = 0; i < n; i++) {
-		char device[32];
+		char device[32] = {0};
 
-		snprintf(device, 32, "/dev/%s", list[i]->d_name);
+		// Use the return value of snprintf to prevent truncation warning.
+		int written = snprintf(device, 32, "/dev/%s", list[i]->d_name);
+		if (written >= 32)
+			blog(LOG_DEBUG,
+			     "v4l2-output: A format truncation may have occurred."
+			     " This can be ignored since it is quite improbable.");
 
 		if (try_connect(vcam, device)) {
 			success = true;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -327,6 +327,9 @@ static bool nvenc_reconfigure(void *data, obs_data_t *settings)
 		enc->context->bit_rate = rate;
 		enc->context->rc_max_rate = rate;
 	}
+#else
+	UNUSED_PARAMETER(data);
+	UNUSED_PARAMETER(settings);
 #endif
 	return true;
 }

--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -600,8 +600,16 @@ static obs_properties_t *vaapi_properties(void *unused)
 			    strcmp(file_name, "..") == 0)
 				continue;
 
-			char path[64] = "\0";
-			sprintf(path, "/dev/dri/by-path/%s", file_name);
+			char path[64] = {0};
+
+			// Use the return value of snprintf to prevent truncation warning.
+			int written = snprintf(path, 64, "/dev/dri/by-path/%s",
+					       file_name);
+			if (written >= 64)
+				blog(LOG_DEBUG,
+				     "obs-ffmpeg-vaapi: A format truncation may have occurred."
+				     " This can be ignored since it is quite improbable.");
+
 			type = strrchr(file_name, '-');
 			if (type == NULL)
 				continue;

--- a/plugins/obs-outputs/net-if.c
+++ b/plugins/obs-outputs/net-if.c
@@ -118,8 +118,13 @@ bool netif_str_to_addr(struct sockaddr_storage *out, int *addr_len,
 #else
 	*addr_len = ipv6 ? sizeof(struct sockaddr_in6)
 			 : sizeof(struct sockaddr_in);
-	void *dst = ipv6 ? &((struct sockaddr_in6 *)out)->sin6_addr
-			 : &((struct sockaddr_in *)out)->sin_addr;
+
+	void *dst = NULL;
+	if (ipv6)
+		dst = &((struct sockaddr_in6 *)out)->sin6_addr;
+	else
+		dst = &((struct sockaddr_in *)out)->sin_addr;
+
 	if (inet_pton(out->ss_family, addr, dst))
 		return true;
 

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -280,6 +280,8 @@ static void reinsert_packet_at_front(struct rtmp_stream *stream,
 
 static bool process_recv_data(struct rtmp_stream *stream, size_t size)
 {
+	UNUSED_PARAMETER(size);
+
 	RTMP *rtmp = &stream->rtmp;
 	RTMPPacket packet = {0};
 

--- a/test/cmocka/test_bitstream.c
+++ b/test/cmocka/test_bitstream.c
@@ -7,6 +7,8 @@
 
 static void bitstream_test(void **state)
 {
+	UNUSED_PARAMETER(state);
+
 	struct bitstream_reader reader;
 	uint8_t data[6] = {0x34, 0xff, 0xe1, 0x23, 0x91, 0x45};
 

--- a/test/cmocka/test_darray.c
+++ b/test/cmocka/test_darray.c
@@ -7,6 +7,8 @@
 
 static void array_basic_test(void **state)
 {
+	UNUSED_PARAMETER(state);
+
 	DARRAY(uint8_t) testarray;
 	da_init(testarray);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR is meant to fix some compilation warnings, ignoring FFmpeg deprecation, AJA NT2 and FTL related ones:
 - obs-ffmpeg-vaapi emits a format-overflow warning.

 - obs-outputs emits a warning because of a pointer type mismatch in conditional expression and an unused-parameter warning.
 - v4l2-output emits a format-truncation warning.
 -  media-playback, test/cmocka and obs-ffmpeg emits unused parameter warnings in the CI.
 - obs-scripting: PyEval_InitThreads() and PyEval_ThreadsInitialized() are deprecated since Python 3.9. Fixes based on https://github.com/swig/swig/commit/9c50887daa2b44251e77be8123c63df238034cf5.
 - obs-scripting (python wrap) emits a warning because of an unused parameter. A workaround to put the parameter as in a `UNUSED_PARAMETER()` was made. It really just adds `(void)varargs;` to the wrapper code.

#### Unfixed warning
I just wanted to list some warning that I couldn't fix or that can't be fixed:
 - `libobs/util/base.c` emits a warning because a ‘noreturn’ function does return. Can't be fixed because SWIG seems to not support the `noreturn` attribute.
 - ~A PyEval_InitThreads() deprecation warning is still emitted but will be fixed once SWIG 4.1 is out and used by OBS.~ (fixed for version earlier than 4.1)
 - FFmpeg deprecation, a few are normally fixed by #5501.
 - obs-ffmpeg-av1 emits an absolute-value warning caused by making the absolute value of an unsigned type.
 - And warnings from AJA plugins since I can't fix all of them.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Less there is warning, the better is. No ?
Yes, I don't like warnings so I tried to fix what I can fix.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Just build this branch on Arch Linux (with and without obs-browser) and in the Ubuntu CI and no warning were emitted where it should be fixed.
obs-ffmpeg-vaapi and v4l2-output changes were tested.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
