### PR TITLE
UI: Set automatic file splitting time in minutes

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -2461,16 +2461,16 @@
                             <item row="8" column="1">
                              <widget class="QSpinBox" name="advOutSplitFileTime">
                               <property name="suffix">
-                               <string> s</string>
+                               <string> min</string>
                               </property>
                               <property name="minimum">
-                               <number>5</number>
+                               <number>1</number>
                               </property>
                               <property name="maximum">
-                               <number>21600</number>
+                               <number>360</number>
                               </property>
                               <property name="value">
-                               <number>900</number>
+                               <number>15</number>
                               </property>
                              </widget>
                             </item>

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1910,7 +1910,7 @@ bool AdvancedOutput::StartRecording()
 			obs_data_set_bool(settings, "allow_overwrite",
 					  overwriteIfExists);
 			obs_data_set_int(settings, "max_time_sec",
-					 splitFileTime);
+					 splitFileTime * 60);
 			obs_data_set_int(settings, "max_size_mb",
 					 splitFileSize);
 			obs_data_set_bool(settings, "reset_timestamps",

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1424,7 +1424,7 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_uint(basicConfig, "AdvOut", "Track5Bitrate", 160);
 	config_set_default_uint(basicConfig, "AdvOut", "Track6Bitrate", 160);
 
-	config_set_default_uint(basicConfig, "AdvOut", "RecSplitFileTime", 900);
+	config_set_default_uint(basicConfig, "AdvOut", "RecSplitFileTime", 15);
 	config_set_default_uint(basicConfig, "AdvOut", "RecSplitFileSize",
 				2048);
 	config_set_default_bool(basicConfig, "AdvOut",


### PR DESCRIPTION
The original PR was made with time specified in seconds because it was
useful to debug the behavior. For production, assuming most users want
to specify 10 minutes or more, the time should be specified in minutes.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR changes the unit for the settings time in automatic file splitting. Originally it was implemented in seconds but changes to minutes.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The PR #5371 was made with the time settings specified with the unit `second`. However it was useful for debugging, it looks not useful for production since I assume most users want to set 10 minutes or more.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
1. Enable Automatic File Splitting.
2. Set Split by Time
3. Specify 1 minute.
4. Start recording for more than 1 minute and check the length of the recording file.
OS: Fedora 34.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.