### PR TITLE
virtualcam-module: Copy Windows virtual camera files to rundir

### DIFF
--- a/plugins/win-dshow/virtualcam-module/CMakeLists.txt
+++ b/plugins/win-dshow/virtualcam-module/CMakeLists.txt
@@ -57,9 +57,8 @@ target_compile_definitions(
 if(MSVC)
   target_compile_options(obs-virtualcam-module
                          PRIVATE "$<IF:$<CONFIG:Debug>,/MTd,/MT>")
-  add_target_resource(
-    obs-virtualcam-module "$<TARGET_PDB_FILE:obs-virtualcam-module>"
-    "obs-plugins/win-dshow/")
+  add_target_resource(win-dshow "$<TARGET_PDB_FILE:obs-virtualcam-module>"
+                      "obs-plugins/win-dshow/" OPTIONAL)
 
 endif()
 
@@ -83,6 +82,5 @@ set_target_properties(
   obs-virtualcam-module PROPERTIES OUTPUT_NAME
                                    "obs-virtualcam-module${_output_suffix}")
 
-add_target_resource(
-  obs-virtualcam-module "$<TARGET_FILE:obs-virtualcam-module>"
-  "obs-plugins/win-dshow/")
+add_target_resource(win-dshow "$<TARGET_FILE:obs-virtualcam-module>"
+                    "obs-plugins/win-dshow/")


### PR DESCRIPTION
### Description
Fixes the Windows virtual cam module not being copied into the runtime directory.

### Motivation and Context
Root issue is the same as in https://github.com/obsproject/obs-studio/pull/6245, namely that the modules are build artifacts of a separate subproject, but are related to the `win-dshow` plugin and are required to be placed in that plugin's data directory.

### How Has This Been Tested?
Tested in Windows 11 VM locally.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
