### PR TITLE
deps/media-playback: Fix AVColorSpace usages

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -207,15 +207,19 @@ static inline int get_sws_colorspace(enum AVColorSpace cs)
 		return SWS_CS_ITU709;
 	case AVCOL_SPC_FCC:
 		return SWS_CS_FCC;
+	case AVCOL_SPC_BT470BG:
+		return SWS_CS_ITU624;
 	case AVCOL_SPC_SMPTE170M:
 		return SWS_CS_SMPTE170M;
 	case AVCOL_SPC_SMPTE240M:
 		return SWS_CS_SMPTE240M;
+	case AVCOL_SPC_BT2020_NCL:
+		return SWS_CS_BT2020;
 	default:
 		break;
 	}
 
-	return SWS_CS_ITU601;
+	return SWS_CS_ITU709;
 }
 
 static inline int get_sws_range(enum AVColorRange r)
@@ -445,7 +449,10 @@ static void mp_media_next_video(mp_media_t *m, bool preload)
 	frame->flags |= m->is_linear_alpha ? OBS_SOURCE_FRAME_LINEAR_ALPHA : 0;
 	switch (f->color_trc) {
 	case AVCOL_TRC_BT709:
+	case AVCOL_TRC_GAMMA22:
+	case AVCOL_TRC_GAMMA28:
 	case AVCOL_TRC_SMPTE170M:
+	case AVCOL_TRC_SMPTE240M:
 	case AVCOL_TRC_IEC61966_2_1:
 		frame->trc = VIDEO_TRC_SRGB;
 		break;


### PR DESCRIPTION
### Description
More completeness and consistency.

### Motivation and Context
Want accurate video decoding.

### How Has This Been Tested?
Set breakpoints for AVCOL_SPC_BT709 and AVCOL_SPC_BT2020_NCL in get_sws_colorspace, and VIDEO_TRC_SRGB and VIDEO_TRC_PQ in mp_media_next_video, and all media source playbacks looked fine. Needed to modify the code to test get_sws_colorspace to activate the swscale path.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.