### PR TITLE
linux-v4l2: Fix fallback framerate for camera

### DIFF
--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -39,6 +39,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "v4l2-helpers.h"
 #include "v4l2-decoder.h"
 
+#define FALLBACK_FRAMERATE 30
+
 #if HAVE_UDEV
 #include "v4l2-udev.h"
 #endif
@@ -1028,6 +1030,11 @@ static void v4l2_init(struct v4l2_data *data)
 	if (v4l2_set_framerate(data->dev, &data->framerate) < 0) {
 		blog(LOG_ERROR, "Unable to set framerate");
 		goto fail;
+	}
+	if (data->framerate == 0) {
+		blog(LOG_ERROR, "Framerate is not set, falling back to %i",
+		     FALLBACK_FRAMERATE);
+		data->framerate = v4l2_pack_tuple(1, FALLBACK_FRAMERATE);
 	}
 	v4l2_unpack_tuple(&fps_num, &fps_denom, data->framerate);
 	blog(LOG_INFO, "Framerate: %.2f fps", (float)fps_denom / fps_num);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Fixes very large log sizes and STDOUT spam when camera does not report framerate.

Code taken from https://github.com/Mikael-Lovqvist/obs-studio/commit/3cd5742be5168f625558c14c1b38fedf23116277

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This adds a fallback framerate if the camera does not report one. It defaults to 10 frames per second, but can be manually changed later in the UI (included).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

- Fixes https://github.com/obsproject/obs-studio/issues/4926
- Fixes https://github.com/obsproject/obs-studio/issues/8397

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on `Linux hostname 5.16.11-arch1-1 #1 SMP PREEMPT Thu, 24 Feb 2022 02:18:20 +0000 x86_64 GNU/Linux`. Built with `mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX="/usr" -DBUILD_BROWSER=OFF -DBUILD_VST=OFF -DDISABLE_VLC=ON .. && make -j$(nproc) && mkdir dist && make install DESTDIR=dist`. Tested by checking log sizes and STDOUT for affected camera. Log was as expected: without the hundreds of thousands of error messages.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
