### PR TITLE
UI: Make window-projector its own top level QWidget

### DIFF
--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -26,12 +26,13 @@ enum class MultiviewLayout : uint8_t {
 	SCENES_ONLY_25_SCENES = 9,
 };
 
-class OBSProjector : public OBSQTDisplay {
+class OBSProjector : public QWidget {
 	Q_OBJECT
 
 private:
 	OBSSource source;
 	OBSSignal removedSignal;
+	OBSQTDisplay display;
 
 	static void OBSRenderMultiview(void *data, uint32_t cx, uint32_t cy);
 	static void OBSRender(void *data, uint32_t cx, uint32_t cy);
@@ -40,6 +41,13 @@ private:
 	void mousePressEvent(QMouseEvent *event) override;
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
 	void closeEvent(QCloseEvent *event) override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	virtual bool nativeEvent(const QByteArray &eventType, void *message,
+				 qintptr *result) override;
+#else
+	virtual bool nativeEvent(const QByteArray &eventType, void *message,
+				 long *result) override;
+#endif
 
 	bool isAlwaysOnTop;
 	bool isAlwaysOnTopOverridden = false;


### PR DESCRIPTION
### Description
Previously OBSProjector was a subclass of OBSQTDisplay, which is
intended to own the entire surface it draws on. On wayland some
compositors expect the client to draw decorations (window titlebar), but
because OBSQTDisplay draws on the entire surface directly the client
decorations from QT are overwritten.

Instead promote OBSProjector to a simple QWidget with a single layout
containing the OBSQTDisplay. This allows the OBSQTDisplay to own the
entire contents while OBSProjector draws the decorations.

fixes #6283

### Motivation and Context
Broken rendering on wayland isnt that great.

### How Has This Been Tested?
Tested on gnome/i3. I couldnt immediately find any issues with projector (windowed/fullscreen) or with multi-scene previews (windowed/fullscreen). But some more testing that this doesnt adversely affect other platforms would be good, though this brings the display closer to rendering like the preview than it was before.

I'm also not very proficient at Qt so there could be some subtle issues with this minor change.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
