### PR TITLE
libobs: Don't destroy mutex before destroying sources is done

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -699,6 +699,8 @@ static void obs_free_data(void)
 	FREE_OBS_LINKED_LIST(display);
 	FREE_OBS_LINKED_LIST(service);
 
+	os_task_queue_wait(obs->destruction_task_thread);
+
 	pthread_mutex_destroy(&data->sources_mutex);
 	pthread_mutex_destroy(&data->audio_sources_mutex);
 	pthread_mutex_destroy(&data->displays_mutex);


### PR DESCRIPTION
### Description

Don't destroy mutex before destroying sources is done

### Motivation and Context
Don't like crashes

### How Has This Been Tested?
on windows 64 bit

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
