### PR TITLE
plugins: Allow adding image files with uppercase extension

### DIFF
--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -248,14 +248,15 @@ static void image_source_tick(void *data, float seconds)
 }
 
 static const char *image_filter =
-	"All formats (*.bmp *.tga *.png *.jpeg *.jpg *.gif *.psd *.webp);;"
-	"BMP Files (*.bmp);;"
-	"Targa Files (*.tga);;"
-	"PNG Files (*.png);;"
-	"JPEG Files (*.jpeg *.jpg);;"
-	"GIF Files (*.gif);;"
-	"PSD Files (*.psd);;"
-	"WebP Files (*.webp);;"
+	"All Supported Formats (*.bmp *.tga *.png *.jpeg *.jpg *.gif *.psd *.webp"
+	"*.BMP *.TGA *.PNG *.JPEG *.JPG *.GIF *.PSD *.WEBP);;"
+	"BMP Files (*.bmp *.BMP);;"
+	"Targa Files (*.tga *.TGA);;"
+	"PNG Files (*.png *.PNG);;"
+	"JPEG Files (*.jpeg *.JPEG *.jpg *.JPG);;"
+	"GIF Files (*.gif *.GIF);;"
+	"PSD Files (*.psd *.PSD);;"
+	"WebP Files (*.webp *.WEBP);;"
 	"All Files (*.*)";
 
 static obs_properties_t *image_source_properties(void *data)


### PR DESCRIPTION
### Description
While adding an Image source to a scene, allow selection of
supported image files having uppercase extensions.

Also changed the label `All formats` to `All Supported Formats` to convey the functionality correctly

#### Before:
<img src="https://user-images.githubusercontent.com/42087941/146669316-495f5417-c9dc-4fbb-8d3a-18de09e36199.png" width="640">

#### After:
<img src="https://user-images.githubusercontent.com/42087941/146669334-fa55d9c4-05d6-4921-9083-95b3657bd578.png" width="640">

 <br>

### Motivation and Context
Valid image files having upercase extensions (JPEG, PNG, GIF etc) did not show up in the file browser when an Image source was being added to a Scene.
I modified the `image_filter` string to allow showing of files with such extensions.

This PR fixes the issue #5463

 <br>

### How Has This Been Tested?
Fedora 35 (kernel: 5.15.6-200.fc35.x86_64), AMD Ryzen 5 3500.
* Code compiled and run correctly.
* Got desired output.

 <br>

### Types of changes
- Tweak (non-breaking change to improve existing functionality) 

 <br>

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
