### PR TITLE
UI: Disable auto-reconnects for srt  when there's no host

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -231,7 +231,6 @@ static bool get_audio_params(struct audio_params *audio, int *argc,
 static void ffmpeg_log_callback(void *param, int level, const char *format,
 				va_list args)
 {
-#ifdef DEBUG_FFMPEG
 	char out_buffer[4096];
 	struct dstr out = {0};
 
@@ -240,7 +239,7 @@ static void ffmpeg_log_callback(void *param, int level, const char *format,
 	if (global_stream_key && *global_stream_key) {
 		dstr_replace(&out, global_stream_key, "{stream_key}");
 	}
-
+#ifdef DEBUG_FFMPEG
 	switch (level) {
 	case AV_LOG_INFO:
 		fprintf(stdout, "info: [ffmpeg_muxer] %s", out.array);
@@ -258,13 +257,13 @@ static void ffmpeg_log_callback(void *param, int level, const char *format,
 			out.array, ANSI_COLOR_RESET);
 		fflush(stderr);
 	}
-
-	dstr_free(&out);
 #else
-	UNUSED_PARAMETER(level);
-	UNUSED_PARAMETER(format);
-	UNUSED_PARAMETER(args);
+	if (level == AV_LOG_ERROR) {
+		fprintf(stderr, "%s", out.array);
+		fflush(stderr);
+	}
 #endif
+	dstr_free(&out);
 	UNUSED_PARAMETER(param);
 }
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -443,13 +443,19 @@ static void signal_failure(struct ffmpeg_muxer *stream)
 
 	ret = deactivate(stream, 0);
 
+#define SRT_HOST_ERROR "Failed to resolve hostname"
+
 	switch (ret) {
 	case FFM_UNSUPPORTED:
 		code = OBS_OUTPUT_UNSUPPORTED;
 		break;
 	default:
 		if (stream->is_network) {
-			code = OBS_OUTPUT_DISCONNECTED;
+			char *result = strstr(error, SRT_HOST_ERROR);
+			if (result != NULL)
+				code = OBS_OUTPUT_CONNECT_FAILED;
+			else
+				code = OBS_OUTPUT_DISCONNECTED;
 		} else {
 			code = OBS_OUTPUT_ENCODE_ERROR;
 		}


### PR DESCRIPTION
### Description
When streaming with srt protocol, if the server is down and if auto-reconnect is enabled
(in Settings > Advanced), the stream hangs forever and obs must be killed.
This PR disables auto-reconnect for srt URLs when libsrt complains there's no host so that obs doesn't hang any more.
If there's a host, the auto-reconnect capability is preserved for srt.
In order to achieve that, librist log message "Failed to resolve hostname"
(https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/libsrt.c#L423) is transmitted to obs-ffmpeg-mux
which then signals OBS_OUTPUT_CONNECT_FAILED instead of OBS_OUTPUT_DISCONNECTED

### Motivation and Context
Bug reported in beta-testing channel of obs discord server by TheBigG.
`Using srt for streaming I noticed that if you get disconnected from your streaming ingest and you want to stop the stream, OBS will be stuck at "Attempting to reconnect" for ever and you have to kill it with taskmanager.`

NB: bug confirmed by @Gol-D-Ace and myself.

### How Has This Been Tested?
Tested against brime.tv Frankfurt srt server which was down at the time of testing.
Obs no longer hangs and disconnects gracefully.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
