### PR TITLE
UI: Increment showing in filters dialog

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -136,6 +136,8 @@ OBSBasicFilters::OBSBasicFilters(QWidget *parent, OBSSource source_)
 		UpdateSplitter();
 	}
 
+	obs_source_inc_showing(source);
+
 	auto addDrawCallback = [this]() {
 		obs_display_add_draw_callback(ui->preview->GetDisplay(),
 					      OBSBasicFilters::DrawPreview,
@@ -180,6 +182,7 @@ OBSBasicFilters::OBSBasicFilters(QWidget *parent, OBSSource source_)
 
 OBSBasicFilters::~OBSBasicFilters()
 {
+	obs_source_dec_showing(source);
 	ClearListItems(ui->asyncFilters);
 	ClearListItems(ui->effectFilters);
 }


### PR DESCRIPTION
### Description
Increment the show reference of a source when the filters dialog is open, just like the properties dialog.

### Motivation and Context
Keep the behavior of video displays in OBS consistent.

### How Has This Been Tested?
Subscribed to the `InputShowStateChanged` event in obs-websocket

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
