### PR TITLE
libobs, UI: Handle more window events

### DIFF
--- a/UI/qt-display.hpp
+++ b/UI/qt-display.hpp
@@ -13,8 +13,16 @@ class OBSQTDisplay : public QWidget {
 
 	OBSDisplay display;
 
-	void resizeEvent(QResizeEvent *event) override;
-	void paintEvent(QPaintEvent *event) override;
+	virtual void paintEvent(QPaintEvent *event) override;
+	virtual void moveEvent(QMoveEvent *event) override;
+	virtual void resizeEvent(QResizeEvent *event) override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	virtual bool nativeEvent(const QByteArray &eventType, void *message,
+				 qintptr *result) override;
+#else
+	virtual bool nativeEvent(const QByteArray &eventType, void *message,
+				 long *result) override;
+#endif
 
 signals:
 	void DisplayCreated(OBSQTDisplay *window);
@@ -35,4 +43,7 @@ public:
 	void SetDisplayBackgroundColor(const QColor &color);
 	void UpdateDisplayBackgroundColor();
 	void CreateDisplay(bool force = false);
+
+	void OnMove();
+	void OnDisplayChange();
 };

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -36,6 +36,11 @@
 #include <QMenu>
 #include <QVariant>
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN 1
+#include <Windows.h>
+#endif
+
 using namespace std;
 
 Q_DECLARE_METATYPE(OBSSource);
@@ -684,6 +689,32 @@ void OBSBasicFilters::closeEvent(QCloseEvent *event)
 					 OBSBasicFilters::DrawPreview, this);
 
 	main->SaveProject();
+}
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+bool OBSBasicFilters::nativeEvent(const QByteArray &, void *message, qintptr *)
+#else
+bool OBSBasicFilters::nativeEvent(const QByteArray &, void *message, long *)
+#endif
+{
+#ifdef _WIN32
+	const MSG &msg = *static_cast<MSG *>(message);
+	switch (msg.message) {
+	case WM_MOVE:
+		for (OBSQTDisplay *const display :
+		     findChildren<OBSQTDisplay *>()) {
+			display->OnMove();
+		}
+		break;
+	case WM_DISPLAYCHANGE:
+		for (OBSQTDisplay *const display :
+		     findChildren<OBSQTDisplay *>()) {
+			display->OnDisplayChange();
+		}
+	}
+#endif
+
+	return false;
 }
 
 /* OBS Signals */

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -135,4 +135,11 @@ public:
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	virtual bool nativeEvent(const QByteArray &eventType, void *message,
+				 qintptr *result) override;
+#else
+	virtual bool nativeEvent(const QByteArray &eventType, void *message,
+				 long *result) override;
+#endif
 };

--- a/UI/window-basic-interaction.hpp
+++ b/UI/window-basic-interaction.hpp
@@ -65,6 +65,13 @@ public:
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	virtual bool nativeEvent(const QByteArray &eventType, void *message,
+				 qintptr *result) override;
+#else
+	virtual bool nativeEvent(const QByteArray &eventType, void *message,
+				 long *result) override;
+#endif
 };
 
 typedef std::function<bool(QObject *, QEvent *)> EventFilterFunc;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4679,6 +4679,32 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 	QMetaObject::invokeMethod(App(), "quit", Qt::QueuedConnection);
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+bool OBSBasic::nativeEvent(const QByteArray &, void *message, qintptr *)
+#else
+bool OBSBasic::nativeEvent(const QByteArray &, void *message, long *)
+#endif
+{
+#ifdef _WIN32
+	const MSG &msg = *static_cast<MSG *>(message);
+	switch (msg.message) {
+	case WM_MOVE:
+		for (OBSQTDisplay *const display :
+		     findChildren<OBSQTDisplay *>()) {
+			display->OnMove();
+		}
+		break;
+	case WM_DISPLAYCHANGE:
+		for (OBSQTDisplay *const display :
+		     findChildren<OBSQTDisplay *>()) {
+			display->OnDisplayChange();
+		}
+	}
+#endif
+
+	return false;
+}
+
 void OBSBasic::changeEvent(QEvent *event)
 {
 	if (event->type() == QEvent::WindowStateChange) {

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -947,6 +947,13 @@ public:
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	virtual bool nativeEvent(const QByteArray &eventType, void *message,
+				 qintptr *result) override;
+#else
+	virtual bool nativeEvent(const QByteArray &eventType, void *message,
+				 long *result) override;
+#endif
 	virtual void changeEvent(QEvent *event) override;
 
 private slots:

--- a/UI/window-basic-properties.hpp
+++ b/UI/window-basic-properties.hpp
@@ -72,5 +72,12 @@ public:
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	virtual bool nativeEvent(const QByteArray &eventType, void *message,
+				 qintptr *result) override;
+#else
+	virtual bool nativeEvent(const QByteArray &eventType, void *message,
+				 long *result) override;
+#endif
 	virtual void reject() override;
 };

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -204,9 +204,9 @@ extern void obs_view_free(struct obs_view *view);
 /* displays */
 
 struct obs_display {
-	bool size_changed;
 	bool enabled;
 	uint32_t cx, cy;
+	uint32_t next_cx, next_cy;
 	uint32_t background_color;
 	gs_swapchain_t *swap;
 	pthread_mutex_t draw_callbacks_mutex;


### PR DESCRIPTION
### Description
Add support for handling WM_DISPLAYCHANGE and WM_MOVE on Windows (and Qt moveEvent).

Also modify resize handling to filter unnecessary size changes.

### Motivation and Context
Will be used in the future for SDR/HDR transitions.

### How Has This Been Tested?
Breakpoint inspection for window messages against preview panels, projector, source/filter properties, and interact window.

Stepped through new resize logic.

### Types of changes
- New feature (non-breaking change which adds functionality)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.