### PR TITLE
rtmp-services: Update Picarto ingests

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 190,
+	"version": 191,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 190
+			"version": 191
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -918,15 +918,27 @@
             "name": "Picarto",
             "servers": [
                 {
-                    "name": "US East (Chicago, USA)",
-                    "url": "rtmp://live.us-east1.picarto.tv/golive"
+                    "name": "Autoselect closest server",
+                    "url": "rtmp://live.us.picarto.tv/golive"
                 },
                 {
-                    "name": "US West (Los Angeles, USA)",
-                    "url": "rtmp://live.us-west1.picarto.tv/golive"
+                    "name": "Los Angeles, USA",
+                    "url": "rtmp://live.us-losangeles.picarto.tv/golive"
                 },
                 {
-                    "name": "EU West (Düsseldorf, Germany)",
+                    "name": "Dallas, USA",
+                    "url": "rtmp://live.us-dallas.picarto.tv/golive"
+                },
+                {
+                    "name": "Miami, USA",
+                    "url": "rtmp://live.us-miami.picarto.tv/golive"
+                },
+                {
+                    "name": "New York, USA",
+                    "url": "rtmp://live.us-newyork.picarto.tv/golive"
+                },
+                {
+                    "name": "Europe",
                     "url": "rtmp://live.eu-west1.picarto.tv/golive"
                 }
             ],


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Updates RTMP ingests for Picarto.

### Motivation and Context
Picarto changed their ingest server list a while ago, and all the old servers are auto-redirecting to closest now. This new list makes it possible for users to manually override the server directly from OBS' presets again, as before.

### How Has This Been Tested?
New ingest list has been verified against list published here: https://help.picarto.tv/help/how-to-configure-open-broadcaster-software
In addition, all the servers have been checked and work.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

Note: did not run `clang-format` on `services.json`, as doing so changed practically every line of the file.