### PR TITLE
Add additional buffer when writing to file with obs-ffmpeg-mux

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/CMakeLists.txt
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/CMakeLists.txt
@@ -11,6 +11,9 @@ target_sources(obs-ffmpeg-mux PRIVATE ffmpeg-mux.c ffmpeg-mux.h)
 
 target_link_libraries(obs-ffmpeg-mux PRIVATE OBS::libobs FFmpeg::avcodec
                                              FFmpeg::avutil FFmpeg::avformat)
+if(OS_WINDOWS)
+  target_link_libraries(obs-ffmpeg-mux PRIVATE OBS::w32-pthreads)
+endif()
 
 if(ENABLE_FFMPEG_MUX_DEBUG)
   target_compile_definitions(obs-ffmpeg-mux PRIVATE ENABLE_FFMPEG_MUX_DEBUG)


### PR DESCRIPTION
### Description
This adds a circular buffer to ffmpeg-mux when writing to a file. Output from ffmpeg is buffered so that slow disk I/O does not block ffmpeg writes, as this causes the pipe to become full and OBS stops sending frames with a misleading "Encoding overloaded!" warning. The buffer may grow to 256 MB depending on the rate of data coming in and out, if the buffer is full OBS will start waiting in ffmpeg writes.

A separate I/O thread is responsible for processing the contents of the buffer and writing them to the output file. It tries to process 1 MB at a time ~~and align writes to 4 KB for better performance on drives with caching disabled~~. Small writes are batched up to a minimum of 64 KB.

It also supports seeking in case the muxer has to go back to an earlier part of the file. This works by flushing any pending buffers and then moving the file offset and collecting more writes until enough data is ready or another seek occurs. This is necessary for MOV and MP4 in case the user passes `movflags=faststart`, without the seek callback these formats would not even work at all.

### Motivation and Context
A common problem that users experience is an "Encoding overloaded!" warning when writing to external drives or even internal HDDs with formats such as MKV where writes can be small. External drives often have write caching disabled for quick removal, so small writes become latency bound and block the ffmpeg output, resulting in skipped frames.

The large buffer also allows for other I/O hiccups to be less impactful, for example writing to a network drive might stall due to temporary bandwidth use by other network traffic and with this PR the data would be buffered instead of dropped.

### How Has This Been Tested?
Extensive testing of various rates of data coming in and out of the buffer, with artificial sleep calls to simulate a slow disk. Tested cases of buffer being full or too small. Tested a real-world example on Discord where it solved the problem outlined above.

One potential risk this feature adds is a user recording to a disk that cannot physically keep up with the output bitrate. Instead of getting near-immediate feedback with an "Encoding overloaded!" warning, the user will only notice something is wrong once the buffer is full, which could take a long time depending on the output bitrate. I don't consider this a practical issue though, as even an extremely slow disk or network at 100mbps would only take ~30 seconds before filling the buffer.

As there is the chance of introducing a dangerous race condition between threads (output data would be lost if this code has bugs), I'm marking this as draft until it has had more testing. For testing purposes, you only need to replace the `obs-ffmpeg-mux.exe` in a regular OBS install with [obs-ffmpeg-mux.zip](https://github.com/obsproject/obs-studio/files/7795071/obs-ffmpeg-mux.zip).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
