### PR TITLE
libobs-d3d11: Log display color space info

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -25,7 +25,7 @@
 #include <memory>
 
 #include <windows.h>
-#include <dxgi1_5.h>
+#include <dxgi1_6.h>
 #include <d3d11_1.h>
 #include <d3dcompiler.h>
 


### PR DESCRIPTION
### Description
Add DXGI_COLOR_SPACE_TYPE and SDR white level when available for HDR
characteristics.

GetPathInfo/IsInternalVideoOutput functions were copied from MS docs.

### Motivation and Context
Will be useful for debugging HDR issues in the future.

### How Has This Been Tested?
Verified proper logging of color space when "Use HDR" is off/on, and white level when "SDR content brightness" slider is set to 0/40/100; 80/240/480 nits respectively. The slider uses this formula: `nits=4*x+80`

Windows 7 skips past the nonexistent functionality gracefully.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.