### PR TITLE
Add JSONSchema definitions for services & validate using CI

### DIFF
--- a/.github/workflows/services-json.yml
+++ b/.github/workflows/services-json.yml
@@ -1,0 +1,40 @@
+name: Services Validator
+
+on:
+  push:
+    paths:
+      - "plugins/rtmp-services/data/services.json"
+      - "plugins/rtmp-services/data/package.json"
+  pull_request:
+    paths:
+      - "plugins/rtmp-services/data/services.json"
+      - "plugins/rtmp-services/data/package.json"
+
+jobs:
+  schema:
+    name: Schema
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install & Configure Python
+        run: |
+          sudo apt install python3.9-dev
+          python3.9 -m pip install jsonschema json_source_map
+
+      - name: Validate Service JSON Schema
+        run: |
+          JSON_FILES=(
+            plugins/rtmp-services/data/services.json
+            plugins/rtmp-services/data/package.json
+          )
+          python3.9 CI/check-jsonschema.py "${JSON_FILES[@]}"
+
+      - name: Annotate Errors
+        if: failure()
+        uses: yuzutech/annotations-action@v0.4.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          title: "Service JSON Errors"
+          input: "./validation_errors.json"

--- a/CI/check-jsonschema.py
+++ b/CI/check-jsonschema.py
@@ -1,0 +1,84 @@
+import json
+from jsonschema import Draft7Validator
+from json_source_map import calculate
+from json_source_map.errors import InvalidInputError
+import os
+import sys
+
+
+errors = []
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("JSON path required.")
+        return 1
+
+    for filename in sys.argv[1:]:
+        prep(filename)
+
+    try:
+        with open('validation_errors.json', 'w') as outfile:
+            json.dump(errors, outfile)
+    except OSError as e:
+        print(f'Failed to write validation output to file: {e}')
+        return 1
+
+    if errors:
+        return 1
+
+    return 0
+
+
+def prep(filename):
+    try:
+        with open(filename) as json_file:
+            json_string = json_file.read()
+            json_data = json.loads(json_string)
+    except OSError as e:
+        print(f'Failed to load file "{filename}": {e}')
+        return
+
+    schema_filename = json_data.get('$schema')
+    if not schema_filename:
+        print('File has no schema:', filename)
+        return
+
+    file_path = os.path.split(filename)[0]
+    schema_file = os.path.join(file_path, schema_filename)
+
+    try:
+        with open(schema_file) as json_file:
+            schema = json.load(json_file)
+    except OSError as e:
+        print(f'Failed to load schema file "{schema_file}": {e}')
+        return
+
+    validate(filename, json_data, json_string, schema)
+
+
+def validate(filename, json_data, json_string, schema):
+    try:
+        servicesPaths = calculate(json_string)
+    except InvalidInputError as e:
+        print("Error with file:", e)
+        return
+
+    cls = Draft7Validator(schema)
+
+    for e in sorted(cls.iter_errors(json_data), key=str):
+        print(f'{e}\nIn "{filename}"\n\n')
+        errorPath = '/'.join(str(v) for v in e.absolute_path)
+        errorEntry = servicesPaths['/' + errorPath]
+        errors.append({
+            "file": filename,
+            "start_line": errorEntry.value_start.line + 1,
+            "end_line": errorEntry.value_end.line + 1,
+            "title": "Validation Error",
+            "message": e.message,
+            "annotation_level": "failure"
+        })
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "schema/package-schema.json",
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
 	"version": 196,
 	"files": [

--- a/plugins/rtmp-services/data/schema/package-schema.json
+++ b/plugins/rtmp-services/data/schema/package-schema.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "url": {
+            "$ref": "#/definitions/saneUrl",
+            "description": "Points to the base URL of hosted package.json and services.json files, used to automatically fetch the latest version."
+        },
+        "version": {
+            "type": "integer"
+        },
+        "files": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Filename to read,, containing service definitions."
+                    },
+                    "version": {
+                        "type": "integer",
+                        "description": "This value should be bumped any time the file defined by the 'name' field is changed. This value will be used when determining whether a new version is available."
+                    }
+                },
+                "required": [
+                    "name",
+                    "version"
+                ]
+            },
+            "description": "List of files to read, each containing a list of services.",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "url",
+        "version",
+        "files"
+    ],
+    "definitions": {
+        "saneUrl": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https?://"
+        }
+    }
+}

--- a/plugins/rtmp-services/data/schema/service-schema-v3.json
+++ b/plugins/rtmp-services/data/schema/service-schema-v3.json
@@ -1,0 +1,212 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "format_version": {
+            "type": "integer",
+            "description": "Identifier for parsing this file.\n- v3 introduced 'ffmpeg_hls_muxer' to services/recommended/output\n - v2 introduced 'alt_names' to services"
+        },
+        "services": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the streaming service. Will be displayed in the Service dropdown.",
+                        "minLength": 1
+                    },
+                    "common": {
+                        "type": "boolean",
+                        "description": "Whether or not the service is shown in the list before it is expanded to all services by the user.",
+                        "default": false
+                    },
+                    "stream_key_link": {
+                        "$ref": "#/definitions/saneUrl",
+                        "description": "Link where a logged-in user can find the 'stream key', presented as a button alongside the stream key field."
+                    },
+                    "servers": {
+                        "type": "array",
+                        "description": "List of servers.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the server (e.g. location, primary/backup), displayed in the Server dropdown.",
+                                    "minLength": 1
+                                },
+                                "url": {
+                                    "$ref": "#/definitions/serviceUri",
+                                    "description": "RTMP(S) or HLS URL of the ingest server.",
+                                    "minLength": 1
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "name",
+                                "url"
+                            ]
+                        },
+                        "default": [
+                            {
+                                "name": "",
+                                "url": ""
+                            }
+                        ],
+                        "minItems": 1,
+                        "additionalItems": true
+                    },
+                    "recommended": {
+                        "type": "object",
+                        "description": "Recommended service settings. Users will be unable to choose values outside of these by default, so choose recommended values carefully.",
+                        "properties": {
+                            "keyint": {
+                                "type": "integer",
+                                "description": "Keyframe interval (seconds)."
+                            },
+                            "max video bitrate": {
+                                "type": "integer",
+                                "description": "Highest supported video bitrate (kbps)."
+                            },
+                            "max audio bitrate": {
+                                "type": "integer",
+                                "description": "Highest supported audio bitrate (kbps)."
+                            },
+                            "x264opts": {
+                                "type": "string",
+                                "description": "Additional x264 encoder options. Space-separated.",
+                                "pattern": "^(\\S+=\\S+\\s*)+$"
+                            },
+                            "output": {
+                                "type": "string",
+                                "description": "OBS output module used.",
+                                "enum": [
+                                    "rtmp_output",
+                                    "ffmpeg_hls_muxer",
+                                    "ftl_output"
+                                ]
+                            },
+                            "profile": {
+                                "type": "string",
+                                "description": "H.264 Profile.",
+                                "minLength": 1,
+                                "enum": [
+                                    "high",
+                                    "main",
+                                    "baseline"
+                                ]
+                            },
+                            "bframes": {
+                                "type": "integer",
+                                "description": "Maximum allowed number of B-Frames."
+                            },
+                            "supported resolutions": {
+                                "type": "array",
+                                "description": "List of supported resolutions in format {width}x{height}",
+                                "items": {
+                                    "$ref": "#/definitions/resolution"
+                                },
+                                "minItems": 1,
+                                "additionalItems": true
+                            },
+                            "max fps": {
+                                "type": "integer",
+                                "description": "Maximum supported framerate."
+                            },
+                            "bitrate matrix": {
+                                "type": "array",
+                                "description": "List of resolutions and frame rate combinations with their recommended maximum bitrate.",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "res": {
+                                            "$ref": "#/definitions/resolution",
+                                            "description": "Resolution in format {width}x{height}"
+                                        },
+                                        "fps": {
+                                            "type": "integer",
+                                            "description": "Frame rate"
+                                        },
+                                        "max bitrate": {
+                                            "type": "integer",
+                                            "description": "Maximum bitrate in kbps."
+                                        }
+                                    },
+                                    "minItems": 1,
+                                    "additionalProperties": false,
+                                    "required": [
+                                        "res",
+                                        "fps",
+                                        "max bitrate"
+                                    ]
+                                },
+                                "default": [
+                                    {
+                                        "res": "",
+                                        "fps": "",
+                                        "max bitrate": ""
+                                    }
+                                ],
+                                "additionalItems": true
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "more_info_link": {
+                        "$ref": "#/definitions/saneUrl",
+                        "description": "Link that provides additional info about the service, presented in the UI as a button next to the services dropdown."
+                    },
+                    "alt_names": {
+                        "type": "array",
+                        "description": "Previous names of the service used for migrating existing users to the updated entry.",
+                        "items": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "default": [
+                            ""
+                        ]
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "servers"
+                ]
+            },
+            "additionalItems": true
+        }
+    },
+    "additionalProperties": true,
+    "required": [
+        "format_version",
+        "services"
+    ],
+    "definitions": {
+        "resolution": {
+            "type": "string",
+            "pattern": "^\\d+x\\d+$",
+            "default": ""
+        },
+        "saneUrl": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https?://.+",
+            "default": "https://"
+        },
+        "serviceUri": {
+            "anyOf": [
+                {
+                    "type": "string",
+                    "format": "uri",
+                    "pattern": "^(https|http|rtmps|rtmp|srt|rist)?://"
+                },
+                {
+                    "type": "string",
+                    "format": "hostname"
+                }
+            ]
+        }
+    }
+}

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "schema/service-schema-v3.json",
     "format_version": 3,
     "services": [
         {


### PR DESCRIPTION
### Description

This adds full JSONSchema definition files for both services.json and package.json, which can be validated using various tools, including an IDE. This includes user-friendly descriptions pulled from [Service Submission Guidelines](https://github.com/obsproject/obs-studio/wiki/Service-Submission-Guidelines).

![image](https://user-images.githubusercontent.com/941350/163961215-100d99a2-4226-4532-9eaa-aab2ba221384.png)

![image](https://user-images.githubusercontent.com/941350/163960917-0285ff32-8eed-4243-97a4-6cb760bd9f0f.png)

![image](https://user-images.githubusercontent.com/941350/163960968-ed2ef177-fadc-4780-896f-2171dfc26586.png)

![image](https://user-images.githubusercontent.com/941350/163961044-1fa6590e-8335-4b81-a9b6-a34f099eca0e.png)

![image](https://user-images.githubusercontent.com/941350/163961146-14cf7f40-0527-4a48-aa71-329162e9bb32.png)


Additionally, this adds a Python-based validation runner when users submit Pull Requests, informing them of any failing validations directly within the diff.

![image](https://user-images.githubusercontent.com/941350/163961341-fb376c18-b3a0-4ec8-b7a7-f4202bd5f09c.png)

![image](https://user-images.githubusercontent.com/941350/163961381-b2fd53e5-4e21-4156-b238-bedd97994dbd.png)

Unfortunately, I had to write a custom python script to perform complete validation, as none of the existing libraries provide line numbers by default - it's exclusively _paths_ within the JSON structure. Additionally, errors would be poorly formatted and generally hard to read. Instead I have to return a custom JSON result and write that to a file, to be read by an annotation GitHub Action.

By default, CI will only validate the services.json file. If needed, I can add the package.json to the CI run too.

Bonus: json_source_map was built incorrectly and only works on Python 3.9 and above, so I had to manually install that too.

If the services.json format is changed, the schema should be bumped too, which is why the file is v3.

### Motivation and Context

When new services are submitted, there isn't enough feedback to the submitter about what was done incorrectly.

### How Has This Been Tested?

Install Python 3.9 and the required dependencies.

```sh
sudo apt install python3.9-dev
python3.9 -m pip install jsonschema json_source_map
```

Then run the validation script.

```sh
python3.9 CI/check-jsonschema.py plugins/rtmp-services/data/services.json plugins/rtmp-services/data/schema/service-schema-v3.json
```

Note that it silently succeeds. Modify the services.json to be invalid, then run the script again.

Additionally, ran the CI script manually.

### Types of changes

 - New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
