### PR TITLE
mac-syphon: Mark source as deprecated

### DIFF
--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -1223,7 +1223,7 @@ struct obs_source_info syphon_info = {
 	.id = "syphon-input",
 	.type = OBS_SOURCE_TYPE_INPUT,
 	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-			OBS_SOURCE_DO_NOT_DUPLICATE,
+			OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_DEPRECATED,
 	.get_name = syphon_get_name,
 	.create = syphon_create,
 	.destroy = syphon_destroy,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Marks the syphon client source as deprecated, moving it to the
deprecated section in the Add Source popup:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/59806498/155985794-0ea8372e-ee34-4890-9c30-0168f6932f04.png">


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Syphon Inject was the main usage of the syphon source, mostly as a game
capture replacement, but no longer works since macOS 10.14, causing more
support requests than value.
Additionally, Syphon itself appears to be mostly abandoned for a year
now, which doesn't induce much confidence its future.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.3 Beta 4, compiled and run

Syphon Client source has moved, as shown in the screenshot above.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to ***improve*** existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
