### PR TITLE
UI: Add about to exit event

### DIFF
--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -58,6 +58,7 @@ enum obs_frontend_event {
 	OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGING,
 	OBS_FRONTEND_EVENT_PROFILE_CHANGING,
 	OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN,
+	OBS_FRONTEND_EVENT_ABOUT_TO_EXIT,
 };
 
 /* ------------------------------------------------------------------------- */

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4631,6 +4631,9 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 	if (!event->isAccepted())
 		return;
 
+	if (api)
+		api->on_event(OBS_FRONTEND_EVENT_ABOUT_TO_EXIT);
+
 	blog(LOG_INFO, SHUTDOWN_SEPARATOR);
 
 	closing = true;

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -120,9 +120,13 @@ Structures/Enumerations
      **OBS_FRONTEND_EVENT_EXIT** event is normally called after scripts
      have been destroyed.
 
+   - **OBS_FRONTEND_EVENT_ABOUT_TO_EXIT**
+
+     Triggered when the program is starting to exit, before anything is cleaned up.
+
    - **OBS_FRONTEND_EVENT_EXIT**
 
-     Triggered when the program is about to exit.
+     Triggered when the program is exiting.
 
    - **OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTING**
 


### PR DESCRIPTION
### Description
Event is called when exiting and before anything is cleaned up.

### Motivation and Context
Event is so developers know when OBS is starting to exit and before any cleanup is done whatsoever.

### How Has This Been Tested?
Tested with script.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
