### PR TITLE
UI: Fix undo causing window captures to disappear in studio mode

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7854,13 +7854,12 @@ void OBSBasic::on_actionCopyTransform_triggered()
 
 void undo_redo(const std::string &data)
 {
-	OBSDataAutoRelease dat = obs_data_create_from_json(data.c_str());
-	OBSSourceAutoRelease source =
-		obs_get_source_by_name(obs_data_get_string(dat, "scene_name"));
-	reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-		->SetCurrentScene(source.Get(), true);
+	obs_scene_t *scene = obs_scene_load_transform_states(data.c_str());
 
-	obs_scene_load_transform_states(data.c_str());
+	if (scene != nullptr) {
+		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
+			->SetCurrentScene(scene, true);
+	}
 }
 
 void OBSBasic::on_actionPasteTransform_triggered()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -474,7 +474,6 @@ private:
 
 	void SetPreviewProgramMode(bool enabled);
 	void ResizeProgram(uint32_t cx, uint32_t cy);
-	void SetCurrentScene(obs_scene_t *scene, bool force = false);
 	static void RenderProgram(void *data, uint32_t cx, uint32_t cy);
 
 	std::vector<QuickTransition> quickTransitions;
@@ -818,6 +817,7 @@ public:
 	undo_stack undo_s;
 	OBSSource GetProgramSource();
 	OBSScene GetCurrentScene();
+	void SetCurrentScene(obs_scene_t *scene, bool force = false);
 
 	void SysTrayNotify(const QString &text, QSystemTrayIcon::MessageIcon n);
 

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -710,14 +710,13 @@ void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 		obs_scene_save_transform_states(main->GetCurrentScene(), true);
 
 	auto undo_redo = [](const std::string &data) {
-		OBSDataAutoRelease dat =
-			obs_data_create_from_json(data.c_str());
-		OBSSourceAutoRelease source = obs_get_source_by_name(
-			obs_data_get_string(dat, "scene_name"));
-		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(source.Get(), true);
+		obs_scene_t *scene =
+			obs_scene_load_transform_states(data.c_str());
 
-		obs_scene_load_transform_states(data.c_str());
+		if (scene != nullptr) {
+			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
+				->SetCurrentScene(scene, true);
+		}
 	};
 
 	if (wrapper && rwrapper) {

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -91,13 +91,13 @@ OBSBasicTransform::~OBSBasicTransform()
 		obs_scene_save_transform_states(main->GetCurrentScene(), false);
 
 	auto undo_redo = [](const std::string &data) {
-		OBSDataAutoRelease dat =
-			obs_data_create_from_json(data.c_str());
-		OBSSourceAutoRelease source = obs_get_source_by_name(
-			obs_data_get_string(dat, "scene_name"));
-		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(source.Get(), true);
-		obs_scene_load_transform_states(data.c_str());
+		obs_scene_t *scene =
+			obs_scene_load_transform_states(data.c_str());
+
+		if (scene != nullptr) {
+			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
+				->SetCurrentScene(scene, true);
+		}
 	};
 
 	std::string redo_data(obs_data_get_json(wrapper));

--- a/docs/sphinx/reference-scenes.rst
+++ b/docs/sphinx/reference-scenes.rst
@@ -328,7 +328,7 @@ Scene Item Functions
 ---------------------
 
 .. function:: obs_data_t *obs_scene_save_transform_states(obs_scene_t *scene, bool all_items)
-.. function:: void obs_scene_load_transform_states(oconst char *states)
+.. function:: obs_scene_t *obs_scene_load_transform_states(oconst char *states)
 
    Saves all the transformation states for the sceneitms in scene. When all_items is false, it
    will only save selected items

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1675,7 +1675,7 @@ EXPORT obs_data_t *obs_scene_save_transform_states(obs_scene_t *scene,
 						   bool all_items);
 
 /** Load all the transform states of sceneitems in that scene */
-EXPORT void obs_scene_load_transform_states(const char *state);
+EXPORT obs_scene_t *obs_scene_load_transform_states(const char *state);
 
 /**  Gets a sceneitem's order in its scene */
 EXPORT int obs_sceneitem_get_order_position(obs_sceneitem_t *item);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When group undo/redo behavior was added in 2932cd0fd3, the saved json was modified such that the root object no longer contained the `"scene"` key (instead it is now contained within `"scenes_and_groups"`).

The lines of code removed in this patch were failing to find the scene in the json, so were setting the current scene to nullptr. This caused the window capture width/height to be set to 0 - and so they disappeared from the preview.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This should fix #5516. I'm not positive of the original intent of this code, however - I _suspect_ it was intended to reset the preview to the scene you had edited if you clicked away, but I don't know if that ever worked correctly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows 10 x64.

1. Be in Studio Mode
2. Move a Window Capture source in one of the following ways:
   - dragging in the preview scene
   - via the Edit Transform dialog
   - via the Reset Transform
3. Hit Ctrl-Z
4. Verified source transform un-dos without disappearing
5. Verified the same worked while not in Studio Mode

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
