### PR TITLE
Video timing improvements

### DIFF
--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -723,7 +723,12 @@ static inline void video_sleep(struct obs_core_video *video, bool raw_active,
 		*p_time = t;
 		count = 1;
 	} else {
-		count = (int)((os_gettime_ns() - cur_time) / interval_ns);
+		const uint64_t udiff = os_gettime_ns() - cur_time;
+		int64_t diff;
+		memcpy(&diff, &udiff, sizeof(diff));
+		const uint64_t clamped_diff =
+			(diff > (int64_t)interval_ns) ? diff : interval_ns;
+		count = (int)(clamped_diff / interval_ns);
 		*p_time = cur_time + interval_ns * count;
 	}
 

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -26,6 +26,7 @@
 #include "platform.h"
 #include "darray.h"
 #include "dstr.h"
+#include "util_uint64.h"
 #include "windows/win-registry.h"
 #include "windows/win-version.h"
 
@@ -332,9 +333,9 @@ void os_cpu_usage_info_destroy(os_cpu_usage_info_t *info)
 
 bool os_sleepto_ns(uint64_t time_target)
 {
-	const double freq = (double)get_clockfreq();
+	const uint64_t freq = get_clockfreq();
 	const LONGLONG count_target =
-		(LONGLONG)(round((double)time_target * freq / 1000000000.0));
+		util_mul_div64(time_target, freq, 1000000000);
 
 	LARGE_INTEGER count;
 	QueryPerformanceCounter(&count);
@@ -371,14 +372,9 @@ void os_sleep_ms(uint32_t duration)
 uint64_t os_gettime_ns(void)
 {
 	LARGE_INTEGER current_time;
-	double time_val;
-
 	QueryPerformanceCounter(&current_time);
-	time_val = (double)current_time.QuadPart;
-	time_val *= 1000000000.0;
-	time_val /= (double)get_clockfreq();
-
-	return (uint64_t)time_val;
+	return util_mul_div64(current_time.QuadPart, 1000000000,
+			      get_clockfreq());
 }
 
 /* returns [folder]\[name] on windows */


### PR DESCRIPTION
### Description
Use integer math for Windows timings, and clamp interval computation to prevent infinite stalls.

### Motivation and Context
Noticed double math was unnecessary on Windows. Don't want OBS graphics thread to hang.

### How Has This Been Tested?
Debugger inspection showed math behaving as desired. OBS 60 FPS recording was verified 60 FPS.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.