### PR TITLE
cmake: Fix disabling rtmp-services

### DIFF
--- a/plugins/rtmp-services/CMakeLists.txt
+++ b/plugins/rtmp-services/CMakeLists.txt
@@ -1,6 +1,10 @@
 project(rtmp-services)
 
 option(ENABLE_SERVICE_UPDATES "Checks for service updates" OFF)
+if(NOT ENABLE_SERVICE_UPDATES)
+  message(STATUS "OBS:  DISABLED   rtmp-services")
+  return()
+endif()
 
 set(RTMP_SERVICES_URL
     "https://obsproject.com/obs2_update/rtmp-services"


### PR DESCRIPTION
It looks like this option wasn't actually doing anything.

The old logic was quite different, so it's no surprise it got lost in translation.

### Description

Add a check for the option status, and exit if not enabled.

### Motivation and Context

Without this change, 'rtmp-services' is always enabled.

### How Has This Been Tested?

Running configure with ENABLE_SERVICE_UPDATES disabled or enabled, and comparing the output as well as build directories.

Tested on Gentoo Linux.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
