### PR TITLE
UI: Do not localize timestamp in log file

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -245,7 +245,7 @@ string CurrentTimeString()
 	auto now = system_clock::to_time_t(tp);
 	tstruct = *localtime(&now);
 
-	size_t written = strftime(buf, sizeof(buf), "%X", &tstruct);
+	size_t written = strftime(buf, sizeof(buf), "%T", &tstruct);
 	if (ratio_less<system_clock::period, seconds::period>::value &&
 	    written && (sizeof(buf) - written) > 5) {
 		auto tp_secs = time_point_cast<seconds>(tp);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
`%T` is specified for `strtime` instead of `%X` so that the time format is not localized.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Time format in the log was fluctuating in Linux. (I think its also applicable for Windows and macOS.) Sometimes `AM` or `PM` was inserted so that the milisecond was not always located just after the second.
Millisecond time in the log was added in 36ad777b8 but the millisecond was not always added just after the second digits depending on locale settings. Some locale settings add `AM` or `PM` at the end so that second and millisecond are separated.

The log is also read by support volunteers among a lot of country so that it should not be translated. Currently, some Asian language is written.
| `LANG` | Time format in log |
|--------|--------------------|
| `en_US.utf8` | `11:14:38 AM.952` |
| `C` | `14:10:19.180` |
| `ja_JP.UTF-8` | `14時11分44秒.347` |
| `ko_KR.UTF-8` | `14시 13분 57초.998` |
| `zh_CN.UTF-8` | `14:29:53.318` |

Previously, the log analyzer failed to parse the log file to retrieve OBS Version because the number of space (` `) changes.
https://discord.com/channels/348973006581923840/636682839382949888/883004441572278333
This bug was fixed in log analyzer but it would be easier to fix in OBS Studio to avoid similar error in future.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Fedora 34.

Since the `%T` format is same as the `%X` format in some locale, I think it won't break the behavior of the log analyzer.

The function `CurrentTimeString` is exported through `obs.hpp`. It could affect plugins. (I don't think there is a plugin depending on the format of this function.)

For Windows, `%T` is available for `strftime` according to [this document](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/strftime-wcsftime-strftime-l-wcsftime-l?view=msvc-170).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
  - Only tested on Linux.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
