### PR TITLE
win-dshow: Log buffered state

### DIFF
--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -972,6 +972,8 @@ bool DShowInput::UpdateVideoConfig(obs_data_t *settings)
 	os_wcs_to_utf8_ptr(videoConfig.path.c_str(), videoConfig.path.size(),
 			   &path_utf8);
 
+	SetupBuffering(settings);
+
 	blog(LOG_INFO, "---------------------------------");
 	blog(LOG_INFO,
 	     "[DShow Device: '%s'] settings updated: \n"
@@ -980,13 +982,13 @@ bool DShowInput::UpdateVideoConfig(obs_data_t *settings)
 	     "\tresolution: %dx%d\n"
 	     "\tflip: %d\n"
 	     "\tfps: %0.2f (interval: %lld)\n"
-	     "\tformat: %s",
+	     "\tformat: %s\n"
+	     "\tbuffering: %s",
 	     obs_source_get_name(source), (const char *)name_utf8,
 	     (const char *)path_utf8, videoConfig.cx, videoConfig.cy_abs,
 	     (int)videoConfig.cy_flip, fps, videoConfig.frameInterval,
-	     formatName->array);
-
-	SetupBuffering(settings);
+	     formatName->array,
+	     obs_source_async_unbuffered(source) ? "disabled" : "enabled");
 
 	return true;
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds entry for buffering state of dshow sources to the log.

In order for this to operate successfully, and continue to do so in the future, it moves the `SetupBuffering()` above the `blog` so the buffering is set before the log prints.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Dshow issues show up fairly frequently in support context, and knowing the state of buffering can be useful when troubleshooting. Applicable for issues regarding smoothness/stutter as well as latency.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on windows 10 20H2, verifying correct log output using auto and enabled/disable buffering on the following:
* virtual devices (virtualcam)
* eos Webcam utility
* basic capture card (cantlink)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
