### PR TITLE
aja: Add ability to toggle AJA HDMI Multi View feature from AJA Output UI

### DIFF
--- a/UI/frontend-plugins/aja-output-ui/AJAOutputUI.h
+++ b/UI/frontend-plugins/aja-output-ui/AJAOutputUI.h
@@ -5,12 +5,17 @@
 #include "ui_output.h"
 #include "../../UI/properties-view.hpp"
 
+namespace aja {
+class CardManager;
+}
+
 class AJAOutputUI : public QDialog {
 	Q_OBJECT
 private:
 	OBSPropertiesView *propertiesView;
 	OBSPropertiesView *previewPropertiesView;
-
+	OBSPropertiesView *miscPropertiesView;
+	aja::CardManager *cardManager;
 public slots:
 	void on_outputButton_clicked();
 	void PropertiesChanged();
@@ -20,14 +25,18 @@ public slots:
 	void PreviewPropertiesChanged();
 	void PreviewOutputStateChanged(bool);
 
+	void MiscPropertiesChanged();
+
 public:
 	std::unique_ptr<Ui_Output> ui;
 	AJAOutputUI(QWidget *parent);
 
+	void SetCardManager(aja::CardManager *cm);
+	aja::CardManager *GetCardManager();
+
 	void ShowHideDialog();
-
 	void SaveSettings(const char *filename, obs_data_t *settings);
-
 	void SetupPropertiesView();
 	void SetupPreviewPropertiesView();
+	void SetupMiscPropertiesView();
 };

--- a/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
@@ -44,8 +44,16 @@ set(aja-output-ui_HEADERS
 	../../spinbox-ignorewheel.hpp
 	AJAOutputUI.h
 	aja-ui-main.h
+	../../../plugins/aja/aja-card-manager.hpp
+	../../../plugins/aja/aja-common.hpp
+	../../../plugins/aja/aja-enums.hpp
+	../../../plugins/aja/aja-presets.hpp
+	../../../plugins/aja/aja-props.hpp
+	../../../plugins/aja/aja-routing.hpp
 	../../../plugins/aja/aja-ui-props.hpp
-	../../../plugins/aja/aja-enums.hpp)
+	../../../plugins/aja/aja-vpid-data.hpp
+	../../../plugins/aja/aja-widget-io.hpp
+	)
 
 set(aja-output-ui_SOURCES
 	${aja-output-ui_SOURCES}
@@ -57,7 +65,15 @@ set(aja-output-ui_SOURCES
 	../../combobox-ignorewheel.cpp
 	../../spinbox-ignorewheel.cpp
 	AJAOutputUI.cpp
-	aja-ui-main.cpp)
+	aja-ui-main.cpp
+	../../../plugins/aja/aja-card-manager.cpp
+	../../../plugins/aja/aja-common.cpp
+	../../../plugins/aja/aja-presets.cpp
+	../../../plugins/aja/aja-props.cpp
+	../../../plugins/aja/aja-routing.cpp
+	../../../plugins/aja/aja-vpid-data.cpp
+	../../../plugins/aja/aja-widget-io.cpp
+	)
 
 set(aja-output-ui_UI
 	${aja-output-ui_UI}

--- a/UI/frontend-plugins/aja-output-ui/aja-ui-main.h
+++ b/UI/frontend-plugins/aja-output-ui/aja-ui-main.h
@@ -2,9 +2,23 @@
 
 #include <obs.hpp>
 
+#include <ajantv2/includes/ntv2enums.h>
+namespace aja {
+class CardManager;
+}
+
 static const char *kProgramPropsFilename = "ajaOutputProps.json";
 static const char *kPreviewPropsFilename = "ajaPreviewOutputProps.json";
+static const char *kMiscPropsFilename = "ajaMiscProps.json";
 
 OBSData load_settings(const char *filename);
 void output_toggle();
 void preview_output_toggle();
+void populate_misc_device_list(obs_property_t *list,
+			       aja::CardManager *cardManager,
+			       NTV2DeviceID &firstDeviceID);
+void populate_multi_view_audio_sources(obs_property_t *list, NTV2DeviceID id);
+bool on_misc_device_selected(void *data, obs_properties_t *props,
+			     obs_property_t *list, obs_data_t *settings);
+bool on_multi_view_toggle(void *data, obs_properties_t *props,
+			  obs_property_t *list, obs_data_t *settings);

--- a/UI/frontend-plugins/aja-output-ui/data/locale/en-US.ini
+++ b/UI/frontend-plugins/aja-output-ui/data/locale/en-US.ini
@@ -1,3 +1,6 @@
 AJAOutput.Device="AJA I/O Device Output"
 AJAOutput.ProgramOutput="Program Output"
 AJAOutput.PreviewOutput="Preview Output"
+AJAOutput.MiscOutput="Additional Settings"
+AJAOutput.MultiViewEnable="Enable Multi View"
+AJAOutput.MultiViewAudioSource="Multi View Audio Source"

--- a/UI/frontend-plugins/aja-output-ui/forms/output.ui
+++ b/UI/frontend-plugins/aja-output-ui/forms/output.ui
@@ -106,6 +106,16 @@
      </item>
     </layout>
    </item>
+   <item>
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>AJAOutput.MiscOutput</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="miscPropertiesLayout"/>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/plugins/aja/aja-common.cpp
+++ b/plugins/aja/aja-common.cpp
@@ -1135,4 +1135,9 @@ VPIDStandard DetermineVPIDStandard(NTV2DeviceID id, IOSelection io,
 	return vpid;
 }
 
+std::vector<NTV2DeviceID> MultiViewCards()
+{
+	return {DEVICE_ID_IOX3};
+}
+
 } // aja

--- a/plugins/aja/aja-common.hpp
+++ b/plugins/aja/aja-common.hpp
@@ -98,4 +98,6 @@ extern VPIDStandard DetermineVPIDStandard(NTV2DeviceID id, IOSelection io,
 					  NTV2VideoFormat vf,
 					  NTV2PixelFormat pf, SDITransport trx,
 					  SDITransport4K t4k);
+extern std::vector<NTV2DeviceID> MultiViewCards();
+
 } // aja


### PR DESCRIPTION
### Description
Add GUI options to the AJA Output UI window for toggling the AJA HDMI Multi View feature on the upcoming AJA ioX3 device. The UI for this feature will only appear if an ioX3 device is connected to the host system. The AJA HDMI Multi View feature in the ioX3 device allows monitoring each of the 4 SDI inputs as separate 1080p quadrants of a UHD/4K HDMI output stream. Monitoring of the HDMI Multi View stream requires a UHD/4K capable monitor. All rasterization of the Multi View frame occurs in hardware of the ioX3.

### Changes
1. Added an "Additional Settings" section to the AJA Output window containing the following UI elements:
    - **Device** selection drop-down menu enumerating the AJA devices connected to the host system. If an ioX3 device is selected the **Enable Multi View** checkbox and **Multi View Audio Source** drop-down will be enabled for interaction. If another device is selected the checkbox and drop-down will be grayed-out/disabled.
    - **Enable Multi View** checkbox - toggles the HDMI Multi View output on and off for the selected ioX3 device.
    - **Multi View Audio Source** drop-down - Select one of the available SDI spigots to use for audio pass-through to the HDMI Multi View output.
2. Add functions to toggle the Multi View output stream on and off for the selected ioX3 device via the AJA NTV2 SDK. Requires at least version 16.1 of the AJA NTV2 driver.
3. Receive aja::CardManager instance passed from `aja` plugin via OBS signal/calldata mechanism.
![image](https://user-images.githubusercontent.com/78836538/148905751-de75cf4f-c769-4fa3-aa75-ab23b0a02b1e.png)

### Motivation and Context
This change was added to allow toggling the HDMI Multi View feature of the upcoming AJA ioX3 capture device from within the AJA Output UI in OBS.

### How Has This Been Tested?
Tested by AJA QA with pre-production AJA ioX3 units on Windows 10 and macOS Catalina.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation. (N/A)
