### PR TITLE
cmake: Fix compiler flags from FindWayland and FindPipeWire

### DIFF
--- a/cmake/Modules/FindPipeWire.cmake
+++ b/cmake/Modules/FindPipeWire.cmake
@@ -10,8 +10,8 @@
 # be passed to target_link_libraries() instead of the ``PipeWire::PipeWire``
 # target ``PIPEWIRE_INCLUDE_DIRS`` This should be passed to
 # target_include_directories() if the target is not used for linking
-# ``PIPEWIRE_DEFINITIONS`` This should be passed to target_compile_options() if
-# the target is not used for linking
+# ``PIPEWIRE_COMPILE_FLAGS`` This should be passed to target_compile_options()
+# if the target is not used for linking
 #
 # If ``PIPEWIRE_FOUND`` is TRUE, it will also define the following imported
 # target:
@@ -56,7 +56,7 @@ find_package(PkgConfig QUIET)
 pkg_search_module(PKG_PIPEWIRE QUIET libpipewire-0.3)
 pkg_search_module(PKG_SPA QUIET libspa-0.2)
 
-set(PIPEWIRE_DEFINITIONS "${PKG_PIPEWIRE_CFLAGS}" "${PKG_SPA_CFLAGS}")
+set(PIPEWIRE_COMPILE_FLAGS "${PKG_PIPEWIRE_CFLAGS}" "${PKG_SPA_CFLAGS}")
 set(PIPEWIRE_VERSION "${PKG_PIPEWIRE_VERSION}")
 
 find_path(
@@ -86,7 +86,7 @@ if(PIPEWIRE_FOUND AND NOT TARGET PipeWire::PipeWire)
   set_target_properties(
     PipeWire::PipeWire
     PROPERTIES IMPORTED_LOCATION "${PIPEWIRE_LIBRARIES}"
-               INTERFACE_COMPILE_OPTIONS "${PIPEWIRE_DEFINITIONS}"
+               INTERFACE_COMPILE_OPTIONS "${PIPEWIRE_COMPILE_FLAGS}"
                INTERFACE_INCLUDE_DIRECTORIES
                "${PIPEWIRE_INCLUDE_DIRS};${SPA_INCLUDE_DIRS}")
 endif()

--- a/cmake/Modules/FindWayland.cmake
+++ b/cmake/Modules/FindWayland.cmake
@@ -4,7 +4,7 @@
 #
 # WAYLAND_FOUND        - True if Wayland is found WAYLAND_LIBRARIES    - Link
 # these to use Wayland WAYLAND_INCLUDE_DIRS - Include directory for Wayland
-# WAYLAND_DEFINITIONS  - Compiler flags for using Wayland
+# WAYLAND_COMPILE_FLAGS  - Compiler flags for using Wayland
 #
 # In addition the following more fine grained variables will be defined:
 #
@@ -25,7 +25,7 @@ find_package(PkgConfig)
 pkg_check_modules(PKG_WAYLAND QUIET wayland-client wayland-server wayland-egl
                   wayland-cursor)
 
-set(WAYLAND_DEFINITIONS ${PKG_WAYLAND_CFLAGS})
+set(WAYLAND_COMPILE_FLAGS ${PKG_WAYLAND_CFLAGS})
 
 find_path(
   WAYLAND_CLIENT_INCLUDE_DIRS
@@ -125,8 +125,8 @@ foreach(component "Client" "Server" "EGL" "Cursor")
                    "${WAYLAND_${component_u}_INCLUDE_DIRS}")
 
       set_target_properties(
-        Wayland::${component} PROPERTIES INTERFACE_COMPILE_DEFINITIONS
-                                         "${WAYLAND_DEFINITIONS}")
+        Wayland::${component} PROPERTIES INTERFACE_COMPILE_OPTIONS
+                                         "${WAYLAND_COMPILE_FLAGS}")
     endif()
   endif()
 endforeach()


### PR DESCRIPTION
${WAYLAND_DEFINITIONS} is set to  "-I/usr/include/wayland" on my system

Setting it as INTERFACE_COMPILE_DEFINITIONS leads to CMake emitting "-D-I/usr/include/wayland" in the compiler flags
this breaks the compilation

Instead add WAYLAND_DEFINITIONS as compile option so it just gets appended without adding the superflours "-D"

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
I was trying to compile OBS for the first time using openSUSE Tumbleweed. I was able to set the dependencies and cmake up, but during compilation GCC throws an error:

> \<command-line>: error: macro names must be identifiers

This is caused by cmake emitting
`cd /home/user/Programming/OBS/obs-studio/build/libobs && /usr/bin/cc -D-I/usr/include/wayland -DENABLE_DARRAY_TYPE_TEST [...]`
-D makes gcc wait for a macro, but instead the include flag follows immediately.

To fix it we just have to tell cmake to not interpret WAYLAND_DEFINITIONS as macro definition, but only append it to the compiler flags. (This is inline with what is done in [FindPipeWire.cmake.](https://github.com/obsproject/obs-studio/blob/ba68eda590b2621b13691a40bb9541ebb353257d/cmake/Modules/FindPipeWire.cmake#L89))

This issue was likely introduced by commit df94b02075636dc0ace7b4d1e9706abeb64dfbbd from PR #5155

P.S.: First day of working with OBS and first patch. I've tried following all contributor guidelines, but please tell me if I could've done better. :)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
With this commit I am able to compile OBS using openSUSE Tumbleweed on a Thinkpad P14s.
Snapshot 20220322 with CMake 3.22.2
Snapshot 20220323 with CMake 3.22.3
I'm able to launch the compiled binary on X11 and Wayland using KDE 5.24.3, do some simple screen capture using XSHM and Pipewire, record my desktop and click through menus.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.