### PR TITLE
CI: Specify Windows Server 2019

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -494,7 +494,7 @@ jobs:
           path: './nightly/*.tar.gz'
   win64:
     name: 'Windows 64-bit'
-    runs-on: [windows-latest]
+    runs-on: [windows-2019]
     env:
       QT_VERSION: '5.15.2'
       CMAKE_GENERATOR: "Visual Studio 16 2019"
@@ -604,7 +604,7 @@ jobs:
           path: build/*
   win32:
     name: 'Windows 32-bit'
-    runs-on: [windows-latest]
+    runs-on: [windows-2019]
     env:
       QT_VERSION: '5.15.2'
       CMAKE_GENERATOR: "Visual Studio 16 2019"


### PR DESCRIPTION
### Description
Explicitly sets Windows runners to use the 2019 image.

### Motivation and Context
Builds appear to fail with the 2022 image (which is now default for `windows-latest`). Until #5155 lands we probably still want to keep our builds working.

### How Has This Been Tested?

(It hasn't)

(This PR *is* the test)

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
