### PR TITLE
UI: Fix crash when pressing `tab` key in rename

### DIFF
--- a/UI/visibility-item-widget.cpp
+++ b/UI/visibility-item-widget.cpp
@@ -7,6 +7,7 @@
 #include <QHBoxLayout>
 #include <QMessageBox>
 #include <QLabel>
+#include <QKeyEvent>
 
 VisibilityItemWidget::VisibilityItemWidget(obs_source_t *source_)
 	: source(source_),
@@ -142,6 +143,24 @@ void VisibilityItemDelegate::paint(QPainter *painter,
 		role = QPalette::WindowText;
 
 	widget->SetColor(palette.color(group, role), active, selected);
+}
+
+bool VisibilityItemDelegate::eventFilter(QObject *object, QEvent *event)
+{
+	QWidget *editor = qobject_cast<QWidget *>(object);
+	if (!editor)
+		return false;
+
+	if (event->type() == QEvent::KeyPress) {
+		QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+
+		if (keyEvent->key() == Qt::Key_Tab ||
+		    keyEvent->key() == Qt::Key_Backtab) {
+			return false;
+		}
+	}
+
+	return QStyledItemDelegate::eventFilter(object, event);
 }
 
 void SetupVisibilityItem(QListWidget *list, QListWidgetItem *item,

--- a/UI/visibility-item-widget.hpp
+++ b/UI/visibility-item-widget.hpp
@@ -47,6 +47,9 @@ public:
 
 	void paint(QPainter *painter, const QStyleOptionViewItem &option,
 		   const QModelIndex &index) const override;
+
+protected:
+	bool eventFilter(QObject *object, QEvent *event) override;
 };
 
 void SetupVisibilityItem(QListWidget *list, QListWidgetItem *item,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

`VisibilityItemDelegate` Override the default method `eventFilter` to Filter KeyPressEvent `Tab` and `BackTab`, to Avoid basic feature "focus on prev/next item".

### Motivation and Context

Avoids crash when pressing `Tab` key while renaming the last item in filter list. Fixes #6092
and when pressing `BackTab` while renaming the first item in filter list.
and display error when pressing `Tab` / `BackTab` while renaming other item in filter list.

### How Has This Been Tested?

Press `Tab`, `BackTab` while renaming items of filter list. NO crash happen. 
And the new name saved.
And popup promt when the new name is empty or the new name existed as usual.

### Types of changes

Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
