### PR TITLE
libobs: Fix sign mismatch

### DIFF
--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -378,7 +378,7 @@ stage_output_texture(struct obs_core_video *video, int cur_texture,
 
 		video->textures_copied[cur_texture] = true;
 	} else if (video->texture_converted) {
-		for (int i = 0; i < channel_count; i++) {
+		for (size_t i = 0; i < channel_count; i++) {
 			gs_stagesurf_t *copy = copy_surfaces[i];
 			if (copy) {
 				gs_stage_texture(copy, convert_textures[i]);


### PR DESCRIPTION
### Description
Change int/size_t compare to size_t/size_t compare.

### Motivation and Context
Saw a warning for it that I can't reproduce for some reason.

### How Has This Been Tested?
Debugger inspection of loop using x264.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.