### PR TITLE
CI/deps: Move obspython.py to Resources (27.2 branch)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,7 +211,7 @@ jobs:
           if [ -d ./OBS.app/Contents/Resources/data/obs-scripting ]; then
             mv ./OBS.app/Contents/Resources/data/obs-scripting/obslua.so ./OBS.app/Contents/MacOS/
             mv ./OBS.app/Contents/Resources/data/obs-scripting/_obspython.so ./OBS.app/Contents/MacOS/
-            mv ./OBS.app/Contents/Resources/data/obs-scripting/obspython.py ./OBS.app/Contents/MacOS/
+            mv ./OBS.app/Contents/Resources/data/obs-scripting/obspython.py ./OBS.app/Contents/Resources/
             rm -rf ./OBS.app/Contents/Resources/data/obs-scripting/
           fi
 

--- a/CI/full-build-macos.sh
+++ b/CI/full-build-macos.sh
@@ -419,7 +419,7 @@ prepare_macos_bundle() {
     if [ -d ./OBS.app/Contents/Resources/data/obs-scripting ]; then
         /bin/mv ./OBS.app/Contents/Resources/data/obs-scripting/obslua.so ./OBS.app/Contents/MacOS/
         /bin/mv ./OBS.app/Contents/Resources/data/obs-scripting/_obspython.so ./OBS.app/Contents/MacOS/
-        /bin/mv ./OBS.app/Contents/Resources/data/obs-scripting/obspython.py ./OBS.app/Contents/MacOS/
+        /bin/mv ./OBS.app/Contents/Resources/data/obs-scripting/obspython.py ./OBS.app/Contents/Resources/
         /bin/rm -rf ./OBS.app/Contents/Resources/data/obs-scripting/
     fi
     # dylibbundler will only copy actually linked files into bundle, but not symlinks

--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -1676,10 +1676,24 @@ bool obs_scripting_load_python(const char *python_path)
 	bfree(absolute_script_path);
 
 #if __APPLE__
-	char *exec_path = os_get_executable_path_ptr("");
-	if (exec_path)
-		add_to_python_path(exec_path);
-	bfree(exec_path);
+	char *absolute_exec_path = os_get_executable_path_ptr("");
+
+	if (absolute_exec_path != NULL) {
+		add_to_python_path(absolute_exec_path);
+
+		struct dstr resources_path;
+		dstr_init_move_array(&resources_path, absolute_exec_path);
+		dstr_cat(&resources_path, "../Resources");
+
+		char *absolute_resources_path = os_get_abs_path_ptr(resources_path.array);
+		if (absolute_resources_path != NULL) {
+			add_to_python_path(absolute_resources_path);
+			bfree(absolute_resources_path);
+		}
+
+		dstr_free(&resources_path);
+		bfree(absolute_exec_path);
+	}
 #endif
 
 	py_obspython = PyImport_ImportModule("obspython");


### PR DESCRIPTION
### Description

Moves `obspython.py` to `Resources` on macOS.

This is a variation of #6196 but for the legacy build system in case we want to create another 27.2.x bugfix release.

### Motivation and Context

Having `obspython.py` in the code directories requires it to be signed, since it's a text file this is done via extended attributes. This breaks on Steam or when using another packaging method that does not retain those.

Additionally per Apple themselves it is not recommended to store scripts there, and they should live in resources instead: https://developer.apple.com/library/archive/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG201

### How Has This Been Tested?

- Checked that files are in the correct folders, but was unable to test scripts on my Mac since only arm64 python was installed

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
