### PR TITLE
win-capture: Add DXGI/WGC HDR support

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -1036,6 +1036,8 @@ struct gs_device {
 	vector<gs_device_loss> loss_callbacks;
 	gs_obj *first_obj = nullptr;
 
+	vector<std::pair<HMONITOR, bool>> monitor_to_hdr;
+
 	void InitCompiler();
 	void InitFactory();
 	void ReorderAdapters(uint32_t &adapterIdx);

--- a/libobs-winrt/winrt-capture.h
+++ b/libobs-winrt/winrt-capture.h
@@ -20,6 +20,8 @@ EXPORT void winrt_capture_free(struct winrt_capture *capture);
 EXPORT BOOL winrt_capture_active(const struct winrt_capture *capture);
 EXPORT BOOL winrt_capture_show_cursor(struct winrt_capture *capture,
 				      BOOL visible);
+EXPORT enum gs_color_space
+winrt_capture_get_color_space(const struct winrt_capture *capture);
 EXPORT void winrt_capture_render(struct winrt_capture *capture);
 EXPORT uint32_t winrt_capture_width(const struct winrt_capture *capture);
 EXPORT uint32_t winrt_capture_height(const struct winrt_capture *capture);


### PR DESCRIPTION
### Description
HDR for DXGI/WGC display capture, and WGC window capture.

Also add fast SDR paths for BitBlt to skip color conversions.

### Motivation and Context
HDR

### How Has This Been Tested?
Breakpoint inspection for all render path permutations.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.