### PR TITLE
win-capture: Use normal blend equation for cursor

### DIFF
--- a/plugins/win-capture/cursor-capture.c
+++ b/plugins/win-capture/cursor-capture.c
@@ -228,14 +228,14 @@ void cursor_draw(struct cursor_data *data, long x_offset, long y_offset,
 
 	if (data->visible && !!data->texture) {
 		gs_blend_state_push();
-		gs_blend_function(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA);
-		gs_enable_color(true, true, true, false);
+		gs_blend_function_separate(GS_BLEND_SRCALPHA,
+					   GS_BLEND_INVSRCALPHA, GS_BLEND_ONE,
+					   GS_BLEND_INVSRCALPHA);
 
 		gs_matrix_push();
 		obs_source_draw(data->texture, x_draw, y_draw, 0, 0, false);
 		gs_matrix_pop();
 
-		gs_enable_color(true, true, true, true);
 		gs_blend_state_pop();
 	}
 }


### PR DESCRIPTION
### Description
Not sure what the previous setup was trying to do. I guess we'll find
out if users complain.

### Motivation and Context
Need to test cursor drawing as part of HDR changes, and I don't want the code doing weird things.

### How Has This Been Tested?
Cursor renders correctly in master and HDR branches.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.