### PR TITLE
Fix missing last audio packet

### DIFF
--- a/docs/sphinx/reference-encoders.rst
+++ b/docs/sphinx/reference-encoders.rst
@@ -400,6 +400,12 @@ General Encoder Functions
 
 ---------------------
 
+.. function:: uint32_t obs_encoder_get_frame_size(const obs_encoder_t *encoder)
+
+   :return: The frame size of the audio packet
+
+---------------------
+
 .. function:: void obs_encoder_set_preferred_video_format(obs_encoder_t *encoder, enum video_format format)
               enum video_format obs_encoder_get_preferred_video_format(const obs_encoder_t *encoder)
 

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -760,6 +760,21 @@ uint32_t obs_encoder_get_sample_rate(const obs_encoder_t *encoder)
 		       : audio_output_get_sample_rate(encoder->media);
 }
 
+uint32_t obs_encoder_get_frame_size(const obs_encoder_t *encoder)
+{
+	if (!obs_encoder_valid(encoder, "obs_encoder_get_frame_size"))
+		return 0;
+	if (encoder->info.type != OBS_ENCODER_AUDIO) {
+		blog(LOG_WARNING,
+		     "obs_encoder_get_frame_size: "
+		     "encoder '%s' is not an audio encoder",
+		     obs_encoder_get_name(encoder));
+		return 0;
+	}
+
+	return encoder->framesize != 0 ? encoder->framesize : 0;
+}
+
 void obs_encoder_set_video(obs_encoder_t *encoder, video_t *video)
 {
 	const struct video_output_info *voi;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2209,6 +2209,9 @@ EXPORT uint32_t obs_encoder_get_height(const obs_encoder_t *encoder);
 /** For audio encoders, returns the sample rate of the audio */
 EXPORT uint32_t obs_encoder_get_sample_rate(const obs_encoder_t *encoder);
 
+/** For audio encoders, returns the frame size of the audio packet */
+EXPORT uint32_t obs_encoder_get_frame_size(const obs_encoder_t *encoder);
+
 /**
  * Sets the preferred video format for a video encoder.  If the encoder can use
  * the format specified, it will force a conversion to that format if the

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -100,6 +100,7 @@ struct audio_params {
 	char *name;
 	int abitrate;
 	int sample_rate;
+	int frame_size;
 	int channels;
 };
 
@@ -219,6 +220,8 @@ static bool get_audio_params(struct audio_params *audio, int *argc,
 	if (!get_opt_int(argc, argv, &audio->abitrate, "audio bitrate"))
 		return false;
 	if (!get_opt_int(argc, argv, &audio->sample_rate, "audio sample rate"))
+		return false;
+	if (!get_opt_int(argc, argv, &audio->frame_size, "audio frame size"))
 		return false;
 	if (!get_opt_int(argc, argv, &audio->channels, "audio channels"))
 		return false;
@@ -446,6 +449,7 @@ static void create_audio_stream(struct ffmpeg_mux *ffm, int idx)
 	context->bit_rate = (int64_t)ffm->audio[idx].abitrate * 1000;
 	context->channels = ffm->audio[idx].channels;
 	context->sample_rate = ffm->audio[idx].sample_rate;
+	context->frame_size = ffm->audio[idx].frame_size;
 	context->sample_fmt = AV_SAMPLE_FMT_S16;
 	context->time_base = stream->time_base;
 	context->extradata = extradata;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -169,8 +169,9 @@ static void add_audio_encoder_params(struct dstr *cmd, obs_encoder_t *aencoder)
 	dstr_copy(&name, obs_encoder_get_name(aencoder));
 	dstr_replace(&name, "\"", "\"\"");
 
-	dstr_catf(cmd, "\"%s\" %d %d %d ", name.array, bitrate,
+	dstr_catf(cmd, "\"%s\" %d %d %d %d ", name.array, bitrate,
 		  (int)obs_encoder_get_sample_rate(aencoder),
+		  (int)obs_encoder_get_frame_size(aencoder),
 		  (int)audio_output_get_channels(audio));
 
 	dstr_free(&name);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Set frame size (number of samples for each encoded packet) to audio stream parameter for the ffmpeg mux.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Sometimes the last audio packet is missing in MP4 file.
This issue is found when debugging the audio glitch in #5371.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Environment: Fedora 34, ffmpeg 4.4.1
1. Add debug information of PTS and DTS of packets written by ffmpeg-mux. See 232a94a06.
2. Set output mode `Advanced`, encoder `x264`, recording format `mp4`, audio bitrate `160` kbps.
3. Start and stop recording
4. Run `ffprobe -hide_banner -loglevel error -show_entries packet=codec_type,pts,dts -of compact` and compare the output made by step 1.
5. Continue steps 3 and 4 several times.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
