### PR TITLE
win-dshow: Fix wrong AVCodecContext free call

### DIFF
--- a/plugins/win-dshow/ffmpeg-decode.c
+++ b/plugins/win-dshow/ffmpeg-decode.c
@@ -112,10 +112,8 @@ void ffmpeg_decode_free(struct ffmpeg_decode *decode)
 	if (decode->hw_frame)
 		av_frame_free(&decode->hw_frame);
 
-	if (decode->decoder) {
-		avcodec_close(decode->decoder);
-		av_free(decode->decoder);
-	}
+	if (decode->decoder)
+		avcodec_free_context(&decode->decoder);
 
 	if (decode->frame)
 		av_frame_free(&decode->frame);


### PR DESCRIPTION
### Description
Replace AVCodecContext cleanup with avcodec_free_context.

### Motivation and Context
Comment for avcodec_alloc_context3 says to use avcodec_free_context.

### How Has This Been Tested?
Function call seems to work okay. Can see from avcodec_free_context implementation that avcodec_close is no longer needed.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.