### PR TITLE
win-capture: Don't list minimized UWP apps

### DIFF
--- a/plugins/win-capture/window-helpers.c
+++ b/plugins/win-capture/window-helpers.c
@@ -224,13 +224,22 @@ static void add_window(obs_property_t *p, HWND hwnd, add_window_cb callback)
 	dstr_free(&exe);
 }
 
+static inline bool IsWindowCloaked(window)
+{
+	int cloaked;
+	HRESULT hr = DwmGetWindowAttribute(window, DWMWA_CLOAKED, &cloaked,
+					   sizeof(cloaked));
+	return (SUCCEEDED(hr) && cloaked);
+}
+
 static bool check_window_valid(HWND window, enum window_search_mode mode)
 {
 	DWORD styles, ex_styles;
 	RECT rect;
 
 	if (!IsWindowVisible(window) ||
-	    (mode == EXCLUDE_MINIMIZED && IsIconic(window)))
+	    (mode == EXCLUDE_MINIMIZED &&
+	     (IsIconic(window) || IsWindowCloaked(window))))
 		return false;
 
 	GetClientRect(window, &rect);
@@ -485,10 +494,7 @@ BOOL CALLBACK enum_windows_proc(HWND window, LPARAM lParam)
 	if (!check_window_valid(window, data->mode))
 		return TRUE;
 
-	int cloaked;
-	if (SUCCEEDED(DwmGetWindowAttribute(window, DWMWA_CLOAKED, &cloaked,
-					    sizeof(cloaked))) &&
-	    cloaked)
+	if (IsWindowCloaked(window))
 		return TRUE;
 
 	const int rating = window_rating(window, data->priority, data->class,


### PR DESCRIPTION

### Description

We currently try not to list minimised windows in the Window Capture source. Apparently, `IsIconic()` and `IsWindowVisible()` aren't enough to check if a UWP window is minimised. [From what I can find](https://social.msdn.microsoft.com/Forums/windows/en-US/0d7419a7-1d25-40bc-909e-a0db33b109a8/iswindowvisible-fails-to-detect-if-store-app-is-visible?forum=vclanguage), `DwmGetWindowAttribute` looking for the `DWMWA_CLOAKED` attribute seems to be the right fix.

### Motivation and Context

* #5769 exposed that minimised UWP apps appear in the window capture list, even though they cannot be captured.
* As we don't currently list minimised apps, let's avoid it with UWP apps too

### How Has This Been Tested?

* Open two UWP apps. Minimise one of them.
* Open Window Capture properties and try to capture. The visible one should appear, and the minimised shouldn't.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
