### PR TITLE
UI: Bunch of RAII stuff

### DIFF
--- a/UI/audio-encoders.cpp
+++ b/UI/audio-encoders.cpp
@@ -69,9 +69,7 @@ static void HandleListProperty(obs_property_t *prop, const char *id)
 
 static void HandleSampleRate(obs_property_t *prop, const char *id)
 {
-	auto ReleaseData = [](obs_data_t *data) { obs_data_release(data); };
-	std::unique_ptr<obs_data_t, decltype(ReleaseData)> data{
-		obs_encoder_defaults(id), ReleaseData};
+	OBSDataAutoRelease data = obs_encoder_defaults(id);
 
 	if (!data) {
 		blog(LOG_ERROR,
@@ -91,9 +89,9 @@ static void HandleSampleRate(obs_property_t *prop, const char *id)
 	uint32_t sampleRate =
 		config_get_uint(main->Config(), "Audio", "SampleRate");
 
-	obs_data_set_int(data.get(), "samplerate", sampleRate);
+	obs_data_set_int(data, "samplerate", sampleRate);
 
-	obs_property_modified(prop, data.get());
+	obs_property_modified(prop, data);
 }
 
 static void HandleEncoderProperties(const char *id)

--- a/UI/audio-encoders.cpp
+++ b/UI/audio-encoders.cpp
@@ -96,11 +96,7 @@ static void HandleSampleRate(obs_property_t *prop, const char *id)
 
 static void HandleEncoderProperties(const char *id)
 {
-	auto DestroyProperties = [](obs_properties_t *props) {
-		obs_properties_destroy(props);
-	};
-	std::unique_ptr<obs_properties_t, decltype(DestroyProperties)> props{
-		obs_get_encoder_properties(id), DestroyProperties};
+	OBSProperties props = obs_get_encoder_properties(id);
 
 	if (!props) {
 		blog(LOG_ERROR,
@@ -110,12 +106,11 @@ static void HandleEncoderProperties(const char *id)
 		return;
 	}
 
-	obs_property_t *samplerate =
-		obs_properties_get(props.get(), "samplerate");
+	obs_property_t *samplerate = obs_properties_get(props, "samplerate");
 	if (samplerate)
 		HandleSampleRate(samplerate, id);
 
-	obs_property_t *bitrate = obs_properties_get(props.get(), "bitrate");
+	obs_property_t *bitrate = obs_properties_get(props, "bitrate");
 
 	obs_property_type type = obs_property_get_type(bitrate);
 	switch (type) {

--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -30,7 +30,7 @@
 SourceToolbar::SourceToolbar(QWidget *parent, OBSSource source)
 	: QWidget(parent),
 	  weakSource(OBSGetWeakRef(source)),
-	  props(obs_source_properties(source), obs_properties_destroy)
+	  props(obs_source_properties(source))
 {
 }
 
@@ -109,7 +109,7 @@ void BrowserToolbar::on_refresh_clicked()
 		return;
 	}
 
-	obs_property_t *p = obs_properties_get(props.get(), "refreshnocache");
+	obs_property_t *p = obs_properties_get(props, "refreshnocache");
 	obs_property_button_clicked(p, source.Get());
 }
 
@@ -192,8 +192,8 @@ void ComboSelectToolbar::Init()
 		return;
 	}
 
-	UpdateSourceComboToolbarProperties(ui->device, source, props.get(),
-					   prop_name, is_int);
+	UpdateSourceComboToolbarProperties(ui->device, source, props, prop_name,
+					   is_int);
 }
 
 void UpdateSourceComboToolbarValue(QComboBox *combo, OBSSource source, int idx,
@@ -388,13 +388,13 @@ GameCaptureToolbar::GameCaptureToolbar(QWidget *parent, OBSSource source)
 	std::string cur_window = obs_data_get_string(settings, "window");
 
 	ui->mode->blockSignals(true);
-	p = obs_properties_get(props.get(), "capture_mode");
+	p = obs_properties_get(props, "capture_mode");
 	cur_idx = FillPropertyCombo(ui->mode, p, cur_mode);
 	ui->mode->setCurrentIndex(cur_idx);
 	ui->mode->blockSignals(false);
 
 	ui->window->blockSignals(true);
-	p = obs_properties_get(props.get(), "window");
+	p = obs_properties_get(props, "window");
 	cur_idx = FillPropertyCombo(ui->window, p, cur_window);
 	ui->window->setCurrentIndex(cur_idx);
 	ui->window->blockSignals(false);
@@ -481,7 +481,7 @@ void ImageSourceToolbar::on_browse_clicked()
 		return;
 	}
 
-	obs_property_t *p = obs_properties_get(props.get(), "file");
+	obs_property_t *p = obs_properties_get(props, "file");
 	const char *desc = obs_property_description(p);
 	const char *filter = obs_property_path_filter(p);
 	const char *default_path = obs_property_path_default_path(p);
@@ -558,7 +558,7 @@ void ColorSourceToolbar::on_choose_clicked()
 		return;
 	}
 
-	obs_property_t *p = obs_properties_get(props.get(), "color");
+	obs_property_t *p = obs_properties_get(props, "color");
 	const char *desc = obs_property_description(p);
 
 	QColorDialog::ColorDialogOptions options;
@@ -682,7 +682,7 @@ void TextSourceToolbar::on_selectColor_clicked()
 		strncmp(obs_source_get_id(source), "text_ft2_source", 15) == 0;
 
 	obs_property_t *p =
-		obs_properties_get(props.get(), freetype ? "color1" : "color");
+		obs_properties_get(props, freetype ? "color1" : "color");
 
 	const char *desc = obs_property_description(p);
 

--- a/UI/context-bar-controls.hpp
+++ b/UI/context-bar-controls.hpp
@@ -17,11 +17,7 @@ class SourceToolbar : public QWidget {
 	OBSWeakSource weakSource;
 
 protected:
-	using properties_delete_t = decltype(&obs_properties_destroy);
-	using properties_t =
-		std::unique_ptr<obs_properties_t, properties_delete_t>;
-
-	properties_t props;
+	OBSProperties props;
 	OBSDataAutoRelease oldData;
 
 	void SaveOldProperties(obs_source_t *source);

--- a/UI/frontend-plugins/aja-output-ui/AJAOutputUI.cpp
+++ b/UI/frontend-plugins/aja-output-ui/AJAOutputUI.cpp
@@ -40,7 +40,7 @@ void AJAOutputUI::SetupPropertiesView()
 	if (propertiesView)
 		delete propertiesView;
 
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 	OBSData data = load_settings(kProgramPropsFilename);
 	if (data) {
 		obs_data_apply(settings, data);
@@ -71,7 +71,6 @@ void AJAOutputUI::SetupPropertiesView()
 		(PropertiesReloadCallback)obs_get_output_properties, 170);
 
 	ui->propertiesLayout->addWidget(propertiesView);
-	obs_data_release(settings);
 
 	connect(propertiesView, SIGNAL(Changed()), this,
 		SLOT(PropertiesChanged()));
@@ -96,7 +95,7 @@ void AJAOutputUI::SetupPreviewPropertiesView()
 	if (previewPropertiesView)
 		delete previewPropertiesView;
 
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 
 	OBSData data = load_settings(kPreviewPropsFilename);
 	if (data) {
@@ -128,7 +127,6 @@ void AJAOutputUI::SetupPreviewPropertiesView()
 		(PropertiesReloadCallback)obs_get_output_properties, 170);
 
 	ui->previewPropertiesLayout->addWidget(previewPropertiesView);
-	obs_data_release(settings);
 
 	connect(previewPropertiesView, SIGNAL(Changed()), this,
 		SLOT(PreviewPropertiesChanged()));
@@ -257,7 +255,7 @@ void AJAOutputUI::SetupMiscPropertiesView()
 	if (miscPropertiesView)
 		delete miscPropertiesView;
 
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 	OBSData data = load_settings(kMiscPropsFilename);
 	if (data) {
 		obs_data_apply(settings, data);
@@ -268,7 +266,6 @@ void AJAOutputUI::SetupMiscPropertiesView()
 		nullptr, nullptr, 170);
 
 	ui->miscPropertiesLayout->addWidget(miscPropertiesView);
-	obs_data_release(settings);
 	connect(miscPropertiesView, SIGNAL(Changed()), this,
 		SLOT(MiscPropertiesChanged()));
 }

--- a/UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp
+++ b/UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp
@@ -47,9 +47,8 @@ OBSData load_settings(const char *filename)
 		obs_module_get_config_path(obs_current_module(), filename);
 	BPtr<char> jsonData = os_quick_read_utf8_file(path);
 	if (!!jsonData) {
-		obs_data_t *data = obs_data_create_from_json(jsonData);
+		OBSDataAutoRelease data = obs_data_create_from_json(jsonData);
 		OBSData dataRet(data);
-		obs_data_release(data);
 
 		return dataRet;
 	}
@@ -67,14 +66,13 @@ void output_stop()
 
 void output_start()
 {
-	OBSData settings = load_settings(kProgramPropsFilename);
+	OBSDataAutoRelease settings = load_settings(kProgramPropsFilename);
 
 	if (settings != nullptr) {
 		output = obs_output_create("aja_output", kProgramOutputID,
 					   settings, NULL);
 
 		bool started = obs_output_start(output);
-		obs_data_release(settings);
 
 		main_output_running = started;
 
@@ -120,7 +118,7 @@ void preview_output_stop()
 
 void preview_output_start()
 {
-	OBSData settings = load_settings(kPreviewPropsFilename);
+	OBSDataAutoRelease settings = load_settings(kPreviewPropsFilename);
 
 	if (settings != nullptr) {
 		context.output = obs_output_create(
@@ -167,8 +165,6 @@ void preview_output_start()
 		obs_output_set_media(context.output, context.video_queue,
 				     obs_get_audio());
 		bool started = obs_output_start(context.output);
-
-		obs_data_release(settings);
 
 		preview_output_running = started;
 		ajaOutputUI->PreviewOutputStateChanged(started);

--- a/UI/frontend-plugins/decklink-captions/decklink-captions.cpp
+++ b/UI/frontend-plugins/decklink-captions/decklink-captions.cpp
@@ -72,13 +72,12 @@ static void caption_callback(void *param, obs_source_t *source,
 {
 	UNUSED_PARAMETER(param);
 	UNUSED_PARAMETER(source);
-	obs_output *output = obs_frontend_get_streaming_output();
+	OBSOutputAutoRelease output = obs_frontend_get_streaming_output();
 	if (output) {
 		if (obs_frontend_streaming_active() &&
 		    obs_output_active(output)) {
 			obs_output_caption(output, captions);
 		}
-		obs_output_release(output);
 	}
 }
 
@@ -104,17 +103,16 @@ static void save_decklink_caption_data(obs_data_t *save_data, bool saving,
 				       void *)
 {
 	if (saving) {
-		obs_data_t *obj = obs_data_create();
+		OBSDataAutoRelease obj = obs_data_create();
 
 		obs_data_set_string(obj, "source",
 				    captions->source_name.c_str());
 
 		obs_data_set_obj(save_data, "decklink_captions", obj);
-		obs_data_release(obj);
 	} else {
 		captions->stop();
 
-		obs_data_t *obj =
+		OBSDataAutoRelease obj =
 			obs_data_get_obj(save_data, "decklink_captions");
 		if (!obj)
 			obj = obs_data_create();
@@ -122,7 +120,6 @@ static void save_decklink_caption_data(obs_data_t *save_data, bool saving,
 		captions->source_name = obs_data_get_string(obj, "source");
 		captions->source =
 			GetWeakSourceByName(captions->source_name.c_str());
-		obs_data_release(obj);
 
 		captions->start();
 	}

--- a/UI/frontend-plugins/decklink-captions/decklink-captions.h
+++ b/UI/frontend-plugins/decklink-captions/decklink-captions.h
@@ -16,15 +16,12 @@ public slots:
 	void on_source_currentIndexChanged(int idx);
 };
 
-static inline OBSWeakSource GetWeakSourceByName(const char *name)
+static inline obs_weak_source_t *GetWeakSourceByName(const char *name)
 {
-	OBSWeakSource weak;
-	obs_source_t *source = obs_get_source_by_name(name);
-	if (source) {
+	OBSWeakSourceAutoRelease weak;
+	OBSSourceAutoRelease source = obs_get_source_by_name(name);
+	if (source)
 		weak = obs_source_get_weak_source(source);
-		obs_weak_source_release(weak);
-		obs_source_release(source);
-	}
 
 	return weak;
 }

--- a/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.cpp
@@ -3,6 +3,7 @@
 #include <util/platform.h>
 #include <util/util.hpp>
 #include "decklink-ui-main.h"
+#include "obs.hpp"
 
 DecklinkOutputUI::DecklinkOutputUI(QWidget *parent)
 	: QDialog(parent), ui(new Ui_Output)
@@ -30,7 +31,7 @@ void DecklinkOutputUI::SetupPropertiesView()
 	if (propertiesView)
 		delete propertiesView;
 
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 
 	OBSData data = load_settings();
 	if (data)
@@ -41,7 +42,6 @@ void DecklinkOutputUI::SetupPropertiesView()
 		(PropertiesReloadCallback)obs_get_output_properties, 170);
 
 	ui->propertiesLayout->addWidget(propertiesView);
-	obs_data_release(settings);
 
 	connect(propertiesView, SIGNAL(Changed()), this,
 		SLOT(PropertiesChanged()));
@@ -67,7 +67,7 @@ void DecklinkOutputUI::SetupPreviewPropertiesView()
 	if (previewPropertiesView)
 		delete previewPropertiesView;
 
-	obs_data_t *settings = obs_data_create();
+	OBSDataAutoRelease settings = obs_data_create();
 
 	OBSData data = load_preview_settings();
 	if (data)
@@ -78,7 +78,6 @@ void DecklinkOutputUI::SetupPreviewPropertiesView()
 		(PropertiesReloadCallback)obs_get_output_properties, 170);
 
 	ui->previewPropertiesLayout->addWidget(previewPropertiesView);
-	obs_data_release(settings);
 
 	connect(previewPropertiesView, SIGNAL(Changed()), this,
 		SLOT(PreviewPropertiesChanged()));

--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
@@ -43,9 +43,8 @@ OBSData load_settings()
 		obs_current_module(), "decklinkOutputProps.json");
 	BPtr<char> jsonData = os_quick_read_utf8_file(path);
 	if (!!jsonData) {
-		obs_data_t *data = obs_data_create_from_json(jsonData);
+		OBSDataAutoRelease data = obs_data_create_from_json(jsonData);
 		OBSData dataRet(data);
-		obs_data_release(data);
 
 		return dataRet;
 	}
@@ -97,9 +96,8 @@ OBSData load_preview_settings()
 		obs_current_module(), "decklinkPreviewOutputProps.json");
 	BPtr<char> jsonData = os_quick_read_utf8_file(path);
 	if (!!jsonData) {
-		obs_data_t *data = obs_data_create_from_json(jsonData);
+		OBSDataAutoRelease data = obs_data_create_from_json(jsonData);
 		OBSData dataRet(data);
-		obs_data_release(data);
 
 		return dataRet;
 	}

--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -245,10 +245,8 @@ void ScriptsTool::ReloadScript(const char *path)
 
 			OBSDataAutoRelease settings = obs_data_create();
 
-			obs_properties_t *prop =
-				obs_script_get_properties(script);
+			OBSProperties prop = obs_script_get_properties(script);
 			obs_properties_apply_settings(prop, settings);
-			obs_properties_destroy(prop);
 
 			break;
 		}
@@ -354,10 +352,8 @@ void ScriptsTool::on_addScripts_clicked()
 
 			OBSDataAutoRelease settings = obs_data_create();
 
-			obs_properties_t *prop =
-				obs_script_get_properties(script);
+			OBSProperties prop = obs_script_get_properties(script);
 			obs_properties_apply_settings(prop, settings);
-			obs_properties_destroy(prop);
 
 			ui->scripts->setCurrentItem(item);
 		}

--- a/UI/frontend-plugins/frontend-tools/tool-helpers.hpp
+++ b/UI/frontend-plugins/frontend-tools/tool-helpers.hpp
@@ -4,20 +4,17 @@
 #include <string>
 #include <QString>
 
-static inline OBSWeakSource GetWeakSourceByName(const char *name)
+static inline obs_weak_source_t *GetWeakSourceByName(const char *name)
 {
-	OBSWeakSource weak;
-	obs_source_t *source = obs_get_source_by_name(name);
-	if (source) {
+	OBSWeakSourceAutoRelease weak;
+	OBSSourceAutoRelease source = obs_get_source_by_name(name);
+	if (source)
 		weak = obs_source_get_weak_source(source);
-		obs_weak_source_release(weak);
-		obs_source_release(source);
-	}
 
 	return weak;
 }
 
-static inline OBSWeakSource GetWeakSourceByQString(const QString &name)
+static inline obs_weak_source_t *GetWeakSourceByQString(const QString &name)
 {
 	return GetWeakSourceByName(name.toUtf8().constData());
 }
@@ -26,11 +23,9 @@ static inline std::string GetWeakSourceName(obs_weak_source_t *weak_source)
 {
 	std::string name;
 
-	obs_source_t *source = obs_weak_source_get_source(weak_source);
-	if (source) {
+	OBSSourceAutoRelease source = obs_weak_source_get_source(weak_source);
+	if (source)
 		name = obs_source_get_name(source);
-		obs_source_release(source);
-	}
 
 	return name;
 }

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -174,7 +174,7 @@ void OBSPropertiesView::GetScrollPos(int &h, int &v)
 		v = scroll->value();
 }
 
-OBSPropertiesView::OBSPropertiesView(OBSData settings_, void *obj_,
+OBSPropertiesView::OBSPropertiesView(obs_data_t *settings_, void *obj_,
 				     PropertiesReloadCallback reloadCallback,
 				     PropertiesUpdateCallback callback_,
 				     PropertiesVisualUpdateCb cb_, int minSize_)
@@ -192,7 +192,7 @@ OBSPropertiesView::OBSPropertiesView(OBSData settings_, void *obj_,
 				  Qt::QueuedConnection);
 }
 
-OBSPropertiesView::OBSPropertiesView(OBSData settings_, const char *type_,
+OBSPropertiesView::OBSPropertiesView(obs_data_t *settings_, const char *type_,
 				     PropertiesReloadCallback reloadCallback_,
 				     int minSize_)
 	: VScrollArea(nullptr),
@@ -1925,7 +1925,6 @@ void WidgetInfo::ControlChanged()
 	if (!recently_updated) {
 		old_settings_cache = obs_data_create();
 		obs_data_apply(old_settings_cache, view->settings);
-		obs_data_release(old_settings_cache);
 	}
 
 	switch (type) {

--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -30,7 +30,7 @@ private:
 	QWidget *widget;
 	QPointer<QTimer> update_timer;
 	bool recently_updated = false;
-	OBSData old_settings_cache;
+	OBSDataAutoRelease old_settings_cache;
 
 	void BoolChanged(const char *setting);
 	void IntChanged(const char *setting);
@@ -61,7 +61,6 @@ public:
 			update_timer->stop();
 			QMetaObject::invokeMethod(update_timer, "timeout");
 			update_timer->deleteLater();
-			obs_data_release(old_settings_cache);
 		}
 	}
 
@@ -152,12 +151,12 @@ signals:
 	void PropertiesRefreshed();
 
 public:
-	OBSPropertiesView(OBSData settings, void *obj,
+	OBSPropertiesView(obs_data_t *settings, void *obj,
 			  PropertiesReloadCallback reloadCallback,
 			  PropertiesUpdateCallback callback,
 			  PropertiesVisualUpdateCb cb = nullptr,
 			  int minSize = 0);
-	OBSPropertiesView(OBSData settings, const char *type,
+	OBSPropertiesView(obs_data_t *settings, const char *type,
 			  PropertiesReloadCallback reloadCallback,
 			  int minSize = 0);
 

--- a/UI/source-label.cpp
+++ b/UI/source-label.cpp
@@ -37,8 +37,4 @@ void OBSSourceLabel::SourceDestroyed(void *data, calldata_t *)
 {
 	auto &label = *static_cast<OBSSourceLabel *>(data);
 	emit label.Destroyed();
-
-	label.destroyedSignal.Disconnect();
-	label.removedSignal.Disconnect();
-	label.renamedSignal.Disconnect();
 }

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -1230,10 +1230,9 @@ void SourceTree::dropEvent(QDropEvent *event)
 
 	bool dropOnCollapsed = false;
 	if (dropGroup) {
-		obs_data_t *data =
+		OBSDataAutoRelease data =
 			obs_sceneitem_get_private_settings(dropGroup);
 		dropOnCollapsed = obs_data_get_bool(data, "collapsed");
-		obs_data_release(data);
 	}
 
 	if (indicator == QAbstractItemView::BelowItem ||

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -183,24 +183,8 @@ void SourceTreeItem::paintEvent(QPaintEvent *event)
 	QWidget::paintEvent(event);
 }
 
-void SourceTreeItem::DisconnectSignals()
-{
-	sceneRemoveSignal.Disconnect();
-	itemRemoveSignal.Disconnect();
-	selectSignal.Disconnect();
-	deselectSignal.Disconnect();
-	visibleSignal.Disconnect();
-	lockedSignal.Disconnect();
-	renameSignal.Disconnect();
-	removeSignal.Disconnect();
-
-	if (obs_sceneitem_is_group(sceneitem))
-		groupReorderSignal.Disconnect();
-}
-
 void SourceTreeItem::Clear()
 {
-	DisconnectSignals();
 	sceneitem = nullptr;
 }
 
@@ -208,8 +192,6 @@ void SourceTreeItem::ReconnectSignals()
 {
 	if (!sceneitem)
 		return;
-
-	DisconnectSignals();
 
 	/* --------------------------------------------------------- */
 
@@ -311,7 +293,6 @@ void SourceTreeItem::ReconnectSignals()
 	auto removeSource = [](void *data, calldata_t *) {
 		SourceTreeItem *this_ =
 			reinterpret_cast<SourceTreeItem *>(data);
-		this_->DisconnectSignals();
 		this_->sceneitem = nullptr;
 		QMetaObject::invokeMethod(this_->tree, "RefreshItems");
 	};

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -50,7 +50,6 @@ class SourceTreeItem : public QWidget {
 		SubItem,
 	};
 
-	void DisconnectSignals();
 	void ReconnectSignals();
 
 	Type type = Type::Unknown;

--- a/UI/ui-validation.cpp
+++ b/UI/ui-validation.cpp
@@ -57,7 +57,8 @@ bool UIValidation::NoSourcesConfirmation(QWidget *parent)
 }
 
 StreamSettingsAction
-UIValidation::StreamSettingsConfirmation(QWidget *parent, OBSService service)
+UIValidation::StreamSettingsConfirmation(QWidget *parent,
+					 obs_service_t *service)
 {
 	// Custom services can user API key in URL or user/pass combo.
 	// So only check there is a URL

--- a/UI/ui-validation.hpp
+++ b/UI/ui-validation.hpp
@@ -26,5 +26,5 @@ public:
 	 * open settings, cancel, or continue.  Returns Continue if all
 	 * settings are valid. */
 	static StreamSettingsAction
-	StreamSettingsConfirmation(QWidget *parent, OBSService service);
+	StreamSettingsConfirmation(QWidget *parent, obs_service_t *service);
 };

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -327,8 +327,6 @@ VolControl::~VolControl()
 	signal_handler_disconnect(obs_source_get_signal_handler(source), "mute",
 				  OBSVolumeMuted, this);
 
-	obs_fader_destroy(obs_fader);
-	obs_volmeter_destroy(obs_volmeter);
 	if (contextMenu)
 		contextMenu->close();
 }

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -268,8 +268,8 @@ private:
 	QPushButton *config = nullptr;
 	float levelTotal;
 	float levelCount;
-	obs_fader_t *obs_fader;
-	obs_volmeter_t *obs_volmeter;
+	OBSFader obs_fader;
+	OBSVolMeter obs_volmeter;
 	bool vertical;
 	QMenu *contextMenu;
 

--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -238,8 +238,6 @@ void OBSBasicAdvAudio::SetShowInactive(bool show)
 
 	showInactive = show;
 	activeOnly->setChecked(!showInactive);
-	sourceAddedSignal.Disconnect();
-	sourceRemovedSignal.Disconnect();
 
 	if (showInactive) {
 		sourceAddedSignal.Connect(obs_get_signal_handler(),

--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -121,7 +121,7 @@ void AutoConfigTestPage::GetServers(std::vector<ServerInfo> &servers)
 	OBSDataAutoRelease settings = obs_data_create();
 	obs_data_set_string(settings, "service", wiz->serviceName.c_str());
 
-	obs_properties_t *ppts = obs_get_service_properties("rtmp_common");
+	OBSProperties ppts = obs_get_service_properties("rtmp_common");
 	obs_property_t *p = obs_properties_get(ppts, "service");
 	obs_property_modified(p, settings);
 
@@ -138,8 +138,6 @@ void AutoConfigTestPage::GetServers(std::vector<ServerInfo> &servers)
 			servers.push_back(info);
 		}
 	}
-
-	obs_properties_destroy(ppts);
 }
 
 static inline void string_depad_key(string &key)

--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -24,7 +24,7 @@ using namespace std;
 
 class TestMode {
 	obs_video_info ovi;
-	OBSSource source[6];
+	OBSSourceAutoRelease source[6];
 
 	static void render_rand(void *, uint32_t cx, uint32_t cy)
 	{
@@ -55,7 +55,6 @@ public:
 
 		for (uint32_t i = 0; i < 6; i++) {
 			source[i] = obs_get_output_source(i);
-			obs_source_release(source[i]);
 			obs_set_output_source(i, nullptr);
 		}
 	}

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -689,7 +689,7 @@ void AutoConfigStreamPage::UpdateMoreInfoLink()
 	}
 
 	QString serviceName = ui->service->currentText();
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
 	OBSDataAutoRelease settings = obs_data_create();
@@ -706,7 +706,6 @@ void AutoConfigStreamPage::UpdateMoreInfoLink()
 		ui->moreInfoButton->setTargetUrl(QUrl(more_info_link));
 		ui->moreInfoButton->show();
 	}
-	obs_properties_destroy(props);
 }
 
 void AutoConfigStreamPage::UpdateKeyLink()
@@ -715,7 +714,7 @@ void AutoConfigStreamPage::UpdateKeyLink()
 	QString customServer = ui->customServer->text().trimmed();
 	QString streamKeyLink;
 
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
 	OBSDataAutoRelease settings = obs_data_create();
@@ -745,12 +744,11 @@ void AutoConfigStreamPage::UpdateKeyLink()
 		ui->streamKeyButton->setTargetUrl(QUrl(streamKeyLink));
 		ui->streamKeyButton->show();
 	}
-	obs_properties_destroy(props);
 }
 
 void AutoConfigStreamPage::LoadServices(bool showAll)
 {
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 
 	OBSDataAutoRelease settings = obs_data_create();
 
@@ -793,8 +791,6 @@ void AutoConfigStreamPage::LoadServices(bool showAll)
 			ui->service->setCurrentIndex(idx);
 	}
 
-	obs_properties_destroy(props);
-
 	ui->service->blockSignals(false);
 }
 
@@ -812,7 +808,7 @@ void AutoConfigStreamPage::UpdateServerList()
 		lastService = serviceName;
 	}
 
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
 	OBSDataAutoRelease settings = obs_data_create();
@@ -830,8 +826,6 @@ void AutoConfigStreamPage::UpdateServerList()
 		const char *server = obs_property_list_item_string(servers, i);
 		ui->server->addItem(name, server);
 	}
-
-	obs_properties_destroy(props);
 }
 
 void AutoConfigStreamPage::UpdateCompleted()
@@ -899,14 +893,12 @@ AutoConfig::AutoConfig(QWidget *parent) : QWizard(parent)
 
 	obs_data_set_string(twitchSettings, "service", "Twitch");
 
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_properties_apply_settings(props, twitchSettings);
 
 	obs_property_t *p = obs_properties_get(props, "server");
 	const char *first = obs_property_list_item_string(p, 0);
 	twitchAuto = strcmp(first, "auto") == 0;
-
-	obs_properties_destroy(props);
 
 	/* ----------------------------------------- */
 	/* load service/servers                      */

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -263,7 +263,6 @@ void FilterChangeUndoRedo(void *vp, obs_data_t *nd_old_settings,
 void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 {
 	if (view) {
-		updatePropertiesSignal.Disconnect();
 		ui->propertiesFrame->setVisible(false);
 		view->hide();
 		view->deleteLater();

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -597,23 +597,20 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
 				->GetCurrentSceneSource());
 		auto undo = [scene_name](const std::string &data) {
-			obs_source_t *ssource =
+			OBSSourceAutoRelease ssource =
 				obs_get_source_by_name(scene_name.c_str());
 			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
 				->SetCurrentScene(ssource, true);
-			obs_source_release(ssource);
 
-			obs_data_t *dat =
+			OBSDataAutoRelease dat =
 				obs_data_create_from_json(data.c_str());
-			obs_source_t *source = obs_get_source_by_name(
+			OBSSourceAutoRelease source = obs_get_source_by_name(
 				obs_data_get_string(dat, "sname"));
-			obs_source_t *filter = obs_source_get_filter_by_name(
-				source, obs_data_get_string(dat, "fname"));
+			OBSSourceAutoRelease filter =
+				obs_source_get_filter_by_name(
+					source,
+					obs_data_get_string(dat, "fname"));
 			obs_source_filter_remove(source, filter);
-
-			obs_data_release(dat);
-			obs_source_release(source);
-			obs_source_release(filter);
 		};
 
 		OBSDataAutoRelease rwrapper = obs_data_create();

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -756,11 +756,6 @@ bool SimpleOutput::SetupStreaming(obs_service_t *service)
 
 	/* XXX: this is messy and disgusting and should be refactored */
 	if (outputType != type) {
-		streamDelayStarting.Disconnect();
-		streamStopping.Disconnect();
-		startStreaming.Disconnect();
-		stopStreaming.Disconnect();
-
 		streamOutput = obs_output_create(type, "simple_stream", nullptr,
 						 nullptr);
 		if (!streamOutput) {
@@ -1686,11 +1681,6 @@ bool AdvancedOutput::SetupStreaming(obs_service_t *service)
 
 	/* XXX: this is messy and disgusting and should be refactored */
 	if (outputType != type) {
-		streamDelayStarting.Disconnect();
-		streamStopping.Disconnect();
-		startStreaming.Disconnect();
-		stopStreaming.Disconnect();
-
 		streamOutput =
 			obs_output_create(type, "adv_stream", nullptr, nullptr);
 		if (!streamOutput) {

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1152,8 +1152,7 @@ static OBSData GetDataFromJsonFile(const char *jsonFile)
 static void ApplyEncoderDefaults(OBSData &settings,
 				 const obs_encoder_t *encoder)
 {
-	OBSData dataRet = obs_encoder_get_defaults(encoder);
-	obs_data_release(dataRet);
+	OBSDataAutoRelease dataRet = obs_encoder_get_defaults(encoder);
 
 	if (!!settings)
 		obs_data_apply(dataRet, settings);

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -586,7 +586,7 @@ void SimpleOutput::UpdateRecordingSettings_x264_crf(int crf)
 
 static bool icq_available(obs_encoder_t *encoder)
 {
-	obs_properties_t *props = obs_encoder_properties(encoder);
+	OBSProperties props = obs_encoder_properties(encoder);
 	obs_property_t *p = obs_properties_get(props, "rate_control");
 	bool icq_found = false;
 
@@ -599,7 +599,6 @@ static bool icq_available(obs_encoder_t *encoder)
 		}
 	}
 
-	obs_properties_destroy(props);
 	return icq_found;
 }
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -753,7 +753,7 @@ static void LoadAudioDevice(const char *name, int channel, obs_data_t *parent)
 static inline bool HasAudioDevices(const char *source_id)
 {
 	const char *output_id = source_id;
-	obs_properties_t *props = obs_get_source_properties(output_id);
+	OBSProperties props = obs_get_source_properties(output_id);
 	size_t count = 0;
 
 	if (!props)
@@ -762,8 +762,6 @@ static inline bool HasAudioDevices(const char *source_id)
 	obs_property_t *devices = obs_properties_get(props, "device_id");
 	if (devices)
 		count = obs_property_list_item_count(devices);
-
-	obs_properties_destroy(props);
 
 	return count != 0;
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -251,7 +251,7 @@ private:
 
 	os_cpu_usage_info_t *cpuUsageInfo = nullptr;
 
-	OBSService service;
+	OBSServiceAutoRelease service;
 	std::unique_ptr<BasicOutputHandler> outputHandler;
 	bool streamingStopping = false;
 	bool recordingStopping = false;
@@ -661,7 +661,7 @@ public slots:
 			       bool quickTransition = false,
 			       int quickDuration = 0, bool black = false,
 			       bool manual = false);
-	void SetCurrentScene(OBSSource scene, bool force = false);
+	void SetCurrentScene(obs_source_t *scene, bool force = false);
 
 	bool AddSceneCollection(bool create_new,
 				const QString &name = QString());

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -75,9 +75,6 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 
 	QMetaObject::connectSlotsByName(this);
 
-	/* The OBSData constructor increments the reference once */
-	obs_data_release(oldSettings);
-
 	OBSDataAutoRelease nd_settings = obs_source_get_settings(source);
 	obs_data_apply(oldSettings, nd_settings);
 

--- a/UI/window-basic-properties.hpp
+++ b/UI/window-basic-properties.hpp
@@ -40,7 +40,7 @@ private:
 	OBSSignal removedSignal;
 	OBSSignal renamedSignal;
 	OBSSignal updatePropertiesSignal;
-	OBSData oldSettings;
+	OBSDataAutoRelease oldSettings;
 	OBSPropertiesView *view;
 	QDialogButtonBox *buttonBox;
 	QSplitter *windowSplitter;

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -254,7 +254,7 @@ void OBSBasicSettings::UpdateMoreInfoLink()
 	}
 
 	QString serviceName = ui->service->currentText();
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
 	OBSDataAutoRelease settings = obs_data_create();
@@ -271,7 +271,6 @@ void OBSBasicSettings::UpdateMoreInfoLink()
 		ui->moreInfoButton->setTargetUrl(QUrl(more_info_link));
 		ui->moreInfoButton->show();
 	}
-	obs_properties_destroy(props);
 }
 
 void OBSBasicSettings::UpdateKeyLink()
@@ -280,7 +279,7 @@ void OBSBasicSettings::UpdateKeyLink()
 	QString customServer = ui->customServer->text().trimmed();
 	QString streamKeyLink;
 
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
 	OBSDataAutoRelease settings = obs_data_create();
@@ -310,12 +309,11 @@ void OBSBasicSettings::UpdateKeyLink()
 		ui->getStreamKeyButton->setTargetUrl(QUrl(streamKeyLink));
 		ui->getStreamKeyButton->show();
 	}
-	obs_properties_destroy(props);
 }
 
 void OBSBasicSettings::LoadServices(bool showAll)
 {
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 
 	OBSDataAutoRelease settings = obs_data_create();
 
@@ -357,8 +355,6 @@ void OBSBasicSettings::LoadServices(bool showAll)
 		if (idx != -1)
 			ui->service->setCurrentIndex(idx);
 	}
-
-	obs_properties_destroy(props);
 
 	ui->service->blockSignals(false);
 }
@@ -498,7 +494,7 @@ void OBSBasicSettings::UpdateServerList()
 		lastService = serviceName;
 	}
 
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
 	OBSDataAutoRelease settings = obs_data_create();
@@ -516,8 +512,6 @@ void OBSBasicSettings::UpdateServerList()
 		const char *server = obs_property_list_item_string(servers, i);
 		ui->server->addItem(name, server);
 	}
-
-	obs_properties_destroy(props);
 }
 
 void OBSBasicSettings::on_show_clicked()

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1854,10 +1854,10 @@ OBSBasicSettings::CreateEncoderPropertyView(const char *encoder,
 		int ret = GetProfilePath(encoderJsonPath,
 					 sizeof(encoderJsonPath), path);
 		if (ret > 0) {
-			obs_data_t *data = obs_data_create_from_json_file_safe(
-				encoderJsonPath, "bak");
+			OBSDataAutoRelease data =
+				obs_data_create_from_json_file_safe(
+					encoderJsonPath, "bak");
 			obs_data_apply(settings, data);
-			obs_data_release(data);
 		}
 	}
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -814,7 +814,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 		SLOT(SimpleRecordingEncoderChanged()));
 
 	// Get Bind to IP Addresses
-	obs_properties_t *ppts = obs_get_output_properties("rtmp_output");
+	OBSProperties ppts = obs_get_output_properties("rtmp_output");
 	obs_property_t *p = obs_properties_get(ppts, "bind_ip");
 
 	size_t count = obs_property_list_item_count(p);
@@ -824,8 +824,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 
 		ui->bindToIP->addItem(QT_UTF8(name), val);
 	}
-
-	obs_properties_destroy(ppts);
 
 	InitStreamPage();
 	LoadSettings(false);
@@ -2267,8 +2265,8 @@ void OBSBasicSettings::LoadAudioDevices()
 	const char *input_id = App()->InputAudioSource();
 	const char *output_id = App()->OutputAudioSource();
 
-	obs_properties_t *input_props = obs_get_source_properties(input_id);
-	obs_properties_t *output_props = obs_get_source_properties(output_id);
+	OBSProperties input_props = obs_get_source_properties(input_id);
+	OBSProperties output_props = obs_get_source_properties(output_id);
 
 	if (input_props) {
 		obs_property_t *inputs =
@@ -2277,7 +2275,6 @@ void OBSBasicSettings::LoadAudioDevices()
 		LoadListValues(ui->auxAudioDevice2, inputs, 4);
 		LoadListValues(ui->auxAudioDevice3, inputs, 5);
 		LoadListValues(ui->auxAudioDevice4, inputs, 6);
-		obs_properties_destroy(input_props);
 	}
 
 	if (output_props) {
@@ -2285,7 +2282,6 @@ void OBSBasicSettings::LoadAudioDevices()
 			obs_properties_get(output_props, "device_id");
 		LoadListValues(ui->desktopAudioDevice1, outputs, 1);
 		LoadListValues(ui->desktopAudioDevice2, outputs, 2);
-		obs_properties_destroy(output_props);
 	}
 
 	if (obs_video_active()) {
@@ -4692,8 +4688,6 @@ void OBSBasicSettings::SimpleStreamingEncoderChanged()
 
 			ui->simpleOutPreset->addItem(QT_UTF8(name), val);
 		}
-
-		obs_properties_destroy(props);
 
 		defaultPreset = "default";
 		preset = curNVENCPreset;

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -163,7 +163,6 @@ static void AddExisting(OBSSource source, bool visible, bool duplicate,
 		char *new_name =
 			get_new_source_name(obs_source_get_name(source));
 		source = obs_source_duplicate(from, new_name, false);
-		obs_source_release(source);
 		bfree(new_name);
 
 		if (!source)
@@ -258,12 +257,12 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 
 		auto undo = [scene_name, main](const std::string &data) {
 			UNUSED_PARAMETER(data);
-			obs_source_t *scene_source =
+			OBSSourceAutoRelease scene_source =
 				obs_get_source_by_name(scene_name);
 			main->SetCurrentScene(scene_source, true);
-			obs_source_release(scene_source);
 
-			obs_scene_t *scene = obs_get_scene_by_name(scene_name);
+			OBSSceneAutoRelease scene =
+				obs_get_scene_by_name(scene_name);
 			OBSSceneItem item;
 			auto cb = [](obs_scene_t *scene,
 				     obs_sceneitem_t *sceneitem, void *data) {
@@ -276,16 +275,14 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 			obs_scene_enum_items(scene, cb, &item);
 
 			obs_sceneitem_remove(item);
-			obs_scene_release(scene);
 		};
 
 		auto redo = [scene_name, main, source_name,
 			     visible](const std::string &data) {
 			UNUSED_PARAMETER(data);
-			obs_source_t *scene_source =
+			OBSSourceAutoRelease scene_source =
 				obs_get_source_by_name(scene_name);
 			main->SetCurrentScene(scene_source, true);
-			obs_source_release(scene_source);
 			AddExisting(QT_TO_UTF8(source_name), visible, false,
 				    nullptr, nullptr, nullptr);
 		};

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -160,10 +160,9 @@ static void AddExisting(OBSSource source, bool visible, bool duplicate,
 
 	if (duplicate) {
 		OBSSource from = source;
-		char *new_name =
+		BPtr<char> new_name =
 			get_new_source_name(obs_source_get_name(source));
 		source = obs_source_duplicate(from, new_name, false);
-		bfree(new_name);
 
 		if (!source)
 			return;

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -111,11 +111,6 @@ OBSBasicTransform::~OBSBasicTransform()
 
 void OBSBasicTransform::SetScene(OBSScene scene)
 {
-	transformSignal.Disconnect();
-	selectSignal.Disconnect();
-	deselectSignal.Disconnect();
-	removeSignal.Disconnect();
-
 	if (scene) {
 		OBSSource source = obs_scene_get_source(scene);
 		signal_handler_t *signal =

--- a/UI/window-missing-files.cpp
+++ b/UI/window-missing-files.cpp
@@ -549,9 +549,9 @@ void OBSMissingFiles::saveFiles()
 			if (state == MissingFilesState::Cleared) {
 				obs_missing_file_issue_callback(f, "");
 			} else {
-				char *p = bstrdup(path.toStdString().c_str());
+				BPtr<char> p =
+					bstrdup(path.toStdString().c_str());
 				obs_missing_file_issue_callback(f, p);
-				bfree(p);
 			}
 		}
 	}

--- a/libobs/obs.hpp
+++ b/libobs/obs.hpp
@@ -291,6 +291,7 @@ using OBSDisplay = OBSObj<obs_display_t *, obs_display_destroy>;
 using OBSView = OBSObj<obs_view_t *, obs_view_destroy>;
 using OBSFader = OBSObj<obs_fader_t *, obs_fader_destroy>;
 using OBSVolMeter = OBSObj<obs_volmeter_t *, obs_volmeter_destroy>;
+using OBSProperties = OBSObj<obs_properties_t *, obs_properties_destroy>;
 
 /* signal handler connection */
 class OBSSignal {

--- a/libobs/obs.hpp
+++ b/libobs/obs.hpp
@@ -289,6 +289,8 @@ public:
 
 using OBSDisplay = OBSObj<obs_display_t *, obs_display_destroy>;
 using OBSView = OBSObj<obs_view_t *, obs_view_destroy>;
+using OBSFader = OBSObj<obs_fader_t *, obs_fader_destroy>;
+using OBSVolMeter = OBSObj<obs_volmeter_t *, obs_volmeter_destroy>;
 
 /* signal handler connection */
 class OBSSignal {


### PR DESCRIPTION
### Description
- Add auto release for refs that don't have them
- Remove disconnect signals for OBSSignal
- Add RAII wrappers for volume meters, faders and properties
- Use BPtr for chars that don't have it

### Motivation and Context
WIth RAII, resources are automatically managed.

### How Has This Been Tested?
Went through the entire program with my setup to see if there were any bugs or memory leaks.
More testing on other setups would be appreciated.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
