### PR TITLE
libobs: Add Rec. 2020 video_colorspace enum values

### DIFF
--- a/docs/sphinx/reference-libobs-media-io.rst
+++ b/docs/sphinx/reference-libobs-media-io.rst
@@ -39,10 +39,12 @@ Video Handler
 
    YUV color space.  Can be one of the following values:
 
-   - VIDEO_CS_DEFAULT - Equivalent to VIDEO_CS_709
-   - VIDEO_CS_601     - 601 color space
-   - VIDEO_CS_709     - 709 color space
-   - VIDEO_CS_SRGB    - sRGB color space
+   - VIDEO_CS_DEFAULT  - Equivalent to VIDEO_CS_709
+   - VIDEO_CS_601      - Rec. 601 color space
+   - VIDEO_CS_709      - Rec. 709 color space
+   - VIDEO_CS_SRGB     - sRGB color space
+   - VIDEO_CS_2020_PQ  - Rec. 2020 color space, PQ transfer
+   - VIDEO_CS_2020_HLG - Rec. 2020 color space, HLG transfer
 
 ---------------------
 

--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -695,6 +695,24 @@ Functions used by outputs
    
            /* planar 4:4:4 */
            VIDEO_FORMAT_I444,
+   
+           /* more packed uncompressed formats */
+           VIDEO_FORMAT_BGR3,
+   
+           /* planar 4:2:2 */
+           VIDEO_FORMAT_I422,
+   
+           /* planar 4:2:0 with alpha */
+           VIDEO_FORMAT_I40A,
+   
+           /* planar 4:2:2 with alpha */
+           VIDEO_FORMAT_I42A,
+   
+           /* planar 4:4:4 with alpha */
+           VIDEO_FORMAT_YUVA,
+   
+           /* packed 4:4:4 with alpha */
+           VIDEO_FORMAT_AYUV,
    };
    
    enum video_colorspace {
@@ -702,6 +720,8 @@ Functions used by outputs
            VIDEO_CS_601,
            VIDEO_CS_709,
            VIDEO_CS_SRGB,
+           VIDEO_CS_2020_PQ,
+           VIDEO_CS_2020_HLG,
    };
    
    enum video_range_type {

--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -75,12 +75,14 @@ enum video_colorspace {
 	VIDEO_CS_601,
 	VIDEO_CS_709,
 	VIDEO_CS_SRGB,
+	VIDEO_CS_2020_PQ,
+	VIDEO_CS_2020_HLG,
 };
 
 enum video_range_type {
 	VIDEO_RANGE_DEFAULT,
 	VIDEO_RANGE_PARTIAL,
-	VIDEO_RANGE_FULL
+	VIDEO_RANGE_FULL,
 };
 
 struct video_data {
@@ -176,13 +178,18 @@ static inline const char *get_video_colorspace_name(enum video_colorspace cs)
 	switch (cs) {
 	case VIDEO_CS_DEFAULT:
 	case VIDEO_CS_709:
-		return "709";
+		return "Rec. 709";
 	case VIDEO_CS_SRGB:
 		return "sRGB";
-	case VIDEO_CS_601:;
+	case VIDEO_CS_601:
+		return "Rec. 601";
+	case VIDEO_CS_2020_PQ:
+		return "Rec. 2020 (PQ)";
+	case VIDEO_CS_2020_HLG:
+		return "Rec. 2020 (HLG)";
 	}
 
-	return "601";
+	return "Unknown";
 }
 
 static inline enum video_range_type

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -270,6 +270,12 @@ static bool obs_init_textures(struct obs_video_info *ovi)
 
 	enum gs_color_format format = GS_RGBA;
 	enum gs_color_space space = GS_CS_SRGB;
+	switch (ovi->colorspace) {
+	case VIDEO_CS_2020_PQ:
+	case VIDEO_CS_2020_HLG:
+		format = GS_RGBA16F;
+		space = GS_CS_709_EXTENDED;
+	}
 
 	video->render_texture = gs_texture_create(ovi->base_width,
 						  ovi->base_height, format, 1,


### PR DESCRIPTION
### Description
Add VIDEO_CS_2020_PQ and VIDEO_CS_2020_HLG for future Rec. 2020 support.

### Motivation and Context
HDR is coming.

### How Has This Been Tested?
- [x] Verify 601/709/2020 matrix usages input/output in HDR branch
- [x] Verify 601/709 matrix usages input/output in PR branch
- [x] Verify SDR/HDR recordings in HDR branch
- [x] Verify SDR recordings in SDR branch

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.