### PR TITLE
UI: Fix UI file changes not being picked up by CMake

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -91,6 +91,36 @@ target_include_directories(obs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
                                        ${CMAKE_CURRENT_BINARY_DIR})
 
 target_sources(obs PRIVATE forms/obs.qrc)
+target_sources(
+  obs
+  PRIVATE forms/AutoConfigFinishPage.ui
+          forms/AutoConfigStartPage.ui
+          forms/AutoConfigStartPage.ui
+          forms/AutoConfigStreamPage.ui
+          forms/AutoConfigTestPage.ui
+          forms/AutoConfigVideoPage.ui
+          forms/ColorSelect.ui
+          forms/OBSAbout.ui
+          forms/OBSBasic.ui
+          forms/OBSBasicFilters.ui
+          forms/OBSBasicInteraction.ui
+          forms/OBSBasicSettings.ui
+          forms/OBSBasicSourceSelect.ui
+          forms/OBSBasicTransform.ui
+          forms/OBSExtraBrowsers.ui
+          forms/OBSImporter.ui
+          forms/OBSLogReply.ui
+          forms/OBSMissingFiles.ui
+          forms/OBSRemux.ui
+          forms/OBSUpdate.ui
+          forms/OBSYoutubeActions.ui
+          forms/source-toolbar/browser-source-toolbar.ui
+          forms/source-toolbar/color-source-toolbar.ui
+          forms/source-toolbar/device-select-toolbar.ui
+          forms/source-toolbar/game-capture-toolbar.ui
+          forms/source-toolbar/image-source-toolbar.ui
+          forms/source-toolbar/media-controls.ui
+          forms/source-toolbar/text-source-toolbar.ui)
 
 target_sources(
   obs
@@ -405,6 +435,17 @@ elseif(OS_POSIX)
     target_link_libraries(obs PRIVATE procstat)
   endif()
 endif()
+
+get_target_property(_SOURCES obs SOURCES)
+set(_UI ${_SOURCES})
+list(FILTER _UI INCLUDE REGEX ".*\\.ui?")
+
+source_group(
+  TREE "${CMAKE_CURRENT_SOURCE_DIR}/forms"
+  PREFIX "UI Files"
+  FILES ${_UI})
+unset(_SOURCES)
+unset(_UI)
 
 define_graphic_modules(obs)
 setup_obs_app(obs)

--- a/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
@@ -18,6 +18,8 @@ set_target_properties(
              AUTORCC ON
              AUTOUIC_SEARCH_PATHS "forms")
 
+target_sources(aja-output-ui PRIVATE forms/output.ui)
+
 target_sources(
   aja-output-ui
   PRIVATE AJAOutputUI.h
@@ -81,5 +83,16 @@ else()
 endif()
 
 set_target_properties(aja-output-ui PROPERTIES FOLDER "frontend" PREFIX "")
+
+get_target_property(_SOURCES aja-output-ui SOURCES)
+set(_UI ${_SOURCES})
+list(FILTER _UI INCLUDE REGEX ".*\\.ui?")
+
+source_group(
+  TREE "${CMAKE_CURRENT_SOURCE_DIR}/forms"
+  PREFIX "UI Files"
+  FILES ${_UI})
+unset(_SOURCES)
+unset(_UI)
 
 setup_plugin_target(aja-output-ui)

--- a/UI/frontend-plugins/decklink-captions/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-captions/CMakeLists.txt
@@ -20,6 +20,8 @@ set_target_properties(
 
 target_compile_features(decklink-captions PRIVATE cxx_std_17)
 
+target_sources(decklink-captions PRIVATE forms/captions.ui)
+
 target_sources(decklink-captions PRIVATE decklink-captions.cpp
                                          decklink-captions.h)
 
@@ -44,5 +46,16 @@ endif()
 
 set_target_properties(decklink-captions PROPERTIES FOLDER "plugins/decklink"
                                                    PREFIX "")
+
+get_target_property(_SOURCES decklink-captions SOURCES)
+set(_UI ${_SOURCES})
+list(FILTER _UI INCLUDE REGEX ".*\\.ui?")
+
+source_group(
+  TREE "${CMAKE_CURRENT_SOURCE_DIR}/forms"
+  PREFIX "UI Files"
+  FILES ${_UI})
+unset(_SOURCES)
+unset(_UI)
 
 setup_plugin_target(decklink-captions)

--- a/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
@@ -4,40 +4,6 @@ if(NOT ENABLE_DECKLINK)
   return()
 endif()
 
-if(NOT COMMAND find_qt)
-  macro(find_qt)
-    set(oneValueArgs VERSION)
-    set(multiValueArgs COMPONENTS COMPONENTS_WIN COMPONENTS_MAC
-                       COMPONENTS_LINUX)
-    cmake_parse_arguments(FIND_QT "" "${oneValueArgs}" "${multiValueArgs}"
-                          ${ARGN})
-
-    if(OS_WINDOWS)
-      find_package(
-        Qt${FIND_QT_VERSION}
-        COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_WIN}
-        REQUIRED)
-    elseif(OS_MACOS)
-      find_package(
-        Qt${FIND_QT_VERSION}
-        COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_MAC}
-        REQUIRED)
-    else()
-      find_package(
-        Qt${FIND_QT_VERSION}
-        COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_LINUX}
-        REQUIRED)
-    endif()
-
-    foreach(_COMPONENT IN LISTS ${FIND_QT_COMPONENTS})
-      if(NOT TARGET Qt::${_COMPONENT} AND TARGET
-                                          Qt${FIND_QT_VERSION}::${_COMPONENT})
-        add_library(Qt::${_COMPONENT} ALIAS Qt${FIND_QT_VERSION}::${_COMPONENT})
-      endif()
-    endforeach()
-  endmacro()
-endif()
-
 add_library(decklink-output-ui MODULE)
 add_library(OBS::decklink-output-ui ALIAS decklink-output-ui)
 
@@ -52,6 +18,8 @@ set_target_properties(
              AUTOUIC ON
              AUTORCC ON
              AUTOUIC_SEARCH_PATHS "forms")
+
+target_sources(decklink-output-ui PRIVATE forms/output.ui)
 
 target_sources(
   decklink-output-ui
@@ -100,5 +68,16 @@ elseif(OS_POSIX)
   target_link_libraries(decklink-output-ui PRIVATE X11::X11
                                                    Qt${QT_VERSION}::GuiPrivate)
 endif()
+
+get_target_property(_SOURCES decklink-output-ui SOURCES)
+set(_UI ${_SOURCES})
+list(FILTER _UI INCLUDE REGEX ".*\\.ui?")
+
+source_group(
+  TREE "${CMAKE_CURRENT_SOURCE_DIR}/forms"
+  PREFIX "UI Files"
+  FILES ${_UI})
+unset(_SOURCES)
+unset(_UI)
 
 setup_plugin_target(decklink-output-ui)

--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -16,6 +16,10 @@ set_target_properties(
              AUTOUIC_SEARCH_PATHS "forms")
 
 target_sources(
+  frontend-tools PRIVATE forms/auto-scene-switcher.ui forms/captions.ui
+                         forms/output-timer.ui forms/scripts.ui)
+
+target_sources(
   frontend-tools
   PRIVATE frontend-tools.c
           auto-scene-switcher.hpp
@@ -102,5 +106,16 @@ elseif(OS_POSIX)
 
   target_sources(frontend-tools PRIVATE auto-scene-switcher-nix.cpp)
 endif()
+
+get_target_property(_SOURCES frontend-tools SOURCES)
+set(_UI ${_SOURCES})
+list(FILTER _UI INCLUDE REGEX ".*\\.ui?")
+
+source_group(
+  TREE "${CMAKE_CURRENT_SOURCE_DIR}/forms"
+  PREFIX "UI Files"
+  FILES ${_UI})
+unset(_SOURCES)
+unset(_UI)
 
 setup_plugin_target(frontend-tools)


### PR DESCRIPTION
### Description
Due to how CMake and generated project files are structured, just using
AUTOUIC to pick up Qt `.ui` files will lead to a situation where
changing such a file doesn't trigger a regeneration of the associated
header files and thus a re-build of the target.

Upstream fix still requires `.ui` files to be added as target sources.

CMake issue: https://gitlab.kitware.com/cmake/cmake/-/issues/17959

Also adds the UI files to the target file overview in Visual Studio and Xcode.

### Motivation and Context
Removes necessity to change a code file just to have the build system recompile the UI header files.

### How Has This Been Tested?
Changed single UI file and checked build output.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
