### PR TITLE
aja: Fix Kona1 not auto-detecting capture pixel format

### DIFF
--- a/plugins/aja/aja-source.cpp
+++ b/plugins/aja/aja-source.cpp
@@ -487,12 +487,11 @@ bool AJASource::ReadWireFormats(NTV2DeviceID device_id, IOSelection io_select,
 		if (NTV2_INPUT_SOURCE_IS_SDI(src)) {
 			if (NTV2DeviceHasBiDirectionalSDI(device_id)) {
 				mCard->SetSDITransmitEnable(channel, false);
-				mCard->WaitForInputVerticalInterrupt(channel);
-
-				VPIDData vpid_data;
-				if (ReadChannelVPIDs(channel, vpid_data))
-					vpids.push_back(vpid_data);
 			}
+			mCard->WaitForInputVerticalInterrupt(channel);
+			VPIDData vpid_data;
+			if (ReadChannelVPIDs(channel, vpid_data))
+				vpids.push_back(vpid_data);
 		} else if (NTV2_INPUT_SOURCE_IS_HDMI(src)) {
 			mCard->WaitForInputVerticalInterrupt(channel);
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix for Kona1 card not auto-detecting the capture pixel format when Pixel Format is set to "Auto".

We use the video payload ID (VPID) data in the SDI stream to detect the pixel format and this was accidentally gated behind `NTV2DeviceHasBiDirectionalSDI`, which does not apply to the Kona1, and a number of other older cards. This was preventing uni-directional SDI cards (input-only) from detecting the VPID on the wire.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The Kona1 card was not auto-detecting the pixel format when the capture plugin Pixel Format setting was set to "Auto".

### How Has This Been Tested?
Tested by the developer on a Kona1 card and io4K+ to make sure it didn't break the existing newer cards auto-detection.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
