### PR TITLE
UI: Fix a stack overlow caused by using OBSScene

### DIFF
--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -23,7 +23,7 @@ static bool find_sel(obs_scene_t *, obs_sceneitem_t *item, void *param)
 	return true;
 };
 
-static OBSSceneItem FindASelectedItem(OBSScene scene)
+static OBSSceneItem FindASelectedItem(obs_scene_t *scene)
 {
 	OBSSceneItem item;
 	obs_scene_enum_items(scene, find_sel, &item);
@@ -184,8 +184,8 @@ void OBSBasicTransform::OBSSceneItemRemoved(void *param, calldata_t *data)
 {
 	OBSBasicTransform *window =
 		reinterpret_cast<OBSBasicTransform *>(param);
-	OBSScene scene = (obs_scene_t *)calldata_ptr(data, "scene");
-	OBSSceneItem item = (obs_sceneitem_t *)calldata_ptr(data, "item");
+	obs_scene_t *scene = (obs_scene_t *)calldata_ptr(data, "scene");
+	obs_sceneitem_t *item = (obs_sceneitem_t *)calldata_ptr(data, "item");
 
 	if (item == window->item)
 		window->SetItem(FindASelectedItem(scene));
@@ -205,8 +205,8 @@ void OBSBasicTransform::OBSSceneItemDeselect(void *param, calldata_t *data)
 {
 	OBSBasicTransform *window =
 		reinterpret_cast<OBSBasicTransform *>(param);
-	OBSScene scene = (obs_scene_t *)calldata_ptr(data, "scene");
-	OBSSceneItem item = (obs_sceneitem_t *)calldata_ptr(data, "item");
+	obs_scene_t *scene = (obs_scene_t *)calldata_ptr(data, "scene");
+	obs_sceneitem_t *item = (obs_sceneitem_t *)calldata_ptr(data, "item");
 
 	if (item == window->item) {
 		window->setWindowTitle(


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix a stack overflow caused by using OBSScene in OBSBasicTransform::OBSSceneItemRemoved, which is callback of signal.
OBSSceneItemRemoved is called as this callstack (dead cycle):

![1639619195](https://user-images.githubusercontent.com/18413354/146292927-b84aa5ae-787e-4ab7-a8e3-1b00e3279735.png)
![1639618417](https://user-images.githubusercontent.com/18413354/146292379-71c4cbb7-c56e-4b93-aea5-946886fec6ff.png)


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I think it is really quite dangerous to use OBSSource/OBSScene/OBSSceneItem in callback of signal, especilly using these variable type to params of invokeMethod.

Because in callback of signal, we can't ensure source's refs. If refs has been -1, that means any thread is being destroying it. 
If we use OBSSource for param, after running function passed to invokeMehtod, refs will be -1 again. Then obs_source_destroy will be called for this deleted object, crash happen!

I have meet this kind of crash many times. Such as https://github.com/obsproject/obs-studio/pull/5605
@jp9000  It's perfect if this can be considered in "destroy defer system".

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
open window of OBSBasicTransform, exit OBS or delete current scene.
I can't reproduce this callstack because sometimes signal won't be invoked.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
