### PR TITLE
aja: Fix UHD/4K YCbCr 3G Level-B 2SI preset

### DIFF
--- a/plugins/aja/aja-presets.cpp
+++ b/plugins/aja/aja-presets.cpp
@@ -952,7 +952,7 @@ void RoutingConfigurator::build_preset_table()
 		  VPIDStandard_2160_DualLink,
 		  2,
 		  2,
-		  kConvert3GIn | kEnable4KTSI,
+		  kEnable4KTSI,
 		  "sdi[{ch1}][0]->tsi[{ch1}][0];"
 		  "sdi[{ch1}][1]->tsi[{ch1}][1];"
 		  "sdi[{ch2}][0]->tsi[{ch2}][0];"


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Remove the flag to enable the 3G Level-B to Level-A converter from the `UHD4K_ST425_Dual_3Gb_2SI_YCbCr_Capture` preset. The converter was enabled erroneously and caused problems with UHD/4K YCbCr 2SI 3G Level-B SDI signals on the Kona5. 

Enabling the 3Gb->3Ga converter alters the signal on the Kona5 and other newer boards that return `true` for `NTV2DeviceCanDo3GLevelConversion`. Older boards can safely enable the converter even if it is not needed, as was the case with this bug.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
UHD/4K YCbCr 2SI 3G Level-B capture was broken on boards which return `true` for `NTV2DeviceCanDo3GLevelConversion` due to the enablement of the 3Gb->3Ga level conversion register in the associated capture preset.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Verified that the change fixes UHD/4K YCbCr 3G Level-B 2SI SDI signals on Kona5 but does not break the signal on older devices such as the io4K+.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
