### PR TITLE
CMake: Fix PDB install directory for library installation

### DIFF
--- a/cmake/Modules/ObsHelpers_Windows.cmake
+++ b/cmake/Modules/ObsHelpers_Windows.cmake
@@ -210,11 +210,11 @@ function(export_target target)
 
   if(MSVC)
     install(
-      DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/pdbs/"
+      FILES $<TARGET_PDB_FILE:${target}>
+      CONFIGURATIONS "RelWithDebInfo" "Debug"
       DESTINATION "${OBS_EXECUTABLE_EXPORT_DESTINATION}"
-      CONFIGURATIONS Debug RelWithDebInfo
       COMPONENT obs_libraries
-      EXCLUDE_FROM_ALL)
+      OPTIONAL EXCLUDE_FROM_ALL)
   endif()
 
   include(GenerateExportHeader)


### PR DESCRIPTION
### Description
obs-plugintemplate uses the `obs_libraries` component to install
obs components required for plugin development. The need of the separate
`pdbs` directory was removed a while ago (as PDB target installation
can be flagged as `OPTIONAL` and enabled for specific configurations
only). This part was overlooked in that change.

### Motivation and Context
Enables simple CMake configuration for building OBS plugins.

### How Has This Been Tested?
Checked in local plugin builds and within rewrite of obs-plugintmmplate (PR pending).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
