### PR TITLE
UI: Fix handling of remove signal with projectors

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -665,11 +665,7 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 void OBSProjector::OBSSourceRemoved(void *data, calldata_t *params)
 {
 	OBSProjector *window = reinterpret_cast<OBSProjector *>(data);
-
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
-	main->DeleteProjector(window);
-	allProjectors.removeAll(window);
-
+	QMetaObject::invokeMethod(window, "EscapeTriggered");
 	UNUSED_PARAMETER(params);
 }
 


### PR DESCRIPTION
### Description
Since the remove signal is coming from another thread,
QMetaObject::invokeMethod has to be used, or corruption
could possibly occur.

### Motivation and Context
Noticed invokeMethod was not being used with the signal.

### How Has This Been Tested?
Tested by removing a scene and seeing if the scene projector was deleted.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
