### PR TITLE
obs-transitions: Add HDR support to cut/fade

### DIFF
--- a/plugins/obs-transitions/CMakeLists.txt
+++ b/plugins/obs-transitions/CMakeLists.txt
@@ -14,6 +14,23 @@ target_sources(
           transition-luma-wipe.c
           transition-stinger.c)
 
+if(NOT OS_MACOS)
+  target_sources(
+    obs-transitions
+    PRIVATE data/fade_to_color_transition.effect data/fade_transition.effect
+            data/luma_wipe_transition.effect data/slide_transition.effect
+            data/stinger_matte_transition.effect data/swipe_transition.effect)
+
+  get_target_property(_SOURCES obs-transitions SOURCES)
+  set(_FILTERS ${_SOURCES})
+  list(FILTER _FILTERS INCLUDE REGEX ".*\\.effect")
+
+  source_group(
+    TREE "${CMAKE_CURRENT_SOURCE_DIR}"
+    PREFIX "Effect Files"
+    FILES ${_FILTERS})
+endif()
+
 target_link_libraries(obs-transitions PRIVATE OBS::libobs)
 
 if(OS_WINDOWS)

--- a/plugins/obs-transitions/data/fade_transition.effect
+++ b/plugins/obs-transitions/data/fade_transition.effect
@@ -10,15 +10,19 @@ sampler_state textureSampler {
 };
 
 struct VertData {
+	float2 uv  : TEXCOORD0;
 	float4 pos : POSITION;
+};
+
+struct FragData {
 	float2 uv  : TEXCOORD0;
 };
 
 VertData VSDefault(VertData v_in)
 {
 	VertData vert_out;
-	vert_out.pos = mul(float4(v_in.pos.xyz, 1.0), ViewProj);
 	vert_out.uv  = v_in.uv;
+	vert_out.pos = mul(float4(v_in.pos.xyz, 1.0), ViewProj);
 	return vert_out;
 }
 
@@ -32,12 +36,32 @@ float3 srgb_nonlinear_to_linear(float3 v)
 	return float3(srgb_nonlinear_to_linear_channel(v.r), srgb_nonlinear_to_linear_channel(v.g), srgb_nonlinear_to_linear_channel(v.b));
 }
 
-float4 PSFade(VertData v_in) : TARGET
+float4 Fade(FragData f_in)
 {
-	float4 a_val = tex_a.Sample(textureSampler, v_in.uv);
-	float4 b_val = tex_b.Sample(textureSampler, v_in.uv);
+	float4 a_val = tex_a.Sample(textureSampler, f_in.uv);
+	float4 b_val = tex_b.Sample(textureSampler, f_in.uv);
 	float4 rgba = lerp(a_val, b_val, fade_val);
 	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
+	return rgba;
+}
+
+float4 PSFade(FragData f_in) : TARGET
+{
+	float4 rgba = Fade(f_in);
+	return rgba;
+}
+
+float4 FadeLinear(FragData f_in)
+{
+	float4 a_val = tex_a.Sample(textureSampler, f_in.uv);
+	float4 b_val = tex_b.Sample(textureSampler, f_in.uv);
+	float4 rgba = lerp(a_val, b_val, fade_val);
+	return rgba;
+}
+
+float4 PSFadeLinear(FragData f_in) : TARGET
+{
+	float4 rgba = FadeLinear(f_in);
 	return rgba;
 }
 
@@ -46,6 +70,15 @@ technique Fade
 	pass
 	{
 		vertex_shader = VSDefault(v_in);
-		pixel_shader = PSFade(v_in);
+		pixel_shader = PSFade(f_in);
+	}
+}
+
+technique FadeLinear
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader = PSFadeLinear(f_in);
 	}
 }

--- a/plugins/obs-transitions/transition-cut.c
+++ b/plugins/obs-transitions/transition-cut.c
@@ -57,6 +57,14 @@ static bool cut_audio_render(void *data, uint64_t *ts_out,
 					   channels, sample_rate, mix_a, mix_b);
 }
 
+static enum gs_color_space
+cut_video_get_color_space(void *data, size_t count,
+			  const enum gs_color_space *preferred_spaces)
+{
+	struct cut_info *const cut = data;
+	return obs_transition_video_get_color_space(cut->source);
+}
+
 struct obs_source_info cut_transition = {
 	.id = "cut_transition",
 	.type = OBS_SOURCE_TYPE_TRANSITION,
@@ -65,4 +73,5 @@ struct obs_source_info cut_transition = {
 	.destroy = cut_destroy,
 	.video_render = cut_video_render,
 	.audio_render = cut_audio_render,
+	.video_get_color_space = cut_video_get_color_space,
 };


### PR DESCRIPTION
### Description
Both transitions are capable of passing through HDR sources now.

Also update VS solution to list transition effect files.

### Motivation and Context
Need transitions to support HDR to render their HDR scene children.

### How Has This Been Tested?
HDR scenes were being tonemapped behind these transitions before, and now they aren't.
SDR scenes continue to look SDR.
Tested fade transition for scenes and sources using SDR & HDR.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.