### PR TITLE
UI: Restore LC_NUMERIC to C locale on Mac/Linux

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1156,6 +1156,12 @@ bool OBSApp::InitTheme()
 OBSApp::OBSApp(int &argc, char **argv, profiler_name_store_t *store)
 	: QApplication(argc, argv), profilerNameStore(store)
 {
+	/* fix float handling */
+#if defined(Q_OS_UNIX)
+	if (!setlocale(LC_NUMERIC, "C"))
+		blog(LOG_WARNING, "Failed to set LC_NUMERIC to C locale");
+#endif
+
 	sleepInhibitor = os_inhibit_sleep_create("OBS Video/audio");
 
 #ifdef __APPLE__

--- a/UI/platform-x11.cpp
+++ b/UI/platform-x11.cpp
@@ -213,7 +213,6 @@ string GetDefaultVideoSavePath()
 
 vector<string> GetPreferredLocales()
 {
-	setlocale(LC_ALL, "");
 	vector<string> matched;
 	string messages = setlocale(LC_MESSAGES, NULL);
 	if (!messages.size() || messages == "C" || messages == "POSIX")


### PR DESCRIPTION
### Description
Suspicion is that floats were not being parsed correctly when a foreign locale is set.
- CUBE files now load correctly.
- HLS arguments to custom FFmpeg now parse correctly.

The Qt recommendation is to set LC_NUMERIC to "C" in the QCoreApplication doc:
https://doc.qt.io/qt-5/qcoreapplication.html
> On Unix/Linux Qt is configured to use the system locale settings by default. This can cause a conflict when using POSIX functions, for instance, when converting between data types such as floats and strings, since the notation may differ between locales. To get around this problem, call the POSIX function setlocale(LC_NUMERIC,"C") right after initializing [QApplication](https://doc.qt.io/qt-5/qapplication.html), [QGuiApplication](https://doc.qt.io/qt-5/qguiapplication.html) or QCoreApplication to reset the locale that is used for number formatting to "C"-locale.

### Motivation and Context
Fixes #3770
Fixes #5385

### How Has This Been Tested?
- Verified broken -> fixed on Ubuntu with `LANG=es_ES.UTF-8` for both issues.
- Verified broken -> fixed on Mac with `LANG=es_ES.UTF-8` for CUBE load, and no regression for HLS arguments.
- Scene JSON does not seem to care what the locale is.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.