### PR TITLE
Various fixes for mac-vth264

### DIFF
--- a/plugins/mac-vth264/encoder.c
+++ b/plugins/mac-vth264/encoder.c
@@ -319,13 +319,13 @@ static bool create_encoder(struct vt_h264_encoder *enc)
 
 	// This can fail depending on hardware configuration
 	code = session_set_prop(s, kVTCompressionPropertyKey_RealTime,
-				kCFBooleanTrue);
+				kCFBooleanFalse);
 	if (code != noErr)
-		log_osstatus(LOG_WARNING, enc,
-			     "setting "
-			     "kVTCompressionPropertyKey_RealTime, "
-			     "frame delay might be increased",
-			     code);
+		log_osstatus(
+			LOG_WARNING, enc,
+			"setting kVTCompressionPropertyKey_RealTime failed, "
+			"frame delay might be increased",
+			code);
 
 	STATUS_CHECK(session_set_prop(s, kVTCompressionPropertyKey_ProfileLevel,
 				      obs_to_vt_profile(enc->profile)));

--- a/plugins/mac-vth264/encoder.c
+++ b/plugins/mac-vth264/encoder.c
@@ -19,20 +19,6 @@
 #define VT_BLOG(level, format, ...) \
 	VT_LOG_ENCODER(enc->encoder, level, format, ##__VA_ARGS__)
 
-// Clipped from NSApplication as it is in a ObjC header
-extern const double NSAppKitVersionNumber;
-#define NSAppKitVersionNumber10_8 1187
-
-// Get around missing symbol on 10.8 during compilation
-enum {
-	kCMFormatDescriptionBridgeError_InvalidParameter_ = -12712,
-};
-
-static bool is_appkit10_9_or_greater()
-{
-	return floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_8;
-}
-
 static DARRAY(struct vt_encoder {
 	const char *name;
 	const char *disp_name;
@@ -616,7 +602,7 @@ static bool convert_sample_to_annexb(struct vt_h264_encoder *enc,
 		format_desc, 0, NULL, NULL, &param_count, &nal_length_bytes);
 	// it is not clear what errors this function can return
 	// so we check the two most reasonable
-	if (code == kCMFormatDescriptionBridgeError_InvalidParameter_ ||
+	if (code == kCMFormatDescriptionBridgeError_InvalidParameter ||
 	    code == kCMFormatDescriptionError_InvalidParameter) {
 		VT_BLOG(LOG_WARNING, "assuming 2 parameter sets "
 				     "and 4 byte NAL length header");
@@ -993,12 +979,6 @@ void register_encoders()
 
 bool obs_module_load(void)
 {
-	if (!is_appkit10_9_or_greater()) {
-		VT_LOG(LOG_WARNING, "Not adding VideoToolbox H264 encoder; "
-				    "AppKit must be version 10.9 or greater");
-		return false;
-	}
-
 	encoder_list_create();
 	register_encoders();
 

--- a/plugins/mac-vth264/encoder.c
+++ b/plugins/mac-vth264/encoder.c
@@ -108,6 +108,16 @@ static CFStringRef obs_to_vt_colorspace(enum video_colorspace cs)
 	if ((code = (x)) != noErr) \
 		return code;
 
+static OSStatus session_set_prop_float(VTCompressionSessionRef session,
+				       CFStringRef key, float val)
+{
+	CFNumberRef n = CFNumberCreate(NULL, kCFNumberFloat32Type, &val);
+	OSStatus code = VTSessionSetProperty(session, key, n);
+	CFRelease(n);
+
+	return code;
+}
+
 static OSStatus session_set_prop_int(VTCompressionSessionRef session,
 				     CFStringRef key, int32_t val)
 {
@@ -300,9 +310,9 @@ static bool create_encoder(struct vt_h264_encoder *enc)
 	STATUS_CHECK(session_set_prop_int(
 		s, kVTCompressionPropertyKey_MaxKeyFrameInterval,
 		enc->keyint * ((float)enc->fps_num / enc->fps_den)));
-	STATUS_CHECK(session_set_prop_int(
+	STATUS_CHECK(session_set_prop_float(
 		s, kVTCompressionPropertyKey_ExpectedFrameRate,
-		ceil((float)enc->fps_num / enc->fps_den)));
+		(float)enc->fps_num / enc->fps_den));
 	STATUS_CHECK(session_set_prop(
 		s, kVTCompressionPropertyKey_AllowFrameReordering,
 		enc->bframes ? kCFBooleanTrue : kCFBooleanFalse));


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR consists of three commits that provide various fixes for the mac-vth264 encoder plugin.

----

mac-vth264: Remove OSX 10.8 compatibility code
    
OBS no longer supports building on OSX. The minimum version of macOS that we support is macOS 10.13. We can safely remove this 10.8 compatibility code.

The changes in this commit apparently make the minimum version supported macOS 10.10 due to no longer providing a custom enum for [kCMFormatDescriptionBridgeError_InvalidParameter](https://developer.apple.com/documentation/coremedia/1416276-format_description_bridge_error_/kcmformatdescriptionbridgeerror_invalidparameter?language=objc).

----

mac-vth264: Use float for expected frame rate

The encoder property kVTCompressionPropertyKey_ExpectedFrameRate is a hint to the video encoder. Since frame rates can be fractional, let's use a float here instead of an int.

----

mac-vth264: Set RealTime property to False

While the Apple documentation currently seems to indicate that we should set RealTime to True, it appears that this may be causing issues with the encoder not being able to meet the target frame rate. Both FFmpeg and Handbrake have recently explicitly set this value to False, and preliminary tests seem to indicate that setting this to false in OBS has favorable results. 

----

Given that this is a Bug Fix.  I'm pushing for this to be fast-tracked into OBS Studio 27.2.0.

I'm willing to split commits off into separate PRs if needed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fixes #5840.

Bad or sub-par behavior is bad, and we should fix it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Preliminary tests by @Shirk and @AuroraWright seem promising.  Would appreciate more testing on any or all of these commits by macOS devs.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
