### PR TITLE
Add GS_RG16

### DIFF
--- a/docs/sphinx/reference-libobs-graphics-graphics.rst
+++ b/docs/sphinx/reference-libobs-graphics-graphics.rst
@@ -45,6 +45,7 @@ Graphics Enumerations
    - GS_RGBA_UNORM  - RGBA, 8 bits per channel, no SRGB aliasing
    - GS_BGRX_UNORM  - BGRX, 8 bits per channel, no SRGB aliasing
    - GS_BGRA_UNORM  - BGRA, 8 bits per channel, no SRGB aliasing
+   - GS_RG16        - RG, 16 bits per channel
 
 .. type:: enum gs_zstencil_format
 

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -105,6 +105,8 @@ static inline DXGI_FORMAT ConvertGSTextureFormatResource(gs_color_format format)
 		return DXGI_FORMAT_B8G8R8X8_UNORM;
 	case GS_BGRA_UNORM:
 		return DXGI_FORMAT_B8G8R8A8_UNORM;
+	case GS_RG16:
+		return DXGI_FORMAT_R16G16_UNORM;
 	}
 
 	return DXGI_FORMAT_UNKNOWN;
@@ -184,6 +186,8 @@ static inline gs_color_format ConvertDXGITextureFormat(DXGI_FORMAT format)
 		return GS_BGRX_UNORM;
 	case DXGI_FORMAT_B8G8R8A8_UNORM:
 		return GS_BGRA_UNORM;
+	case DXGI_FORMAT_R16G16_UNORM:
+		return GS_RG16;
 	}
 
 	return GS_UNKNOWN;

--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -77,6 +77,8 @@ static inline GLenum convert_gs_format(enum gs_color_format format)
 		return GL_BGRA;
 	case GS_BGRA_UNORM:
 		return GL_BGRA;
+	case GS_RG16:
+		return GL_RG;
 	case GS_UNKNOWN:
 		return 0;
 	}
@@ -129,6 +131,8 @@ static inline GLenum convert_gs_internal_format(enum gs_color_format format)
 		return GL_RGB;
 	case GS_BGRA_UNORM:
 		return GL_RGBA;
+	case GS_RG16:
+		return GL_RG16;
 	case GS_UNKNOWN:
 		return 0;
 	}
@@ -181,6 +185,8 @@ static inline GLenum get_gl_format_type(enum gs_color_format format)
 		return GL_UNSIGNED_BYTE;
 	case GS_BGRA_UNORM:
 		return GL_UNSIGNED_BYTE;
+	case GS_RG16:
+		return GL_UNSIGNED_SHORT;
 	case GS_UNKNOWN:
 		return 0;
 	}

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -76,6 +76,7 @@ enum gs_color_format {
 	GS_RGBA_UNORM,
 	GS_BGRX_UNORM,
 	GS_BGRA_UNORM,
+	GS_RG16,
 };
 
 enum gs_zstencil_format {
@@ -963,48 +964,33 @@ EXPORT bool gs_query_dmabuf_modifiers_for_format(uint32_t drm_format,
 static inline uint32_t gs_get_format_bpp(enum gs_color_format format)
 {
 	switch (format) {
+	case GS_DXT1:
+		return 4;
 	case GS_A8:
-		return 8;
 	case GS_R8:
+	case GS_DXT3:
+	case GS_DXT5:
 		return 8;
+	case GS_R16:
+	case GS_R16F:
+	case GS_R8G8:
+		return 16;
 	case GS_RGBA:
-		return 32;
 	case GS_BGRX:
-		return 32;
 	case GS_BGRA:
-		return 32;
 	case GS_R10G10B10A2:
+	case GS_RG16F:
+	case GS_R32F:
+	case GS_RGBA_UNORM:
+	case GS_BGRX_UNORM:
+	case GS_BGRA_UNORM:
+	case GS_RG16:
 		return 32;
 	case GS_RGBA16:
-		return 64;
-	case GS_R16:
-		return 16;
-	case GS_RGBA16F:
+	case GS_RG32F:
 		return 64;
 	case GS_RGBA32F:
 		return 128;
-	case GS_RG16F:
-		return 32;
-	case GS_RG32F:
-		return 64;
-	case GS_R16F:
-		return 16;
-	case GS_R32F:
-		return 32;
-	case GS_DXT1:
-		return 4;
-	case GS_DXT3:
-		return 8;
-	case GS_DXT5:
-		return 8;
-	case GS_R8G8:
-		return 16;
-	case GS_RGBA_UNORM:
-		return 32;
-	case GS_BGRX_UNORM:
-		return 32;
-	case GS_BGRA_UNORM:
-		return 32;
 	case GS_UNKNOWN:
 		return 0;
 	}


### PR DESCRIPTION
### Description
This format will be useful for P010 chroma in the future.

### Motivation and Context
HDR

### How Has This Been Tested?
Verified D3D11 and OpenGL paths work in separate fork.

### Types of changes
- New feature (non-breaking change which adds functionality)
- Documentation (a change to documentation pages)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.