### PR TITLE
obs-frontend-api: Add function to get frontend translated string

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -620,6 +620,11 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		return bstrdup(recordOutputPath);
 	}
 
+	const char *obs_frontend_get_locale_string(const char *string) override
+	{
+		return Str(string);
+	}
+
 	void on_load(obs_data_t *settings) override
 	{
 		for (size_t i = saveCallbacks.size(); i > 0; i--) {

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -559,3 +559,9 @@ char *obs_frontend_get_current_record_output_path(void)
 		       ? c->obs_frontend_get_current_record_output_path()
 		       : nullptr;
 }
+
+const char *obs_frontend_get_locale_string(const char *string)
+{
+	return !!callbacks_valid() ? c->obs_frontend_get_locale_string(string)
+				   : nullptr;
+}

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -225,6 +225,7 @@ EXPORT void obs_frontend_open_source_filters(obs_source_t *source);
 EXPORT void obs_frontend_open_source_interaction(obs_source_t *source);
 
 EXPORT char *obs_frontend_get_current_record_output_path(void);
+EXPORT const char *obs_frontend_get_locale_string(const char *string);
 
 /* ------------------------------------------------------------------------- */
 

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -142,6 +142,8 @@ struct obs_frontend_callbacks {
 	obs_frontend_open_source_interaction(obs_source_t *source) = 0;
 
 	virtual char *obs_frontend_get_current_record_output_path(void) = 0;
+	virtual const char *
+	obs_frontend_get_locale_string(const char *string) = 0;
 };
 
 EXPORT void

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -768,3 +768,9 @@ Functions
 
    :return: A new pointer to the current record output path.  Free
             with :c:func:`bfree()`
+
+---------------------------------------
+
+.. function:: const char *obs_frontend_get_locale_string(const char *string)
+
+   :return: Gets the frontend translation of a given string.


### PR DESCRIPTION
### Description
Developers now can easily get a translated string from the frontend
instead of using their own translations.

### Motivation and Context
Makes it easier for plugin developers.

### How Has This Been Tested?
Tested with my plugin.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
