### PR TITLE
libobs: add function obs_source_get_active_fps()

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -913,6 +913,21 @@ void obs_source_replace_missing_file(obs_missing_file_cb cb,
 	cb(source->context.data, new_path, data);
 }
 
+double obs_source_get_active_fps(const obs_source_t *source)
+{
+	if (!data_valid(source, "obs_source_get_active_fps"))
+		return 0.0;
+	if (OBS_SOURCE_TYPE_INPUT != obs_source_get_type(source))
+		return 0.0;
+	if (OBS_SOURCE_ASYNC_VIDEO != (obs_source_get_output_flags(source) & OBS_SOURCE_ASYNC_VIDEO))
+		return 0.0;
+	if (source->info.get_active_fps) {
+		return source->info.get_active_fps(source->context.data);
+	} else {
+		return 0.0;
+	}
+}
+
 bool obs_is_source_configurable(const char *id)
 {
 	const struct obs_source_info *info = get_source_info(id);

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -551,6 +551,9 @@ struct obs_source_info {
 	enum gs_color_space (*video_get_color_space)(
 		void *data, size_t count,
 		const enum gs_color_space *preferred_spaces);
+
+	/** Get active fps **/
+	double (*get_active_fps)(void *data);
 };
 
 EXPORT void obs_register_source_s(const struct obs_source_info *info,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1004,6 +1004,8 @@ EXPORT void obs_source_replace_missing_file(obs_missing_file_cb cb,
 					    obs_source_t *source,
 					    const char *new_path, void *data);
 
+EXPORT double obs_source_get_active_fps(const obs_source_t *source);
+
 /** Returns whether the source has custom properties or not */
 EXPORT bool obs_is_source_configurable(const char *id);
 

--- a/plugins/aja/aja-source.hpp
+++ b/plugins/aja/aja-source.hpp
@@ -84,4 +84,15 @@ private:
 	obs_source_t *mSource;
 
 	NTV2XptConnections mCrosspoints;
+
+	uint64_t last_timestamp;
+	uint32_t active_frame_count;
+public:
+	double_t active_fps;
+	void ResetActiveFpsContextData()
+	{
+		last_timestamp = 0;
+		active_frame_count = 0;
+		active_fps = 0.0;
+	}
 };

--- a/plugins/decklink/DecklinkInput.hpp
+++ b/plugins/decklink/DecklinkInput.hpp
@@ -53,4 +53,14 @@ public:
 	bool allow10Bit = false;
 	BMDVideoConnection videoConnection;
 	BMDAudioConnection audioConnection;
+
+    uint64_t last_timestamp;
+    uint32_t active_frame_count;
+	double_t active_fps;
+	void ResetActiveFpsContextData()
+	{
+		last_timestamp = 0;
+		active_frame_count = 0;
+		active_fps = 0.0;
+	}
 };

--- a/plugins/decklink/decklink-device-instance.cpp
+++ b/plugins/decklink/decklink-device-instance.cpp
@@ -141,6 +141,15 @@ void DeckLinkDeviceInstance::HandleVideoFrame(
 {
 	if (videoFrame == nullptr)
 		return;
+    
+    DeckLinkInput *input = static_cast<DeckLinkInput *>(decklink);
+    long long delta_time = timestamp - input->last_timestamp;
+    if (delta_time >= 1000000000) {
+        input->active_fps = input->active_frame_count * 1000000000.0 / delta_time;
+        input->last_timestamp = timestamp;
+        input->active_frame_count = 0;
+    }
+    input->active_frame_count++;
 
 	ComPtr<IDeckLinkVideoFrameAncillaryPackets> packets;
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -68,7 +68,24 @@ struct ffmpeg_source {
 	enum obs_media_state state;
 	obs_hotkey_pair_id play_pause_hotkey;
 	obs_hotkey_id stop_hotkey;
+
+	uint64_t last_timestamp;
+	uint32_t active_frame_count;
+	double_t active_fps;
 };
+
+static inline void ffmpeg_source_reset_active_fps_context_data(struct ffmpeg_source *s)
+{
+	s->last_timestamp = 0;
+	s->active_frame_count = 0;
+	s->active_fps = 0.0;
+}
+
+static double ffmpeg_source_get_active_fps(void* data)
+{
+	struct ffmpeg_source *s = data;
+	return s->active_fps;
+}
 
 static void set_media_state(void *data, enum obs_media_state state)
 {
@@ -250,6 +267,13 @@ static void dump_source_info(struct ffmpeg_source *s, const char *input,
 static void get_frame(void *opaque, struct obs_source_frame *f)
 {
 	struct ffmpeg_source *s = opaque;
+	long long delta_time = f->timestamp - s->last_timestamp;
+	if (delta_time >= 1000000000) {
+		s->active_fps = s->active_frame_count * 1000000000.0 / delta_time;
+		s->last_timestamp = f->timestamp;
+		s->active_frame_count = 0;
+	}
+	s->active_frame_count++;
 	obs_source_output_video(s->source, f);
 }
 
@@ -601,6 +625,7 @@ static void *ffmpeg_source_create(obs_data_t *settings, obs_source_t *source)
 	UNUSED_PARAMETER(settings);
 
 	struct ffmpeg_source *s = bzalloc(sizeof(struct ffmpeg_source));
+	ffmpeg_source_reset_active_fps_context_data(s);
 	s->source = source;
 
 	s->hotkey = obs_hotkey_register_source(source, "MediaSource.Restart",
@@ -631,6 +656,7 @@ static void *ffmpeg_source_create(obs_data_t *settings, obs_source_t *source)
 static void ffmpeg_source_destroy(void *data)
 {
 	struct ffmpeg_source *s = data;
+	ffmpeg_source_reset_active_fps_context_data(s);
 
 	if (s->hotkey)
 		obs_hotkey_unregister(s->hotkey);
@@ -653,6 +679,7 @@ static void ffmpeg_source_destroy(void *data)
 static void ffmpeg_source_activate(void *data)
 {
 	struct ffmpeg_source *s = data;
+	ffmpeg_source_reset_active_fps_context_data(s);
 
 	if (s->restart_on_activate)
 		obs_source_media_restart(s->source);
@@ -661,6 +688,7 @@ static void ffmpeg_source_activate(void *data)
 static void ffmpeg_source_deactivate(void *data)
 {
 	struct ffmpeg_source *s = data;
+	ffmpeg_source_reset_active_fps_context_data(s);
 
 	if (s->restart_on_activate) {
 		if (s->media_valid) {
@@ -675,6 +703,7 @@ static void ffmpeg_source_deactivate(void *data)
 static void ffmpeg_source_play_pause(void *data, bool pause)
 {
 	struct ffmpeg_source *s = data;
+	ffmpeg_source_reset_active_fps_context_data(s);
 
 	if (!s->media_valid)
 		ffmpeg_source_open(s);
@@ -697,6 +726,7 @@ static void ffmpeg_source_play_pause(void *data, bool pause)
 static void ffmpeg_source_stop(void *data)
 {
 	struct ffmpeg_source *s = data;
+	ffmpeg_source_reset_active_fps_context_data(s);
 
 	if (s->media_valid) {
 		mp_media_stop(&s->media);
@@ -708,6 +738,7 @@ static void ffmpeg_source_stop(void *data)
 static void ffmpeg_source_restart(void *data)
 {
 	struct ffmpeg_source *s = data;
+	ffmpeg_source_reset_active_fps_context_data(s);
 
 	if (obs_source_showing(s->source))
 		ffmpeg_source_start(s);
@@ -805,4 +836,5 @@ struct obs_source_info ffmpeg_source = {
 	.media_get_time = ffmpeg_source_get_time,
 	.media_set_time = ffmpeg_source_set_time,
 	.media_get_state = ffmpeg_source_get_state,
+	.get_active_fps = ffmpeg_source_get_active_fps,
 };


### PR DESCRIPTION
(cherry picked from commit 79e68e99cca41dfce21238b7578d851a6fc4683d)

### Description
export new function: obs_source_get_active_fps() to get fps of a active source.

### Motivation and Context
the obs_source_get_active_fps()  make me know the source's active performence (like camera)

### How Has This Been Tested?
Mac: 12.3.1
Win: Win10
Camera: Logical E930

### Types of changes
New feature

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ x] My code is not on the master branch.
- [ x] The code has been tested.
- [ x] All commit messages are properly formatted and commits squashed where appropriate.
- [ x] I have included updates to all appropriate documentation.
