### PR TITLE
decklink: Use ComPtr for variables

### DIFF
--- a/plugins/decklink/decklink-device-discovery.cpp
+++ b/plugins/decklink/decklink-device-discovery.cpp
@@ -5,7 +5,7 @@
 
 DeckLinkDeviceDiscovery::DeckLinkDeviceDiscovery()
 {
-	discovery = CreateDeckLinkDiscoveryInstance();
+	discovery.Set(CreateDeckLinkDiscoveryInstance());
 	if (discovery == nullptr)
 		blog(LOG_INFO, "No blackmagic support");
 }

--- a/plugins/decklink/decklink-device-instance.hpp
+++ b/plugins/decklink/decklink-device-instance.hpp
@@ -38,7 +38,7 @@ protected:
 	bool allow10Bit;
 
 	OBSVideoFrame *convertFrame = nullptr;
-	IDeckLinkMutableVideoFrame *decklinkOutputFrame = nullptr;
+	ComPtr<IDeckLinkMutableVideoFrame> decklinkOutputFrame;
 
 	void FinalizeStream();
 	void SetupVideoFormat(DeckLinkDeviceMode *mode_);

--- a/plugins/decklink/decklink-device-mode.cpp
+++ b/plugins/decklink/decklink-device-mode.cpp
@@ -18,11 +18,7 @@ DeckLinkDeviceMode::DeckLinkDeviceMode(const std::string &name, long long id)
 {
 }
 
-DeckLinkDeviceMode::~DeckLinkDeviceMode(void)
-{
-	if (mode != nullptr)
-		mode->Release();
-}
+DeckLinkDeviceMode::~DeckLinkDeviceMode(void) {}
 
 BMDDisplayMode DeckLinkDeviceMode::GetDisplayMode(void) const
 {
@@ -82,11 +78,5 @@ bool DeckLinkDeviceMode::IsEqualFrameRate(int64_t num, int64_t den)
 
 void DeckLinkDeviceMode::SetMode(IDeckLinkDisplayMode *mode_)
 {
-	IDeckLinkDisplayMode *old = mode;
-	if (old != nullptr)
-		old->Release();
-
 	mode = mode_;
-	if (mode != nullptr)
-		mode->AddRef();
 }

--- a/plugins/decklink/decklink-device-mode.hpp
+++ b/plugins/decklink/decklink-device-mode.hpp
@@ -9,7 +9,7 @@
 class DeckLinkDeviceMode {
 protected:
 	long long id;
-	IDeckLinkDisplayMode *mode;
+	ComPtr<IDeckLinkDisplayMode> mode;
 	std::string name;
 
 public:

--- a/plugins/decklink/decklink-device.cpp
+++ b/plugins/decklink/decklink-device.cpp
@@ -49,9 +49,9 @@ bool DeckLinkDevice::Init()
 	ComPtr<IDeckLinkInput> input;
 	if (device->QueryInterface(IID_IDeckLinkInput, (void **)&input) ==
 	    S_OK) {
-		IDeckLinkDisplayModeIterator *modeIterator;
+		ComPtr<IDeckLinkDisplayModeIterator> modeIterator;
 		if (input->GetDisplayModeIterator(&modeIterator) == S_OK) {
-			IDeckLinkDisplayMode *displayMode;
+			ComPtr<IDeckLinkDisplayMode> displayMode;
 			long long modeId = 1;
 
 			while (modeIterator->Next(&displayMode) == S_OK) {
@@ -63,11 +63,8 @@ bool DeckLinkDevice::Init()
 							       modeId);
 				inputModes.push_back(mode);
 				inputModeIdMap[modeId] = mode;
-				displayMode->Release();
 				++modeId;
 			}
-
-			modeIterator->Release();
 		}
 	}
 
@@ -88,9 +85,9 @@ bool DeckLinkDevice::Init()
 	if (device->QueryInterface(IID_IDeckLinkOutput, (void **)&output) ==
 	    S_OK) {
 
-		IDeckLinkDisplayModeIterator *modeIterator;
+		ComPtr<IDeckLinkDisplayModeIterator> modeIterator;
 		if (output->GetDisplayModeIterator(&modeIterator) == S_OK) {
-			IDeckLinkDisplayMode *displayMode;
+			ComPtr<IDeckLinkDisplayMode> displayMode;
 			long long modeId = 1;
 
 			while (modeIterator->Next(&displayMode) == S_OK) {
@@ -102,11 +99,8 @@ bool DeckLinkDevice::Init()
 							       modeId);
 				outputModes.push_back(mode);
 				outputModeIdMap[modeId] = mode;
-				displayMode->Release();
 				++modeId;
 			}
-
-			modeIterator->Release();
 		}
 	}
 

--- a/plugins/decklink/plugin-main.cpp
+++ b/plugins/decklink/plugin-main.cpp
@@ -16,8 +16,8 @@ struct obs_output_info decklink_output_info;
 
 void log_sdk_version()
 {
-	IDeckLinkIterator *deckLinkIterator;
-	IDeckLinkAPIInformation *deckLinkAPIInformation;
+	ComPtr<IDeckLinkIterator> deckLinkIterator;
+	ComPtr<IDeckLinkAPIInformation> deckLinkAPIInformation;
 	HRESULT result;
 
 	deckLinkIterator = CreateDeckLinkIteratorInstance();
@@ -42,8 +42,6 @@ void log_sdk_version()
 
 		blog(LOG_INFO, "Decklink API Installed version %s",
 		     versionString.c_str());
-
-		deckLinkAPIInformation->Release();
 	}
 }
 


### PR DESCRIPTION
### Description
This makes sure Decklink variables are automatically released.

Closes https://github.com/obsproject/obs-studio/pull/5508

### Motivation and Context
The original PR, #5508, didn't use smart pointers, so this replaces it.

Fixes crash on exit and code cleanup.

### How Has This Been Tested?
Needs more testing on other Decklink devices, so needs seeking testers tag.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
