### PR TITLE
libobs/graphics: Fix gs_get_format_bpp

### DIFF
--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -987,6 +987,7 @@ static inline uint32_t gs_get_format_bpp(enum gs_color_format format)
 	case GS_RG16:
 		return 32;
 	case GS_RGBA16:
+	case GS_RGBA16F:
 	case GS_RG32F:
 		return 64;
 	case GS_RGBA32F:


### PR DESCRIPTION
### Description
Was missing case for GS_RGBA16F.

### Motivation and Context
Bug.

### How Has This Been Tested?
Verified GS_RGBA16F returns 64.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.