### PR TITLE
linux-v4l2: Fix warnings in mjpeg

### DIFF
--- a/plugins/linux-v4l2/v4l2-mjpeg.c
+++ b/plugins/linux-v4l2/v4l2-mjpeg.c
@@ -75,7 +75,6 @@ void v4l2_destroy_mjpeg(struct v4l2_mjpeg_decoder *decoder)
 int v4l2_decode_mjpeg(struct obs_source_frame *out, uint8_t *data,
 		      size_t length, struct v4l2_mjpeg_decoder *decoder)
 {
-
 	decoder->packet->data = data;
 	decoder->packet->size = length;
 	if (avcodec_send_packet(decoder->context, decoder->packet) < 0) {
@@ -105,6 +104,8 @@ int v4l2_decode_mjpeg(struct obs_source_frame *out, uint8_t *data,
 	case AV_PIX_FMT_YUVJ444P:
 	case AV_PIX_FMT_YUV444P:
 		out->format = VIDEO_FORMAT_I444;
+		break;
+	default:
 		break;
 	}
 

--- a/plugins/linux-v4l2/v4l2-mjpeg.h
+++ b/plugins/linux-v4l2/v4l2-mjpeg.h
@@ -29,7 +29,7 @@ extern "C" {
  * Data structure for mjpeg decoding
  */
 struct v4l2_mjpeg_decoder {
-	AVCodec *codec;
+	const AVCodec *codec;
 	AVCodecContext *context;
 	AVPacket *packet;
 	AVFrame *frame;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Previously the switch did not catch all cases issuing a quite large
warning. Also there was a const-ness warning for codecs on ffmpeg 5.0
that this addresses.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
A clean compile is a happy compile.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable) 
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
