### PR TITLE
libobs: Adjust path for legacy browser source block

### DIFF
--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -110,7 +110,7 @@ int obs_open_module(obs_module_t **module, const char *path,
 	/* HACK: Do not load obsolete obs-browser build on macOS; the
 	 * obs-browser plugin used to live in the Application Support
 	 * directory. */
-	if (astrstri(path, "Library/Application Support") != NULL &&
+	if (astrstri(path, "Library/Application Support/obs-studio") != NULL &&
 	    astrstri(path, "obs-browser") != NULL) {
 		blog(LOG_WARNING, "Ignoring old obs-browser.so version");
 		return MODULE_ERROR;


### PR DESCRIPTION
### Description
The current path would prevent the browser source from loading if OBS itself is in the "Application Support" folder, where it might end up when being installed via certain distribution platforms.
This adjusts the existing hack to specifically check for the obs-studio subfolder where the old browser source library would reside.

This PR should ideally be merged into master and `release/27.2` to distribute a fixed, signed, build for those platforms.

### Motivation and Context
Browser source not loading is sort of inconvenient.

### How Has This Been Tested?
Verified that adjusting the path fixes loading the browser source.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
