### PR TITLE
CI: Fix Windows build scripts relying on localized architecture string

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -284,7 +284,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        arch: [64, 32]
+        arch: [x64, x86]
     env:
       CMAKE_GENERATOR: 'Visual Studio 16 2019'
       CMAKE_SYSTEM_VERSION: '10.0.18363.657'
@@ -325,8 +325,8 @@ jobs:
         env:
           CACHE_NAME: 'cef-cache'
         with:
-          path: ${{ github.workspace }}/obs-build-dependencies/cef_binary_${{ env.CEF_BUILD_VERSION_WIN }}_windows${{ matrix.arch }}_minimal
-          key: ${{ runner.os }}-pr-${{ env.CACHE_NAME }}-${{ env.CEF_BUILD_VERSION_WIN }}-${{ env.CACHE_REVISION }}
+          path: ${{ github.workspace }}/obs-build-dependencies/cef_binary_${{ env.CEF_BUILD_VERSION_WIN }}_windows_${{ matrix.arch }}
+          key: ${{ runner.os }}-pr-${{ env.CACHE_NAME }}-${{ env.CEF_BUILD_VERSION_WIN }}-${{ matrix.arch }}-${{ env.CACHE_REVISION }}
 
       - name: Setup Environment
         id: setup
@@ -338,23 +338,23 @@ jobs:
         env:
           RESTORED_VLC: ${{ steps.vlc-cache.outputs.cache-hit }}
           RESTORED_CEF: ${{ steps.cef-cache.outputs.cache-hit }}
-        run: CI/windows/01_install_dependencies.ps1 -BuildArch ${{ matrix.arch }}-bit
+        run: CI/windows/01_install_dependencies.ps1 -BuildArch ${{ matrix.arch }}
 
       - name: 'Build OBS'
-        run: CI/windows/02_build_obs.ps1 -BuildArch ${{ matrix.arch }}-bit
+        run: CI/windows/02_build_obs.ps1 -BuildArch ${{ matrix.arch }}
 
       - name: 'Create build artifact'
         if: ${{ success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1') }}
         run: |
-          CI/windows/03_package_obs.ps1 -BuildArch ${{ matrix.arch }}-bit -Package
-          $ArtifactName = Get-ChildItem -filter "OBS-Studio-*-Win${{ matrix.arch }}.zip" -File
+          CI/windows/03_package_obs.ps1 -BuildArch ${{ matrix.arch }} -Package
+          $ArtifactName = Get-ChildItem -filter "OBS-Studio-*-Win-${{ matrix.arch }}.zip" -File
           Write-Output "FILE_NAME=${ArtifactName}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: 'Upload build artifact'
         if: ${{ success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1') }}
         uses: actions/upload-artifact@v3
         with:
-          name: 'obs-win${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}'
+          name: 'obs-win-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}'
           path: '${{ env.FILE_NAME }}'
 
   linux_package:
@@ -431,12 +431,12 @@ jobs:
             $null = New-Item -ItemType Directory -Force -Path install_temp
           }
 
-          Expand-Archive -Path "$(Get-ChildItem -filter "OBS-Studio-*-Win32.zip" -File)" -DestinationPath install_temp
-          Expand-Archive -Path "$(Get-ChildItem -filter "OBS-Studio-*-Win64.zip" -File)" -Force -DestinationPath install_temp
+          Expand-Archive -Path "$(Get-ChildItem -filter "OBS-Studio-*-Win-x86.zip" -File)" -DestinationPath install_temp
+          Expand-Archive -Path "$(Get-ChildItem -filter "OBS-Studio-*-Win-x64.zip" -File)" -Force -DestinationPath install_temp
 
           CI/windows/03_package_obs.ps1 -CombinedArchs -Package
 
-          $ArtifactName = (Get-ChildItem -filter "OBS-Studio-*-Windows.zip" -File).Name
+          $ArtifactName = (Get-ChildItem -filter "OBS-Studio-*-Win-x64+x86.zip" -File).Name
           Write-Output "FILE_NAME=${ArtifactName}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: 'Upload build artifact'

--- a/CI/build-windows.ps1
+++ b/CI/build-windows.ps1
@@ -7,8 +7,8 @@ Param(
     [Switch]$BuildInstaller,
     [Switch]$CombinedArchs,
     [String]$BuildDirectory = "build",
-    [ValidateSet("32-bit", "64-bit")]
-    [String]$BuildArch = (Get-CimInstance CIM_OperatingSystem).OSArchitecture,
+    [ValidateSet('x86', 'x64')]
+    [String]$BuildArch = ('x86', 'x64')[[System.Environment]::Is64BitOperatingSystem],
     [ValidateSet("Release", "RelWithDebInfo", "MinSizeRel", "Debug")]
     [String]$BuildConfiguration = "RelWithDebInfo"
 )
@@ -30,11 +30,11 @@ Param(
 #   -BuildDirectory         : Directory to use for builds
 #                             Default: build64 on 64-bit systems
 #                                      build32 on 32-bit systems
-#   -BuildArch              : Build architecture to use ("32-bit" or "64-bit")
+#   -BuildArch              : Build architecture to use (x86 or x64)
 #   -BuildConfiguration     : Build configuration to use
 #                             Default: RelWithDebInfo
 #   -CombinedArchs          : Create combined packages and installer
-#                             (64-bit and 32-bit) - Default: off
+#                             (x86 and x64) - Default: off
 #   -Package                : Prepare folder structure for installer creation
 #
 # Environment Variables (optional):
@@ -87,16 +87,16 @@ function Build-OBS-Main {
         }
 
         if(!($SkipDependencyChecks.isPresent)) {
-            Install-Dependencies -BuildArch 64-bit
+            Install-Dependencies -BuildArch x64
         }
 
-        Build-OBS -BuildArch 64-bit
+        Build-OBS -BuildArch x64
 
         if(!($SkipDependencyChecks.isPresent)) {
-            Install-Dependencies -BuildArch 32-bit
+            Install-Dependencies -BuildArch x86
         }
 
-        Build-OBS -BuildArch 32-bit
+        Build-OBS -BuildArch x86
     } else {
         if(!($SkipDependencyChecks.isPresent)) {
             Install-Dependencies
@@ -120,7 +120,7 @@ function Print-Usage {
         "-Verbose                 : Enable more verbose build process output"
         "-SkipDependencyChecks    : Skip dependency checks - Default: off",
         "-BuildDirectory          : Directory to use for builds - Default: build64 on 64-bit systems, build32 on 32-bit systems",
-        "-BuildArch               : Build architecture to use ('32-bit' or '64-bit') - Default: local architecture",
+        "-BuildArch               : Build architecture to use (x86 or x64) - Default: local architecture",
         "-BuildConfiguration      : Build configuration to use - Default: RelWithDebInfo",
         "-CombinedArchs           : Create combined packages and installer (64-bit and 32-bit) - Default: off"
         "-Package                 : Prepare folder structure for installer creation"

--- a/CI/windows/01_install_dependencies.ps1
+++ b/CI/windows/01_install_dependencies.ps1
@@ -2,8 +2,8 @@ Param(
     [Switch]$Help = $(if (Test-Path variable:Help) { $Help }),
     [Switch]$Quiet = $(if (Test-Path variable:Quiet) { $Quiet }),
     [Switch]$Verbose = $(if (Test-Path variable:Verbose) { $Verbose }),
-    [ValidateSet("32-bit", "64-bit")]
-    [String]$BuildArch = $(if (Test-Path variable:BuildArch) { "${BuildArch}" } else { (Get-CimInstance CIM_OperatingSystem).OSArchitecture })
+    [ValidateSet('x86', 'x64')]
+    [String]$BuildArch = $(if (Test-Path variable:BuildArch) { "${BuildArch}" } else { ('x86', 'x64')[[System.Environment]::Is64BitOperatingSystem] })
 )
 
 ##############################################################################
@@ -26,7 +26,7 @@ Function Install-obs-deps {
     Write-Status "Setup for pre-built Windows OBS dependencies v${Version}"
     Ensure-Directory $DepsBuildDir
 
-    $ArchSuffix = "$(if ($BuildArch -eq "64-bit") { "x64" } else { "x86" })"
+    $ArchSuffix = $BuildArch
 
     if (!(Test-Path "${DepsBuildDir}/windows-deps-${Version}-${ArchSuffix}")) {
 
@@ -52,7 +52,7 @@ function Install-qt-deps {
     Write-Status "Setup for pre-built dependency Qt v${Version}"
     Ensure-Directory $DepsBuildDir
 
-    $ArchSuffix = "$(if ($BuildArch -eq "64-bit") { "x64" } else { "x86" })"
+    $ArchSuffix = $BuildArch
 
     if (!(Test-Path "${DepsBuildDir}/windows-deps-${Version}-${ArchSuffix}/mkspecs")) {
 
@@ -101,7 +101,7 @@ function Install-cef {
     Write-Status "Setup for dependency CEF v${Version} - ${BuildArch}"
 
     Ensure-Directory $DepsBuildDir
-    $ArchSuffix = "$(if ($BuildArch -eq "64-bit") { "x64" } else { "x86" })"
+    $ArchSuffix = $BuildArch
 
     if (!((Test-Path "${DepsBuildDir}/cef_binary_${Version}_windows_${ArchSuffix}") -and (Test-Path "${DepsBuildDir}/cef_binary_${Version}_windows_${ArchSuffix}/build/libcef_dll_wrapper/Release/libcef_dll_wrapper.lib"))) {
         Write-Step "Download..."
@@ -160,7 +160,7 @@ function Print-Usage {
         "-Quiet                   : Suppress most build process output",
         "-Verbose                 : Enable more verbose build process output",
         "-Choco                   : Enable automatic dependency installation via Chocolatey - Default: off"
-        "-BuildArch               : Build architecture to use (32-bit or 64-bit) - Default: local architecture"
+        "-BuildArch               : Build architecture to use (x86 or x64) - Default: local architecture"
     )
 
     $Lines | Write-Host


### PR DESCRIPTION
### Description
Changes architecture identifiers for Windows build scripts to `x86` and `x64` to avoid possible localisation issues.

### Motivation and Context
Current build scripts rely on comparing a architecture string provided
by the OS which will be localised in certain languages.

This change uses a boolean 64-bit flag to use script-defined identifiers
to avoid this issue.

Fixes #6229.

### How Has This Been Tested?
* Built OBS via the scripts from PowerShell using `x86` and `x64` identifiers.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
