### PR TITLE
UI: Make theme change require restart under Wayland and enforce Qt default decoration

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2070,9 +2070,15 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 	 * use other QPA platforms using this env var, or the -platform command
 	 * line option. */
 
+	/* NOTE 2: Some Wayland decoration can gave too big title bar to docks
+	 * like with QGnome decorations. So we force Qt default decoration (bradient).
+	 * It's still possible to use other decoration using this env var. */
+
 	const char *session_type = getenv("XDG_SESSION_TYPE");
-	if (session_type && strcmp(session_type, "wayland") == 0)
+	if (session_type && strcmp(session_type, "wayland") == 0) {
 		setenv("QT_QPA_PLATFORM", "wayland", false);
+		setenv("QT_WAYLAND_DECORATION", "bradient", false);
+	}
 #endif
 
 	OBSApp program(argc, argv, profilerNameStore.get());

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -251,6 +251,9 @@ private:
 	void OnAuthConnected();
 	QString lastService;
 	int prevLangIndex;
+#if !defined(_WIN32) && !defined(__APPLE__) && defined(ENABLE_WAYLAND)
+	int prevThemeIndex;
+#endif
 	bool prevBrowserAccel;
 private slots:
 	void UpdateServerList();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
#### Restart for theme change on Wayland

With Qt default decoration, the decoration match OBS theme.
But changing theme doesn't change the color of decoration of already created Window until OBS is restarted.
So under Wayland, I made the theme setting will behave like the language setting. It will ask to restart and be unchangeable when if a video feature is active.

Look at the title bar after a theme change.
![Screenshot from 2022-03-04 07-00-20](https://user-images.githubusercontent.com/17492366/156708632-9fd92d33-68dd-4d7d-9f56-2a55083377b9.png)

This happen should happen with the Flatpak installed from a non-GNOME DE and on distro that does not install Wayland decoration like QGnome by default.

#### Enforce Qt default decoration

Fedora and Flatpak under GNOME apply/install QGnome Wayland decoration by default. But this decoration gave big title bar to docks.

![Screenshot from 2022-03-03 13-08-23](https://user-images.githubusercontent.com/17492366/156590505-cb78fae9-2382-42ea-83cb-5f303fe01b85.png)

So this PR enforce the use Qt default decoration that is used if no other is installed. Making docks title bar less big and even match OBS theme.

The user still can override this by settings `QT_WAYLAND_DECORATION` is his environments.

![Screenshot from 2022-03-03 13-08-07](https://user-images.githubusercontent.com/17492366/156591515-5fb88ffb-19ff-4880-96fe-ef8a8c619986.png)

![Screenshot from 2022-03-03 14-27-28](https://user-images.githubusercontent.com/17492366/156591525-21057063-07e9-4e5d-9e26-97ddc7ad07a3.png)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
User can see this color mismatch as a bug.

I think those GNOME title bar are too big for the floating docks and doesn't match them.
And also maybe unify OBS look between distros.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Run under GNOME Wayland with QGnome installed, and check that the decoration are not QGnome's.
- Run under Wayland, and check if the theme is changed only after a restart and the settings locked when the replay buffer is enabled.
- Run under X11/Xorg and check if the theme is changeable without restart and even with replay buffer enabled.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
