### PR TITLE
libobs: Remove redundant async_color_format member

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -721,7 +721,6 @@ struct obs_source {
 	enum video_format async_format;
 	bool async_full_range;
 	uint8_t async_trc;
-	enum gs_color_format async_color_format;
 	enum video_format async_cache_format;
 	bool async_cache_full_range;
 	uint8_t async_cache_trc;
@@ -897,22 +896,13 @@ convert_video_format(enum video_format format)
 	}
 }
 
-static inline enum gs_color_space
-convert_video_space(enum video_format format, enum video_trc trc,
-		    enum gs_color_format color_format, size_t count,
-		    const enum gs_color_space *preferred_spaces)
+static inline enum gs_color_space convert_video_space(enum video_format format,
+						      enum video_trc trc)
 {
-	enum gs_color_space video_space = GS_CS_SRGB;
-	if (color_format == GS_RGBA16F) {
-		video_space = (trc == VIDEO_TRC_SRGB) ? GS_CS_SRGB_16F
-						      : GS_CS_709_EXTENDED;
-	}
-
-	enum gs_color_space space = video_space;
-	for (size_t i = 0; i < count; ++i) {
-		space = preferred_spaces[i];
-		if (space == video_space)
-			break;
+	enum gs_color_space space = GS_CS_SRGB;
+	if (convert_video_format(format) == GS_RGBA16F) {
+		space = (trc == VIDEO_TRC_SRGB) ? GS_CS_SRGB_16F
+						: GS_CS_709_EXTENDED;
 	}
 
 	return space;


### PR DESCRIPTION
### Description
As titled.

### Motivation and Context
Redundant field/logic is bad.

### How Has This Been Tested?
Stepped through all modified logic in debugger for SDR and HDR videos.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.