### PR TITLE
libobs-d3d11: Simplify duplicator formats

### DIFF
--- a/libobs-d3d11/d3d11-duplicator.cpp
+++ b/libobs-d3d11/d3d11-duplicator.cpp
@@ -48,7 +48,6 @@ void gs_duplicator::Start()
 	if (SUCCEEDED(hr)) {
 		constexpr DXGI_FORMAT supportedFormats[]{
 			DXGI_FORMAT_R16G16B16A16_FLOAT,
-			DXGI_FORMAT_R10G10B10A2_UNORM,
 			DXGI_FORMAT_B8G8R8A8_UNORM,
 		};
 		hr = output5->DuplicateOutput1(device->device, 0,


### PR DESCRIPTION
### Description
Remove DXGI_FORMAT_R10G10B10A2_UNORM since it can be ambiguous whether
it is Rec. 2020 PQ, or high-precision sRGB. We can revisit later.

### Motivation and Context
Don't want to deal with bugs from an untested format. I'm not even sure how to convince DXGI to use the format as all my attempts have failed.

### How Has This Been Tested?
Remaining two formats still work when HDR is toggled on and off.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.