### PR TITLE
cmake: Fix usage of relative paths for CEF finder

### DIFF
--- a/cmake/Modules/FindCEF.cmake
+++ b/cmake/Modules/FindCEF.cmake
@@ -1,7 +1,9 @@
 include(FindPackageHandleStandardArgs)
 
-set_property(CACHE CEF_ROOT_DIR PROPERTY HELPSTRING
-                                         "Path to CEF distributed build")
+set(CEF_ROOT_DIR
+    ""
+    CACHE PATH "Path to CEF distributed build")
+
 if(NOT DEFINED CEF_ROOT_DIR OR CEF_ROOT_DIR STREQUAL "")
   message(
     FATAL_ERROR
@@ -10,58 +12,58 @@ if(NOT DEFINED CEF_ROOT_DIR OR CEF_ROOT_DIR STREQUAL "")
   )
 endif()
 
-find_path(CEF_INCLUDE_DIR "include/cef_version.h" HINTS "${CEF_ROOT_DIR}")
+find_path(CEF_INCLUDE_DIR "include/cef_version.h" HINTS ${CEF_ROOT_DIR})
 
 if(OS_MACOS)
   find_library(
     CEF_LIBRARY
     NAMES cef libcef cef.lib libcef.o "Chromium Embedded Framework"
     NO_DEFAULT_PATH
-    PATHS "${CEF_ROOT_DIR}" "${CEF_ROOT_DIR}/Release")
+    PATHS ${CEF_ROOT_DIR} ${CEF_ROOT_DIR}/Release)
 
   find_library(
     CEFWRAPPER_LIBRARY
     NAMES cef_dll_wrapper libcef_dll_wrapper
     NO_DEFAULT_PATH
-    PATHS "${CEF_ROOT_DIR}/build/libcef_dll/Release"
-          "${CEF_ROOT_DIR}/build/libcef_dll_wrapper/Release"
-          "${CEF_ROOT_DIR}/build/libcef_dll"
-          "${CEF_ROOT_DIR}/build/libcef_dll_wrapper")
+    PATHS ${CEF_ROOT_DIR}/build/libcef_dll/Release
+          ${CEF_ROOT_DIR}/build/libcef_dll_wrapper/Release
+          ${CEF_ROOT_DIR}/build/libcef_dll
+          ${CEF_ROOT_DIR}/build/libcef_dll_wrapper)
 
 elseif(OS_POSIX)
   find_library(
     CEF_LIBRARY
     NAMES libcef.so "Chromium Embedded Framework"
     NO_DEFAULT_PATH
-    PATHS "${CEF_ROOT_DIR}" "${CEF_ROOT_DIR}/Release")
+    PATHS ${CEF_ROOT_DIR} ${CEF_ROOT_DIR}/Release)
 
   find_library(
     CEFWRAPPER_LIBRARY
     NAMES libcef_dll_wrapper.a
     NO_DEFAULT_PATH
-    PATHS "${CEF_ROOT_DIR}/build/libcef_dll_wrapper"
-          "${CEF_ROOT_DIR}/libcef_dll_wrapper")
+    PATHS ${CEF_ROOT_DIR}/build/libcef_dll_wrapper
+          ${CEF_ROOT_DIR}/libcef_dll_wrapper)
 
 else()
   find_library(
     CEF_LIBRARY
     NAMES cef libcef cef.lib libcef.o "Chromium Embedded Framework"
-    PATHS "${CEF_ROOT_DIR}" "${CEF_ROOT_DIR}/Release")
+    PATHS ${CEF_ROOT_DIR} ${CEF_ROOT_DIR}/Release)
 
   find_library(
     CEFWRAPPER_LIBRARY
     NAMES cef_dll_wrapper libcef_dll_wrapper
-    PATHS "${CEF_ROOT_DIR}/build/libcef_dll/Release"
-          "${CEF_ROOT_DIR}/build/libcef_dll_wrapper/Release"
-          "${CEF_ROOT_DIR}/build/libcef_dll"
-          "${CEF_ROOT_DIR}/build/libcef_dll_wrapper")
+    PATHS ${CEF_ROOT_DIR}/build/libcef_dll/Release
+          ${CEF_ROOT_DIR}/build/libcef_dll_wrapper/Release
+          ${CEF_ROOT_DIR}/build/libcef_dll
+          ${CEF_ROOT_DIR}/build/libcef_dll_wrapper)
 
   if(OS_WINDOWS)
     find_library(
       CEFWRAPPER_LIBRARY_DEBUG
       NAMES cef_dll_wrapper libcef_dll_wrapper
-      PATHS "${CEF_ROOT_DIR}/build/libcef_dll/Debug"
-            "${CEF_ROOT_DIR}/build/libcef_dll_wrapper/Debug")
+      PATHS ${CEF_ROOT_DIR}/build/libcef_dll/Debug
+            ${CEF_ROOT_DIR}/build/libcef_dll_wrapper/Debug)
   endif()
 endif()
 


### PR DESCRIPTION
### Description
Re-enables usage of relative paths for `CEF_ROOT_DIR`.

### Motivation and Context
On some build systems (and in some usage scenarios) it is necessary to pass a relative path as `CEF_ROOT_DIR`. During testing it occurred that relative paths seem to be supported only for cache variables that have been explicitly marked as `PATH` variables.

### How Has This Been Tested?
Tested locally with relative paths used for `CEF_ROOT_DIR`.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
