### PR TITLE
vlc-video: Enable surround sound support

### DIFF
--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -460,8 +460,6 @@ static int vlcs_audio_setup(void **p_data, char *format, unsigned *rate,
 	enum audio_format new_audio_format;
 
 	new_audio_format = convert_vlc_audio_format(format);
-	if (*channels > 2)
-		*channels = 2;
 
 	/* don't free audio data if the data is the same format */
 	if (c->audio.format == new_audio_format &&


### PR DESCRIPTION
### Description
The vlc plugin was keeping only up to two audio channels. It was overlooked when surround sound support was added to obs-studio. This commit remedies this oversight.

Signed-off-by: pkv <pkv@obsproject.com>

### Motivation and Context
Media with surround sound pass only one or two audio channels to obs through the vlc plugin.
We want parity with Media Source (ffmpeg libs).

### How Has This Been Tested?
Tested on windows 10 vs 2019. 
A video file with 5.1 audio plays correctly with 6 audio channels.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)
 - New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
