### PR TITLE
libobs, UI: Default mixer volume meter to two channels

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -750,6 +750,14 @@ inline void VolumeMeter::resetLevels()
 bool VolumeMeter::needLayoutChange()
 {
 	int currentNrAudioChannels = obs_volmeter_get_nr_channels(obs_volmeter);
+
+	if (!currentNrAudioChannels) {
+		struct obs_audio_info oai;
+		obs_get_audio_info(&oai);
+		currentNrAudioChannels = (oai.speakers == SPEAKERS_MONO) ? 1
+									 : 2;
+	}
+
 	if (displayNrAudioChannels != currentNrAudioChannels) {
 		displayNrAudioChannels = currentNrAudioChannels;
 		recalculateLayout = true;
@@ -758,8 +766,9 @@ bool VolumeMeter::needLayoutChange()
 	return recalculateLayout;
 }
 
-// When this is called from the constructor, obs_volmeter_get_nr_channels returns 1
-// and Q_PROPERTY settings have not yet been read from the stylesheet.
+// When this is called from the constructor, obs_volmeter_get_nr_channels has not
+// yet been called and Q_PROPERTY settings have not yet been read from the
+// stylesheet.
 inline void VolumeMeter::doLayout()
 {
 	QMutexLocker locker(&dataMutex);

--- a/libobs/obs-audio-controls.c
+++ b/libobs/obs-audio-controls.c
@@ -897,7 +897,7 @@ int obs_volmeter_get_nr_channels(obs_volmeter_t *volmeter)
 		source_nr_audio_channels = get_audio_channels(
 			volmeter->source->sample_info.speakers);
 	} else {
-		source_nr_audio_channels = 1;
+		source_nr_audio_channels = 0;
 	}
 
 	struct obs_audio_info audio_info;
@@ -907,7 +907,7 @@ int obs_volmeter_get_nr_channels(obs_volmeter_t *volmeter)
 		obs_nr_audio_channels = 2;
 	}
 
-	return CLAMP(source_nr_audio_channels, 1, obs_nr_audio_channels);
+	return CLAMP(source_nr_audio_channels, 0, obs_nr_audio_channels);
 }
 
 void obs_volmeter_add_callback(obs_volmeter_t *volmeter,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Audio sources that have not yet output (or whatever) any audio currently
do not know which speaker configuration and how many channels the audio
will have, so the audio mixer defaults to 1.
This changes this to 2 since the majority of sources are stereo.
Browser source that hasn't put out any audio yet:
<img width="319" alt="image" src="https://user-images.githubusercontent.com/59806498/163601137-5860b839-dd65-4dbb-8e45-50af186cc2f9.png">

This changes how `obs_volmeter_get_nr_channels` works (it will now default
to 0 if the number is unknown instead of 1), technically making it a breaking
change. However, that function is neither documented in the docs (like the
rest of `obs-audio-controls.h`, I'll maybe write that in the future, but don't
really have the time right now) nor used anywhere else in OBS; so I'd personally
assume plugins don't use it and find it safe enough to make this change.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
From Warchamps list

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.3, compiled and run
Verified it now defaults to 2 channels if sources have yet to output audio

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
