### PR TITLE
UI: Dropfiles Undo/Redo

### DIFF
--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -106,7 +106,6 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 {
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 	OBSDataAutoRelease settings = obs_data_create();
-	OBSSourceAutoRelease source = nullptr;
 	const char *type = nullptr;
 	std::vector<const char *> types;
 	QString name;
@@ -171,11 +170,36 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 
 	if (name.isEmpty())
 		name = obs_source_get_display_name(type);
-	source = obs_source_create(type,
-				   GenerateSourceName(QT_TO_UTF8(name)).c_str(),
-				   settings, nullptr);
+	std::string sourceName = GenerateSourceName(QT_TO_UTF8(name));
+	OBSSourceAutoRelease source =
+		obs_source_create(type, sourceName.c_str(), settings, nullptr);
 	if (source) {
 		OBSScene scene = main->GetCurrentScene();
+		const char *sceneName =
+			obs_source_get_name(obs_scene_get_source(scene));
+		auto undo = [sceneName, sourceName](const std::string &) {
+			OBSSourceAutoRelease source =
+				obs_get_source_by_name(sourceName.c_str());
+			obs_source_remove(source);
+			OBSSourceAutoRelease scene =
+				obs_get_source_by_name(sceneName);
+			OBSBasic::Get()->SetCurrentScene(scene.Get(), true);
+		};
+		auto redo = [sceneName, sourceName,
+			     type](const std::string &data) {
+			OBSSourceAutoRelease scene =
+				obs_get_source_by_name(sceneName);
+			OBSBasic::Get()->SetCurrentScene(scene.Get(), true);
+			OBSDataAutoRelease settings =
+				obs_data_create_from_json(data.c_str());
+			OBSSourceAutoRelease source = obs_source_create(
+				type, sourceName.c_str(), settings, nullptr);
+			obs_scene_add(obs_scene_from_source(scene),
+				      source.Get());
+		};
+		undo_s.add_action(QTStr("Undo.Add").arg(sourceName.c_str()),
+				  undo, redo, "",
+				  std::string(obs_data_get_json(settings)));
 		obs_scene_add(scene, source);
 	}
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
- Adds undo/redo to dropfiles, so that sources created by drag-and-drop can be removed
again via Ctrl-Z.
~~- Adds a dialog telling the user that the file is not supported if a file with an unknown
extension is drag-and-dropped into OBS. So far, this fails silently.~~

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
- Source actions like this should have undo/redo
~~- Having nothing happen if a user drags an unknown file into OBS can be confusing to the
user who might have no idea what's going on (and is just wondering why no new source
appears)~~


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.3 Beta 4, compiled and run
- Undo/Redo works, tested with raw text, a media file and a url
~~- Dialog appears if I try to add an unknown file type: 
*<<Removed>>*~~


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (undo/redo)
~~- Tweak (dialog)~~
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
