### PR TITLE
UI: Avoid emiting events 2 times when renaming a profile

### DIFF
--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -305,7 +305,7 @@ bool OBSBasic::CreateProfile(const std::string &newName, bool create_new,
 		return false;
 	}
 
-	if (api)
+	if (api && !rename)
 		api->on_event(OBS_FRONTEND_EVENT_PROFILE_CHANGING);
 
 	config_set_string(App()->GlobalConfig(), "Basic", "Profile",
@@ -350,7 +350,7 @@ bool OBSBasic::CreateProfile(const std::string &newName, bool create_new,
 		wizard.exec();
 	}
 
-	if (api) {
+	if (api && !rename) {
 		api->on_event(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
 		api->on_event(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Make the action of renaming a profile send only one of each of those events:
- `OBS_FRONTEND_EVENT_PROFILE_CHANGING`
- `OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED`
- `OBS_FRONTEND_EVENT_PROFILE_CHANGED`

Actually `on_actionRenameProfile_triggered()` sent those events but when `CreateProfile()` is called through `AddProfile()` which is called through the first method those events are sent a second time.

The `rename` is only true when renaming a profile thanks to `on_actionRenameProfile_triggered()`, so for any other `CreateProfile()` call `rename` is false.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Depending on how future plugins that use the new `_CHANGING` event, it could provoke crashes because they were expecting a `_CHANGED` and not a second `_CHANGING` and do something that they should not have done twice.

Crashing while the second `_CHANGING` is emitted, let the user with two profile with the same name but not the same folder. Both are selected in the UI.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I discover this when renaming my profile and saw that those are sent two times.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I just checked that those events are not sent two times when renaming a profile.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
