### PR TITLE
plugins: Use av_packet_alloc instead of av_init_packet

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -57,6 +57,8 @@ struct vaapi_encoder {
 	AVCodec *vaapi;
 	AVCodecContext *context;
 
+	AVPacket *packet;
+
 	AVFrame *vframe;
 
 	DARRAY(uint8_t) buffer;
@@ -158,6 +160,8 @@ static bool vaapi_init_codec(struct vaapi_encoder *enc, const char *path)
 		warn("Failed to open VAAPI codec: %s", av_err2str(ret));
 		return false;
 	}
+
+	enc->packet = av_packet_alloc();
 
 	enc->initialized = true;
 	return true;
@@ -298,29 +302,33 @@ static bool vaapi_update(void *data, obs_data_t *settings)
 	return vaapi_init_codec(enc, device);
 }
 
+static inline void flush_remaining_packets(struct vaapi_encoder *enc)
+{
+	int r_pkt = 1;
+
+	while (r_pkt) {
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 40, 101)
+		if (avcodec_receive_packet(enc->context, enc->packet) < 0)
+			break;
+#else
+		if (avcodec_encode_video2(enc->context, enc->packet, NULL,
+					  &r_pkt) < 0)
+			break;
+#endif
+
+		if (r_pkt)
+			av_packet_unref(enc->packet);
+	}
+}
+
 static void vaapi_destroy(void *data)
 {
 	struct vaapi_encoder *enc = data;
 
-	if (enc->initialized) {
-		AVPacket pkt = {0};
-		int r_pkt = 1;
+	if (enc->initialized)
+		flush_remaining_packets(enc);
 
-		while (r_pkt) {
-#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 40, 101)
-			if (avcodec_receive_packet(enc->context, &pkt) < 0)
-				break;
-#else
-			if (avcodec_encode_video2(enc->context, &pkt, NULL,
-						  &r_pkt) < 0)
-				break;
-#endif
-
-			if (r_pkt)
-				av_packet_unref(&pkt);
-		}
-	}
-
+	av_packet_free(&enc->packet);
 	avcodec_close(enc->context);
 	av_frame_unref(enc->vframe);
 	av_frame_free(&enc->vframe);
@@ -405,7 +413,6 @@ static bool vaapi_encode(void *data, struct encoder_frame *frame,
 {
 	struct vaapi_encoder *enc = data;
 	AVFrame *hwframe = NULL;
-	AVPacket av_pkt;
 	int got_packet;
 	int ret;
 
@@ -443,19 +450,17 @@ static bool vaapi_encode(void *data, struct encoder_frame *frame,
 		goto fail;
 	}
 
-	av_init_packet(&av_pkt);
-
 #if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 40, 101)
 	ret = avcodec_send_frame(enc->context, hwframe);
 	if (ret == 0)
-		ret = avcodec_receive_packet(enc->context, &av_pkt);
+		ret = avcodec_receive_packet(enc->context, enc->packet);
 
 	got_packet = (ret == 0);
 
 	if (ret == AVERROR_EOF || ret == AVERROR(EAGAIN))
 		ret = 0;
 #else
-	ret = avcodec_encode_video2(enc->context, &av_pkt, hwframe,
+	ret = avcodec_encode_video2(enc->context, enc->packet, hwframe,
 				    &got_packet);
 #endif
 	if (ret < 0) {
@@ -463,25 +468,27 @@ static bool vaapi_encode(void *data, struct encoder_frame *frame,
 		goto fail;
 	}
 
-	if (got_packet && av_pkt.size) {
+	if (got_packet && enc->packet->size) {
 		if (enc->first_packet) {
 			uint8_t *new_packet;
 			size_t size;
 
 			enc->first_packet = false;
-			obs_extract_avc_headers(av_pkt.data, av_pkt.size,
-						&new_packet, &size,
-						&enc->header, &enc->header_size,
-						&enc->sei, &enc->sei_size);
+			obs_extract_avc_headers(enc->packet->data,
+						enc->packet->size, &new_packet,
+						&size, &enc->header,
+						&enc->header_size, &enc->sei,
+						&enc->sei_size);
 
 			da_copy_array(enc->buffer, new_packet, size);
 			bfree(new_packet);
 		} else {
-			da_copy_array(enc->buffer, av_pkt.data, av_pkt.size);
+			da_copy_array(enc->buffer, enc->packet->data,
+				      enc->packet->size);
 		}
 
-		packet->pts = av_pkt.pts;
-		packet->dts = av_pkt.dts;
+		packet->pts = enc->packet->pts;
+		packet->dts = enc->packet->dts;
 		packet->data = enc->buffer.array;
 		packet->size = enc->buffer.num;
 		packet->type = OBS_ENCODER_VIDEO;
@@ -491,7 +498,7 @@ static bool vaapi_encode(void *data, struct encoder_frame *frame,
 		*received_packet = false;
 	}
 
-	av_packet_unref(&av_pkt);
+	av_packet_unref(enc->packet);
 	av_frame_free(&hwframe);
 	return true;
 

--- a/plugins/win-dshow/ffmpeg-decode.c
+++ b/plugins/win-dshow/ffmpeg-decode.c
@@ -220,7 +220,6 @@ bool ffmpeg_decode_audio(struct ffmpeg_decode *decode, uint8_t *data,
 			 size_t size, struct obs_source_audio *audio,
 			 bool *got_output)
 {
-	AVPacket packet = {0};
 	int got_frame = false;
 	int ret = 0;
 
@@ -228,18 +227,21 @@ bool ffmpeg_decode_audio(struct ffmpeg_decode *decode, uint8_t *data,
 
 	copy_data(decode, data, size);
 
-	av_init_packet(&packet);
-	packet.data = decode->packet_buffer;
-	packet.size = (int)size;
-
 	if (!decode->frame) {
 		decode->frame = av_frame_alloc();
 		if (!decode->frame)
 			return false;
 	}
 
-	if (data && size)
-		ret = avcodec_send_packet(decode->decoder, &packet);
+	if (data && size) {
+		AVPacket *packet = av_packet_alloc();
+		packet->data = decode->packet_buffer;
+		packet->size = (int)size;
+
+		ret = avcodec_send_packet(decode->decoder, packet);
+
+		av_packet_free(&packet);
+	}
 	if (ret == 0)
 		ret = avcodec_receive_frame(decode->decoder, decode->frame);
 
@@ -292,7 +294,6 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode, uint8_t *data,
 			 enum video_range_type range,
 			 struct obs_source_frame2 *frame, bool *got_output)
 {
-	AVPacket packet = {0};
 	int got_frame = false;
 	AVFrame *out_frame;
 	int ret;
@@ -300,15 +301,6 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode, uint8_t *data,
 	*got_output = false;
 
 	copy_data(decode, data, size);
-
-	av_init_packet(&packet);
-	packet.data = decode->packet_buffer;
-	packet.size = (int)size;
-	packet.pts = *ts;
-
-	if (decode->codec->id == AV_CODEC_ID_H264 &&
-	    obs_avc_keyframe(data, size))
-		packet.flags |= AV_PKT_FLAG_KEY;
 
 	if (!decode->frame) {
 		decode->frame = av_frame_alloc();
@@ -324,10 +316,21 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode, uint8_t *data,
 
 	out_frame = decode->hw ? decode->hw_frame : decode->frame;
 
-	ret = avcodec_send_packet(decode->decoder, &packet);
+	AVPacket *packet = av_packet_alloc();
+	packet->data = decode->packet_buffer;
+	packet->size = (int)size;
+	packet->pts = *ts;
+
+	if (decode->codec->id == AV_CODEC_ID_H264 &&
+	    obs_avc_keyframe(data, size))
+		packet->flags |= AV_PKT_FLAG_KEY;
+
+	ret = avcodec_send_packet(decode->decoder, packet);
 	if (ret == 0) {
 		ret = avcodec_receive_frame(decode->decoder, out_frame);
 	}
+
+	av_packet_free(&packet);
 
 	got_frame = (ret == 0);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Instead of allocating `AVPacket` on stack, allocate it by `av_packet_alloc()`.
In ffmpeg-mux, ffmpeg-vaapi, and obs-ffmpeg-nvenc, AVPacket is allocated at the initialization to avoid frequent allocation of AVPacket.
The deprecated function `av_packet_alloc` is also found in `deps` but this PR does not change `deps`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
According to FFmpeg, `av_init_packet` and `sizeof (AVPacket)` are deprecated.
> sizeof(AVPacket) being a part of the public ABI is deprecated. once av_init_packet() is removed, new packets will only be able to be allocated with av_packet_alloc().

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Fedora 34 (Linux).

Note that `obs-ffmpeg/obs-ffmpeg-nvenc.c` and `win-dshow/ffmpeg-decode.c` are never tested.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
