### PR TITLE
UI: Log YouTube API HTTP request errors

### DIFF
--- a/UI/youtube-api-wrappers.cpp
+++ b/UI/youtube-api-wrappers.cpp
@@ -84,8 +84,13 @@ bool YoutubeApiWrappers::TryInsertCommand(const char *url,
 	if (error_code)
 		*error_code = httpStatusCode;
 
-	if (!success || output.empty())
+	if (!success || output.empty()) {
+		if (!error.empty())
+			blog(LOG_WARNING, "YouTube API request failed: %s",
+			     error.c_str());
 		return false;
+	}
+
 	json_out = Json::parse(output, error);
 #ifdef _DEBUG
 	blog(LOG_DEBUG, "YouTube API command answer: %s",


### PR DESCRIPTION
### Description
Adds a log message of the error returned by cURL.

### Motivation and Context
Some users are experiencing issues with the YouTube API, but not errors related to the HTTP request themselves are currently being logged. 

### How Has This Been Tested?
Intentionally timed-out requests by proxying them through Fiddler.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
