### PR TITLE
CI: Update editorconfig to match CMake-format configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,15 @@ indent_size = 8
 [plugins/obs-outputs/librtmp/*.{cpp,c,h}]
 indent_style = space
 indent_size = 4
+
+[CMakeLists.txt]
+indent_style = space
+indent_size = 2
+
+[**/CMakeLists.txt]
+indent_style = space
+indent_size = 2
+
+[cmake/**/*.cmake]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
### Description
Adds editorconfig entries to align with CMake-format configuration.

### Motivation and Context
CMake-Format by default uses spaces with 2-character widths for formatting. This is predominantly used to align long lists of files and parameters along the same visual vertical axes (which are often dynamically defined by the length of the first token in function calls).

Forcing CMake-format to use tabs breaks this important formatting step, so the choice was made to adapt its own formatting rules for all files ending with `.cmake` or named `CMakeLists.txt`

### How Has This Been Tested?
Probably requires some testing by users with different editors/IDEs which support editorconfig files.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
