### PR TITLE
libobs: Clear image on color convert

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2563,6 +2563,9 @@ static void source_render(obs_source_t *source, gs_effect_t *effect)
 			    source_space)) {
 			gs_enable_blending(false);
 
+			struct vec4 clear_color;
+			vec4_zero(&clear_color);
+			gs_clear(GS_CLEAR_COLOR, &clear_color, 0.0f, 0);
 			gs_ortho(0.0f, (float)cx, 0.0f, (float)cy, -100.0f,
 				 100.0f);
 


### PR DESCRIPTION
### Description
Avoid redrawing potentially stale image from previous frame.

### Motivation and Context
Nasty. Confusing.

### How Has This Been Tested?
Draw SDR transition against HDR scene, then hide it. Needs HDR fork to repro. Broken before; fixed after.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.