### PR TITLE
image-source: Make maximum memory usage a source property

### DIFF
--- a/plugins/image-source/data/locale/en-US.ini
+++ b/plugins/image-source/data/locale/en-US.ini
@@ -29,6 +29,7 @@ SlideShow.Stop="Stop"
 SlideShow.NextSlide="Next Slide"
 SlideShow.PreviousSlide="Previous Slide"
 SlideShow.HideWhenDone="Hide when slideshow is done"
+SlideShow.MaxMemoryUsage="Maximum GPU Memory Usage"
 
 ColorSource="Color Source"
 ColorSource.Color="Color"


### PR DESCRIPTION
### Description
Moves the maximum memory usage setting to a per-source configurable
property. The current default of 400MB is maintained:
![image](https://user-images.githubusercontent.com/31592439/161329802-069b312a-6656-40ca-85cf-98dcfa56a742.png)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Partial fix for [a pinned issue, #3366](https://github.com/obsproject/obs-studio/issues/3366).
A redesign is complete but needs review. This is a much more minor change that should make the current version
of the slideshow source more user-friendly until the redesign can be reviewed.

### How Has This Been Tested?
Tested on Ubuntu 21.10 from upstream master.
Changing the limit through the UI changes the number of images that successfully load.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation. (N/A)
