### PR TITLE
deps/media-playback: New AVPacket pattern

### DIFF
--- a/deps/media-playback/media-playback/decode.h
+++ b/deps/media-playback/media-playback/decode.h
@@ -68,9 +68,7 @@ struct mp_decode {
 	bool eof;
 	bool hw;
 
-	AVPacket orig_pkt;
-	AVPacket pkt;
-	bool packet_pending;
+	AVPacket *pkt;
 	struct circlebuf packets;
 };
 

--- a/deps/media-playback/media-playback/media.h
+++ b/deps/media-playback/media-playback/media.h
@@ -62,6 +62,7 @@ struct mp_media {
 	int scale_linesizes[4];
 	uint8_t *scale_pic[4];
 
+	DARRAY(AVPacket *) packet_pool;
 	struct mp_decode v;
 	struct mp_decode a;
 	bool is_local_file;
@@ -136,10 +137,6 @@ extern int64_t mp_get_current_time(mp_media_t *m);
 extern void mp_media_seek_to(mp_media_t *m, int64_t pos);
 
 /* #define DETAILED_DEBUG_INFO */
-
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
-#define USE_NEW_FFMPEG_DECODE_API
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description
FFmpeg has deprecated stack-allocated AVPacket objects, so make a pool
and use the new pattern instead.

### Motivation and Context
Hate compiler warnings.

### How Has This Been Tested?
Debugger inspection of all modifications.

No crashes/leaks for these scenarios:
- Loop off, exit during playback
- Loop off, exit after playback
- Loop on, exit during first loop
- Loop on, exit during second loop

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.