### PR TITLE
obs-ffmpeg: Add max luminance metadata for PQ

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -162,11 +162,17 @@ static void add_video_encoder_params(struct ffmpeg_muxer *stream,
 						? AVCOL_RANGE_JPEG
 						: AVCOL_RANGE_MPEG;
 
-	dstr_catf(cmd, "%s %d %d %d %d %d %d %d %d %d ",
+	const int max_luminance =
+		(trc == AVCOL_TRC_SMPTE2084)
+			? (int)obs_get_video_hdr_nominal_peak_level()
+			: 0;
+
+	dstr_catf(cmd, "%s %d %d %d %d %d %d %d %d %d %d ",
 		  obs_encoder_get_codec(vencoder), bitrate,
 		  obs_output_get_width(stream->output),
 		  obs_output_get_height(stream->output), (int)pri, (int)trc,
-		  (int)spc, (int)range, (int)info->fps_num, (int)info->fps_den);
+		  (int)spc, (int)range, max_luminance, (int)info->fps_num,
+		  (int)info->fps_den);
 }
 
 static void add_audio_encoder_params(struct dstr *cmd, obs_encoder_t *aencoder)

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.h
@@ -27,6 +27,7 @@ struct ffmpeg_cfg {
 	enum AVColorPrimaries color_primaries;
 	enum AVColorTransferCharacteristic color_trc;
 	enum AVColorSpace colorspace;
+	int max_luminance;
 	int scale_width;
 	int scale_height;
 	int width;


### PR DESCRIPTION
### Description
Necessary for video player to remap display ranges.

### Motivation and Context
Want HDR to look good.

### How Has This Been Tested?
Verified max luminance metadata appears in VLC for Rec. 2100 (PQ), but not Rec. 709 for direct NVENC, and FFmpeg output.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.