### PR TITLE
libobs, UI: Fix `--verbose` logging for stdout

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -389,20 +389,23 @@ static void do_log(int log_level, const char *msg, va_list args, void *param)
 			OutputDebugStringW(wide_buf.c_str());
 		}
 	}
-#else
-	def_log_handler(log_level, msg, args2, nullptr);
-	va_end(args2);
 #endif
 
 	if (log_level <= LOG_INFO || log_verbose) {
-		if (too_many_repeated_entries(logFile, msg, str))
-			return;
-		LogStringChunk(logFile, str, log_level);
+#ifndef _WIN32
+		def_log_handler(log_level, msg, args2, nullptr);
+#endif
+		if (!too_many_repeated_entries(logFile, msg, str))
+			LogStringChunk(logFile, str, log_level);
 	}
 
 #if defined(_WIN32) && defined(OBS_DEBUGBREAK_ON_ERROR)
 	if (log_level <= LOG_ERROR && IsDebuggerPresent())
 		__debugbreak();
+#endif
+
+#ifndef _WIN32
+	va_end(args2);
 #endif
 }
 

--- a/libobs/util/base.c
+++ b/libobs/util/base.c
@@ -20,12 +20,6 @@
 #include "c99defs.h"
 #include "base.h"
 
-#ifdef _DEBUG
-static int log_output_level = LOG_DEBUG;
-#else
-static int log_output_level = LOG_INFO;
-#endif
-
 static int crashing = 0;
 static void *log_param = NULL;
 static void *crash_param = NULL;
@@ -36,27 +30,25 @@ static void def_log_handler(int log_level, const char *format, va_list args,
 	char out[4096];
 	vsnprintf(out, sizeof(out), format, args);
 
-	if (log_level <= log_output_level) {
-		switch (log_level) {
-		case LOG_DEBUG:
-			fprintf(stdout, "debug: %s\n", out);
-			fflush(stdout);
-			break;
+	switch (log_level) {
+	case LOG_DEBUG:
+		fprintf(stdout, "debug: %s\n", out);
+		fflush(stdout);
+		break;
 
-		case LOG_INFO:
-			fprintf(stdout, "info: %s\n", out);
-			fflush(stdout);
-			break;
+	case LOG_INFO:
+		fprintf(stdout, "info: %s\n", out);
+		fflush(stdout);
+		break;
 
-		case LOG_WARNING:
-			fprintf(stdout, "warning: %s\n", out);
-			fflush(stdout);
-			break;
+	case LOG_WARNING:
+		fprintf(stdout, "warning: %s\n", out);
+		fflush(stdout);
+		break;
 
-		case LOG_ERROR:
-			fprintf(stderr, "error: %s\n", out);
-			fflush(stderr);
-		}
+	case LOG_ERROR:
+		fprintf(stderr, "error: %s\n", out);
+		fflush(stderr);
 	}
 
 	UNUSED_PARAMETER(param);


### PR DESCRIPTION
### Description
This makes the behavior of `--verbose` make sense in all places.

### Motivation and Context
Verbosity of stdout was previously hardcoded to INFO, while log viewer and log files had correct verbosity behavior.

### How Has This Been Tested?
- Ran with `--verbose`, got verbose stdout
- Ran without `--verbose`, got standard stdout

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
