### PR TITLE
UI: Avoid calling obs_source_update multiple times

### DIFF
--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -81,20 +81,10 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 	OBSDataAutoRelease nd_settings = obs_source_get_settings(source);
 	obs_data_apply(oldSettings, nd_settings);
 
-	auto handle_memory = [](void *vp, obs_data_t *old_settings,
-				obs_data_t *new_settings) {
-		obs_source_t *source = reinterpret_cast<obs_source_t *>(vp);
-
-		obs_source_update(source, new_settings);
-
-		UNUSED_PARAMETER(old_settings);
-		UNUSED_PARAMETER(vp);
-	};
-
 	view = new OBSPropertiesView(
 		nd_settings.Get(), source,
 		(PropertiesReloadCallback)obs_source_properties,
-		(PropertiesUpdateCallback)handle_memory,
+		(PropertiesUpdateCallback) nullptr, // No special handling required for undo/redo
 		(PropertiesVisualUpdateCb)obs_source_update);
 	view->setMinimumHeight(150);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When we added undo/redo in 86eb7aeb a distinction between Updates and
Visual updates was made, presumably for filters which need special
handling of the update case. These functions were also added to regular
source properties, but didnt use any special code instead calling
obs_source_update an additional time after a short time.

Instead lets remove the 2nd delayed call and only call obs_source_update
once per settings change.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
some sources perform work during update or log additional information (xcomposite is both) this second
call causes graphical weirdness for the user in this case and extra logging to read through for support.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Undo/redo of xcomposite and v4l2 capture didnt break. Its unclear to me if this change was made to workaround some slow
source which might desync between their visual and actual settings, but if it was I think that should be resolved in the source 
itself.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
