### PR TITLE
aja: Fix format-security warning which lead to a build error on some Linux distributions

### DIFF
--- a/plugins/aja/aja-routing.cpp
+++ b/plugins/aja/aja-routing.cpp
@@ -574,8 +574,7 @@ void Routing::LogRoutingPreset(const RoutingPreset &rp)
 	};
 
 	std::stringstream ss;
-	ss << "[ AJA Crosspoint Routing Preset ]"
-	   << "\nPreset: " << rp.name;
+	ss << "\nPreset: " << rp.name;
 	if (rp.kind == ConnectionKind::SDI) {
 		ss << "\nVPID Standard: 0x"
 		   << hexStr(static_cast<uint8_t>(rp.vpid_standard));
@@ -584,7 +583,7 @@ void Routing::LogRoutingPreset(const RoutingPreset &rp)
 	   << "\nChannels: " << rp.num_channels
 	   << "\nFramestores: " << rp.num_framestores;
 
-	blog(LOG_INFO, ss.str().c_str());
+	blog(LOG_INFO, "[ AJA Crosspoint Routing Preset ]%s", ss.str().c_str());
 
 	if (rp.device_ids.size() > 0) {
 		ss.clear();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Issue introduced by f09137a2e00aecbce634d3e46a8a809ca8cd6907.

On some Linux distributions `-Werror=format-security` is set when building package keeping OBS Studio from being built with AJA plugins.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Allow OBS Studio to be build with `-Werror=format-security` set. Which is the case on ArchLinux build system.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Build OBS Studio with `makepkg`. 
- On master it would emit an error.
- On this branch it builds.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
