### PR TITLE
cmake: Fix obs-ffmpeg-mux missing rpath entries for libobs in build tree

### DIFF
--- a/cmake/Modules/ObsHelpers_macOS.cmake
+++ b/cmake/Modules/ObsHelpers_macOS.cmake
@@ -304,11 +304,15 @@ function(setup_obs_modules target)
   if(TARGET obs-ffmpeg-mux)
     add_dependencies(${target} obs-ffmpeg-mux)
 
+    install(TARGETS obs-ffmpeg-mux
+            RUNTIME DESTINATION $<TARGET_FILE_BASE_NAME:obs>.app/Contents/MacOS
+                    COMPONENT obs_plugins)
+
     install(
-      TARGETS obs-ffmpeg-mux
-      RUNTIME DESTINATION "MacOS"
-              COMPONENT obs_plugin_dev
-              EXCLUDE_FROM_ALL)
+      PROGRAMS $<TARGET_FILE:obs-ffmpeg-mux>
+      DESTINATION "MacOS"
+      COMPONENT obs_plugin_dev
+      EXCLUDE_FROM_ALL)
 
     set(_COMMAND
         "/usr/bin/codesign --force --sign \\\"${OBS_BUNDLE_CODESIGN_IDENTITY}\\\" $<$<BOOL:${OBS_CODESIGN_LINKER}>:--options linker-signed > \\\"\${CMAKE_INSTALL_PREFIX}/MacOS/$<TARGET_FILE_NAME:obs-ffmpeg-mux>\\\" > /dev/null"
@@ -319,9 +323,6 @@ function(setup_obs_modules target)
       COMPONENT obs_plugin_dev
       EXCLUDE_FROM_ALL)
 
-    install(TARGETS obs-ffmpeg-mux
-            RUNTIME DESTINATION $<TARGET_FILE_BASE_NAME:obs>.app/Contents/MacOS
-                    COMPONENT obs_plugins)
   endif()
 
   if(TARGET mac-dal-plugin)


### PR DESCRIPTION
### Description
Fixes broken recording functionality on macOS when running OBS from Xcode.

### Motivation and Context
When using `install`, CMake will fix up a binary's rpath entries automatically. As `install` is also used to copy all build artifacts into a common runtime directory, this will lead to independent binaries such as "obs-ffmpeg-mux" to be fixed up to run within a fully portable app bundle.

Yet during development, the app bundle is not fully portable, so rpath entries to e.g. libobs need to be retained. Using CMake's `install PROGRAMS` variant will achieve just that.

### How Has This Been Tested?
OBS built, run, and recording created straight from Xcode.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
