### PR TITLE
wayland: Map keymap with MAP_PRIVATE

### DIFF
--- a/libobs/obs-nix-wayland.c
+++ b/libobs/obs-nix-wayland.c
@@ -84,7 +84,7 @@ static void platform_keyboard_keymap(void *data, struct wl_keyboard *keyboard,
 	UNUSED_PARAMETER(format);
 	obs_hotkeys_platform_t *plat = (obs_hotkeys_platform_t *)data;
 
-	char *keymap_shm = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+	char *keymap_shm = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
 	if (keymap_shm == MAP_FAILED) {
 		close(fd);
 		return;


### PR DESCRIPTION
### Description

Fixes a bug where keymaps were mapped with MAP_SHARED.

### Motivation and Context

OBS currently segfaults under weston because xkb_state is NULL if mmap fails.

### How Has This Been Tested?

OBS no longer segfaults under weston.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
