### PR TITLE
libobs: Add color space management

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -210,6 +210,7 @@ if(NOT OS_MACOS)
     PRIVATE data/area.effect
             data/bicubic_scale.effect
             data/bilinear_lowres_scale.effect
+            data/color.effect
             data/default.effect
             data/default_rect.effect
             data/deinterlace_base.effect

--- a/libobs/data/area.effect
+++ b/libobs/data/area.effect
@@ -1,7 +1,10 @@
+#include "color.effect"
+
 uniform float4x4 ViewProj;
 uniform float2 base_dimension;
 uniform float2 base_dimension_i;
 uniform texture2d image;
+uniform float multiplier;
 
 sampler_state textureSampler {
 	Filter    = Linear;
@@ -31,8 +34,9 @@ VertInOut VSDefault(VertData vert_in)
 	return vert_out;
 }
 
-float4 DrawArea(float2 uv)
+float4 DrawArea(FragData frag_in)
 {
+	float2 uv = frag_in.uv;
 	float2 uv_delta = float2(ddx(uv.x), ddy(uv.y));
 
 	// Handle potential OpenGL flip.
@@ -84,18 +88,44 @@ float4 DrawArea(float2 uv)
 
 float4 PSDrawAreaRGBA(FragData frag_in) : TARGET
 {
-	return DrawArea(frag_in.uv);
+	return DrawArea(frag_in);
+}
+
+float4 PSDrawAreaRGBAMultiply(FragData frag_in) : TARGET
+{
+	float4 rgba = DrawArea(frag_in);
+	rgba.rgb *= multiplier;
+	return rgba;
+}
+
+float4 PSDrawAreaRGBATonemap(FragData frag_in) : TARGET
+{
+	float4 rgba = DrawArea(frag_in);
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
+float4 PSDrawAreaRGBAMultiplyTonemap(FragData frag_in) : TARGET
+{
+	float4 rgba = DrawArea(frag_in);
+	rgba.rgb *= multiplier;
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
 }
 
 float4 PSDrawAreaRGBADivide(FragData frag_in) : TARGET
 {
-	float4 rgba = DrawArea(frag_in.uv);
+	float4 rgba = DrawArea(frag_in);
 	float alpha = rgba.a;
 	float multiplier = (alpha > 0.0) ? (1.0 / alpha) : 0.0;
 	return float4(rgba.rgb * multiplier, alpha);
 }
 
-float4 PSDrawAreaRGBAUpscale(FragData frag_in) : TARGET
+float4 DrawAreaUpscale(FragData frag_in)
 {
 	float2 uv = frag_in.uv;
 	float2 uv_delta = float2(ddx(uv.x), ddy(uv.y));
@@ -124,12 +154,70 @@ float4 PSDrawAreaRGBAUpscale(FragData frag_in) : TARGET
 	return image.Sample(textureSampler, uv);
 }
 
+float4 PSDrawAreaRGBAUpscale(FragData frag_in) : TARGET
+{
+	return DrawAreaUpscale(frag_in);
+}
+
+float4 PSDrawAreaRGBAUpscaleMultiply(FragData frag_in) : TARGET
+{
+	float4 rgba = DrawAreaUpscale(frag_in);
+	rgba.rgb *= multiplier;
+	return rgba;
+}
+
+float4 PSDrawAreaRGBAUpscaleTonemap(FragData frag_in) : TARGET
+{
+	float4 rgba = DrawAreaUpscale(frag_in);
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
+float4 PSDrawAreaRGBAUpscaleMultiplyTonemap(FragData frag_in) : TARGET
+{
+	float4 rgba = DrawAreaUpscale(frag_in);
+	rgba.rgb *= multiplier;
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
 technique Draw
 {
 	pass
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawAreaRGBA(frag_in);
+	}
+}
+
+technique DrawMultiply
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawAreaRGBAMultiply(frag_in);
+	}
+}
+
+technique DrawTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawAreaRGBATonemap(frag_in);
+	}
+}
+
+technique DrawMultiplyTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawAreaRGBAMultiplyTonemap(frag_in);
 	}
 }
 
@@ -148,5 +236,32 @@ technique DrawUpscale
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawAreaRGBAUpscale(frag_in);
+	}
+}
+
+technique DrawUpscaleMultiply
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawAreaRGBAUpscaleMultiply(frag_in);
+	}
+}
+
+technique DrawUpscaleTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawAreaRGBAUpscaleTonemap(frag_in);
+	}
+}
+
+technique DrawUpscaleMultiplyTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawAreaRGBAUpscaleMultiplyTonemap(frag_in);
 	}
 }

--- a/libobs/data/bicubic_scale.effect
+++ b/libobs/data/bicubic_scale.effect
@@ -4,11 +4,14 @@
  * there.
  */
 
+#include "color.effect"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 uniform float2 base_dimension;
 uniform float2 base_dimension_i;
 uniform float undistort_factor = 1.0;
+uniform float multiplier;
 
 sampler_state textureSampler {
 	Filter    = Linear;
@@ -134,6 +137,32 @@ float4 PSDrawBicubicRGBA(FragData f_in, bool undistort) : TARGET
 	return DrawBicubic(f_in, undistort);
 }
 
+float4 PSDrawBicubicRGBAMultiply(FragData f_in, bool undistort) : TARGET
+{
+	float4 rgba = DrawBicubic(f_in, undistort);
+	rgba.rgb *= multiplier;
+	return rgba;
+}
+
+float4 PSDrawBicubicRGBATonemap(FragData f_in, bool undistort) : TARGET
+{
+	float4 rgba = DrawBicubic(f_in, undistort);
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
+float4 PSDrawBicubicRGBAMultiplyTonemap(FragData f_in, bool undistort) : TARGET
+{
+	float4 rgba = DrawBicubic(f_in, undistort);
+	rgba.rgb *= multiplier;
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
 float4 PSDrawBicubicRGBADivide(FragData f_in) : TARGET
 {
 	float4 rgba = DrawBicubic(f_in, false);
@@ -148,6 +177,33 @@ technique Draw
 	{
 		vertex_shader = VSDefault(v_in);
 		pixel_shader = PSDrawBicubicRGBA(f_in, false);
+	}
+}
+
+technique DrawMultiply
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawBicubicRGBAMultiply(f_in, false);
+	}
+}
+
+technique DrawTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawBicubicRGBATonemap(f_in, false);
+	}
+}
+
+technique DrawMultiplyTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawBicubicRGBAMultiplyTonemap(f_in, false);
 	}
 }
 
@@ -166,5 +222,32 @@ technique DrawUndistort
 	{
 		vertex_shader = VSDefault(v_in);
 		pixel_shader = PSDrawBicubicRGBA(f_in, true);
+	}
+}
+
+technique DrawUndistortMultiply
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawBicubicRGBAMultiply(f_in, true);
+	}
+}
+
+technique DrawUndistortTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawBicubicRGBATonemap(f_in, true);
+	}
+}
+
+technique DrawUndistortMultiplyTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawBicubicRGBAMultiplyTonemap(f_in, true);
 	}
 }

--- a/libobs/data/bilinear_lowres_scale.effect
+++ b/libobs/data/bilinear_lowres_scale.effect
@@ -3,8 +3,11 @@
  * low resolution image below half size
  */
 
+#include "color.effect"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
+uniform float multiplier;
 
 sampler_state textureSampler {
 	Filter    = Linear;
@@ -30,9 +33,9 @@ float4 pixel(float2 uv)
 	return image.Sample(textureSampler, uv);
 }
 
-float4 DrawLowresBilinear(VertData v_in)
+float4 DrawLowresBilinear(VertData f_in)
 {
-	float2 uv = v_in.uv;
+	float2 uv = f_in.uv;
 	float2 stepxy  = float2(ddx(uv.x), ddy(uv.y));
 	float2 stepxy1 = stepxy * 0.0625;
 	float2 stepxy3 = stepxy * 0.1875;
@@ -52,14 +55,40 @@ float4 DrawLowresBilinear(VertData v_in)
 	return out_color * 0.125;
 }
 
-float4 PSDrawLowresBilinearRGBA(VertData v_in) : TARGET
+float4 PSDrawLowresBilinearRGBA(VertData f_in) : TARGET
 {
-	return DrawLowresBilinear(v_in);
+	return DrawLowresBilinear(f_in);
 }
 
-float4 PSDrawLowresBilinearRGBADivide(VertData v_in) : TARGET
+float4 PSDrawLowresBilinearRGBAMultiply(VertData f_in) : TARGET
 {
-	float4 rgba = DrawLowresBilinear(v_in);
+	float4 rgba = DrawLowresBilinear(f_in);
+	rgba.rgb *= multiplier;
+	return rgba;
+}
+
+float4 PSDrawLowresBilinearRGBATonemap(VertData f_in) : TARGET
+{
+	float4 rgba = DrawLowresBilinear(f_in);
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
+float4 PSDrawLowresBilinearRGBAMultiplyTonemap(VertData f_in) : TARGET
+{
+	float4 rgba = DrawLowresBilinear(f_in);
+	rgba.rgb *= multiplier;
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
+float4 PSDrawLowresBilinearRGBADivide(VertData f_in) : TARGET
+{
+	float4 rgba = DrawLowresBilinear(f_in);
 	float alpha = rgba.a;
 	float multiplier = (alpha > 0.0) ? (1.0 / alpha) : 0.0;
 	return float4(rgba.rgb * multiplier, alpha);
@@ -70,7 +99,34 @@ technique Draw
 	pass
 	{
 		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSDrawLowresBilinearRGBA(v_in);
+		pixel_shader  = PSDrawLowresBilinearRGBA(f_in);
+	}
+}
+
+technique DrawMultiply
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLowresBilinearRGBAMultiply(f_in);
+	}
+}
+
+technique DrawTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLowresBilinearRGBATonemap(f_in);
+	}
+}
+
+technique DrawMultiplyTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLowresBilinearRGBAMultiplyTonemap(f_in);
 	}
 }
 
@@ -79,7 +135,6 @@ technique DrawAlphaDivide
 	pass
 	{
 		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSDrawLowresBilinearRGBADivide(v_in);
+		pixel_shader  = PSDrawLowresBilinearRGBADivide(f_in);
 	}
 }
-

--- a/libobs/data/color.effect
+++ b/libobs/data/color.effect
@@ -1,0 +1,45 @@
+float srgb_linear_to_nonlinear_channel(float u)
+{
+	return (u <= 0.0031308) ? (12.92 * u) : ((1.055 * pow(u, 1.0 / 2.4)) - 0.055);
+}
+
+float3 srgb_linear_to_nonlinear(float3 v)
+{
+	return float3(srgb_linear_to_nonlinear_channel(v.r), srgb_linear_to_nonlinear_channel(v.g), srgb_linear_to_nonlinear_channel(v.b));
+}
+
+float srgb_nonlinear_to_linear_channel(float u)
+{
+	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
+}
+
+float3 srgb_nonlinear_to_linear(float3 v)
+{
+	return float3(srgb_nonlinear_to_linear_channel(v.r), srgb_nonlinear_to_linear_channel(v.g), srgb_nonlinear_to_linear_channel(v.b));
+}
+
+float3 rec709_to_rec2020(float3 v)
+{
+	float r = dot(v, float3(0.6274040f, 0.3292820f, 0.0433136f));
+	float g = dot(v, float3(0.0690970f, 0.9195400f, 0.0113612f));
+	float b = dot(v, float3(0.0163916f, 0.0880132f, 0.8955950f));
+	return float3(r, g, b);
+}
+
+float3 rec2020_to_rec709(float3 v)
+{
+	float r = dot(v, float3(1.6604910, -0.5876411, -0.0728499));
+	float g = dot(v, float3(-0.1245505, 1.1328999, -0.0083494));
+	float b = dot(v, float3(-0.0181508, -0.1005789, 1.1187297));
+	return float3(r, g, b);
+}
+
+float reinhard_channel(float x)
+{
+	return x / (x + 1.0);
+}
+
+float3 reinhard(float3 rgb)
+{
+	return float3(reinhard_channel(rgb.r), reinhard_channel(rgb.g), reinhard_channel(rgb.b));
+}

--- a/libobs/data/default.effect
+++ b/libobs/data/default.effect
@@ -1,3 +1,5 @@
+#include "color.effect"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 uniform float multiplier;
@@ -34,26 +36,6 @@ float4 PSDrawAlphaDivide(VertInOut vert_in) : TARGET
 	return float4(rgba.rgb * multiplier, alpha);
 }
 
-float srgb_linear_to_nonlinear_channel(float u)
-{
-	return (u <= 0.0031308) ? (12.92 * u) : ((1.055 * pow(u, 1.0 / 2.4)) - 0.055);
-}
-
-float3 srgb_linear_to_nonlinear(float3 v)
-{
-	return float3(srgb_linear_to_nonlinear_channel(v.r), srgb_linear_to_nonlinear_channel(v.g), srgb_linear_to_nonlinear_channel(v.b));
-}
-
-float srgb_nonlinear_to_linear_channel(float u)
-{
-	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
-}
-
-float3 srgb_nonlinear_to_linear(float3 v)
-{
-	return float3(srgb_nonlinear_to_linear_channel(v.r), srgb_nonlinear_to_linear_channel(v.g), srgb_nonlinear_to_linear_channel(v.b));
-}
-
 float4 PSDrawNonlinearAlpha(VertInOut vert_in) : TARGET
 {
 	float4 rgba = image.Sample(def_sampler, vert_in.uv);
@@ -77,35 +59,19 @@ float4 PSDrawMultiply(VertInOut vert_in) : TARGET
 	return rgba;
 }
 
-float3 rec709_to_rec2020(float3 v)
-{
-	float r = dot(v, float3(0.6274040f, 0.3292820f, 0.0433136f));
-	float g = dot(v, float3(0.0690970f, 0.9195400f, 0.0113612f));
-	float b = dot(v, float3(0.0163916f, 0.0880132f, 0.8955950f));
-	return float3(r, g, b);
-}
-
-float3 rec2020_to_rec709(float3 v)
-{
-	float r = dot(v, float3(1.6604910, -0.5876411, -0.0728499));
-	float g = dot(v, float3(-0.1245505, 1.1328999, -0.0083494));
-	float b = dot(v, float3(-0.0181508, -0.1005789, 1.1187297));
-	return float3(r, g, b);
-}
-
-float reinhard_channel(float x)
-{
-	return x / (x + 1.0);
-}
-
-float3 reinhard(float3 rgb)
-{
-	return float3(reinhard_channel(rgb.r), reinhard_channel(rgb.g), reinhard_channel(rgb.b));
-}
-
 float4 PSDrawTonemap(VertInOut vert_in) : TARGET
 {
 	float4 rgba = image.Sample(def_sampler, vert_in.uv);
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
+float4 PSDrawMultiplyTonemap(VertInOut vert_in) : TARGET
+{
+	float4 rgba = image.Sample(def_sampler, vert_in.uv);
+	rgba.rgb *= multiplier;
 	rgba.rgb = rec709_to_rec2020(rgba.rgb);
 	rgba.rgb = reinhard(rgba.rgb);
 	rgba.rgb = rec2020_to_rec709(rgba.rgb);
@@ -163,5 +129,14 @@ technique DrawTonemap
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawTonemap(vert_in);
+	}
+}
+
+technique DrawMultiplyTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawMultiplyTonemap(vert_in);
 	}
 }

--- a/libobs/data/default_rect.effect
+++ b/libobs/data/default_rect.effect
@@ -1,3 +1,5 @@
+#include "color.effect"
+
 uniform float4x4 ViewProj;
 uniform texture_rect image;
 
@@ -28,16 +30,6 @@ float4 PSDrawBare(VertInOut vert_in) : TARGET
 float4 PSDrawOpaque(VertInOut vert_in) : TARGET
 {
 	return float4(image.Sample(def_sampler, vert_in.uv).rgb, 1.0);
-}
-
-float srgb_nonlinear_to_linear_channel(float u)
-{
-	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
-}
-
-float3 srgb_nonlinear_to_linear(float3 v)
-{
-	return float3(srgb_nonlinear_to_linear_channel(v.r), srgb_nonlinear_to_linear_channel(v.g), srgb_nonlinear_to_linear_channel(v.b));
 }
 
 float4 PSDrawSrgbDecompress(VertInOut vert_in) : TARGET

--- a/libobs/data/lanczos_scale.effect
+++ b/libobs/data/lanczos_scale.effect
@@ -4,11 +4,14 @@
  * there.
  */
 
+#include "color.effect"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 uniform float2 base_dimension;
 uniform float2 base_dimension_i;
 uniform float undistort_factor = 1.0;
+uniform float multiplier;
 
 sampler_state textureSampler
 {
@@ -190,6 +193,32 @@ float4 PSDrawLanczosRGBA(FragData f_in, bool undistort) : TARGET
 	return DrawLanczos(f_in, undistort);
 }
 
+float4 PSDrawLanczosRGBAMultiply(FragData f_in, bool undistort) : TARGET
+{
+	float4 rgba = DrawLanczos(f_in, undistort);
+	rgba.rgb *= multiplier;
+	return rgba;
+}
+
+float4 PSDrawLanczosRGBATonemap(FragData f_in, bool undistort) : TARGET
+{
+	float4 rgba = DrawLanczos(f_in, undistort);
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
+float4 PSDrawLanczosRGBAMultiplyTonemap(FragData f_in, bool undistort) : TARGET
+{
+	float4 rgba = DrawLanczos(f_in, undistort);
+	rgba.rgb *= multiplier;
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
 float4 PSDrawLanczosRGBADivide(FragData f_in) : TARGET
 {
 	float4 rgba = DrawLanczos(f_in, false);
@@ -204,6 +233,33 @@ technique Draw
 	{
 		vertex_shader = VSDefault(v_in);
 		pixel_shader  = PSDrawLanczosRGBA(f_in, false);
+	}
+}
+
+technique DrawMultiply
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLanczosRGBAMultiply(f_in, false);
+	}
+}
+
+technique DrawTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLanczosRGBATonemap(f_in, false);
+	}
+}
+
+technique DrawMultiplyTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLanczosRGBAMultiplyTonemap(f_in, false);
 	}
 }
 
@@ -222,5 +278,32 @@ technique DrawUndistort
 	{
 		vertex_shader = VSDefault(v_in);
 		pixel_shader  = PSDrawLanczosRGBA(f_in, true);
+	}
+}
+
+technique DrawUndistortMultiply
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLanczosRGBAMultiply(f_in, true);
+	}
+}
+
+technique DrawUndistortTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLanczosRGBATonemap(f_in, true);
+	}
+}
+
+technique DrawUndistortMultiplyTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSDrawLanczosRGBAMultiplyTonemap(f_in, true);
 	}
 }

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -762,6 +762,7 @@ struct obs_source {
 	gs_texrender_t *filter_texrender;
 	enum obs_allow_direct_render allow_direct;
 	bool rendering_filter;
+	bool filter_bypass_active;
 
 	/* sources specific hotkeys */
 	obs_hotkey_pair_id mute_unmute_key;
@@ -802,6 +803,9 @@ struct obs_source {
 	enum obs_transition_mode transition_mode;
 	enum obs_transition_scale_type transition_scale_type;
 	struct matrix4 transition_matrices[2];
+
+	/* color space */
+	gs_texrender_t *color_space_texrender;
 
 	struct audio_monitor *monitor;
 	enum obs_monitoring_type monitoring_type;

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -546,6 +546,11 @@ struct obs_source_info {
 
 	/** Missing files **/
 	obs_missing_files_t *(*missing_files)(void *data);
+
+	/** Get color space **/
+	enum gs_color_space (*video_get_color_space)(
+		void *data, size_t count,
+		const enum gs_color_space *preferred_spaces);
 };
 
 EXPORT void obs_register_source_s(const struct obs_source_info *info,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1017,6 +1017,11 @@ EXPORT uint32_t obs_source_get_width(obs_source_t *source);
 /** Gets the height of a source (if it has video) */
 EXPORT uint32_t obs_source_get_height(obs_source_t *source);
 
+/** Gets the color space of a source (if it has video) */
+EXPORT enum gs_color_space
+obs_source_get_color_space(obs_source_t *source, size_t count,
+			   const enum gs_color_space *preferred_spaces);
+
 /** Hints whether or not the source will blend texels */
 EXPORT bool obs_source_get_texcoords_centered(obs_source_t *source);
 
@@ -1386,6 +1391,10 @@ obs_source_process_filter_begin(obs_source_t *filter,
 				enum gs_color_format format,
 				enum obs_allow_direct_render allow_direct);
 
+EXPORT bool obs_source_process_filter_begin_with_color_space(
+	obs_source_t *filter, enum gs_color_format format,
+	enum gs_color_space space, enum obs_allow_direct_render allow_direct);
+
 /**
  * Draws the filter.
  *
@@ -1569,6 +1578,9 @@ EXPORT void obs_transition_force_stop(obs_source_t *transition);
 EXPORT void
 obs_transition_video_render(obs_source_t *transition,
 			    obs_transition_video_render_callback_t callback);
+
+EXPORT enum gs_color_space
+obs_transition_video_get_color_space(obs_source_t *transition);
 
 /** Directly renders its sub-source instead of to texture.  Returns false if no
  * longer transitioning */


### PR DESCRIPTION
### Description
This provides the framework for automatically compositing SDR and HDR
sources together. Source will need to leverage the new
video_get_color_space to opt into HDR support.

### Motivation and Context
HDR spaces are coming, not just sRGB anymore.

### How Has This Been Tested?
HDR branch
- [x] Check filter bypass works
- [x] Input, SRGB, SRGB -> SRGB (Draw)
- [x] Input, SRGB, EDR -> EDR (Draw, PS linear)
- [x] Input, SRGB, CCCS -> CCCS (DrawMultiply, paper_white/80)
- [x] Input, SRGB, SRGB/EDR -> SRGB (Draw)
- [x] Input, EDR, SRGB -> SRGB (DrawTonemap)
- [x] Input, EDR, EDR -> EDR (Draw)
- [x] Input, EDR, CCCS -> CCCS (DrawMultiply, paper_white/80)
- [x] Input, EDR, SRGB/EDR -> EDR (Draw)
- [x] Input, CCCS, SRGB -> SRGB (DrawMultiplyTonemap, 80/paper_white)
- [x] Input, CCCS, EDR -> EDR (DrawMultiply, 80/paper_white)
- [x] Input, CCCS, CCCS -> CCCS (Draw)
- [x] Input, CCCS, SRGB/EDR -> EDR (DrawMultiply, 80/paper_white)
- [x] Filter, SRGB/EDR -> SRGB, SRGB -> SRGB (Draw)
- [x] Filter, SRGB/EDR -> SRGB, EDR -> EDR (Draw, PS linear)
- [x] Filter, SRGB/EDR -> SRGB, CCCS -> CCCS (DrawMultiply, paper_white/80)
- [x] Filter, SRGB/EDR -> SRGB, SRGB/EDR -> SRGB (Draw)
- [x] Filter, SRGB/EDR -> EDR, SRGB -> SRGB (DrawTonemap)
- [x] Filter, SRGB/EDR -> EDR, EDR -> EDR (Draw)
- [x] Filter, SRGB/EDR -> EDR, CCCS -> CCCS (DrawMultiply, paper_white/80)
- [x] Filter, SRGB/EDR -> EDR, SRGB/EDR -> EDR (Draw)
- [x] Transition, (SRGB/EDR -> X, SRGB/EDR -> Y, X|Y == SRGB), SRGB -> SRGB (Draw)
- [x] Transition, (SRGB/EDR -> X, SRGB/EDR -> Y, X|Y == EDR), EDR -> EDR (Draw)
- [x] Scene, 709 -> SDR, SRGB -> SRGB (Draw)
- [x] Scene, 2020 -> EDR, EDR -> EDR (Draw)
- [x] Group, 709 -> SDR, SRGB -> SRGB (Draw)
- [x] Group, 2020 -> EDR, EDR -> EDR (Draw)
- [x] Point filter, Draw (SDR source on SDR canvas)
- [x] Point filter, DrawMultiply (SDR source on CCCS preview)
- [x] Point filter, DrawTonemap (HDR source on SDR canvas)
- [x] Bilinear filter, Draw (SDR source on SDR canvas)
- [x] Bilinear filter, DrawMultiply (SDR source on CCCS preview)
- [x] Bilinear filter, DrawTonemap (HDR source on SDR canvas)
- [x] Bicubic filter, Draw (SDR source on SDR canvas)
- [x] Bicubic filter, DrawMultiply (SDR source on CCCS preview)
- [x] Bicubic filter, DrawTonemap (HDR source on SDR canvas)
- [x] Bicubic filter (undistort), Draw (SDR source on SDR canvas)
- [x] Bicubic filter (undistort), DrawMultiply (SDR source on CCCS preview)
- [x] Bicubic filter (undistort), DrawTonemap (HDR source on SDR canvas)
- [x] Lanczos filter, Draw (SDR source on SDR canvas)
- [x] Lanczos filter, DrawMultiply (SDR source on CCCS preview)
- [x] Lanczos filter, DrawTonemap (HDR source on SDR canvas)
- [x] Lanczos filter (undistort), Draw (SDR source on SDR canvas)
- [x] Lanczos filter (undistort), DrawMultiply (SDR source on CCCS preview)
- [x] Lanczos filter (undistort), DrawTonemap (HDR source on SDR canvas)
- [x] Area filter (downscale), Draw (SDR source on SDR canvas)
- [x] Area filter (downscale), DrawMultiply (SDR source on CCCS preview)
- [x] Area filter (downscale), DrawTonemap (HDR source on SDR canvas)
- [x] Area filter (upscale), Draw (SDR source on SDR canvas)
- [x] Area filter (upscale), DrawMultiply (SDR source on CCCS preview)
- [x] Area filter (upscale), DrawTonemap (HDR source on SDR canvas)
- [x] Bilinear lowres filter, Draw (SDR source on SDR canvas)
- [x] Bilinear lowres filter, DrawMultiply (SDR source on CCCS preview)
- [x] Bilinear lowres filter, DrawTonemap (HDR source on SDR canvas)

PR branch
- [x] Check filter bypass works
- [x] Input, SRGB (Draw)
- [x] Filter, SRGB (Draw)
- [x] Transition, SRGB (Draw)
- [x] Scene, 709 -> SDR, SRGB -> SRGB (Draw)
- [x] Group, 709 -> SDR, SRGB -> SRGB (Draw)
- [x] Point filter, Draw (SDR source on SDR canvas)
- [x] Bilinear filter, Draw (SDR source on SDR canvas)
- [x] Bicubic filter, Draw (SDR source on SDR canvas)
- [x] Bicubic filter (undistort), Draw (SDR source on SDR canvas)
- [x] Lanczos filter, Draw (SDR source on SDR canvas)
- [x] Lanczos filter (undistort), Draw (SDR source on SDR canvas)
- [x] Area filter (downscale), Draw (SDR source on SDR canvas)
- [x] Area filter (upscale), Draw (SDR source on SDR canvas)
- [x] Bilinear lowres filter, Draw (SDR source on SDR canvas)

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.