### PR TITLE
media-playback: Fix bug with rist streams.

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -606,6 +606,8 @@ static int interrupt_callback(void *data)
 	return stop;
 }
 
+#define RIST_PROTO "rist"
+
 static bool init_avformat(mp_media_t *m)
 {
 #if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(59, 0, 100)
@@ -624,7 +626,8 @@ static bool init_avformat(mp_media_t *m)
 	}
 
 	AVDictionary *opts = NULL;
-	if (m->buffering && !m->is_local_file)
+	bool is_rist = strncmp(m->path, RIST_PROTO, strlen(RIST_PROTO)) == 0;
+	if (m->buffering && !m->is_local_file && !is_rist)
 		av_dict_set_int(&opts, "buffer_size", m->buffering, 0);
 
 	m->fmt = avformat_alloc_context();


### PR DESCRIPTION
### Description
We currently pass a 'buffer_size' option to avformat in bytes.
Unfortunately, avformat/librist.c admits an option with the same name but in milliseconds.
The default values set in the UI (2 MB= 2 10^6) go beyond the range admitted in ms (0-30 000)
so avformat issues errors.
This fix disables the option when rist protocol is detected.

### Motivation and Context

Bug notice given in discord #beta channel : 

- Deagan: `Was RIST support only for outputting from OBS then, not currently for an inbound Media Source? I am attempting to use Larix Streamer to receive a RIST transmission using the "rist://@192.168.x.x:PORT?cname=RECEIVER" formatting, still to no resolve.`
- leb: `while i can't seem to get it working either with the same setup, i can replicate a crash with a rist url in the media source when the network buffer is set to 0mb`

rist streams currently aren't working with Media Source because of the buffer_size param
which is passed in wrong units.
It's better to be able to decode these streams.

Note that instead of disabling the buffer_size option which is set in UI (0-16 MB),
another option would be to translate the MB into milliseconds.
Since we don't know the incoming bitrate, it can't be an exact correspondence
though. 
An option I considered would be to have defaults in correspondence (2 MB <-> 1000 ms).
I leave this open to discussion. It wouldn't be difficult to implement.

### How Has This Been Tested?
Throw a rist stream (ex: w/ Larix Broadcaster) to obs-studio and check it is displayed.
(tested on windows 10 and macos 10.15.4)

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
