### PR TITLE
UI: Cleanup hotkey settings UI file

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -4690,32 +4690,7 @@
          </item>
         </layout>
        </widget>
-       <widget class="QScrollArea" name="hotkeyPage">
-        <property name="widgetResizable">
-         <bool>true</bool>
-        </property>
-        <widget class="QWidget" name="hotkeyWidget">
-         <property name="geometry">
-          <rect>
-           <x>0</x>
-           <y>0</y>
-           <width>98</width>
-           <height>28</height>
-          </rect>
-         </property>
-         <layout class="QFormLayout" name="hotkeyLayout">
-          <property name="fieldGrowthPolicy">
-           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-          </property>
-          <property name="labelAlignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="verticalSpacing">
-           <number>0</number>
-          </property>
-         </layout>
-        </widget>
-       </widget>
+       <widget class="QWidget" name="hotkeyPage"/>
        <widget class="QWidget" name="advancedPage">
         <layout class="QVBoxLayout" name="verticalLayout_16">
          <property name="leftMargin">

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2700,7 +2700,10 @@ static inline void AddHotkeys(
 void OBSBasicSettings::LoadHotkeySettings(obs_hotkey_id ignoreKey)
 {
 	hotkeys.clear();
-	ui->hotkeyPage->takeWidget()->deleteLater();
+
+	QLayout *oldLayout = ui->hotkeyPage->layout();
+	if (oldLayout)
+		delete oldLayout;
 
 	using keys_t = map<obs_hotkey_id, vector<obs_key_combination_t>>;
 	keys_t keys;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes `hotkeyPage` from `QScrollArea` to `QWidget` so that we no longer have nested scrollAreas.
Also since 0c1524b, all of the content of `hotkeyPage` in OBSBasicSettings.ui gets overridden from code.
This means that it's no longer needed.

The change in `window-basic-settings.cpp` is because when changing to `QWidget` it wouldn't compile (takeWidget is a function of `QScrollArea`). So manually delete the layout instead.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Right now we have two nested ScrollAreas which means there are two borders in the hotkey window, with the outer one making no sense. Removing the outer ScrollArea, which doesn't scroll anymore anyways, means the outer border is gone.
While digging into this I noticed the dead content of the UI file, which should get removed since it doesn't serve any purpose anymore.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.0.1, compiled and run

Scrolling still works the same it did before, and the outer border is gone:
<img width="981" alt="Bildschirmfoto 2021-12-28 um 21 30 58" src="https://user-images.githubusercontent.com/59806498/147605450-eab0f57b-de8a-44b7-924f-02e8db544f29.png">

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Tweak *(Removing the outer border)*
- Code cleanup

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
