### PR TITLE
win-dshow: Use OBS_SOURCE_FRAME_LINEAR_ALPHA

### DIFF
--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -548,6 +548,7 @@ void DShowInput::OnVideoData(const VideoConfig &config, unsigned char *data,
 	frame.height = cy_abs;
 	frame.format = ConvertVideoFormat(config.format);
 	frame.flip = flip;
+	frame.flags = OBS_SOURCE_FRAME_LINEAR_ALPHA;
 
 	/* YUV DIBS are always top-down */
 	if (config.format == VideoFormat::XRGB ||


### PR DESCRIPTION
### Description
This flag leads to a cheaper technique, "Draw" instead of
"DrawNonlinearAlpha", and all the paths are opaque anyway.

### Motivation and Context
Faster is better.

### How Has This Been Tested?
Tested 4K NV12 source. Image looked fine. Verified shader swap in Intel GPA. Seems to be a few microseconds faster on average, maybe 76 -> 73 µs.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.