### PR TITLE
libobs/graphics, libobs-d3d11: Add P010 support

### DIFF
--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -122,9 +122,9 @@ void gs_texture_2d::Rebuild(ID3D11Device *dev)
 	}
 }
 
-void gs_texture_2d::RebuildNV12_Y(ID3D11Device *dev)
+void gs_texture_2d::RebuildPaired_Y(ID3D11Device *dev)
 {
-	gs_texture_2d *tex_uv = pairedNV12texture;
+	gs_texture_2d *tex_uv = pairedTexture;
 	HRESULT hr;
 
 	hr = dev->CreateTexture2D(&td, nullptr, &texture);
@@ -147,7 +147,7 @@ void gs_texture_2d::RebuildNV12_Y(ID3D11Device *dev)
 	if (isRenderTarget)
 		InitRenderTargets();
 
-	tex_uv->RebuildNV12_UV(dev);
+	tex_uv->RebuildPaired_UV(dev);
 
 	acquired = false;
 
@@ -159,9 +159,9 @@ void gs_texture_2d::RebuildNV12_Y(ID3D11Device *dev)
 	}
 }
 
-void gs_texture_2d::RebuildNV12_UV(ID3D11Device *dev)
+void gs_texture_2d::RebuildPaired_UV(ID3D11Device *dev)
 {
-	gs_texture_2d *tex_y = pairedNV12texture;
+	gs_texture_2d *tex_y = pairedTexture;
 	HRESULT hr;
 
 	texture = tex_y->texture;
@@ -501,10 +501,10 @@ try {
 			break;
 		case gs_type::gs_texture_2d: {
 			gs_texture_2d *tex = (gs_texture_2d *)obj;
-			if (!tex->nv12) {
+			if (!tex->pairedTexture) {
 				tex->Rebuild(dev);
 			} else if (!tex->chroma) {
-				tex->RebuildNV12_Y(dev);
+				tex->RebuildPaired_Y(dev);
 			}
 		} break;
 		case gs_type::gs_zstencil_buffer:

--- a/libobs-d3d11/d3d11-stagesurf.cpp
+++ b/libobs-d3d11/d3d11-stagesurf.cpp
@@ -43,12 +43,12 @@ gs_stage_surface::gs_stage_surface(gs_device_t *device, uint32_t width,
 }
 
 gs_stage_surface::gs_stage_surface(gs_device_t *device, uint32_t width,
-				   uint32_t height)
+				   uint32_t height, bool p010)
 	: gs_obj(device, gs_type::gs_stage_surface),
 	  width(width),
 	  height(height),
 	  format(GS_UNKNOWN),
-	  dxgiFormat(DXGI_FORMAT_NV12)
+	  dxgiFormat(p010 ? DXGI_FORMAT_P010 : DXGI_FORMAT_NV12)
 {
 	HRESULT hr;
 

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -515,8 +515,8 @@ struct gs_texture_2d : gs_texture {
 	bool genMipmaps = false;
 	uint32_t sharedHandle = GS_INVALID_HANDLE;
 
-	gs_texture_2d *pairedNV12texture = nullptr;
-	bool nv12 = false;
+	gs_texture_2d *pairedTexture = nullptr;
+	bool twoPlane = false;
 	bool chroma = false;
 	bool acquired = false;
 
@@ -533,8 +533,8 @@ struct gs_texture_2d : gs_texture {
 
 	void RebuildSharedTextureFallback();
 	void Rebuild(ID3D11Device *dev);
-	void RebuildNV12_Y(ID3D11Device *dev);
-	void RebuildNV12_UV(ID3D11Device *dev);
+	void RebuildPaired_Y(ID3D11Device *dev);
+	void RebuildPaired_UV(ID3D11Device *dev);
 
 	inline void Release()
 	{
@@ -554,7 +554,7 @@ struct gs_texture_2d : gs_texture {
 		      gs_color_format colorFormat, uint32_t levels,
 		      const uint8_t *const *data, uint32_t flags,
 		      gs_texture_type type, bool gdiCompatible,
-		      bool nv12 = false);
+		      bool twoPlane = false);
 
 	gs_texture_2d(gs_device_t *device, ID3D11Texture2D *nv12,
 		      uint32_t flags);
@@ -654,7 +654,8 @@ struct gs_stage_surface : gs_obj {
 
 	gs_stage_surface(gs_device_t *device, uint32_t width, uint32_t height,
 			 gs_color_format colorFormat);
-	gs_stage_surface(gs_device_t *device, uint32_t width, uint32_t height);
+	gs_stage_surface(gs_device_t *device, uint32_t width, uint32_t height,
+			 bool p010);
 };
 
 struct gs_sampler_state : gs_obj {
@@ -985,6 +986,7 @@ struct gs_device {
 	ComPtr<ID3D11DeviceContext> context;
 	uint32_t adpIdx = 0;
 	bool nv12Supported = false;
+	bool p010Supported = false;
 
 	gs_texture_2d *curRenderTarget = nullptr;
 	gs_zstencil_buffer *curZStencilBuffer = nullptr;

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -190,6 +190,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT(gs_shader_set_next_sampler);
 
 	GRAPHICS_IMPORT_OPTIONAL(device_nv12_available);
+	GRAPHICS_IMPORT_OPTIONAL(device_p010_available);
 
 	GRAPHICS_IMPORT(device_debug_marker_begin);
 	GRAPHICS_IMPORT(device_debug_marker_end);
@@ -222,7 +223,9 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_acquire_sync);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_release_sync);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_create_nv12);
+	GRAPHICS_IMPORT_OPTIONAL(device_texture_create_p010);
 	GRAPHICS_IMPORT_OPTIONAL(device_stagesurface_create_nv12);
+	GRAPHICS_IMPORT_OPTIONAL(device_stagesurface_create_p010);
 	GRAPHICS_IMPORT_OPTIONAL(device_register_loss_callbacks);
 	GRAPHICS_IMPORT_OPTIONAL(device_unregister_loss_callbacks);
 #elif __linux__

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -266,6 +266,7 @@ struct gs_exports {
 					   gs_samplerstate_t *sampler);
 
 	bool (*device_nv12_available)(gs_device_t *device);
+	bool (*device_p010_available)(gs_device_t *device);
 
 	void (*device_debug_marker_begin)(gs_device_t *device,
 					  const char *markername,
@@ -323,8 +324,16 @@ struct gs_exports {
 					   gs_texture_t **tex_uv,
 					   uint32_t width, uint32_t height,
 					   uint32_t flags);
+	bool (*device_texture_create_p010)(gs_device_t *device,
+					   gs_texture_t **tex_y,
+					   gs_texture_t **tex_uv,
+					   uint32_t width, uint32_t height,
+					   uint32_t flags);
 
 	gs_stagesurf_t *(*device_stagesurface_create_nv12)(gs_device_t *device,
+							   uint32_t width,
+							   uint32_t height);
+	gs_stagesurf_t *(*device_stagesurface_create_p010)(gs_device_t *device,
 							   uint32_t width,
 							   uint32_t height);
 	void (*device_register_loss_callbacks)(

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -835,6 +835,7 @@ EXPORT bool gs_timer_range_get_data(gs_timer_range_t *range, bool *disjoint,
 				    uint64_t *frequency);
 
 EXPORT bool gs_nv12_available(void);
+EXPORT bool gs_p010_available(void);
 
 #define GS_USE_DEBUG_MARKERS 0
 #if GS_USE_DEBUG_MARKERS
@@ -931,8 +932,13 @@ EXPORT int gs_texture_release_sync(gs_texture_t *tex, uint64_t key);
 EXPORT bool gs_texture_create_nv12(gs_texture_t **tex_y, gs_texture_t **tex_uv,
 				   uint32_t width, uint32_t height,
 				   uint32_t flags);
+EXPORT bool gs_texture_create_p010(gs_texture_t **tex_y, gs_texture_t **tex_uv,
+				   uint32_t width, uint32_t height,
+				   uint32_t flags);
 
 EXPORT gs_stagesurf_t *gs_stagesurface_create_nv12(uint32_t width,
+						   uint32_t height);
+EXPORT gs_stagesurf_t *gs_stagesurface_create_p010(uint32_t width,
 						   uint32_t height);
 
 EXPORT void gs_register_loss_callbacks(const struct gs_device_loss *callbacks);


### PR DESCRIPTION
### Description
Add wide-channel format support for encoding HDR on GPU.

Needs more support code to actually use HDR in OBS.

### Motivation and Context
Want to support HDR in the future.

### How Has This Been Tested?
Functionality works in HDR fork.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.