### PR TITLE
UI: Filter out incompatible audio filters in A/V list

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -477,7 +477,8 @@ static bool filter_compatible(bool async, uint32_t sourceFlags,
 	bool audioOnly = (sourceFlags & OBS_SOURCE_VIDEO) == 0;
 	bool asyncSource = (sourceFlags & OBS_SOURCE_ASYNC) != 0;
 
-	if (async && ((audioOnly && filterVideo) || (!audio && !asyncSource)))
+	if (async && ((audioOnly && filterVideo) || (!audio && !asyncSource) ||
+		      (filterAudio && !audio)))
 		return false;
 
 	return (async && (filterAudio || filterAsync)) ||


### PR DESCRIPTION
### Description

This hides audio filters if a source supports async video but not filters.

**Note:** I am unsure if this is better suited in the first check that returns `false`, or the more programmatic one directly after it. Feedback welcome.

**Before:**

![image](https://user-images.githubusercontent.com/941350/146666926-7f55db99-eb52-4e20-a478-923ed416090c.png)


**After:**

![image](https://user-images.githubusercontent.com/941350/146666860-59354a11-ee90-4177-b9e8-7cbfb7be3201.png)


### Motivation and Context

* UI shouldn't display items that are unsupported/incompatible/do nothing.

* Fixes #5136

### How Has This Been Tested?

1. On Windows, enable `BUILD_TESTS` in CMake and add a "20x20 Random Pixel Texture Source (Test)" source
2. On macOS, add a Window Capture source.
3. Open the Filters window
4. Under "Audio/Video Filters" click the + (Add) button
5. Notice the list provided, and try clicking an audio filter then adding it

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
