### PR TITLE
Fix window flashing when starting minimized to tray

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1981,9 +1981,7 @@ void OBSBasic::OBSInit()
 	ui->lockUI->setChecked(docksLocked);
 	ui->lockUI->blockSignals(false);
 
-#ifndef __APPLE__
 	SystemTray(true);
-#endif
 
 #if defined(_WIN32) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 	taskBtn->setWindow(windowHandle());
@@ -2059,11 +2057,6 @@ void OBSBasic::OBSInit()
 	OnFirstLoad();
 
 	activateWindow();
-
-#ifdef __APPLE__
-	QMetaObject::invokeMethod(this, "DeferredSysTrayLoad",
-				  Qt::QueuedConnection, Q_ARG(int, 10));
-#endif
 }
 
 void OBSBasic::OnFirstLoad()
@@ -2090,20 +2083,6 @@ void OBSBasic::OnFirstLoad()
 
 	if (showLogViewerOnStartup)
 		on_actionViewCurrentLog_triggered();
-}
-
-void OBSBasic::DeferredSysTrayLoad(int requeueCount)
-{
-	if (--requeueCount > 0) {
-		QMetaObject::invokeMethod(this, "DeferredSysTrayLoad",
-					  Qt::QueuedConnection,
-					  Q_ARG(int, requeueCount));
-		return;
-	}
-
-	/* Minimizng to tray on initial startup does not work on mac
-	 * unless it is done in the deferred load */
-	SystemTray(true);
 }
 
 /* shows a "what's new" page on startup of new versions using CEF */

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1118,8 +1118,6 @@ private slots:
 	void OpenMultiviewWindow();
 	void OpenSceneWindow();
 
-	void DeferredSysTrayLoad(int requeueCount);
-
 	void StackedMixerAreaContextMenuRequested();
 
 	void ResizeOutputSizeOfSource();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
Moves the processing to hide the window earlier in the startup process - rather than showing the main window and hiding it in the tray initialization, just _don't_ show the main window. This prevents the window from briefly flashing and taking focus from other apps.

This requires a new check for `sysTrayEnabled` - we need to know whether the tray icon will be visible. (If it's not, and the window is hidden, there would be no way to maximize the window.)

Lastly, this PR removes the Apple-specific workarounds, as they no longer appear to be necessary.
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #2668 and prevents the main window flashing on startup.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

_Setting_
1. Enable **System Tray** and **Minimize to system tray when started**.
2. Restart OBS.
2. Verify tray icon appears and window does not flash.
3. Disable **System Tray** and restart OBS.
4. Verify window opens on start.

_Launch Flag_
1. Enable **System Tray**
2. Start OBS with `--minimze-to-tray` option.
3. Verify tray icon appears and window does not flash.
4. Disable **System Tray**
6. Start OBS with `--minimze-to-tray` option.
7. Verify window opens on start (you cannot minimize to tray if no tray icon)

Verified on Windows 10 x64 (19043.1415) and MacOS Big Sur (11.6.2).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
