### PR TITLE
libobs, UI: prevent disabling global audio source by mistake

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2240,7 +2240,11 @@ void OBSBasicSettings::LoadListValues(QComboBox *widget, obs_property_t *prop,
 			deviceId = obs_data_get_string(settings, "device_id");
 	}
 
-	widget->addItem(QTStr("Basic.Settings.Audio.Disabled"), "disabled");
+	bool occupied = source && obs_source_get_cnt_refs(source) > 2;
+	if (!occupied) {
+		widget->addItem(QTStr("Basic.Settings.Audio.Disabled"),
+				"disabled");
+	}
 
 	for (size_t i = 0; i < count; i++) {
 		const char *name = obs_property_list_item_name(prop, i);

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -4286,6 +4286,12 @@ bool obs_source_showing(const obs_source_t *source)
 		       : false;
 }
 
+long obs_source_get_cnt_refs(const obs_source_t *source)
+{
+	obs_weak_source_t *control = source ? get_weak(source) : NULL;
+	return control ? os_atomic_load_long(&(control->ref.refs)) : 0;
+}
+
 static inline void signal_flags_updated(obs_source_t *source)
 {
 	struct calldata data;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1103,6 +1103,11 @@ EXPORT bool obs_source_active(const obs_source_t *source);
  */
 EXPORT bool obs_source_showing(const obs_source_t *source);
 
+/**
+ * Returns a copy of value of count of refs of source.
+ */
+EXPORT long obs_source_get_cnt_refs(const obs_source_t *source);
+
 /** Unused flag */
 #define OBS_SOURCE_FLAG_UNUSED_1 (1 << 0)
 /** Specifies to force audio to mono */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The changes prevent disabling global source by mistake when it has already been added to scenes 
and referenced by scene items. The effect goes like below:

![img1](https://i.ibb.co/n3N5Qdb/1.png)
![img2](https://i.ibb.co/yhQRqS3/2.png)
![img3](https://i.ibb.co/4m7kcz2/3.png)
![img4](https://i.ibb.co/qDGgMt3/4.png)

Further explanation see comments at [issue #5621 ](https://github.com/obsproject/obs-studio/issues/5621).


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This pr is to fix [issue #5621 ](https://github.com/obsproject/obs-studio/issues/5621).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
The effect is tested on Windows 10 21H2 and it works without problem.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
