### PR TITLE
linux-capture: Fix for pipewire capture leaking texture handles

### DIFF
--- a/plugins/linux-capture/pipewire.c
+++ b/plugins/linux-capture/pipewire.c
@@ -298,8 +298,10 @@ static void destroy_session(obs_pipewire_data *obs_pw)
 	}
 
 	g_clear_pointer(&obs_pw->sender_name, bfree);
+	obs_enter_graphics();
 	g_clear_pointer(&obs_pw->cursor.texture, gs_texture_destroy);
 	g_clear_pointer(&obs_pw->texture, gs_texture_destroy);
+	obs_leave_graphics();
 	g_cancellable_cancel(obs_pw->cancellable);
 	g_clear_object(&obs_pw->cancellable);
 }


### PR DESCRIPTION
Enter the graphics context before calling `gs_texture_destroy()` or else the call will fail causing the texture handles to leak.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Upon Pipewire session destruction, enter the graphics context when textures are being destroyed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I was getting leak reports from OBS on shutdown when using Pipewire capture, thought I'd investigate..

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Run with and without the change.

Before on OBS Shutdown:
> info: Number of memory leaks: 2

Also in debug build:
> debug: gs_texture_destroy: called while not in a graphics context


With the patch:
> info: Number of memory leaks: 0


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
