### PR TITLE
Automatic file splitting duplicate audio

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -941,6 +941,11 @@ Basic.Settings.Output.Adv.FFmpeg.AEncoderSettings="Audio Encoder Settings (if an
 Basic.Settings.Output.Adv.FFmpeg.MuxerSettings="Muxer Settings (if any)"
 Basic.Settings.Output.Adv.FFmpeg.GOPSize="Keyframe interval (frames)"
 Basic.Settings.Output.Adv.FFmpeg.IgnoreCodecCompat="Show all codecs (even if potentially incompatible)"
+Basic.Settings.Output.EnableSplitFile="Automatic File Splitting"
+Basic.Settings.Output.SplitFile.TypeTime="Split by Time"
+Basic.Settings.Output.SplitFile.TypeSize="Split by Size"
+Basic.Settings.Output.SplitFile.Time="Split Time"
+Basic.Settings.Output.SplitFile.Size="Split Size"
 
 # Screenshot
 Screenshot="Screenshot Output"

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -946,6 +946,7 @@ Basic.Settings.Output.SplitFile.TypeTime="Split by Time"
 Basic.Settings.Output.SplitFile.TypeSize="Split by Size"
 Basic.Settings.Output.SplitFile.Time="Split Time"
 Basic.Settings.Output.SplitFile.Size="Split Size"
+Basic.Settings.Output.SplitFile.ResetTimestamps="Reset timestamps at the beginning of each split file"
 
 # Screenshot
 Screenshot="Screenshot Output"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -2408,6 +2408,85 @@
                             <item row="6" column="1">
                              <widget class="QLineEdit" name="advOutMuxCustom"/>
                             </item>
+                            <item row="7" column="0">
+                             <widget class="QCheckBox" name="advOutSplitFile">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="layoutDirection">
+                               <enum>Qt::RightToLeft</enum>
+                              </property>
+                              <property name="text">
+                               <string>Basic.Settings.Output.EnableSplitFile</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="7" column="1">
+                             <widget class="QComboBox" name="advOutSplitFileType">
+                              <property name="enabled">
+                               <bool>false</bool>
+                              </property>
+                              <item>
+                               <property name="text">
+                                <string>Basic.Settings.Output.SplitFile.TypeTime</string>
+                               </property>
+                              </item>
+                              <item>
+                               <property name="text">
+                                <string>Basic.Settings.Output.SplitFile.TypeSize</string>
+                               </property>
+                              </item>
+                             </widget>
+                            </item>
+                            <item row="8" column="0">
+                             <widget class="QLabel" name="advOutSplitFileTimeLabel">
+                              <property name="text">
+                               <string>Basic.Settings.Output.SplitFile.Time</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="8" column="1">
+                             <widget class="QSpinBox" name="advOutSplitFileTime">
+                              <property name="suffix">
+                               <string> s</string>
+                              </property>
+                              <property name="minimum">
+                               <number>5</number>
+                              </property>
+                              <property name="maximum">
+                               <number>21600</number>
+                              </property>
+                              <property name="value">
+                               <number>900</number>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="9" column="0">
+                             <widget class="QLabel" name="advOutSplitFileSizeLabel">
+                              <property name="text">
+                               <string>Basic.Settings.Output.SplitFile.Size</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="9" column="1">
+                             <widget class="QSpinBox" name="advOutSplitFileSize">
+                              <property name="suffix">
+                               <string> MB</string>
+                              </property>
+                              <property name="minimum">
+                               <number>20</number>
+                              </property>
+                              <property name="maximum">
+                               <number>8192</number>
+                              </property>
+                              <property name="value">
+                               <number>2048</number>
+                              </property>
+                             </widget>
+                            </item>
                             <item row="3" column="1">
                              <widget class="QStackedWidget" name="advRecTrackWidget">
                               <property name="sizePolicy">
@@ -5675,6 +5754,10 @@
   <tabstop>advOutRecUseRescale</tabstop>
   <tabstop>advOutRecRescale</tabstop>
   <tabstop>advOutMuxCustom</tabstop>
+  <tabstop>advOutSplitFile</tabstop>
+  <tabstop>advOutSplitFileType</tabstop>
+  <tabstop>advOutSplitFileTime</tabstop>
+  <tabstop>advOutSplitFileSize</tabstop>
   <tabstop>advOutFFType</tabstop>
   <tabstop>advOutFFRecPath</tabstop>
   <tabstop>advOutFFPathBrowse</tabstop>
@@ -6195,6 +6278,22 @@
     <hint type="destinationlabel">
      <x>454</x>
      <y>87</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>advOutSplitFile</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>advOutSplitFileType</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>327</x>
+     <y>355</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>701</x>
+     <y>355</y>
     </hint>
    </hints>
   </connection>

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -2487,6 +2487,16 @@
                               </property>
                              </widget>
                             </item>
+                            <item row="10" column="1">
+                             <widget class="QCheckBox" name="advOutSplitFileRstTS">
+                              <property name="text">
+                               <string>Basic.Settings.Output.SplitFile.ResetTimestamps</string>
+                              </property>
+                              <property name="checked">
+                               <bool>true</bool>
+                              </property>
+                             </widget>
+                            </item>
                             <item row="3" column="1">
                              <widget class="QStackedWidget" name="advRecTrackWidget">
                               <property name="sizePolicy">
@@ -5758,6 +5768,7 @@
   <tabstop>advOutSplitFileType</tabstop>
   <tabstop>advOutSplitFileTime</tabstop>
   <tabstop>advOutSplitFileSize</tabstop>
+  <tabstop>advOutSplitFileRstTS</tabstop>
   <tabstop>advOutFFType</tabstop>
   <tabstop>advOutFFRecPath</tabstop>
   <tabstop>advOutFFPathBrowse</tabstop>

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -110,6 +110,20 @@ static void OBSRecordStopping(void *data, calldata_t *params)
 	UNUSED_PARAMETER(params);
 }
 
+static void OBSRecordFileChanged(void *data, calldata_t *params)
+{
+	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
+	const char *next_file = calldata_string(params, "next_file");
+
+	QString arg_last_file =
+		QString::fromUtf8(output->lastRecordingPath.c_str());
+
+	QMetaObject::invokeMethod(output->main, "RecordingFileChanged",
+				  Q_ARG(QString, arg_last_file));
+
+	output->lastRecordingPath = next_file;
+}
+
 static void OBSStartReplayBuffer(void *data, calldata_t *params)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
@@ -1311,6 +1325,8 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 			      OBSStopRecording, this);
 	recordStopping.Connect(obs_output_get_signal_handler(fileOutput),
 			       "stopping", OBSRecordStopping, this);
+	recordFileChanged.Connect(obs_output_get_signal_handler(fileOutput),
+				  "file_changed", OBSRecordFileChanged, this);
 }
 
 void AdvancedOutput::UpdateStreamSettings()

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1902,6 +1902,8 @@ bool AdvancedOutput::StartRecording()
 			obs_data_set_string(settings, "format", filenameFormat);
 			obs_data_set_string(settings, "extension", recFormat);
 			obs_data_set_bool(settings, "allow_spaces", !noSpace);
+			obs_data_set_bool(settings, "allow_overwrite",
+					  overwriteIfExists);
 			obs_data_set_int(settings, "max_time_sec",
 					 splitFileTime);
 			obs_data_set_int(settings, "max_size_mb",

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1838,6 +1838,7 @@ bool AdvancedOutput::StartRecording()
 	const char *splitFileType;
 	int splitFileTime;
 	int splitFileSize;
+	bool splitFileResetTimestamps;
 
 	if (!useStreamEncoder) {
 		if (!ffmpegOutput) {
@@ -1894,6 +1895,9 @@ bool AdvancedOutput::StartRecording()
 							 "AdvOut",
 							 "RecSplitFileSize")
 					: 0;
+			splitFileResetTimestamps =
+				config_get_bool(main->Config(), "AdvOut",
+						"RecSplitFileResetTimestamps");
 			obs_data_set_string(settings, "directory", path);
 			obs_data_set_string(settings, "format", filenameFormat);
 			obs_data_set_string(settings, "extension", recFormat);
@@ -1902,6 +1906,8 @@ bool AdvancedOutput::StartRecording()
 					 splitFileTime);
 			obs_data_set_int(settings, "max_size_mb",
 					 splitFileSize);
+			obs_data_set_bool(settings, "reset_timestamps",
+					  splitFileResetTimestamps);
 		}
 
 		obs_output_update(fileOutput, settings);

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1834,6 +1834,10 @@ bool AdvancedOutput::StartRecording()
 	const char *filenameFormat;
 	bool noSpace = false;
 	bool overwriteIfExists = false;
+	bool splitFile;
+	const char *splitFileType;
+	int splitFileTime;
+	int splitFileSize;
 
 	if (!useStreamEncoder) {
 		if (!ffmpegOutput) {
@@ -1863,6 +1867,8 @@ bool AdvancedOutput::StartRecording()
 					  ffmpegRecording
 						  ? "FFFileNameWithoutSpace"
 						  : "RecFileNameWithoutSpace");
+		splitFile = config_get_bool(main->Config(), "AdvOut",
+					    "RecSplitFile");
 
 		string strPath = GetRecordingFilename(path, recFormat, noSpace,
 						      overwriteIfExists,
@@ -1872,6 +1878,31 @@ bool AdvancedOutput::StartRecording()
 		OBSDataAutoRelease settings = obs_data_create();
 		obs_data_set_string(settings, ffmpegRecording ? "url" : "path",
 				    strPath.c_str());
+
+		if (splitFile) {
+			splitFileType = config_get_string(
+				main->Config(), "AdvOut", "RecSplitFileType");
+			splitFileTime =
+				(astrcmpi(splitFileType, "Time") == 0)
+					? config_get_int(main->Config(),
+							 "AdvOut",
+							 "RecSplitFileTime")
+					: 0;
+			splitFileSize =
+				(astrcmpi(splitFileType, "Size") == 0)
+					? config_get_int(main->Config(),
+							 "AdvOut",
+							 "RecSplitFileSize")
+					: 0;
+			obs_data_set_string(settings, "directory", path);
+			obs_data_set_string(settings, "format", filenameFormat);
+			obs_data_set_string(settings, "extension", recFormat);
+			obs_data_set_bool(settings, "allow_spaces", !noSpace);
+			obs_data_set_int(settings, "max_time_sec",
+					 splitFileTime);
+			obs_data_set_int(settings, "max_size_mb",
+					 splitFileSize);
+		}
 
 		obs_output_update(fileOutput, settings);
 	}

--- a/UI/window-basic-main-outputs.hpp
+++ b/UI/window-basic-main-outputs.hpp
@@ -32,6 +32,7 @@ struct BasicOutputHandler {
 	OBSSignal streamDelayStarting;
 	OBSSignal streamStopping;
 	OBSSignal recordStopping;
+	OBSSignal recordFileChanged;
 	OBSSignal replayBufferStopping;
 	OBSSignal replayBufferSaved;
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1417,6 +1417,8 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_uint(basicConfig, "AdvOut", "RecSplitFileTime", 900);
 	config_set_default_uint(basicConfig, "AdvOut", "RecSplitFileSize",
 				2048);
+	config_set_default_bool(basicConfig, "AdvOut",
+				"RecSplitFileResetTimestamps", true);
 
 	config_set_default_bool(basicConfig, "AdvOut", "RecRB", false);
 	config_set_default_uint(basicConfig, "AdvOut", "RecRBTime", 20);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1414,6 +1414,10 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_uint(basicConfig, "AdvOut", "Track5Bitrate", 160);
 	config_set_default_uint(basicConfig, "AdvOut", "Track6Bitrate", 160);
 
+	config_set_default_uint(basicConfig, "AdvOut", "RecSplitFileTime", 900);
+	config_set_default_uint(basicConfig, "AdvOut", "RecSplitFileSize",
+				2048);
+
 	config_set_default_bool(basicConfig, "AdvOut", "RecRB", false);
 	config_set_default_uint(basicConfig, "AdvOut", "RecRBTime", 20);
 	config_set_default_int(basicConfig, "AdvOut", "RecRBSize", 512);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6953,7 +6953,7 @@ void OBSBasic::StreamingStop(int code, QString last_error)
 		SetBroadcastFlowEnabled(auth && auth->broadcastFlow());
 }
 
-void OBSBasic::AutoRemux(QString input)
+void OBSBasic::AutoRemux(QString input, bool no_show)
 {
 	bool autoRemux = config_get_bool(Config(), "Video", "AutoRemux");
 
@@ -6985,7 +6985,8 @@ void OBSBasic::AutoRemux(QString input)
 	output += "mp4";
 
 	OBSRemux *remux = new OBSRemux(QT_TO_UTF8(path), this, true);
-	remux->show();
+	if (!no_show)
+		remux->show();
 	remux->AutoRemux(input, output);
 }
 
@@ -7136,6 +7137,14 @@ void OBSBasic::RecordingStop(int code, QString last_error)
 
 	OnDeactivate();
 	UpdatePause(false);
+}
+
+void OBSBasic::RecordingFileChanged(QString lastRecordingPath)
+{
+	QString str = QTStr("Basic.StatusBar.RecordingSavedTo");
+	ShowStatusBarMessage(str.arg(lastRecordingPath));
+
+	AutoRemux(lastRecordingPath, true);
 }
 
 void OBSBasic::ShowReplayBufferPauseWarning()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -630,6 +630,7 @@ public slots:
 	void RecordingStart();
 	void RecordStopping();
 	void RecordingStop(int code, QString last_error);
+	void RecordingFileChanged(QString lastRecordingPath);
 
 	void ShowReplayBufferPauseWarning();
 	void StartReplayBuffer();
@@ -797,7 +798,7 @@ private:
 
 	static void HotkeyTriggered(void *data, obs_hotkey_id id, bool pressed);
 
-	void AutoRemux(QString input);
+	void AutoRemux(QString input, bool no_show = false);
 
 	void UpdatePause(bool activate = true);
 	void UpdateReplayBuffer(bool activate = true);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -461,6 +461,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->advOutSplitFileType,  COMBO_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->advOutSplitFileTime,  SCROLL_CHANGED, OUTPUTS_CHANGED);
 	HookWidget(ui->advOutSplitFileSize,  SCROLL_CHANGED, OUTPUTS_CHANGED);
+	HookWidget(ui->advOutSplitFileRstTS, CHECK_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->advOutRecTrack1,      CHECK_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->advOutRecTrack2,      CHECK_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->advOutRecTrack3,      CHECK_CHANGED,  OUTPUTS_CHANGED);
@@ -1918,6 +1919,8 @@ void OBSBasicSettings::LoadAdvOutputRecordingSettings()
 		config_get_int(main->Config(), "AdvOut", "RecSplitFileTime");
 	int splitFileSize =
 		config_get_int(main->Config(), "AdvOut", "RecSplitFileSize");
+	bool splitFileResetTimestamps = config_get_bool(
+		main->Config(), "AdvOut", "RecSplitFileResetTimestamps");
 
 	int typeIndex = (astrcmpi(type, "FFmpeg") == 0) ? 1 : 0;
 	ui->advOutRecType->setCurrentIndex(typeIndex);
@@ -1942,6 +1945,7 @@ void OBSBasicSettings::LoadAdvOutputRecordingSettings()
 	ui->advOutSplitFileType->setCurrentIndex(idx);
 	ui->advOutSplitFileTime->setValue(splitFileTime);
 	ui->advOutSplitFileSize->setValue(splitFileSize);
+	ui->advOutSplitFileRstTS->setChecked(splitFileResetTimestamps);
 
 	switch (flvTrack) {
 	case 1:
@@ -3550,6 +3554,8 @@ void OBSBasicSettings::SaveOutputSettings()
 		SplitFileTypeFromIdx(ui->advOutSplitFileType->currentIndex()));
 	SaveSpinBox(ui->advOutSplitFileTime, "AdvOut", "RecSplitFileTime");
 	SaveSpinBox(ui->advOutSplitFileSize, "AdvOut", "RecSplitFileSize");
+	SaveCheckBox(ui->advOutSplitFileRstTS, "AdvOut",
+		     "RecSplitFileResetTimestamps");
 
 	config_set_int(
 		main->Config(), "AdvOut", "RecTracks",
@@ -4462,6 +4468,7 @@ void OBSBasicSettings::AdvOutSplitFileChanged()
 	ui->advOutSplitFileTime->setVisible(splitFileType == 0);
 	ui->advOutSplitFileSizeLabel->setVisible(splitFileType == 1);
 	ui->advOutSplitFileSize->setVisible(splitFileType == 1);
+	ui->advOutSplitFileRstTS->setVisible(splitFile);
 }
 
 void OBSBasicSettings::AdvOutRecCheckWarnings()

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -457,6 +457,10 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->advOutRecUseRescale,  CHECK_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->advOutRecRescale,     CBEDIT_CHANGED, OUTPUTS_CHANGED);
 	HookWidget(ui->advOutMuxCustom,      EDIT_CHANGED,   OUTPUTS_CHANGED);
+	HookWidget(ui->advOutSplitFile,      CHECK_CHANGED,  OUTPUTS_CHANGED);
+	HookWidget(ui->advOutSplitFileType,  COMBO_CHANGED,  OUTPUTS_CHANGED);
+	HookWidget(ui->advOutSplitFileTime,  SCROLL_CHANGED, OUTPUTS_CHANGED);
+	HookWidget(ui->advOutSplitFileSize,  SCROLL_CHANGED, OUTPUTS_CHANGED);
 	HookWidget(ui->advOutRecTrack1,      CHECK_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->advOutRecTrack2,      CHECK_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->advOutRecTrack3,      CHECK_CHANGED,  OUTPUTS_CHANGED);
@@ -769,6 +773,10 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 		this, SLOT(SimpleReplayBufferChanged()));
 	connect(ui->simpleRBSecMax, SIGNAL(valueChanged(int)), this,
 		SLOT(SimpleReplayBufferChanged()));
+	connect(ui->advOutSplitFile, SIGNAL(stateChanged(int)), this,
+		SLOT(AdvOutSplitFileChanged()));
+	connect(ui->advOutSplitFileType, SIGNAL(currentIndexChanged(int)), this,
+		SLOT(AdvOutSplitFileChanged()));
 	connect(ui->advReplayBuf, SIGNAL(toggled(bool)), this,
 		SLOT(AdvReplayBufferChanged()));
 	connect(ui->advOutRecTrack1, SIGNAL(toggled(bool)), this,
@@ -895,6 +903,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	ui->buttonBox->button(QDialogButtonBox::Cancel)->setIcon(QIcon());
 
 	SimpleRecordingQualityChanged();
+	AdvOutSplitFileChanged();
 
 	UpdateAutomaticReplayBufferCheckboxes();
 
@@ -1901,6 +1910,14 @@ void OBSBasicSettings::LoadAdvOutputRecordingSettings()
 		config_get_string(main->Config(), "AdvOut", "RecMuxerCustom");
 	int tracks = config_get_int(main->Config(), "AdvOut", "RecTracks");
 	int flvTrack = config_get_int(main->Config(), "AdvOut", "FLVTrack");
+	bool splitFile =
+		config_get_bool(main->Config(), "AdvOut", "RecSplitFile");
+	const char *splitFileType =
+		config_get_string(main->Config(), "AdvOut", "RecSplitFileType");
+	int splitFileTime =
+		config_get_int(main->Config(), "AdvOut", "RecSplitFileTime");
+	int splitFileSize =
+		config_get_int(main->Config(), "AdvOut", "RecSplitFileSize");
 
 	int typeIndex = (astrcmpi(type, "FFmpeg") == 0) ? 1 : 0;
 	ui->advOutRecType->setCurrentIndex(typeIndex);
@@ -1919,6 +1936,12 @@ void OBSBasicSettings::LoadAdvOutputRecordingSettings()
 	ui->advOutRecTrack4->setChecked(tracks & (1 << 3));
 	ui->advOutRecTrack5->setChecked(tracks & (1 << 4));
 	ui->advOutRecTrack6->setChecked(tracks & (1 << 5));
+
+	idx = (astrcmpi(splitFileType, "Size") == 0) ? 1 : 0;
+	ui->advOutSplitFile->setChecked(splitFile);
+	ui->advOutSplitFileType->setCurrentIndex(idx);
+	ui->advOutSplitFileTime->setValue(splitFileTime);
+	ui->advOutSplitFileSize->setValue(splitFileSize);
 
 	switch (flvTrack) {
 	case 1:
@@ -3378,6 +3401,14 @@ static inline const char *RecTypeFromIdx(int idx)
 		return "Standard";
 }
 
+static inline const char *SplitFileTypeFromIdx(int idx)
+{
+	if (idx == 1)
+		return "Size";
+	else
+		return "Time";
+}
+
 static void WriteJsonData(OBSPropertiesView *view, const char *path)
 {
 	char full_path[512];
@@ -3513,6 +3544,12 @@ void OBSBasicSettings::SaveOutputSettings()
 	SaveCheckBox(ui->advOutRecUseRescale, "AdvOut", "RecRescale");
 	SaveCombo(ui->advOutRecRescale, "AdvOut", "RecRescaleRes");
 	SaveEdit(ui->advOutMuxCustom, "AdvOut", "RecMuxerCustom");
+	SaveCheckBox(ui->advOutSplitFile, "AdvOut", "RecSplitFile");
+	config_set_string(
+		main->Config(), "AdvOut", "RecSplitFileType",
+		SplitFileTypeFromIdx(ui->advOutSplitFileType->currentIndex()));
+	SaveSpinBox(ui->advOutSplitFileTime, "AdvOut", "RecSplitFileTime");
+	SaveSpinBox(ui->advOutSplitFileSize, "AdvOut", "RecSplitFileSize");
 
 	config_set_int(
 		main->Config(), "AdvOut", "RecTracks",
@@ -4412,6 +4449,19 @@ void OBSBasicSettings::AdvancedChanged()
 		sender()->setProperty("changed", QVariant(true));
 		EnableApplyButton(true);
 	}
+}
+
+void OBSBasicSettings::AdvOutSplitFileChanged()
+{
+	bool splitFile = ui->advOutSplitFile->isChecked();
+	int splitFileType = splitFile ? ui->advOutSplitFileType->currentIndex()
+				      : -1;
+
+	ui->advOutSplitFileType->setEnabled(splitFile);
+	ui->advOutSplitFileTimeLabel->setVisible(splitFileType == 0);
+	ui->advOutSplitFileTime->setVisible(splitFileType == 0);
+	ui->advOutSplitFileSizeLabel->setVisible(splitFileType == 1);
+	ui->advOutSplitFileSize->setVisible(splitFileType == 1);
 }
 
 void OBSBasicSettings::AdvOutRecCheckWarnings()

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -381,6 +381,7 @@ private slots:
 
 	void UpdateAutomaticReplayBufferCheckboxes();
 
+	void AdvOutSplitFileChanged();
 	void AdvOutRecCheckWarnings();
 
 	void SimpleRecordingQualityChanged();

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -821,6 +821,35 @@ static inline bool ffmpeg_mux_packet(struct ffmpeg_mux *ffm, uint8_t *buf,
 	return ret >= 0;
 }
 
+static inline bool read_change_file(struct ffmpeg_mux *ffm, uint32_t size,
+				    struct resize_buf *filename, int argc,
+				    char **argv)
+{
+	resize_buf_resize(filename, size + 1);
+	if (safe_read(filename->buf, size) != size) {
+		return false;
+	}
+	filename->buf[size] = 0;
+
+	fprintf(stderr, "info: New output file name: %s\n", filename->buf);
+
+	int ret;
+	char *argv1_backup = argv[1];
+	argv[1] = (char *)filename->buf;
+
+	ffmpeg_mux_free(ffm);
+
+	ret = ffmpeg_mux_init(ffm, argc, argv);
+	if (ret != FFM_SUCCESS) {
+		fprintf(stderr, "Couldn't initialize muxer\n");
+		return false;
+	}
+
+	argv[1] = argv1_backup;
+
+	return true;
+}
+
 /* ------------------------------------------------------------------------- */
 
 #ifdef _WIN32
@@ -832,6 +861,7 @@ int main(int argc, char *argv[])
 	struct ffm_packet_info info = {0};
 	struct ffmpeg_mux ffm = {0};
 	struct resize_buf rb = {0};
+	struct resize_buf rb_filename = {0};
 	bool fail = false;
 	int ret;
 
@@ -864,6 +894,12 @@ int main(int argc, char *argv[])
 	}
 
 	while (!fail && safe_read(&info, sizeof(info)) == sizeof(info)) {
+		if (info.type == FFM_PACKET_CHANGE_FILE) {
+			fail = !read_change_file(&ffm, info.size, &rb_filename,
+						 argc, argv);
+			continue;
+		}
+
 		resize_buf_resize(&rb, info.size);
 
 		if (safe_read(rb.buf, info.size) == info.size) {
@@ -875,6 +911,7 @@ int main(int argc, char *argv[])
 
 	ffmpeg_mux_free(&ffm);
 	resize_buf_free(&rb);
+	resize_buf_free(&rb_filename);
 
 #ifdef _WIN32
 	for (int i = 0; i < argc; i++)

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.h
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.h
@@ -22,6 +22,7 @@
 enum ffm_packet_type {
 	FFM_PACKET_VIDEO,
 	FFM_PACKET_AUDIO,
+	FFM_PACKET_CHANGE_FILE,
 };
 
 #define FFM_SUCCESS 0

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -339,7 +339,7 @@ inline static void ts_offset_update(struct ffmpeg_muxer *stream,
 	if (stream->found_audio[packet->track_idx])
 		return;
 
-	stream->audio_dts_offsets[packet->track_idx] = packet->dts;
+	stream->audio_dts_offsets[packet->track_idx] = stream->video_pts_offset_usec * packet->timebase_den / 1000000;
 	stream->found_audio[packet->track_idx] = true;
 }
 
@@ -731,6 +731,7 @@ static bool prepare_split_file(struct ffmpeg_muxer *stream,
 
 	stream->cur_size = 0;
 	stream->cur_time = packet->dts_usec;
+	stream->video_pts_offset_usec = packet_pts_usec(packet);
 	ts_offset_clear(stream);
 
 	return true;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -779,6 +779,12 @@ static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 				return;
 			stream->split_file_ready = true;
 		}
+		else {
+			// Duplicating packets to both files.
+			// TODO: Number of duplicated packets is controlled by video's PTS-DTS offset.
+			// That means this feature does not work if B-frame is not enabled.
+			push_back_packet(&stream->mux_packets.da, packet);
+		}
 	} else if (stream->split_file && should_split(stream, packet)) {
 		if (has_audio(stream)) {
 			push_back_packet(&stream->mux_packets.da, packet);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -654,6 +654,32 @@ static inline bool should_split(struct ffmpeg_muxer *stream,
 	return false;
 }
 
+static bool send_new_filename(struct ffmpeg_muxer *stream, const char *filename)
+{
+	size_t ret;
+	uint32_t size = strlen(filename);
+	struct ffm_packet_info info = {.type = FFM_PACKET_CHANGE_FILE,
+				       .size = size};
+
+	ret = os_process_pipe_write(stream->pipe, (const uint8_t *)&info,
+				    sizeof(info));
+	if (ret != sizeof(info)) {
+		warn("os_process_pipe_write for info structure failed");
+		signal_failure(stream);
+		return false;
+	}
+
+	ret = os_process_pipe_write(stream->pipe, (const uint8_t *)filename,
+				    size);
+	if (ret != size) {
+		warn("os_process_pipe_write for packet data failed");
+		signal_failure(stream);
+		return false;
+	}
+
+	return true;
+}
+
 static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 {
 	struct ffmpeg_muxer *stream = data;
@@ -669,26 +695,21 @@ static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 
 	if (stream->split_file && should_split(stream, packet)) {
 
-		os_process_pipe_destroy(stream->pipe);
-
 		generate_filename(stream, &stream->path,
 				  stream->allow_overwrite);
 		info("Changing output file to '%s'", stream->path.array);
+
+		if (!send_new_filename(stream, stream->path.array)) {
+			warn("Failed to send new file name");
+			return;
+		}
+
 		calldata_t cd = {0};
 		signal_handler_t *sh =
 			obs_output_get_signal_handler(stream->output);
 		calldata_set_string(&cd, "next_file", stream->path.array);
 		signal_handler_signal(sh, "file_changed", &cd);
 		calldata_free(&cd);
-
-		start_pipe(stream, stream->path.array);
-		if (!stream->pipe) {
-			obs_output_set_last_error(
-				stream->output,
-				obs_module_text("HelperProcessFailed"));
-			warn("Failed to create process pipe to split file");
-			return;
-		}
 
 		stream->cur_size = 0;
 		stream->sent_headers = false;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -337,6 +337,8 @@ static bool ffmpeg_mux_start(void *data)
 				     stream->max_size > 0;
 		stream->reset_timestamps =
 			obs_data_get_bool(settings, "reset_timestamps");
+		stream->allow_overwrite =
+			obs_data_get_bool(settings, "allow_overwrite");
 		stream->cur_size = 0;
 		stream->sent_headers = false;
 	}
@@ -479,14 +481,41 @@ static void signal_failure(struct ffmpeg_muxer *stream)
 	os_atomic_set_bool(&stream->capturing, false);
 }
 
-static void generate_filename(struct ffmpeg_muxer *stream, struct dstr *dst)
+static void find_best_filename(struct dstr *path, bool space)
+{
+	int num = 2;
+
+	if (!os_file_exists(path->array))
+		return;
+
+	const char *ext = strrchr(path->array, '.');
+	if (!ext)
+		return;
+
+	size_t extstart = ext - path->array;
+	struct dstr testpath;
+	dstr_init_copy_dstr(&testpath, path);
+	for (;;) {
+		dstr_resize(&testpath, extstart);
+		dstr_catf(&testpath, space ? " (%d)" : "_%d", num++);
+		dstr_cat(&testpath, ext);
+
+		if (!os_file_exists(testpath.array)) {
+			dstr_free(path);
+			dstr_init_move(path, &testpath);
+			break;
+		}
+	}
+}
+
+static void generate_filename(struct ffmpeg_muxer *stream, struct dstr *dst,
+			      bool overwrite)
 {
 	obs_data_t *settings = obs_output_get_settings(stream->output);
 	const char *dir = obs_data_get_string(settings, "directory");
 	const char *fmt = obs_data_get_string(settings, "format");
 	const char *ext = obs_data_get_string(settings, "extension");
 	bool space = obs_data_get_bool(settings, "allow_spaces");
-	// TODO: allow_overwrite
 
 	char *filename = os_generate_formatted_filename(ext, space, fmt);
 
@@ -502,6 +531,9 @@ static void generate_filename(struct ffmpeg_muxer *stream, struct dstr *dst)
 		os_mkdirs(dst->array);
 		*slash = '/';
 	}
+
+	if (!overwrite)
+		find_best_filename(dst, space);
 
 	bfree(filename);
 	obs_data_release(settings);
@@ -636,7 +668,8 @@ static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 
 		os_process_pipe_destroy(stream->pipe);
 
-		generate_filename(stream, &stream->path);
+		generate_filename(stream, &stream->path,
+				  stream->allow_overwrite);
 		info("Changing output file to '%s'", stream->path.array);
 		start_pipe(stream, stream->path.array);
 		if (!stream->pipe) {
@@ -1039,7 +1072,7 @@ static void replay_buffer_save(struct ffmpeg_muxer *stream)
 			      audio_dts_offsets);
 	}
 
-	generate_filename(stream, &stream->path);
+	generate_filename(stream, &stream->path, true);
 
 	os_atomic_set_bool(&stream->muxing, true);
 	stream->mux_thread_joinable = pthread_create(&stream->mux_thread, NULL,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -87,6 +87,9 @@ static void *ffmpeg_mux_create(obs_data_t *settings, obs_output_t *output)
 	if (obs_output_get_flags(output) & OBS_OUTPUT_SERVICE)
 		stream->is_network = true;
 
+	signal_handler_t *sh = obs_output_get_signal_handler(output);
+	signal_handler_add(sh, "void file_changed(string next_file)");
+
 	UNUSED_PARAMETER(settings);
 	return stream;
 }
@@ -671,6 +674,13 @@ static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 		generate_filename(stream, &stream->path,
 				  stream->allow_overwrite);
 		info("Changing output file to '%s'", stream->path.array);
+		calldata_t cd = {0};
+		signal_handler_t *sh =
+			obs_output_get_signal_handler(stream->output);
+		calldata_set_string(&cd, "next_file", stream->path.array);
+		signal_handler_signal(sh, "file_changed", &cd);
+		calldata_free(&cd);
+
 		start_pipe(stream, stream->path.array);
 		if (!stream->pipe) {
 			obs_output_set_last_error(

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -324,8 +324,18 @@ static bool ffmpeg_mux_start(void *data)
 		if (!service)
 			return false;
 		path = obs_service_get_url(service);
+		stream->split_file = false;
 	} else {
 		path = obs_data_get_string(settings, "path");
+
+		stream->max_time =
+			obs_data_get_int(settings, "max_time_sec") * 1000000LL;
+		stream->max_size = obs_data_get_int(settings, "max_size_mb") *
+				   (1024 * 1024);
+		stream->split_file = stream->max_time > 0 ||
+				     stream->max_size > 0;
+		stream->cur_size = 0;
+		stream->sent_headers = false;
 	}
 
 	if (!stream->is_network) {
@@ -516,6 +526,10 @@ bool write_packet(struct ffmpeg_muxer *stream, struct encoder_packet *packet)
 	}
 
 	stream->total_bytes += packet->size;
+
+	if (stream->split_file)
+		stream->cur_size += packet->size;
+
 	return true;
 }
 
@@ -561,6 +575,30 @@ bool send_headers(struct ffmpeg_muxer *stream)
 	return true;
 }
 
+static inline bool should_split(struct ffmpeg_muxer *stream,
+				struct encoder_packet *packet)
+{
+	/* split at video frame */
+	if (packet->type != OBS_ENCODER_VIDEO)
+		return false;
+
+	/* don't split group of pictures */
+	if (!packet->keyframe)
+		return false;
+
+	/* reached maximum file size */
+	if (stream->max_size > 0 &&
+	    stream->cur_size + (int64_t)packet->size >= stream->max_size)
+		return true;
+
+	/* reached maximum duration */
+	if (stream->max_time > 0 &&
+	    packet->dts_usec - stream->cur_time >= stream->max_time)
+		return true;
+
+	return false;
+}
+
 static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 {
 	struct ffmpeg_muxer *stream = data;
@@ -574,11 +612,33 @@ static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 		return;
 	}
 
+	if (stream->split_file && should_split(stream, packet)) {
+
+		os_process_pipe_destroy(stream->pipe);
+
+		generate_filename(stream, &stream->path);
+		info("Changing output file to '%s'", stream->path.array);
+		start_pipe(stream, stream->path.array);
+		if (!stream->pipe) {
+			obs_output_set_last_error(
+				stream->output,
+				obs_module_text("HelperProcessFailed"));
+			warn("Failed to create process pipe to split file");
+			return;
+		}
+
+		stream->cur_size = 0;
+		stream->sent_headers = false;
+	}
+
 	if (!stream->sent_headers) {
 		if (!send_headers(stream))
 			return;
 
 		stream->sent_headers = true;
+
+		if (stream->split_file)
+			stream->cur_time = packet->dts_usec;
 	}
 
 	if (stopping(stream)) {

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -309,6 +309,35 @@ static void set_file_not_readable_error(struct ffmpeg_muxer *stream,
 	obs_data_release(settings);
 }
 
+inline static void ts_offset_clear(struct ffmpeg_muxer *stream)
+{
+	stream->found_video = false;
+	stream->video_pts_offset = 0;
+
+	for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
+		stream->found_audio[i] = false;
+		stream->audio_dts_offsets[i] = 0;
+	}
+}
+
+inline static void ts_offset_update(struct ffmpeg_muxer *stream,
+				    struct encoder_packet *packet)
+{
+	if (packet->type == OBS_ENCODER_VIDEO) {
+		if (!stream->found_video) {
+			stream->video_pts_offset = packet->pts;
+			stream->found_video = true;
+		}
+		return;
+	}
+
+	if (stream->found_audio[packet->track_idx])
+		return;
+
+	stream->audio_dts_offsets[packet->track_idx] = packet->dts;
+	stream->found_audio[packet->track_idx] = true;
+}
+
 static bool ffmpeg_mux_start(void *data)
 {
 	struct ffmpeg_muxer *stream = data;
@@ -346,12 +375,7 @@ static bool ffmpeg_mux_start(void *data)
 		stream->sent_headers = false;
 	}
 
-	stream->found_video = false;
-	stream->video_pts_offset = 0;
-	for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
-		stream->found_audio[i] = false;
-		stream->audio_dts_offsets[i] = 0;
-	}
+	ts_offset_clear(stream);
 
 	if (!stream->is_network) {
 		/* ensure output path is writable to avoid generic error
@@ -680,6 +704,33 @@ static bool send_new_filename(struct ffmpeg_muxer *stream, const char *filename)
 	return true;
 }
 
+static bool prepare_split_file(struct ffmpeg_muxer *stream,
+			       struct encoder_packet *packet)
+{
+	generate_filename(stream, &stream->path, stream->allow_overwrite);
+	info("Changing output file to '%s'", stream->path.array);
+
+	if (!send_new_filename(stream, stream->path.array)) {
+		warn("Failed to send new file name");
+		return false;
+	}
+
+	calldata_t cd = {0};
+	signal_handler_t *sh = obs_output_get_signal_handler(stream->output);
+	calldata_set_string(&cd, "next_file", stream->path.array);
+	signal_handler_signal(sh, "file_changed", &cd);
+	calldata_free(&cd);
+
+	if (!send_headers(stream))
+		return false;
+
+	stream->cur_size = 0;
+	stream->cur_time = packet->dts_usec;
+	ts_offset_clear(stream);
+
+	return true;
+}
+
 static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 {
 	struct ffmpeg_muxer *stream = data;
@@ -693,33 +744,11 @@ static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 		return;
 	}
 
+	bool split_file_ready = false;
 	if (stream->split_file && should_split(stream, packet)) {
-
-		generate_filename(stream, &stream->path,
-				  stream->allow_overwrite);
-		info("Changing output file to '%s'", stream->path.array);
-
-		if (!send_new_filename(stream, stream->path.array)) {
-			warn("Failed to send new file name");
+		if (!prepare_split_file(stream, packet))
 			return;
-		}
-
-		calldata_t cd = {0};
-		signal_handler_t *sh =
-			obs_output_get_signal_handler(stream->output);
-		calldata_set_string(&cd, "next_file", stream->path.array);
-		signal_handler_signal(sh, "file_changed", &cd);
-		calldata_free(&cd);
-
-		stream->cur_size = 0;
-		stream->sent_headers = false;
-
-		stream->found_video = false;
-		stream->video_pts_offset = 0;
-		for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
-			stream->found_audio[i] = false;
-			stream->audio_dts_offsets[i] = 0;
-		}
+		split_file_ready = true;
 	}
 
 	if (!stream->sent_headers) {
@@ -740,18 +769,7 @@ static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 	}
 
 	if (stream->split_file && stream->reset_timestamps) {
-		if (packet->type == OBS_ENCODER_VIDEO) {
-			if (!stream->found_video) {
-				stream->video_pts_offset = packet->pts;
-				stream->found_video = true;
-			}
-		} else {
-			if (!stream->found_audio[packet->track_idx]) {
-				stream->audio_dts_offsets[packet->track_idx] =
-					packet->dts;
-				stream->found_audio[packet->track_idx] = true;
-			}
-		}
+		ts_offset_update(stream, packet);
 	}
 
 	write_packet(stream, packet);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -320,6 +320,11 @@ inline static void ts_offset_clear(struct ffmpeg_muxer *stream)
 	}
 }
 
+static inline int64_t packet_pts_usec(struct encoder_packet *packet)
+{
+	return packet->pts * 1000000 / packet->timebase_den;
+}
+
 inline static void ts_offset_update(struct ffmpeg_muxer *stream,
 				    struct encoder_packet *packet)
 {
@@ -731,6 +736,19 @@ static bool prepare_split_file(struct ffmpeg_muxer *stream,
 	return true;
 }
 
+static inline bool has_audio(struct ffmpeg_muxer *stream)
+{
+	return !!obs_output_get_audio_encoder(stream->output, 0);
+}
+
+static void push_back_packet(struct darray *packets,
+			     struct encoder_packet *packet)
+{
+	struct encoder_packet pkt;
+	obs_encoder_packet_ref(&pkt, packet);
+	darray_push_back(sizeof(pkt), packets, &pkt);
+}
+
 static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 {
 	struct ffmpeg_muxer *stream = data;
@@ -744,11 +762,31 @@ static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 		return;
 	}
 
-	bool split_file_ready = false;
-	if (stream->split_file && should_split(stream, packet)) {
-		if (!prepare_split_file(stream, packet))
+	if (stream->split_file && stream->mux_packets.num) {
+		int64_t pts_usec = packet_pts_usec(packet);
+		struct encoder_packet *first_pkt = stream->mux_packets.array;
+		int64_t first_pts_usec = packet_pts_usec(first_pkt);
+
+		if (pts_usec >= first_pts_usec) {
+			if (packet->type != OBS_ENCODER_AUDIO) {
+				push_back_packet(&stream->mux_packets.da,
+						 packet);
+				return;
+			}
+
+			if (!prepare_split_file(stream, first_pkt))
+				return;
+			stream->split_file_ready = true;
+		}
+	} else if (stream->split_file && should_split(stream, packet)) {
+		if (has_audio(stream)) {
+			push_back_packet(&stream->mux_packets.da, packet);
 			return;
-		split_file_ready = true;
+		} else {
+			if (!prepare_split_file(stream, packet))
+				return;
+			stream->split_file_ready = true;
+		}
 	}
 
 	if (!stream->sent_headers) {
@@ -766,6 +804,19 @@ static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 			deactivate(stream, 0);
 			return;
 		}
+	}
+
+	if (stream->split_file && stream->split_file_ready) {
+		for (size_t i = 0; i < stream->mux_packets.num; i++) {
+			struct encoder_packet *pkt =
+				&stream->mux_packets.array[i];
+			if (stream->reset_timestamps)
+				ts_offset_update(stream, pkt);
+			write_packet(stream, pkt);
+			obs_encoder_packet_release(pkt);
+		}
+		da_free(stream->mux_packets);
+		stream->split_file_ready = false;
 	}
 
 	if (stream->split_file && stream->reset_timestamps) {

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -325,6 +325,7 @@ static bool ffmpeg_mux_start(void *data)
 			return false;
 		path = obs_service_get_url(service);
 		stream->split_file = false;
+		stream->reset_timestamps = false;
 	} else {
 		path = obs_data_get_string(settings, "path");
 
@@ -334,8 +335,17 @@ static bool ffmpeg_mux_start(void *data)
 				   (1024 * 1024);
 		stream->split_file = stream->max_time > 0 ||
 				     stream->max_size > 0;
+		stream->reset_timestamps =
+			obs_data_get_bool(settings, "reset_timestamps");
 		stream->cur_size = 0;
 		stream->sent_headers = false;
+	}
+
+	stream->found_video = false;
+	stream->video_pts_offset = 0;
+	for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
+		stream->found_audio[i] = false;
+		stream->audio_dts_offsets[i] = 0;
 	}
 
 	if (!stream->is_network) {
@@ -510,6 +520,16 @@ bool write_packet(struct ffmpeg_muxer *stream, struct encoder_packet *packet)
 							: FFM_PACKET_AUDIO,
 				       .keyframe = packet->keyframe};
 
+	if (stream->split_file && stream->reset_timestamps) {
+		if (is_video) {
+			info.dts -= stream->video_pts_offset;
+			info.pts -= stream->video_pts_offset;
+		} else {
+			info.dts -= stream->audio_dts_offsets[info.index];
+			info.pts -= stream->audio_dts_offsets[info.index];
+		}
+	}
+
 	ret = os_process_pipe_write(stream->pipe, (const uint8_t *)&info,
 				    sizeof(info));
 	if (ret != sizeof(info)) {
@@ -629,6 +649,13 @@ static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 
 		stream->cur_size = 0;
 		stream->sent_headers = false;
+
+		stream->found_video = false;
+		stream->video_pts_offset = 0;
+		for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
+			stream->found_audio[i] = false;
+			stream->audio_dts_offsets[i] = 0;
+		}
 	}
 
 	if (!stream->sent_headers) {
@@ -645,6 +672,21 @@ static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 		if (packet->sys_dts_usec >= stream->stop_ts) {
 			deactivate(stream, 0);
 			return;
+		}
+	}
+
+	if (stream->split_file && stream->reset_timestamps) {
+		if (packet->type == OBS_ENCODER_VIDEO) {
+			if (!stream->found_video) {
+				stream->video_pts_offset = packet->pts;
+				stream->found_video = true;
+			}
+		} else {
+			if (!stream->found_audio[packet->track_idx]) {
+				stream->audio_dts_offsets[packet->track_idx] =
+					packet->dts;
+				stream->found_audio[packet->track_idx] = true;
+			}
 		}
 	}
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
@@ -42,6 +42,7 @@ struct ffmpeg_muxer {
 	bool found_audio[MAX_AUDIO_MIXES];
 	int64_t video_pts_offset;
 	int64_t audio_dts_offsets[MAX_AUDIO_MIXES];
+	bool split_file_ready;
 
 	/* these are accessed both by replay buffer and by HLS */
 	pthread_t mux_thread;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
@@ -41,6 +41,7 @@ struct ffmpeg_muxer {
 	bool found_video;
 	bool found_audio[MAX_AUDIO_MIXES];
 	int64_t video_pts_offset;
+	int64_t video_pts_offset_usec;
 	int64_t audio_dts_offsets[MAX_AUDIO_MIXES];
 	bool split_file_ready;
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
@@ -61,6 +61,7 @@ struct ffmpeg_muxer {
 	bool is_network;
 	bool split_file;
 	bool reset_timestamps;
+	bool allow_overwrite;
 };
 
 bool stopping(struct ffmpeg_muxer *stream);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
@@ -24,11 +24,13 @@ struct ffmpeg_muxer {
 	struct dstr muxer_settings;
 	struct dstr stream_key;
 
-	/* replay buffer */
+	/* replay buffer and split file */
 	int64_t cur_size;
 	int64_t cur_time;
 	int64_t max_size;
 	int64_t max_time;
+
+	/* replay buffer */
 	int64_t save_ts;
 	int keyframes;
 	obs_hotkey_id hotkey;
@@ -51,6 +53,7 @@ struct ffmpeg_muxer {
 	int64_t last_dts_usec;
 
 	bool is_network;
+	bool split_file;
 };
 
 bool stopping(struct ffmpeg_muxer *stream);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
@@ -37,6 +37,12 @@ struct ffmpeg_muxer {
 	volatile bool muxing;
 	DARRAY(struct encoder_packet) mux_packets;
 
+	/* split file */
+	bool found_video;
+	bool found_audio[MAX_AUDIO_MIXES];
+	int64_t video_pts_offset;
+	int64_t audio_dts_offsets[MAX_AUDIO_MIXES];
+
 	/* these are accessed both by replay buffer and by HLS */
 	pthread_t mux_thread;
 	bool mux_thread_joinable;
@@ -54,6 +60,7 @@ struct ffmpeg_muxer {
 
 	bool is_network;
 	bool split_file;
+	bool reset_timestamps;
 };
 
 bool stopping(struct ffmpeg_muxer *stream);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When splitting file (#5371), audio packets are duplicated and saved to both previous and new files.
In the new file, audio timestamps will be offset by video timestamp so that video and audio has the same alignment among the split files in one recording.

Currently, the implementation relays on a video encoder that has DTS < PTS to duplicate audio packet. If DTS = PTS, the audio won't be duplicated. This behavior should be resolved before removing draft state.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Audio glitch is the issue in the new WIP feature Automatic File Splitting (#5371).
Since the audio has different frame size than that for video, it is not easy for the boundary audio packet to be sent into just one file without audio glitch.

This change will resolve audio glitch when editing on NLEs. However, since the audio packets are duplicated, ffmpeg `concat` input might not be able to recover the original video. This function should be an optional.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OBS Studio is built with FFmpeg 4.4.1 on Fedora 34. Encoder setting is libx264.
Output video files are tested with Kdenlive 21.08.1.
Kdenlive sometimes treats the length of the file one frame longer, which results audio glitch. User has to manually shrink the video length to have smooth switch to the new file.

It would be welcome if someone can test with other platforms, encoder settings, and NLEs.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
