### PR TITLE
docs: Fix names of filter/properties functions

### DIFF
--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -733,7 +733,7 @@ Functions
 
 ---------------------------------------
 
-.. function:: void *obs_frontend_open_properties(obs_source_t *source)
+.. function:: void *obs_frontend_open_source_properties(obs_source_t *source)
 
    Opens the properties window of the specified source.
 
@@ -741,7 +741,7 @@ Functions
 
 ---------------------------------------
 
-.. function:: void *obs_frontend_open_filters(obs_source_t *source)
+.. function:: void *obs_frontend_open_source_filters(obs_source_t *source)
 
    Opens the filters window of the specified source.
 


### PR DESCRIPTION
### Description
Fixes the function names of `obs_frontend_open_source_properties()` and `obs_frontend_open_source_filters()`

### Motivation and Context
Accurate docs are a nice thing to have

### How Has This Been Tested?
n/a

### Types of changes
- Documentation (a change to documentation pages)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
