### PR TITLE
UI: Add Wine detection/warning

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -109,6 +109,9 @@ AlreadyRunning.LaunchAnyway="Launch Anyway"
 ChromeOS.Title="Unsupported Platform"
 ChromeOS.Text="OBS appears to be running inside a ChromeOS container. This platform is unsupported"
 
+Wine.Title="Wine detected"
+Wine.Text="Running OBS in Wine is unsupported, and many features such as capture or device sources will not work or only in limited capacity.<br><br>It is recommended to run a native version of OBS instead, for example <a href='https://flathub.org/apps/details/com.obsproject.Studio'>our Flatpak version</a> or your operating system's packages."
+
 # warning when closing docks. it's frustrating that we actually need this.
 DockCloseWarning.Title="Closing Dockable Window"
 DockCloseWarning.Text="You just closed a dockable window. If you'd like to show it again, use the Docks menu on the menu bar."

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2168,7 +2168,7 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 #endif
 
 #ifdef _WIN32
-		if (IsRunningOnWine() || true) {
+		if (IsRunningOnWine()) {
 			QMessageBox mb(QMessageBox::Question,
 				       QTStr("Wine.Title"), QTStr("Wine.Text"));
 			mb.setTextFormat(Qt::RichText);

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2156,16 +2156,33 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		}
 #endif
 
+		if (!created_log) {
+			create_log_file(logFile);
+			created_log = true;
+		}
+
 #ifdef __APPLE__
 		bool rosettaTranslated = ProcessIsRosettaTranslated();
 		blog(LOG_INFO, "Rosetta translation used: %s",
 		     rosettaTranslated ? "true" : "false");
 #endif
 
-		if (!created_log) {
-			create_log_file(logFile);
-			created_log = true;
+#ifdef _WIN32
+		if (IsRunningOnWine() || true) {
+			QMessageBox mb(QMessageBox::Question,
+				       QTStr("Wine.Title"), QTStr("Wine.Text"));
+			mb.setTextFormat(Qt::RichText);
+			mb.addButton(QTStr("AlreadyRunning.LaunchAnyway"),
+				     QMessageBox::AcceptRole);
+			QPushButton *closeButton =
+				mb.addButton(QMessageBox::Close);
+			mb.setDefaultButton(closeButton);
+
+			mb.exec();
+			if (mb.clickedButton() == closeButton)
+				return 0;
 		}
+#endif
 
 		if (argc > 1) {
 			stringstream stor;

--- a/UI/platform-windows.cpp
+++ b/UI/platform-windows.cpp
@@ -449,3 +449,23 @@ QString GetMonitorName(const QString &id)
 
 	return QString::fromWCharArray(target.monitorFriendlyDeviceName);
 }
+
+/* Based on https://www.winehq.org/pipermail/wine-devel/2008-September/069387.html */
+typedef const char *(CDECL *WINEGETVERSION)(void);
+bool IsRunningOnWine()
+{
+	WINEGETVERSION func;
+	HMODULE nt;
+
+	nt = GetModuleHandleW(L"ntdll");
+	if (!nt)
+		return false;
+
+	func = (WINEGETVERSION)GetProcAddress(nt, "wine_get_version");
+	if (func) {
+		blog(LOG_WARNING, "Running on Wine version \"%s\"", func());
+		return true;
+	}
+
+	return false;
+}

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -64,6 +64,7 @@ public:
 
 RunOnceMutex GetRunOnceMutex(bool &already_running);
 QString GetMonitorName(const QString &id);
+bool IsRunningOnWine();
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
Screenshot from Ubuntu 20.04 running in Wine stable:
![Screenshot_from_2022-02-06_11-26-27](https://user-images.githubusercontent.com/3123295/152663471-a500755c-78fa-49ba-bb3c-70b8e13ddeac.png)

### Description
Adds a warning on startup if OBS is run in Wine and logs Wine version.

Note: this moves the creation of the log file so it's ready once the check happens. This will also fix the Rosetta status not being logged.

### Motivation and Context
While running OBS in Wine works surprisingly well, you shouldn't.
This just warns people who don't realise that (they exist, we had them in #linux-support).

### How Has This Been Tested?
- Ran OBS in Wine
- Ran OBS not in Wine

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
