### PR TITLE
libobs: use rwlock instead of mutex for obs_context_data

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -109,7 +109,7 @@ create_encoder(const char *id, enum obs_encoder_type type, const char *name,
 
 	obs_context_init_control(&encoder->context, encoder,
 				 (obs_destroy_cb)obs_encoder_destroy);
-	obs_context_data_insert(&encoder->context, &obs->data.encoders_mutex,
+	obs_context_data_insert(&encoder->context, &obs->data.encoders_rwlock,
 				&obs->data.first_encoder);
 
 	blog(LOG_DEBUG, "encoder '%s' (%s) created", name, id);

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -354,11 +354,11 @@ struct obs_core_data {
 	struct obs_encoder *first_encoder;
 	struct obs_service *first_service;
 
-	pthread_mutex_t sources_mutex;
+	pthread_rwlock_t sources_rwlock;
 	pthread_mutex_t displays_mutex;
-	pthread_mutex_t outputs_mutex;
-	pthread_mutex_t encoders_mutex;
-	pthread_mutex_t services_mutex;
+	pthread_rwlock_t outputs_rwlock;
+	pthread_rwlock_t encoders_rwlock;
+	pthread_rwlock_t services_rwlock;
 	pthread_mutex_t audio_sources_mutex;
 	pthread_mutex_t draw_callbacks_mutex;
 	DARRAY(struct draw_callback) draw_callbacks;
@@ -514,7 +514,7 @@ struct obs_context_data {
 	DARRAY(char *) rename_cache;
 	pthread_mutex_t rename_cache_mutex;
 
-	pthread_mutex_t *mutex;
+	pthread_rwlock_t *rwlock;
 	struct obs_context_data *next;
 	struct obs_context_data **prev_next;
 
@@ -530,7 +530,7 @@ extern void obs_context_init_control(struct obs_context_data *context,
 extern void obs_context_data_free(struct obs_context_data *context);
 
 extern void obs_context_data_insert(struct obs_context_data *context,
-				    pthread_mutex_t *mutex, void *first);
+				    pthread_rwlock_t *rwlock, void *first);
 extern void obs_context_data_remove(struct obs_context_data *context);
 extern void obs_context_wait(struct obs_context_data *context);
 

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -149,7 +149,7 @@ obs_output_t *obs_output_create(const char *id, const char *name,
 
 	obs_context_init_control(&output->context, output,
 				 (obs_destroy_cb)obs_output_destroy);
-	obs_context_data_insert(&output->context, &obs->data.outputs_mutex,
+	obs_context_data_insert(&output->context, &obs->data.outputs_rwlock,
 				&obs->data.first_output);
 
 	if (info)

--- a/libobs/obs-service.c
+++ b/libobs/obs-service.c
@@ -65,7 +65,7 @@ static obs_service_t *obs_service_create_internal(const char *id,
 
 	obs_context_init_control(&service->context, service,
 				 (obs_destroy_cb)obs_service_destroy);
-	obs_context_data_insert(&service->context, &obs->data.services_mutex,
+	obs_context_data_insert(&service->context, &obs->data.services_rwlock,
 				&obs->data.first_service);
 
 	blog(LOG_DEBUG, "service '%s' (%s) created", name, id);

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -243,7 +243,7 @@ static void obs_source_init_finalize(struct obs_source *source)
 		pthread_mutex_unlock(&obs->data.audio_sources_mutex);
 	}
 
-	obs_context_data_insert(&source->context, &obs->data.sources_mutex,
+	obs_context_data_insert(&source->context, &obs->data.sources_rwlock,
 				&obs->data.first_source);
 }
 

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -59,7 +59,7 @@ static uint64_t tick_sources(uint64_t cur_time, uint64_t last_time)
 	/* ------------------------------------- */
 	/* call the tick function of each source */
 
-	pthread_mutex_lock(&data->sources_mutex);
+	pthread_rwlock_rdlock(&data->sources_rwlock);
 
 	source = data->first_source;
 	while (source) {
@@ -73,7 +73,7 @@ static uint64_t tick_sources(uint64_t cur_time, uint64_t last_time)
 		source = (struct obs_source *)source->context.next;
 	}
 
-	pthread_mutex_unlock(&data->sources_mutex);
+	pthread_rwlock_unlock(&data->sources_rwlock);
 
 	return cur_time;
 }


### PR DESCRIPTION
### Description
use rwlock instead of mutex for obs_context_data

### Motivation and Context
less time threads waiting on each other is better

### How Has This Been Tested?
On windows 64 bit

### Types of changes
 - Performance enhancement (non-breaking change which improves efficiency) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.