### PR TITLE
libobs: Duplicate URL string for OBS_BUTTON_URL

### DIFF
--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -167,6 +167,12 @@ static inline void float_data_free(struct float_data *data)
 		bfree(data->suffix);
 }
 
+static inline void button_data_free(struct button_data *data)
+{
+	if (data->url)
+		bfree(data->url);
+}
+
 struct obs_properties;
 
 struct obs_property {
@@ -257,6 +263,8 @@ static void obs_property_destroy(struct obs_property *property)
 		int_data_free(get_property_data(property));
 	else if (property->type == OBS_PROPERTY_FLOAT)
 		float_data_free(get_property_data(property));
+	else if (property->type == OBS_PROPERTY_BUTTON)
+		button_data_free(get_property_data(property));
 
 	bfree(property->name);
 	bfree(property->desc);
@@ -1119,7 +1127,7 @@ void obs_property_button_set_url(obs_property_t *p, char *url)
 	if (!data)
 		return;
 
-	data->url = url;
+	data->url = bstrdup(url);
 }
 
 void obs_property_list_clear(obs_property_t *p)


### PR DESCRIPTION
### Description
The change includes allocation of a new string to store the string passed to the Python function

### Motivation and Context
Fixes #5712 

### How Has This Been Tested?
Tested using Python script from the issue description.
MacBook Air M1, MacOS 12.3
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
