### PR TITLE
UI: Stop locking filter mutex while loading properties

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -188,7 +188,8 @@ OBSPropertiesView::OBSPropertiesView(OBSData settings_, void *obj_,
 	  minSize(minSize_)
 {
 	setFrameShape(QFrame::NoFrame);
-	ReloadProperties();
+	QMetaObject::invokeMethod(this, "ReloadProperties",
+				  Qt::QueuedConnection);
 }
 
 OBSPropertiesView::OBSPropertiesView(OBSData settings_, const char *type_,
@@ -202,7 +203,8 @@ OBSPropertiesView::OBSPropertiesView(OBSData settings_, const char *type_,
 	  minSize(minSize_)
 {
 	setFrameShape(QFrame::NoFrame);
-	ReloadProperties();
+	QMetaObject::invokeMethod(this, "ReloadProperties",
+				  Qt::QueuedConnection);
 }
 
 void OBSPropertiesView::resizeEvent(QResizeEvent *event)


### PR DESCRIPTION
### Description
Reordering the filters makes the filter mutex of the source locked while loading a new the properties of a filter which may require other locks. By loading the properties of the filter on a QueuedConnection we make sure the filter mutex is cleared when that happens.

### Motivation and Context
I don't like deadlocks.
The main UI thread gets a lock on the filter mutex followed by a lock on the app sources mutex to fill the properties of the filter
while the graphics thread does a lock on the app sources mutex followed by a lock on the filter mutex

### How Has This Been Tested?
On windows 64 bit by reordering move transition override filters

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
