### PR TITLE
vlc-video: Upgrade to vlc 4 (Draft)

### DIFF
--- a/plugins/vlc-video/vlc-video-plugin.h
+++ b/plugins/vlc-video/vlc-video-plugin.h
@@ -1,16 +1,16 @@
 #include <obs-module.h>
-#include <libvlc.h>
+#include <vlc/libvlc.h>
 
 #ifdef _MSC_VER
 #include <basetsd.h>
 typedef SSIZE_T ssize_t;
 #endif
 
-#include <libvlc_media.h>
-#include <libvlc_events.h>
-#include <libvlc_media_list.h>
-#include <libvlc_media_player.h>
-#include <libvlc_media_list_player.h>
+#include <vlc/libvlc_media.h>
+#include <vlc/libvlc_events.h>
+#include <vlc/libvlc_media_list.h>
+#include <vlc/libvlc_media_player.h>
+#include <vlc/libvlc_media_list_player.h>
 
 extern libvlc_instance_t *libvlc;
 extern uint64_t time_start;
@@ -61,11 +61,11 @@ typedef void (*LIBVLC_AUDIO_SET_FORMAT_CALLBACKS)(
 	libvlc_media_player_t *mp, libvlc_audio_setup_cb setup,
 	libvlc_audio_cleanup_cb cleanup);
 typedef int (*LIBVLC_MEDIA_PLAYER_PLAY)(libvlc_media_player_t *p_mi);
-typedef void (*LIBVLC_MEDIA_PLAYER_STOP)(libvlc_media_player_t *p_mi);
+typedef void (*LIBVLC_MEDIA_PLAYER_STOP_ASYNC)(libvlc_media_player_t *p_mi);
 typedef libvlc_time_t (*LIBVLC_MEDIA_PLAYER_GET_TIME)(
 	libvlc_media_player_t *p_mi);
 typedef void (*LIBVLC_MEDIA_PLAYER_SET_TIME)(libvlc_media_player_t *p_mi,
-					     libvlc_time_t i_time);
+					     libvlc_time_t i_time, bool b_fast);
 typedef int (*LIBVLC_VIDEO_GET_SIZE)(libvlc_media_player_t *p_mi, unsigned num,
 				     unsigned *px, unsigned *py);
 typedef libvlc_event_manager_t *(*LIBVLC_MEDIA_PLAYER_EVENT_MANAGER)(
@@ -96,7 +96,8 @@ typedef void (*LIBVLC_MEDIA_LIST_PLAYER_RELEASE)(
 typedef void (*LIBVLC_MEDIA_LIST_PLAYER_PLAY)(libvlc_media_list_player_t *p_mlp);
 typedef void (*LIBVLC_MEDIA_LIST_PLAYER_PAUSE)(
 	libvlc_media_list_player_t *p_mlp);
-typedef void (*LIBVLC_MEDIA_LIST_PLAYER_STOP)(libvlc_media_list_player_t *p_mlp);
+typedef void (*LIBVLC_MEDIA_LIST_PLAYER_STOP_ASYNC)(
+	libvlc_media_list_player_t *p_mlp);
 typedef void (*LIBVLC_MEDIA_LIST_PLAYER_SET_MEDIA_PLAYER)(
 	libvlc_media_list_player_t *p_mlp, libvlc_media_player_t *p_mp);
 typedef void (*LIBVLC_MEDIA_LIST_PLAYER_SET_MEDIA_LIST)(
@@ -135,7 +136,7 @@ extern LIBVLC_VIDEO_SET_FORMAT_CALLBACKS libvlc_video_set_format_callbacks_;
 extern LIBVLC_AUDIO_SET_CALLBACKS libvlc_audio_set_callbacks_;
 extern LIBVLC_AUDIO_SET_FORMAT_CALLBACKS libvlc_audio_set_format_callbacks_;
 extern LIBVLC_MEDIA_PLAYER_PLAY libvlc_media_player_play_;
-extern LIBVLC_MEDIA_PLAYER_STOP libvlc_media_player_stop_;
+extern LIBVLC_MEDIA_PLAYER_STOP_ASYNC libvlc_media_player_stop_async_;
 extern LIBVLC_MEDIA_PLAYER_GET_TIME libvlc_media_player_get_time_;
 extern LIBVLC_MEDIA_PLAYER_SET_TIME libvlc_media_player_set_time_;
 extern LIBVLC_VIDEO_GET_SIZE libvlc_video_get_size_;
@@ -157,7 +158,7 @@ extern LIBVLC_MEDIA_LIST_PLAYER_NEW libvlc_media_list_player_new_;
 extern LIBVLC_MEDIA_LIST_PLAYER_RELEASE libvlc_media_list_player_release_;
 extern LIBVLC_MEDIA_LIST_PLAYER_PLAY libvlc_media_list_player_play_;
 extern LIBVLC_MEDIA_LIST_PLAYER_PAUSE libvlc_media_list_player_pause_;
-extern LIBVLC_MEDIA_LIST_PLAYER_STOP libvlc_media_list_player_stop_;
+extern LIBVLC_MEDIA_LIST_PLAYER_STOP_ASYNC libvlc_media_list_player_stop_async_;
 extern LIBVLC_MEDIA_LIST_PLAYER_SET_MEDIA_PLAYER
 	libvlc_media_list_player_set_media_player_;
 extern LIBVLC_MEDIA_LIST_PLAYER_SET_MEDIA_LIST

--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -350,7 +350,7 @@ static void vlcs_destroy(void *data)
 	struct vlc_source *c = data;
 
 	if (c->media_list_player) {
-		libvlc_media_list_player_stop_(c->media_list_player);
+		libvlc_media_list_player_stop_async_(c->media_list_player);
 		libvlc_media_list_player_release_(c->media_list_player);
 	}
 	if (c->media_player) {
@@ -658,7 +658,7 @@ static void vlcs_update(void *data, obs_data_t *settings)
 	/* ------------------------------------- */
 	/* update settings data */
 
-	libvlc_media_list_player_stop_(c->media_list_player);
+	libvlc_media_list_player_stop_async_(c->media_list_player);
 
 	pthread_mutex_lock(&c->mutex);
 	old_files.da = c->files.da;
@@ -786,7 +786,7 @@ static void vlcs_restart(void *data)
 {
 	struct vlc_source *c = data;
 
-	libvlc_media_list_player_stop_(c->media_list_player);
+	libvlc_media_list_player_stop_async_(c->media_list_player);
 	libvlc_media_list_player_play_(c->media_list_player);
 }
 
@@ -794,7 +794,7 @@ static void vlcs_stop(void *data)
 {
 	struct vlc_source *c = data;
 
-	libvlc_media_list_player_stop_(c->media_list_player);
+	libvlc_media_list_player_stop_async_(c->media_list_player);
 	obs_source_output_video(c->source, NULL);
 }
 
@@ -830,7 +830,8 @@ static void vlcs_set_time(void *data, int64_t ms)
 {
 	struct vlc_source *c = data;
 
-	libvlc_media_player_set_time_(c->media_player, (libvlc_time_t)ms);
+	libvlc_media_player_set_time_(c->media_player, (libvlc_time_t)ms,
+				      false);
 }
 
 static void vlcs_play_pause_hotkey(void *data, obs_hotkey_id id,
@@ -991,7 +992,7 @@ static void vlcs_deactivate(void *data)
 	struct vlc_source *c = data;
 
 	if (c->behavior == BEHAVIOR_STOP_RESTART) {
-		libvlc_media_list_player_stop_(c->media_list_player);
+		libvlc_media_list_player_stop_async_(c->media_list_player);
 		obs_source_output_video(c->source, NULL);
 
 	} else if (c->behavior == BEHAVIOR_PAUSE_UNPAUSE) {


### PR DESCRIPTION
### Description
vlc 4 will be released in the near-future.
(In early 2021, JB Kempf talked of releasing vlc 4 by late 2021.)
libvlc 12 (used in vlc 4) breaks libvlc 5 API (used in vlc 3) though.
If we want to support vlc 4, we need to update the vlc-video plugin.
I leave this PR in a draft state at the moment, until vlc 4 is released.
One discussion which we'll have to sort out is whether to try or not 
to keep compatibility with vlc 3.
The current code loads only vlc 4.

**Note 1:** CI fails because it loads vlc 3. A CI update is deferred
to later since important changes are already expected for v28.
**Note 2:** libvlc_media.h requires to be patched with
`#include <vlc/libvlc_media_track.h>`
`#include <vlc/libvlc_picture.h>`

### Motivation and Context
We want the internal plugins not to break.
Since the vlc-video plugin relies on loading dynamic libraries of libvlc;
the plugin would break upon upgrade by a user to vlc 4.

Maintainer edit: Closes #5178.

### How Has This Been Tested?
Tested on win 10.
The plugin loads correctly vlc 4, seeking works, track selection work.
File as well as url are played fine.
I haven't tested subtitle selection, nor playlists and will delay those tests 
to the actual moment when vlc 4 is released.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)
 - Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
