### PR TITLE
UI: Add `obs_frontend_open_source_interaction()`

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -618,6 +618,12 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 					  Q_ARG(OBSSource, OBSSource(source)));
 	}
 
+	void obs_frontend_open_source_interaction(obs_source_t *source) override
+	{
+		QMetaObject::invokeMethod(main, "OpenInteraction",
+					  Q_ARG(OBSSource, OBSSource(source)));
+	}
+
 	char *obs_frontend_get_current_record_output_path(void) override
 	{
 		const char *recordOutputPath = main->GetCurrentOutputPath();

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -547,6 +547,12 @@ void obs_frontend_open_source_filters(obs_source_t *source)
 		c->obs_frontend_open_source_filters(source);
 }
 
+void obs_frontend_open_source_interaction(obs_source_t *source)
+{
+	if (callbacks_valid())
+		c->obs_frontend_open_source_interaction(source);
+}
+
 char *obs_frontend_get_current_record_output_path(void)
 {
 	return !!callbacks_valid()

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -220,6 +220,7 @@ EXPORT void obs_frontend_reset_video(void);
 
 EXPORT void obs_frontend_open_source_properties(obs_source_t *source);
 EXPORT void obs_frontend_open_source_filters(obs_source_t *source);
+EXPORT void obs_frontend_open_source_interaction(obs_source_t *source);
 
 EXPORT char *obs_frontend_get_current_record_output_path(void);
 

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -138,6 +138,8 @@ struct obs_frontend_callbacks {
 	virtual void
 	obs_frontend_open_source_properties(obs_source_t *source) = 0;
 	virtual void obs_frontend_open_source_filters(obs_source_t *source) = 0;
+	virtual void
+	obs_frontend_open_source_interaction(obs_source_t *source) = 0;
 
 	virtual char *obs_frontend_get_current_record_output_path(void) = 0;
 };

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6199,6 +6199,15 @@ void OBSBasic::OpenProperties(OBSSource source)
 	CreatePropertiesWindow(source);
 }
 
+void OBSBasic::OpenInteraction(OBSSource source)
+{
+	if (source == nullptr) {
+		OBSSceneItem item = GetCurrentSceneItem();
+		source = obs_sceneitem_get_source(item);
+	}
+	CreateInteractionWindow(source);
+}
+
 void OBSBasic::OpenSceneFilters()
 {
 	OBSScene scene = GetCurrentScene();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1092,6 +1092,7 @@ private slots:
 	void OpenSceneFilters();
 	void OpenFilters(OBSSource source = nullptr);
 	void OpenProperties(OBSSource source = nullptr);
+	void OpenInteraction(OBSSource source = nullptr);
 
 	void EnablePreviewDisplay(bool enable);
 	void TogglePreview();

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -749,6 +749,15 @@ Functions
 
 ---------------------------------------
 
+.. function:: void *obs_frontend_open_source_interaction(obs_source_t *source)
+
+   Opens the interact window of the specified source. Only call if
+   source has the *OBS_SOURCE_INTERACTION* output flag.
+
+   :param source: The source to open the interact window of
+
+---------------------------------------
+
 .. function:: char *obs_frontend_get_current_record_output_path(void)
 
    :return: A new pointer to the current record output path.  Free


### PR DESCRIPTION
### Description
Adds a frontend api call to open the interact dialog of a source, just like the `_properties` and `_filters` functions.

### Motivation and Context
Wanted to have complete functionality for obs-websocket's `OpenInputPropertiesDialog` and `OpenInputFiltersDialog` requests.

### How Has This Been Tested?
Tested using unmerged `OpenInputInteractDialog` request.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
