### PR TITLE
UI: Add dock widget title bars

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -141,6 +141,8 @@ TwitchAuth.Feed="Twitch Activity Feed"
 TwitchAuth.TwoFactorFail.Title="Could not query stream key"
 TwitchAuth.TwoFactorFail.Text="OBS was unable to connect to your Twitch account. Please make sure two-factor authentication is set up in your <a href='https://www.twitch.tv/settings/security'>Twitch security settings</a> as this is required to stream."
 RestreamAuth.Channels="Restream Channels"
+SetFloating="Set Floating"
+SetDocked="Set Docked"
 
 # copy filters
 Copy.Filters="Copy Filters"

--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -154,10 +154,6 @@ QListView QLineEdit {
 }
 
 /* Dock stuff */
-QDockWidget {
-	titlebar-close-icon: url('./Dark/close.svg');
-	titlebar-normal-icon: url('./Dark/popout.svg');
-}
 
 QDockWidget {
 	background: palette(window);
@@ -167,7 +163,7 @@ QDockWidget {
 	border-bottom: 2px solid rgb(47,47,47);
 }
 
-QDockWidget::title {
+QFrame#dockTitleBar {
 	border-bottom: 2px solid rgb(47,47,47);
 	margin-left: 5px;
 	margin-right: 5px;
@@ -181,19 +177,15 @@ QDockWidget::title {
 	background-repeat: none;
 }
 
-QDockWidget::close-button,
-QDockWidget::float-button {
-	icon-size: 20px;
-	subcontrol-position: top right;
-	subcontrol-origin: padding;
-	right: 0px;
-	margin: 0px;
+QFrame#dockTitleBar > QLabel {
+    font-weight: bold;
+	font-size: 12px;
+	background: transparent;
 }
 
-QDockWidget::float-button {
-	right: 20px;
+* [themeID="dotsIcon"] {
+    qproperty-icon: url(./Dark/dots.svg);
 }
-
 
 QListView#scenes,
 SourceListWidget {

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -119,28 +119,34 @@ SourceTree QLineEdit {
 
 /* Dock Widget */
 
-QDockWidget {
-	titlebar-close-icon: url('./Dark/close.svg');
-	titlebar-normal-icon: url('./Dark/popout.svg');
-}
-
-QDockWidget::title {
-    text-align: center;
+QFrame#dockTitleBar {
     background-color: rgb(70,69,70);
 }
 
-QDockWidget::close-button, QDockWidget::float-button {
-    border: 1px solid transparent;
-    background: transparent;
-    padding: 0px;
-}
-
-QDockWidget::close-button:hover, QDockWidget::float-button:hover {
+QFrame#dockTitleBar > QLabel {
+    font-weight: bold;
+    font-size: 12px;
     background: transparent;
 }
 
-QDockWidget::close-button:pressed, QDockWidget::float-button:pressed {
-    padding: 1px -1px -1px 1px;
+QPushButton#dockTitleBarButton::flat {
+    background-color: rgb(70,69,70);
+}
+
+QPushButton#dockTitleBarButton::flat:hover {
+    background-color: rgb(122,121,122); /* light */
+}
+
+QPushButton#dockTitleBarButton::flat:pressed {
+    background-color: palette(base);
+}
+
+QPushButton#dockTitleBarButton::flat:disabled {
+    background-color: rgb(46,45,46);
+}
+
+* [themeID="dotsIcon"] {
+    qproperty-icon: url(./Dark/dots.svg);
 }
 
 /* Group Box */

--- a/UI/data/themes/Dark/dots.svg
+++ b/UI/data/themes/Dark/dots.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#d2d2d2" class="bi bi-three-dots-vertical" viewBox="0 0 16 16">
+  <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/>
+</svg>

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -189,37 +189,44 @@ QListView::item:hover:!active {
 /***********************/
 
 QDockWidget {
-	titlebar-close-icon: url('./Dark/close.svg');
-	titlebar-normal-icon: url('./Dark/popout.svg');
-}
-
-QDockWidget {
 	background: palette(window);
 	border: 1px solid rgb(58, 64, 69); /* Light Blue-gray */
 }
 
-QDockWidget::title {
-	text-align: left;
+QFrame#dockTitleBar {
 	background: palette(shadow);
 	padding-left: 5px;
 }
 
-
-QDockWidget::close-button, QDockWidget::float-button {
-	border: 1px solid transparent;
-	border-radius: 2px;
+QFrame#dockTitleBar > QLabel {
+	font-weight: bold;
+	font-size: 12px;
 	background: transparent;
 }
 
-QDockWidget::close-button:hover, QDockWidget::float-button:hover {
-	background: rgba(255, 148, 194, 0.25); /* Light Pink (Secondary Light) */
+QPushButton#dockTitleBarButton::flat {
+	background-color: palette(shadow);
+	border: none;
+	outline: none;
 }
 
-QDockWidget::close-button:pressed, QDockWidget::float-button:pressed {
-	padding: 1px -1px -1px 1px;
-	background: rgba(255, 148, 194, 0.25); /* Light Pink (Secondary Light) */
+QPushButton#dockTitleBarButton::flat:hover {
+	background-color: rgba(240, 98, 146, 0.5); /* Pink (Secondary) */
+	margin: 0;
+	padding: 0;
+	border-radius: 2px;
+	border: none;
+	outline: none;
 }
 
+QPushButton#dockTitleBarButton::flat:pressed {
+	background-color: rgb(240, 98, 146); /* Pink (Secondary) */
+	border: 1px solid rgb(240, 98, 146); /* Pink (Secondary) */
+}
+
+* [themeID="dotsIcon"] {
+	qproperty-icon: url(./Dark/dots.svg);
+}
 
 /***********************/
 /* --- Group Boxes --- */

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -358,3 +358,14 @@ QCalendarWidget #qt_calendar_nextmonth {
     qproperty-icon: url(./Dark/expand.svg);
     icon-size: 16px, 16px;
 }
+
+/* Dock Title Bar */
+#dockTitleBar > QLabel {
+    font-weight: bold;
+    font-size: 12px;
+    background: transparent;
+}
+
+* [themeID="dotsIcon"] {
+    qproperty-icon: url(:/res/images/dots.svg);
+}

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -667,7 +667,6 @@
     </action>
     <addaction name="actionFullscreenInterface"/>
     <addaction name="separator"/>
-    <addaction name="toggleListboxToolbars"/>
     <addaction name="toggleContextBar"/>
     <addaction name="toggleSourceIcons"/>
     <addaction name="toggleStatusBar"/>
@@ -801,24 +800,6 @@
          </widget>
         </item>
         <item>
-         <widget class="QToolBar" name="scenesToolbar">
-          <property name="iconSize">
-           <size>
-            <width>16</width>
-            <height>16</height>
-           </size>
-          </property>
-          <property name="floatable">
-           <bool>false</bool>
-          </property>
-          <addaction name="actionAddScene"/>
-          <addaction name="actionRemoveScene"/>
-          <addaction name="separator"/>
-          <addaction name="actionSceneUp"/>
-          <addaction name="actionSceneDown"/>
-         </widget>
-        </item>
-        <item>
          <spacer name="scenesFixedSizeHSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -933,25 +914,6 @@
            <enum>QAbstractItemView::ExtendedSelection</enum>
           </property>
           <addaction name="actionRemoveSource"/>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolBar" name="sourcesToolbar">
-          <property name="iconSize">
-           <size>
-            <width>16</width>
-            <height>16</height>
-           </size>
-          </property>
-          <property name="floatable">
-           <bool>false</bool>
-          </property>
-          <addaction name="actionAddSource"/>
-          <addaction name="actionRemoveSource"/>
-          <addaction name="actionSourceProperties"/>
-          <addaction name="separator"/>
-          <addaction name="actionSourceUp"/>
-          <addaction name="actionSourceDown"/>
          </widget>
         </item>
         <item>

--- a/UI/forms/images/dots.svg
+++ b/UI/forms/images/dots.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-three-dots-vertical" viewBox="0 0 16 16">
+  <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/>
+</svg>

--- a/UI/forms/obs.qrc
+++ b/UI/forms/obs.qrc
@@ -56,6 +56,7 @@
     <file>images/media/media_restart.svg</file>
     <file>images/media/media_stop.svg</file>
     <file>images/interact.svg</file>
+    <file>images/dots.svg</file>
   </qresource>
   <qresource prefix="/settings">
     <file>images/settings/output.svg</file>

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -185,6 +185,7 @@ class OBSBasic : public OBSMainWindow {
 	friend class OBSYoutubeActions;
 	friend struct BasicOutputHandler;
 	friend struct OBSStudioAPI;
+	friend class OBSDock;
 
 	enum class MoveDir { Up, Down, Left, Right };
 
@@ -240,7 +241,7 @@ private:
 	QPointer<OBSBasicTransform> transformWindow;
 	QPointer<OBSBasicAdvAudio> advAudioWindow;
 	QPointer<OBSBasicFilters> filters;
-	QPointer<QDockWidget> statsDock;
+	QPointer<OBSDock> statsDock;
 	QPointer<OBSAbout> about;
 	QPointer<OBSMissingFiles> missDialog;
 	QPointer<OBSLogViewer> logView;
@@ -538,6 +539,8 @@ private:
 	void ReceivedIntroJson(const QString &text);
 	void ShowWhatsNew(const QString &url);
 
+	void SetupDockTitleBars();
+
 #ifdef BROWSER_AVAILABLE
 	QList<QSharedPointer<QDockWidget>> extraBrowserDocks;
 	QList<QSharedPointer<QAction>> extraBrowserDockActions;
@@ -804,7 +807,6 @@ private:
 	void AddSource(const char *id);
 	QMenu *CreateAddSourcePopupMenu();
 	void AddSourcePopupMenu(const QPoint &pos);
-	void copyActionsDynamicProperties();
 
 	static void HotkeyTriggered(void *data, obs_hotkey_id id, bool pressed);
 
@@ -1062,7 +1064,6 @@ private slots:
 
 	void on_actionAlwaysOnTop_triggered();
 
-	void on_toggleListboxToolbars_toggled(bool visible);
 	void on_toggleContextBar_toggled(bool visible);
 	void on_toggleStatusBar_toggled(bool visible);
 	void on_toggleSourceIcons_toggled(bool visible);

--- a/UI/window-dock.cpp
+++ b/UI/window-dock.cpp
@@ -3,6 +3,31 @@
 
 #include <QMessageBox>
 #include <QCheckBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QMenu>
+
+OBSDock::OBSDock(QWidget *parent) : QDockWidget(parent)
+{
+	QFrame *titleBar = new QFrame(this);
+
+	titleBar->setObjectName("dockTitleBar");
+
+	title = new QLabel(titleBar);
+	title->setAlignment(Qt::AlignVCenter);
+
+	layout = new QHBoxLayout(titleBar);
+	layout->setContentsMargins(4, 2, 4, 2);
+	layout->setSpacing(4);
+
+	layout->addWidget(title);
+	layout->addStretch();
+
+	titleBar->setLayout(layout);
+
+	setTitleBarWidget(titleBar);
+}
 
 void OBSDock::closeEvent(QCloseEvent *event)
 {
@@ -33,4 +58,76 @@ void OBSDock::closeEvent(QCloseEvent *event)
 	}
 
 	QDockWidget::closeEvent(event);
+}
+
+void OBSDock::ToggleFloating()
+{
+	if (isFloating())
+		setFloating(false);
+	else
+		setFloating(true);
+}
+
+void OBSDock::ShowControlMenu()
+{
+	QMenu popup;
+
+	QDockWidget::DockWidgetFeatures dockFeatures = features();
+
+	if ((QDockWidget::DockWidgetClosable & dockFeatures) != 0)
+		popup.addAction(QTStr("Hide"), this, SLOT(close()));
+
+	popup.addAction(isFloating() ? QTStr("SetDocked")
+				     : QTStr("SetFloating"),
+			this, SLOT(ToggleFloating()));
+
+	popup.exec(QCursor::pos());
+}
+
+void OBSDock::EnableControlMenu(bool lock)
+{
+	menuButton->setVisible(!lock);
+}
+
+void OBSDock::AddControlMenu()
+{
+	menuButton = new QPushButton(this);
+	menuButton->setFlat(true);
+	menuButton->setObjectName("dockTitleBarButton");
+	menuButton->setFixedSize(16, 16);
+	menuButton->setIconSize(QSize(12, 12));
+	menuButton->setProperty("themeID", "dotsIcon");
+
+	connect(menuButton, SIGNAL(clicked()), this, SLOT(ShowControlMenu()));
+
+	layout->addWidget(menuButton);
+}
+
+void OBSDock::SetTitle(const QString &newTitle)
+{
+	title->setText(newTitle);
+}
+
+void OBSDock::AddButton(const QString &themeID, const QString &toolTip,
+			const QObject *receiver, const char *slot)
+{
+	QPushButton *button = new QPushButton(this);
+	button->setFlat(true);
+	button->setObjectName("dockTitleBarButton");
+	button->setFixedSize(16, 16);
+	button->setIconSize(QSize(12, 12));
+	button->setProperty("themeID", themeID);
+	button->setToolTip(toolTip);
+
+	connect(button, SIGNAL(clicked()), receiver, slot);
+
+	layout->addWidget(button);
+}
+
+void OBSDock::AddSeparator()
+{
+	QFrame *line = new QFrame(this);
+	line->setFrameShape(QFrame::VLine);
+	line->setFixedWidth(1);
+	layout->addWidget(line);
 }

--- a/UI/window-dock.hpp
+++ b/UI/window-dock.hpp
@@ -2,11 +2,31 @@
 
 #include <QDockWidget>
 
+class QHBoxLayout;
+class QLabel;
+class QPushButton;
+
 class OBSDock : public QDockWidget {
 	Q_OBJECT
 
-public:
-	inline OBSDock(QWidget *parent = nullptr) : QDockWidget(parent) {}
+private:
+	QLabel *title = nullptr;
+	QHBoxLayout *layout = nullptr;
+	QPushButton *menuButton = nullptr;
 
+private slots:
+	void ShowControlMenu();
+	void ToggleFloating();
+
+public:
+	void EnableControlMenu(bool lock);
+	void AddControlMenu();
+
+	void SetTitle(const QString &newTitle);
+	void AddButton(const QString &themeID, const QString &toolTip,
+		       const QObject *receiver, const char *slot);
+	void AddSeparator();
+
+	OBSDock(QWidget *parent = nullptr);
 	virtual void closeEvent(QCloseEvent *event);
 };

--- a/UI/window-extra-browsers.cpp
+++ b/UI/window-extra-browsers.cpp
@@ -534,7 +534,7 @@ void OBSBasic::AddExtraBrowserDock(const QString &title, const QString &url,
 	dock->setObjectName(title + OBJ_NAME_SUFFIX);
 	dock->resize(460, 600);
 	dock->setMinimumSize(80, 80);
-	dock->setWindowTitle(title);
+	dock->SetTitle(title);
 	dock->setAllowedAreas(Qt::AllDockWidgetAreas);
 
 	QCefWidget *browser =


### PR DESCRIPTION
### Description
This moves the dock toolbars to the title bar of
the dock, saving space.

![Capture](https://user-images.githubusercontent.com/19962531/164242984-af2b29c0-79c8-48f6-a0bf-513e26060d66.PNG)

### Motivation and Context
Makes UI look better.

### How Has This Been Tested?
Made sure the title bars rendered properly for each dock and made the buttons worked. Only tested on Windows 10, but should be fine elsewhere.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
