### PR TITLE
UI: Fix projectors not closing when source is deleted

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -17,11 +17,12 @@ static bool updatingMultiview = false, mouseSwitching, transitionOnDoubleClick;
 
 OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 			   ProjectorType type_)
-	: OBSQTDisplay(widget, Qt::Window),
-	  source(source_),
-	  removedSignal(obs_source_get_signal_handler(source), "remove",
-			OBSSourceRemoved, this)
+	: OBSQTDisplay(widget, Qt::Window), weakSource(OBSGetWeakRef(source_))
 {
+	OBSSource source = GetSource();
+	destroyedSignal.Connect(obs_source_get_signal_handler(source),
+				"destroy", OBSSourceDestroyed, this);
+
 	isAlwaysOnTop = config_get_bool(GetGlobalConfig(), "BasicWindow",
 					"ProjectorAlwaysOnTop");
 
@@ -106,6 +107,7 @@ OBSProjector::~OBSProjector()
 		GetDisplay(), isMultiview ? OBSRenderMultiview : OBSRender,
 		this);
 
+	OBSSource source = GetSource();
 	if (source)
 		obs_source_dec_showing(source);
 
@@ -161,7 +163,7 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 		return;
 
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
-	OBSSource source = window->source;
+	OBSSource source = window->GetSource();
 
 	uint32_t targetCX;
 	uint32_t targetCY;
@@ -195,11 +197,11 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 			obs_source_dec_showing(source);
 			obs_source_inc_showing(curSource);
 			source = curSource;
-			window->source = source;
+			window->weakSource = OBSGetWeakRef(source);
 		}
 	} else if (window->type == ProjectorType::Preview &&
 		   !main->IsPreviewProgramMode()) {
-		window->source = nullptr;
+		window->weakSource = nullptr;
 	}
 
 	if (source)
@@ -210,7 +212,7 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 	endRegion();
 }
 
-void OBSProjector::OBSSourceRemoved(void *data, calldata_t *params)
+void OBSProjector::OBSSourceDestroyed(void *data, calldata_t *params)
 {
 	OBSProjector *window = reinterpret_cast<OBSProjector *>(data);
 	QMetaObject::invokeMethod(window, "EscapeTriggered");
@@ -371,7 +373,7 @@ void OBSProjector::UpdateProjectorTitle(QString name)
 
 OBSSource OBSProjector::GetSource()
 {
-	return source;
+	return OBSGetStrongRef(weakSource);
 }
 
 ProjectorType OBSProjector::GetProjectorType()
@@ -414,6 +416,7 @@ void OBSProjector::OpenFullScreenProjector()
 	int monitor = sender()->property("monitor").toInt();
 	SetMonitor(monitor);
 
+	OBSSource source = GetSource();
 	UpdateProjectorTitle(QT_UTF8(obs_source_get_name(source)));
 }
 
@@ -430,6 +433,7 @@ void OBSProjector::OpenWindowedProjector()
 
 	savedMonitor = -1;
 
+	OBSSource source = GetSource();
 	UpdateProjectorTitle(QT_UTF8(obs_source_get_name(source)));
 	screen = nullptr;
 }

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -18,12 +18,12 @@ class OBSProjector : public OBSQTDisplay {
 	Q_OBJECT
 
 private:
-	OBSSource source;
-	OBSSignal removedSignal;
+	OBSWeakSourceAutoRelease weakSource;
+	OBSSignal destroyedSignal;
 
 	static void OBSRenderMultiview(void *data, uint32_t cx, uint32_t cy);
 	static void OBSRender(void *data, uint32_t cx, uint32_t cy);
-	static void OBSSourceRemoved(void *data, calldata_t *params);
+	static void OBSSourceDestroyed(void *data, calldata_t *params);
 
 	void mousePressEvent(QMouseEvent *event) override;
 	void mouseDoubleClickEvent(QMouseEvent *event) override;


### PR DESCRIPTION
### Description
The projectors would still hold on to a reference of a source, even if the source was deleted, so use weak sources

### Motivation and Context
A source projector would still be opened, even when its source is deleted.

### How Has This Been Tested?
- Added source projector
- Deleted the source
- Made sure the projector was closed properly

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
