### PR TITLE
libobs: Fix stale active_copy_surfaces entries

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -557,6 +557,8 @@ static void obs_free_video(void)
 						video->copy_surfaces[i][c]);
 					video->copy_surfaces[i][c] = NULL;
 				}
+
+				video->active_copy_surfaces[i][c] = NULL;
 			}
 #ifdef _WIN32
 			if (video->copy_surfaces_encode[i]) {


### PR DESCRIPTION
### Description
OBS can crash when recording again after resetting video after a previous record.

### Motivation and Context
Crashes are bad.

### How Has This Been Tested?
Crash repro no longer crashes.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.