### PR TITLE
UI: Refresh edit menu on item select/deselect

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -623,12 +623,14 @@ void SourceTreeItem::Select()
 {
 	tree->SelectItem(sceneitem, true);
 	OBSBasic::Get()->UpdateContextBarDeferred();
+	OBSBasic::Get()->UpdateEditMenu();
 }
 
 void SourceTreeItem::Deselect()
 {
 	tree->SelectItem(sceneitem, false);
 	OBSBasic::Get()->UpdateContextBarDeferred();
+	OBSBasic::Get()->UpdateEditMenu();
 }
 
 /* ========================================================================= */

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1842,6 +1842,7 @@ void OBSBasic::OBSInit()
 	ui->contextContainer->setVisible(contextVisible);
 	if (contextVisible)
 		UpdateContextBar(true);
+	UpdateEditMenu();
 
 	{
 		ProfileScope("OBSBasic::Load");
@@ -5369,8 +5370,6 @@ ColorSelect::ColorSelect(QWidget *parent)
 
 void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 {
-	UpdateEditMenu();
-
 	QMenu popup(this);
 	delete previewProjectorSource;
 	delete sourceProjector;
@@ -7823,11 +7822,6 @@ void OBSBasic::UpdateEditMenu()
 	ui->actionCenterToScreen->setEnabled(canTransform);
 	ui->actionVerticalCenter->setEnabled(canTransform);
 	ui->actionHorizontalCenter->setEnabled(canTransform);
-}
-
-void OBSBasic::on_menuBasic_MainMenu_Edit_aboutToShow()
-{
-	UpdateEditMenu();
 }
 
 void OBSBasic::on_actionEditTransform_triggered()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -966,8 +966,6 @@ private slots:
 	void on_actionShowCrashLogs_triggered();
 	void on_actionUploadLastCrashLog_triggered();
 
-	void on_menuBasic_MainMenu_Edit_aboutToShow();
-
 	void on_actionEditTransform_triggered();
 	void on_actionCopyTransform_triggered();
 	void on_actionPasteTransform_triggered();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Calls the refresh function of the "Edit" menu (which enables options like copy/paste and transform) when items get selected and deselected instead of when the menu is creted.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Warchamp found that copying and transforming with shortcuts is broken - this was because the state of the menu items, to which the shortcuts are bound, only refreshes when the menu gets called. This means that when the a source was selected, the shortcuts for copying or transforming would be disabled until either the Edit menu was selected or the source right clicked, forcing the menu to refresh (which would enable the menu entry).

Now, the state of the menu items (and with that the shortcuts) will get refreshed when items are selected or deselected.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.3 Beta 3, compiled and run.

Shortcuts like copy and transform are now correctly enabled and disabled when sceneitems are selected and deselected, even if they don't get right clicked.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
