### PR TITLE
obs-transitions: More HDR support

### DIFF
--- a/plugins/obs-transitions/data/luma_wipe_transition.effect
+++ b/plugins/obs-transitions/data/luma_wipe_transition.effect
@@ -60,7 +60,6 @@ float4 PSLumaWipe(VertData v_in) : TARGET
 		rgba = lerp(a_color, b_color, alpha);
 	}
 
-	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
 	return rgba;
 }
 

--- a/plugins/obs-transitions/data/slide_transition.effect
+++ b/plugins/obs-transitions/data/slide_transition.effect
@@ -45,7 +45,6 @@ float4 PSSlide(VertData v_in) : TARGET
 		   ? tex_b.Sample(textureSampler, tex_b_uv)
 		   : tex_a.Sample(textureSampler, tex_a_uv);
 
-	outc.rgb = srgb_nonlinear_to_linear(outc.rgb);
 	return outc;
 }
 

--- a/plugins/obs-transitions/data/swipe_transition.effect
+++ b/plugins/obs-transitions/data/swipe_transition.effect
@@ -42,7 +42,6 @@ float4 PSSwipe(VertData v_in) : TARGET
 		   ? tex_b.Sample(textureSampler, v_in.uv)
 		   : tex_a.Sample(textureSampler, swipe_uv);
 
-	outc.rgb = srgb_nonlinear_to_linear(outc.rgb);
 	return outc;
 }
 

--- a/plugins/obs-transitions/transition-luma-wipe.c
+++ b/plugins/obs-transitions/transition-luma-wipe.c
@@ -168,8 +168,8 @@ static void luma_wipe_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 	const bool previous = gs_framebuffer_srgb_enabled();
 	gs_enable_framebuffer_srgb(true);
 
-	gs_effect_set_texture(lwipe->ep_a_tex, a);
-	gs_effect_set_texture(lwipe->ep_b_tex, b);
+	gs_effect_set_texture_srgb(lwipe->ep_a_tex, a);
+	gs_effect_set_texture_srgb(lwipe->ep_b_tex, b);
 	gs_effect_set_texture(lwipe->ep_l_tex, lwipe->luma_image.texture);
 	gs_effect_set_float(lwipe->ep_progress, t);
 
@@ -210,6 +210,14 @@ bool luma_wipe_audio_render(void *data, uint64_t *ts_out,
 					   channels, sample_rate, mix_a, mix_b);
 }
 
+static enum gs_color_space
+luma_wipe_video_get_color_space(void *data, size_t count,
+				const enum gs_color_space *preferred_spaces)
+{
+	struct luma_wipe_info *const lwipe = data;
+	return obs_transition_video_get_color_space(lwipe->source);
+}
+
 struct obs_source_info luma_wipe_transition = {
 	.id = "wipe_transition",
 	.type = OBS_SOURCE_TYPE_TRANSITION,
@@ -221,4 +229,5 @@ struct obs_source_info luma_wipe_transition = {
 	.audio_render = luma_wipe_audio_render,
 	.get_properties = luma_wipe_properties,
 	.get_defaults = luma_wipe_defaults,
+	.video_get_color_space = luma_wipe_video_get_color_space,
 };

--- a/plugins/obs-transitions/transition-slide.c
+++ b/plugins/obs-transitions/transition-slide.c
@@ -96,8 +96,8 @@ static void slide_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 	const bool previous = gs_framebuffer_srgb_enabled();
 	gs_enable_framebuffer_srgb(true);
 
-	gs_effect_set_texture(slide->a_param, a);
-	gs_effect_set_texture(slide->b_param, b);
+	gs_effect_set_texture_srgb(slide->a_param, a);
+	gs_effect_set_texture_srgb(slide->b_param, b);
 
 	gs_effect_set_vec2(slide->tex_a_dir_param, &tex_a_dir);
 	gs_effect_set_vec2(slide->tex_b_dir_param, &tex_b_dir);
@@ -157,6 +157,14 @@ static obs_properties_t *slide_properties(void *data)
 	return ppts;
 }
 
+static enum gs_color_space
+slide_video_get_color_space(void *data, size_t count,
+			    const enum gs_color_space *preferred_spaces)
+{
+	struct slide_info *const slide = data;
+	return obs_transition_video_get_color_space(slide->source);
+}
+
 struct obs_source_info slide_transition = {
 	.id = "slide_transition",
 	.type = OBS_SOURCE_TYPE_TRANSITION,
@@ -167,4 +175,5 @@ struct obs_source_info slide_transition = {
 	.video_render = slide_video_render,
 	.audio_render = slide_audio_render,
 	.get_properties = slide_properties,
+	.video_get_color_space = slide_video_get_color_space,
 };

--- a/plugins/obs-transitions/transition-swipe.c
+++ b/plugins/obs-transitions/transition-swipe.c
@@ -91,8 +91,8 @@ static void swipe_callback(void *data, gs_texture_t *a, gs_texture_t *b,
 	const bool previous = gs_framebuffer_srgb_enabled();
 	gs_enable_framebuffer_srgb(true);
 
-	gs_effect_set_texture(swipe->a_param, swipe->swipe_in ? b : a);
-	gs_effect_set_texture(swipe->b_param, swipe->swipe_in ? a : b);
+	gs_effect_set_texture_srgb(swipe->a_param, swipe->swipe_in ? b : a);
+	gs_effect_set_texture_srgb(swipe->b_param, swipe->swipe_in ? a : b);
 	gs_effect_set_vec2(swipe->swipe_param, &swipe_val);
 
 	while (gs_effect_loop(swipe->effect, "Swipe"))
@@ -153,6 +153,14 @@ static obs_properties_t *swipe_properties(void *data)
 	return ppts;
 }
 
+static enum gs_color_space
+swipe_video_get_color_space(void *data, size_t count,
+			    const enum gs_color_space *preferred_spaces)
+{
+	struct swipe_info *const swipe = data;
+	return obs_transition_video_get_color_space(swipe->source);
+}
+
 struct obs_source_info swipe_transition = {
 	.id = "swipe_transition",
 	.type = OBS_SOURCE_TYPE_TRANSITION,
@@ -163,4 +171,5 @@ struct obs_source_info swipe_transition = {
 	.video_render = swipe_video_render,
 	.audio_render = swipe_audio_render,
 	.get_properties = swipe_properties,
+	.video_get_color_space = swipe_video_get_color_space,
 };


### PR DESCRIPTION
### Description
Updated luma wipe, slide, and swipe.

Only transition left is stinger, but that one is a bit more complicated.

### Motivation and Context
Need to update transitions to support HDR, or they will clamp to SDR.

### How Has This Been Tested?
Tested various SDR/HDR permutations of output settings and sources.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.