### PR TITLE
obs-libfdk: Set bitstream to ADTS for mpegts output

### DIFF
--- a/plugins/obs-libfdk/obs-libfdk.c
+++ b/plugins/obs-libfdk/obs-libfdk.c
@@ -96,6 +96,8 @@ static void *libfdk_create(obs_data_t *settings, obs_encoder_t *encoder)
 	int bitrate = (int)obs_data_get_int(settings, "bitrate") * 1000;
 	int afterburner = obs_data_get_bool(settings, "afterburner") ? 1 : 0;
 	audio_t *audio = obs_encoder_audio(encoder);
+	bool set_to_ADTS = obs_data_get_bool(settings, "set_to_ADTS");
+	int transmux = set_to_ADTS ? 2 : 0;
 	int mode = 0;
 	AACENC_ERROR err;
 
@@ -159,7 +161,9 @@ static void *libfdk_create(obs_data_t *settings, obs_encoder_t *encoder)
 		aacEncoder_SetParam(enc->fdkhandle, AACENC_BITRATEMODE, 0));
 	CHECK_LIBFDK(
 		aacEncoder_SetParam(enc->fdkhandle, AACENC_BITRATE, bitrate));
-	CHECK_LIBFDK(aacEncoder_SetParam(enc->fdkhandle, AACENC_TRANSMUX, 0));
+
+	CHECK_LIBFDK(
+		aacEncoder_SetParam(enc->fdkhandle, AACENC_TRANSMUX, transmux));
 	CHECK_LIBFDK(aacEncoder_SetParam(enc->fdkhandle, AACENC_AFTERBURNER,
 					 afterburner));
 

--- a/plugins/rtmp-services/rtmp-custom.c
+++ b/plugins/rtmp-services/rtmp-custom.c
@@ -122,6 +122,7 @@ static void rtmp_custom_apply_settings(void *data, obs_data_t *video_settings,
 	    strncmp(service->server, RTMP_PROTOCOL, strlen(RTMP_PROTOCOL)) !=
 		    0) {
 		obs_data_set_bool(video_settings, "repeat_headers", true);
+		obs_data_set_bool(audio_settings, "set_to_ADTS", true);
 	}
 }
 


### PR DESCRIPTION
### Description
Also modifies rtmp-services.
This sets the aac bitstream to ADTS for the mpegts output.
This fixes a bug with mpegts ouput where the avformat muxer issues
an error with fdk-aac encoder.

### Motivation and Context
Fixes a bug.

### How Has This Been Tested?
Streams work with mpegts output.
Both srt & rist are fine.
Tested on win 10 to nimble server.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
