### PR TITLE
aja: Use correct colorspace/range for SD or HD/UHD/4K

### DIFF
--- a/plugins/aja/aja-source.cpp
+++ b/plugins/aja/aja-source.cpp
@@ -157,7 +157,10 @@ void AJASource::GenerateTestPattern(NTV2VideoFormat vf, NTV2PixelFormat pf,
 	obsFrame.format = aja::AJAPixelFormatToOBSVideoFormat(pix_fmt);
 	obsFrame.data[0] = mTestPattern.data();
 	obsFrame.linesize[0] = fd.GetBytesPerRow();
-	video_format_get_parameters(VIDEO_CS_DEFAULT, VIDEO_RANGE_FULL,
+	video_colorspace colorspace = VIDEO_CS_709;
+	if (NTV2_IS_SD_VIDEO_FORMAT(vid_fmt))
+		colorspace = VIDEO_CS_601;
+	video_format_get_parameters(colorspace, VIDEO_RANGE_PARTIAL,
 				    obsFrame.color_matrix,
 				    obsFrame.color_range_min,
 				    obsFrame.color_range_max);
@@ -362,8 +365,10 @@ void AJASource::CaptureThread(AJAThread *thread, void *data)
 		obsFrame.data[0] = reinterpret_cast<uint8_t *>(
 			(ULWord *)ajaSource->mVideoBuffer.GetHostPointer());
 		obsFrame.linesize[0] = fd.GetBytesPerRow();
-
-		video_format_get_parameters(VIDEO_CS_DEFAULT, VIDEO_RANGE_FULL,
+		video_colorspace colorspace = VIDEO_CS_709;
+		if (NTV2_IS_SD_VIDEO_FORMAT(actualVideoFormat))
+			colorspace = VIDEO_CS_601;
+		video_format_get_parameters(colorspace, VIDEO_RANGE_PARTIAL,
 					    obsFrame.color_matrix,
 					    obsFrame.color_range_min,
 					    obsFrame.color_range_max);


### PR DESCRIPTION
- Set the colorspace to 601 for SD video and 709 for HD/UHD/4K video
- Set video range to VIDEO_RANGE_PARTIAL

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The AJA source plugin had the colorspace and video range set to `VIDEO_CS_DEFAULT` and `VIDEO_RANGE_FULL` respectively. This change tells OBS to use the colorspace `VIDEO_CS_601` for SD video and `VIDEO_CS_709` for HD/UHD. Additionally, partial range should be used by default with the AJA card at this time. I need to do some digging to find out what our support for full range looks like before enabling a path for that.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The colors looked washed out when capturing video with the AJA source plugin. Setting the correct colorspace matrices for SD (601) and HD/UHD (709) fixes this.

Washed out video (current version)
![image](https://user-images.githubusercontent.com/78836538/160592073-57aa6c53-8b30-42d9-98e0-c58f51d945f0.png)

Fixed colors (with this PR)
![image](https://user-images.githubusercontent.com/78836538/160592261-8efbb170-c7e5-4ac0-bc51-eb59860592b3.png)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with SD, HD and UHD/4K formats captured into an AJA io4K+ and verified that the colors no longer look washed out.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
