### PR TITLE
linux-v4l2: fixup mjpeg pixel format computation

### DIFF
--- a/plugins/linux-v4l2/v4l2-helpers.h
+++ b/plugins/linux-v4l2/v4l2-helpers.h
@@ -79,8 +79,6 @@ static inline enum video_format v4l2_to_obs_video_format(uint_fast32_t format)
 #endif
 	case V4L2_PIX_FMT_BGR24:
 		return VIDEO_FORMAT_BGR3;
-	case V4L2_PIX_FMT_MJPEG:
-		return VIDEO_FORMAT_I422;
 	default:
 		return VIDEO_FORMAT_NONE;
 	}

--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -148,13 +148,6 @@ static void v4l2_prep_obs_frame(struct v4l2_data *data,
 		plane_offsets[1] = data->linesize * data->height;
 		plane_offsets[2] = data->linesize * data->height * 5 / 4;
 		break;
-	case V4L2_PIX_FMT_MJPEG:
-		frame->linesize[0] = 0;
-		frame->linesize[1] = 0;
-		frame->linesize[2] = 0;
-		plane_offsets[1] = 0;
-		plane_offsets[2] = 0;
-		break;
 	default:
 		frame->linesize[0] = data->linesize;
 		break;
@@ -479,7 +472,8 @@ static void v4l2_format_list(int dev, obs_property_t *prop)
 			dstr_cat(&buffer, " (Emulated)");
 
 		if (v4l2_to_obs_video_format(fmt.pixelformat) !=
-		    VIDEO_FORMAT_NONE) {
+			    VIDEO_FORMAT_NONE ||
+		    fmt.pixelformat == V4L2_PIX_FMT_MJPEG) {
 			obs_property_list_add_int(prop, buffer.array,
 						  fmt.pixelformat);
 			blog(LOG_INFO, "Pixelformat: %s (available)",
@@ -1003,7 +997,8 @@ static void v4l2_init(struct v4l2_data *data)
 		blog(LOG_ERROR, "Unable to set format");
 		goto fail;
 	}
-	if (v4l2_to_obs_video_format(data->pixfmt) == VIDEO_FORMAT_NONE) {
+	if (v4l2_to_obs_video_format(data->pixfmt) == VIDEO_FORMAT_NONE &&
+	    data->pixfmt != V4L2_PIX_FMT_MJPEG) {
 		blog(LOG_ERROR, "Selected video format not supported");
 		goto fail;
 	}

--- a/plugins/linux-v4l2/v4l2-mjpeg.c
+++ b/plugins/linux-v4l2/v4l2-mjpeg.c
@@ -45,7 +45,6 @@ int v4l2_init_mjpeg(struct v4l2_mjpeg_decoder *decoder)
 	}
 
 	decoder->context->flags2 |= AV_CODEC_FLAG2_FAST;
-	decoder->context->pix_fmt = AV_PIX_FMT_YUVJ422P;
 
 	if (avcodec_open2(decoder->context, decoder->codec, NULL) < 0) {
 		blog(LOG_ERROR, "failed to open codec");
@@ -92,6 +91,21 @@ int v4l2_decode_mjpeg(struct obs_source_frame *out, uint8_t *data,
 	for (uint_fast32_t i = 0; i < MAX_AV_PLANES; ++i) {
 		out->data[i] = decoder->frame->data[i];
 		out->linesize[i] = decoder->frame->linesize[i];
+	}
+
+	switch (decoder->context->pix_fmt) {
+	case AV_PIX_FMT_YUVJ422P:
+	case AV_PIX_FMT_YUV422P:
+		out->format = VIDEO_FORMAT_I422;
+		break;
+	case AV_PIX_FMT_YUVJ420P:
+	case AV_PIX_FMT_YUV420P:
+		out->format = VIDEO_FORMAT_I420;
+		break;
+	case AV_PIX_FMT_YUVJ444P:
+	case AV_PIX_FMT_YUV444P:
+		out->format = VIDEO_FORMAT_I444;
+		break;
 	}
 
 	return 0;


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Previously we assumed mjpeg was always decoded to 422 but it seems some
cameras provide different pixel formats such as 420.

This change delays setting the obs frame pixel format until after we
have decoded the v4l2 frame.

fixes #5821


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

People prefer when their webcams render correctly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

My c920 with mjpeg remains unchanged. Hopefully the users from the issue can test this with their webcams.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
