### PR TITLE
linux-capture: Don't initialize format info if init_obs_pipewire fails

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -1434,8 +1434,10 @@ void *obs_pipewire_create(enum obs_pw_capture_type capture_type,
 	obs_pw->restore_token =
 		bstrdup(obs_data_get_string(settings, "RestoreToken"));
 
-	if (!init_obs_pipewire(obs_pw))
+	if (!init_obs_pipewire(obs_pw)) {
 		g_clear_pointer(&obs_pw, bfree);
+		return NULL;
+	}
 
 	init_format_info(obs_pw);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Fixes a crash when init_obs_pipewire fails.

### Motivation and Context

I was implementing a non-portal based PW backend and had something fail when it crashed here, and noticed it was a problem in the regular code also.

### How Has This Been Tested?

Made `init_obs_pipewire` return FALSE in the regular code base to simulate a failure, which would always crash.
With the fix, it no longer crashes if there is a failure.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
