### PR TITLE
libobs-winrt: Add null checks to capture

### DIFF
--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -1,3 +1,5 @@
+#include "winrt-capture.h"
+
 extern "C" {
 HRESULT __stdcall CreateDirect3D11DeviceFromDXGIDevice(
 	::IDXGIDevice *dxgiDevice, ::IInspectable **graphicsDevice);
@@ -336,6 +338,8 @@ static void winrt_capture_device_loss_rebuild(void *device_void, void *data)
 	winrt::Windows::Graphics::Capture::GraphicsCaptureItem item =
 		winrt_capture_create_item(interop_factory.get(),
 					  capture->window, capture->monitor);
+	if (!item)
+		return;
 
 	ID3D11Device *const d3d_device = (ID3D11Device *)device_void;
 	ComPtr<IDXGIDevice> dxgi_device;
@@ -533,7 +537,8 @@ extern "C" EXPORT void winrt_capture_free(struct winrt_capture *capture)
 		capture->closed.revoke();
 
 		try {
-			capture->frame_pool.Close();
+			if (capture->frame_pool)
+				capture->frame_pool.Close();
 		} catch (winrt::hresult_error &err) {
 			blog(LOG_ERROR,
 			     "Direct3D11CaptureFramePool::Close (0x%08X): %ls",
@@ -545,7 +550,8 @@ extern "C" EXPORT void winrt_capture_free(struct winrt_capture *capture)
 		}
 
 		try {
-			capture->session.Close();
+			if (capture->session)
+				capture->session.Close();
 		} catch (winrt::hresult_error &err) {
 			blog(LOG_ERROR,
 			     "GraphicsCaptureSession::Close (0x%08X): %ls",


### PR DESCRIPTION
### Description
Try harder to avoid crashing when capture is in a dead state.

Not sure how normal operation would lead to `active = false` -> `RebuildDevice` without `winrt_capture_free` being called in between, but it wouldn't kill us to add these checks, so just add them. Don't want our users to crash just because I can't force it to happen.

Copied from stream-labs/obs-studio#416. Not taking the active check because it will 100% early exit since we set active to false on device loss entry.

### Motivation and Context
Crashes are bad.

### How Has This Been Tested?
- [x] Force a device rebuild with capture active.
- [x] Force two device rebuilds immediately after window close.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.