### PR TITLE
libobs: Rename obs_audio_monitoring_supported to _available

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -41,7 +41,7 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	percent = new QSpinBox();
 	forceMono = new QCheckBox();
 	balance = new BalanceSlider();
-	if (obs_audio_monitoring_supported())
+	if (obs_audio_monitoring_available())
 		monitoringType = new QComboBox();
 	syncOffset = new QSpinBox();
 	mixer1 = new QCheckBox();
@@ -60,7 +60,7 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 				 this);
 	flagsSignal.Connect(handler, "update_flags", OBSSourceFlagsChanged,
 			    this);
-	if (obs_audio_monitoring_supported())
+	if (obs_audio_monitoring_available())
 		monitoringTypeSignal.Connect(handler, "audio_monitoring",
 					     OBSSourceMonitoringTypeChanged,
 					     this);
@@ -175,7 +175,7 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 		QTStr("Basic.AdvAudio.SyncOffsetSource").arg(sourceName));
 
 	int idx;
-	if (obs_audio_monitoring_supported()) {
+	if (obs_audio_monitoring_available()) {
 		monitoringType->addItem(QTStr("Basic.AdvAudio.Monitoring.None"),
 					(int)OBS_MONITORING_TYPE_NONE);
 		monitoringType->addItem(
@@ -245,7 +245,7 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 			 SLOT(ResetBalance()));
 	QWidget::connect(syncOffset, SIGNAL(valueChanged(int)), this,
 			 SLOT(syncOffsetChanged(int)));
-	if (obs_audio_monitoring_supported())
+	if (obs_audio_monitoring_available())
 		QWidget::connect(monitoringType,
 				 SIGNAL(currentIndexChanged(int)), this,
 				 SLOT(monitoringTypeChanged(int)));
@@ -274,7 +274,7 @@ OBSAdvAudioCtrl::~OBSAdvAudioCtrl()
 	forceMonoContainer->deleteLater();
 	balanceContainer->deleteLater();
 	syncOffset->deleteLater();
-	if (obs_audio_monitoring_supported())
+	if (obs_audio_monitoring_available())
 		monitoringType->deleteLater();
 	mixerContainer->deleteLater();
 }
@@ -291,7 +291,7 @@ void OBSAdvAudioCtrl::ShowAudioControl(QGridLayout *layout)
 	layout->addWidget(forceMonoContainer, lastRow, idx++);
 	layout->addWidget(balanceContainer, lastRow, idx++);
 	layout->addWidget(syncOffset, lastRow, idx++);
-	if (obs_audio_monitoring_supported())
+	if (obs_audio_monitoring_available())
 		layout->addWidget(monitoringType, lastRow, idx++);
 	layout->addWidget(mixerContainer, lastRow, idx++);
 	layout->layout()->setAlignment(mixerContainer, Qt::AlignVCenter);

--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -69,7 +69,7 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 	label = new QLabel(QTStr("Basic.AdvAudio.SyncOffset"));
 	label->setStyleSheet("font-weight: bold;");
 	mainLayout->addWidget(label, 0, idx++);
-	if (obs_audio_monitoring_supported()) {
+	if (obs_audio_monitoring_available()) {
 		label = new QLabel(QTStr("Basic.AdvAudio.Monitoring"));
 		label->setStyleSheet("font-weight: bold;");
 		mainLayout->addWidget(label, 0, idx++);

--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -492,7 +492,7 @@ void OBSBasic::ResetProfileData()
 	CreateHotkeys();
 
 	/* load audio monitoring */
-	if (obs_audio_monitoring_supported()) {
+	if (obs_audio_monitoring_available()) {
 		const char *device_name = config_get_string(
 			basicConfig, "Audio", "MonitoringDeviceName");
 		const char *device_id = config_get_string(basicConfig, "Audio",

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1749,7 +1749,7 @@ void OBSBasic::OBSInit()
 	}
 
 	/* load audio monitoring */
-	if (obs_audio_monitoring_supported()) {
+	if (obs_audio_monitoring_available()) {
 		const char *device_name = config_get_string(
 			basicConfig, "Audio", "MonitoringDeviceName");
 		const char *device_id = config_get_string(basicConfig, "Audio",

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -531,7 +531,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->colorRange,           COMBO_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->disableOSXVSync,      CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->resetOSXVSync,        CHECK_CHANGED,  ADV_CHANGED);
-	if (obs_audio_monitoring_supported())
+	if (obs_audio_monitoring_available())
 		HookWidget(ui->monitoringDevice,     COMBO_CHANGED,  ADV_CHANGED);
 #ifdef _WIN32
 	HookWidget(ui->disableAudioDucking,  CHECK_CHANGED,  ADV_CHANGED);
@@ -581,7 +581,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 #endif
 
 	// Remove the Advanced Audio section if monitoring is not supported, as the monitoring device selection is the only item in the group box.
-	if (!obs_audio_monitoring_supported()) {
+	if (!obs_audio_monitoring_available()) {
 		delete ui->audioAdvGroupBox;
 		ui->audioAdvGroupBox = nullptr;
 	}
@@ -734,7 +734,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 
 	FillSimpleRecordingValues();
 	FillSimpleStreamingValues();
-	if (obs_audio_monitoring_supported())
+	if (obs_audio_monitoring_available())
 		FillAudioMonitoringDevices();
 
 	connect(ui->channelSetup, SIGNAL(currentIndexChanged(int)), this,
@@ -2478,7 +2478,7 @@ void OBSBasicSettings::LoadAdvancedSettings()
 
 	QString monDevName;
 	QString monDevId;
-	if (obs_audio_monitoring_supported()) {
+	if (obs_audio_monitoring_available()) {
 		monDevName = config_get_string(main->Config(), "Audio",
 					       "MonitoringDeviceName");
 		monDevId = config_get_string(main->Config(), "Audio",
@@ -2519,7 +2519,7 @@ void OBSBasicSettings::LoadAdvancedSettings()
 
 	LoadRendererList();
 
-	if (obs_audio_monitoring_supported() &&
+	if (obs_audio_monitoring_available() &&
 	    !SetComboByValue(ui->monitoringDevice, monDevId.toUtf8()))
 		SetInvalidValue(ui->monitoringDevice, monDevName.toUtf8(),
 				monDevId.toUtf8());
@@ -3311,7 +3311,7 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	SaveCombo(ui->colorFormat, "Video", "ColorFormat");
 	SaveCombo(ui->colorSpace, "Video", "ColorSpace");
 	SaveComboData(ui->colorRange, "Video", "ColorRange");
-	if (obs_audio_monitoring_supported()) {
+	if (obs_audio_monitoring_available()) {
 		SaveCombo(ui->monitoringDevice, "Audio",
 			  "MonitoringDeviceName");
 		SaveComboData(ui->monitoringDevice, "Audio",
@@ -3345,7 +3345,7 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	SaveCheckBox(ui->autoRemux, "Video", "AutoRemux");
 	SaveCheckBox(ui->dynBitrate, "Output", "DynamicBitrate");
 
-	if (obs_audio_monitoring_supported()) {
+	if (obs_audio_monitoring_available()) {
 		QString newDevice =
 			ui->monitoringDevice->currentData().toString();
 

--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -425,9 +425,9 @@ Video, Audio, and Graphics
 
 ---------------------
 
-.. function:: bool obs_audio_monitoring_supported(void)
+.. function:: bool obs_audio_monitoring_available(void)
 
-   :return: Whether audio monitoring is supported on the current platform
+   :return: Whether audio monitoring is supported and available on the current platform
 
 ---------------------
 

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -115,7 +115,7 @@ if(WIN32)
 		util/windows/WinHandle.hpp)
 	set(libobs_audio_monitoring_SOURCES
 		audio-monitoring/win32/wasapi-enum-devices.c
-		audio-monitoring/win32/wasapi-monitoring-supported.c
+		audio-monitoring/win32/wasapi-monitoring-available.c
 		audio-monitoring/win32/wasapi-output.c
 		)
 	set(libobs_audio_monitoring_HEADERS
@@ -139,7 +139,7 @@ elseif(APPLE)
 		util/apple/cfstring-utils.h)
 	set(libobs_audio_monitoring_SOURCES
 		audio-monitoring/osx/coreaudio-enum-devices.c
-		audio-monitoring/osx/coreaudio-monitoring-supported.c
+		audio-monitoring/osx/coreaudio-monitoring-available.c
 		audio-monitoring/osx/coreaudio-output.c
 		)
 	set(libobs_audio_monitoring_HEADERS
@@ -224,7 +224,7 @@ elseif(UNIX)
 		set(libobs_audio_monitoring_SOURCES
 			audio-monitoring/pulse/pulseaudio-wrapper.c
 			audio-monitoring/pulse/pulseaudio-enum-devices.c
-			audio-monitoring/pulse/pulseaudio-monitoring-supported.c
+			audio-monitoring/pulse/pulseaudio-monitoring-available.c
 			audio-monitoring/pulse/pulseaudio-output.c)
 	else()
 		set(libobs_audio_monitoring_SOURCES

--- a/libobs/audio-monitoring/null/null-audio-monitoring.c
+++ b/libobs/audio-monitoring/null/null-audio-monitoring.c
@@ -1,6 +1,6 @@
 #include <obs-internal.h>
 
-bool obs_audio_monitoring_supported(void)
+bool obs_audio_monitoring_available(void)
 {
 	return false;
 }

--- a/libobs/audio-monitoring/osx/coreaudio-monitoring-available.c
+++ b/libobs/audio-monitoring/osx/coreaudio-monitoring-available.c
@@ -1,6 +1,6 @@
 #include "../../obs-internal.h"
 
-bool obs_audio_monitoring_supported(void)
+bool obs_audio_monitoring_available(void)
 {
 	return true;
 }

--- a/libobs/audio-monitoring/pulse/pulseaudio-monitoring-available.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-monitoring-available.c
@@ -1,6 +1,6 @@
 #include <obs-internal.h>
 
-bool obs_audio_monitoring_supported(void)
+bool obs_audio_monitoring_available(void)
 {
 	return true;
 }

--- a/libobs/audio-monitoring/win32/wasapi-monitoring-available.c
+++ b/libobs/audio-monitoring/win32/wasapi-monitoring-available.c
@@ -1,6 +1,6 @@
 #include "../../obs-internal.h"
 
-bool obs_audio_monitoring_supported(void)
+bool obs_audio_monitoring_available(void)
 {
 	return true;
 }

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2298,7 +2298,7 @@ bool obs_set_audio_monitoring_device(const char *name, const char *id)
 	if (!name || !id || !*name || !*id)
 		return false;
 
-	if (!obs_audio_monitoring_supported())
+	if (!obs_audio_monitoring_available())
 		return false;
 
 	pthread_mutex_lock(&obs->audio.monitoring_mutex);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -753,7 +753,7 @@ EXPORT bool obs_obj_is_private(void *obj);
 typedef bool (*obs_enum_audio_device_cb)(void *data, const char *name,
 					 const char *id);
 
-EXPORT bool obs_audio_monitoring_supported(void);
+EXPORT bool obs_audio_monitoring_available(void);
 
 EXPORT void obs_enum_audio_monitoring_devices(obs_enum_audio_device_cb cb,
 					      void *data);


### PR DESCRIPTION
### Description
A nitpick to my own PR #5225

### Motivation and Context
With the reasonable possibility of monitoring support becoming a runtime check, the phrase `available` is more fitting.

### How Has This Been Tested?
\> Built OBS
\> Ran OBS

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
