### PR TITLE
UI: Unify function definitions in properties-view

### DIFF
--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -112,28 +112,24 @@ private:
 	QWidget *NewWidget(obs_property_t *prop, QWidget *widget,
 			   const char *signal);
 
-	QWidget *AddCheckbox(obs_property_t *prop);
-	QWidget *AddText(obs_property_t *prop, QFormLayout *layout,
-			 QLabel *&label);
-	void AddPath(obs_property_t *prop, QFormLayout *layout, QLabel **label);
-	void AddInt(obs_property_t *prop, QFormLayout *layout, QLabel **label);
-	void AddFloat(obs_property_t *prop, QFormLayout *layout,
-		      QLabel **label);
-	QWidget *AddList(obs_property_t *prop, bool &warning);
-	void AddEditableList(obs_property_t *prop, QFormLayout *layout,
-			     QLabel *&label);
-	QWidget *AddButton(obs_property_t *prop);
-	void AddColorInternal(obs_property_t *prop, QFormLayout *layout,
-			      QLabel *&label, bool supportAlpha);
-	void AddColor(obs_property_t *prop, QFormLayout *layout,
-		      QLabel *&label);
-	void AddColorAlpha(obs_property_t *prop, QFormLayout *layout,
-			   QLabel *&label);
-	void AddFont(obs_property_t *prop, QFormLayout *layout, QLabel *&label);
-	void AddFrameRate(obs_property_t *prop, bool &warning,
-			  QFormLayout *layout, QLabel *&label);
-
-	void AddGroup(obs_property_t *prop, QFormLayout *layout);
+	void AddCheckbox(obs_property_t *prop, QLabel *&label,
+			 QWidget *&widget);
+	void AddText(obs_property_t *prop, QLayout *&subLayout,
+		     QWidget *&widget);
+	void AddPath(obs_property_t *prop, QLayout *&subLayout);
+	void AddInt(obs_property_t *prop, QLayout *&subLayout);
+	void AddFloat(obs_property_t *prop, QLayout *&subLayout);
+	void AddList(obs_property_t *prop, QLabel *&label, QWidget *&widget);
+	void AddEditableList(obs_property_t *prop, QLayout *&subLayout);
+	void AddButton(obs_property_t *prop, QLabel *&label, QWidget *&widget);
+	void AddColorInternal(obs_property_t *prop, QLayout *&subLayout,
+			      bool supportAlpha);
+	void AddColor(obs_property_t *prop, QLayout *&subLayout);
+	void AddColorAlpha(obs_property_t *prop, QLayout *&subLayout);
+	void AddFont(obs_property_t *prop, QLayout *&subLayout);
+	void AddFrameRate(obs_property_t *prop, QLabel *&label,
+			  QWidget *&returnWidget);
+	void AddGroup(obs_property_t *prop, QLabel *&label, QWidget *&widget);
 
 	void AddProperty(obs_property_t *property, QFormLayout *layout);
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The AddProperty function was a mess, partly due to the Add# functions
having very different headers. That would lead to redundant code and
having quite a few cases where then in AddProperty things would get
replaced again.
Now, all of them return void, and none of them add the entry to the
QFormLayout themselves. Instead, every function gets the property, and
either a QLayout or QWidget (or both) which it can modify.
This cuts down on code, and makes it more readable.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The `AddProperty` function was a mess, with a lot of special cases for
different property types, like
```
if (!label && type != OBS_PROPERTY_BOOL &&
	    type != OBS_PROPERTY_BUTTON && type != OBS_PROPERTY_GROUP)
		label = new QLabel(QT_UTF8(obs_property_description(property)));
```
(or more examples), where this configuration could be done universally or in
the AddCheckbox/AddButton function.
The only distinction left are groups, since they need the entire width of the
QFormLayout for the widget.

It's so much cleaner this way.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
The following widget types have been explicitly tested to work, both normal and with a `obs_property_set_enabled(property, false)` in the beginning to make sure they are
correctly disabled:
- Bool
- Int
- Text
    - Multiline
    - Password
    - Normal
- Path
- List
    - Normal
    - Editable
- Color (w/ alpha)
- Font
- Button
- Editable List (e.g. slideshow)
- Frame Rate
- Group

Ran static analysis to make sure no memory is being leaked.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
