### PR TITLE
libobs: Add array check for deinterlace logic

### DIFF
--- a/libobs/obs-source-deinterlace.c
+++ b/libobs/obs-source-deinterlace.c
@@ -181,7 +181,8 @@ static inline void deinterlace_get_closest_frames(obs_source_t *s,
 
 		da_erase(s->async_frames, 0);
 
-		if (s->cur_async_frame->prev_frame) {
+		if ((s->async_frames.num > 0) &&
+		    s->cur_async_frame->prev_frame) {
 			s->prev_async_frame = s->cur_async_frame;
 			s->cur_async_frame = s->async_frames.array[0];
 


### PR DESCRIPTION
### Description
Seeing a rare assert on startup for a media source with deinterlacing
already on. Tested with Yadif 2x. Repro is maybe 10% of OBS launches?

### Motivation and Context
Accessing bad memory is bad.

### How Has This Been Tested?
Verified OBS still runs if the rare case occurs using conditional breakpoint.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.