### PR TITLE
CMake: Fix targets not being copied into rundir on Windows and Linux

### DIFF
--- a/cmake/Modules/ObsHelpers_Windows.cmake
+++ b/cmake/Modules/ObsHelpers_Windows.cmake
@@ -7,12 +7,12 @@ function(setup_binary_target target)
       TARGETS ${target}
       RUNTIME
         DESTINATION $ENV{OBS_InstallerTempDir}/${OBS_EXECUTABLE_DESTINATION}
-        COMPONENT obs_rundir
+        COMPONENT obs_${target}
       LIBRARY DESTINATION $ENV{OBS_InstallerTempDir}/${OBS_LIBRARY_DESTINATION}
-              COMPONENT obs_rundir
+              COMPONENT obs_${target}
       PUBLIC_HEADER
         DESTINATION ${OBS_INCLUDE_DESTINATION}
-        COMPONENT obs_rundir
+        COMPONENT obs_${target}
         EXCLUDE_FROM_ALL)
 
     if(MSVC)
@@ -21,7 +21,7 @@ function(setup_binary_target target)
         CONFIGURATIONS "RelWithDebInfo" "Debug"
         DESTINATION
           $ENV{OBS_InstallerTempDir}/$<IF:$<STREQUAL:$<TARGET_PROPERTY:${target},TYPE>,EXECUTABLE>,${OBS_EXECUTABLE_DESTINATION},${OBS_LIBRARY_DESTINATION}>
-        COMPONENT obs_rundir
+        COMPONENT obs_${target}
         OPTIONAL EXCLUDE_FROM_ALL)
     endif()
   endif()
@@ -40,7 +40,7 @@ function(setup_binary_target target)
       CONFIGURATIONS "RelWithDebInfo" "Debug"
       DESTINATION
         $<IF:$<STREQUAL:$<TARGET_PROPERTY:${target},TYPE>,EXECUTABLE>,${OBS_EXECUTABLE_DESTINATION},${OBS_LIBRARY_DESTINATION}>
-      COMPONENT obs_rundir
+      COMPONENT obs_${target}
       OPTIONAL EXCLUDE_FROM_ALL)
   endif()
 
@@ -65,7 +65,7 @@ function(setup_plugin_target target)
       FILES $<TARGET_PDB_FILE:${target}>
       CONFIGURATIONS "RelWithDebInfo" "Debug"
       DESTINATION ${OBS_PLUGIN_DESTINATION}
-      COMPONENT obs_rundir
+      COMPONENT obs_${target}
       OPTIONAL EXCLUDE_FROM_ALL)
   endif()
 
@@ -73,9 +73,9 @@ function(setup_plugin_target target)
     install(
       TARGETS ${target}
       RUNTIME DESTINATION $ENV{OBS_InstallerTempDir}/${OBS_PLUGIN_DESTINATION}
-              COMPONENT obs_rundir
+              COMPONENT obs_${target}
       LIBRARY DESTINATION $ENV{OBS_InstallerTempDir}/${OBS_PLUGIN_DESTINATION}
-              COMPONENT obs_rundir
+              COMPONENT obs_${target}
               EXCLUDE_FROM_ALL)
 
     if(MSVC)
@@ -83,7 +83,7 @@ function(setup_plugin_target target)
         FILES $<TARGET_PDB_FILE:${target}>
         CONFIGURATIONS "RelWithDebInfo" "Debug"
         DESTINATION $ENV{OBS_InstallerTempDir}/${OBS_PLUGIN_DESTINATION}
-        COMPONENT obs_rundir
+        COMPONENT obs_${target}
         OPTIONAL EXCLUDE_FROM_ALL)
     endif()
   endif()
@@ -98,7 +98,7 @@ function(setup_script_plugin_target target)
       FILES $<TARGET_PDB_FILE:${target}>
       CONFIGURATIONS "RelWithDebInfo" "Debug"
       DESTINATION ${OBS_SCRIPT_PLUGIN_DESTINATION}
-      COMPONENT obs_rundir
+      COMPONENT obs_${target}
       OPTIONAL EXCLUDE_FROM_ALL)
   endif()
 
@@ -107,10 +107,10 @@ function(setup_script_plugin_target target)
       TARGETS ${target}
       RUNTIME
         DESTINATION $ENV{OBS_InstallerTempDir}/${OBS_SCRIPT_PLUGIN_DESTINATION}
-        COMPONENT obs_rundir
+        COMPONENT obs_${target}
       LIBRARY
         DESTINATION $ENV{OBS_InstallerTempDir}/${OBS_SCRIPT_PLUGIN_DESTINATION}
-        COMPONENT obs_rundir
+        COMPONENT obs_${target}
         EXCLUDE_FROM_ALL)
 
     if(MSVC)
@@ -118,7 +118,7 @@ function(setup_script_plugin_target target)
         FILES $<TARGET_PDB_FILE:${target}>
         CONFIGURATIONS "RelWithDebInfo" "Debug"
         DESTINATION $ENV{OBS_InstallerTempDir}/${OBS_SCRIPT_PLUGIN_DESTINATION}
-        COMPONENT obs_rundir
+        COMPONENT obs_${target}
         OPTIONAL EXCLUDE_FROM_ALL)
     endif()
 
@@ -127,7 +127,7 @@ function(setup_script_plugin_target target)
         FILES
           "$<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_BASE_NAME:${target}>.py"
         DESTINATION $ENV{OBS_InstallerTempDir}/${OBS_SCRIPT_PLUGIN_DESTINATION}
-        COMPONENT obs_rundir
+        COMPONENT obs_${target}
         EXCLUDE_FROM_ALL)
     endif()
   endif()
@@ -145,7 +145,7 @@ function(setup_target_resources target destination)
         DESTINATION
           $ENV{OBS_InstallerTempDir}/${OBS_DATA_DESTINATION}/${destination}
         USE_SOURCE_PERMISSIONS
-        COMPONENT obs_rundir
+        COMPONENT obs_${target}
         EXCLUDE_FROM_ALL)
     endif()
   endif()
@@ -160,7 +160,7 @@ function(add_target_resource target resource destination)
       FILES ${resource}
       DESTINATION
         $ENV{OBS_InstallerTempDir}/${OBS_DATA_DESTINATION}/${destination}
-      COMPONENT obs_rundir
+      COMPONENT obs_${target}
       EXCLUDE_FROM_ALL)
   endif()
 endfunction()

--- a/cmake/Modules/ObsHelpers_macOS.cmake
+++ b/cmake/Modules/ObsHelpers_macOS.cmake
@@ -222,7 +222,7 @@ function(setup_target_browser target)
         EXCLUDE_FROM_ALL)
 
       set(_COMMAND
-          "/usr/bin/codesign --force --sign \\\"${OBS_BUNDLE_CODESIGN_IDENTITY}\\\" $<$<BOOL:${OBS_CODESIGN_LINKER}>:--options linker-signed > \\\"\${CMAKE_INSTALL_PREFIX}/Frameworks/$<TARGET_FILE_NAME:OBS::browser-helper${_SUFFIX}>.app\\\""
+          "/usr/bin/codesign --force --sign \\\"${OBS_BUNDLE_CODESIGN_IDENTITY}\\\" $<$<BOOL:${OBS_CODESIGN_LINKER}>:--options linker-signed > \\\"\${CMAKE_INSTALL_PREFIX}/Frameworks/$<TARGET_FILE_NAME:OBS::browser-helper${_SUFFIX}>.app\\\" > /dev/null"
       )
 
       install(
@@ -235,8 +235,10 @@ function(setup_target_browser target)
   add_custom_command(
     TARGET ${target}
     POST_BUILD
-    COMMAND "${CMAKE_COMMAND}" --install . --config $<CONFIG> --prefix
-            $<TARGET_BUNDLE_CONTENT_DIR:${target}> --component obs_browser_dev
+    COMMAND
+      "${CMAKE_COMMAND}" --install . --config $<CONFIG> --prefix
+      $<TARGET_BUNDLE_CONTENT_DIR:${target}> --component obs_browser_dev >
+      /dev/null
     COMMENT "Installing Chromium Embedded Framework for development"
     VERBATIM)
 endfunction()
@@ -295,7 +297,7 @@ function(setup_obs_modules target)
       EXCLUDE_FROM_ALL)
 
     set(_COMMAND
-        "/usr/bin/codesign --force --sign \\\"${OBS_BUNDLE_CODESIGN_IDENTITY}\\\" $<$<BOOL:${OBS_CODESIGN_LINKER}>:--options linker-signed > \\\"\${CMAKE_INSTALL_PREFIX}/PlugIns/obspython.py\\\""
+        "/usr/bin/codesign --force --sign \\\"${OBS_BUNDLE_CODESIGN_IDENTITY}\\\" $<$<BOOL:${OBS_CODESIGN_LINKER}>:--options linker-signed > \\\"\${CMAKE_INSTALL_PREFIX}/PlugIns/obspython.py\\\" > /dev/null"
     )
 
     install(
@@ -318,7 +320,7 @@ function(setup_obs_modules target)
               EXCLUDE_FROM_ALL)
 
     set(_COMMAND
-        "/usr/bin/codesign --force --sign \\\"${OBS_BUNDLE_CODESIGN_IDENTITY}\\\" $<$<BOOL:${OBS_CODESIGN_LINKER}>:--options linker-signed > \\\"\${CMAKE_INSTALL_PREFIX}/MacOS/$<TARGET_FILE_NAME:obs-ffmpeg-mux>\\\""
+        "/usr/bin/codesign --force --sign \\\"${OBS_BUNDLE_CODESIGN_IDENTITY}\\\" $<$<BOOL:${OBS_CODESIGN_LINKER}>:--options linker-signed > \\\"\${CMAKE_INSTALL_PREFIX}/MacOS/$<TARGET_FILE_NAME:obs-ffmpeg-mux>\\\" > /dev/null"
     )
 
     install(
@@ -344,8 +346,10 @@ function(setup_obs_modules target)
   add_custom_command(
     TARGET ${target}
     POST_BUILD
-    COMMAND "${CMAKE_COMMAND}" --install .. --config $<CONFIG> --prefix
-            $<TARGET_BUNDLE_CONTENT_DIR:${target}> --component obs_plugin_dev
+    COMMAND
+      "${CMAKE_COMMAND}" --install .. --config $<CONFIG> --prefix
+      $<TARGET_BUNDLE_CONTENT_DIR:${target}> --component obs_plugin_dev >
+      /dev/null
     COMMENT "Installing OBS plugins for development"
     VERBATIM)
 endfunction()


### PR DESCRIPTION
### Description
Windows and Linux do not require a contained application bundle to run
and debug OBS - as such targets can and should be copied independently
from the main OBS application target.

Also silences the output of the `install` step that sets up those files.

### Motivation and Context
Allows updating single plugins inside the build tree without the need to build and package the main OBS project.

### How Has This Been Tested?
Checked on Linux and Windows by changing a single plugin to force a recompile, then comparing the checksums of the files copied into the `rundir` to confirm they've been updated.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
