### PR TITLE
libobs, frontend-tools, docs: Free frontend Decklink modules

### DIFF
--- a/UI/frontend-plugins/decklink-captions/decklink-captions.cpp
+++ b/UI/frontend-plugins/decklink-captions/decklink-captions.cpp
@@ -158,8 +158,10 @@ bool obs_module_load(void)
 
 void obs_module_post_load(void)
 {
-	if (!obs_get_module("decklink"))
+	if (!obs_get_module("decklink")) {
+		obs_free_module(obs_current_module());
 		return;
+	}
 
 	addOutputUI();
 }

--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
@@ -356,8 +356,10 @@ void obs_module_unload(void)
 
 void obs_module_post_load(void)
 {
-	if (!obs_get_module("decklink"))
+	if (!obs_get_module("decklink")) {
+		obs_free_module(obs_current_module());
 		return;
+	}
 
 	addOutputUI();
 

--- a/docs/sphinx/reference-modules.rst
+++ b/docs/sphinx/reference-modules.rst
@@ -317,3 +317,11 @@ plugin modules.
 
    :param  module: The module where to find library file.
    :return:        Pointer to module library.
+
+---------------------
+
+.. function:: void *obs_free_module(obs_module_t *module)
+
+   Frees specified module.
+
+   :param  module: The module to free.

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -274,6 +274,11 @@ void obs_add_module_path(const char *bin, const char *data)
 	da_push_back(obs->module_paths, &omp);
 }
 
+void obs_free_module(obs_module_t *module)
+{
+	free_module(module);
+}
+
 static void load_all_callback(void *param, const struct obs_module_info *info)
 {
 	obs_module_t *module;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -450,6 +450,9 @@ EXPORT obs_module_t *obs_get_module(const char *name);
 /** Gets library of module */
 EXPORT void *obs_get_module_lib(obs_module_t *module);
 
+/** Frees module */
+EXPORT void obs_free_module(obs_module_t *module);
+
 /** Returns locale text from a specific module */
 EXPORT bool obs_module_get_locale_string(const obs_module_t *mod,
 					 const char *lookup_string,


### PR DESCRIPTION
### Description
If Decklink was not found, the UI woudn't load, but the modules were
still loaded.

### Motivation and Context
Less memory usage if not using Decklink devices.

### How Has This Been Tested?
Loaded OBS on a computer without Decklink devices.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
