### PR TITLE
win-waspai: Tighten version check for RTWQ

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -328,7 +328,14 @@ WASAPISource::WASAPISource(obs_data_t *settings, obs_source_t *source_,
 
 	// while RTWQ was introduced in Win 8.1, it silently fails
 	// to capture Desktop Audio for some reason. Disable for now.
-	if (get_win_ver_int() >= _WIN32_WINNT_WIN10)
+	struct win_version_info win1703 = {};
+	win1703.major = 10;
+	win1703.minor = 0;
+	win1703.build = 15063;
+	win1703.revis = 0;
+	struct win_version_info ver;
+	get_win_ver(&ver);
+	if (win_version_compare(&ver, &win1703) >= 0)
 		rtwq_supported = rtwq_module != NULL;
 
 	if (rtwq_supported) {


### PR DESCRIPTION
### Description
Getting reports that it isn't working for 1607 and below.

If they continue, we should probably just pull the RTWQ path.

NOTE: Audio is currently broken because of da4d98d0e46b60b993ff222a266354e6cff06417. Need revert to test audio recording.

Fixes #6132

### Motivation and Context
Want WASAPI to work.

### How Has This Been Tested?
Verified version check passes on Windows 11, and audio plays fine.

Reporter of #6132 has verified his 1607 server edition works.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.