### PR TITLE
decklink: Don't load modules if Decklink not found

### DIFF
--- a/UI/frontend-plugins/decklink-captions/decklink-captions.cpp
+++ b/UI/frontend-plugins/decklink-captions/decklink-captions.cpp
@@ -153,7 +153,13 @@ void addOutputUI(void)
 
 bool obs_module_load(void)
 {
-	addOutputUI();
-
 	return true;
+}
+
+void obs_module_post_load(void)
+{
+	if (!obs_get_module("decklink"))
+		return;
+
+	addOutputUI();
 }

--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
@@ -340,10 +340,6 @@ static void OBSEvent(enum obs_frontend_event event, void *)
 
 bool obs_module_load(void)
 {
-	addOutputUI();
-
-	obs_frontend_add_event_callback(OBSEvent, nullptr);
-
 	return true;
 }
 
@@ -356,4 +352,14 @@ void obs_module_unload(void)
 
 	if (main_output_running)
 		output_stop();
+}
+
+void obs_module_post_load(void)
+{
+	if (!obs_get_module("decklink"))
+		return;
+
+	addOutputUI();
+
+	obs_frontend_add_event_callback(OBSEvent, nullptr);
 }

--- a/plugins/decklink/plugin-main.cpp
+++ b/plugins/decklink/plugin-main.cpp
@@ -14,7 +14,7 @@ struct obs_source_info decklink_source_info;
 extern struct obs_output_info create_decklink_output_info();
 struct obs_output_info decklink_output_info;
 
-void log_sdk_version()
+bool log_sdk_version()
 {
 	IDeckLinkIterator *deckLinkIterator;
 	IDeckLinkAPIInformation *deckLinkAPIInformation;
@@ -24,7 +24,7 @@ void log_sdk_version()
 	if (deckLinkIterator == NULL) {
 		blog(LOG_WARNING,
 		     "A DeckLink iterator could not be created.  The DeckLink drivers may not be installed");
-		return;
+		return false;
 	}
 
 	result = deckLinkIterator->QueryInterface(
@@ -45,15 +45,18 @@ void log_sdk_version()
 
 		deckLinkAPIInformation->Release();
 	}
+
+	return true;
 }
 
 bool obs_module_load(void)
 {
-	log_sdk_version();
+	if (!log_sdk_version())
+		return false;
 
 	deviceEnum = new DeckLinkDeviceDiscovery();
 	if (!deviceEnum->Init())
-		return true;
+		return false;
 
 	decklink_source_info = create_decklink_source_info();
 	obs_register_source(&decklink_source_info);


### PR DESCRIPTION
### Description
The modules were still being loaded even if the user didn't have any Decklink devices.

### Motivation and Context
Don't show Decklink tool menu items if it is not installed and less memory usage.

### How Has This Been Tested?
Checked the tools menu to see if the items were removed.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
