### PR TITLE
mac-capture: Add vbcable to whitelist for loopback devices

### DIFF
--- a/plugins/mac-capture/audio-device-enum.c
+++ b/plugins/mac-capture/audio-device-enum.c
@@ -15,7 +15,8 @@ static inline bool device_is_input(char *device)
 	       astrstri(device, "ishowu") == NULL &&
 	       astrstri(device, "blackhole") == NULL &&
 	       astrstri(device, "loopback") == NULL &&
-	       astrstri(device, "groundcontrol") == NULL;
+	       astrstri(device, "groundcontrol") == NULL &&
+	       astrstri(device, "vbcable") == NULL;
 }
 
 static inline bool enum_success(OSStatus stat, const char *msg)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add vbcable to the whitelist for loopback devices. VB-Cable is now available on "Audio Output Capture" window


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
There's currently a manual whitelist for loopback devices, due to there being no way to programmatically detect them. User can't use VB-Cable with OBS.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compile on MacOS 11.6. I checked if all VB-Cable (VB-Cable, vb-cable A, VB-Cable B, VB-Cable C and VB-Cable D ) are listed in Audio Output Capture.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 - Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
