### PR TITLE
UI: Display dock-relevant context menu on titlebar

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -9922,11 +9922,25 @@ void OBSBasic::on_customContextMenuRequested(const QPoint &pos)
 {
 	QWidget *widget = childAt(pos);
 	const char *className = nullptr;
-	if (widget != nullptr)
+	QString objName;
+	if (widget != nullptr) {
 		className = widget->metaObject()->className();
+		objName = widget->objectName();
+	}
 
-	if (!className || strstr(className, "Dock") != nullptr)
-		ui->menuDocks->exec(mapToGlobal(pos));
+	QPoint globalPos = mapToGlobal(pos);
+	if (className && strstr(className, "Dock") != nullptr &&
+	    !objName.isEmpty()) {
+		if (objName.compare("scenesDock") == 0) {
+			ui->scenes->customContextMenuRequested(globalPos);
+		} else if (objName.compare("sourcesDock") == 0) {
+			ui->sources->customContextMenuRequested(globalPos);
+		} else if (objName.compare("mixerDock") == 0) {
+			StackedMixerAreaContextMenuRequested();
+		}
+	} else if (!className) {
+		ui->menuDocks->exec(globalPos);
+	}
 }
 
 void OBSBasic::UpdateProjectorHideCursor()


### PR DESCRIPTION
### Description

When the user right clicks a dock titlebar, display a context-aware context menu rather than the generic Docks menu.

**Before**:

![image](https://user-images.githubusercontent.com/941350/156865903-f8419c34-6140-4530-b91c-4790f3432501.png)


**After**:

![image](https://user-images.githubusercontent.com/941350/156865880-33b9a7db-7545-4b5b-9333-c4b3e9f48060.png)


### Motivation and Context

**At @Warchamp7's request.**

His belief is it shouldn't matter where you're right clicking on a dock, it should show that dock's context menu.

Additionally, we moved the Docks menu to the main menu bar so accessing it from a context menu should no longer be necessary.

### How Has This Been Tested?

* Right click on a dock titlebar

### Types of changes

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
