### PR TITLE
linux-capture: Simplify xcompcap

### DIFF
--- a/plugins/linux-capture/xcompcap-main.hpp
+++ b/plugins/linux-capture/xcompcap-main.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "xcompcap-helper.hpp"
+
 struct XCompcapMain_private;
 
 class XCompcapMain {
@@ -22,5 +24,6 @@ public:
 	uint32_t height();
 
 private:
+	void updateTexture(XErrorLock *xlock);
 	XCompcapMain_private *p;
 };


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This attempts to simplify and remove many helpers from xcompcap capture
methods and rearrange some functionality to fix error handling broken some
time after 4ac77ee (xlocks collided again).

Removes some lock helpers, replaced with a RAII based defer macro to
call the functions directly.

Splits updateSettings into updateTexture to be called from
updateSettings and tick. This also avoids excessive logging when windows
are resized.

Renames xcc_cleanup to cleanupPixmap and moves the non-pixmap related
cleanup directly into XCompCap destructor. This also involves some
changes to texture validity checks to preserve behavior but makes things
more straightforward.

Removes redundant lockX option because XErrorLock already implements
this functionality and is held during the same lifetime.

Removes excessive error checking from cleanup functions. Because of the
earlier xlock collisions our state tracking was incorrect and we saw
errors in these functions. After fixing xlock issues that state tracking works and
those errors go away so lets remove the extra logging as well.

Don't release TexImage on nvidia since we are using loose binding.
Tested via nvidia-smi that resources are released as expected.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Deleting code is good, but primarily this restores the correct errors to our logs again which makes it easier to
tell if/when we introduce regressions. And fixes our error handling that further simplifies the code. Removing
some unused code and codifying our requirements that xlocks not be taken recursively should prevent regression
by crashing new code that breaks this assumption before it reaches a PR, but may be we want this to be a log instead.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on nvidia on i3/gnome and on intel on i3/gnome. Nothing appears to have regressed but by reducing the
log spam it becomes easier to see some underlying errors such as gs_copy_texture failures occurring (due to cross process sync issues?). These copy failures could be replicated on master on intel and nvidia so I don't think this is
a regression (the rate seems more or less the same as master).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
