### PR TITLE
UI: Ignore resizing item when it is locked

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -572,6 +572,11 @@ void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 
 void OBSBasicPreview::UpdateCursor(uint32_t &flags)
 {
+	if (obs_sceneitem_locked(stretchItem)) {
+		unsetCursor();
+		return;
+	}
+
 	if (!flags && cursor().shape() != Qt::OpenHandCursor)
 		unsetCursor();
 	if (cursor().shape() != Qt::ArrowCursor)
@@ -1481,6 +1486,9 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 		pos.y = std::round(pos.y);
 
 		if (stretchHandle != ItemHandle::None) {
+			if (obs_sceneitem_locked(stretchItem))
+				return;
+
 			selectionBox = false;
 
 			OBSBasic *main = reinterpret_cast<OBSBasic *>(


### PR DESCRIPTION
### Description
Fixes https://github.com/obsproject/obs-studio/issues/5724

### Motivation and Context
Bug fix

### How Has This Been Tested?
Locked scene item and made sure it couldn't be resized.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
