### PR TITLE
libobs, docs: Add option to defer source saving

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -504,6 +504,9 @@ static obs_data_t *GenerateSaveData(obs_data_array_t *sceneOrder,
 		if (obs_source_is_group(source))
 			return false;
 
+		if (obs_source_saving_deferred(source))
+			return false;
+
 		return find(begin(audioSources), end(audioSources), source) ==
 		       end(audioSources);
 	};

--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -1566,6 +1566,12 @@ Functions used by transitions
    with the new transition, then call
    :c:func:`obs_transition_swap_begin()`.
 
+---------------------
+
+.. function:: void obs_source_defer_saving(obs_source_t *source, bool defer)
+
+   Prevents the source from being saved by the frontend.
+
 .. ---------------------------------------------------------------------------
 
 .. _libobs/obs-source.h: https://github.com/jp9000/obs-studio/blob/master/libobs/obs-source.h

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -519,6 +519,7 @@ struct obs_context_data {
 	struct obs_context_data **prev_next;
 
 	bool private;
+	bool defer_save;
 };
 
 extern bool obs_context_data_init(struct obs_context_data *context,

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -5486,3 +5486,18 @@ void obs_source_restore_filters(obs_source_t *source, obs_data_array_t *array)
 
 	da_free(cur_filters);
 }
+
+void obs_source_defer_saving(obs_source_t *source, bool defer)
+{
+	if (!obs_source_valid(source, "obs_source_defer_saving"))
+		return;
+
+	source->context.defer_save = defer;
+}
+
+bool obs_source_saving_deferred(const obs_source_t *source)
+{
+	return obs_source_valid(source, "obs_source_defer_saving")
+		       ? source->context.defer_save
+		       : false;
+}

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1484,6 +1484,10 @@ EXPORT enum obs_media_state obs_source_media_get_state(obs_source_t *source);
 EXPORT void obs_source_media_started(obs_source_t *source);
 EXPORT void obs_source_media_ended(obs_source_t *source);
 
+/** Defer saving of a source */
+EXPORT void obs_source_defer_saving(obs_source_t *source, bool defer);
+EXPORT bool obs_source_saving_deferred(const obs_source_t *source);
+
 /* ------------------------------------------------------------------------- */
 /* Transition-specific functions */
 enum obs_transition_target {


### PR DESCRIPTION
### Description
Currently all sources are saved by the frontend, with no
ability to skip sources, unless they are private. A plugin
might want to add a source to the audio mixer, for example, which
doesn't work with private sources. The defer option is added so
developers can save sources in plugins as they see fit.

### Motivation and Context
Developers might want to save sources with their own code.

### How Has This Been Tested?
Tested with plugin I'm making.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
