### PR TITLE
obs-ffmpeg : use I422 for YUV422P input format

### DIFF
--- a/deps/media-playback/media-playback/closest-format.h
+++ b/deps/media-playback/media-playback/closest-format.h
@@ -36,6 +36,8 @@ static enum AVPixelFormat closest_format(enum AVPixelFormat fmt)
 		return AV_PIX_FMT_YUV444P;
 
 	case AV_PIX_FMT_YUV422P:
+        return AV_PIX_FMT_YUV422P;
+
 	case AV_PIX_FMT_YUVJ422P:
 	case AV_PIX_FMT_UYVY422:
 	case AV_PIX_FMT_YUV422P16LE:

--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -38,6 +38,8 @@ static inline enum video_format convert_pixel_format(int f)
 		return VIDEO_FORMAT_NV12;
 	case AV_PIX_FMT_YUYV422:
 		return VIDEO_FORMAT_YUY2;
+    case AV_PIX_FMT_YUV422P:
+        return VIDEO_FORMAT_I422;
 	case AV_PIX_FMT_YUV444P:
 		return VIDEO_FORMAT_I444;
 	case AV_PIX_FMT_UYVY422:


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
YUV422P have an equivalent video format : I422.
Use it instead of UYVY.

### Motivation and Context
Avoid conversion to UYVY422 for 422P video input files (like dnxhd or xdcam422)

### How Has This Been Tested?
Mac os 11.6.2 (Intel)
Reading DnxHD 422 file (and xdcam HD 422)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
