### PR TITLE
libobs: Hold source ref during `source_remove` signal

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -793,8 +793,12 @@ void obs_source_remove(obs_source_t *source)
 		return;
 
 	if (!source->removed) {
-		source->removed = true;
-		obs_source_dosignal(source, "source_remove", "remove");
+		obs_source_t *s = obs_source_get_ref(source);
+		if (s) {
+			s->removed = true;
+			obs_source_dosignal(s, "source_remove", "remove");
+			obs_source_release(s);
+		}
 	}
 }
 


### PR DESCRIPTION
### Description
Holds an active reference to a source during signaling of the `source_remove` signal, to prevent receivers from being given an already-destroyed source.

### Motivation and Context
All receivers of the `source_remove` signal should receive a valid source to operate on.

- Call obs_source_remove(source)
- Receiver 1 gets signal, calls `obs_source_release(source)`
- Receiver 2 gets signal, calls `obs_source_release(source)`, refs == -1, source destroyed
- Receiver 3 gets signal, source already destroyed, is forced to ignore signal due to invalid source



### How Has This Been Tested?
This is a theoretical situation which is currently possible in obs-websocket. While I can believe I've seen crashes related to this, I cannot prove it.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
