### PR TITLE
aja: Disable Analog In/Out selections in the UI

### DIFF
--- a/plugins/aja/aja-common.cpp
+++ b/plugins/aja/aja-common.cpp
@@ -95,6 +95,8 @@ void populate_io_selection_input_list(const std::string &cardID,
 	for (auto i = 0; i < static_cast<int32_t>(IOSelection::NumIOSelections);
 	     i++) {
 		auto ioSelect = static_cast<IOSelection>(i);
+		if (ioSelect == IOSelection::AnalogIn)
+			continue;
 		if (aja::DeviceCanDoIOSelectionIn(deviceID, ioSelect)) {
 			obs_property_list_add_int(
 				list,
@@ -125,7 +127,8 @@ void populate_io_selection_output_list(const std::string &cardID,
 		     i < static_cast<int32_t>(IOSelection::NumIOSelections);
 		     i++) {
 			auto ioSelect = static_cast<IOSelection>(i);
-			if (ioSelect == IOSelection::Invalid)
+			if (ioSelect == IOSelection::Invalid ||
+			    ioSelect == IOSelection::AnalogOut)
 				continue;
 
 			if (aja::DeviceCanDoIOSelectionOut(deviceID,


### PR DESCRIPTION
### Description
This change hides the ANALOG IN/OUT list items from the AJA Capture and Output UI, respectively.

Proper support for analog video capture and display with supported AJA cards (Kona4, Kona LHI, etc.) will be added in a future version of the plugin.

### Motivation and Context
Placeholder list items for ANALOG IN and OUT were accidentally left in the UI. There is not enough time left in this release cycle to add and test the rest of the code needed to support analog capture and display with supported AJA cards.

### How Has This Been Tested?
1. Spot-checked on an AJA Kona4 card to verify that the ANALOG IN/OUT list items were hidden from the AJA capture and output UI.
2. Checked a Corvid44 card to make sure the UI for a non-analog-capable card didn't break.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
