### PR TITLE
fix virtual studio warning: C6011

### DIFF
--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -1031,6 +1031,10 @@ static inline void rtl_get_ver(struct win_version_info *ver)
 static inline bool get_reg_sz(HKEY key, const wchar_t *val, wchar_t *buf,
 			      const size_t size)
 {
+	if (!buf) {
+		return false;
+	}
+
 	DWORD dwsize = (DWORD)size;
 	LSTATUS status;
 


### PR DESCRIPTION


### Description
fix virtual studio warning: C6011

### Motivation and Context
in vs2019, there is a compile warning: C6011
https://docs.microsoft.com/zh-cn/cpp/code-quality/c6011?view=msvc-170

### How Has This Been Tested?
just compile warning, no test case

### Types of changes
Code cleanup 

### Checklist:
fix virtual studio warning: C6011
