### PR TITLE
libobs-d3d11: Make gs_clear honor FRAMEBUFFER_SRGB

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -2200,11 +2200,17 @@ void device_load_swapchain(gs_device_t *device, gs_swapchain_t *swapchain)
 void device_clear(gs_device_t *device, uint32_t clear_flags,
 		  const struct vec4 *color, float depth, uint8_t stencil)
 {
-	int side = device->curRenderSide;
-	if ((clear_flags & GS_CLEAR_COLOR) != 0 && device->curRenderTarget)
-		device->context->ClearRenderTargetView(
-			device->curRenderTarget->renderTarget[side],
-			color->ptr);
+	if (clear_flags & GS_CLEAR_COLOR) {
+		gs_texture_2d *const tex = device->curRenderTarget;
+		if (tex) {
+			const int side = device->curRenderSide;
+			ID3D11RenderTargetView *const rtv =
+				device->curFramebufferSrgb
+					? tex->renderTargetLinear[side]
+					: tex->renderTarget[side];
+			device->context->ClearRenderTargetView(rtv, color->ptr);
+		}
+	}
 
 	if (device->curZStencilBuffer) {
 		uint32_t flags = 0;


### PR DESCRIPTION
### Description
This matches the behavior of glClearColor/glClear on OpenGL.

### Motivation and Context
Both renderers should behave the same when possible.

### How Has This Been Tested?
Verified color difference with FRAMEBUFFER_SRGB on/off for both renderers on Windows.

Mac doesn't always seem to honor the current FRAMEBUFFER_SRGB setting at glClear time, but I'm not sure what we can do about that if anything.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.