### PR TITLE
CI: Do not run Steam workflow on forks

### DIFF
--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -29,6 +29,7 @@ jobs:
   upload:
     name: Steam upload
     runs-on: ubuntu-20.04
+    if: github.repository_owner == 'obsproject'
 
     steps:
     - name: Checkout


### PR DESCRIPTION
### Description

Only runs Steam CI workflow when running on the obsproject org.

### Motivation and Context

People complained about emails.

### How Has This Been Tested?

Tried running it on my repo, job was skipped.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
