### PR TITLE
UI: Fix bugtracker URL in AppData file

### DIFF
--- a/UI/xdg-data/com.obsproject.Studio.appdata.xml.in
+++ b/UI/xdg-data/com.obsproject.Studio.appdata.xml.in
@@ -11,7 +11,7 @@
     <p>Free and open source software for video capturing, recording, and live streaming.</p>
   </description>
   <url type="homepage">https://obsproject.com</url>
-  <url type="bugtracker">https://github.org/obsproject/obs-studio/issues</url>
+  <url type="bugtracker">https://github.com/obsproject/obs-studio/issues</url>
   <url type="donation">https://obsproject.com/contribute</url>
   <url type="translate">https://crowdin.com/project/obs-studio</url>
   <screenshots>


### PR DESCRIPTION
### Description

It is mistakenly set to github.org, instead of github.com. Sorry :(

### Motivation and Context

While the idea of leading people to report bugs to the wrong website is entertaining, we should at least make sure this wrong website exists and has an issue report form.

Meanwhile, let's just point people to our actual issue tracker.

### How Has This Been Tested?

Open the URL, and observe that it leads you to the correct website.

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
