### PR TITLE
mac-capture: Improve window capture performance

### DIFF
--- a/plugins/mac-capture/mac-display-capture.m
+++ b/plugins/mac-capture/mac-display-capture.m
@@ -134,7 +134,7 @@ static inline void update_window_params(struct display_capture *dc)
 			[dc->screen convertRectToBacking:dc->window_rect];
 
 	} else {
-		if (find_window(&dc->window, NULL, false))
+		if (find_window(&dc->window, NULL))
 			update_window_params(dc);
 		else
 			dc->on_screen = false;

--- a/plugins/mac-capture/mac-window-capture.m
+++ b/plugins/mac-capture/mac-window-capture.m
@@ -13,13 +13,7 @@ struct window_capture {
 
 	struct cocoa_window window;
 
-	//CGRect              bounds;
-	//CGWindowListOption  window_option;
 	CGWindowImageOption image_option;
-
-	CGColorSpaceRef color_space;
-
-	DARRAY(uint8_t) buffer;
 
 	pthread_t capture_thread;
 	os_event_t *capture_event;
@@ -28,55 +22,62 @@ struct window_capture {
 
 static CGImageRef get_image(struct window_capture *wc)
 {
-	NSArray *arr = (NSArray *)CGWindowListCreate(
-		kCGWindowListOptionIncludingWindow, wc->window.window_id);
-	[arr autorelease];
+	CFMutableArrayRef arr =
+		CFArrayCreateMutable(kCFAllocatorDefault, 0, NULL);
+	CFArrayAppendValue(arr, (void *)(uintptr_t)wc->window.window_id);
 
-	if (!arr.count && !find_window(&wc->window, NULL, false))
-		return NULL;
+	CGImageRef image = CGWindowListCreateImageFromArray(
+		CGRectNull, (CFArrayRef)arr, wc->image_option);
+	CFRelease(arr);
 
-	return CGWindowListCreateImage(CGRectNull,
-				       kCGWindowListOptionIncludingWindow,
-				       wc->window.window_id, wc->image_option);
+	if (!image && find_window(&wc->window, NULL))
+		image = get_image(wc);
+
+	return image;
 }
 
 static inline void capture_frame(struct window_capture *wc)
 {
 	uint64_t ts = os_gettime_ns();
-	CGImageRef img = get_image(wc);
-	if (!img)
+	CGImageRef image = get_image(wc);
+
+	if (!image)
 		return;
 
-	size_t width = CGImageGetWidth(img);
-	size_t height = CGImageGetHeight(img);
+	size_t width = CGImageGetWidth(image);
+	size_t height = CGImageGetHeight(image);
+	size_t bytes_per_row = CGImageGetBytesPerRow(image);
 
-	CGRect rect = {{0, 0}, {width, height}};
-	da_resize(wc->buffer, width * height * 4);
-	uint8_t *data = wc->buffer.array;
+	if ((!width && !height) || CGImageGetBitsPerPixel(image) != 32 ||
+	    CGImageGetBitsPerComponent(image) != 8) {
+		CGImageRelease(image);
+		return;
+	}
 
-	CGContextRef cg_context = CGBitmapContextCreate(
-		data, width, height, 8, width * 4, wc->color_space,
-		kCGBitmapByteOrder32Host | kCGImageAlphaPremultipliedFirst);
-	CGContextSetBlendMode(cg_context, kCGBlendModeCopy);
-	CGContextDrawImage(cg_context, rect, img);
-	CGContextRelease(cg_context);
-	CGImageRelease(img);
+	CGDataProviderRef provider = CGImageGetDataProvider(image);
+	CFDataRef data = CGDataProviderCopyData(provider);
+	const uint8_t *buffer = CFDataGetBytePtr(data);
 
 	struct obs_source_frame frame = {
 		.format = VIDEO_FORMAT_BGRA,
 		.width = width,
 		.height = height,
-		.data[0] = data,
-		.linesize[0] = width * 4,
+		.data[0] = (uint8_t *)buffer,
+		.linesize[0] = bytes_per_row,
 		.timestamp = ts,
 	};
 
 	obs_source_output_video(wc->source, &frame);
+
+	CFRelease(data);
+	CGImageRelease(image);
 }
 
 static void *capture_thread(void *data)
 {
 	struct window_capture *wc = data;
+
+	os_set_thread_name(obs_source_get_name(wc->source));
 
 	for (;;) {
 		os_event_wait(wc->capture_event);
@@ -98,10 +99,6 @@ static inline void *window_capture_create_internal(obs_data_t *settings,
 
 	wc->source = source;
 
-	wc->color_space = CGColorSpaceCreateDeviceRGB();
-
-	da_init(wc->buffer);
-
 	init_window(&wc->window, settings);
 
 	wc->image_option = obs_data_get_bool(settings, "show_shadow")
@@ -111,7 +108,21 @@ static inline void *window_capture_create_internal(obs_data_t *settings,
 	os_event_init(&wc->capture_event, OS_EVENT_TYPE_AUTO);
 	os_event_init(&wc->stop_event, OS_EVENT_TYPE_MANUAL);
 
-	pthread_create(&wc->capture_thread, NULL, capture_thread, wc);
+	/*
+	 * "To let Cocoa know that you intend to use multiple threads, all you
+	 * have to do is spawn a single thread using the NSThread class and
+	 * let that thread immediately exit."
+	 *
+	 * @see https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html#//apple_ref/doc/uid/10000057i-CH15-SW21
+	 */
+
+	[[NSThread new] start];
+
+	if ([NSThread isMultiThreaded] != 1)
+		abort();
+
+	if (pthread_create(&wc->capture_thread, NULL, capture_thread, wc))
+		abort();
 
 	return wc;
 }
@@ -125,29 +136,26 @@ static void *window_capture_create(obs_data_t *settings, obs_source_t *source)
 
 static void window_capture_destroy(void *data)
 {
-	struct window_capture *cap = data;
+	struct window_capture *wc = data;
 
-	os_event_signal(cap->stop_event);
-	os_event_signal(cap->capture_event);
+	os_event_signal(wc->stop_event);
+	os_event_signal(wc->capture_event);
 
-	pthread_join(cap->capture_thread, NULL);
+	pthread_join(wc->capture_thread, NULL);
 
-	CGColorSpaceRelease(cap->color_space);
+	os_event_destroy(wc->capture_event);
+	os_event_destroy(wc->stop_event);
 
-	da_free(cap->buffer);
+	destroy_window(&wc->window);
 
-	os_event_destroy(cap->capture_event);
-	os_event_destroy(cap->stop_event);
-
-	destroy_window(&cap->window);
-
-	bfree(cap);
+	bfree(wc);
 }
 
 static void window_capture_defaults(obs_data_t *settings)
 {
-	obs_data_set_default_bool(settings, "show_shadow", false);
 	window_defaults(settings);
+
+	obs_data_set_default_bool(settings, "show_shadow", false);
 }
 
 static obs_properties_t *window_capture_properties(void *unused)
@@ -173,15 +181,14 @@ static inline void window_capture_update_internal(struct window_capture *wc,
 
 	update_window(&wc->window, settings);
 
-	if (wc->window.window_name.length) {
-		blog(LOG_INFO,
-		     "[window-capture: '%s'] update settings:\n"
-		     "\twindow: %s\n"
-		     "\towner:  %s",
-		     obs_source_get_name(wc->source),
-		     [wc->window.window_name UTF8String],
-		     [wc->window.owner_name UTF8String]);
-	}
+	blog(LOG_INFO,
+	     "[window-capture: '%s'] update settings:\n"
+	     "\twindow: %s\n"
+	     "\towner:  %s",
+	     obs_source_get_name(wc->source),
+	     wc->window.window_name.length ? [wc->window.window_name UTF8String]
+					   : "(null)",
+	     [wc->window.owner_name UTF8String]);
 }
 
 static void window_capture_update(void *data, obs_data_t *settings)
@@ -197,23 +204,16 @@ static const char *window_capture_getname(void *unused)
 	return obs_module_text("WindowCapture");
 }
 
-static inline void window_capture_tick_internal(struct window_capture *wc,
-						float seconds)
-{
-	UNUSED_PARAMETER(seconds);
-	os_event_signal(wc->capture_event);
-}
-
 static void window_capture_tick(void *data, float seconds)
 {
+	UNUSED_PARAMETER(seconds);
+
 	struct window_capture *wc = data;
 
 	if (!obs_source_showing(wc->source))
 		return;
 
-	@autoreleasepool {
-		return window_capture_tick_internal(data, seconds);
-	}
+	os_event_signal(wc->capture_event);
 }
 
 struct obs_source_info window_capture_info = {

--- a/plugins/mac-capture/window-utils.h
+++ b/plugins/mac-capture/window-utils.h
@@ -8,17 +8,18 @@ struct cocoa_window {
 	CGWindowID window_id;
 	int owner_pid;
 
-	pthread_mutex_t name_lock;
 	NSString *owner_name;
 	NSString *window_name;
 
-	uint64_t next_search_time;
+	uint64_t last_search_time;
+
+	pthread_mutex_t mutex;
 };
 typedef struct cocoa_window *cocoa_window_t;
 
-NSArray *enumerate_cocoa_windows(void);
+NSArray *enumerate_windows(void);
 
-bool find_window(cocoa_window_t cw, obs_data_t *settings, bool force);
+bool find_window(cocoa_window_t cw, obs_data_t *settings);
 
 void init_window(cocoa_window_t cw, obs_data_t *settings);
 


### PR DESCRIPTION
### Description

Reduce CPU utilization on macOS when using Window Capture.

### Motivation and Context

The current implementation of Window Capture on macOS uses Core Graphics to render a bitmap raster which is then handed off to OBS.

This PR replaces that with an implementation that accesses the window's CGImage bitmap directly and blits it and hands that off as a frame to OBS, instead.

### How Has This Been Tested?

Tested on a 2020 iMac 27" w/ 3.6 GHz 10-Core Intel Core i9, AMD Radeon Pro 5700 XT 16 GB, macOS Catalina 10.15.7.

Tested with OBS 26.1.2 and Riot Games League of Legends, with an empty scene with only the Window Capture input source, OBS was consuming 55%-70% CPU.

Tested with the changes in this PR, OBS only consumed 30-35% CPU.

### Types of changes

- Performance enhancement (non-breaking change which improves efficiency)
- Code cleanup (non-breaking change which makes code smaller or more readable)

#### Summary of changes

* I removed any code that was solely used by the previous `CGBitmap`-based implementation, as it's no longer needed.
* I added a small quality-of-life improvement in `capture_thread()` that names the thread using the source name to make debugging easier when you have multiple instances of the input source in a scene.
* I added an `assert()` in `window_capture_create_internal()` to ensure that [the Cocoa Framework is properly multithreaded](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html#//apple_ref/doc/uid/10000057i-CH15-SW21).
* Renamed the locally scoped variable `cap` to `wc` in `window_capture_destroy()` to be consistent with the rest of the file's name for the `window_capture` structure ptr.
* Reordered the setting of property defaults in `window_capture_defaults()` so that anything defined in `mac-window-capture` would override what was defined by `window_defaults()`.
* Renamed `next_search_time` to `last_search_time` to improve the semantics and, I suppose, indirectly fix a bug that resulted from `next_search_time` never being initialized, resulting in `cw->next_search_time > os_gettime_ns()` always evaluating to false, which effectively made `find_window()` a no-op.
* After fixing the issue with `find_window()`, I had to fix the implementation to properly find the correct window, including applications whose window names were `NULL` (such as the League of Legends client).
* I removed the unnecessary `pthread_{lock, unlock}`ing in `init_window()` as that is called from the main thread, before the `capture_thread()` is started, so the locks are unnecessary there.
* Eliminated some NS-value local variable ptrs to make the code easier to read.
* Changed `destroy_window()` to destroy the mutex after the retained vars are released, not before.  In this particular case the order of operations doesn't really matter, but this is just good hygiene.
* Wrapped the `pthread_{lock, unlock}` and other related calls with `assert()` as basic error checking.  Presumably if any of those syscalls actually fail, your process is likely in a state that is unrecoverable and should be terminated, anyway.
* Changed the implementation of `make_name()` because I thought ARC was `free()`ing the buffer before `obs_property_list_add_int()` could `bstrdup()` it, because I was seeing a hard-to-explain crash.  Turns out, that crash was likely fixed by [2d524580](https://github.com/obsproject/obs-studio/commit/2d524580fe7251336169efc46466277a6af8aeff), so I may be able to revert the change relating to the change of this function's implementation.
* Inlined the contents of `find_window_dict()` into its only caller, as it didn't really aid in comprehension of the code having it in its own function, and wasn't called from anywhere else, anyway.
* Fixed the implementation in `window_changed_internal()` to repopulate the window list combobox while matching the currently selected window and disabling it.

I think this is a fairly complete summary of the changes in this PR.  Please let me know if you feel I missed anything, or would like me to elaborate further on any of these.

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
