### PR TITLE
aja: Workaround for SDI5 output not working on io4K+

### DIFF
--- a/plugins/aja/aja-common.cpp
+++ b/plugins/aja/aja-common.cpp
@@ -6,6 +6,7 @@
 #include <ajantv2/includes/ntv2debug.h>
 #include <ajantv2/includes/ntv2devicescanner.h>
 #include <ajantv2/includes/ntv2devicefeatures.h>
+#include <ajantv2/includes/ntv2signalrouter.h>
 #include <ajantv2/includes/ntv2utils.h>
 
 void filter_io_selection_input_list(const std::string &cardID,
@@ -393,6 +394,16 @@ NTV2VideoFormat HandleSpecialCaseFormats(IOSelection io, NTV2VideoFormat vf,
 		vf = GetQuadSizedVideoFormat(GetQuarterSizedVideoFormat(vf));
 	}
 	return vf;
+}
+
+NTV2Channel WidgetIDToChannel(NTV2WidgetID id)
+{
+#if AJA_NTV2_SDK_VERSION_MAJOR <= 16 && AJA_NTV2_SDK_VERSION_MINOR <= 2
+	// Workaround for bug in NTV2 SDK <= 16.2 where NTV2_WgtSDIMonOut1 maps incorrectly to NTV2_CHANNEL1.
+	if (id == NTV2_WgtSDIMonOut1)
+		return NTV2_CHANNEL5;
+#endif
+	return CNTV2SignalRouter::WidgetIDToChannel(id);
 }
 
 uint32_t CardNumFramestores(NTV2DeviceID id)

--- a/plugins/aja/aja-common.hpp
+++ b/plugins/aja/aja-common.hpp
@@ -66,6 +66,8 @@ extern void GetSortedVideoFormats(NTV2DeviceID id,
 extern NTV2VideoFormat
 HandleSpecialCaseFormats(IOSelection io, NTV2VideoFormat vf, NTV2DeviceID id);
 
+extern NTV2Channel WidgetIDToChannel(NTV2WidgetID id);
+
 extern uint32_t CardNumFramestores(NTV2DeviceID id);
 extern uint32_t CardNumAudioSystems(NTV2DeviceID id);
 extern bool CardCanDoSDIMonitorOutput(NTV2DeviceID id);

--- a/plugins/aja/aja-widget-io.cpp
+++ b/plugins/aja/aja-widget-io.cpp
@@ -1,4 +1,5 @@
 #include "aja-widget-io.hpp"
+#include "aja-common.hpp"
 
 #include <ajantv2/includes/ntv2utils.h>
 #include <ajantv2/includes/ntv2signalrouter.h>
@@ -351,8 +352,7 @@ bool WidgetInputSocket::Find(const std::string &name, NTV2Channel channel,
 {
 	for (const auto &in : kWidgetInputSockets) {
 		if (name == in.name &&
-		    channel == CNTV2SignalRouter::WidgetIDToChannel(
-				       in.widget_id) &&
+		    channel == aja::WidgetIDToChannel(in.widget_id) &&
 		    datastream == in.datastream_index) {
 			inp = in;
 			return true;
@@ -392,8 +392,7 @@ NTV2Channel WidgetInputSocket::InputXptChannel(InputXpt xpt)
 	NTV2Channel channel = NTV2_CHANNEL_INVALID;
 	for (auto &x : kWidgetInputSockets) {
 		if (x.id == xpt) {
-			channel = CNTV2SignalRouter::WidgetIDToChannel(
-				x.widget_id);
+			channel = aja::WidgetIDToChannel(x.widget_id);
 			break;
 		}
 	}
@@ -420,8 +419,7 @@ bool WidgetOutputSocket::Find(const std::string &name, NTV2Channel channel,
 	// 	  << ", datastream = " << datastream << std::endl;
 	for (const auto &wo : kWidgetOutputSockets) {
 		if (name == wo.name &&
-		    channel == CNTV2SignalRouter::WidgetIDToChannel(
-				       wo.widget_id) &&
+		    channel == aja::WidgetIDToChannel(wo.widget_id) &&
 		    datastream == wo.datastream_index) {
 			out = wo;
 			return true;
@@ -461,8 +459,7 @@ NTV2Channel WidgetOutputSocket::OutputXptChannel(OutputXpt xpt)
 	NTV2Channel channel = NTV2_CHANNEL_INVALID;
 	for (auto &x : kWidgetOutputSockets) {
 		if (x.id == xpt) {
-			channel = CNTV2SignalRouter::WidgetIDToChannel(
-				x.widget_id);
+			channel = aja::WidgetIDToChannel(x.widget_id);
 			break;
 		}
 	}


### PR DESCRIPTION
The result from `CNTV2SignalRouter::WidgetIDToChannel` was incorrect for SDI Output 5 on cards with a discrete SDI Monitor Output (io4K/io4K+/etc). This results in SDI5 output not working on certain cards with a dedicated SDI MONITOR output, such as the io4K/io4K+.

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Created a wrapper function `WidgetIDToChannel` to perform the `NTV2WidgetID`-to-`NTV2Channel` lookup. Hard-code `NTV2_WgtSDIMonOut1` to `NTV2_CHANNEL5` if building against NTV2 SDK 16.2 or earlier, otherwise continue to use `CNTV2SignalRouter::WidgetIDToChannel`.

The bug in the NTV2 SDK will be fixed in 16.3.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
AJA QA found that there was a regression in functionality, in that SDI5 output (SDI MONITOR) was no longer working. SDI MONITOR is a special dedicated monitor output on certain AJA external I/O devices and is technically treated as SDI5/Channel 5 under the hood.

This bug was a result of a recent refactor to remove the `NTV2Channel` column from the widget-io socket tables, which had the correct mapping for `NTV2_WgtSDIMonOut1` -> `NTV2_CHANNEL5`, in favor of using the NTV2 SDK function `CNTV2SignalRouter::WidgetIDToChannel`, which incorrectly maps to NTV2_CHANNEL1.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested against io4K+ with SDI5 output, and verifying that it didn't break SDI outputs 1-4.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
