### PR TITLE
UI: Move "Check For Updates" menu to app menu on macOS

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -354,6 +354,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	ui->actionRemoveSource->setShortcuts({Qt::Key_Backspace});
 	ui->actionRemoveScene->setShortcuts({Qt::Key_Backspace});
 
+	ui->actionCheckForUpdates->setMenuRole(QAction::AboutQtRole);
 	ui->action_Settings->setMenuRole(QAction::PreferencesRole);
 	ui->actionE_xit->setMenuRole(QAction::QuitRole);
 #else


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
For apps using sparkle, it's normal for the "Check For Updates" button
to be in the app menu instead of the help menu, so let's put it there.

![image](https://user-images.githubusercontent.com/59806498/150675803-efa3faed-fc91-4038-9fe6-b080db6454d4.png)

While `ApplicationSpecificRole` is what Qt recommends for such purposes, this would move
it between the separator and "Preferences...". However, we can hijack `AboutQtRole` which
moves it right below "About OBS" (which is where it should go, and where most other sparkle
apps put it (In particular, I checked VLC and Cyberduck)).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
- [Ideas page](https://ideas.obsproject.com/posts/1545/check-for-updates-should-appear-in-the-obs-menu-in-the-main-menu-not-help)
- https://github.com/obsproject/obs-studio/issues/5338


While there is no formal documentation, there is plenty of precedent for this (see the discussion on the issue linked above). In addition to that, this text (which comes from sparkle) says you can check for updates in the app menu, which is as close to official sparkle documentation as it gets.
![image](https://user-images.githubusercontent.com/59806498/150675867-9589c1ae-044d-4fa3-81fd-86c7085c17f0.png)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.1
Menu item moved correctly (see screenshot above) and is no longer under "Help". The separator which was
between "Log Files >" and "Check For Updates" is gone as well.
Confirmed that pressing the menu item still correctly triggers `OBSBasic::on_actionCheckForUpdates_triggered()`.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
