### PR TITLE
cmake: check empty OBS_MODULE_LIST and OBS_SCRIPTING_MODULE_LIST on macOS 

### DIFF
--- a/cmake/Modules/ObsHelpers_macOS.cmake
+++ b/cmake/Modules/ObsHelpers_macOS.cmake
@@ -281,25 +281,28 @@ function(setup_obs_modules target)
 
   get_property(OBS_SCRIPTING_MODULE_LIST GLOBAL
                PROPERTY OBS_SCRIPTING_MODULE_LIST)
-  add_dependencies(${target} ${OBS_SCRIPTING_MODULE_LIST})
+  if("${OBS_SCRIPTING_MODULE_LIST}")
+    add_dependencies(${target} ${OBS_SCRIPTING_MODULE_LIST})
 
-  install(
-    TARGETS ${OBS_SCRIPTING_MODULE_LIST}
-    LIBRARY DESTINATION "PlugIns"
-            COMPONENT obs_plugin_dev
-            EXCLUDE_FROM_ALL)
-
-  if(TARGET obspython)
     install(
-      FILES "$<TARGET_FILE_DIR:obspython>/obspython.py"
-      DESTINATION "Resources"
-      COMPONENT obs_plugin_dev
-      EXCLUDE_FROM_ALL)
-  endif()
+      TARGETS ${OBS_SCRIPTING_MODULE_LIST}
+      LIBRARY DESTINATION "PlugIns"
+              COMPONENT obs_plugin_dev
+              EXCLUDE_FROM_ALL)
 
-  install(TARGETS ${OBS_SCRIPTING_MODULE_LIST}
-          LIBRARY DESTINATION $<TARGET_FILE_BASE_NAME:obs>.app/Contents/PlugIns
-                  COMPONENT obs_scripting_plugins)
+    if(TARGET obspython)
+      install(
+        FILES "$<TARGET_FILE_DIR:obspython>/obspython.py"
+        DESTINATION "Resources"
+        COMPONENT obs_plugin_dev
+        EXCLUDE_FROM_ALL)
+    endif()
+
+    install(
+      TARGETS ${OBS_SCRIPTING_MODULE_LIST}
+      LIBRARY DESTINATION $<TARGET_FILE_BASE_NAME:obs>.app/Contents/PlugIns
+              COMPONENT obs_scripting_plugins)
+  endif()
 
   if(TARGET obs-ffmpeg-mux)
     add_dependencies(${target} obs-ffmpeg-mux)

--- a/cmake/Modules/ObsHelpers_macOS.cmake
+++ b/cmake/Modules/ObsHelpers_macOS.cmake
@@ -265,19 +265,22 @@ endfunction()
 function(setup_obs_modules target)
 
   get_property(OBS_MODULE_LIST GLOBAL PROPERTY OBS_MODULE_LIST)
-  add_dependencies(${target} ${OBS_MODULE_LIST})
+  if("${OBS_MODULE_LIST}")
+    add_dependencies(${target} ${OBS_MODULE_LIST})
 
-  install(
-    TARGETS ${OBS_MODULE_LIST}
-    LIBRARY DESTINATION "PlugIns"
-            COMPONENT obs_plugin_dev
-            EXCLUDE_FROM_ALL)
+    install(
+      TARGETS ${OBS_MODULE_LIST}
+      LIBRARY DESTINATION "PlugIns"
+              COMPONENT obs_plugin_dev
+              EXCLUDE_FROM_ALL)
 
-  install(
-    TARGETS ${OBS_MODULE_LIST}
-    LIBRARY DESTINATION $<TARGET_FILE_BASE_NAME:${target}>.app/Contents/PlugIns
-            COMPONENT obs_plugins
-            NAMELINK_COMPONENT ${target}_Development)
+    install(
+      TARGETS ${OBS_MODULE_LIST}
+      LIBRARY
+        DESTINATION $<TARGET_FILE_BASE_NAME:${target}>.app/Contents/PlugIns
+        COMPONENT obs_plugins
+        NAMELINK_COMPONENT ${target}_Development)
+  endif()
 
   get_property(OBS_SCRIPTING_MODULE_LIST GLOBAL
                PROPERTY OBS_SCRIPTING_MODULE_LIST)


### PR DESCRIPTION
# Description

Check empty OBS_MODULE_LIST and OBS_SCRIPTING_MODULE_LIST before use them, since empty list leads to add_dependencies() failure.

# Motivation and Context

Don't fail when -DENABLE_SCRIPTING=OFF.

# How Has This Been Tested?

On MacOS, tested with -DENABLE_SCRIPTING=OFF and -DENABLE_SCRIPTING=ON.

# Types of changes

* Bug fix (non-breaking change which fixes an issue) 

# Checklist:
 
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [contributing document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.