### PR TITLE
obs-ffmpeg, win-dshow, deps/media-playback: Use recommended API for AVCodecContext

### DIFF
--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -113,7 +113,8 @@ static int mp_open_codec(struct mp_decode *d, bool hw)
 	return ret;
 
 fail:
-	avcodec_close(c);
+	avcodec_free_context(&c);
+
 #if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 40, 101)
 	av_free(d->decoder);
 #endif
@@ -220,13 +221,10 @@ void mp_decode_free(struct mp_decode *d)
 		av_frame_unref(d->hw_frame);
 		av_free(d->hw_frame);
 	}
-	if (d->decoder) {
-#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 40, 101)
+
+	if (d->decoder)
 		avcodec_free_context(&d->decoder);
-#else
-		avcodec_close(d->decoder);
-#endif
-	}
+
 	if (d->sw_frame) {
 		av_frame_unref(d->sw_frame);
 		av_free(d->sw_frame);

--- a/libobs/graphics/graphics-ffmpeg.c
+++ b/libobs/graphics/graphics-ffmpeg.c
@@ -72,11 +72,7 @@ static bool ffmpeg_image_open_decoder_context(struct ffmpeg_image *info)
 
 static void ffmpeg_image_free(struct ffmpeg_image *info)
 {
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
 	avcodec_free_context(&info->decoder_ctx);
-#else
-	avcodec_close(info->decoder_ctx);
-#endif
 	avformat_close_input(&info->fmt_ctx);
 }
 

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -150,6 +150,7 @@ static void free_avformat(struct ffmpeg_mux *ffm)
 	if (ffm->audio_infos) {
 		for (int i = 0; i < ffm->num_audio_streams; ++i)
 			avcodec_free_context(&ffm->audio_infos[i].ctx);
+
 		free(ffm->audio_infos);
 	}
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
@@ -124,8 +124,10 @@ static void enc_destroy(void *data)
 
 	if (enc->samples[0])
 		av_freep(&enc->samples[0]);
+
 	if (enc->context)
-		avcodec_close(enc->context);
+		avcodec_free_context(&enc->context);
+
 	if (enc->aframe)
 		av_frame_free(&enc->aframe);
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -349,7 +349,7 @@ static void nvenc_destroy(void *data)
 		flush_remaining_packets(enc);
 
 	av_packet_free(&enc->packet);
-	avcodec_close(enc->context);
+	avcodec_free_context(&enc->context);
 	av_frame_unref(enc->vframe);
 	av_frame_free(&enc->vframe);
 	da_free(enc->buffer);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -457,11 +457,7 @@ static inline bool open_output_file(struct ffmpeg_data *data)
 
 static void close_video(struct ffmpeg_data *data)
 {
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
 	avcodec_free_context(&data->video_ctx);
-#else
-	avcodec_close(data->video->codec);
-#endif
 	av_frame_unref(data->vframe);
 
 	// This format for some reason derefs video frame
@@ -481,13 +477,8 @@ static void close_audio(struct ffmpeg_data *data)
 
 		if (data->samples[idx][0])
 			av_freep(&data->samples[idx][0]);
-		if (data->audio_infos[idx].ctx) {
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
+		if (data->audio_infos[idx].ctx)
 			avcodec_free_context(&data->audio_infos[idx].ctx);
-#else
-			avcodec_close(data->audio_infos[idx].stream->codec);
-#endif
-		}
 		if (data->aframe[idx])
 			av_frame_free(&data->aframe[idx]);
 	}

--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -329,7 +329,7 @@ static void vaapi_destroy(void *data)
 		flush_remaining_packets(enc);
 
 	av_packet_free(&enc->packet);
-	avcodec_close(enc->context);
+	avcodec_free_context(&enc->context);
 	av_frame_unref(enc->vframe);
 	av_frame_free(&enc->vframe);
 	av_buffer_unref(&enc->vaframes_ref);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Use `avcodec_free_context()` to replace `avcodec_close`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
```
 * @note Do not use this function. Use avcodec_free_context() to destroy a
 * codec context (either open or closed). Opening and closing a codec context
 * multiple times is not supported anymore -- use multiple codec contexts
 * instead.
 */
int avcodec_close(AVCodecContext *avctx);
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
test using ffmpeg-nvenc on Windows

### Types of changes
Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
