### PR TITLE
libobs,obs-outputs: Fix librtmp1 dependency interference on some linuxes

### DIFF
--- a/libobs/util/c99defs.h
+++ b/libobs/util/c99defs.h
@@ -50,7 +50,7 @@
 #ifdef _MSC_VER
 #define EXPORT __declspec(dllexport)
 #else
-#define EXPORT
+#define EXPORT __attribute__((visibility("default")))
 #endif
 
 #include <stddef.h>

--- a/plugins/obs-outputs/CMakeLists.txt
+++ b/plugins/obs-outputs/CMakeLists.txt
@@ -96,9 +96,11 @@ if(ENABLE_RTMPS STREQUAL "AUTO" OR ENABLE_RTMPS STREQUAL "ON")
       target_link_libraries(obs-outputs PRIVATE ${FOUNDATION_FRAMEWORK}
                                                 ${SECURITY_FRAMEWORK})
       set_target_properties(obs-outputs PROPERTIES CXX_VISIBILITY_PRESET hidden)
+      set_target_properties(obs-outputs PROPERTIES C_VISIBILITY_PRESET hidden)
 
     elseif(OS_POSIX)
       set_target_properties(obs-outputs PROPERTIES CXX_VISIBILITY_PRESET hidden)
+      set_target_properties(obs-outputs PROPERTIES C_VISIBILITY_PRESET hidden)
     endif()
   endif()
 else()


### PR DESCRIPTION
### Description
Details in #6226, basically this fixes an issue where OBS links to the system-installed librtmp1, which is incompatible with our librtmp.

Closes #6226 

### Motivation and Context
Spent all day trying to fix an ambiguous issue only to find that this hasn't been PR'd yet.

### How Has This Been Tested?
Without PR: OBS crashes when starting stream to RTMP server
With PR: No OBS crash any longer

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
