### PR TITLE
Enable curl ALPN support

### DIFF
--- a/UI/remote-text.cpp
+++ b/UI/remote-text.cpp
@@ -77,11 +77,6 @@ void RemoteTextThread::run()
 			curl_easy_setopt(curl.get(), CURLOPT_TIMEOUT,
 					 timeoutSec);
 
-#if LIBCURL_VERSION_NUM >= 0x072400
-		// A lot of servers don't yet support ALPN
-		curl_easy_setopt(curl.get(), CURLOPT_SSL_ENABLE_ALPN, 0);
-#endif
-
 		if (!postData.empty()) {
 			curl_easy_setopt(curl.get(), CURLOPT_POSTFIELDS,
 					 postData.c_str());
@@ -177,10 +172,6 @@ bool GetRemoteFile(const char *url, std::string &str, std::string &error,
 			curl_easy_setopt(curl.get(), CURLOPT_TIMEOUT,
 					 timeoutSec);
 
-#if LIBCURL_VERSION_NUM >= 0x072400
-		// A lot of servers don't yet support ALPN
-		curl_easy_setopt(curl.get(), CURLOPT_SSL_ENABLE_ALPN, 0);
-#endif
 		if (!request_type.empty()) {
 			if (request_type != "GET")
 				curl_easy_setopt(curl.get(),

--- a/deps/file-updater/file-updater/file-updater.c
+++ b/deps/file-updater/file-updater/file-updater.c
@@ -127,11 +127,6 @@ static bool do_http_request(struct update_info *info, const char *url,
 		curl_easy_setopt(info->curl, CURLOPT_HEADERDATA, info);
 	}
 
-#if LIBCURL_VERSION_NUM >= 0x072400
-	// A lot of servers don't yet support ALPN
-	curl_easy_setopt(info->curl, CURLOPT_SSL_ENABLE_ALPN, 0);
-#endif
-
 	code = curl_easy_perform(info->curl);
 	if (code != CURLE_OK) {
 		warn("Remote update of URL \"%s\" failed: %s", url,

--- a/plugins/rtmp-services/service-specific/nimotv.c
+++ b/plugins/rtmp-services/service-specific/nimotv.c
@@ -94,11 +94,6 @@ const char *nimotv_get_ingest(const char *key)
 	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
 	curl_obs_set_revoke_setting(curl_handle);
 
-#if LIBCURL_VERSION_NUM >= 0x072400
-	// A lot of servers don't yet support ALPN
-	curl_easy_setopt(curl_handle, CURLOPT_SSL_ENABLE_ALPN, 0);
-#endif
-
 	res = curl_easy_perform(curl_handle);
 	dstr_free(&uri);
 

--- a/plugins/rtmp-services/service-specific/showroom.c
+++ b/plugins/rtmp-services/service-specific/showroom.c
@@ -125,10 +125,6 @@ struct showroom_ingest *showroom_get_ingest(const char *server,
 	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&json);
 	curl_obs_set_revoke_setting(curl_handle);
 
-#if LIBCURL_VERSION_NUM >= 0x072400
-	curl_easy_setopt(curl_handle, CURLOPT_SSL_ENABLE_ALPN, 0);
-#endif
-
 	res = curl_easy_perform(curl_handle);
 	dstr_free(&uri);
 	if (res != CURLE_OK) {

--- a/plugins/rtmp-services/service-specific/younow.c
+++ b/plugins/rtmp-services/service-specific/younow.c
@@ -65,11 +65,6 @@ const char *younow_get_ingest(const char *server, const char *key)
 	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
 	curl_obs_set_revoke_setting(curl_handle);
 
-#if LIBCURL_VERSION_NUM >= 0x072400
-	// A lot of servers don't yet support ALPN
-	curl_easy_setopt(curl_handle, CURLOPT_SSL_ENABLE_ALPN, 0);
-#endif
-
 	res = curl_easy_perform(curl_handle);
 	dstr_free(&uri);
 


### PR DESCRIPTION
### Description
ALPN was disabled in 2016 due to poor server support, occasionally resulting in failed negotiations. Six years later, ALPN is now widely supported, and NPN is being removed in the latest version of nginx.

### Motivation and Context
NPN support is being removed from major web servers, leaving no way to negotiate protocol upgrades.

### How Has This Been Tested?
Verified connectivity still works on Windows 10. **Needs testing on Windows 7 / 8**.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
