### PR TITLE
deps/media-playback: Add P010 to closest_format

### DIFF
--- a/deps/media-playback/media-playback/closest-format.h
+++ b/deps/media-playback/media-playback/closest-format.h
@@ -95,6 +95,9 @@ static enum AVPixelFormat closest_format(enum AVPixelFormat fmt)
 #endif
 		return AV_PIX_FMT_YUVA444P;
 
+	case AV_PIX_FMT_P010LE:
+		return AV_PIX_FMT_P010LE;
+
 	case AV_PIX_FMT_RGBA:
 	case AV_PIX_FMT_BGRA:
 	case AV_PIX_FMT_BGR0:


### PR DESCRIPTION
### Description
Used by HDR media playback with hardware decode.

### Motivation and Context
Noticed HDR video is invisible when used for stinger transition, which enables hardware decode by default. (Stinger still needs more fixing for HDR though.)

### How Has This Been Tested?
HDR video is now visible.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.