### PR TITLE
Set a fixed size socket buffer on Windows 7

### DIFF
--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -16,6 +16,9 @@
 ******************************************************************************/
 
 #include "rtmp-stream.h"
+#ifdef _WIN32
+#include <util/windows/win-version.h>
+#endif
 
 #ifndef SEC_TO_NSEC
 #define SEC_TO_NSEC 1000000000ULL
@@ -605,6 +608,24 @@ static void *send_thread(void *data)
 	os_set_thread_name("rtmp-stream: send_thread");
 
 #if defined(_WIN32)
+	// Despite MSDN claiming otherwise, send buffer auto tuning on
+	// Windows 7 doesn't seem to work very well.
+	if (get_win_ver_int() == 0x601) {
+		DWORD cur_sendbuf_size;
+		DWORD desired_sendbuf_size = 524288;
+		socklen_t int_size = sizeof(int);
+
+		if (!getsockopt(stream->rtmp.m_sb.sb_socket, SOL_SOCKET,
+				SO_SNDBUF, (char *)&cur_sendbuf_size,
+				&int_size) &&
+		    cur_sendbuf_size < desired_sendbuf_size) {
+
+			setsockopt(stream->rtmp.m_sb.sb_socket, SOL_SOCKET,
+				   SO_SNDBUF, (char *)&desired_sendbuf_size,
+				   sizeof(desired_sendbuf_size));
+		}
+	}
+
 	log_sndbuf_size(stream);
 #endif
 


### PR DESCRIPTION
### Description
Auto tuning apparently doesn't work very well on this version and af6844f5c24d77ca7b4b1bcc000504d8e693a563 reportedly caused throughput regressions. Set a fixed 512k buffer instead.

### Motivation and Context
RTMP throughput regression on Windows 7.

### How Has This Been Tested?
Breakpoints.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
