### PR TITLE
libobs: Add preprocessor directive for AutoRelease types

### DIFF
--- a/libobs/obs.hpp
+++ b/libobs/obs.hpp
@@ -47,6 +47,7 @@ using OBSWeakEncoder = OBSRef<obs_weak_encoder_t *, obs_weak_encoder_addref,
 using OBSWeakService = OBSRef<obs_weak_service_t *, obs_weak_service_addref,
 			      obs_weak_service_release>;
 
+#define OBS_AUTORELEASE
 inline void ___source_dummy_addref(obs_source_t *){};
 inline void ___scene_dummy_addref(obs_scene_t *){};
 inline void ___sceneitem_dummy_addref(obs_sceneitem_t *){};


### PR DESCRIPTION
### Description
Adds the `OBS_AUTORELEASE` #define to obs.hpp.

### Motivation and Context
Since these helpers come from obs-websocket, obs-websocket needs a way to disable its own helpers if OBS is new enough to include them already. We need this in order to fix building for new and older OBS.

### How Has This Been Tested?
Built obs-websocket successfully

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
