### PR TITLE
Fix random audio dropouts and corruption of audio data (2/2)

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -471,6 +471,7 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in,
 	struct ts_info ts = {start_ts_in, end_ts_in};
 	size_t audio_size;
 	uint64_t min_ts;
+	bool audio_pending = false;
 
 	da_resize(audio->render_order, 0);
 	da_resize(audio->root_nodes, 0);
@@ -515,6 +516,9 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in,
 		obs_source_t *source = audio->render_order.array[i];
 		obs_source_audio_render(source, mixers, channels, sample_rate,
 					audio_size);
+
+		if (source->audio_pending && source->audio_ts)
+			audio_pending = true;
 
 		/* if a source has gone backward in time and we can no
 		 * longer buffer, drop some or all of its audio */
@@ -611,5 +615,5 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in,
 	execute_audio_tasks();
 
 	UNUSED_PARAMETER(param);
-	return true;
+	return !audio_pending;
 }

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1481,7 +1481,7 @@ static void source_output_audio_data(obs_source_t *source,
 
 	source->last_audio_ts = in.timestamp;
 	source->next_audio_ts_min =
-		in.timestamp + conv_frames_to_time(sample_rate, in.frames);
+		data->timestamp + conv_frames_to_time(sample_rate, in.frames);
 
 	in.timestamp += source->timing_adjust;
 


### PR DESCRIPTION
(Draft PR since I'm trying to get a few more positive test results before merging).

### Description

#### 1) libobs: Fix corruption of audio data in audio_input_buf

Previously, `source->next_audio_ts_min` was incremented by `conv_frames_to_time(sample_rate, in.frames)` in each call of `source_output_audio_data()`, so only by the duration of the audio data which is basically a fixed value (if `in.frames` doesn't vary).

However, this does not take the incoming audio timestamps into account, which also include execution time. In `ProcessCaptureData()` for example `os_gettime_ns()` is used to generate the audio timestamp if device timestamps are off so it's unavoidable that the incoming timestamps are always a little later than the raw duration of the audio data. This also applies if device timestamps are enabled though, at least when recording from desktop audio (Windows 10) which I have used to verify the issue.
This adds up, because `in.timestamp` is being set to `source->next_audio_ts_min` before calculating the next timestamp `source->next_audio_ts_min = in.timestamp + conv_frames_to_time(sample_rate, in.frames)`.

If you watch the values over time, you can see the timestamps deviating like this (extract of a few thousand iterations):
```
next_audio_ts_min: 366688637418000, actual timestamp: 366688637507100, diff: 89100
next_audio_ts_min: 366690227418000, actual timestamp: 366690227453000, diff: 350000
next_audio_ts_min: 366697247418000, actual timestamp: 366697247892200, diff: 474200
next_audio_ts_min: 366702747418000, actual timestamp: 366702748130500, diff: 712500
next_audio_ts_min: 366705197418000, actual timestamp: 366705198281800, diff: 863800
next_audio_ts_min: 366708257418000, actual timestamp: 366708258445200, diff: 1027200
```

So the incoming audio timestamps gradually deviate further from the expected `next_audio_ts_min` timestamp, eventually exceeding `TS_SMOOTHING_THRESHOLD` and then causing a call to `source_output_audio_place()` which either overwrites existing audio data and causes a glitch or puts data beyond the end of the buffer, resizing it and inserting a gap and thus causing an audio dropout.

Now `next_audio_ts_min` is incremented based on the current incoming audio timestamp to prevent this issue.

For testing purposes, this issue can be detected by looking for "frames: %lu, size: %lu, placement: %lu, base_ts: %llu, ts: %llu" debug messages (with DEBUG_AUDIO enabled).

#### 2) libobs: Fix audio dropouts in input_and_output()

If the audio buffer is not currently sufficiently filled (at least `AUDIO_OUTPUT_FRAMES`), `process_audio_source_tick()` does not put any data into `audio_output_buf`. This situation is also taken into consideration in `discard_audio()` which will emit a debug message "can't discard, data still pending" (assuming `DEBUG_AUDIO == 1`) in this situation.

However, `input_and_output()` still executes `do_audio_output()`, taking exactly `AUDIO_OUTPUT_FRAMES` from the buffer, causing an audio dropout.

The change now returns false in `audio_callback()` if any audio source is still pending, so that further processing in `input_and_output()` is prevented.

For testing purposes, this issue can be detected by looking for "can't discard, data still pending" debug messages (with DEBUG_AUDIO enabled).

### Motivation and Context

These two fixes solve the issues discussed in #4600.

In short, audio recorded or streamed by OBS contains random short dropouts or corruption, independently of settings and environment, though frequency may vary. The frequency of the issue occuring ranges from every couple of minutes to maybe once or twice per hour based on my observations and the reports in the mentioned issue.

### How Has This Been Tested?

For my tests I use a test tone generator to record continuous uniform audio data with OBS (default settings, Windows 10). I then check the resulting audio stream for dropouts. For testing, I usually record 1 to 2 h of audio data.

I tried to make the changes so that the overall behaviour of the code changes as little as possible.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
