### PR TITLE
libobs,docs: Allow to enforce unique name and value in list property

### DIFF
--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -186,7 +186,8 @@ Property Object Functions
 .. function:: obs_property_t *obs_properties_add_list(obs_properties_t *props, const char *name, const char *description, enum obs_combo_type type, enum obs_combo_format format)
 
    Adds an integer/string/floating point item list.  This would be
-   implemented as a combo box in user interface.
+   implemented as a combo box in user interface. Duplicated item are
+   allowed by default.
 
    :param    name:        Setting identifier string
    :param    description: Localized name shown to user
@@ -215,6 +216,8 @@ Property Object Functions
    - :c:func:`obs_property_list_insert_float`
    - :c:func:`obs_property_list_item_remove`
    - :c:func:`obs_property_list_clear`
+   - :c:func:`obs_property_list_set_enforce_unique_name`
+   - :c:func:`obs_property_list_set_enforce_unique_value`
 
 ---------------------
 
@@ -479,6 +482,14 @@ Property Enumeration Functions
 
 ---------------------
 
+.. function:: bool obs_property_list_enforce_unique_name(obs_property_t *p)
+
+---------------------
+
+.. function:: bool obs_property_list_enforce_unique_value(obs_property_t *p)
+
+---------------------
+
 .. function:: bool obs_property_list_item_disabled(obs_property_t *p, size_t idx)
 
 ---------------------
@@ -726,3 +737,15 @@ Property Modification Functions
 ---------------------
 
 .. function:: void obs_property_button_set_url(obs_property_t *p, char *url)
+
+---------------------
+
+.. function:: void obs_property_list_set_enforce_unique_name(obs_property_t *p, bool enforce)
+
+    Set up the property to disallow or not items with the same name.
+
+---------------------
+
+.. function:: void obs_property_list_set_enforce_unique_value(obs_property_t *p, bool enforce)
+
+    Set up the property to disallow or not items with the same value.

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -338,6 +338,8 @@ EXPORT const char *obs_property_path_filter(obs_property_t *p);
 EXPORT const char *obs_property_path_default_path(obs_property_t *p);
 EXPORT enum obs_combo_type obs_property_list_type(obs_property_t *p);
 EXPORT enum obs_combo_format obs_property_list_format(obs_property_t *p);
+EXPORT bool obs_property_list_enforce_unique_name(obs_property_t *p);
+EXPORT bool obs_property_list_enforce_unique_value(obs_property_t *p);
 
 EXPORT void obs_property_int_set_limits(obs_property_t *p, int min, int max,
 					int step);
@@ -355,6 +357,12 @@ EXPORT void obs_property_text_set_info_word_wrap(obs_property_t *p,
 EXPORT void obs_property_button_set_type(obs_property_t *p,
 					 enum obs_button_type type);
 EXPORT void obs_property_button_set_url(obs_property_t *p, char *url);
+
+EXPORT void obs_property_list_set_enforce_unique_name(obs_property_t *p,
+						      bool enforce);
+
+EXPORT void obs_property_list_set_enforce_unique_value(obs_property_t *p,
+						       bool enforce);
 
 EXPORT void obs_property_list_clear(obs_property_t *p);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add to the Properties API the possibility to not allow adding duplicate by name and/or by value in lists with `obs_property_list_set_enforce_unique_name` and `obs_property_list_set_enforce_unique_val`.

If duplicates are not allowed, adding/inserting functions will not add data to the `DARRAY` if duplicate.

Duplicates are allowed by default to not break how the Properties API actually behave.

#### My use case
I'm working on my RFCs and I actually get into a situation where I have a list of items (server with their protocol) where I get duplicates (protocol when listed) that I don't want to have inside my list (of protocol in my case).

So rather implementing it in my properties function, I thought that adding it to the Properties API could be a nice addition since my use case could not be the only one to have a use of it.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Rather then forcing developer to check if they are inserting an item that is already inside the property by reinventing the wheel, why not add the check inside the libobs itself.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Adding this to a properties function and each of this list should have only one item.
```c
p = obs_properties_add_list(props, "test_str_dup", "Test name duplicate string", OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_STRING);
obs_property_list_set_enforce_unique_name(p, true);
obs_property_list_add_string(p, "TEST", "test");
obs_property_list_add_string(p, "TEST", "test2");

p = obs_properties_add_list(props, "test_int_dup", "Test name duplicate integer", OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
obs_property_list_set_enforce_unique_name(p, true);
obs_property_list_add_int(p, "TEST", 1);
obs_property_list_add_int(p, "TEST", 2);

p = obs_properties_add_list(props, "test_val_dup", "Test value duplicate integrer", OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
obs_property_list_set_enforce_unique_value(p, true);
obs_property_list_add_int(p, "TEST", 1);
obs_property_list_add_int(p, "TEST 2", 1);
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
 - New feature (non-breaking change which adds functionality)
 - Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
