### PR TITLE
obs-ffmpeg: Set P3-D65 metadata for HDR

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -423,8 +423,18 @@ static void create_video_stream(struct ffmpeg_mux *ffm)
 	if (ffm->params.max_luminance > 0) {
 		AVMasteringDisplayMetadata *const mastering =
 			av_mastering_display_metadata_alloc();
+		mastering->display_primaries[0][0] = av_make_q(17, 25);
+		mastering->display_primaries[0][1] = av_make_q(8, 25);
+		mastering->display_primaries[1][0] = av_make_q(53, 200);
+		mastering->display_primaries[1][1] = av_make_q(69, 100);
+		mastering->display_primaries[2][0] = av_make_q(3, 20);
+		mastering->display_primaries[2][1] = av_make_q(3, 50);
+		mastering->white_point[0] = av_make_q(3127, 10000);
+		mastering->white_point[1] = av_make_q(329, 1000);
+		mastering->min_luminance = av_make_q(0, 1);
 		mastering->max_luminance =
 			av_make_q(ffm->params.max_luminance, 1);
+		mastering->has_primaries = 1;
 		mastering->has_luminance = 1;
 		av_stream_add_side_data(ffm->video_stream,
 					AV_PKT_DATA_MASTERING_DISPLAY_METADATA,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -163,7 +163,8 @@ static void add_video_encoder_params(struct ffmpeg_muxer *stream,
 						: AVCOL_RANGE_MPEG;
 
 	const int max_luminance =
-		(trc == AVCOL_TRC_SMPTE2084)
+		((trc == AVCOL_TRC_SMPTE2084) ||
+		 (trc == AVCOL_TRC_ARIB_STD_B67))
 			? (int)obs_get_video_hdr_nominal_peak_level()
 			: 0;
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -223,11 +223,22 @@ static bool create_video_stream(struct ffmpeg_data *data)
 			data->config.video_encoder))
 		return false;
 
-	if (data->config.color_trc == AVCOL_TRC_SMPTE2084) {
+	if ((data->config.color_trc == AVCOL_TRC_SMPTE2084) ||
+	    (data->config.color_trc == AVCOL_TRC_ARIB_STD_B67)) {
 		AVMasteringDisplayMetadata *const mastering =
 			av_mastering_display_metadata_alloc();
+		mastering->display_primaries[0][0] = av_make_q(17, 25);
+		mastering->display_primaries[0][1] = av_make_q(8, 25);
+		mastering->display_primaries[1][0] = av_make_q(53, 200);
+		mastering->display_primaries[1][1] = av_make_q(69, 100);
+		mastering->display_primaries[2][0] = av_make_q(3, 20);
+		mastering->display_primaries[2][1] = av_make_q(3, 50);
+		mastering->white_point[0] = av_make_q(3127, 10000);
+		mastering->white_point[1] = av_make_q(329, 1000);
+		mastering->min_luminance = av_make_q(0, 1);
 		mastering->max_luminance = av_make_q(
 			(int)obs_get_video_hdr_nominal_peak_level(), 1);
+		mastering->has_primaries = 1;
 		mastering->has_luminance = 1;
 		av_stream_add_side_data(data->video,
 					AV_PKT_DATA_MASTERING_DISPLAY_METADATA,


### PR DESCRIPTION
### Description
Want to avoid receiver gamut remapping from Rec. 2100 to P3.

Fix min luminance appearing as NaN by switching from 0/0 to 0/1.

Also set max luminance for HLG because why not.

### Motivation and Context
Hopefully better-quality processing for viewer.

### How Has This Been Tested?
Verified metadata for PQ/HLG recordings in VLC and mkvtoolnix.

Not sure how to round trip test the FFmpeg output path, but I at least inspected the AVMasteringDisplayMetadata struct in debugger had the right values.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.