### PR TITLE
CI: Fix clang-format to include Objective-C

### DIFF
--- a/CI/check-format.sh
+++ b/CI/check-format.sh
@@ -53,7 +53,7 @@ find . -type d \( \
     -name '*.h' -or \
     -name '*.hpp' -or \
     -name '*.m' -or \
-    -name '*.m,' -or \
+    -name '*.mm' -or \
     -name '*.c' -or \
     -name '*.cpp' \
  | xargs -L100 -P ${NPROC} ${CLANG_FORMAT} ${VERBOSITY} -i -style=file -fallback-style=none


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Objective-C files end on `.mm`, not `.m,`, so that's what the formatter should look for.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When, looking at #5449, I noticed some tabs were instead spaces and wondered
why it didn't get changed when running the formatter locally and why the check
didn't fail.
Turns out that typos are bad.
Objective-C is uncommon enough in this project that just no one has noticed yet,
but that also means that no files have been modified during the time where this was
wrong and on current master all files are still properly formatted.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. →
macOS 12.4 Beta 1.
Messed with objective-c files and ran check-format to see them get re-formatted

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
