### PR TITLE
UI: Add ability to toggle projector frame/border

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -101,7 +101,7 @@ LogViewer="Log Viewer"
 ShowOnStartup="Show on startup"
 OpenFile="Open file"
 AddValue="Add %1"
-ToggleWindowBorder="Toggle window border"
+HideProjectorFrame="Hide the window frame"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"
@@ -796,6 +796,7 @@ Basic.Settings.General.WarnBeforeStoppingStream="Show confirmation dialog when s
 Basic.Settings.General.WarnBeforeStoppingRecord="Show confirmation dialog when stopping recording"
 Basic.Settings.General.Projectors="Projectors"
 Basic.Settings.General.HideProjectorCursor="Hide cursor over projectors"
+Basic.Settings.General.HideProjectorFrame="Hide window frames on projectors"
 Basic.Settings.General.ProjectorAlwaysOnTop="Make projectors always on top"
 Basic.Settings.General.Snapping="Source Alignment Snapping"
 Basic.Settings.General.ScreenSnapping="Snap Sources to edge of screen"

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -101,6 +101,7 @@ LogViewer="Log Viewer"
 ShowOnStartup="Show on startup"
 OpenFile="Open file"
 AddValue="Add %1"
+ToggleWindowBorder="Toggle window border"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -473,20 +473,27 @@
                     </widget>
                    </item>
                    <item row="1" column="1">
+                    <widget class="QCheckBox" name="hideProjectorFrame">
+                     <property name="text">
+                      <string>Basic.Settings.General.HideProjectorFrame</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="1">
                     <widget class="QCheckBox" name="projectorAlwaysOnTop">
                      <property name="text">
                       <string>Basic.Settings.General.ProjectorAlwaysOnTop</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="2" column="1">
+                   <item row="3" column="1">
                     <widget class="QCheckBox" name="saveProjectors">
                      <property name="text">
                       <string>Basic.Settings.General.SaveProjectors</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="3" column="1">
+                   <item row="4" column="1">
                     <widget class="QCheckBox" name="closeProjectors">
                      <property name="text">
                       <string>Basic.Settings.General.CloseExistingProjectors</string>
@@ -5817,6 +5824,7 @@
   <tabstop>sourceSnapping</tabstop>
   <tabstop>centerSnapping</tabstop>
   <tabstop>hideProjectorCursor</tabstop>
+  <tabstop>hideProjectorFrame</tabstop>
   <tabstop>projectorAlwaysOnTop</tabstop>
   <tabstop>saveProjectors</tabstop>
   <tabstop>systemTrayEnabled</tabstop>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -10071,6 +10071,12 @@ void OBSBasic::UpdateProjectorHideCursor()
 		projectors[i]->SetHideCursor();
 }
 
+void OBSBasic::UpdateProjectorHideFrame(bool hideFrame)
+{
+	for (size_t i = 0; i < projectors.size(); i++)
+		projectors[i]->SetHideFrame(hideFrame);
+}
+
 void OBSBasic::UpdateProjectorAlwaysOnTop(bool top)
 {
 	for (size_t i = 0; i < projectors.size(); i++)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -588,6 +588,7 @@ private:
 	int GetOverrideTransitionDuration(OBSSource source);
 
 	void UpdateProjectorHideCursor();
+	void UpdateProjectorHideFrame(bool hideFrame);
 	void UpdateProjectorAlwaysOnTop(bool top);
 	void ResetProjectors();
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -389,6 +389,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->warnBeforeStreamStop, CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeRecordStop, CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->hideProjectorCursor,  CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->hideProjectorFrame,   CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->projectorAlwaysOnTop, CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->recordWhenStreaming,  CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->keepRecordStreamStops,CHECK_CHANGED,  GENERAL_CHANGED);
@@ -1351,6 +1352,10 @@ void OBSBasicSettings::LoadGeneralSettings()
 	bool hideProjectorCursor = config_get_bool(
 		GetGlobalConfig(), "BasicWindow", "HideProjectorCursor");
 	ui->hideProjectorCursor->setChecked(hideProjectorCursor);
+
+	bool hideProjectorFrame = config_get_bool(
+		GetGlobalConfig(), "BasicWindow", "HideProjectorFrame");
+	ui->hideProjectorFrame->setChecked(hideProjectorFrame);
 
 	bool projectorAlwaysOnTop = config_get_bool(
 		GetGlobalConfig(), "BasicWindow", "ProjectorAlwaysOnTop");
@@ -3186,6 +3191,14 @@ void OBSBasicSettings::SaveGeneralSettings()
 				"HideProjectorCursor",
 				ui->hideProjectorCursor->isChecked());
 		main->UpdateProjectorHideCursor();
+	}
+
+	if (WidgetChanged(ui->hideProjectorFrame)) {
+		config_set_bool(GetGlobalConfig(), "BasicWindow",
+				"HideProjectorFrame",
+				ui->hideProjectorFrame->isChecked());
+		main->UpdateProjectorHideFrame(
+			ui->hideProjectorFrame->isChecked());
 	}
 
 	if (WidgetChanged(ui->projectorAlwaysOnTop)) {

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -922,6 +922,14 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 					this, SLOT(ResizeToContent()));
 		}
 
+		if (bool(windowFlags() & Qt::FramelessWindowHint)) {
+			popup.addAction(QTStr("ToggleWindowBorder"), this,
+					SLOT(AddWindowBorder()));
+		} else {
+			popup.addAction(QTStr("ToggleWindowBorder"), this,
+					SLOT(RemoveWindowBorder()));
+		}
+
 		QAction *alwaysOnTopButton =
 			new QAction(QTStr("Basic.MainMenu.AlwaysOnTop"), this);
 		alwaysOnTopButton->setCheckable(true);
@@ -1196,6 +1204,36 @@ void OBSProjector::OpenWindowedProjector()
 
 	UpdateProjectorTitle(QT_UTF8(obs_source_get_name(source)));
 	screen = nullptr;
+}
+
+void OBSProjector::RemoveWindowBorder()
+{
+	// Calculate the current content position.
+	QRect contentBox = geometry();
+
+	// Remove the window frame.
+	setWindowFlags(Qt::FramelessWindowHint);
+
+	// Make sure the content box doesn't change.
+	setGeometry(contentBox);
+
+	// Restore the window.
+	showNormal();
+}
+
+void OBSProjector::AddWindowBorder()
+{
+	// Calculate the current content position.
+	QRect contentBox = geometry();
+
+	// Restore the window frame.
+	setWindowFlags(windowFlags() & ~Qt::FramelessWindowHint);
+
+	// Make sure the content box doesn't change.
+	setGeometry(contentBox);
+
+	// Restore the window.
+	showNormal();
 }
 
 void OBSProjector::ResizeToContent()

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -41,6 +41,7 @@ private:
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
 	void closeEvent(QCloseEvent *event) override;
 
+	bool hideFrame;
 	bool isAlwaysOnTop;
 	bool isAlwaysOnTopOverridden = false;
 	int savedMonitor = -1;
@@ -84,8 +85,6 @@ private slots:
 	void OpenWindowedProjector();
 	void AlwaysOnTopToggled(bool alwaysOnTop);
 	void ScreenRemoved(QScreen *screen_);
-	void AddWindowBorder();
-	void RemoveWindowBorder();
 
 public:
 	OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
@@ -101,5 +100,6 @@ public:
 
 	bool IsAlwaysOnTop() const;
 	bool IsAlwaysOnTopOverridden() const;
+	void SetHideFrame(bool hideFrame);
 	void SetIsAlwaysOnTop(bool isAlwaysOnTop, bool isOverridden);
 };

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -84,6 +84,8 @@ private slots:
 	void OpenWindowedProjector();
 	void AlwaysOnTopToggled(bool alwaysOnTop);
 	void ScreenRemoved(QScreen *screen_);
+	void AddWindowBorder();
+	void RemoveWindowBorder();
 
 public:
 	OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This feature adds a "Toggle window border" option to the projector window's context (popup) menu.

<img width="1792" alt="Screen Shot 2022-01-16 at 3 01 13 PM" src="https://user-images.githubusercontent.com/922012/149675973-b811447e-7177-47e6-af3d-09c720d98269.png">
<img width="1792" alt="Screen Shot 2022-01-16 at 3 01 24 PM" src="https://user-images.githubusercontent.com/922012/149675972-2fa69daf-d738-4104-8afb-a59dcfa212a7.png">

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

When using the OBS projector as a source for screen sharing in various apps (Discord, Meet, Zoom, etc), the title bar is included in the screen share and distracts from the presentation.

- https://obsproject.com/forum/threads/please-make-title-less-projector-windows-for-better-screen-sharing.151889/
- https://obsproject.com/forum/threads/is-it-possible-to-hide-the-title-bar-on-projector-when-on-windowed-mode.117065/
- https://obsproject.com/forum/threads/remove-menue-bar-in-projector-mode.41633/
- https://obsproject.com/forum/threads/macos-windowed-projector-preview-remove-title-bar.124256/

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I have manually tested this on my machine.

```
System Version:	macOS 11.4 (20F71)
Kernel Version:	Darwin 20.5.0
```

```
Model Name:	MacBook Pro
Model Identifier:	MacBookPro16,1
Processor Name:	8-Core Intel Core i9
Processor Speed:	2.4 GHz
Number of Processors:	1
Total Number of Cores:	8
L2 Cache (per Core):	256 KB
L3 Cache:	16 MB
Hyper-Threading Technology:	Enabled
Memory:	64 GB
System Firmware Version:	1554.120.19.0.0 (iBridge: 18.16.14663.0.0,0)
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
