### PR TITLE
Various EGL & PipeWire cleanups

### DIFF
--- a/libobs-opengl/gl-egl-common.c
+++ b/libobs-opengl/gl-egl-common.c
@@ -221,7 +221,7 @@ static inline bool is_implicit_dmabuf_modifiers_supported(void)
 }
 
 static inline bool query_dmabuf_formats(EGLDisplay egl_display,
-					EGLint *num_formats, EGLint **formats)
+					EGLint **formats, EGLint *num_formats)
 {
 	EGLint max_formats = 0;
 	EGLint *format_list = NULL;
@@ -268,8 +268,8 @@ bool gl_egl_query_dmabuf_capabilities(EGLDisplay egl_display,
 		return ret;
 	}
 
-	if (!query_dmabuf_formats(egl_display, (EGLint *)n_formats,
-				  (EGLint **)formats)) {
+	if (!query_dmabuf_formats(egl_display, (EGLint **)formats,
+				  (EGLint *)n_formats)) {
 		*n_formats = 0;
 		*formats = NULL;
 	}

--- a/libobs-opengl/gl-egl-common.c
+++ b/libobs-opengl/gl-egl-common.c
@@ -215,10 +215,8 @@ gl_egl_create_dmabuf_image(EGLDisplay egl_display, unsigned int width,
 	return texture;
 }
 
-static inline bool
-is_implicit_dmabuf_modifiers_supported(EGLDisplay egl_display)
+static inline bool is_implicit_dmabuf_modifiers_supported(void)
 {
-	UNUSED_PARAMETER(egl_display);
 	return EGL_EXT_image_dma_buf_import > 0;
 }
 
@@ -260,7 +258,7 @@ bool gl_egl_query_dmabuf_capabilities(EGLDisplay egl_display,
 {
 	bool ret = false;
 
-	if (is_implicit_dmabuf_modifiers_supported(egl_display)) {
+	if (is_implicit_dmabuf_modifiers_supported()) {
 		*dmabuf_flags = GS_DMABUF_FLAG_IMPLICIT_MODIFIERS_SUPPORTED;
 		ret = true;
 	}

--- a/plugins/linux-capture/pipewire.c
+++ b/plugins/linux-capture/pipewire.c
@@ -688,10 +688,10 @@ static void on_process_cb(void *user_data)
 		}
 	} else {
 		blog(LOG_DEBUG, "[pipewire] Buffer has memory texture");
-		enum gs_color_format obs_format;
+		enum gs_color_format gs_format;
 
 		if (!lookup_format_info_from_spa_format(
-			    obs_pw->format.info.raw.format, NULL, &obs_format,
+			    obs_pw->format.info.raw.format, NULL, &gs_format,
 			    &swap_red_blue)) {
 			blog(LOG_ERROR,
 			     "[pipewire] unsupported DMA buffer format: %d",
@@ -702,7 +702,7 @@ static void on_process_cb(void *user_data)
 		g_clear_pointer(&obs_pw->texture, gs_texture_destroy);
 		obs_pw->texture = gs_texture_create(
 			obs_pw->format.info.raw.size.width,
-			obs_pw->format.info.raw.size.height, obs_format, 1,
+			obs_pw->format.info.raw.size.height, gs_format, 1,
 			(const uint8_t **)&buffer->datas[0].data, GS_DYNAMIC);
 	}
 
@@ -735,7 +735,7 @@ read_metadata:
 	obs_pw->cursor.valid = cursor && spa_meta_cursor_is_valid(cursor);
 	if (obs_pw->cursor.visible && obs_pw->cursor.valid) {
 		struct spa_meta_bitmap *bitmap = NULL;
-		enum gs_color_format format;
+		enum gs_color_format gs_format;
 
 		if (cursor->bitmap_offset)
 			bitmap = SPA_MEMBER(cursor, cursor->bitmap_offset,
@@ -744,7 +744,7 @@ read_metadata:
 		if (bitmap && bitmap->size.width > 0 &&
 		    bitmap->size.height > 0 &&
 		    lookup_format_info_from_spa_format(
-			    bitmap->format, NULL, &format, &swap_red_blue)) {
+			    bitmap->format, NULL, &gs_format, &swap_red_blue)) {
 			const uint8_t *bitmap_data;
 
 			bitmap_data =
@@ -758,7 +758,7 @@ read_metadata:
 					gs_texture_destroy);
 			obs_pw->cursor.texture = gs_texture_create(
 				obs_pw->cursor.width, obs_pw->cursor.height,
-				format, 1, &bitmap_data, GS_DYNAMIC);
+				gs_format, 1, &bitmap_data, GS_DYNAMIC);
 
 			if (swap_red_blue)
 				swap_texture_red_blue(obs_pw->cursor.texture);

--- a/plugins/linux-capture/pipewire.c
+++ b/plugins/linux-capture/pipewire.c
@@ -648,7 +648,7 @@ static void on_process_cb(void *user_data)
 		uint32_t strides[planes];
 		uint64_t modifiers[planes];
 		int fds[planes];
-		bool modifierless; // DMA-BUF without explicit modifier
+		bool use_modifiers;
 
 		blog(LOG_DEBUG,
 		     "[pipewire] DMA-BUF info: fd:%ld, stride:%d, offset:%u, size:%dx%d",
@@ -674,13 +674,13 @@ static void on_process_cb(void *user_data)
 
 		g_clear_pointer(&obs_pw->texture, gs_texture_destroy);
 
-		modifierless = obs_pw->format.info.raw.modifier ==
-			       DRM_FORMAT_MOD_INVALID;
+		use_modifiers = obs_pw->format.info.raw.modifier !=
+				DRM_FORMAT_MOD_INVALID;
 		obs_pw->texture = gs_texture_create_from_dmabuf(
 			obs_pw->format.info.raw.size.width,
 			obs_pw->format.info.raw.size.height, drm_format,
 			GS_BGRX, planes, fds, strides, offsets,
-			modifierless ? NULL : modifiers);
+			use_modifiers ? modifiers : NULL);
 
 		if (obs_pw->texture == NULL) {
 			remove_modifier_from_format(

--- a/plugins/linux-capture/pipewire.c
+++ b/plugins/linux-capture/pipewire.c
@@ -409,14 +409,18 @@ static inline struct spa_pod *build_format(struct spa_pod_builder *b,
 		spa_pod_builder_prop(b, SPA_FORMAT_VIDEO_modifier,
 				     SPA_POD_PROP_FLAG_MANDATORY |
 					     SPA_POD_PROP_FLAG_DONT_FIXATE);
+
 		spa_pod_builder_push_choice(b, &f[1], SPA_CHOICE_Enum, 0);
+
+		/* The first element of choice pods is the preferred value. Here
+		 * we arbitrarily pick the first modifier as the preferred one.
+		 */
+		spa_pod_builder_long(b, modifiers[0]);
+
 		/* modifiers from  an array */
-		for (uint32_t i = 0; i < modifier_count; i++) {
-			uint64_t modifier = modifiers[i];
-			spa_pod_builder_long(b, modifier);
-			if (i == 0)
-				spa_pod_builder_long(b, modifier);
-		}
+		for (uint32_t i = 0; i < modifier_count; i++)
+			spa_pod_builder_long(b, modifiers[i]);
+
 		spa_pod_builder_pop(b, &f[1]);
 	}
 	/* add size and framerate ranges */

--- a/plugins/linux-capture/pipewire.c
+++ b/plugins/linux-capture/pipewire.c
@@ -386,13 +386,13 @@ static inline struct spa_pod *build_format(struct spa_pod_builder *b,
 					   uint32_t format, uint64_t *modifiers,
 					   size_t modifier_count)
 {
-	struct spa_pod_frame f[2];
+	struct spa_pod_frame format_frame;
 
 	/* Make an object of type SPA_TYPE_OBJECT_Format and id SPA_PARAM_EnumFormat.
 	 * The object type is important because it defines the properties that are
 	 * acceptable. The id gives more context about what the object is meant to
 	 * contain. In this case we enumerate supported formats. */
-	spa_pod_builder_push_object(b, &f[0], SPA_TYPE_OBJECT_Format,
+	spa_pod_builder_push_object(b, &format_frame, SPA_TYPE_OBJECT_Format,
 				    SPA_PARAM_EnumFormat);
 	/* add media type and media subtype properties */
 	spa_pod_builder_add(b, SPA_FORMAT_mediaType,
@@ -405,12 +405,15 @@ static inline struct spa_pod *build_format(struct spa_pod_builder *b,
 
 	/* modifier */
 	if (modifier_count > 0) {
+		struct spa_pod_frame modifier_frame;
+
 		/* build an enumeration of modifiers */
 		spa_pod_builder_prop(b, SPA_FORMAT_VIDEO_modifier,
 				     SPA_POD_PROP_FLAG_MANDATORY |
 					     SPA_POD_PROP_FLAG_DONT_FIXATE);
 
-		spa_pod_builder_push_choice(b, &f[1], SPA_CHOICE_Enum, 0);
+		spa_pod_builder_push_choice(b, &modifier_frame, SPA_CHOICE_Enum,
+					    0);
 
 		/* The first element of choice pods is the preferred value. Here
 		 * we arbitrarily pick the first modifier as the preferred one.
@@ -421,7 +424,7 @@ static inline struct spa_pod *build_format(struct spa_pod_builder *b,
 		for (uint32_t i = 0; i < modifier_count; i++)
 			spa_pod_builder_long(b, modifiers[i]);
 
-		spa_pod_builder_pop(b, &f[1]);
+		spa_pod_builder_pop(b, &modifier_frame);
 	}
 	/* add size and framerate ranges */
 	spa_pod_builder_add(b, SPA_FORMAT_VIDEO_size,
@@ -434,7 +437,7 @@ static inline struct spa_pod *build_format(struct spa_pod_builder *b,
 				    &SPA_FRACTION(ovi->fps_num, ovi->fps_den),
 				    &SPA_FRACTION(0, 1), &SPA_FRACTION(360, 1)),
 			    0);
-	return spa_pod_builder_pop(b, &f[0]);
+	return spa_pod_builder_pop(b, &format_frame);
 }
 
 static bool build_format_params(obs_pipewire_data *obs_pw,


### PR DESCRIPTION
### Description

Various unassorted cleanups to the PipeWire code of the `linux-capture` plugin, and to `libobs-opengl`.

### Motivation and Context

As the code grows in scope and complexity, we need to do some conscious effort to keep it tidy.

### How Has This Been Tested?

There shouldn't be any actual functional changes here. All (except one) commits are aesthetical cleanups.

### Types of changes

 - Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
