### PR TITLE
win-dshow: Use Rec. 2100 (PQ) by default for P010

### DIFF
--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -1100,6 +1100,9 @@ DShowInput::GetColorSpace(obs_data_t *settings) const
 	if (astrcmpi(space, "2100HLG") == 0)
 		return VIDEO_CS_2100_HLG;
 
+	if (videoConfig.format == VideoFormat::P010)
+		return VIDEO_CS_2100_PQ;
+
 	return VIDEO_CS_DEFAULT;
 }
 


### PR DESCRIPTION
### Description
Makes more sense than Rec. 709.

### Motivation and Context
Easy of use.

### How Has This Been Tested?
Verified Rec. 2100 (PQ) is used by default for this setting.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.