### PR TITLE
win-wasapi: Fall back to old code if RTWQ fails

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -347,46 +347,54 @@ WASAPISource::WASAPISource(obs_data_t *settings, obs_source_t *source_,
 			(PFN_RtwqPutWaitingWorkItem)GetProcAddress(
 				rtwq_module, "RtwqPutWaitingWorkItem");
 
-		hr = rtwq_create_async_result(nullptr, &startCapture, nullptr,
-					      &startCaptureAsyncResult);
-		if (FAILED(hr)) {
-			enumerator->UnregisterEndpointNotificationCallback(
-				notify);
-			throw HRError(
-				"Could not create startCaptureAsyncResult", hr);
-		}
+		try {
+			hr = rtwq_create_async_result(nullptr, &startCapture,
+						      nullptr,
+						      &startCaptureAsyncResult);
+			if (FAILED(hr)) {
+				throw HRError(
+					"Could not create startCaptureAsyncResult",
+					hr);
+			}
 
-		hr = rtwq_create_async_result(nullptr, &sampleReady, nullptr,
-					      &sampleReadyAsyncResult);
-		if (FAILED(hr)) {
-			enumerator->UnregisterEndpointNotificationCallback(
-				notify);
-			throw HRError("Could not create sampleReadyAsyncResult",
-				      hr);
-		}
+			hr = rtwq_create_async_result(nullptr, &sampleReady,
+						      nullptr,
+						      &sampleReadyAsyncResult);
+			if (FAILED(hr)) {
+				throw HRError(
+					"Could not create sampleReadyAsyncResult",
+					hr);
+			}
 
-		hr = rtwq_create_async_result(nullptr, &restart, nullptr,
-					      &restartAsyncResult);
-		if (FAILED(hr)) {
-			enumerator->UnregisterEndpointNotificationCallback(
-				notify);
-			throw HRError("Could not create restartAsyncResult",
-				      hr);
-		}
+			hr = rtwq_create_async_result(nullptr, &restart,
+						      nullptr,
+						      &restartAsyncResult);
+			if (FAILED(hr)) {
+				throw HRError(
+					"Could not create restartAsyncResult",
+					hr);
+			}
 
-		DWORD taskId = 0;
-		DWORD id = 0;
-		hr = rtwq_lock_shared_work_queue(L"Capture", 0, &taskId, &id);
-		if (FAILED(hr)) {
-			enumerator->UnregisterEndpointNotificationCallback(
-				notify);
-			throw HRError("RtwqLockSharedWorkQueue failed", hr);
-		}
+			DWORD taskId = 0;
+			DWORD id = 0;
+			hr = rtwq_lock_shared_work_queue(L"Capture", 0, &taskId,
+							 &id);
+			if (FAILED(hr)) {
+				throw HRError("RtwqLockSharedWorkQueue failed",
+					      hr);
+			}
 
-		startCapture.SetQueueId(id);
-		sampleReady.SetQueueId(id);
-		restart.SetQueueId(id);
-	} else {
+			startCapture.SetQueueId(id);
+			sampleReady.SetQueueId(id);
+			restart.SetQueueId(id);
+		} catch (HRError &err) {
+			blog(LOG_ERROR, "RTWQ setup failed: %s (0x%08X)",
+			     err.str, err.hr);
+			rtwq_supported = false;
+		}
+	}
+
+	if (!rtwq_supported) {
 		captureThread = CreateThread(nullptr, 0,
 					     WASAPISource::CaptureThread, this,
 					     0, nullptr);


### PR DESCRIPTION
### Description
Catch `HRError` if the RTWQ functions fail so that we can fallback to the old code instead of crashing.

### Motivation and Context
Crash bad.

### How Has This Been Tested?
Stopped mmcss service, ran OBS.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
