### PR TITLE
aja: Fix crash when capture thread is reset

### DIFF
--- a/plugins/aja/aja-source.cpp
+++ b/plugins/aja/aja-source.cpp
@@ -187,6 +187,8 @@ void AJASource::CaptureThread(AJAThread *thread, void *data)
 	}
 
 	auto sourceProps = ajaSource->GetSourceProps();
+	ajaSource->ResetVideoBuffer(sourceProps.videoFormat,
+				    sourceProps.pixelFormat);
 	auto inputSource = sourceProps.InitialInputSource();
 	auto channel = sourceProps.Channel();
 	auto audioSystem = sourceProps.AudioSystem();
@@ -1028,8 +1030,6 @@ static void aja_source_update(void *data, obs_data_t *settings)
 	}
 
 	ajaSource->SetSourceProps(want_props);
-	ajaSource->ResetVideoBuffer(want_props.videoFormat,
-				    want_props.pixelFormat);
 	aja::Routing::StartSourceAudio(want_props, card);
 	card->SetReference(NTV2_REFERENCE_FREERUN);
 	ajaSource->Activate(true);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Moved the call to `ResetVideoBuffer` from within the `aja_source_update` callback to the body of the `AJASource::CaptureThread`, just before the thread loop starts running.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
AJA QA was finding intermittent crashes as the result of changing settings (video/pixel format, etc.) in the GUI of the AJA Source plugin. The stack traces provided by QA, and my reproduction of the issue in the debugger, indicated that the crashes were a result of calling `Deactivate` to destroy the currently running `CaptureThread` from within `aja_source_update`, followed by a call to `ResetVideoBuffer`. The call to `ResetVideoBuffer` would sometimes free the video buffer that was in-flight to OBS before the active `CaptureThread` was fully torn down and re-created with new settings.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested by running an automated test which randomly switches the video format on the SDI signal sent to the AJA card. This test was ran overnight without evidence of crashing.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
