### PR TITLE
obs-transitions: Remove unused shader functions

### DIFF
--- a/plugins/obs-transitions/data/luma_wipe_transition.effect
+++ b/plugins/obs-transitions/data/luma_wipe_transition.effect
@@ -28,16 +28,6 @@ VertData VSDefault(VertData v_in)
 	return vert_out;
 }
 
-float srgb_nonlinear_to_linear_channel(float u)
-{
-	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
-}
-
-float3 srgb_nonlinear_to_linear(float3 v)
-{
-	return float3(srgb_nonlinear_to_linear_channel(v.r), srgb_nonlinear_to_linear_channel(v.g), srgb_nonlinear_to_linear_channel(v.b));
-}
-
 float4 PSLumaWipe(VertData v_in) : TARGET
 {
 	float2 uv = v_in.uv;

--- a/plugins/obs-transitions/data/slide_transition.effect
+++ b/plugins/obs-transitions/data/slide_transition.effect
@@ -24,16 +24,6 @@ VertData VSDefault(VertData v_in)
 	return vert_out;
 }
 
-float srgb_nonlinear_to_linear_channel(float u)
-{
-	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
-}
-
-float3 srgb_nonlinear_to_linear(float3 v)
-{
-	return float3(srgb_nonlinear_to_linear_channel(v.r), srgb_nonlinear_to_linear_channel(v.g), srgb_nonlinear_to_linear_channel(v.b));
-}
-
 float4 PSSlide(VertData v_in) : TARGET
 {
 	float2 tex_a_uv = v_in.uv + tex_a_dir;

--- a/plugins/obs-transitions/data/swipe_transition.effect
+++ b/plugins/obs-transitions/data/swipe_transition.effect
@@ -22,16 +22,6 @@ VertData VSDefault(VertData v_in)
 	return vert_out;
 }
 
-float srgb_nonlinear_to_linear_channel(float u)
-{
-	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
-}
-
-float3 srgb_nonlinear_to_linear(float3 v)
-{
-	return float3(srgb_nonlinear_to_linear_channel(v.r), srgb_nonlinear_to_linear_channel(v.g), srgb_nonlinear_to_linear_channel(v.b));
-}
-
 float4 PSSwipe(VertData v_in) : TARGET
 {
 	float2 swipe_uv = v_in.uv + swipe_val;


### PR DESCRIPTION
### Description
Leftover from previous commit.

### Motivation and Context
Don't like to leave a mess.

### How Has This Been Tested?
Verified all three transitions still work.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.