### PR TITLE
 UI: Add ability to update volume control source

### DIFF
--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -273,7 +273,8 @@ class VolControl : public QWidget {
 	Q_OBJECT
 
 private:
-	OBSSource source;
+	OBSWeakSourceAutoRelease weakSource;
+	std::vector<OBSSignal> sigs;
 	QLabel *nameLabel;
 	QLabel *volLabel;
 	VolumeMeter *volMeter;
@@ -286,6 +287,7 @@ private:
 	obs_volmeter_t *obs_volmeter;
 	bool vertical;
 	QMenu *contextMenu;
+	bool showConfig = false;
 
 	static void OBSVolumeChanged(void *param, float db);
 	static void OBSVolumeLevel(void *data,
@@ -293,6 +295,7 @@ private:
 				   const float peak[MAX_AUDIO_CHANNELS],
 				   const float inputPeak[MAX_AUDIO_CHANNELS]);
 	static void OBSVolumeMuted(void *data, calldata_t *calldata);
+	static void OBSVolumeRenamed(void *data, calldata_t *calldata);
 
 	void EmitConfigClicked();
 
@@ -303,19 +306,23 @@ private slots:
 	void SetMuted(bool checked);
 	void SliderChanged(int vol);
 	void updateText();
+	void SetName(const QString &newName);
 
 signals:
 	void ConfigClicked();
 
 public:
-	explicit VolControl(OBSSource source, bool showConfig = false,
+	explicit VolControl(obs_source_t *source, bool showConfig_ = false,
 			    bool vertical = false);
 	~VolControl();
 
-	inline obs_source_t *GetSource() const { return source; }
+	inline obs_source_t *GetSource() const
+	{
+		return OBSGetStrongRef(weakSource);
+	}
+	void SetSource(obs_source_t *newSource);
 
 	QString GetName() const;
-	void SetName(const QString &newName);
 
 	void SetMeterDecayRate(qreal q);
 	void setPeakMeterType(enum obs_peak_meter_type peakMeterType);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2988,11 +2988,6 @@ void OBSBasic::RenameSources(OBSSource source, QString newName,
 {
 	RenameListValues(ui->scenes, newName, prevName);
 
-	for (size_t i = 0; i < volumes.size(); i++) {
-		if (volumes[i]->GetName().compare(prevName) == 0)
-			volumes[i]->SetName(newName);
-	}
-
 	for (size_t i = 0; i < projectors.size(); i++) {
 		if (projectors[i]->GetSource() == source)
 			projectors[i]->RenameProjector(prevName, newName);


### PR DESCRIPTION
### Description
Sources can now be updated in the audio mixer without
deleting and recreating the volume controls.

This also moves the rename signal for the volume controls
to the class instead of in OBSBasic.

### Motivation and Context
Originally part of #4741. It is now split off of it to simplify that PR.

This also makes it possible to add private sources to the audio mixer.

### How Has This Been Tested?
Made sure all volume controls worked properly in the audio mixer.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
