### PR TITLE
UI: Fix performance issues with the Log Viewer

### DIFF
--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -24,7 +24,7 @@ OBSLogViewer::OBSLogViewer(QWidget *parent) : QDialog(parent)
 	const QFont fixedFont =
 		QFontDatabase::systemFont(QFontDatabase::FixedFont);
 
-	textArea = new QTextEdit();
+	textArea = new QPlainTextEdit();
 	textArea->setReadOnly(true);
 	textArea->setFont(fixedFont);
 
@@ -106,13 +106,21 @@ void OBSLogViewer::InitLog()
 		in.setCodec("UTF-8");
 #endif
 
+		QTextDocument *doc = textArea->document();
+		QTextCursor cursor(doc);
+		cursor.movePosition(QTextCursor::End);
+		cursor.beginEditBlock();
 		while (!in.atEnd()) {
 			QString line = in.readLine();
-			AddLine(LOG_INFO, line);
+			cursor.insertHtml(line);
+			cursor.insertBlock();
 		}
+		cursor.endEditBlock();
 
 		file.close();
 	}
+	QScrollBar *scroll = textArea->verticalScrollBar();
+	scroll->setValue(scroll->maximum());
 
 	obsLogViewer = this;
 }
@@ -123,12 +131,10 @@ void OBSLogViewer::AddLine(int type, const QString &str)
 
 	switch (type) {
 	case LOG_WARNING:
-		msg = QStringLiteral("<font color=\"#c08000\">") + msg +
-		      QStringLiteral("</font>");
+		msg = QString("<font color=\"#c08000\">%1</font>").arg(msg);
 		break;
 	case LOG_ERROR:
-		msg = QStringLiteral("<font color=\"#c00000\">") + msg +
-		      QStringLiteral("</font>");
+		msg = QString("<font color=\"#c00000\">%1</font>").arg(msg);
 		break;
 	}
 
@@ -138,11 +144,13 @@ void OBSLogViewer::AddLine(int type, const QString &str)
 	if (bottomScrolled)
 		scroll->setValue(scroll->maximum());
 
-	QTextCursor newCursor = textArea->textCursor();
-	newCursor.movePosition(QTextCursor::End);
-	newCursor.insertHtml(
-		QStringLiteral("<pre style=\"white-space: pre-wrap\">") + msg +
-		QStringLiteral("<br></pre>"));
+	QTextDocument *doc = textArea->document();
+	QTextCursor cursor(doc);
+	cursor.movePosition(QTextCursor::End);
+	cursor.beginEditBlock();
+	cursor.insertHtml(msg);
+	cursor.insertBlock();
+	cursor.endEditBlock();
 
 	if (bottomScrolled)
 		scroll->setValue(scroll->maximum());

--- a/UI/log-viewer.hpp
+++ b/UI/log-viewer.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <QDialog>
-#include <QTextEdit>
+#include <QPlainTextEdit>
 #include "obs-app.hpp"
 
 class OBSLogViewer : public QDialog {
 	Q_OBJECT
 
-	QPointer<QTextEdit> textArea;
+	QPointer<QPlainTextEdit> textArea;
 
 	void InitLog();
 


### PR DESCRIPTION
### Description

This includes 3 fixes. 2 very big ones, and a smaller one to improve readability

1) Update the internal QTextDocument of the text component directly
2) Use QPlainTextEdit, which supports HTML & is designed for long text
3) Use QString's arg function for formatting strings

Fix 1 significantly improves realtime performance when adding lines individually, to the point that the UI no longer freezes if the viewer is open and the log is being spammed. It also improves initial launch speed when there's a large amount of text already in the file.
Reference: https://stackoverflow.com/a/54501760/2763321

Fix 2 completely eliminates delay when opening the viewer, regardless of how many lines are already in the log file. For a standard log after OBS launch, this cuts opening time from about 2 seconds to half a second. For anything longer than 1,000 lines, the UI no longer freezes, and the viewer (& its contents) open within half a second.
Reference: https://stackoverflow.com/a/17466240/2763321

My tests conclude: **Log Viewer startup is 3 seconds per 100,000 lines** with these changes

Demo:


https://user-images.githubusercontent.com/941350/154947950-b02bd0ff-afb1-4e17-b06c-bf01cfdaba8e.mp4




### Motivation and Context

Users have complained about the log viewer causing the UI to hang, or taking a while to open.

### How Has This Been Tested?

* Open the log viewer
* Spam 10,000 log lines using the browser source + dev tools using the below script and wait for all messages to come through
* Close and reopen the log viewer.

<details>
  <summary>Click to expand JS script</summary>

```js
var verbs, nouns, adjectives, adverbs, preposition;
nouns = ["bird", "clock", "boy", "plastic", "duck", "teacher", "old lady", "professor", "hamster", "dog"];
verbs = ["kicked", "ran", "flew", "dodged", "sliced", "rolled", "died", "breathed", "slept", "killed"];
adjectives = ["beautiful", "lazy", "professional", "lovely", "dumb", "rough", "soft", "hot", "vibrating", "slimy"];
adverbs = ["slowly", "elegantly", "precisely", "quickly", "sadly", "humbly", "proudly", "shockingly", "calmly", "passionately"];
preposition = ["down", "into", "up", "on", "upon", "below", "above", "through", "across", "towards"];

let count = 0;
var sentence = () => {
	const rand = () => Math.floor(Math.random() * 10);
	var content = "The " + adjectives[rand()] + " " + nouns[rand()] + " " + adverbs[rand()] + " " + verbs[rand()] + " because some " + nouns[rand()] + " " + adverbs[rand()] + " " + verbs[rand()] + " " + preposition[rand()] + " a " + adjectives[rand()] + " " + nouns[rand()] + " which, became a " + adjectives[rand()] + ", " + adjectives[rand()] + " " + nouns[rand()] + ".";

	console.error(count, content);
};

const loop = () => {
	sentence();
	count++;
    if (count < 10000) setTimeout(loop, 1);
};
loop();
```
</details>


### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
