### PR TITLE
linux-pipewire: Provide the parent_window identifier to the portal

### DIFF
--- a/plugins/linux-pipewire/CMakeLists.txt
+++ b/plugins/linux-pipewire/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 find_package(PipeWire REQUIRED)
 find_package(Gio QUIET)
 find_package(Libdrm QUIET) # we require libdrm/drm_fourcc.h to build
+find_qt(VERSION ${QT_VERSION} COMPONENTS Widgets)
 
 if(NOT TARGET PipeWire::PipeWire)
   obs_status(
@@ -33,6 +34,7 @@ add_library(OBS::pipewire ALIAS linux-pipewire)
 target_sources(
   linux-pipewire
   PRIVATE linux-pipewire.c
+          parent_window.cpp
           pipewire-common.c
           pipewire-common.h
           pipewire.c
@@ -42,9 +44,42 @@ target_sources(
           portal.c
           portal.h)
 
+if(ENABLE_WAYLAND)
+  find_program(WaylandScanner wayland-scanner)
+  if(NOT WaylandScanner)
+    obs_status(
+      FATAL_ERROR
+      "wayland-scanner not found! Please install wayland-scanner or set ENABLE_PIPEWIRE=OFF or set ENABLE_WAYLAND=OFF."
+    )
+  endif()
+  add_custom_command(
+    OUTPUT xdg-foreign-unstable-v2-client-protocol.h
+    COMMAND
+      ${WaylandScanner} --strict --include-core-only client-header
+      ${CMAKE_CURRENT_SOURCE_DIR}/xdg-foreign-unstable-v2.xml
+      xdg-foreign-unstable-v2-client-protocol.h)
+  add_custom_command(
+    OUTPUT xdg-foreign-unstable-v2-client-protocol.c
+    COMMAND
+      ${WaylandScanner} --strict --include-core-only private-code
+      ${CMAKE_CURRENT_SOURCE_DIR}/xdg-foreign-unstable-v2.xml
+      xdg-foreign-unstable-v2-client-protocol.c)
+  target_include_directories(linux-pipewire PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+  target_sources(
+    linux-pipewire PRIVATE xdg-foreign-unstable-v2-client-protocol.h
+                           xdg-foreign-unstable-v2-client-protocol.c)
+  target_link_libraries(linux-pipewire PRIVATE Qt::GuiPrivate)
+endif()
+
 target_link_libraries(
-  linux-pipewire PRIVATE OBS::libobs OBS::obsglad PipeWire::PipeWire GIO::GIO
-                         Libdrm::Libdrm)
+  linux-pipewire
+  PRIVATE OBS::libobs
+          OBS::obsglad
+          PipeWire::PipeWire
+          GIO::GIO
+          Libdrm::Libdrm
+          OBS::frontend-api
+          Qt::Widgets)
 
 set_target_properties(linux-pipewire PROPERTIES FOLDER "plugins")
 

--- a/plugins/linux-pipewire/parent_window.cpp
+++ b/plugins/linux-pipewire/parent_window.cpp
@@ -1,0 +1,132 @@
+/*
+	SPDX-License-Identifier: LGPL-3.0-or-later
+	SPDX-FileCopyrightText: 2022 David Redondo <kde@david-redondo.de>
+*/
+
+#include "parent_window.h"
+
+#include <obs-config.h>
+#include <obs-nix-platform.h>
+#include <obs-frontend-api.h>
+
+#include <QMainWindow>
+
+#include <string>
+
+#ifdef ENABLE_WAYLAND
+#include <QGuiApplication>
+#include <QtGui/qpa/qplatformnativeinterface.h>
+#include <QWindow>
+
+#include <wayland-client.h>
+#include <xdg-foreign-unstable-v2-client-protocol.h>
+#endif
+
+#ifdef ENABLE_WAYLAND
+
+struct exporter_data {
+	zxdg_exporter_v2 *xdg_exporter = nullptr;
+	uint32_t interface_id = 0;
+};
+
+static void registry_global(void *data, wl_registry *registry, uint32_t id,
+			    const char *interface, uint32_t version)
+{
+	if (strcmp(interface, "zxdg_exporter_v2") != 0) {
+		return;
+	}
+
+	auto exporter = static_cast<exporter_data *>(data);
+	void *proxy = wl_registry_bind(registry, id,
+				       &zxdg_exporter_v2_interface,
+				       std::min(version, 1u));
+	exporter->xdg_exporter = static_cast<zxdg_exporter_v2 *>(proxy);
+	exporter->interface_id = id;
+}
+static void registry_global_remove(void *data, wl_registry *registry,
+				   uint32_t id)
+{
+	UNUSED_PARAMETER(registry);
+	using std::exchange;
+	auto exporter = static_cast<exporter_data *>(data);
+	zxdg_exporter_v2_destroy(exchange(exporter->xdg_exporter, nullptr));
+}
+
+constexpr wl_registry_listener registry_listener = {
+	.global = &registry_global,
+	.global_remove = &registry_global_remove,
+};
+
+static void xdg_exported_handle(void *data, zxdg_exported_v2 *xdg_exported,
+				const char *handle)
+{
+	auto result = static_cast<std::string *>(data);
+	*result = handle;
+}
+
+constexpr zxdg_exported_v2_listener xdg_exported_listener = {
+	.handle = &xdg_exported_handle};
+
+std::string export_toplevel(QMainWindow *main_window)
+{
+	auto display =
+		static_cast<wl_display *>(obs_get_nix_platform_display());
+	if (!display) {
+		return "";
+	}
+
+	static exporter_data exporter = [display] {
+		wl_registry *registry = wl_display_get_registry(display);
+		wl_registry_add_listener(registry, &registry_listener,
+					 &exporter);
+		wl_display_roundtrip(display);
+		return exporter;
+	}();
+
+	if (!exporter.xdg_exporter) {
+		return "";
+	}
+
+	QPlatformNativeInterface *native = qGuiApp->platformNativeInterface();
+	QWindow *window = main_window->windowHandle();
+	auto surface = native->nativeResourceForWindow("surface", window);
+	if (!window || !window->isVisible() || !surface) {
+		return "";
+	}
+	auto wayland_surface = static_cast<wl_surface *>(surface);
+	auto exported = zxdg_exporter_v2_export_toplevel(exporter.xdg_exporter,
+							 wayland_surface);
+	std::string handle;
+	zxdg_exported_v2_add_listener(exported, &xdg_exported_listener,
+				      &handle);
+	wl_display_roundtrip(display);
+	return handle;
+}
+#endif
+
+dstr parent_window_string()
+{
+	dstr identifier;
+	dstr_init_copy(&identifier, "");
+	auto window =
+		static_cast<QMainWindow *>(obs_frontend_get_main_window());
+	if (!window) {
+		return identifier;
+	}
+
+	switch (obs_get_nix_platform()) {
+	case OBS_NIX_PLATFORM_X11_EGL:
+	case OBS_NIX_PLATFORM_X11_GLX:
+		dstr_printf(&identifier, "x11:%llx", window->winId());
+		break;
+#ifdef ENABLE_WAYLAND
+	case OBS_NIX_PLATFORM_WAYLAND:
+		const std::string handle = export_toplevel(window);
+		if (!handle.empty()) {
+			dstr_printf(&identifier, "wayland:%s", handle.c_str());
+		}
+		break;
+#endif
+	}
+	return identifier;
+}

--- a/plugins/linux-pipewire/parent_window.h
+++ b/plugins/linux-pipewire/parent_window.h
@@ -1,0 +1,16 @@
+/*
+	SPDX-License-Identifier: LGPL-3.0-or-later
+	SPDX-FileCopyrightText: 2022 David Redondo <kde@david-redondo.de>
+*/
+
+#pragma once
+
+#include <util/dstr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+struct dstr parent_window_string();
+#ifdef __cplusplus
+}
+#endif

--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -20,6 +20,7 @@
 
 #include "pipewire.h"
 
+#include "parent_window.h"
 #include "portal.h"
 
 #include <util/darray.h>
@@ -1146,12 +1147,13 @@ static void start(obs_pipewire_data *obs_pw)
 	g_variant_builder_add(&builder, "{sv}", "handle_token",
 			      g_variant_new_string(request_token));
 
+	struct dstr parent_window = parent_window_string();
 	g_dbus_proxy_call(portal_get_dbus_proxy(), "Start",
-			  g_variant_new("(osa{sv})", obs_pw->session_handle, "",
-					&builder),
+			  g_variant_new("(osa{sv})", obs_pw->session_handle,
+					parent_window.array, &builder),
 			  G_DBUS_CALL_FLAGS_NONE, -1, obs_pw->cancellable,
 			  on_started_cb, call);
-
+	dstr_free(&parent_window);
 	bfree(request_token);
 	bfree(request_path);
 }

--- a/plugins/linux-pipewire/xdg-foreign-unstable-v2.xml
+++ b/plugins/linux-pipewire/xdg-foreign-unstable-v2.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xdg_foreign_unstable_v2">
+
+  <copyright>
+    Copyright © 2015-2016 Red Hat Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol for exporting xdg surface handles">
+    This protocol specifies a way for making it possible to reference a surface
+    of a different client. With such a reference, a client can, by using the
+    interfaces provided by this protocol, manipulate the relationship between
+    its own surfaces and the surface of some other client. For example, stack
+    some of its own surface above the other clients surface.
+
+    In order for a client A to get a reference of a surface of client B, client
+    B must first export its surface using xdg_exporter.export_toplevel. Upon
+    doing this, client B will receive a handle (a unique string) that it may
+    share with client A in some way (for example D-Bus). After client A has
+    received the handle from client B, it may use xdg_importer.import_toplevel
+    to create a reference to the surface client B just exported. See the
+    corresponding requests for details.
+
+    A possible use case for this is out-of-process dialogs. For example when a
+    sandboxed client without file system access needs the user to select a file
+    on the file system, given sandbox environment support, it can export its
+    surface, passing the exported surface handle to an unsandboxed process that
+    can show a file browser dialog and stack it above the sandboxed client's
+    surface.
+
+    Warning! The protocol described in this file is experimental and backward
+    incompatible changes may be made. Backward compatible changes may be added
+    together with the corresponding interface version bump. Backward
+    incompatible changes are done by bumping the version number in the protocol
+    and interface names and resetting the interface version. Once the protocol
+    is to be declared stable, the 'z' prefix and the version number in the
+    protocol and interface names are removed and the interface version number is
+    reset.
+  </description>
+
+  <interface name="zxdg_exporter_v2" version="1">
+    <description summary="interface for exporting surfaces">
+      A global interface used for exporting surfaces that can later be imported
+      using xdg_importer.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_exporter object">
+	Notify the compositor that the xdg_exporter object will no longer be
+	used.
+      </description>
+    </request>
+
+    <enum name="error">
+      <description summary="error values">
+        These errors can be emitted in response to invalid xdg_exporter
+        requests.
+      </description>
+      <entry name="invalid_surface" value="0" summary="surface is not an xdg_toplevel"/>
+    </enum>
+
+    <request name="export_toplevel">
+      <description summary="export a toplevel surface">
+	The export_toplevel request exports the passed surface so that it can later be
+	imported via xdg_importer. When called, a new xdg_exported object will
+	be created and xdg_exported.handle will be sent immediately. See the
+	corresponding interface and event for details.
+
+	A surface may be exported multiple times, and each exported handle may
+	be used to create an xdg_imported multiple times. Only xdg_toplevel
+        equivalent surfaces may be exported, otherwise an invalid_surface
+        protocol error is sent.
+      </description>
+      <arg name="id" type="new_id" interface="zxdg_exported_v2"
+	   summary="the new xdg_exported object"/>
+      <arg name="surface" type="object" interface="wl_surface"
+	   summary="the surface to export"/>
+    </request>
+  </interface>
+
+  <interface name="zxdg_importer_v2" version="1">
+    <description summary="interface for importing surfaces">
+      A global interface used for importing surfaces exported by xdg_exporter.
+      With this interface, a client can create a reference to a surface of
+      another client.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_importer object">
+	Notify the compositor that the xdg_importer object will no longer be
+	used.
+      </description>
+    </request>
+
+    <request name="import_toplevel">
+      <description summary="import a toplevel surface">
+	The import_toplevel request imports a surface from any client given a handle
+	retrieved by exporting said surface using xdg_exporter.export_toplevel.
+	When called, a new xdg_imported object will be created. This new object
+	represents the imported surface, and the importing client can
+	manipulate its relationship using it. See xdg_imported for details.
+      </description>
+      <arg name="id" type="new_id" interface="zxdg_imported_v2"
+	   summary="the new xdg_imported object"/>
+      <arg name="handle" type="string"
+	   summary="the exported surface handle"/>
+    </request>
+  </interface>
+
+  <interface name="zxdg_exported_v2" version="1">
+    <description summary="an exported surface handle">
+      An xdg_exported object represents an exported reference to a surface. The
+      exported surface may be referenced as long as the xdg_exported object not
+      destroyed. Destroying the xdg_exported invalidates any relationship the
+      importer may have established using xdg_imported.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="unexport the exported surface">
+	Revoke the previously exported surface. This invalidates any
+	relationship the importer may have set up using the xdg_imported created
+	given the handle sent via xdg_exported.handle.
+      </description>
+    </request>
+
+    <event name="handle">
+      <description summary="the exported surface handle">
+	The handle event contains the unique handle of this exported surface
+	reference. It may be shared with any client, which then can use it to
+	import the surface by calling xdg_importer.import_toplevel. A handle
+	may be used to import the surface multiple times.
+      </description>
+      <arg name="handle" type="string" summary="the exported surface handle"/>
+    </event>
+  </interface>
+
+  <interface name="zxdg_imported_v2" version="1">
+    <description summary="an imported surface handle">
+      An xdg_imported object represents an imported reference to surface exported
+      by some client. A client can use this interface to manipulate
+      relationships between its own surfaces and the imported surface.
+    </description>
+
+    <enum name="error">
+      <description summary="error values">
+        These errors can be emitted in response to invalid xdg_imported
+        requests.
+      </description>
+      <entry name="invalid_surface" value="0" summary="surface is not an xdg_toplevel"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_imported object">
+	Notify the compositor that it will no longer use the xdg_imported
+	object. Any relationship that may have been set up will at this point
+	be invalidated.
+      </description>
+    </request>
+
+    <request name="set_parent_of">
+      <description summary="set as the parent of some surface">
+        Set the imported surface as the parent of some surface of the client.
+        The passed surface must be an xdg_toplevel equivalent, otherwise an
+        invalid_surface protocol error is sent. Calling this function sets up
+        a surface to surface relation with the same stacking and positioning
+        semantics as xdg_toplevel.set_parent.
+      </description>
+      <arg name="surface" type="object" interface="wl_surface"
+	   summary="the child surface"/>
+    </request>
+
+    <event name="destroyed">
+      <description summary="the imported surface handle has been destroyed">
+	The imported surface handle has been destroyed and any relationship set
+	up has been invalidated. This may happen for various reasons, for
+	example if the exported surface or the exported surface handle has been
+	destroyed, if the handle used for importing was invalid.
+      </description>
+    </event>
+  </interface>
+
+</protocol>


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Send the parent_window specifier as described in https://flatpak.github.io/xdg-desktop-portal/#parent_window
On X for this the window id is used. on Wayland a handle
acquired from the compositor via the xdg-foreign protocol.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This enables the system to associate any windows/dialogs opened
by the portal with the OBS main window. For example positioning
them on/near the OBS window instead randomly somewhere on the
screen.
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Plasma Wayland,  the portal dialog is not placed somewhere randomly but on top
of obs.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 - Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
