### PR TITLE
obs-qsv11: Memory leak bug fix in QSV plugin module

### DIFF
--- a/plugins/obs-qsv11/common_directx11.cpp
+++ b/plugins/obs-qsv11/common_directx11.cpp
@@ -460,6 +460,9 @@ mfxStatus simple_copytex(mfxHDL pthis, mfxMemId mid, mfxU32 tex_handle,
 
 	km->ReleaseSync(*next_key);
 
+	km->Release();
+	input_tex->Release();
+
 	return MFX_ERR_NONE;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This is a simple bug fix for a memory leak in the QSV plugin module

### Motivation and Context
Memory leaks (exacerbated by 4K and discrete graphics) will cause encoding failures on long recordings. These destructor checks/calls should have been in the original code but were missed and now fixed.

### How Has This Been Tested?
Re-tested on TGL and DG2 systems with QSV recording for 12+ hours to verify fix is working. 

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ X] My code is not on the master branch.
- [ X] The code has been tested.
- [ X] All commit messages are properly formatted and commits squashed where appropriate.
- [ X] I have included updates to all appropriate documentation.
