### PR TITLE
UI: Post events in scene collection cleanup to properly destroy removed sources

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4563,6 +4563,13 @@ void OBSBasic::ClearSceneData()
 
 	undo_s.clear();
 
+	// Wait one frame for the graphics thread to remove any remaining references
+	obs_queue_task(
+		OBS_TASK_GRAPHICS, [](void *) {}, nullptr, true);
+
+	// Post all UI events to purge any remaining references
+	QApplication::sendPostedEvents(this);
+
 	auto leakCb = [](void *, obs_source_t *source) {
 		blog(LOG_WARNING,
 		     "Source '%s' not destroyed after remove! Leaking refs: %ld",

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4563,6 +4563,16 @@ void OBSBasic::ClearSceneData()
 
 	undo_s.clear();
 
+	auto leakCb = [](void *, obs_source_t *source) {
+		blog(LOG_WARNING,
+		     "Source '%s' not destroyed after remove! Leaking refs: %ld",
+		     obs_source_get_name(source),
+		     obs_source_get_refs(source) + 1);
+		return true;
+	};
+
+	obs_enum_all_sources(leakCb, nullptr);
+
 	disableSaving--;
 
 	blog(LOG_INFO, "All scene data cleared");

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -712,6 +712,14 @@ void obs_source_addref(obs_source_t *source)
 	obs_ref_addref(&source->control->ref);
 }
 
+long obs_source_get_refs(obs_source_t *source)
+{
+	if (!source)
+		return 0;
+
+	return os_atomic_load_long(&source->control->ref);
+}
+
 void obs_source_release(obs_source_t *source)
 {
 	if (!obs) {

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -905,6 +905,7 @@ EXPORT obs_source_t *obs_source_duplicate(obs_source_t *source,
  * released, the source is destroyed.
  */
 EXPORT void obs_source_addref(obs_source_t *source);
+EXPORT long obs_source_get_refs(obs_source_t *source);
 EXPORT void obs_source_release(obs_source_t *source);
 
 EXPORT void obs_weak_source_addref(obs_weak_source_t *weak);


### PR DESCRIPTION
### Description
- Adds the `obs_source_get_refs()` function (used for logging purposes)
- Adds logging to ClearSceneData() to log lingering sources
- Waits one frame and clears the Qt event queue to ensure all sources have been destroyed

Fixes #2715 

### Motivation and Context
- Logging lingering sources can be extremely helpful while debugging memory leaks.
- Data loss is generally regarded as a bad thing.

### How Has This Been Tested?
- Added logging before posting events
- Opened OBS and switched from one large scene collection to another
- Before waiting, sources get logged
- After posting events, no sources remain

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
