### PR TITLE
cmake: Fixes plugins not being copied into application bundle on macOS

### DIFF
--- a/cmake/Modules/ObsHelpers_macOS.cmake
+++ b/cmake/Modules/ObsHelpers_macOS.cmake
@@ -265,7 +265,8 @@ endfunction()
 function(setup_obs_modules target)
 
   get_property(OBS_MODULE_LIST GLOBAL PROPERTY OBS_MODULE_LIST)
-  if("${OBS_MODULE_LIST}")
+  list(LENGTH OBS_MODULE_LIST _LEN)
+  if(_LEN GREATER 0)
     add_dependencies(${target} ${OBS_MODULE_LIST})
 
     install(
@@ -284,7 +285,8 @@ function(setup_obs_modules target)
 
   get_property(OBS_SCRIPTING_MODULE_LIST GLOBAL
                PROPERTY OBS_SCRIPTING_MODULE_LIST)
-  if("${OBS_SCRIPTING_MODULE_LIST}")
+  list(LENGTH OBS_SCRIPTING_MODULE_LIST _LEN)
+  if(_LEN GREATER 0)
     add_dependencies(${target} ${OBS_SCRIPTING_MODULE_LIST})
 
     install(


### PR DESCRIPTION
### Description
Fixes plugins not being copied into the application bundle for macOS builds.

### Motivation and Context
Makes the check for the number of plugins in the global list an explicit length check (not relying on CMake implicit functionality), also moves it in line with how the same was solved in `ObsHelpers.cmake` globally.

### How Has This Been Tested?
Built OBS with a fresh build directory on macOS and checked application bundle contents.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
