### PR TITLE
linux-v4l2: Fix camera reconnecting issue

### DIFF
--- a/plugins/linux-v4l2/CMakeLists.txt
+++ b/plugins/linux-v4l2/CMakeLists.txt
@@ -23,13 +23,12 @@ target_link_libraries(
 
 set_target_properties(linux-v4l2 PROPERTIES FOLDER "plugins")
 
-if(NOT ENABLE_UDEV)
-  target_compile_definitions(linux-v4l2 PRIVATE HAVE_UDEV)
-else()
+if(ENABLE_UDEV)
   find_package(Udev REQUIRED)
   target_sources(linux-v4l2 PRIVATE v4l2-udev.c)
 
   target_link_libraries(linux-v4l2 PRIVATE Udev::Udev)
+  target_compile_definitions(linux-v4l2 PRIVATE HAVE_UDEV)
 endif()
 
 setup_plugin_target(linux-v4l2)

--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -1037,7 +1037,7 @@ static void v4l2_init(struct v4l2_data *data)
 		goto fail;
 	return;
 fail:
-	blog(LOG_ERROR, "Initialization failed");
+	blog(LOG_ERROR, "Initialization failed, errno: %s", strerror(errno));
 	v4l2_terminate(data);
 }
 
@@ -1166,6 +1166,8 @@ static void *v4l2_create(obs_data_t *settings, obs_source_t *source)
 
 	signal_handler_connect(sh, "device_added", &device_added, data);
 	signal_handler_connect(sh, "device_removed", &device_removed, data);
+#else
+	blog(LOG_INFO, "Compiled without libudev, you can't reconnect devices");
 #endif
 
 	return data;


### PR DESCRIPTION
### Description

It is a small fix of obvious cmake typo

### Motivation and Context

Unable to add device after OBS start.

### How Has This Been Tested?

Ubuntu 20.04
Tested with c920

Start OBS without any webcam plugged in.
Plug camera
Click Sources -> Video Capture Device

Preview is not available.

The reason is that device_added is never called. HAVE_UDEV is not set correctly by cmake.
HAVE_UDEV was set to ON only when ENABLE_UDEV was set to OFF

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
