### PR TITLE
UI: Hold refs to existing sources during remove scene undo

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3903,8 +3903,8 @@ void OBSBasic::RemoveSelectedScene()
 			auto cb = [](obs_scene_t *scene, obs_sceneitem_t *item,
 				     void *data) {
 				UNUSED_PARAMETER(scene);
-				std::vector<obs_source_t *> *existing =
-					(std::vector<obs_source_t *> *)data;
+				std::vector<OBSSource> *existing =
+					(std::vector<OBSSource> *)data;
 				OBSSource source =
 					obs_sceneitem_get_source(item);
 				obs_sceneitem_remove(item);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Similar fix to #5693 (but for scene removal instead of source removal), due to changes in 3d54465 sources could get lost.
I would've combined the two had I noticed this one as well when I did #5693.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Steps to reproduce:
- Have two scenes
- Scene `1` has scene `2` nested, as well as another source. Scene `2` can be empty.
- Delete `2`. Undo.
- Notice the other source that used to be in `1` is gone and destroyed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0.1, compiled and run.
Sources no longer get destroyed.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
