### PR TITLE
aja: Fix input/output selections on devices with discrete ANALOG/HDMI ports.

### DIFF
--- a/plugins/aja/aja-common.cpp
+++ b/plugins/aja/aja-common.cpp
@@ -418,7 +418,15 @@ bool CardCanDoSDIMonitorOutput(NTV2DeviceID id)
 	return (id == DEVICE_ID_IO4K || id == DEVICE_ID_IO4KPLUS);
 }
 
-// Cards with a dedicated HDMI Monitor Output tie it to "Framestore 4".
+// Cards with a dedicated HDMI Monitor Input, tied to "Framestore 4".
+bool CardCanDoHDMIMonitorInput(NTV2DeviceID id)
+{
+	return (id == DEVICE_ID_IO4K || id == DEVICE_ID_IO4KUFC ||
+		id == DEVICE_ID_IO4KPLUS || id == DEVICE_ID_IOXT ||
+		id == DEVICE_ID_IOX3 || id == DEVICE_ID_KONALHI);
+}
+
+// Cards with a dedicated HDMI Monitor Output, tied to "Framestore 4".
 bool CardCanDoHDMIMonitorOutput(NTV2DeviceID id)
 {
 	return (id == DEVICE_ID_IO4K || id == DEVICE_ID_IO4KPLUS ||
@@ -847,6 +855,11 @@ void IOSelectionToOutputDests(IOSelection io,
 
 bool DeviceCanDoIOSelectionIn(NTV2DeviceID id, IOSelection io)
 {
+	// Hide "HDMI1" list selection on devices which have a discrete "HDMI IN" port.
+	if (io == IOSelection::HDMI1 && CardCanDoHDMIMonitorInput(id)) {
+		return false;
+	}
+
 	NTV2InputSourceSet inputSources;
 	if (io != IOSelection::Invalid) {
 		IOSelectionToInputSources(io, inputSources);

--- a/plugins/aja/aja-common.cpp
+++ b/plugins/aja/aja-common.cpp
@@ -645,16 +645,16 @@ std::string IOSelectionToString(IOSelection io)
 		str = "HDMI 4";
 		break;
 	case IOSelection::HDMIMonitorIn:
-		str = "HDMI Monitor In";
+		str = "HDMI IN";
 		break;
 	case IOSelection::HDMIMonitorOut:
-		str = "HDMI Monitor Out";
+		str = "HDMI OUT";
 		break;
 	case IOSelection::AnalogIn:
-		str = "Analog In";
+		str = "ANALOG IN";
 		break;
 	case IOSelection::AnalogOut:
-		str = "Analog Out";
+		str = "ANALOG OUT";
 		break;
 	case IOSelection::Invalid:
 		str = "Invalid";

--- a/plugins/aja/aja-common.hpp
+++ b/plugins/aja/aja-common.hpp
@@ -69,6 +69,7 @@ HandleSpecialCaseFormats(IOSelection io, NTV2VideoFormat vf, NTV2DeviceID id);
 extern uint32_t CardNumFramestores(NTV2DeviceID id);
 extern uint32_t CardNumAudioSystems(NTV2DeviceID id);
 extern bool CardCanDoSDIMonitorOutput(NTV2DeviceID id);
+extern bool CardCanDoHDMIMonitorInput(NTV2DeviceID id);
 extern bool CardCanDoHDMIMonitorOutput(NTV2DeviceID id);
 extern bool CardCanDo1xSDI12G(NTV2DeviceID id);
 extern bool Is3GLevelB(CNTV2Card *card, NTV2Channel channel);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Two things fixed in this PR per request of AJA QA:
1.  Rename HDMI Monitor In/Out selections as well as Analog In/Out to to HDMI IN/OUT and ANALOG IN/OUT respectively, to match what is shown on those devices. (io4K+, IOXT, etc.)
3. Hide HDMI1 input selection on devices with a discrete HDMI IN port. This was essentially a duplicate menu entry.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
"HDMI Monitor" In and Out were not officially used terms in the AJA products. QA requested those list items be changed to HDMI IN/OUT.

Additionally, certain cards which have those discrete HDMI IN and OUT ports should not show the numbered HDMI input selections. Those are reserved for Kona HDMI, or any future cards that have multiple HDMI input or output ports.

### How Has This Been Tested?
Tested by developer on io4K+. QA will verify on all of the applicable cards/firmwares:
- io4k
- io4k (UFC)
- kona_hdmi
- io4k_plus
- ioxt
- lhi
- iox3

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
