### PR TITLE
aja: Fix signal routing for 4xSDI UHD/4K RGB

### DIFF
--- a/plugins/aja/aja-common.cpp
+++ b/plugins/aja/aja-common.cpp
@@ -1112,6 +1112,14 @@ VPIDStandard DetermineVPIDStandard(NTV2DeviceID id, IOSelection io,
 			}
 		} else if (aja::IsSDIFourWireIOSelection(io)) {
 			if (is_rgb) {
+				if (t4k == SDITransport4K::Squares) {
+					if (trx == SDITransport::SDI3Ga) {
+						vpid = VPIDStandard_1080_3Ga;
+					} else if (trx ==
+						   SDITransport::SDI3Gb) {
+						vpid = VPIDStandard_1080_DualLink_3Gb;
+					}
+				}
 			} else {
 				// YCbCr
 				if (t4k == SDITransport4K::Squares) {

--- a/plugins/aja/aja-presets.cpp
+++ b/plugins/aja/aja-presets.cpp
@@ -318,10 +318,10 @@ void RoutingConfigurator::build_preset_table()
 		  "sdi[{ch3}][1]->dli[{ch3}][1];"
 		  "sdi[{ch4}][0]->dli[{ch4}][0];"
 		  "sdi[{ch4}][1]->dli[{ch4}][1];" // Dual-Links -> Framestores
-		  "dli[{ch1}][0]->fb[{ch1}][2];"
-		  "dli[{ch2}][0]->fb[{ch2}][2];"
-		  "dli[{ch3}][0]->fb[{ch3}][2];"
-		  "dli[{ch4}][0]->fb[{ch4}][2];",
+		  "dli[{ch1}][0]->fb[{ch1}][0];"
+		  "dli[{ch2}][0]->fb[{ch2}][0];"
+		  "dli[{ch3}][0]->fb[{ch3}][0];"
+		  "dli[{ch4}][0]->fb[{ch4}][0];",
 		  {},
 		  true,
 		  false}},


### PR DESCRIPTION
Crosspoint indices were wrong for the UHD4K_ST425_Quad_3Gb_Squares_RGB_Capture preset and VPID was not being set for the selected 3G-Level A or B transport modes passed along from the capture UI.

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix signal routing for 4x 3G SDI UHD/4K RGB low-framerate capture. There was a typo in the crosspoint indices for the 3G Level-B preset, and the VPID values were not being set when SDI Transport was set to 3Ga or 3Gb. Thus the capture preset was not even being recalled for quad-link RGB SDI modes.

### Motivation and Context
Quad-link SDI RGB low-framerate capture was broken.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Verified by sending a quad-link SDI RGB low-framerate signal from an AJA Ki Pro device into an AJA io4K+ capture device in OBS, setting the capture Video Format to UHD/4K low-framerate (23.98 to 30fps) formats, setting Pixel Format to BGR-8, setting SDI Transport to 3Ga and 3Gb, and setting SDI 4K Transport to Squares.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
