### PR TITLE
UI: Remove OBSSceneItem QDataStream

### DIFF
--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -196,30 +196,6 @@ QDataStream &operator>>(QDataStream &in, OBSScene &scene)
 	return in;
 }
 
-QDataStream &operator<<(QDataStream &out, const OBSSceneItem &si)
-{
-	obs_scene_t *scene = obs_sceneitem_get_scene(si);
-	obs_source_t *source = obs_sceneitem_get_source(si);
-	return out << QString(obs_source_get_name(obs_scene_get_source(scene)))
-		   << QString(obs_source_get_name(source));
-}
-
-QDataStream &operator>>(QDataStream &in, OBSSceneItem &si)
-{
-	QString sceneName;
-	QString sourceName;
-
-	in >> sceneName >> sourceName;
-
-	OBSSourceAutoRelease sceneSource =
-		obs_get_source_by_name(QT_TO_UTF8(sceneName));
-
-	obs_scene_t *scene = obs_scene_from_source(sceneSource);
-	si = obs_scene_find_source(scene, QT_TO_UTF8(sourceName));
-
-	return in;
-}
-
 void DeleteLayout(QLayout *layout)
 {
 	if (!layout)

--- a/UI/qt-wrappers.hpp
+++ b/UI/qt-wrappers.hpp
@@ -68,8 +68,6 @@ QDataStream &operator>>(QDataStream &in,
 			std::vector<std::shared_ptr<OBSSignal>> &signal_vec);
 QDataStream &operator<<(QDataStream &out, const OBSScene &scene);
 QDataStream &operator>>(QDataStream &in, OBSScene &scene);
-QDataStream &operator<<(QDataStream &out, const OBSSceneItem &si);
-QDataStream &operator>>(QDataStream &in, OBSSceneItem &si);
 
 QThread *CreateQThread(std::function<void()> func);
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -284,7 +284,6 @@ OBSBasic::OBSBasic(QWidget *parent)
 	qRegisterMetaTypeStreamOperators<std::vector<std::shared_ptr<OBSSignal>>>(
 		"std::vector<std::shared_ptr<OBSSignal>>");
 	qRegisterMetaTypeStreamOperators<OBSScene>("OBSScene");
-	qRegisterMetaTypeStreamOperators<OBSSceneItem>("OBSSceneItem");
 #endif
 
 	ui->scenes->setAttribute(Qt::WA_MacShowFocusRect, false);


### PR DESCRIPTION
### Description
Since the source list is a custom list model, the
QDataStreams for OBSSceneItem are not needed.

### Motivation and Context
Remove unneeded code.

### How Has This Been Tested?
Performed actions in the source list to make sure everything still works.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
