### PR TITLE
UI: Fix label offset on projector view

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -191,11 +191,8 @@ static inline uint32_t labelOffset(obs_source_t *label, uint32_t cx)
 {
 	uint32_t w = obs_source_get_width(label);
 
-	int n; // Number of scenes per row
+	int n; // Twice of scale factor of preview and program scenes
 	switch (multiviewLayout) {
-	case MultiviewLayout::HORIZONTAL_TOP_18_SCENES:
-		n = 6;
-		break;
 	case MultiviewLayout::HORIZONTAL_TOP_24_SCENES:
 		n = 6;
 		break;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
To calculate label offset, program and preview for 18-scene have same size as 8-scene but `labelOffset` returned different value between 18-scene and 8-scene.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fix #5718.

The labels are scaled by `ppiScaleX` and `ppiScaleY`, which is the scale factor for preview and program. Hence, the offset for the labels should be calculated based on the scale factor of preview and program.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: Fedora 34
OBS Version: 27.2.0-beta2-27-ge00195ad6 with this change
All 8 types are displayed and checked by eyeball.
- Horizontal, Top (8 Scenes)
- Horizontal, Bottom (8 Scenes)
- Vertical, Left (8 Scenes)
- Vertical, Right (8 Scenes)
- Horizontal, Top (18 Scenes)
- Horizontal, Top (24 Scenes)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
