### PR TITLE
aja: Fix card frame indices calculation

### DIFF
--- a/plugins/aja/aja-output.cpp
+++ b/plugins/aja/aja-output.cpp
@@ -481,24 +481,24 @@ void AJAOutput::calculate_card_frame_indices(uint32_t numFrames,
 					     NTV2PixelFormat pf)
 {
 	ULWord channelIndex = GetIndexForNTV2Channel(channel);
-
 	ULWord totalCardFrames = NTV2DeviceGetNumberFrameBuffers(
 		id, GetNTV2FrameGeometryFromVideoFormat(vf), pf);
-
 	mFirstCardFrame = channelIndex * numFrames;
-
-	if (mFirstCardFrame < totalCardFrames &&
-	    (mFirstCardFrame + numFrames) < totalCardFrames) {
+	uint32_t lastFrame = mFirstCardFrame + (numFrames - 1);
+	if (totalCardFrames - mFirstCardFrame > 0 &&
+	    totalCardFrames - lastFrame > 0) {
 		// Reserve N framebuffers in card DRAM.
 		mNumCardFrames = numFrames;
 		mWriteCardFrame = mFirstCardFrame;
-		mLastCardFrame = mWriteCardFrame + numFrames;
+		mLastCardFrame = lastFrame;
 	} else {
 		// otherwise just grab 2 frames to ping-pong between
 		mNumCardFrames = 2;
 		mWriteCardFrame = channelIndex * 2;
-		mLastCardFrame = mWriteCardFrame + 2;
+		mLastCardFrame = mWriteCardFrame + (mNumCardFrames - 1);
 	}
+	blog(LOG_DEBUG, "AJA Output using %d card frame indices (%d-%d)",
+	     mNumCardFrames, mFirstCardFrame, mLastCardFrame);
 }
 
 uint32_t AJAOutput::get_frame_count()


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The `plugins/aja/aja-output.cpp::calculate_card_frame_indices` function is used by the AJA Output plugin to set aside a small ring of frame indices, per card channel, into the card's DRAM. Each frame in memory is the size of the currently-configured frame size of the card, depending on the framestore format (8MiB to 64MiB). The plugin copies frames from OBS into DRAM at the current frame index, and then increments the current index.

This PR fixes what is essentially an off-by-one bug in the reservation of these frame indices. The bug led to an over-allocation of card frames per channel, with the start and end indices overlapping those of adjacent channels.
 
### Why is this change required? What problem does it solve?
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
AJA QA found a bug where simultaneously enabling Program and Preview output to the same AJA card, on adjacent card channels (i.e. SDI1 and 2, or SDI3 and 4, etc), caused frames for each output to be DMA'd to the memory space actively used by BOTH channels.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Checked the result of the new calculation with all initial channel indices, to ensure that the start and end card frame indices could not overlap. Tested outputting to adjacent channels from both Program and Preview on an io4K+ card.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
