### PR TITLE
 libobs: Add function to load private sources 

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -821,11 +821,10 @@ struct audio_monitor *audio_monitor_create(obs_source_t *source);
 void audio_monitor_reset(struct audio_monitor *monitor);
 extern void audio_monitor_destroy(struct audio_monitor *monitor);
 
-extern obs_source_t *obs_source_create_set_last_ver(const char *id,
-						    const char *name,
-						    obs_data_t *settings,
-						    obs_data_t *hotkey_data,
-						    uint32_t last_obs_ver);
+extern obs_source_t *
+obs_source_create_set_last_ver(const char *id, const char *name,
+			       obs_data_t *settings, obs_data_t *hotkey_data,
+			       uint32_t last_obs_ver, bool is_private);
 extern void obs_source_destroy(struct obs_source *source);
 
 enum view_type {

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -433,10 +433,11 @@ obs_source_t *obs_source_create_private(const char *id, const char *name,
 obs_source_t *obs_source_create_set_last_ver(const char *id, const char *name,
 					     obs_data_t *settings,
 					     obs_data_t *hotkey_data,
-					     uint32_t last_obs_ver)
+					     uint32_t last_obs_ver,
+					     bool is_private)
 {
 	return obs_source_create_internal(id, name, settings, hotkey_data,
-					  false, last_obs_ver);
+					  is_private, last_obs_ver);
 }
 
 static char *get_new_filter_name(obs_source_t *dst, const char *name)

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1780,7 +1780,8 @@ float obs_get_master_volume(void)
 	return obs->audio.user_volume;
 }
 
-static obs_source_t *obs_load_source_type(obs_data_t *source_data)
+static obs_source_t *obs_load_source_type(obs_data_t *source_data,
+					  bool is_private)
 {
 	obs_data_array_t *filters = obs_data_get_array(source_data, "filters");
 	obs_source_t *source;
@@ -1806,7 +1807,7 @@ static obs_source_t *obs_load_source_type(obs_data_t *source_data)
 		v_id = id;
 
 	source = obs_source_create_set_last_ver(v_id, name, settings, hotkeys,
-						prev_ver);
+						prev_ver, is_private);
 	if (source->owns_info_id) {
 		bfree((void *)source->info.unversioned_id);
 		source->info.unversioned_id = bstrdup(id);
@@ -1894,7 +1895,7 @@ static obs_source_t *obs_load_source_type(obs_data_t *source_data)
 				obs_data_array_item(filters, i);
 
 			obs_source_t *filter =
-				obs_load_source_type(filter_data);
+				obs_load_source_type(filter_data, true);
 			if (filter) {
 				obs_source_filter_add(source, filter);
 				obs_source_release(filter);
@@ -1913,7 +1914,12 @@ static obs_source_t *obs_load_source_type(obs_data_t *source_data)
 
 obs_source_t *obs_load_source(obs_data_t *source_data)
 {
-	return obs_load_source_type(source_data);
+	return obs_load_source_type(source_data, false);
+}
+
+obs_source_t *obs_load_private_source(obs_data_t *source_data)
+{
+	return obs_load_source_type(source_data, true);
 }
 
 void obs_load_sources(obs_data_array_t *array, obs_load_source_cb cb,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -717,6 +717,9 @@ EXPORT obs_data_t *obs_save_source(obs_source_t *source);
 /** Loads a source from settings data */
 EXPORT obs_source_t *obs_load_source(obs_data_t *data);
 
+/** Loads a private source from settings data */
+EXPORT obs_source_t *obs_load_private_source(obs_data_t *data);
+
 /** Send a save signal to sources */
 EXPORT void obs_source_save(obs_source_t *source);
 


### PR DESCRIPTION
### Description
If a private source is loaded with the obs_load_source function,
it is loaded as a normal source, so add a new function
to load private sources.

### Motivation and Context
Makes it easier to save/load private sources.

### How Has This Been Tested?
Saved/loaded private source.

### Types of changes
- New feature
- Bug fix

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
