### PR TITLE
Publish to the correct Flathub branches

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -98,14 +98,14 @@ jobs:
         run: |
           ostree commit --repo=repo --canonical-permissions --branch=screenshots/x86_64 flatpak_app/screenshots
 
-      - name: "Publish to Flathub Beta"
+      - name: Publish to Flathub Beta
         uses: bilelmoussaoui/flatpak-github-actions/flat-manager@v4
         with:
           flat-manager-url: https://hub.flathub.org/
           repository: beta
           token: ${{ secrets.FLATHUB_BETA_TOKEN }}
 
-      - name: "Publish to Flathub"
+      - name: Publish to Flathub
         uses: bilelmoussaoui/flatpak-github-actions/flat-manager@v4
         if: "!contains(github.ref, '-beta') && !contains(github.ref, '-rc')"
         with:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -67,39 +67,55 @@ jobs:
     container:
       image: bilelmoussaoui/flatpak-github-actions:kde-5.15-21.08
       options: --privileged
+    strategy:
+      matrix:
+        branch: [stable, beta]
     steps:
+      - name: Check if job should run
+        id: should_run
+        if: "${{ matrix.branch != 'stable' || (!contains(github.ref, '-beta') && !contains(github.ref, '-rc')) }}"
+        run: |
+          echo "::set-output name=should_run::yes"
+
       - name: Checkout
         uses: actions/checkout@v2.3.3
+        if: steps.should_run.outputs.should_run == 'yes'
         with:
           submodules: 'recursive'
 
       - name: Build Flatpak Manifest
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@master
+        if: steps.should_run.outputs.should_run == 'yes'
         with:
           bundle: obs-studio-${{ github.sha }}.flatpak
           manifest-path: CI/flatpak/com.obsproject.Studio.json
           cache-key: flatpak-builder-${{ github.sha }}
           mirror-screenshots-url: https://dl.flathub.org/repo/screenshots
+          branch: ${{ matrix.branch }}
 
       - name: Validate AppStream
         shell: bash
         working-directory: ${{ env.FLATPAK_BUILD_PATH }}
+        if: steps.should_run.outputs.should_run == 'yes'
         run: |
           appstream-util validate appdata/com.obsproject.Studio.appdata.xml
 
       - name: Verify icon and metadata in app-info
         shell: bash
         working-directory: ${{ env.FLATPAK_BUILD_PATH }}
+        if: steps.should_run.outputs.should_run == 'yes'
         run: |
           test -f app-info/icons/flatpak/128x128/com.obsproject.Studio.png || { echo "Missing 128x128 icon in app-info" ; exit 1; }
           test -f app-info/xmls/com.obsproject.Studio.xml.gz || { echo "Missing com.obsproject.Studio.xml.gz in app-info" ; exit 1; }
 
       - name: Commit screenshots to the OSTree repository
+        if: steps.should_run.outputs.should_run == 'yes'
         run: |
           ostree commit --repo=repo --canonical-permissions --branch=screenshots/x86_64 flatpak_app/screenshots
 
       - name: Publish to Flathub Beta
         uses: bilelmoussaoui/flatpak-github-actions/flat-manager@v4
+        if: steps.should_run.outputs.should_run == 'yes' && matrix.branch == 'beta'
         with:
           flat-manager-url: https://hub.flathub.org/
           repository: beta
@@ -107,7 +123,7 @@ jobs:
 
       - name: Publish to Flathub
         uses: bilelmoussaoui/flatpak-github-actions/flat-manager@v4
-        if: "!contains(github.ref, '-beta') && !contains(github.ref, '-rc')"
+        if: steps.should_run.outputs.should_run == 'yes' && matrix.branch == 'stable'
         with:
           flat-manager-url: https://hub.flathub.org/
           repository: stable


### PR DESCRIPTION
### Description

Publish beta releases to Flathub Beta's `beta` branch, and stable releases to Flathub's `stable` branch.

### Motivation and Context

The publishing jobs only account for the Flathub repository, but they do not account for the branch within these repositories. We should publish to the correct branches of the correct repositories (`beta` branch for the `beta` repo, and `stable` branch for the `stable` repo).

### How Has This Been Tested?

 - I've created a fake beta release in my repo
 - [With this branch, it correctly built and (tried to) publish to the `beta` branch of Flatpak Beta](https://github.com/GeorgesStavracas/obs-studio/runs/4669361217?check_suite_focus=true)
 - [With this branch, the `stable` build was entirely skipped](https://github.com/GeorgesStavracas/obs-studio/runs/4669361193?check_suite_focus=true)

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.