### PR TITLE
win-wasapi: Only enable work queue on Windows 10+

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -7,6 +7,7 @@
 #include <util/windows/ComPtr.hpp>
 #include <util/windows/WinHandle.hpp>
 #include <util/windows/CoTaskMemPtr.hpp>
+#include <util/windows/win-version.h>
 #include <util/threading.h>
 #include <util/util_uint64.h>
 
@@ -324,7 +325,12 @@ WASAPISource::WASAPISource(obs_data_t *settings, obs_source_t *source_,
 
 	/* OBS will already load DLL on startup if it exists */
 	const HMODULE rtwq_module = GetModuleHandle(L"RTWorkQ.dll");
-	rtwq_supported = rtwq_module != NULL;
+
+	// while RTWQ was introduced in Win 8.1, it silently fails
+	// to capture Desktop Audio for some reason. Disable for now.
+	if (get_win_ver_int() >= _WIN32_WINNT_WIN10)
+		rtwq_supported = rtwq_module != NULL;
+
 	if (rtwq_supported) {
 		rtwq_unlock_work_queue =
 			(PFN_RtwqUnlockWorkQueue)GetProcAddress(


### PR DESCRIPTION
### Description

According to rcdrone and Microsoft's documentation, work queues are properly supported on Windows 8.1 and above. However, since 27.2's release, we've heard reports that while Mic/Aux capture works correctly (verified), Desktop Audio does not (also verified).

This locks the work queue code behind a Windows 10 check. 

I did attach a debugger to a debug build of OBS but none of the `throws` were hit, and I don't understand the code well enough to track down what could be happening.

### Motivation and Context

* Fixes #5967

### How Has This Been Tested?

* Launch OBS on Windows 8.1
* Play audio
* Notice it's captured

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
