### PR TITLE
win-dshow: Add hardware decode status to log

### DIFF
--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -981,12 +981,14 @@ bool DShowInput::UpdateVideoConfig(obs_data_t *settings)
 	     "\tflip: %d\n"
 	     "\tfps: %0.2f (interval: %lld)\n"
 	     "\tformat: %s\n"
-	     "\tbuffering: %s",
+	     "\tbuffering: %s\n"
+	     "\thardware decode: %s",
 	     obs_source_get_name(source), (const char *)name_utf8,
 	     (const char *)path_utf8, videoConfig.cx, videoConfig.cy_abs,
 	     (int)videoConfig.cy_flip, fps, videoConfig.frameInterval,
 	     formatName->array,
-	     obs_source_async_unbuffered(source) ? "disabled" : "enabled");
+	     obs_source_async_unbuffered(source) ? "disabled" : "enabled",
+	     hw_decode ? "enabled" : "disabled");
 
 	return true;
 }


### PR DESCRIPTION
### Description
Log status of hardware decoding.

### Motivation and Context
Useful to know whether or not hardware decoding is enabled for support.

### How Has This Been Tested?
Log text looks correct in both checkbox positions.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.