### PR TITLE
libobs: Fix overflow subtracting unsigned numbers

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -1086,13 +1086,15 @@ static inline void push_back_audio(struct obs_encoder *encoder,
 				   struct audio_data *data, size_t size,
 				   size_t offset_size)
 {
+	if (offset_size >= size)
+		return;
+
 	size -= offset_size;
 
 	/* push in to the circular buffer */
-	if (size)
-		for (size_t i = 0; i < encoder->planes; i++)
-			circlebuf_push_back(&encoder->audio_input_buffer[i],
-					    data->data[i] + offset_size, size);
+	for (size_t i = 0; i < encoder->planes; i++)
+		circlebuf_push_back(&encoder->audio_input_buffer[i],
+				    data->data[i] + offset_size, size);
 }
 
 static inline size_t calc_offset_size(struct obs_encoder *encoder,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fix overflow subtracting unsigned numbers
When offset_size is greater than size, size would overflow.

### Motivation and Context
Don't like overflowing numbers causing crashes
![image](https://user-images.githubusercontent.com/5457024/153471916-abca69da-ef42-4990-a0b2-50e668013200.png)
![image](https://user-images.githubusercontent.com/5457024/153473001-809329a1-d9b1-4e37-88c5-8e3024422244.png)

### How Has This Been Tested?
On windows 64 bit

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
