### PR TITLE
libobs,UI: Issue appropriate signals on group / ungroup

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -967,28 +967,17 @@ void SourceTreeModel::GroupSelectedItems(QModelIndexList &indices)
 	for (obs_sceneitem_t *item : item_order)
 		obs_sceneitem_select(item, false);
 
-	int newIdx = indices[0].row();
-
-	beginInsertRows(QModelIndex(), newIdx, newIdx);
-	items.insert(newIdx, item);
-	endInsertRows();
-
-	for (int i = 0; i < indices.size(); i++) {
-		int fromIdx = indices[i].row() + 1;
-		int toIdx = newIdx + i + 1;
-		if (fromIdx != toIdx) {
-			beginMoveRows(QModelIndex(), fromIdx, fromIdx,
-				      QModelIndex(), toIdx);
-			MoveItem(items, fromIdx, toIdx);
-			endMoveRows();
-		}
-	}
-
 	hasGroups = true;
 	st->UpdateWidgets(true);
 
 	obs_sceneitem_select(item, true);
 
+	/* ----------------------------------------------------------------- */
+	/* obs_scene_insert_group triggers a full refresh of scene items via */
+	/* the item_add signal. No need to insert a row, just edit the one   */
+	/* that's created automatically.                                     */
+
+	int newIdx = indices[0].row();
 	QMetaObject::invokeMethod(st, "NewGroupEdit", Qt::QueuedConnection,
 				  Q_ARG(int, newIdx));
 }

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -3334,6 +3334,15 @@ obs_sceneitem_t *obs_scene_insert_group(obs_scene_t *scene, const char *name,
 	full_unlock(sub_scene);
 	full_unlock(scene);
 
+	struct calldata params;
+	uint8_t stack[128];
+
+	calldata_init_fixed(&params, stack, sizeof(stack));
+	calldata_set_ptr(&params, "scene", scene);
+	calldata_set_ptr(&params, "item", item);
+	signal_handler_signal(scene->source->context.signals, "item_add",
+			      &params);
+
 	/* ------------------------- */
 
 	return item;
@@ -3398,6 +3407,8 @@ void obs_sceneitem_group_ungroup(obs_sceneitem_t *item)
 	obs_sceneitem_t *insert_after = item;
 	obs_sceneitem_t *first;
 	obs_sceneitem_t *last;
+
+	signal_item_remove(item);
 
 	full_lock(scene);
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
I identified a deficiency in the API wherein using group and ungroup actions would not issue the expected `item_add` and `item_remove` signals. I've put together a basic implementation that meets my expectations for the API behavior in that regard.

The `item_add` signal is issued after all of the scene items are re-parented to the new group, and the `item_remove` signal is issued right before the group is modified. This allows the API consumer to more easily inspect the group's contents in a meaningful manner.

Unfortunately a side effect I noticed was that the UI's logic for inserting the group row in the sources list had a conflict with the newly issued signal, as the `item_add` signal was introducing a row for the new group automatically. I just went with the least intrusive option, which was to rely on that implicit behavior and get rid of the explicitly added row in the grouping logic. An alternative would be to suppress the refresh triggered by the `item_add` signal, but I feel like that would probably be an even uglier solution, albeit more explicit.

### Motivation and Context
A plugin that I'm working on needs precise and complete knowledge of the scene structure in as close to real time as possible. Without properly working `item_add` / `item_remove` signals, this is a much more expensive task where groups are involved, as presently the only way to get the information reliably would be to poll the entire scene structure continuously. 

### How Has This Been Tested?
Manual testing on Windows 10 with a stub listener plugin that echos signals. I simply just grouped and ungrouped scene items in the UI.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
 - Breaking change (fix or feature that would cause existing functionality to change)
   - It's likely to break some small number of integrations with OBS unfortunately.
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
