### PR TITLE
UI: Use std::unique_ptr for ui variables

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -97,10 +97,7 @@ BrowserToolbar::BrowserToolbar(QWidget *parent, OBSSource source)
 	ui->setupUi(this);
 }
 
-BrowserToolbar::~BrowserToolbar()
-{
-	delete ui;
-}
+BrowserToolbar::~BrowserToolbar() {}
 
 void BrowserToolbar::on_refresh_clicked()
 {
@@ -121,10 +118,7 @@ ComboSelectToolbar::ComboSelectToolbar(QWidget *parent, OBSSource source)
 	ui->setupUi(this);
 }
 
-ComboSelectToolbar::~ComboSelectToolbar()
-{
-	delete ui;
-}
+ComboSelectToolbar::~ComboSelectToolbar() {}
 
 static int FillPropertyCombo(QComboBox *c, obs_property_t *p,
 			     const std::string &cur_id, bool is_int = false)
@@ -332,10 +326,7 @@ DeviceCaptureToolbar::DeviceCaptureToolbar(QWidget *parent, OBSSource source)
 	ui->activateButton->setText(active ? deactivateText : activateText);
 }
 
-DeviceCaptureToolbar::~DeviceCaptureToolbar()
-{
-	delete ui;
-}
+DeviceCaptureToolbar::~DeviceCaptureToolbar() {}
 
 void DeviceCaptureToolbar::on_activateButton_clicked()
 {
@@ -406,10 +397,7 @@ GameCaptureToolbar::GameCaptureToolbar(QWidget *parent, OBSSource source)
 	UpdateWindowVisibility();
 }
 
-GameCaptureToolbar::~GameCaptureToolbar()
-{
-	delete ui;
-}
+GameCaptureToolbar::~GameCaptureToolbar() {}
 
 void GameCaptureToolbar::UpdateWindowVisibility()
 {
@@ -469,10 +457,7 @@ ImageSourceToolbar::ImageSourceToolbar(QWidget *parent, OBSSource source)
 	ui->path->setText(file.c_str());
 }
 
-ImageSourceToolbar::~ImageSourceToolbar()
-{
-	delete ui;
-}
+ImageSourceToolbar::~ImageSourceToolbar() {}
 
 void ImageSourceToolbar::on_browse_clicked()
 {
@@ -530,10 +515,7 @@ ColorSourceToolbar::ColorSourceToolbar(QWidget *parent, OBSSource source)
 	UpdateColor();
 }
 
-ColorSourceToolbar::~ColorSourceToolbar()
-{
-	delete ui;
-}
+ColorSourceToolbar::~ColorSourceToolbar() {}
 
 void ColorSourceToolbar::UpdateColor()
 {
@@ -623,10 +605,7 @@ TextSourceToolbar::TextSourceToolbar(QWidget *parent, OBSSource source)
 		ui->text->setText(text);
 }
 
-TextSourceToolbar::~TextSourceToolbar()
-{
-	delete ui;
-}
+TextSourceToolbar::~TextSourceToolbar() {}
 
 void TextSourceToolbar::on_selectFont_clicked()
 {

--- a/UI/context-bar-controls.hpp
+++ b/UI/context-bar-controls.hpp
@@ -39,7 +39,7 @@ public slots:
 class BrowserToolbar : public SourceToolbar {
 	Q_OBJECT
 
-	Ui_BrowserSourceToolbar *ui;
+	std::unique_ptr<Ui_BrowserSourceToolbar> ui;
 
 public:
 	BrowserToolbar(QWidget *parent, OBSSource source);
@@ -53,7 +53,7 @@ class ComboSelectToolbar : public SourceToolbar {
 	Q_OBJECT
 
 protected:
-	Ui_DeviceSelectToolbar *ui;
+	std::unique_ptr<Ui_DeviceSelectToolbar> ui;
 	const char *prop_name;
 	bool is_int = false;
 
@@ -95,7 +95,7 @@ class DeviceCaptureToolbar : public QWidget {
 
 	OBSWeakSource weakSource;
 
-	Ui_DeviceSelectToolbar *ui;
+	std::unique_ptr<Ui_DeviceSelectToolbar> ui;
 	const char *activateText;
 	const char *deactivateText;
 	bool active;
@@ -111,7 +111,7 @@ public slots:
 class GameCaptureToolbar : public SourceToolbar {
 	Q_OBJECT
 
-	Ui_GameCaptureToolbar *ui;
+	std::unique_ptr<Ui_GameCaptureToolbar> ui;
 
 	void UpdateWindowVisibility();
 
@@ -127,7 +127,7 @@ public slots:
 class ImageSourceToolbar : public SourceToolbar {
 	Q_OBJECT
 
-	Ui_ImageSourceToolbar *ui;
+	std::unique_ptr<Ui_ImageSourceToolbar> ui;
 
 public:
 	ImageSourceToolbar(QWidget *parent, OBSSource source);
@@ -140,7 +140,7 @@ public slots:
 class ColorSourceToolbar : public SourceToolbar {
 	Q_OBJECT
 
-	Ui_ColorSourceToolbar *ui;
+	std::unique_ptr<Ui_ColorSourceToolbar> ui;
 	QColor color;
 
 	void UpdateColor();
@@ -156,7 +156,7 @@ public slots:
 class TextSourceToolbar : public SourceToolbar {
 	Q_OBJECT
 
-	Ui_TextSourceToolbar *ui;
+	std::unique_ptr<Ui_TextSourceToolbar> ui;
 	QFont font;
 	QColor color;
 

--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -218,8 +218,6 @@ ScriptsTool::~ScriptsTool()
 	config_t *global_config = obs_frontend_get_global_config();
 	config_set_int(global_config, "scripts-tool", "prevScriptRow",
 		       ui->scripts->currentRow());
-
-	delete ui;
 }
 
 void ScriptsTool::RemoveScript(const char *path)

--- a/UI/frontend-plugins/frontend-tools/scripts.hpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.hpp
@@ -2,6 +2,7 @@
 
 #include <QWidget>
 #include <QString>
+#include <memory>
 
 class Ui_ScriptsTool;
 
@@ -27,7 +28,7 @@ public slots:
 class ScriptsTool : public QWidget {
 	Q_OBJECT
 
-	Ui_ScriptsTool *ui;
+	std::unique_ptr<Ui_ScriptsTool> ui;
 	QWidget *propertiesView = nullptr;
 
 public:

--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -76,10 +76,7 @@ MediaControls::MediaControls(QWidget *parent)
 	addAction(sliderBack);
 }
 
-MediaControls::~MediaControls()
-{
-	delete ui;
-}
+MediaControls::~MediaControls() {}
 
 bool MediaControls::MediaPaused()
 {

--- a/UI/media-controls.hpp
+++ b/UI/media-controls.hpp
@@ -34,7 +34,7 @@ private:
 	static void OBSMediaPause(void *data, calldata_t *calldata);
 	static void OBSMediaStarted(void *data, calldata_t *calldata);
 
-	Ui_MediaControls *ui;
+	std::unique_ptr<Ui_MediaControls> ui;
 
 private slots:
 	void on_playPauseButton_clicked();

--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -1175,8 +1175,6 @@ AutoConfigTestPage::AutoConfigTestPage(QWidget *parent)
 
 AutoConfigTestPage::~AutoConfigTestPage()
 {
-	delete ui;
-
 	if (testThread.joinable()) {
 		{
 			unique_lock<mutex> ul(m);

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -86,10 +86,7 @@ AutoConfigStartPage::AutoConfigStartPage(QWidget *parent)
 	}
 }
 
-AutoConfigStartPage::~AutoConfigStartPage()
-{
-	delete ui;
-}
+AutoConfigStartPage::~AutoConfigStartPage() {}
 
 int AutoConfigStartPage::nextId() const
 {
@@ -191,10 +188,7 @@ AutoConfigVideoPage::AutoConfigVideoPage(QWidget *parent)
 	ui->canvasRes->setCurrentIndex(0);
 }
 
-AutoConfigVideoPage::~AutoConfigVideoPage()
-{
-	delete ui;
-}
+AutoConfigVideoPage::~AutoConfigVideoPage() {}
 
 int AutoConfigVideoPage::nextId() const
 {
@@ -316,10 +310,7 @@ AutoConfigStreamPage::AutoConfigStreamPage(QWidget *parent)
 		SLOT(UpdateCompleted()));
 }
 
-AutoConfigStreamPage::~AutoConfigStreamPage()
-{
-	delete ui;
-}
+AutoConfigStreamPage::~AutoConfigStreamPage() {}
 
 bool AutoConfigStreamPage::isComplete() const
 {

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -129,7 +129,7 @@ class AutoConfigStartPage : public QWizardPage {
 
 	friend class AutoConfig;
 
-	Ui_AutoConfigStartPage *ui;
+	std::unique_ptr<Ui_AutoConfigStartPage> ui;
 
 public:
 	AutoConfigStartPage(QWidget *parent = nullptr);
@@ -148,7 +148,7 @@ class AutoConfigVideoPage : public QWizardPage {
 
 	friend class AutoConfig;
 
-	Ui_AutoConfigVideoPage *ui;
+	std::unique_ptr<Ui_AutoConfigVideoPage> ui;
 
 public:
 	AutoConfigVideoPage(QWidget *parent = nullptr);
@@ -170,7 +170,7 @@ class AutoConfigStreamPage : public QWizardPage {
 
 	std::shared_ptr<Auth> auth;
 
-	Ui_AutoConfigStreamPage *ui;
+	std::unique_ptr<Ui_AutoConfigStreamPage> ui;
 	QString lastService;
 	bool ready = false;
 
@@ -209,7 +209,7 @@ class AutoConfigTestPage : public QWizardPage {
 
 	QPointer<QFormLayout> results;
 
-	Ui_AutoConfigTestPage *ui;
+	std::unique_ptr<Ui_AutoConfigTestPage> ui;
 	std::thread testThread;
 	std::condition_variable cv;
 	std::mutex m;

--- a/UI/window-extra-browsers.cpp
+++ b/UI/window-extra-browsers.cpp
@@ -440,10 +440,7 @@ OBSExtraBrowsers::OBSExtraBrowsers(QWidget *parent)
 		QAbstractItemView::EditTrigger::CurrentChanged);
 }
 
-OBSExtraBrowsers::~OBSExtraBrowsers()
-{
-	delete ui;
-}
+OBSExtraBrowsers::~OBSExtraBrowsers() {}
 
 void OBSExtraBrowsers::closeEvent(QCloseEvent *event)
 {

--- a/UI/window-extra-browsers.hpp
+++ b/UI/window-extra-browsers.hpp
@@ -4,6 +4,7 @@
 #include <QScopedPointer>
 #include <QAbstractTableModel>
 #include <QStyledItemDelegate>
+#include <memory>
 
 class Ui_OBSExtraBrowsers;
 class ExtraBrowsersModel;
@@ -13,7 +14,7 @@ class QCefWidget;
 class OBSExtraBrowsers : public QDialog {
 	Q_OBJECT
 
-	Ui_OBSExtraBrowsers *ui;
+	std::unique_ptr<Ui_OBSExtraBrowsers> ui;
 	ExtraBrowsersModel *model;
 
 public:


### PR DESCRIPTION
### Description
Most ui variables were using std::unique_ptr, but not all.
Went through all of the UI code to find where they were manually
deleted.

### Motivation and Context
Code cleanup.

### How Has This Been Tested?
Open OBS and went through all of the UI elements and made sure nothing broke.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
