### PR TITLE
UI: Fix mixer hide toggle in studio mode

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3532,6 +3532,8 @@ void OBSBasic::ActivateAudioSource(OBSSource source)
 {
 	if (SourceMixerHidden(source))
 		return;
+	if (!obs_source_active(source))
+		return;
 	if (!obs_source_audio_active(source))
 		return;
 


### PR DESCRIPTION
### Description
If the user would toggle hide in mixer in studio mode,
the source would show up in audio mixer, even if it
wasn't active.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/4142

### How Has This Been Tested?
Toggled hide in mixer for audio sources in studio mode.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
