### PR TITLE
libobs/util: Fix VS static analysis warnings

### DIFF
--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -607,11 +607,13 @@ static void make_globent(struct os_globent *ent, WIN32_FIND_DATA *wfd,
 
 	dstr_from_wcs(&name, wfd->cFileName);
 	dstr_copy(&path, pattern);
-	slash = strrchr(path.array, '/');
-	if (slash)
-		dstr_resize(&path, slash + 1 - path.array);
-	else
-		dstr_free(&path);
+	if (path.array) {
+		slash = strrchr(path.array, '/');
+		if (slash)
+			dstr_resize(&path, slash + 1 - path.array);
+		else
+			dstr_free(&path);
+	}
 
 	dstr_cat_dstr(&path, &name);
 	ent->path = path.array;
@@ -848,7 +850,7 @@ char *os_getcwd(char *path, size_t size)
 	if (!len)
 		return NULL;
 
-	path_w = bmalloc((len + 1) * sizeof(wchar_t));
+	path_w = bmalloc(((size_t)len + 1) * sizeof(wchar_t));
 	GetCurrentDirectoryW(len + 1, path_w);
 	os_wcs_to_utf8(path_w, (size_t)len, path, size);
 	bfree(path_w);
@@ -1005,9 +1007,9 @@ void get_reg_dword(HKEY hkey, LPCWSTR sub_key, LPCWSTR value_name,
 
 static inline void rtl_get_ver(struct win_version_info *ver)
 {
-	RTL_OSVERSIONINFOEXW osver = {0};
 	HMODULE ntdll = GetModuleHandleW(L"ntdll");
-	NTSTATUS s;
+	if (!ntdll)
+		return;
 
 	NTSTATUS(WINAPI * get_ver)
 	(RTL_OSVERSIONINFOEXW *) =
@@ -1016,8 +1018,9 @@ static inline void rtl_get_ver(struct win_version_info *ver)
 		return;
 	}
 
+	RTL_OSVERSIONINFOEXW osver = {0};
 	osver.dwOSVersionInfoSize = sizeof(osver);
-	s = get_ver(&osver);
+	NTSTATUS s = get_ver(&osver);
 	if (s < 0) {
 		return;
 	}
@@ -1029,13 +1032,10 @@ static inline void rtl_get_ver(struct win_version_info *ver)
 }
 
 static inline bool get_reg_sz(HKEY key, const wchar_t *val, wchar_t *buf,
-			      const size_t size)
+			      DWORD size)
 {
-	DWORD dwsize = (DWORD)size;
-	LSTATUS status;
-
-	status = RegQueryValueExW(key, val, NULL, NULL, (LPBYTE)buf, &dwsize);
-	buf[(size / sizeof(wchar_t)) - 1] = 0;
+	const LSTATUS status =
+		RegGetValueW(key, NULL, val, RRF_RT_REG_SZ, NULL, buf, &size);
 	return status == ERROR_SUCCESS;
 }
 
@@ -1222,23 +1222,27 @@ static void os_get_cores_internal(void)
 
 	info = malloc(len);
 
-	if (GetLogicalProcessorInformation(info, &len)) {
-		DWORD num = len / sizeof(*info);
-		temp = info;
+	if (info) {
+		if (GetLogicalProcessorInformation(info, &len)) {
+			DWORD num = len / sizeof(*info);
+			temp = info;
 
-		for (DWORD i = 0; i < num; i++) {
-			if (temp->Relationship == RelationProcessorCore) {
-				ULONG_PTR mask = temp->ProcessorMask;
+			for (DWORD i = 0; i < num; i++) {
+				if (temp->Relationship ==
+				    RelationProcessorCore) {
+					ULONG_PTR mask = temp->ProcessorMask;
 
-				physical_cores++;
-				logical_cores += num_logical_cores(mask);
+					physical_cores++;
+					logical_cores +=
+						num_logical_cores(mask);
+				}
+
+				temp++;
 			}
-
-			temp++;
 		}
-	}
 
-	free(info);
+		free(info);
+	}
 }
 
 int os_get_physical_cores(void)


### PR DESCRIPTION
### Description
Fix VS static analysis warnings in platform-windows.c

### Motivation and Context
PR 5929

### How Has This Been Tested?
Debugger inspection before/after.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.