### PR TITLE
libobs: Free module if obs_module_load callback returns false

### DIFF
--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -291,7 +291,8 @@ static void load_all_callback(void *param, const struct obs_module_info *info)
 		return;
 	}
 
-	obs_init_module(module);
+	if (!obs_init_module(module))
+		free_module(module);
 
 	UNUSED_PARAMETER(param);
 }
@@ -498,6 +499,16 @@ void free_module(struct obs_module *mod)
 		 * and sometimes this can cause issues. */
 		/* os_dlclose(mod->module); */
 	}
+
+	for (obs_module_t *m = obs->first_module; !!m; m = m->next) {
+		if (m->next == mod) {
+			m->next = mod->next;
+			break;
+		}
+	}
+
+	if (obs->first_module == mod)
+		obs->first_module = mod->next;
 
 	bfree(mod->mod_name);
 	bfree(mod->bin_path);


### PR DESCRIPTION
### Description
Currently if a module fails its load callback, it remains loaded and OBS continues to call additional exports such as `obs_module_post_load`. This goes against the [documented behavior](https://obsproject.com/docs/reference-modules.html#c.obs_module_load), which states that a module that fails its load callback is unloaded.

This commit releases locale resources and frees the module's information, preventing further callbacks from libobs. The module itself (the DLL) is not yet unloaded from memory as os_dlclose is commented out for causing unspecified issues - this should be revisited in the future.

### Motivation and Context
I noticed the AJA plugin was having its `obs_module_post_load` code executed even though the module's `obs_module_load` returned false due to no AJA devices on my system. This seemed bad.

### How Has This Been Tested?
Breakpoint tested that modules that failed `obs_module_post_load` were passed to `free_module` and that the linked list was updated correctly. Someone please verify this as linked lists seem to be my kryptonite.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
