### PR TITLE
log: in debug mode, logout all obs item types.

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1789,6 +1789,10 @@ void OBSBasic::OBSInit()
 	obs_load_all_modules();
 	blog(LOG_INFO, "---------------------------------");
 	obs_log_loaded_modules();
+#ifdef _DEBUG
+    blog(LOG_INFO, "---------------------------------");
+    obs_log_all_item_types();
+#endif
 	blog(LOG_INFO, "---------------------------------");
 	obs_post_load_modules();
 

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -179,6 +179,73 @@ void obs_log_loaded_modules(void)
 		blog(LOG_INFO, "    %s", mod->file);
 }
 
+void obs_log_all_item_types(void)
+{
+    // 1. enum all obs_source: input, filter, transition, scene
+    size_t idx = 0;
+    const char *id = NULL;
+    const char *unversioned_id = NULL;
+    
+    blog(LOG_DEBUG, "  1. enum all obs_source: input, filter, transition, scene");
+    
+    idx = 0;
+    blog(LOG_DEBUG, "    1.0. obs_enum_source_types()");
+    while(obs_enum_source_types(idx++,  &id)) {
+        blog(LOG_DEBUG, "      %02zd : id=%s, name=%s", idx, id, obs_source_get_display_name(id));
+    }
+    
+    idx = 0;
+    blog(LOG_DEBUG, "    1.1. obs_enum_input_types()");
+    while (obs_enum_input_types(idx++,  &id)) {
+        blog(LOG_DEBUG, "      %02zd : id=%s, name=%s", idx, id, obs_source_get_display_name(id));
+    }
+    
+    idx = 0;
+    blog(LOG_DEBUG, "    1.2. obs_enum_input_types2()");
+    while (obs_enum_input_types2(idx++,  &id, &unversioned_id)) {
+        blog(LOG_DEBUG, "      %02zd : id=%s, name=%s, unversioned_id=%s", idx, id, obs_source_get_display_name(id), unversioned_id);
+    }
+    
+    idx = 0;
+    blog(LOG_DEBUG, "    1.3. obs_enum_filter_types()");
+    while (obs_enum_filter_types(idx++,  &id)) {
+        blog(LOG_DEBUG, "      %02zd : id=%s, name=%s", idx, id, obs_source_get_display_name(id));
+    }
+    
+    idx = 0;
+    blog(LOG_DEBUG, "    1.4. obs_enum_transition_types()");
+    while (obs_enum_transition_types(idx++,  &id)) {
+        blog(LOG_DEBUG, "      %02zd : id=%s, name=%s", idx, id, obs_source_get_display_name(id));
+    }
+    
+    // 2. enum all output
+    blog(LOG_DEBUG, "  2. enum all output");
+    
+    idx = 0;
+    blog(LOG_DEBUG, "    2.0. obs_enum_output_types()");
+    while(obs_enum_output_types(idx++,  &id)) {
+        blog(LOG_DEBUG, "      %02zd : id=%s, name=%s", idx, id, obs_output_get_display_name(id));
+    }
+    
+    // 3. enum all encoder
+    blog(LOG_DEBUG, "  3. enum all encoder");
+    
+    idx = 0;
+    blog(LOG_DEBUG, "    3.0. obs_enum_encoder_types()");
+    while(obs_enum_encoder_types(idx++,  &id)) {
+        blog(LOG_DEBUG, "      %02zd : id=%s, name=%s", idx, id, obs_encoder_get_display_name(id));
+    }
+    
+    // 4. enum all service
+    blog(LOG_DEBUG, "  4. enum all service");
+    
+    idx = 0;
+    blog(LOG_DEBUG, "    4.0. obs_enum_service_types()");
+    while(obs_enum_service_types(idx++,  &id)) {
+        blog(LOG_DEBUG, "      %02zd : id=%s, name=%s", idx, id, obs_service_get_display_name(id));
+    }
+}
+
 const char *obs_get_module_file_name(obs_module_t *module)
 {
 	return module ? module->file : NULL;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -461,6 +461,9 @@ EXPORT const char *obs_module_get_locale_text(const obs_module_t *mod,
 /** Logs loaded modules */
 EXPORT void obs_log_loaded_modules(void);
 
+/** Logs all obs item types */
+EXPORT void obs_log_all_item_types(void);
+
 /** Returns the module file name */
 EXPORT const char *obs_get_module_file_name(obs_module_t *module);
 


### PR DESCRIPTION
### Description
add some log, to logout all obs item types in debug mode.

### Motivation and Context
just add some logs, to help developers to know how many obs item types.

### How Has This Been Tested?
when run obs.app the console will output the enumnation logs. 

### Types of changes
Tweak

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
