### PR TITLE
CI: Run Flatpak jobs on release branches too

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -5,13 +5,13 @@ name: Flatpak
 on:
   push:
     paths-ignore: ['**.md']
-    branches: [master]
+    branches: [master, 'release/**']
   pull_request:
     paths-ignore: ['**.md']
-    branches: [master]
+    branches: [master, 'release/**']
   release:
     types: [published]
-    branches: [master]
+    branches: [master, 'release/**']
 
 env:
   TWITCH_CLIENTID: ${{ secrets.TWITCH_CLIENT_ID }}


### PR DESCRIPTION
### Description

Adapt the Flatpak workflow to also run on `release/**` branches.

### Motivation and Context

We'll soon be moving to branching before releases, which is a case that the current Flatpak worflow did not account for.

### How Has This Been Tested?

I've created a [fake `release/27.999.0` branch in my personal repository](https://github.com/GeorgesStavracas/obs-studio/tree/release/27.999.0), and the Flatpak actions now run there too.

### Types of changes

 - Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
