### PR TITLE
aja: Fix for invalid default settings and empty cardID string

### DIFF
--- a/UI/frontend-plugins/aja-output-ui/AJAOutputUI.cpp
+++ b/UI/frontend-plugins/aja-output-ui/AJAOutputUI.cpp
@@ -51,17 +51,16 @@ void AJAOutputUI::SetupPropertiesView()
 			static_cast<long long>(IOSelection::Invalid));
 		obs_data_set_default_int(
 			settings, kUIPropVideoFormatSelect.id,
-			static_cast<long long>(NTV2_FORMAT_720p_5994));
+			static_cast<long long>(kDefaultAJAVideoFormat));
 		obs_data_set_default_int(
 			settings, kUIPropPixelFormatSelect.id,
-			static_cast<long long>(NTV2_FBF_8BIT_YCBCR));
+			static_cast<long long>(kDefaultAJAPixelFormat));
 		obs_data_set_default_int(
 			settings, kUIPropSDITransport.id,
-			static_cast<long long>(SDITransport::SingleLink));
+			static_cast<long long>(kDefaultAJASDITransport));
 		obs_data_set_default_int(
 			settings, kUIPropSDITransport4K.id,
-			static_cast<long long>(
-				SDITransport4K::TwoSampleInterleave));
+			static_cast<long long>(kDefaultAJASDITransport4K));
 	}
 
 	// Assign an ID to the program output plugin instance for channel usage tracking
@@ -109,17 +108,16 @@ void AJAOutputUI::SetupPreviewPropertiesView()
 			static_cast<long long>(IOSelection::Invalid));
 		obs_data_set_default_int(
 			settings, kUIPropVideoFormatSelect.id,
-			static_cast<long long>(NTV2_FORMAT_720p_5994));
+			static_cast<long long>(kDefaultAJAVideoFormat));
 		obs_data_set_default_int(
 			settings, kUIPropPixelFormatSelect.id,
-			static_cast<long long>(NTV2_FBF_8BIT_YCBCR));
+			static_cast<long long>(kDefaultAJAPixelFormat));
 		obs_data_set_default_int(
 			settings, kUIPropSDITransport.id,
-			static_cast<long long>(SDITransport::SingleLink));
+			static_cast<long long>(kDefaultAJASDITransport));
 		obs_data_set_default_int(
 			settings, kUIPropSDITransport4K.id,
-			static_cast<long long>(
-				SDITransport4K::TwoSampleInterleave));
+			static_cast<long long>(kDefaultAJASDITransport4K));
 	}
 
 	// Assign an ID to the program output plugin instance for channel usage tracking

--- a/UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp
+++ b/UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp
@@ -224,7 +224,7 @@ bool on_misc_device_selected(void *data, obs_properties_t *props,
 			     obs_property_t *list, obs_data_t *settings)
 {
 	const char *cardID = obs_data_get_string(settings, kUIPropDevice.id);
-	if (!cardID)
+	if (!cardID || !cardID[0])
 		return false;
 	aja::CardManager *cardManager = (aja::CardManager *)data;
 	if (!cardManager)
@@ -305,7 +305,7 @@ bool on_multi_view_toggle(void *data, obs_properties_t *props,
 	const int audioInputSource =
 		obs_data_get_int(settings, kUIPropMultiViewAudioSource.id);
 	const char *cardID = obs_data_get_string(settings, kUIPropDevice.id);
-	if (!cardID)
+	if (!cardID || !cardID[0])
 		return false;
 	aja::CardManager *cardManager = (aja::CardManager *)data;
 	if (!cardManager)

--- a/plugins/aja/aja-common.cpp
+++ b/plugins/aja/aja-common.cpp
@@ -90,7 +90,8 @@ void populate_io_selection_input_list(const std::string &cardID,
 {
 	obs_property_list_clear(list);
 
-	obs_property_list_add_int(list, obs_module_text(kUIPropIOSelect.text),
+	obs_property_list_add_int(list,
+				  obs_module_text(kUIPropIOSelectNone.text),
 				  static_cast<long long>(IOSelection::Invalid));
 
 	for (auto i = 0; i < static_cast<int32_t>(IOSelection::NumIOSelections);
@@ -118,7 +119,8 @@ void populate_io_selection_output_list(const std::string &cardID,
 {
 	obs_property_list_clear(list);
 
-	obs_property_list_add_int(list, obs_module_text(kUIPropIOSelect.text),
+	obs_property_list_add_int(list,
+				  obs_module_text(kUIPropIOSelectNone.text),
 				  static_cast<long long>(IOSelection::Invalid));
 
 	if (deviceID == DEVICE_ID_TTAP_PRO) {

--- a/plugins/aja/aja-common.hpp
+++ b/plugins/aja/aja-common.hpp
@@ -18,7 +18,11 @@ static const uint32_t kDefaultAudioChannels = 8;
 static const uint32_t kDefaultAudioSampleRate = 48000;
 static const uint32_t kDefaultAudioSampleSize = 4;
 static const int kAutoDetect = -1;
+static const NTV2VideoFormat kDefaultAJAVideoFormat = NTV2_FORMAT_720p_5994;
 static const NTV2PixelFormat kDefaultAJAPixelFormat = NTV2_FBF_8BIT_YCBCR;
+static const SDITransport kDefaultAJASDITransport = SDITransport::SingleLink;
+static const SDITransport4K kDefaultAJASDITransport4K =
+	SDITransport4K::TwoSampleInterleave;
 
 // Common OBS property helpers used by both the capture and output plugins
 extern void filter_io_selection_input_list(const std::string &cardID,

--- a/plugins/aja/aja-source.cpp
+++ b/plugins/aja/aja-source.cpp
@@ -602,7 +602,7 @@ bool aja_source_device_changed(void *data, obs_properties_t *props,
 	}
 
 	const char *cardID = obs_data_get_string(settings, kUIPropDevice.id);
-	if (!cardID)
+	if (!cardID || !cardID[0])
 		return false;
 
 	auto &cardManager = aja::CardManager::Instance();
@@ -696,7 +696,7 @@ bool aja_io_selection_changed(void *data, obs_properties_t *props,
 	}
 
 	const char *cardID = obs_data_get_string(settings, kUIPropDevice.id);
-	if (!cardID)
+	if (!cardID || !cardID[0])
 		return false;
 
 	auto &cardManager = aja::CardManager::Instance();
@@ -1100,7 +1100,7 @@ void aja_source_save(void *data, obs_data_t *settings)
 	}
 
 	const char *cardID = obs_data_get_string(settings, kUIPropDevice.id);
-	if (!cardID)
+	if (!cardID || !cardID[0])
 		return;
 
 	auto &cardManager = aja::CardManager::Instance();

--- a/plugins/aja/aja-ui-props.hpp
+++ b/plugins/aja/aja-ui-props.hpp
@@ -51,8 +51,9 @@ static const UIProperty kUIPropInput = {
 	"",
 };
 
-static const UIProperty kUIPropIOSelect = {"ui_prop_select_input", "IOSelect",
-					   ""};
+// Used for showing "Select..." item in Input/Output selection drop-downs
+static const UIProperty kUIPropIOSelectNone = {"ui_prop_select_input",
+					       "IOSelect", ""};
 
 static const UIProperty kUIPropSDITransport = {
 	"ui_prop_sdi_transport",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
1. Fix AJA Output plugin default settings from clear preferences not working properly.
2. Check for empty cardID in addition to cardID NULL check.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The AJA Output plugin UI was showing the default settings we configure in the UI code but the output plugin itself was not passing the default settings to the plugin create callback. This change causes the output plugin to use the default settings seen in the UI when starting the output plugin.

Also, when the cardID was initially read from the device properties list before the AJA devices were enumerated the cardID string was empty. We want a valid cardID before starting the plugins so now we check for both NULL cardID and empty cardID.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Found as the result of an internal bug ticket found by AJA QA when running OBS and the AJA Plugin from a cleared preferences state. Tested on Windows and macOS from a cleared and non-cleared preferences state.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
