### PR TITLE
libobs,UI: Add support for nonlinear SRGB blending

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -480,6 +480,11 @@ ScaleFiltering.Bicubic="Bicubic"
 ScaleFiltering.Lanczos="Lanczos"
 ScaleFiltering.Area="Area"
 
+# blending methods
+BlendingMethod="Blending Method"
+BlendingMethod.Default="Default"
+BlendingMethod.SrgbOff="SRGB Off"
+
 # blending modes
 BlendingMode="Blending Mode"
 BlendingMode.Normal="Normal"

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -94,7 +94,8 @@ struct SourceCopyInfo {
 	bool visible;
 	obs_sceneitem_crop crop;
 	obs_transform_info transform;
-	obs_blending_type blend;
+	obs_blending_method blend_method;
+	obs_blending_type blend_mode;
 };
 
 struct QuickTransition {
@@ -313,6 +314,7 @@ private:
 	QPointer<QMenu> sceneProjectorMenu;
 	QPointer<QMenu> sourceProjector;
 	QPointer<QMenu> scaleFilteringMenu;
+	QPointer<QMenu> blendingMethodMenu;
 	QPointer<QMenu> blendingModeMenu;
 	QPointer<QMenu> colorMenu;
 	QPointer<QWidgetAction> colorWidgetAction;
@@ -715,6 +717,7 @@ private slots:
 
 	void SetScaleFilter();
 
+	void SetBlendingMethod();
 	void SetBlendingMode();
 
 	void IconActivated(QSystemTrayIcon::ActivationReason reason);
@@ -890,6 +893,7 @@ public:
 
 	QMenu *AddDeinterlacingMenu(QMenu *menu, obs_source_t *source);
 	QMenu *AddScaleFilteringMenu(QMenu *menu, obs_sceneitem_t *item);
+	QMenu *AddBlendingMethodMenu(QMenu *menu, obs_sceneitem_t *item);
 	QMenu *AddBlendingModeMenu(QMenu *menu, obs_sceneitem_t *item);
 	QMenu *AddBackgroundColorMenu(QMenu *menu, QWidgetAction *widgetAction,
 				      ColorSelect *select,

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -26,7 +26,8 @@ struct AddSourceData {
 	bool visible;
 	obs_transform_info *transform = nullptr;
 	obs_sceneitem_crop *crop = nullptr;
-	obs_blending_type *blend = nullptr;
+	obs_blending_method *blend_method = nullptr;
+	obs_blending_type *blend_mode = nullptr;
 };
 
 bool OBSBasicSourceSelect::EnumSources(void *data, obs_source_t *source)
@@ -124,8 +125,11 @@ static void AddSource(void *_data, obs_scene_t *scene)
 		obs_sceneitem_set_info(sceneitem, data->transform);
 	if (data->crop != nullptr)
 		obs_sceneitem_set_crop(sceneitem, data->crop);
-	if (data->blend != nullptr)
-		obs_sceneitem_set_blending_mode(sceneitem, *data->blend);
+	if (data->blend_method != nullptr)
+		obs_sceneitem_set_blending_method(sceneitem,
+						  *data->blend_method);
+	if (data->blend_mode != nullptr)
+		obs_sceneitem_set_blending_mode(sceneitem, *data->blend_mode);
 
 	obs_sceneitem_set_visible(sceneitem, data->visible);
 }
@@ -151,7 +155,8 @@ char *get_new_source_name(const char *name, const char *format)
 
 static void AddExisting(OBSSource source, bool visible, bool duplicate,
 			obs_transform_info *transform, obs_sceneitem_crop *crop,
-			obs_blending_type *blend)
+			obs_blending_method *blend_method,
+			obs_blending_type *blend_mode)
 {
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 	OBSScene scene = main->GetCurrentScene();
@@ -175,7 +180,8 @@ static void AddExisting(OBSSource source, bool visible, bool duplicate,
 	data.visible = visible;
 	data.transform = transform;
 	data.crop = crop;
-	data.blend = blend;
+	data.blend_method = blend_method;
+	data.blend_mode = blend_mode;
 
 	obs_enter_graphics();
 	obs_scene_atomic_update(scene, AddSource, &data);
@@ -184,12 +190,13 @@ static void AddExisting(OBSSource source, bool visible, bool duplicate,
 
 static void AddExisting(const char *name, bool visible, bool duplicate,
 			obs_transform_info *transform, obs_sceneitem_crop *crop,
-			obs_blending_type *blend)
+			obs_blending_method *blend_method,
+			obs_blending_type *blend_mode)
 {
 	OBSSourceAutoRelease source = obs_get_source_by_name(name);
 	if (source) {
 		AddExisting(source.Get(), visible, duplicate, transform, crop,
-			    blend);
+			    blend_method, blend_mode);
 	}
 }
 
@@ -249,7 +256,7 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 
 		QString source_name = item->text();
 		AddExisting(QT_TO_UTF8(source_name), visible, false, nullptr,
-			    nullptr, nullptr);
+			    nullptr, nullptr, nullptr);
 
 		OBSBasic *main =
 			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
@@ -287,7 +294,7 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 			main->SetCurrentScene(scene_source, true);
 			obs_source_release(scene_source);
 			AddExisting(QT_TO_UTF8(source_name), visible, false,
-				    nullptr, nullptr, nullptr);
+				    nullptr, nullptr, nullptr, nullptr);
 		};
 
 		undo_s.add_action(QTStr("Undo.Add").arg(source_name), undo,
@@ -438,5 +445,5 @@ void OBSBasicSourceSelect::SourcePaste(SourceCopyInfo &info, bool dup)
 		return;
 
 	AddExisting(source, info.visible, dup, &info.transform, &info.crop,
-		    &info.blend);
+		    &info.blend_method, &info.blend_mode);
 }

--- a/docs/sphinx/reference-scenes.rst
+++ b/docs/sphinx/reference-scenes.rst
@@ -507,6 +507,17 @@ Scene Item Functions
 
 ---------------------
 
+.. function:: void obs_sceneitem_set_blending_method(obs_sceneitem_t *item, enum obs_blending_method method)
+              enum obs_blending_method obs_sceneitem_get_blending_method(obs_sceneitem_t *item)
+
+   Sets/gets the blending method used for the scene item.
+
+   :param method: | Can be one of the following values:
+                  | OBS_BLEND_METHOD_DEFAULT
+                  | OBS_BLEND_METHOD_SRGB_OFF
+
+---------------------
+
 .. function:: void obs_sceneitem_set_blending_mode(obs_sceneitem_t *item, enum obs_blending_type type)
               enum obs_blending_type obs_sceneitem_get_blending_mode(obs_sceneitem_t *item)
 

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -540,6 +540,7 @@ static inline bool item_is_scene(const struct obs_scene_item *item)
 static inline bool item_texture_enabled(const struct obs_scene_item *item)
 {
 	return crop_enabled(&item->crop) || scale_filter_enabled(item) ||
+	       (item->blend_method == OBS_BLEND_METHOD_SRGB_OFF) ||
 	       !default_blending_enabled(item) ||
 	       (item_is_scene(item) && !item->is_group);
 }
@@ -799,7 +800,10 @@ static inline void render_item(struct obs_scene_item *item)
 		}
 	}
 
-	const bool previous = gs_set_linear_srgb(true);
+	const bool linear_srgb =
+		!item->item_render ||
+		(item->blend_method != OBS_BLEND_METHOD_SRGB_OFF);
+	const bool previous = gs_set_linear_srgb(linear_srgb);
 	gs_matrix_push();
 	gs_matrix_mul(&item->draw_transform);
 	if (item->item_render) {
@@ -959,6 +963,7 @@ static void scene_load_item(struct obs_scene *scene, obs_data_t *item_data)
 	const char *name = obs_data_get_string(item_data, "name");
 	obs_source_t *source;
 	const char *scale_filter_str;
+	const char *blend_method_str;
 	const char *blend_str;
 	struct obs_scene_item *item;
 	bool visible;
@@ -1039,6 +1044,14 @@ static void scene_load_item(struct obs_scene *scene, obs_data_t *item_data)
 			item->scale_filter = OBS_SCALE_AREA;
 	}
 
+	blend_method_str = obs_data_get_string(item_data, "blend_method");
+	item->blend_method = OBS_BLEND_METHOD_DEFAULT;
+
+	if (blend_method_str) {
+		if (astrcmpi(blend_method_str, "srgb_off") == 0)
+			item->blend_method = OBS_BLEND_METHOD_SRGB_OFF;
+	}
+
 	blend_str = obs_data_get_string(item_data, "blend_type");
 	item->blend_type = OBS_BLEND_NORMAL;
 
@@ -1116,6 +1129,7 @@ static void scene_save_item(obs_data_array_t *array,
 	obs_data_t *item_data = obs_data_create();
 	const char *name = obs_source_get_name(item->source);
 	const char *scale_filter;
+	const char *blend_method;
 	const char *blend_type;
 	struct vec2 pos = item->pos;
 	struct vec2 scale = item->scale;
@@ -1174,6 +1188,13 @@ static void scene_save_item(obs_data_array_t *array,
 		scale_filter = "disable";
 
 	obs_data_set_string(item_data, "scale_filter", scale_filter);
+
+	if (item->blend_method == OBS_BLEND_METHOD_SRGB_OFF)
+		blend_method = "srgb_off";
+	else
+		blend_method = "default";
+
+	obs_data_set_string(item_data, "blend_method", blend_method);
 
 	if (item->blend_type == OBS_BLEND_NORMAL)
 		blend_type = "normal";
@@ -2976,6 +2997,23 @@ enum obs_scale_type obs_sceneitem_get_scale_filter(obs_sceneitem_t *item)
 	return obs_ptr_valid(item, "obs_sceneitem_get_scale_filter")
 		       ? item->scale_filter
 		       : OBS_SCALE_DISABLE;
+}
+
+void obs_sceneitem_set_blending_method(obs_sceneitem_t *item,
+				       enum obs_blending_method method)
+{
+	if (!obs_ptr_valid(item, "obs_sceneitem_set_blending_method"))
+		return;
+
+	item->blend_method = method;
+}
+
+enum obs_blending_method
+obs_sceneitem_get_blending_method(obs_sceneitem_t *item)
+{
+	return obs_ptr_valid(item, "obs_sceneitem_get_blending_method")
+		       ? item->blend_method
+		       : OBS_BLEND_NORMAL;
 }
 
 void obs_sceneitem_set_blending_mode(obs_sceneitem_t *item,

--- a/libobs/obs-scene.h
+++ b/libobs/obs-scene.h
@@ -63,6 +63,7 @@ struct obs_scene_item {
 	struct vec2 output_scale;
 	enum obs_scale_type scale_filter;
 
+	enum obs_blending_method blend_method;
 	enum obs_blending_type blend_type;
 
 	struct matrix4 box_transform;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -124,6 +124,11 @@ enum obs_scale_type {
 	OBS_SCALE_AREA,
 };
 
+enum obs_blending_method {
+	OBS_BLEND_METHOD_DEFAULT,
+	OBS_BLEND_METHOD_SRGB_OFF,
+};
+
 enum obs_blending_type {
 	OBS_BLEND_NORMAL,
 	OBS_BLEND_ADDITIVE,
@@ -1798,6 +1803,11 @@ EXPORT void obs_sceneitem_set_scale_filter(obs_sceneitem_t *item,
 					   enum obs_scale_type filter);
 EXPORT enum obs_scale_type
 obs_sceneitem_get_scale_filter(obs_sceneitem_t *item);
+
+EXPORT void obs_sceneitem_set_blending_method(obs_sceneitem_t *item,
+					      enum obs_blending_method method);
+EXPORT enum obs_blending_method
+obs_sceneitem_get_blending_method(obs_sceneitem_t *item);
 
 EXPORT void obs_sceneitem_set_blending_mode(obs_sceneitem_t *item,
 					    enum obs_blending_type type);


### PR DESCRIPTION
### Description
Nonlinear blending is useful to emulate blending behavior of other applications.

### Motivation and Context
This is mainly for the browser source, since the web will probably never change to use linear color blending.

### How Has This Been Tested?
- Verified in RenderDoc that alpha blending for browser source behaves as expected when "SRGB Off" method is used, and linearly when "Default" method is used.
- Setting is preserved when source is copy/pasted.
- Setting is preserved across OBS restarts.
- Localized strings appear correctly in English.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.