### PR TITLE
Flatpak: Update FFmpeg to 4.4.1 and add RIST, libaom and SVT-AV1 support

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -122,6 +122,51 @@
       ]
     },
     {
+      "name": "mbedtls",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+        "-DUSE_SHARED_MBEDTLS_LIBRARY=ON",
+        "-DUSE_STATIC_MBEDTLS_LIBRARY=OFF",
+        "-DENABLE_TESTING=OFF",
+        "-DENABLE_PROGRAMS=OFF"
+      ],
+      "cleanup": [
+        "/include"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/ARMmbed/mbedtls.git",
+          "commit": "f71e2878084126737cc39083e1e15afc459bd93d",
+          "tag": "v2.27.0"
+        }
+      ]
+    },
+    {
+      "name": "librist",
+      "buildsystem":"meson",
+      "builddir": true,
+      "config-opts": [
+        "-Duse_mbedtls=true",
+        "-Dtest=false",
+        "-Dbuilt_tools=false",
+        "-Dbuiltin_cjson=true"
+      ],
+      "cleanup": [
+        "/include"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://code.videolan.org/rist/librist.git",
+          "commit": "0b1aaf995c4cad83d562ec7887180cc6ee132c84"
+        }
+      ]
+    },
+    {
       "name": "ffmpeg",
       "config-opts": [
         "--enable-gpl",
@@ -136,7 +181,8 @@
         "--enable-libvorbis",
         "--enable-libx264",
         "--enable-nvenc",
-        "--enable-libsrt"
+        "--enable-libsrt",
+        "--enable-librist"
       ],
       "cleanup": [
         "/share/ffmpeg",
@@ -161,6 +207,7 @@
           "commands": [
             "git cherry-pick -n d1b47f3bfcc625ca1cae210fc198dcbd54381a88 # avcodec/vaapi_encode: Fix segfault upon closing uninitialized encoder",
             "patch -Np1 -i obs-deps/CI/patches/FFmpeg-4.4.1-OBS.patch",
+            "patch -Np1 -i obs-deps/CI/patches/FFmpeg-4.4.1-librist.patch",
             "patch -Np1 -i obs-deps/CI/patches/FFmpeg-9010.patch"
           ]
         }
@@ -207,30 +254,6 @@
           "type": "archive",
           "url": "https://prdownloads.sourceforge.net/swig/swig-4.0.2.tar.gz",
           "sha256": "d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
-        }
-      ]
-    },
-    {
-      "name": "mbedtls",
-      "buildsystem": "cmake-ninja",
-      "builddir": true,
-      "config-opts": [
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
-        "-DUSE_SHARED_MBEDTLS_LIBRARY=ON",
-        "-DUSE_STATIC_MBEDTLS_LIBRARY=OFF",
-        "-DENABLE_TESTING=OFF",
-        "-DENABLE_PROGRAMS=OFF"
-      ],
-      "cleanup": [
-        "/include"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://github.com/ARMmbed/mbedtls.git",
-          "commit": "f71e2878084126737cc39083e1e15afc459bd93d",
-          "tag": "v2.27.0"
         }
       ]
     },

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -167,6 +167,31 @@
       ]
     },
     {
+      "name": "aom",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_SHARED_LIBS=ON",
+        "-DENABLE_DOCS=OFF",
+        "-DENABLE_EXAMPLES=OFF",
+        "-DENABLE_TESTDATA=OFF",
+        "-DENABLE_TESTS=OFF",
+        "-DENABLE_TOOLS=OFF "
+      ],
+      "cleanup": [
+        "/include"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://aomedia.googlesource.com/aom.git",
+          "tag": "v3.2.0",
+          "commit": "287164de79516c25c8c84fd544f67752c170082a"
+        }
+      ]
+    },
+    {
       "name": "ffmpeg",
       "config-opts": [
         "--enable-gpl",
@@ -182,7 +207,8 @@
         "--enable-libx264",
         "--enable-nvenc",
         "--enable-libsrt",
-        "--enable-librist"
+        "--enable-librist",
+        "--enable-libaom"
       ],
       "cleanup": [
         "/share/ffmpeg",
@@ -199,8 +225,8 @@
           "type": "git",
           "dest": "obs-deps",
           "url": "https://github.com/obsproject/obs-deps.git",
-          "tag": "2021-12-22",
-          "commit": "42f0384e2f39a53b6386924cf4c1a643f766e164"
+          "tag": "2022-01-01",
+          "commit": "15072cd42722d87c6b3ed1636b22e98c08575f20"
         },
         {
           "type": "shell",
@@ -208,6 +234,7 @@
             "git cherry-pick -n d1b47f3bfcc625ca1cae210fc198dcbd54381a88 # avcodec/vaapi_encode: Fix segfault upon closing uninitialized encoder",
             "patch -Np1 -i obs-deps/CI/patches/FFmpeg-4.4.1-OBS.patch",
             "patch -Np1 -i obs-deps/CI/patches/FFmpeg-4.4.1-librist.patch",
+            "patch -Np1 -i obs-deps/CI/patches/FFmpeg-4.4.1-libaomenc.patch",
             "patch -Np1 -i obs-deps/CI/patches/FFmpeg-9010.patch"
           ]
         }

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -192,6 +192,30 @@
       ]
     },
     {
+      "name": "svt-av1",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_SHARED_LIBS=ON",
+        "-DBUILD_APPS=OFF",
+        "-DBUILD_DEC=ON",
+        "-DBUILD_ENC=ON",
+        "-DBUILD_TESTING=OFF"
+      ],
+      "cleanup": [
+        "/include"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://gitlab.com/AOMediaCodec/SVT-AV1.git",
+          "tag": "v0.8.6",
+          "commit": "a5ec26c0f0bd6e872a0b2bb340b4a777f4847020"
+        }
+      ]
+    },
+    {
       "name": "ffmpeg",
       "config-opts": [
         "--enable-gpl",
@@ -208,7 +232,8 @@
         "--enable-nvenc",
         "--enable-libsrt",
         "--enable-librist",
-        "--enable-libaom"
+        "--enable-libaom",
+        "--enable-libsvtav1"
       ],
       "cleanup": [
         "/share/ffmpeg",

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -95,8 +95,8 @@
         {
           "type": "git",
           "url": "https://git.videolan.org/git/ffmpeg/nv-codec-headers.git",
-          "commit": "7a81595786463d1c7efcb03aa85def69fc2cad41",
-          "tag": "n11.0.10.0"
+          "tag": "n11.1.5.0",
+          "commit": "b641a195edbe3ac9788e681e22c2e2fad8aacddb"
         }
       ]
     },
@@ -144,9 +144,25 @@
       ],
       "sources": [
         {
-          "type": "archive",
-          "url": "https://www.ffmpeg.org/releases/ffmpeg-4.3.2.tar.xz",
-          "sha256": "46e4e64f1dd0233cbc0934b9f1c0da676008cad34725113fb7f802cfa84ccddb"
+          "type": "git",
+          "url": "https://git.ffmpeg.org/ffmpeg.git",
+          "commit": "cc33e73618a981de7fd96385ecb34719de031f16",
+          "disable-shallow-clone": true
+        },
+        {
+          "type": "git",
+          "dest": "obs-deps",
+          "url": "https://github.com/obsproject/obs-deps.git",
+          "tag": "2021-12-22",
+          "commit": "42f0384e2f39a53b6386924cf4c1a643f766e164"
+        },
+        {
+          "type": "shell",
+          "commands": [
+            "git cherry-pick -n d1b47f3bfcc625ca1cae210fc198dcbd54381a88 # avcodec/vaapi_encode: Fix segfault upon closing uninitialized encoder",
+            "patch -Np1 -i obs-deps/CI/patches/FFmpeg-4.4.1-OBS.patch",
+            "patch -Np1 -i obs-deps/CI/patches/FFmpeg-9010.patch"
+          ]
         }
       ]
     },


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Update FFmpeg to 4.4.1 with a cherry-pick of https://github.com/FFmpeg/FFmpeg/commit/d1b47f3bfcc625ca1cae210fc198dcbd54381a88 to fix issue with VAAPI.

It also apply FFmpeg patches and cherry-picks from [obs-deps](https://github.com/obsproject/obs-deps/tree/master/CI/patches).

It also add RIST support with the same commit hash as macOS and Windows for parity.

Mbed TLS module is also moved before librist to allow the latter to be built with Mbed TLS.

Add libaom and SVT-AV1 ~~(only on x86_64)~~ support.

~~Rather than creating second FFmpeg module for x86_64 to enable SVT-AV1, I use a sed command to enabled it by default on x86_64.~~

Note: I also update nv-codec-headers (surely will be squashed in FFmped update commit).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Feature parity

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Set OBS Studio to stream to this URL: `rist://127.0.0.1:10001?cname=SENDER&bandwidth=5000`
And use `ffplay` (with librist support enabled) with this command:
```
ffplay -f mpegts -i 'rist://@127.0.0.1:10001?cname=RECEIVER&bandwidth=5000'
```

I also check flatpak-builder verbose log to check if patches are applied correctly.

I check advanced record option to check if AOM and SVT AV1 encoder are present.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- CI changes

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
