### PR TITLE
UI: Disable WA_PaintOnScreen for projectors

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -30,6 +30,11 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 	if (isAlwaysOnTop)
 		setWindowFlags(Qt::WindowStaysOnTopHint);
 
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
+	// Prevents resizing of projector windows
+	setAttribute(Qt::WA_PaintOnScreen, false);
+#endif
+
 	type = type_;
 #ifdef __APPLE__
 	setWindowIcon(


### PR DESCRIPTION
Removing this attribute fixes #3582 and allows projector windows to be resized under KDE. It's more of a workaround, so this has to be tested by others. The flag is required for the main preview, since it'll freeze otherwise when restoring obs after minimizing it, but disabling it just for projectors fixed the issue without affecting the main preview or the preview in properties/filter dialogs.

### Description
Disabled the attribute in [UI/window-projector.cpp#L33](https://github.com/univrsal/obs-studio/blob/efbfe9bf9da0fd6680934219ef16bb6771e80c22/UI/window-projector.cpp#L33) for all systems that use X11.
Might need another check to not disable the attribute if Wayland is used.

### Motivation and Context
Resizing projectors is not possible under KDE otherwise without using workarounds listed in #3582.

### How Has This Been Tested?
Projectors and multiviews can be resized again. This was tested on Arch Linux under KDE Plasma 5.23.4 with KDE Frameworks 5.89.0 and Qt 5.15.2 as well as under Kubuntu. It was also tested under Cinnamon, which doesn't have the resizing bug, but the change introduced no regressions there.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] ~I have included updates to all appropriate documentation.~ (Doesn't apply)
