### PR TITLE
libobs: Add OBS_COUNTOF for array count

### DIFF
--- a/libobs/util/base.h
+++ b/libobs/util/base.h
@@ -35,6 +35,8 @@ extern "C" {
 #define INT_CUR_LINE __LINE__
 #define FILE_LINE __FILE__ " (" S__LINE__ "): "
 
+#define OBS_COUNTOF(x) (sizeof(x) / sizeof(x[0]))
+
 enum {
 	/**
 	 * Use if there's a problem that can potentially affect the program,


### PR DESCRIPTION
### Description
Macro is easier than `sizeof(x) / sizeof(x[0])`.

### Motivation and Context
Don't want error-prone typing.

### How Has This Been Tested?
Verified it returned correct size under debugger.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.