### PR TITLE
libobs/UI: solving name conflicts in source list

### DIFF
--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -176,7 +176,7 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 				   settings, nullptr);
 	if (source) {
 		OBSScene scene = main->GetCurrentScene();
-		obs_scene_add(scene, source);
+		obs_scene_add(scene, source, false);
 	}
 }
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3171,7 +3171,7 @@ void OBSBasic::UpdateContextBar(bool force)
 		ui->contextSourceIconSpacer->hide();
 		ui->contextSourceIcon->show();
 
-		const char *name = obs_source_get_name(source);
+		const char *name = obs_sceneitem_get_itemname(item);
 		ui->contextSourceLabel->setText(name);
 
 		ui->sourceFiltersButton->setEnabled(true);

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -294,12 +294,12 @@ static void CreateTransitionScene(OBSSource scene, const char *text,
 	OBSSourceAutoRelease colorBG = obs_source_create_private(
 		"color_source", "background", settings);
 
-	obs_scene_add(obs_scene_from_source(scene), colorBG);
+	obs_scene_add(obs_scene_from_source(scene), colorBG, false);
 
 	OBSSourceAutoRelease label =
 		CreateLabel(text, obs_source_get_height(scene));
 	obs_sceneitem_t *item =
-		obs_scene_add(obs_scene_from_source(scene), label);
+		obs_scene_add(obs_scene_from_source(scene), label, false);
 
 	vec2 size;
 	vec2_set(&size, obs_source_get_width(scene),

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -24,6 +24,7 @@
 struct AddSourceData {
 	obs_source_t *source;
 	bool visible;
+	bool existing;
 	obs_transform_info *transform = nullptr;
 	obs_sceneitem_crop *crop = nullptr;
 	obs_blending_type *blend = nullptr;
@@ -118,7 +119,7 @@ static void AddSource(void *_data, obs_scene_t *scene)
 	AddSourceData *data = (AddSourceData *)_data;
 	obs_sceneitem_t *sceneitem;
 
-	sceneitem = obs_scene_add(scene, data->source);
+	sceneitem = obs_scene_add(scene, data->source, data->existing);
 
 	if (data->transform != nullptr)
 		obs_sceneitem_set_info(sceneitem, data->transform);
@@ -176,6 +177,7 @@ static void AddExisting(OBSSource source, bool visible, bool duplicate,
 	data.transform = transform;
 	data.crop = crop;
 	data.blend = blend;
+	data.existing = true;
 
 	obs_enter_graphics();
 	obs_scene_atomic_update(scene, AddSource, &data);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1660,7 +1660,7 @@ obs_scene_reorder_items2(obs_scene_t *scene,
 EXPORT bool obs_source_is_scene(const obs_source_t *source);
 
 /** Adds/creates a new scene item for a source */
-EXPORT obs_sceneitem_t *obs_scene_add(obs_scene_t *scene, obs_source_t *source);
+EXPORT obs_sceneitem_t *obs_scene_add(obs_scene_t *scene, obs_source_t *source, bool existing);
 
 typedef void (*obs_scene_atomic_update_func)(void *, obs_scene_t *scene);
 EXPORT void obs_scene_atomic_update(obs_scene_t *scene,
@@ -1690,6 +1690,14 @@ EXPORT obs_sceneitem_t *obs_scene_sceneitem_from_source(obs_scene_t *scene,
 EXPORT obs_data_t *obs_scene_save_transform_states(obs_scene_t *scene,
 						   bool all_items);
 
+/** Check if new name alreadys exists. If so, return true.*/
+EXPORT bool obs_scene_if_duplicated_itemname(const obs_scene_t *scene,
+					     const char *newName);
+
+/* Gets unique name for a new scene item in a scene. Release it manually.*/
+EXPORT char *obs_scene_get_new_itemname(const obs_scene_t *scene,
+					const char *name);
+
 /** Load all the transform states of sceneitems in that scene */
 EXPORT void obs_scene_load_transform_states(const char *state);
 
@@ -1701,6 +1709,14 @@ EXPORT obs_scene_t *obs_sceneitem_get_scene(const obs_sceneitem_t *item);
 
 /** Gets the source of a scene item. */
 EXPORT obs_source_t *obs_sceneitem_get_source(const obs_sceneitem_t *item);
+
+/** Gets the name of a scene item.*/
+EXPORT const char *obs_sceneitem_get_itemname(const obs_sceneitem_t *item);
+
+/** Sets the name of a scene item.*/
+EXPORT void obs_sceneitem_set_itemname(obs_sceneitem_t *item,
+				       const char *newName);
+
 
 /* FIXME: The following functions should be deprecated and replaced with a way
  * to specify saveable private user data. -Jim */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
As is explained in my comment at [issue #5621](https://github.com/obsproject/obs-studio/issues/5621), my resolution is to add an independent property for scene items. And because it involves many parts in, finally I store it in `item->private_settings` to prevent memory allocating & releasing issues. 
(see `obs_sceneitem_set_itemname` and more).

Generally, after modification, when you add an existing source, arg `existing` will be set `true` at `obs_scene_add_internal`, thus leading to searching for a new name. On the other side, when you rename scene items, you will never rename source itself but only "item_name" of scene items. **New name property will only be shown on source list and context bar.** 

Also, there are 2 main bold changes that I'm worrying about. 

One is changes in properties of `struct AddSourceData` and arguments of `obs_scene_add_internal` & `obs_scene_add`. I found it hard to directly set "item_name" in function `AddExisting` at windows-basic-source-select.cpp and above, so I add arg & property instead to ask for a new name.

The other is line 539 at source-tree.cpp. Although renaming sources directly is stopped, you can still rename sources in mixer, which leads to incorrect labels changes in source list of scene. As I cannot think of a better idea to stop it, I stopped it at line 539 directly.

Detailed explanation is attached.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This pr is to fix [issue #5621](https://github.com/obsproject/obs-studio/issues/5621).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
The effect is tested on my laptop running Windows 10 21H2 and it works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
