### PR TITLE
UI: Disconnect group reorder signal

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -193,6 +193,9 @@ void SourceTreeItem::DisconnectSignals()
 	lockedSignal.Disconnect();
 	renameSignal.Disconnect();
 	removeSignal.Disconnect();
+
+	if (obs_sceneitem_is_group(sceneitem))
+		groupReorderSignal.Disconnect();
 }
 
 void SourceTreeItem::Clear()


### PR DESCRIPTION
### Description
The group reorder signal was never disconnected when
resetting signals.

### Motivation and Context
Bug fix.

### How Has This Been Tested?
Created groups to make sure nothing broke.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
