### PR TITLE
win-capture: Fix added resources not properly copied to rundir

### DIFF
--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -157,8 +157,7 @@ function(add_target_resource target resource destination)
 
   install(
     FILES ${resource}
-    DESTINATION
-      ${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_DATA_DESTINATION}/${destination}
+    DESTINATION ${OBS_DATA_DESTINATION}/${destination}
     COMPONENT obs_${target}
     EXCLUDE_FROM_ALL)
 endfunction()
@@ -458,20 +457,16 @@ function(_install_obs_datatarget target destination)
 
   install(
     TARGETS ${target}
-    LIBRARY
-      DESTINATION
-        ${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_DATA_DESTINATION}/${destination}
-      COMPONENT obs_${target}
-    RUNTIME
-      DESTINATION
-        ${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_DATA_DESTINATION}/${destination}
-      COMPONENT obs_${target}
-      EXCLUDE_FROM_ALL)
+    LIBRARY DESTINATION ${OBS_DATA_DESTINATION}/${destination}
+            COMPONENT obs_${target}
+    RUNTIME DESTINATION ${OBS_DATA_DESTINATION}/${destination}
+            COMPONENT obs_${target}
+            EXCLUDE_FROM_ALL)
 
   if(OS_WINDOWS)
     if(MSVC)
       add_target_resource(${target} "$<TARGET_PDB_FILE:${target}>"
-                          "${destination}")
+                          "${destination}" OPTIONAL)
     endif()
 
     if(DEFINED ENV{obsInstallerTempDir})
@@ -487,4 +482,14 @@ function(_install_obs_datatarget target destination)
           EXCLUDE_FROM_ALL)
     endif()
   endif()
+
+  add_custom_command(
+    TARGET ${target}
+    POST_BUILD
+    COMMAND
+      "${CMAKE_COMMAND}" --install .. --config $<CONFIG> --prefix
+      ${OBS_OUTPUT_DIR}/$<CONFIG> --component obs_${target} >
+      "$<IF:$<PLATFORM_ID:Windows>,nul,/dev/null>"
+    COMMENT "Installing ${target} to OBS rundir"
+    VERBATIM)
 endfunction()

--- a/cmake/Modules/ObsHelpers_Windows.cmake
+++ b/cmake/Modules/ObsHelpers_Windows.cmake
@@ -152,8 +152,27 @@ function(setup_target_resources target destination)
 endfunction()
 
 # Helper function to set up specific resource files for targets
-function(add_target_resource target resource destination)
-  _add_target_resource(${ARGV})
+function(add_target_resource)
+  set(target ${ARGV0})
+  set(resource ${ARGV1})
+  set(destination ${ARGV2})
+  if(${ARGC} EQUAL 4)
+    set(optional ${ARGV3})
+  else()
+    set(optional "")
+  endif()
+
+  install(
+    FILES ${resource}
+    DESTINATION ${OBS_DATA_DESTINATION}/${destination}
+    COMPONENT ${target}_Runtime
+    ${optional})
+
+  install(
+    FILES ${resource}
+    DESTINATION ${OBS_DATA_DESTINATION}/${destination}
+    COMPONENT obs_${target}
+    ${optional} EXCLUDE_FROM_ALL)
 
   if(DEFINED ENV{OBS_InstallerTempDir})
     install(
@@ -161,7 +180,7 @@ function(add_target_resource target resource destination)
       DESTINATION
         $ENV{OBS_InstallerTempDir}/${OBS_DATA_DESTINATION}/${destination}
       COMPONENT obs_${target}
-      EXCLUDE_FROM_ALL)
+      ${optional} EXCLUDE_FROM_ALL)
   endif()
 endfunction()
 

--- a/plugins/win-capture/get-graphics-offsets/CMakeLists.txt
+++ b/plugins/win-capture/get-graphics-offsets/CMakeLists.txt
@@ -20,9 +20,8 @@ target_link_libraries(get-graphics-offsets d3d9.lib dxgi.lib d3d11.lib)
 if(MSVC)
   target_compile_options(get-graphics-offsets
                          PRIVATE "$<IF:$<CONFIG:Debug>,/MTd,/MT>")
-  add_target_resource(
-    get-graphics-offsets "$<TARGET_PDB_FILE:get-graphics-offsets>"
-    "obs-plugins/win-capture/")
+  add_target_resource(win-capture "$<TARGET_PDB_FILE:get-graphics-offsets>"
+                      "obs-plugins/win-capture/" OPTIONAL)
 endif()
 
 set_target_properties(get-graphics-offsets PROPERTIES FOLDER
@@ -33,5 +32,7 @@ set_target_properties(
              "get-graphics-offsets$<IF:$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>,64,32>"
 )
 
-add_target_resource(get-graphics-offsets "$<TARGET_FILE:get-graphics-offsets>"
+add_target_resource(win-capture "$<TARGET_FILE:get-graphics-offsets>"
                     "obs-plugins/win-capture/")
+
+add_dependencies(win-capture get-graphics-offsets)

--- a/plugins/win-capture/graphics-hook/CMakeLists.txt
+++ b/plugins/win-capture/graphics-hook/CMakeLists.txt
@@ -33,8 +33,8 @@ target_link_libraries(graphics-hook PRIVATE OBS::ipc-util Detours::Detours
 
 if(MSVC)
   target_compile_options(graphics-hook PRIVATE "$<IF:$<CONFIG:Debug>,/MTd,/MT>")
-  add_target_resource(graphics-hook "$<TARGET_PDB_FILE:graphics-hook>"
-                      "obs-plugins/win-capture/")
+  add_target_resource(win-capture "$<TARGET_PDB_FILE:graphics-hook>"
+                      "obs-plugins/win-capture/" OPTIONAL)
 endif()
 
 set_target_properties(
@@ -53,22 +53,14 @@ if(TARGET Vulkan::Vulkan)
   target_compile_definitions(graphics-hook PRIVATE COMPILE_VULKAN_HOOK)
 
   add_target_resource(
-    graphics-hook "${CMAKE_CURRENT_SOURCE_DIR}/obs-vulkan64.json"
+    win-capture "${CMAKE_CURRENT_SOURCE_DIR}/obs-vulkan64.json"
     "obs-plugins/win-capture/")
   add_target_resource(
-    graphics-hook "${CMAKE_CURRENT_SOURCE_DIR}/obs-vulkan32.json"
+    win-capture "${CMAKE_CURRENT_SOURCE_DIR}/obs-vulkan32.json"
     "obs-plugins/win-capture/")
-  add_custom_command(
-    TARGET graphics-hook
-    POST_BUILD
-    COMMAND
-      "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/obs-vulkan64.json"
-      "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/data/obs-plugins/win-capture/obs-vulkan64.json"
-    COMMAND
-      "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/obs-vulkan32.json"
-      "${OBS_OUTPUT_DIR}/$<CONFIGURATION>/data/obs-plugins/win-capture/obs-vulkan32.json"
-    VERBATIM)
 endif()
 
-add_target_resource(graphics-hook "$<TARGET_FILE:graphics-hook>"
+add_target_resource(win-capture "$<TARGET_FILE:graphics-hook>"
                     "obs-plugins/win-capture/")
+
+add_dependencies(win-capture graphics-hook)

--- a/plugins/win-capture/inject-helper/CMakeLists.txt
+++ b/plugins/win-capture/inject-helper/CMakeLists.txt
@@ -10,8 +10,8 @@ target_include_directories(inject-helper PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 if(MSVC)
   target_compile_options(inject-helper PRIVATE "$<IF:$<CONFIG:Debug>,/MTd,/MT>")
-  add_target_resource(inject-helper "$<TARGET_PDB_FILE:inject-helper>"
-                      "obs-plugins/win-capture/")
+  add_target_resource(win-capture "$<TARGET_PDB_FILE:inject-helper>"
+                      "obs-plugins/win-capture/" OPTIONAL)
 endif()
 
 set_target_properties(
@@ -20,5 +20,7 @@ set_target_properties(
              OUTPUT_NAME
              "inject-helper$<IF:$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>,64,32>")
 
-add_target_resource(inject-helper "$<TARGET_FILE:inject-helper>"
+add_target_resource(win-capture "$<TARGET_FILE:inject-helper>"
                     "obs-plugins/win-capture/")
+
+add_dependencies(win-capture inject-helper)


### PR DESCRIPTION
### Description
Fixes `win-capture` support files not being copied into the runtime directory for testing. Also fixes hooks and helpers not being detected and copied into `ProgramData` by OBS in turn.

### Motivation and Context
The `add_target_resource` function uses unnecessary path components when copying files to the rundir, resulting in files added that way not to end up where OBS expects them to.

The generated binaries created by sub-targets also need to be copied as part of `win-capture`'s data files, which was easy to fix as the target exists before CMake switches into the subdirectories.

### How Has This Been Tested?
Build OBS on Windows 11 in Debug config, confirmed `dll` and `pdb` files ended up in support directory of `win-capture` and library was copied to `ProgramData` upon launching OBS.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
