### PR TITLE
libobs: Mark raw_active and gpu_encoder_active as volatile

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -270,8 +270,8 @@ struct obs_core_video {
 	gs_samplerstate_t *point_sampler;
 	gs_stagesurf_t *mapped_surfaces[NUM_CHANNELS];
 	int cur_texture;
-	long raw_active;
-	long gpu_encoder_active;
+	volatile long raw_active;
+	volatile long gpu_encoder_active;
 	pthread_mutex_t gpu_encoder_mutex;
 	struct circlebuf gpu_encoder_queue;
 	struct circlebuf gpu_encoder_avail_queue;

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -931,9 +931,10 @@ bool obs_graphics_thread_loop(struct obs_graphics_context *context)
 
 	uint64_t frame_start = os_gettime_ns();
 	uint64_t frame_time_ns;
-	bool raw_active = obs->video.raw_active > 0;
+	bool raw_active = os_atomic_load_long(&obs->video.raw_active) > 0;
 #ifdef _WIN32
-	const bool gpu_active = obs->video.gpu_encoder_active > 0;
+	const bool gpu_active =
+		os_atomic_load_long(&obs->video.gpu_encoder_active) > 0;
 	const bool active = raw_active || gpu_active;
 #else
 	const bool gpu_active = 0;


### PR DESCRIPTION
### Description
These were operated on by atomic functions but were not marked as volatile or loaded with `os_atomic_load_long`, potentially introducing subtle race conditions. Detected by ThreadSanitizer.

### Motivation and Context
Race conditions are bad.

### How Has This Been Tested?
Checked disassembly to verify loads and stores were atomic.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
