### PR TITLE
Fix building OBS Studio on FreeBSD

### DIFF
--- a/UI/platform-x11.cpp
+++ b/UI/platform-x11.cpp
@@ -136,7 +136,7 @@ const char *RunOnce::thr_name = "OBS runonce";
 void PIDFileCheck(bool &already_running)
 {
 	std::string tmpfile_name =
-		"/tmp/obs-studio.lock." + to_string(geteuid());
+		"/tmp/obs-studio.lock." + std::to_string(geteuid());
 	int fd = open(tmpfile_name.c_str(), O_RDWR | O_CREAT | O_EXLOCK, 0600);
 	if (fd == -1) {
 		already_running = true;

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -936,7 +936,7 @@ EXPORT gs_stagesurf_t *gs_stagesurface_create_nv12(uint32_t width,
 EXPORT void gs_register_loss_callbacks(const struct gs_device_loss *callbacks);
 EXPORT void gs_unregister_loss_callbacks(void *data);
 
-#elif __linux__
+#elif defined(__linux__) || defined(__FreeBSD__)
 
 EXPORT gs_texture_t *gs_texture_create_from_dmabuf(
 	unsigned int width, unsigned int height, uint32_t drm_format,

--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -185,7 +185,14 @@ static bool virtualcam_start(void *data)
 			return false;
 	}
 
-	n = scandir("/dev", &list, scanfilter, versionsort);
+	n = scandir("/dev", &list, scanfilter,
+#if defined(__linux__)
+		    versionsort
+#else
+		    alphasort
+#endif
+	);
+
 	if (n == -1)
 		return false;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix building OBS Studio on FreeBSD:
- `libobs/graphics/graphics.h`: The `gs_texture_create_from_dmabuf` & `gs_query_dmabuf_*` functions were marked as Linux-only as of f7a55f45fdacf9c8383cafae8170294ac8997954.
- `plugins/linux-v4l2/v4l2-output.c`: `versionsort` (and by extension, `__strverscmp`) are not available on FreeBSD, as they are GNU extensions (`versionsort` is used by `virtualcam_start` to read `/dev/video*` devices in the right order), so implemented them.
- `UI/platform-x11.cpp`: Was calling `to_string` on FreeBSD when not `using namespace std;`, so calling `std::to_string` instead.

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fixes building on FreeBSD.

### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on FreeBSD 13.0-RELEASE-p4 and FreeBSD-CURRENT, hardware is non-applicable.
Compiled with clang version 11.0.1 & 13.0.1.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

Perhaps this is usererror, but `git-clang-format` doesn't seem to work?

```
YAML:35:21: error: unknown key 'AfterExternBlock'
  AfterExternBlock: false
                    ^~~~~
Error reading /usr/home/obiwac/obs-studio/.clang-format: Invalid argument
error: `clang-format -lines=178:178 -lines=187:187 -lines=191:191 -lines=196:196 -lines=198:255 -lines=258:258 -lines=260:260 plugins/linux-v4l2/v4l2-output.c` failed
```

So I attempted to format things myself.
Hope that's alright :)