### PR TITLE
UI: Don't recreate properties view if the filter did not change

### DIFF
--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -165,4 +165,5 @@ public:
 
 	inline void UpdateSettings() { callback(obj, nullptr, settings); }
 	inline bool DeferUpdate() const { return deferUpdate; }
+	inline void *GetObj() { return obj; }
 };

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -262,6 +262,10 @@ void FilterChangeUndoRedo(void *vp, obs_data_t *nd_old_settings,
 
 void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 {
+	OBSSource filter = GetFilter(row, async);
+	if (filter && view && view->GetObj() == filter)
+		return;
+
 	if (view) {
 		updatePropertiesSignal.Disconnect();
 		ui->propertiesFrame->setVisible(false);
@@ -270,7 +274,6 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 		view = nullptr;
 	}
 
-	OBSSource filter = GetFilter(row, async);
 	if (!filter)
 		return;
 


### PR DESCRIPTION
### Description
Don't recreate properties view if the filter did not change

### Motivation and Context
The properties view recreated when the focus moved to one of the filter lists, even if the selected row did not change.
This also fixes a crash in the OBS 27.2 beta 3 when removing the last filter of a source.

### How Has This Been Tested?
On windows 64 bit by adding and removing filters and by switching between filters.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
