### PR TITLE
mac-vth264: Fix DTS timestamps when blank

### DIFF
--- a/plugins/mac-vth264/encoder.c
+++ b/plugins/mac-vth264/encoder.c
@@ -669,8 +669,10 @@ static bool parse_sample(struct vt_h264_encoder *enc, CMSampleBufferRef buffer,
 	dts = CMTimeMultiplyByFloat64(dts,
 				      ((Float64)enc->fps_num / enc->fps_den));
 
+	if (CMTIME_IS_INVALID(dts))
+		dts = pts;
 	// imitate x264's negative dts when bframes might have pts < dts
-	if (enc->bframes)
+	else if (enc->bframes)
 		dts = CMTimeSubtract(dts, off);
 
 	bool keyframe = is_sample_keyframe(buffer);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This changes fixes DTS timestamps in videotoolbox packets being always zero (at least on ARM macs). Credit for the changes goes to rcombs <rcombs@rcombs.me>, I was just helping her to debug this stuff.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This was seemingly one of the factors causing https://github.com/obsproject/obs-studio/issues/4670 (Inability to save recordings when limiting bitrate, streams crashing). That issue isn't completely fixed however, as OBS still seems to drop frames after ~5 seconds when "Limit bitrate" is turned on (regardless of settings).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I tried streaming and recording before and after the change with "Limit bitrate" turned on, streaming would hang on a black screen and recording would save an empty file before, they both work now (albeit with frame drops).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
