### PR TITLE
libobs: Add effect files to CMakeLists.txt

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -501,8 +501,31 @@ set(libobs_HEADERS
 	${libobs_audio_monitoring_HEADERS}
 	)
 
+set(libobs_data_EFFECTS
+	data/area.effect
+	data/bicubic_scale.effect
+	data/bilinear_lowres_scale.effect
+	data/default.effect
+	data/default_rect.effect
+	data/deinterlace_base.effect
+	data/deinterlace_blend.effect
+	data/deinterlace_blend_2x.effect
+	data/deinterlace_discard.effect
+	data/deinterlace_discard_2x.effect
+	data/deinterlace_linear.effect
+	data/deinterlace_linear_2x.effect
+	data/deinterlace_yadif.effect
+	data/deinterlace_yadif_2x.effect
+	data/format_conversion.effect
+	data/lanczos_scale.effect
+	data/opaque.effect
+	data/premultiplied_alpha.effect
+	data/repeat.effect
+	data/solid.effect)
+
 source_group("callback\\Source Files" FILES ${libobs_callback_SOURCES})
 source_group("callback\\Header Files" FILES ${libobs_callback_HEADERS})
+source_group("data\\Effect Files" FILES ${libobs_data_EFFECTS})
 source_group("graphics\\Source Files" FILES ${libobs_graphics_SOURCES})
 source_group("graphics\\Header Files" FILES ${libobs_graphics_HEADERS})
 source_group("libobs\\Source Files" FILES ${libobs_libobs_SOURCES})
@@ -519,7 +542,7 @@ set(libobs_PLATFORM_DEPS
 	${libobs_PLATFORM_DEPS}
 	caption)
 
-add_library(libobs SHARED ${libobs_SOURCES} ${libobs_HEADERS})
+add_library(libobs SHARED ${libobs_SOURCES} ${libobs_HEADERS} ${libobs_data_EFFECTS})
 if(UNIX AND NOT APPLE)
 	set(DEST_DIR "${CMAKE_INSTALL_PREFIX}")
 	foreach(LIB "obs" "rt")


### PR DESCRIPTION
### Description
Makes them easily searchable from Visual Studio.

### Motivation and Context
Useful for my workflow of using finding text in solution.

### How Has This Been Tested?
OBS still compiles for me on Windows without trying to compile the effect files. I guess CI will show if this works on Mac/Linux.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.