### PR TITLE
UI: Simplify multi-instance check

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2093,15 +2093,10 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		bool cancel_launch = false;
 		bool already_running = false;
 
-#if defined(_WIN32)
-		RunOnceMutex rom = GetRunOnceMutex(already_running);
-#elif defined(__APPLE__)
-		CheckAppWithSameBundleID(already_running);
-#elif defined(__linux__)
-		RunningInstanceCheck(already_running);
-#elif defined(__FreeBSD__) || defined(__DragonFly__)
-		PIDFileCheck(already_running);
+#ifdef _WIN32
+		RunOnceMutex rom =
 #endif
+			CheckIfAlreadyRunning(already_running);
 
 		if (!already_running) {
 			goto run;

--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -88,7 +88,7 @@ bool InitApplicationBundle()
 #endif
 }
 
-void CheckAppWithSameBundleID(bool &already_running)
+void CheckIfAlreadyRunning(bool &already_running)
 {
 	try {
 		NSBundle *bundle = [NSBundle mainBundle];
@@ -107,7 +107,7 @@ void CheckAppWithSameBundleID(bool &already_running)
 		already_running = app_count > 1;
 
 	} catch (const char *error) {
-		blog(LOG_ERROR, "CheckAppWithSameBundleID: %s", error);
+		blog(LOG_ERROR, "CheckIfAlreadyRunning: %s", error);
 	}
 }
 

--- a/UI/platform-windows.cpp
+++ b/UI/platform-windows.cpp
@@ -328,7 +328,7 @@ RunOnceMutex &RunOnceMutex::operator=(RunOnceMutex &&rom)
 	return *this;
 }
 
-RunOnceMutex GetRunOnceMutex(bool &already_running)
+RunOnceMutex CheckIfAlreadyRunning(bool &already_running)
 {
 	string name;
 

--- a/UI/platform-x11.cpp
+++ b/UI/platform-x11.cpp
@@ -53,7 +53,7 @@ using std::vector;
 using std::ostringstream;
 
 #ifdef __linux__
-void RunningInstanceCheck(bool &already_running)
+void CheckIfAlreadyRunning(bool &already_running)
 {
 	int uniq = socket(AF_LOCAL, SOCK_DGRAM | SOCK_CLOEXEC, 0);
 
@@ -133,7 +133,7 @@ struct RunOnce {
 } RO;
 const char *RunOnce::thr_name = "OBS runonce";
 
-void PIDFileCheck(bool &already_running)
+void CheckIfAlreadyRunning(bool &already_running)
 {
 	std::string tmpfile_name =
 		"/tmp/obs-studio.lock." + std::to_string(geteuid());

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -40,6 +40,14 @@ void SetAlwaysOnTop(QWidget *window, bool enable);
 bool SetDisplayAffinitySupported(void);
 
 #ifdef _WIN32
+class RunOnceMutex;
+RunOnceMutex
+#else
+void
+#endif
+CheckIfAlreadyRunning(bool &already_running);
+
+#ifdef _WIN32
 uint32_t GetWindowsVersion();
 uint32_t GetWindowsBuild();
 void SetAeroEnabled(bool enable);
@@ -62,7 +70,6 @@ public:
 	RunOnceMutex &operator=(RunOnceMutex &&rom);
 };
 
-RunOnceMutex GetRunOnceMutex(bool &already_running);
 QString GetMonitorName(const QString &id);
 bool IsRunningOnWine();
 #endif
@@ -72,12 +79,5 @@ void EnableOSXVSync(bool enable);
 void EnableOSXDockIcon(bool enable);
 void InstallNSApplicationSubclass();
 void disableColorSpaceConversion(QWidget *window);
-void CheckAppWithSameBundleID(bool &already_running);
 bool ProcessIsRosettaTranslated();
-#endif
-#ifdef __linux__
-void RunningInstanceCheck(bool &already_running);
-#endif
-#if defined(__FreeBSD__) || defined(__DragonFly__)
-void PIDFileCheck(bool &already_running);
 #endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the various multi-instance check function names into one, making
calling it much more clean, since it no longer needs to differentiate between
macOS, Linux, FreeBSD and whatever DragonFlyBSD is.
Unfortunately, Windows requires carrying the RunOnceMutex, so it's not *as*
clean as it could be, but imo better than what we currently have.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The ifdef-ladder in obs-app.cpp is ugly and mostly unneeded, since the
check works the same on all operating systems, except Windows where
the function has a return value. Having four different functions doing
the same thing is not very nice to look at.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiles on macOS, Windows and Ubuntu (CI).
Tested on macOS 12.3 and Windows 11 that the check still works.

Not tested on other unix-like (since I don't have them), but other than
the function names the code wasn't changed there and it still compiles.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
