### PR TITLE
libobs,obs-transitions: Smooth source transition fades

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -1576,6 +1576,7 @@ Functions used by transitions
 ---------------------
 
 .. function:: void obs_transition_video_render(obs_source_t *transition, obs_transition_video_render_callback_t callback)
+              void obs_transition_video_render2(obs_source_t *transition, obs_transition_video_render_callback_t callback, gs_texture_t *placeholder_texture)
 
    Helper function used for rendering transitions.  This function will
    render two distinct textures for source A and source B of the
@@ -1586,6 +1587,10 @@ Functions used by transitions
    textures of source A and source B, *t* is the time value
    (0.0f..1.0f), *cx* and *cy* are the current dimensions of the
    transition, and *data* is the implementation's private data.
+
+   The *placeholder_texture* parameter allows a callback to receive
+   a replacement that isn't the default transparent texture, including
+   NULL if the caller desires.
 
    Relevant data types used with this function:
 

--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -726,6 +726,15 @@ void obs_transition_force_stop(obs_source_t *transition)
 void obs_transition_video_render(obs_source_t *transition,
 				 obs_transition_video_render_callback_t callback)
 {
+	obs_transition_video_render2(transition, callback,
+				     obs->video.transparent_texture);
+}
+
+void obs_transition_video_render2(
+	obs_source_t *transition,
+	obs_transition_video_render_callback_t callback,
+	gs_texture_t *placeholder_texture)
+{
 	struct transition_state state;
 	struct matrix4 matrices[2];
 	bool locked = false;
@@ -773,9 +782,9 @@ void obs_transition_video_render(obs_source_t *transition,
 					     source_space);
 				tex[i] = get_texture(transition, i);
 				if (!tex[i])
-					tex[i] = obs->video.transparent_texture;
+					tex[i] = placeholder_texture;
 			} else {
-				tex[i] = obs->video.transparent_texture;
+				tex[i] = placeholder_texture;
 			}
 		}
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1587,6 +1587,11 @@ EXPORT void
 obs_transition_video_render(obs_source_t *transition,
 			    obs_transition_video_render_callback_t callback);
 
+EXPORT void
+obs_transition_video_render2(obs_source_t *transition,
+			     obs_transition_video_render_callback_t callback,
+			     gs_texture_t *placeholder_texture);
+
 EXPORT enum gs_color_space
 obs_transition_video_get_color_space(obs_source_t *transition);
 

--- a/plugins/obs-transitions/data/fade_to_color_transition.effect
+++ b/plugins/obs-transitions/data/fade_to_color_transition.effect
@@ -35,7 +35,6 @@ float3 srgb_nonlinear_to_linear(float3 v)
 float4 PSFadeToColor(VertData v_in) : TARGET
 {
 	float4 rgba = lerp(tex.Sample(textureSampler, v_in.uv), color, swp);
-	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
 	return rgba;
 }
 

--- a/plugins/obs-transitions/data/fade_transition.effect
+++ b/plugins/obs-transitions/data/fade_transition.effect
@@ -65,6 +65,19 @@ float4 PSFadeLinear(FragData f_in) : TARGET
 	return rgba;
 }
 
+float4 FadeSingle(FragData f_in)
+{
+	float4 a_val = tex_a.Sample(textureSampler, f_in.uv);
+	float4 rgba = a_val * fade_val;
+	return rgba;
+}
+
+float4 PSFadeSingle(FragData f_in) : TARGET
+{
+	float4 rgba = FadeSingle(f_in);
+	return rgba;
+}
+
 technique Fade
 {
 	pass
@@ -80,5 +93,14 @@ technique FadeLinear
 	{
 		vertex_shader = VSDefault(v_in);
 		pixel_shader = PSFadeLinear(f_in);
+	}
+}
+
+technique FadeSingle
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader = PSFadeSingle(f_in);
 	}
 }

--- a/plugins/obs-transitions/transition-fade-to-color.c
+++ b/plugins/obs-transitions/transition-fade-to-color.c
@@ -15,6 +15,7 @@ struct fade_to_color_info {
 	gs_eparam_t *ep_color;
 
 	struct vec4 color;
+	struct vec4 color_srgb;
 	float switch_point;
 };
 
@@ -53,6 +54,7 @@ static void fade_to_color_update(void *data, obs_data_t *settings)
 	color |= 0xFF000000;
 
 	vec4_from_rgba(&fade_to_color->color, color);
+	vec4_from_rgba_srgb(&fade_to_color->color_srgb, color);
 
 	fade_to_color->switch_point = (float)swp / 100.0f;
 }
@@ -107,11 +109,21 @@ static void fade_to_color_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 
 	gs_texture_t *const tex = (t < fade_to_color->switch_point) ? a : b;
 
-	const bool previous = gs_framebuffer_srgb_enabled();
-	gs_enable_framebuffer_srgb(true);
+	const bool nonlinear_fade = gs_get_color_space() == GS_CS_SRGB;
 
-	gs_effect_set_texture(fade_to_color->ep_tex, tex);
-	gs_effect_set_vec4(fade_to_color->ep_color, &fade_to_color->color);
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(!nonlinear_fade);
+
+	if (nonlinear_fade) {
+		gs_effect_set_texture(fade_to_color->ep_tex, tex);
+		gs_effect_set_vec4(fade_to_color->ep_color,
+				   &fade_to_color->color);
+	} else {
+		gs_effect_set_texture_srgb(fade_to_color->ep_tex, tex);
+		gs_effect_set_vec4(fade_to_color->ep_color,
+				   &fade_to_color->color_srgb);
+	}
+
 	gs_effect_set_float(fade_to_color->ep_swp, swp);
 
 	while (gs_effect_loop(fade_to_color->effect, "FadeToColor"))
@@ -122,10 +134,15 @@ static void fade_to_color_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 
 static void fade_to_color_video_render(void *data, gs_effect_t *effect)
 {
+	UNUSED_PARAMETER(effect);
+
+	const bool previous = gs_set_linear_srgb(true);
+
 	struct fade_to_color_info *fade_to_color = data;
 	obs_transition_video_render(fade_to_color->source,
 				    fade_to_color_callback);
-	UNUSED_PARAMETER(effect);
+
+	gs_set_linear_srgb(previous);
 }
 
 static float mix_a(void *data, float t)
@@ -174,6 +191,24 @@ static void fade_to_color_defaults(obs_data_t *settings)
 	obs_data_set_default_int(settings, S_SWITCH_POINT, 50);
 }
 
+static enum gs_color_space
+fade_to_color_video_get_color_space(void *data, size_t count,
+				    const enum gs_color_space *preferred_spaces)
+{
+	struct fade_to_color_info *fade_to_color = data;
+	const enum gs_color_space transition_space =
+		obs_transition_video_get_color_space(fade_to_color->source);
+
+	enum gs_color_space space = transition_space;
+	for (size_t i = 0; i < count; ++i) {
+		space = preferred_spaces[i];
+		if (space == transition_space)
+			break;
+	}
+
+	return space;
+}
+
 struct obs_source_info fade_to_color_transition = {
 	.id = "fade_to_color_transition",
 	.type = OBS_SOURCE_TYPE_TRANSITION,
@@ -185,4 +220,5 @@ struct obs_source_info fade_to_color_transition = {
 	.audio_render = fade_to_color_audio_render,
 	.get_properties = fade_to_color_properties,
 	.get_defaults = fade_to_color_defaults,
+	.video_get_color_space = fade_to_color_video_get_color_space,
 };


### PR DESCRIPTION
### Description
Add logic to avoid unexpected deviation.

### Motivation and Context
Multiple people have noticed that fading a solid color in or out with the same solid color behind creates a blend that deviates from the solid color. It should take a straight line and not change color at all.

### How Has This Been Tested?
Verified all code paths were exercised, and that the image data looked good visually and in RenderDoc.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.