### PR TITLE
Remove Qt Windows Extra for Qt 6 and later

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -73,7 +73,7 @@ find_package(Threads REQUIRED)
 find_package(Qt5Network ${FIND_MODE})
 find_package(Qt5Widgets ${FIND_MODE})
 find_package(Qt5Svg ${FIND_MODE})
-if(WIN32)
+if(WIN32 AND (Qt5Widgets_VERSION VERSION_LESS 6.0.0))
 	find_package(Qt5WinExtras ${FIND_MODE})
 endif()
 find_package(Qt5Xml ${FIND_MODE})
@@ -452,8 +452,11 @@ if(WIN32)
 	set_target_properties(obs
 		PROPERTIES
 			OUTPUT_NAME "obs${_output_suffix}")
-	target_link_libraries(obs
-			Qt5::WinExtras)
+
+	if(Qt5Widgets_VERSION VERSION_LESS 6.0.0)
+		target_link_libraries(obs
+				Qt5::WinExtras)		
+	endif()	
 endif()
 
 target_link_libraries(obs

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2015,7 +2015,7 @@ void OBSBasic::OBSInit()
 	SystemTray(true);
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	taskBtn->setWindow(windowHandle());
 #endif
 
@@ -6650,7 +6650,7 @@ inline void OBSBasic::OnActivate(bool force)
 		App()->IncrementSleepInhibition();
 		UpdateProcessPriority();
 
-#ifdef _WIN32
+#if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 		taskBtn->setOverlayIcon(QIcon::fromTheme(
 			"obs-active", QIcon(":/res/images/active.png")));
 #endif
@@ -6681,7 +6681,7 @@ inline void OBSBasic::OnDeactivate()
 		App()->DecrementSleepInhibition();
 		ClearProcessPriority();
 
-#ifdef _WIN32
+#if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 		taskBtn->clearOverlayIcon();
 #endif
 		if (trayIcon && trayIcon->isVisible()) {
@@ -6708,7 +6708,7 @@ inline void OBSBasic::OnDeactivate()
 #endif
 			trayIcon->setIcon(QIcon::fromTheme("obs-tray-paused",
 							   trayIconFile));
-#ifdef _WIN32
+#if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 			taskBtn->setOverlayIcon(QIcon::fromTheme(
 				"obs-paused",
 				QIcon(":/res/images/paused.png")));
@@ -6724,7 +6724,7 @@ inline void OBSBasic::OnDeactivate()
 #endif
 			trayIcon->setIcon(QIcon::fromTheme("obs-tray-active",
 							   trayIconFile));
-#ifdef _WIN32
+#if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 			taskBtn->setOverlayIcon(QIcon::fromTheme(
 				"obs-active",
 				QIcon(":/res/images/active.png")));
@@ -9697,7 +9697,7 @@ void OBSBasic::PauseRecording()
 
 		ui->statusbar->RecordingPaused();
 
-#ifdef _WIN32
+#if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 		taskBtn->setOverlayIcon(QIcon::fromTheme(
 			"obs-paused", QIcon(":/res/images/paused.png")));
 #endif
@@ -9741,7 +9741,7 @@ void OBSBasic::UnpauseRecording()
 
 		ui->statusbar->RecordingUnpaused();
 
-#ifdef _WIN32
+#if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 		taskBtn->setOverlayIcon(QIcon::fromTheme(
 			"obs-active", QIcon(":/res/images/active.png")));
 #endif

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -22,7 +22,7 @@
 #include <QThread>
 #include <QWidgetAction>
 #include <QSystemTrayIcon>
-#ifdef _WIN32
+#if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <QWinTaskbarButton>
 #endif
 #include <QStyledItemDelegate>
@@ -317,7 +317,7 @@ private:
 	QPointer<QAction> renameScene;
 	QPointer<QAction> renameSource;
 
-#ifdef _WIN32
+#if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	QWinTaskbarButton *taskBtn = new QWinTaskbarButton(this);
 #endif
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Remove Qt Windows Extra for Qt 6 and later

### Motivation and Context
Qt 6 and later removed platform-specific extra modules from the code base. 


### How Has This Been Tested?
It compiles.
Tested on Windows 10 x64 and 11 ARM64 without crash.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
