### PR TITLE
CI: Fix missing SOVERSION libraries in macOS App Bundle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: [macos-latest]
     env:
       MIN_MACOS_VERSION: '10.13'
-      MACOS_DEPS_VERSION: '2022-01-31'
+      MACOS_DEPS_VERSION: '2022-02-13'
       VLC_VERSION: '3.0.8'
       SPARKLE_VERSION: '1.23.0'
       QT_VERSION: '5.15.2'

--- a/CI/full-build-macos.sh
+++ b/CI/full-build-macos.sh
@@ -422,6 +422,8 @@ prepare_macos_bundle() {
         /bin/mv ./OBS.app/Contents/Resources/data/obs-scripting/obspython.py ./OBS.app/Contents/MacOS/
         /bin/rm -rf ./OBS.app/Contents/Resources/data/obs-scripting/
     fi
+    # dylibbundler will only copy actually linked files into bundle, but not symlinks
+    /bin/cp -cpR /tmp/obsdeps/lib/*.dylib ./OBS.app/Contents/Frameworks
 
     bundle_dylibs
     install_frameworks


### PR DESCRIPTION
### Description
Ensures that SOVERSION symlinks of bundled libraries (e.g. `libavcodec.58.dylib -> libavcodec.58.134.100.dylib`) are present in the generated App Bundle.

Fixes https://github.com/obsproject/obs-deps/issues/95

Also applies necessary changes to adapt https://github.com/obsproject/obs-deps/pull/93 

### Motivation and Context
When linking to a shared library, it is common to use the SOVERSION variant (e.g. `libavcodec.58.dylib`) because major versions are expected to not break the API. This allows projects to update the specific library versions without breaking link information.

`dylibbundler` only copies the _actual_ library file linked by OBS into the generated App Bundle (per its purpose), which means that e.g. plugins linking against `libavcodec` will break any time OBS updates the specific version of FFmpeg used as part of obs-deps.

### How Has This Been Tested?
* Tested by building and bundling OBS with prebuilt OBS deps on x86_64 macOS host

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
