### PR TITLE
obs-filters: Fix scale undistort, attempt two

### DIFF
--- a/plugins/obs-filters/scale-filter.c
+++ b/plugins/obs-filters/scale-filter.c
@@ -208,7 +208,7 @@ static void scale_filter_tick(void *data, float seconds)
 	vec2_set(&filter->dimension, (float)cx, (float)cy);
 	vec2_set(&filter->dimension_i, 1.0f / (float)cx, 1.0f / (float)cy);
 
-	filter->undistort = filter->can_undistort;
+	filter->undistort = false;
 	filter->upscale = false;
 
 	/* ------------------------- */
@@ -217,7 +217,6 @@ static void scale_filter_tick(void *data, float seconds)
 
 	if (lower_than_2x && filter->sampling != OBS_SCALE_POINT) {
 		type = OBS_EFFECT_BILINEAR_LOWRES;
-		filter->undistort = false;
 	} else {
 		switch (filter->sampling) {
 		default:
@@ -227,9 +226,11 @@ static void scale_filter_tick(void *data, float seconds)
 			break;
 		case OBS_SCALE_BICUBIC:
 			type = OBS_EFFECT_BICUBIC;
+			filter->undistort = filter->can_undistort;
 			break;
 		case OBS_SCALE_LANCZOS:
 			type = OBS_EFFECT_LANCZOS;
+			filter->undistort = filter->can_undistort;
 			break;
 		case OBS_SCALE_AREA:
 			type = OBS_EFFECT_AREA;


### PR DESCRIPTION
### Description
Undistort checkbox should be ignored if bilinear lowres effect is used.

Fix regression caused by #6206.

### Motivation and Context
Clear rectangle without fix; proper draw with fix.

Undistort checkbox still works with bicubic and lanczos.

### How Has This Been Tested?
Checked bicubic, lanczos with and without undistort. Also checked point/bilinear/area this time.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.