### PR TITLE
libobs: Support filter_texrender format changes

### DIFF
--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -464,6 +464,8 @@ EXPORT bool gs_texrender_begin(gs_texrender_t *texrender, uint32_t cx,
 EXPORT void gs_texrender_end(gs_texrender_t *texrender);
 EXPORT void gs_texrender_reset(gs_texrender_t *texrender);
 EXPORT gs_texture_t *gs_texrender_get_texture(const gs_texrender_t *texrender);
+EXPORT enum gs_color_format
+gs_texrender_get_format(const gs_texrender_t *texrender);
 
 /* ---------------------------------------------------
  * graphics subsystem

--- a/libobs/graphics/texture-render.c
+++ b/libobs/graphics/texture-render.c
@@ -140,3 +140,8 @@ gs_texture_t *gs_texrender_get_texture(const gs_texrender_t *texrender)
 {
 	return texrender ? texrender->target : NULL;
 }
+
+enum gs_color_format gs_texrender_get_format(const gs_texrender_t *texrender)
+{
+	return texrender->format;
+}

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3859,9 +3859,16 @@ bool obs_source_process_filter_begin(obs_source_t *filter,
 		return false;
 	}
 
-	if (!filter->filter_texrender)
+	if (filter->filter_texrender &&
+	    (gs_texrender_get_format(filter->filter_texrender) != format)) {
+		gs_texrender_destroy(filter->filter_texrender);
+		filter->filter_texrender = NULL;
+	}
+
+	if (!filter->filter_texrender) {
 		filter->filter_texrender =
 			gs_texrender_create(format, GS_ZS_NONE);
+	}
 
 	if (gs_texrender_begin(filter->filter_texrender, cx, cy)) {
 		gs_blend_state_push();


### PR DESCRIPTION
### Description
Correct oversight where obs_source_process_filter_begin may be called with a different format than filter_texrender expects.

### Motivation and Context
This hasn't been an issue so far because filters historically use GS_RGBA every frame, but format changes can occur in the future when filters start supporting target switches between SDR and HDR.

### How Has This Been Tested?
Verified destroy/create logic is skipped in current branch, and that format switches are handled in an experimental HDR branch.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.