### PR TITLE
UI: Don't switch scenes on undo/redo; Force-switch away from scene when deleting it

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -64,11 +64,7 @@ void SourceToolbar::SetUndoProperties(obs_source_t *source, bool repeatable)
 			obs_data_get_string(settings, "undo_sname"));
 		obs_source_reset_settings(source, settings);
 
-		OBSSourceAutoRelease scene_source =
-			obs_get_source_by_name(scene_name.c_str());
-		main->SetCurrentScene(scene_source.Get(), true);
-
-		main->UpdateContextBar();
+		main->UpdateContextBar(true);
 	};
 
 	OBSDataAutoRelease new_settings = obs_data_create();

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -453,28 +453,18 @@ void SourceTreeItem::ExitEditModeInternal(bool save)
 
 	SignalBlocker sourcesSignalBlocker(this);
 	std::string prevName(obs_source_get_name(source));
-	std::string scene_name =
-		obs_source_get_name(main->GetCurrentSceneSource());
-	auto undo = [scene_name, prevName, main](const std::string &data) {
+	auto undo = [prevName](const std::string &data) {
 		OBSSourceAutoRelease source =
 			obs_get_source_by_name(data.c_str());
 		obs_source_set_name(source, prevName.c_str());
-
-		OBSSourceAutoRelease scene_source =
-			obs_get_source_by_name(scene_name.c_str());
-		main->SetCurrentScene(scene_source.Get(), true);
 	};
 
 	std::string editedName = newName;
 
-	auto redo = [scene_name, main, editedName](const std::string &data) {
+	auto redo = [editedName](const std::string &data) {
 		OBSSourceAutoRelease source =
 			obs_get_source_by_name(data.c_str());
 		obs_source_set_name(source, editedName.c_str());
-
-		OBSSourceAutoRelease scene_source =
-			obs_get_source_by_name(scene_name.c_str());
-		main->SetCurrentScene(scene_source.Get(), true);
 	};
 
 	main->undo_s.add_action(QTStr("Undo.Rename").arg(newName.c_str()), undo,

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -590,16 +590,7 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 		obs_data_set_string(wrapper, "sname",
 				    obs_source_get_name(source));
 		obs_data_set_string(wrapper, "fname", name.c_str());
-		std::string scene_name = obs_source_get_name(
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->GetCurrentSceneSource());
-		auto undo = [scene_name](const std::string &data) {
-			obs_source_t *ssource =
-				obs_get_source_by_name(scene_name.c_str());
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->SetCurrentScene(ssource, true);
-			obs_source_release(ssource);
-
+		auto undo = [](const std::string &data) {
 			obs_data_t *dat =
 				obs_data_create_from_json(data.c_str());
 			obs_source_t *source = obs_get_source_by_name(
@@ -616,13 +607,8 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 		OBSDataAutoRelease rwrapper = obs_data_create();
 		obs_data_set_string(rwrapper, "sname",
 				    obs_source_get_name(source));
-		auto redo = [scene_name, id = std::string(id),
+		auto redo = [id = std::string(id),
 			     name](const std::string &data) {
-			OBSSourceAutoRelease ssource =
-				obs_get_source_by_name(scene_name.c_str());
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->SetCurrentScene(ssource.Get(), true);
-
 			OBSDataAutoRelease dat =
 				obs_data_create_from_json(data.c_str());
 			OBSSourceAutoRelease source = obs_get_source_by_name(
@@ -1073,13 +1059,8 @@ void OBSBasicFilters::FilterNameEdited(QWidget *editor, QListWidget *list)
 		std::string scene_name = obs_source_get_name(
 			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
 				->GetCurrentSceneSource());
-		auto undo = [scene_name, prev = std::string(prevName),
+		auto undo = [prev = std::string(prevName),
 			     name](const std::string &data) {
-			OBSSourceAutoRelease ssource =
-				obs_get_source_by_name(scene_name.c_str());
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->SetCurrentScene(ssource.Get(), true);
-
 			OBSSourceAutoRelease source =
 				obs_get_source_by_name(data.c_str());
 			OBSSourceAutoRelease filter =
@@ -1088,13 +1069,8 @@ void OBSBasicFilters::FilterNameEdited(QWidget *editor, QListWidget *list)
 			obs_source_set_name(filter, prev.c_str());
 		};
 
-		auto redo = [scene_name, prev = std::string(prevName),
+		auto redo = [prev = std::string(prevName),
 			     name](const std::string &data) {
-			OBSSourceAutoRelease ssource =
-				obs_get_source_by_name(scene_name.c_str());
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->SetCurrentScene(ssource.Get(), true);
-
 			OBSSourceAutoRelease source =
 				obs_get_source_by_name(data.c_str());
 			OBSSourceAutoRelease filter =
@@ -1188,15 +1164,7 @@ void OBSBasicFilters::delete_filter(OBSSource filter)
 	std::string parent_name(obs_source_get_name(source));
 	obs_data_set_string(wrapper, "undo_name", parent_name.c_str());
 
-	std::string scene_name = obs_source_get_name(
-		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->GetCurrentSceneSource());
-	auto undo = [scene_name](const std::string &data) {
-		OBSSourceAutoRelease ssource =
-			obs_get_source_by_name(scene_name.c_str());
-		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(ssource.Get(), true);
-
+	auto undo = [](const std::string &data) {
 		OBSDataAutoRelease dat =
 			obs_data_create_from_json(data.c_str());
 		OBSSourceAutoRelease source = obs_get_source_by_name(
@@ -1208,12 +1176,7 @@ void OBSBasicFilters::delete_filter(OBSSource filter)
 	OBSDataAutoRelease rwrapper = obs_data_create();
 	obs_data_set_string(rwrapper, "fname", obs_source_get_name(filter));
 	obs_data_set_string(rwrapper, "sname", parent_name.c_str());
-	auto redo = [scene_name](const std::string &data) {
-		OBSSourceAutoRelease ssource =
-			obs_get_source_by_name(scene_name.c_str());
-		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(ssource.Get(), true);
-
+	auto redo = [](const std::string &data) {
 		OBSDataAutoRelease dat =
 			obs_data_create_from_json(data.c_str());
 		OBSSourceAutoRelease source = obs_get_source_by_name(

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -705,13 +705,6 @@ void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 		obs_scene_save_transform_states(main->GetCurrentScene(), true);
 
 	auto undo_redo = [](const std::string &data) {
-		OBSDataAutoRelease dat =
-			obs_data_create_from_json(data.c_str());
-		OBSSourceAutoRelease source = obs_get_source_by_name(
-			obs_data_get_string(dat, "scene_name"));
-		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(source.Get(), true);
-
 		obs_scene_load_transform_states(data.c_str());
 	};
 

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -343,10 +343,7 @@ void OBSBasicProperties::on_buttonBox_clicked(QAbstractButton *button)
 
 	if (val == QDialogButtonBox::AcceptRole) {
 
-		std::string scene_name =
-			obs_source_get_name(main->GetCurrentSceneSource());
-
-		auto undo_redo = [scene_name](const std::string &data) {
+		auto undo_redo = [](const std::string &data) {
 			OBSDataAutoRelease settings =
 				obs_data_create_from_json(data.c_str());
 			OBSSourceAutoRelease source = obs_get_source_by_name(
@@ -354,12 +351,6 @@ void OBSBasicProperties::on_buttonBox_clicked(QAbstractButton *button)
 			obs_source_reset_settings(source, settings);
 
 			obs_source_update_properties(source);
-
-			OBSSourceAutoRelease scene_source =
-				obs_get_source_by_name(scene_name.c_str());
-
-			OBSBasic::Get()->SetCurrentScene(scene_source.Get(),
-							 true);
 		};
 
 		OBSDataAutoRelease new_settings = obs_data_create();

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -91,12 +91,6 @@ OBSBasicTransform::~OBSBasicTransform()
 		obs_scene_save_transform_states(main->GetCurrentScene(), false);
 
 	auto undo_redo = [](const std::string &data) {
-		OBSDataAutoRelease dat =
-			obs_data_create_from_json(data.c_str());
-		OBSSourceAutoRelease source = obs_get_source_by_name(
-			obs_data_get_string(dat, "scene_name"));
-		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(source.Get(), true);
 		obs_scene_load_transform_states(data.c_str());
 	};
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
#### Preamble
While these two changes don't directly require each other, merging `Force-switch away from scene when deleting it` alone makes the unpredictability that `Don't switch scenes on undo/redo` is eliminating even worse, which is why I don't think they should be separate PRs.
So, here are the changes:

#### Commit 1: `UI: Force-switch away from scene when deleting it`
"When triggering an undo immediately after deleting a scene, if the
transition was still going the scene wouldn't be destroyed yet, while
undo would try to recreate it. This would lead to unpredictable
behavior, including crashes.
Instead of transitioning to the other scene, OBS will now force-switch
to it, skipping the transition and letting the removed scene get
destroyed immediately."
I think this shouldn't require further explanation.

#### Commit 2: `UI: Don't switch scenes on undo/redo`
"Previously, undo/redo would often times (but not always) force switch
back to the scene in which the original action was done. This is not
only unpredictable, but in many cases doesn't make any sense (for
example when modifying properties of a source).
Now, undo/redo no longer switches scenes, instead doing the changes
quietly."
Specifically, the following actions would switch scenes, but will no longer
do so with this PR:
- Add/Delete/Rename filters
- Add/Duplicate/Delete scene
- Edit transform of SceneItem (both in the dialog and the preview)
- Change source properties in the dialog
- Change source properties in the context bar
- Add source (new/exisiting)
- Rename/Delete source


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
- 1: Noticed the problems while working on 2. Scenes disappearing and/or OBS crashing isn't good. The new behaviour (changing without transition) has been agreed to on Discord.
- 2: Discussion in https://github.com/obsproject/obs-studio/pull/5150#issuecomment-901448458

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0.1, compiled and run
- Confirmed that scenes get destroyed immediately after they are deleted
- Tested that each of the undo/redo actions described above individually work correctly, without leaking memory or crashing. Also tested different scenarios with multiple of these actions directly after each other, as well as with nested scenes (because those often cause trouble). Everything in my tests got undone/redone correctly, without the scenes changing.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
