### PR TITLE
libobs: Show plugin search paths in log

### DIFF
--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -466,6 +466,7 @@ void obs_find_modules(obs_find_module_callback_t callback, void *param)
 
 	for (size_t i = 0; i < obs->module_paths.num; i++) {
 		struct obs_module_path *omp = obs->module_paths.array + i;
+		blog(LOG_INFO, "finding modules in %s %s", omp->bin, omp->data);
 		find_modules_in_path(omp, callback, param);
 	}
 }


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This commit add log lines that shows `bin` and `data` paths to search plugins.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Some users try to install a plugin from zip file and possibly make a mistake to expand the plugin into wrong location.
In other case, some users installed OBS Studio to unusual locations or installed multiple locations on Windows, which causes executable installer to take unexpected install path.
When a plugin is installed by a user but not shown up, there is no way to support the user from the log file. The new log lines should be helpful to find the plugin is installed in the correct location.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: Fedora 34
Output of the log with this change is as below.
  https://obsproject.com/logs/195if0CMVjtI6JTa

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
