### PR TITLE
win-dshow: Reference new device-vendor.cpp file

### DIFF
--- a/plugins/win-dshow/CMakeLists.txt
+++ b/plugins/win-dshow/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(
             libdshowcapture/source/dshowencode.cpp
             libdshowcapture/source/device.cpp
             libdshowcapture/source/device.hpp
+            libdshowcapture/source/device-vendor.cpp
             libdshowcapture/source/encoder.cpp
             libdshowcapture/source/encoder.hpp
             libdshowcapture/source/dshow-base.cpp

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -278,6 +278,7 @@ struct DShowInput {
 	void OnEncodedAudioData(enum AVCodecID id, unsigned char *data,
 				size_t size, long long ts);
 
+	void OnReactivate();
 	void OnVideoData(const VideoConfig &config, unsigned char *data,
 			 size_t size, long long startTime, long long endTime,
 			 long rotation);
@@ -520,6 +521,11 @@ void DShowInput::OnEncodedVideoData(enum AVCodecID id, unsigned char *data,
 #endif
 		obs_source_output_video2(source, &frame);
 	}
+}
+
+void DShowInput::OnReactivate()
+{
+	SetActive(true);
 }
 
 void DShowInput::OnVideoData(const VideoConfig &config, unsigned char *data,
@@ -958,6 +964,8 @@ bool DShowInput::UpdateVideoConfig(obs_data_t *settings)
 					 placeholders::_1, placeholders::_2,
 					 placeholders::_3, placeholders::_4,
 					 placeholders::_5, placeholders::_6);
+	videoConfig.reactivateCallback =
+		std::bind(&DShowInput::OnReactivate, this);
 
 	videoConfig.format = videoConfig.internalFormat;
 


### PR DESCRIPTION
### Description
New file added to keep vendor concerns out of device.cpp.

Needs https://github.com/obsproject/libdshowcapture/pull/44 to compile.

### Motivation and Context
Need hardware-specific pokes to support HDR.

### How Has This Been Tested?
Code compiles

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.