### PR TITLE
CI: Change build file names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,7 +193,7 @@ jobs:
         if: ${{ success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1') }}
         uses: actions/upload-artifact@v3
         with:
-          name: 'obs-macos-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}'
+          name: 'obs-studio-macos-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}'
           path: '${{ github.workspace }}/obs-studio/build/${{ env.FILE_NAME }}'
 
   linux_build:
@@ -275,7 +275,7 @@ jobs:
         if: ${{ success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1') }}
         uses: actions/upload-artifact@v3
         with:
-          name: 'obs-linux-${{ matrix.ubuntu }}-deb-${{ steps.setup.outputs.commitHash }}'
+          name: 'obs-studio-${{ matrix.ubuntu }}-${{ steps.setup.outputs.commitHash }}'
           path: '${{ github.workspace }}/obs-studio/build/${{ env.FILE_NAME }}'
 
   windows_build:
@@ -348,14 +348,14 @@ jobs:
         if: ${{ success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1') }}
         run: |
           CI/windows/03_package_obs.ps1 -BuildArch ${{ matrix.arch }} -Package
-          $ArtifactName = Get-ChildItem -filter "OBS-Studio-*-Win-${{ matrix.arch }}.zip" -File
+          $ArtifactName = Get-ChildItem -filter "obs-studio-*-windows-${{ matrix.arch }}.zip" -File
           Write-Output "FILE_NAME=${ArtifactName}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: 'Upload build artifact'
         if: ${{ success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1') }}
         uses: actions/upload-artifact@v3
         with:
-          name: 'obs-win-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}'
+          name: 'obs-studio-windows-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}'
           path: '${{ env.FILE_NAME }}'
 
   linux_package:
@@ -426,12 +426,12 @@ jobs:
       - name: 'Download 64-bit artifact'
         uses: actions/download-artifact@v3
         with:
-          name: 'obs-win-x64-${{ steps.setup.outputs.commitHash }}'
+          name: 'obs-studio-windows-x64-${{ steps.setup.outputs.commitHash }}'
 
       - name: 'Download 32-bit artifact'
         uses: actions/download-artifact@v3
         with:
-          name: 'obs-win-x86-${{ steps.setup.outputs.commitHash }}'
+          name: 'obs-studio-windows-x86-${{ steps.setup.outputs.commitHash }}'
 
       - name: 'Unpack Windows build artifacts'
         id: unpack
@@ -440,18 +440,18 @@ jobs:
             $null = New-Item -ItemType Directory -Force -Path install_temp
           }
 
-          Expand-Archive -Path "$(Get-ChildItem -filter "OBS-Studio-*-Win-x86.zip" -File)" -DestinationPath install_temp
-          Expand-Archive -Path "$(Get-ChildItem -filter "OBS-Studio-*-Win-x64.zip" -File)" -Force -DestinationPath install_temp
+          Expand-Archive -Path "$(Get-ChildItem -filter "obs-studio-windows-*-x86.zip" -File)" -DestinationPath install_temp
+          Expand-Archive -Path "$(Get-ChildItem -filter "obs-studio-windows-*-x64.zip" -File)" -Force -DestinationPath install_temp
 
           CI/windows/03_package_obs.ps1 -CombinedArchs -Package
 
-          $ArtifactName = (Get-ChildItem -filter "OBS-Studio-*-Win-x86+x64.zip" -File).Name
+          $ArtifactName = (Get-ChildItem -filter "obs-studio-*-windows-x86+x64.zip" -File).Name
           Write-Output "::set-output name=filename::${ArtifactName}"
 
       - name: 'Upload build artifact'
         uses: actions/upload-artifact@v3
         with:
-          name: 'obs-windows'
+          name: 'obs-studio-windows-installer'
           path: '${{ steps.unpack.outputs.filename }}'
 
   macos_release:
@@ -482,7 +482,7 @@ jobs:
         if: env.HAVE_CODESIGN_IDENTITY == 'true'
         uses: actions/download-artifact@v3
         with:
-          name: 'obs-macos-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}'
+          name: 'obs-studio-macos-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}'
 
       - name: 'Install Apple Developer Certificate'
         if: env.HAVE_CODESIGN_IDENTITY == 'true'
@@ -507,5 +507,5 @@ jobs:
         if: env.HAVE_CODESIGN_IDENTITY == 'true'
         uses: actions/upload-artifact@v3
         with:
-          name: 'obs-macos-${{ matrix.arch }}-notarized'
+          name: 'obs-studio-macos-${{ matrix.arch }}-notarized'
           path: '${{ github.workspace }}/${{ env.FILE_NAME }}'

--- a/CI/freebsd/03_package_obs.sh
+++ b/CI/freebsd/03_package_obs.sh
@@ -46,7 +46,7 @@ package-obs-standalone() {
     GIT_HASH=$(git rev-parse --short=9 HEAD)
     GIT_TAG=$(git describe --tags --abbrev=0)
 
-    FILE_NAME="obs-studio-${GIT_TAG}-${GIT_HASH}-FreeBSD"
+    FILE_NAME="obs-studio-${GIT_TAG}-${GIT_HASH}-freebsd"
     package_obs
 }
 

--- a/CI/linux/03_package_obs.sh
+++ b/CI/linux/03_package_obs.sh
@@ -43,6 +43,7 @@ package-obs-standalone() {
     GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
     GIT_HASH=$(git rev-parse --short=9 HEAD)
     GIT_TAG=$(git describe --tags --abbrev=0)
+    UBUNTU_VERSION=$(lsb_release -sr)
 
     if [ "${BUILD_FOR_DISTRIBUTION}" = "true" ]; then
         VERSION_STRING="${GIT_TAG}"
@@ -50,7 +51,7 @@ package-obs-standalone() {
         VERSION_STRING="${GIT_TAG}-${GIT_HASH}"
     fi
 
-    FILE_NAME="obs-studio-${VERSION_STRING}-Linux.deb"
+    FILE_NAME="obs-studio-${VERSION_STRING}-ubuntu-${UBUNTU_VERSION}.deb"
     package_obs
 }
 

--- a/CI/macos/03_package_obs.sh
+++ b/CI/macos/03_package_obs.sh
@@ -114,11 +114,11 @@ package-obs-standalone() {
 
     if [ -z "${NOTARIZE_IMAGE}" -a -z "${NOTARIZE_BUNDLE}" ]; then
         if [ "${ARCH}" = "arm64" ]; then
-            FILE_NAME="obs-studio-${VERSION_STRING}-macOS-Apple.dmg"
+            FILE_NAME="obs-studio-${VERSION_STRING}-macos-arm64.dmg"
         elif [ "${ARCH}" = "universal" ]; then
-            FILE_NAME="obs-studio-${VERSION_STRING}-macOS.dmg"
+            FILE_NAME="obs-studio-${VERSION_STRING}-macos.dmg"
         else
-            FILE_NAME="obs-studio-${VERSION_STRING}-macOS-Intel.dmg"
+            FILE_NAME="obs-studio-${VERSION_STRING}-macos-x86_64.dmg"
         fi
 
         package_obs

--- a/CI/windows/03_package_obs.ps1
+++ b/CI/windows/03_package_obs.ps1
@@ -57,7 +57,7 @@ function Package-OBS {
         $CompressVars = @{
             Path = "${CheckoutDir}/build/install/*"
             CompressionLevel = "Optimal"
-            DestinationPath = "${FileName}-Win-x86+x64.zip"
+            DestinationPath = "${FileName}-x86+x64.zip"
         }
 
         Write-Step "Creating zip archive..."
@@ -73,7 +73,7 @@ function Package-OBS {
         $CompressVars = @{
             Path = "${CheckoutDir}/build64/install/bin", "${CheckoutDir}/build64/install/data", "${CheckoutDir}/build64/install/obs-plugins"
             CompressionLevel = "Optimal"
-            DestinationPath = "${FileName}-Win-x64.zip"
+            DestinationPath = "${FileName}-x64.zip"
         }
 
         Write-Step "Creating zip archive..."
@@ -89,7 +89,7 @@ function Package-OBS {
         $CompressVars = @{
             Path = "${CheckoutDir}/build32/install/bin", "${CheckoutDir}/build32/install/data", "${CheckoutDir}/build32/install/obs-plugins"
             CompressionLevel = "Optimal"
-            DestinationPath = "${FileName}-Win-x86.zip"
+            DestinationPath = "${FileName}-x86.zip"
         }
 
         Write-Step "Creating zip archive..."
@@ -123,7 +123,7 @@ function Package-OBS-Standalone {
         $VersionString = "${GitTag}-${GitHash}"
     }
 
-    $FileName = "${ProductName}-${VersionString}"
+    $FileName = "obs-studio-${VersionString}-windows"
 
     Package-OBS
 }


### PR DESCRIPTION
### Description
This makes the build names with each OS consistent with each other.

### Motivation and Context
Makes it easier to work with them in different workflows.

### How Has This Been Tested?
Needs SEEKING_TESTERS tag to confirm.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
