### PR TITLE
win-capture: Fix parameter mismatches

### DIFF
--- a/plugins/win-capture/window-helpers.c
+++ b/plugins/win-capture/window-helpers.c
@@ -236,12 +236,12 @@ static void add_window(obs_property_t *p, HWND hwnd, add_window_cb callback)
 	dstr_free(&exe);
 }
 
-static inline bool IsWindowCloaked(window)
+static inline bool IsWindowCloaked(HWND window)
 {
-	int cloaked;
+	DWORD cloaked;
 	HRESULT hr = DwmGetWindowAttribute(window, DWMWA_CLOAKED, &cloaked,
 					   sizeof(cloaked));
-	return (SUCCEEDED(hr) && cloaked);
+	return SUCCEEDED(hr) && cloaked;
 }
 
 static bool check_window_valid(HWND window, enum window_search_mode mode)


### PR DESCRIPTION
### Description
Fix missing HWND argument type, and use DWORD based on MS sample.

### Motivation and Context
Correctness. Warnings are annoying.

### How Has This Been Tested?
Verified DwmGetWindowAttribute is still behaving as before.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.