### PR TITLE
Flatpak: Add AJA NTV2 and deduplicate CEF

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -304,8 +304,7 @@
         "cp -R ./libcef_dll_wrapper/libcef_dll_wrapper.a /app/cef/libcef_dll_wrapper"
       ],
       "cleanup": [
-        "*.a",
-        "./*"
+        "*"
       ],
       "sources": [
         {

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -264,6 +264,32 @@
       ]
     },
     {
+      "name": "ntv2",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DAJA_BUILD_OPENSOURCE=ON"
+      ],
+      "cleanup": [
+        "/include"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/aja-video/ntv2.git",
+          "commit": "abf17cc1e7aadd9f3e4972774a3aba2812c51b75"
+        },
+        {
+          "type": "shell",
+          "commands": [
+            "sed -i 's/Clang|GNU/GNU/g' cmake/CommonFlags.cmake",
+            "sed -i 's/Linux|Darwin/Linux/g' cmake/CommonFlags.cmake"
+          ]
+        }
+      ]
+    },
+    {
       "name": "cef",
       "buildsystem": "cmake-ninja",
       "no-make-install": true,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add AJA NTV2 library to the Flatpak to enable AJA plugins compilations.

The commit `abf17cc1e7aadd9f3e4972774a3aba2812c51b75` was chosen to get all CMake changes that were added.

Those lines :
``` json
"type": "shell",
  "commands": [
    "sed -i 's/Clang|GNU/GNU/g' cmake/CommonFlags.cmake",
    "sed -i 's/Linux|Darwin/Linux/g' cmake/CommonFlags.cmake"
  ]
```
Were added because some common flags are not correctly added.
- https://github.com/aja-video/ntv2/pull/4

Cleanup CEF installation from the bundle since it's no longer needed after OBS copied the needed files elsewhere.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
- Feature parity
- Reduce bundle size

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Built it with flatpak-builder and check if AJA plugins had an loading attempt.
- Check if browser sources were working.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- CI changes

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
