### PR TITLE
libobs-opengl: Use gl helpers in create_dmabuf_image

### DIFF
--- a/libobs-opengl/gl-egl-common.c
+++ b/libobs-opengl/gl-egl-common.c
@@ -199,17 +199,23 @@ gl_egl_create_dmabuf_image(EGLDisplay egl_display, unsigned int width,
 		return NULL;
 	}
 
-	texture = gs_texture_create(width, height, color_format, 1, NULL,
-				    GS_DYNAMIC);
+	if ((texture = gs_texture_create(width, height, color_format, 1, NULL,
+					 GS_DYNAMIC)) == NULL) {
+		return NULL;
+	}
 	const GLuint gltex = *(GLuint *)gs_texture_get_obj(texture);
 
-	glBindTexture(GL_TEXTURE_2D, gltex);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	gl_bind_texture(GL_TEXTURE_2D, gltex);
+	gl_tex_param_i(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	gl_tex_param_i(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
 	glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, egl_image);
+	if (!gl_success("glEGLImageTargetTexture2DOES")) {
+		gs_texture_destroy(texture);
+		texture = NULL;
+	}
 
-	glBindTexture(GL_TEXTURE_2D, 0);
+	gl_bind_texture(GL_TEXTURE_2D, 0);
 	eglDestroyImage(egl_display, egl_image);
 
 	return texture;


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This replaces direct opengl calls to error handling helpers. Previously
this would cause errors to be misattributed to the next opengl functions
called.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes dmabuf importing returning a texture on failure on kde.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
dmabuf imports fail correctly and cursor texture imports no longer report errors.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
