### PR TITLE
obs-ffmpeg: Further FFmpeg deprecations fixes for FFmpeg 4.4+ (on mac)

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -29,6 +29,7 @@
 #include <util/dstr.h>
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
+#include <libavutil/channel_layout.h>
 
 #define ANSI_COLOR_RED "\x1b[0;91m"
 #define ANSI_COLOR_MAGENTA "\x1b[0;95m"

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -25,6 +25,7 @@
 #include "obs-ffmpeg-output.h"
 #include "obs-ffmpeg-formats.h"
 #include "obs-ffmpeg-compat.h"
+#include <libavutil/channel_layout.h>
 
 struct ffmpeg_output {
 	obs_output_t *output;


### PR DESCRIPTION
### Description
avcodec.h stopped including channel_layout.h per FFmpeg commit
1be3d8a0cb77 [1]. Fixes compilation error on macOS against FFmpeg 
later than the mentioned commit.
[1] https://github.com/FFmpeg/FFmpeg/commit/1be3d8a0cb77f8d34c1f39b47bf5328fe10c82d7

### Motivation and Context
appleclang 12 raises errors when compiling obs with FFmpeg
master.
(On visual studio 2019, we only have warnings. C99 converts these warnings
into errors though on macOS).
This fixes the issue.
Note that in agreement with commit https://github.com/obsproject/obs-studio/pull/5501/commits/abf1d609d29196921df8f09ab6e07340b7cf9660
I haven't ifdef the channel_layout.h include per avcodec version.

Edit: these issues occur also on linux (issue #5756) 

### How Has This Been Tested?
This has been tested on macOS with FFmpeg 4.4, FFmpeg master.
And also on windows.
Obs-Studio now compiles and works fine.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
