### PR TITLE
libobs: Open a separate X11 connection for hotkeys

### DIFF
--- a/libobs/obs-nix-x11.c
+++ b/libobs/obs-nix-x11.c
@@ -828,7 +828,8 @@ static inline void registerMouseEvents(struct obs_core_hotkeys *hotkeys)
 
 static bool obs_nix_x11_hotkeys_platform_init(struct obs_core_hotkeys *hotkeys)
 {
-	Display *display = obs_get_nix_platform_display();
+	// Open a new X11 connection here, this avoids Qt masking events we care about.
+	Display *display = XOpenDisplay(NULL);
 	if (!display)
 		return false;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Qt will mask certain input events. In order to avoid them masking things
like mouse button events we open a new display here.

This ended up getting introduced in 506b950 but we didnt notice until later.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #4843

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Mouse 4 works when pressed while another window is active. This is the same as the behavior we had for 26.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
