### PR TITLE
Set desktopFileName for QApplication

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1164,6 +1164,8 @@ OBSApp::OBSApp(int &argc, char **argv, profiler_name_store_t *store)
 #else
 	setWindowIcon(QIcon::fromTheme("obs", QIcon(":/res/images/obs.png")));
 #endif
+
+	setDesktopFileName("com.obsproject.Studio");
 }
 
 OBSApp::~OBSApp()


### PR DESCRIPTION
This needs to matcht the base name of the .desktop file name.

This is needed for propagating the correct app id on Wayland,
which is needed e.g. for proper window icons on Plasma Wayland
