### PR TITLE
CI: Use GitHub mirror for PipeWire repository

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -348,7 +348,7 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://gitlab.freedesktop.org/pipewire/pipewire.git",
+          "url": "https://github.com/pipewire/pipewire.git",
           "tag": "0.3.40",
           "commit": "7afd80052b7c49754a13c9ab49c368f95b60e0a7"
         }


### PR DESCRIPTION
### Description

Use official Github mirror for Freedesktop Pipewire GitLab.

### Motivation and Context

Constant 504's.

### How Has This Been Tested?
Run CI

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
