### PR TITLE
Fix indent on multiline comments

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5889,7 +5889,7 @@ void OBSBasic::CreateSceneUndoRedoAction(const QString &action_name,
 			sources.push_back(source.Get());
 
 			/* update scene/group settings to restore their
-			* contents to their saved settings */
+			 * contents to their saved settings */
 			obs_scene_t *scene =
 				obs_group_or_scene_from_source(source);
 			if (scene) {

--- a/UI/youtube-api-wrappers.cpp
+++ b/UI/youtube-api-wrappers.cpp
@@ -319,14 +319,14 @@ bool YoutubeApiWrappers::GetVideoCategoriesList(
 		"&regionCode=%1"
 		"&hl=%2";
 	/*
-	* All OBS locale regions aside from "US" are missing category id 29
-	* ("Nonprofits & Activism"), but it is still available to channels
-	* set to those regions via the YouTube Studio website.
-	* To work around this inconsistency with the API all locales will
-	* use the "US" region and only set the language part for localisation.
-	* It is worth noting that none of the regions available on YouTube
-	* feature any category not also available to the "US" region.
-	*/
+	 * All OBS locale regions aside from "US" are missing category id 29
+	 * ("Nonprofits & Activism"), but it is still available to channels
+	 * set to those regions via the YouTube Studio website.
+	 * To work around this inconsistency with the API all locales will
+	 * use the "US" region and only set the language part for localisation.
+	 * It is worth noting that none of the regions available on YouTube
+	 * feature any category not also available to the "US" region.
+	 */
 	QString url = url_template.arg("US", QLocale().name());
 
 	Json json_out;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1505,13 +1505,13 @@ static void source_output_audio_data(obs_source_t *source,
 		if (diff < TS_SMOOTHING_THRESHOLD) {
 			push_back = true;
 
-			/* This typically only happens if used with async video when
-		 * audio/video start transitioning in to a timestamp jump.
-		 * Audio will typically have a timestamp jump, and then video
-		 * will have a timestamp jump.  If that case is encountered,
-		 * just clear the audio data in that small window and force a
-		 * resync.  This handles all cases rather than just looping. */
 		} else if (diff > MAX_TS_VAR) {
+			/* This typically only happens if used with async video when
+			 * audio/video start transitioning in to a timestamp jump.
+			 * Audio will typically have a timestamp jump, and then video
+			 * will have a timestamp jump.  If that case is encountered,
+			 * just clear the audio data in that small window and force a
+			 * resync.  This handles all cases rather than just looping. */
 			reset_audio_timing(source, data->timestamp, os_time);
 			in.timestamp = data->timestamp + source->timing_adjust;
 		}

--- a/plugins/aja/aja-presets.cpp
+++ b/plugins/aja/aja-presets.cpp
@@ -33,8 +33,8 @@ void RoutingConfigurator::build_preset_table()
 {
 	static const RoutingPresetMap kRoutingPresets = {
 		/*
-        * HDMI RGB Capture
-        */
+		 * HDMI RGB Capture
+		 */
 		{"HDMI_HD_RGB_LFR_RGB_Capture",
 		 {"HDMI_HD_RGB_LFR_RGB_Capture",
 		  ConnectionKind::HDMI,
@@ -85,8 +85,8 @@ void RoutingConfigurator::build_preset_table()
 		  true,
 		  false}},
 		/*
-        * HDMI RGB Display
-        */
+		 * HDMI RGB Display
+		 */
 		{"HDMI_HD_RGB_LFR_RGB_Display",
 		 {"HDMI_HD_RGB_LFR_RGB_Display",
 		  ConnectionKind::HDMI,
@@ -150,8 +150,8 @@ void RoutingConfigurator::build_preset_table()
 		  true,
 		  false}},
 		/*
-        * HDMI YCbCr Capture
-        */
+		 * HDMI YCbCr Capture
+		 */
 		{"HDMI_HD_LFR_YCbCr_Capture",
 		 {"HDMI_HD_LFR_YCbCr_Capture",
 		  ConnectionKind::HDMI,
@@ -188,8 +188,8 @@ void RoutingConfigurator::build_preset_table()
 		  false,
 		  false}},
 		/*
-        * HDMI YCbCr Display
-        */
+		 * HDMI YCbCr Display
+		 */
 		{"HDMI_HD_LFR_YCbCr_Display",
 		 {"HDMI_HD_LFR_YCbCr_Display",
 		  ConnectionKind::HDMI,
@@ -286,8 +286,8 @@ void RoutingConfigurator::build_preset_table()
 		  false,
 		  false}},
 		/*
-        * SDI RGB Capture
-        */
+		 * SDI RGB Capture
+		 */
 		{"HD_720p_ST292_RGB_Capture",
 		 {"HD_720p_ST292_RGB_Capture",
 		  ConnectionKind::SDI,
@@ -660,8 +660,8 @@ void RoutingConfigurator::build_preset_table()
 		  true}},
 		/////////////////////////////////
 		/*
-        * SDI RGB Display
-        */
+		 * SDI RGB Display
+		 */
 		{"HD_720p_ST292_RGB_Display",
 		 {"HD_720p_ST292_RGB_Display",
 		  ConnectionKind::SDI,
@@ -1369,8 +1369,8 @@ void RoutingConfigurator::build_preset_table()
 		  false,
 		  false}},
 		/*
-        * SDI YCbCr Display
-        */
+		 * SDI YCbCr Display
+		 */
 		{"SD_ST352_YCbCr_Display",
 		 {"SD_ST352_YCbCr_Display",
 		  ConnectionKind::SDI,

--- a/plugins/obs-filters/color-correction-filter.c
+++ b/plugins/obs-filters/color-correction-filter.c
@@ -229,11 +229,11 @@ static void color_correction_filter_update_v1(void *data, obs_data_t *settings)
 	vec4_from_rgba(&color_v4, color);
 
 	/*
-	* Now let's build our Color 'overlay' matrix.
-	* Earlier (in the function color_correction_filter_create) we set
-	* this matrix to the identity matrix, so now we only need
-	* to set the 6 variables that have changed.
-	*/
+	 * Now let's build our Color 'overlay' matrix.
+	 * Earlier (in the function color_correction_filter_create) we set
+	 * this matrix to the identity matrix, so now we only need
+	 * to set the 6 variables that have changed.
+	 */
 	filter->color_matrix.x.x = color_v4.x;
 	filter->color_matrix.y.y = color_v4.y;
 	filter->color_matrix.z.z = color_v4.z;
@@ -385,11 +385,11 @@ static void color_correction_filter_update_v2(void *data, obs_data_t *settings)
 	vec4_from_rgba_srgb(&color_add_v4, color_add);
 
 	/*
-	* Now let's build our Color 'overlay' matrix.
-	* Earlier (in the function color_correction_filter_create) we set
-	* this matrix to the identity matrix, so now we only need
-	* to set the 6 variables that have changed.
-	*/
+	 * Now let's build our Color 'overlay' matrix.
+	 * Earlier (in the function color_correction_filter_create) we set
+	 * this matrix to the identity matrix, so now we only need
+	 * to set the 6 variables that have changed.
+	 */
 	filter->color_matrix.x.x = color_multiply_v4.x;
 	filter->color_matrix.y.y = color_multiply_v4.y;
 	filter->color_matrix.z.z = color_multiply_v4.z;
@@ -453,11 +453,11 @@ static void *color_correction_filter_create_v1(obs_data_t *settings,
 					       obs_source_t *context)
 {
 	/*
-	* Because of limitations of pre-c99 compilers, you can't create an
-	* array that doesn't have a known size at compile time. The below
-	* function calculates the size needed and allocates memory to
-	* handle the source.
-	*/
+	 * Because of limitations of pre-c99 compilers, you can't create an
+	 * array that doesn't have a known size at compile time. The below
+	 * function calculates the size needed and allocates memory to
+	 * handle the source.
+	 */
 	struct color_correction_filter_data *filter =
 		bzalloc(sizeof(struct color_correction_filter_data));
 
@@ -515,11 +515,11 @@ static void *color_correction_filter_create_v2(obs_data_t *settings,
 					       obs_source_t *context)
 {
 	/*
-	* Because of limitations of pre-c99 compilers, you can't create an
-	* array that doesn't have a known size at compile time. The below
-	* function calculates the size needed and allocates memory to
-	* handle the source.
-	*/
+	 * Because of limitations of pre-c99 compilers, you can't create an
+	 * array that doesn't have a known size at compile time. The below
+	 * function calculates the size needed and allocates memory to
+	 * handle the source.
+	 */
 	struct color_correction_filter_data_v2 *filter =
 		bzalloc(sizeof(struct color_correction_filter_data_v2));
 

--- a/plugins/win-capture/get-graphics-offsets/d3d9-offsets.cpp
+++ b/plugins/win-capture/get-graphics-offsets/d3d9-offsets.cpp
@@ -94,32 +94,32 @@ static const uint8_t mask[][MAX_CMP_SIZE] = {
 
 static const uint8_t mask_cmp[][MAX_CMP_SIZE] = {
 	/*
-	* Windows 7
-	* 48 8B 83 B8 3D 00 00                    mov     rax, [rbx+3DB8h]
-	* 44 39 B8 68 50 00 00                    cmp     [rax+5068h], r15d
-	* 75 12                                   jnz     short loc_7FF7AA90530
-	* 41 B8 F9 19 00 00                       mov     r8d, 19F9h
-	*/
+	 * Windows 7
+	 * 48 8B 83 B8 3D 00 00                    mov     rax, [rbx+3DB8h]
+	 * 44 39 B8 68 50 00 00                    cmp     [rax+5068h], r15d
+	 * 75 12                                   jnz     short loc_7FF7AA90530
+	 * 41 B8 F9 19 00 00                       mov     r8d, 19F9h
+	 */
 	{0x48, 0x8B, 0x80, 0x00, 0x00, 0x00, 0x00, 0x44, 0x39, 0x00, 0x00,
 	 0x00, 0x00, 0x00, 0x75, 0x00, 0x40, 0xB8, 0x00, 0x00, 0x00, 0x00},
 	/*
-	* Windows ???+
-	* 49 8B 87 78 41 00 00                    mov     rax, [r15+4178h]
-	* 39 98 E0 51 00 00                       cmp     [rax+51E0h], ebx
-	* 75 12                                   jnz     short loc_1800AEC9C
-	* 41 B9 C3 1A 00 00                       mov     r9d, 1AC3h
-	*/
+	 * Windows ???+
+	 * 49 8B 87 78 41 00 00                    mov     rax, [r15+4178h]
+	 * 39 98 E0 51 00 00                       cmp     [rax+51E0h], ebx
+	 * 75 12                                   jnz     short loc_1800AEC9C
+	 * 41 B9 C3 1A 00 00                       mov     r9d, 1AC3h
+	 */
 	{0x48, 0x8B, 0x80, 0x00, 0x00, 0x00, 0x00, 0x39, 0x80, 0x00, 0x00,
 	 0x00, 0x00, 0x75, 0x00, 0x40, 0xB8, 0x00, 0x00, 0x00, 0x00},
 	/*
-	* Windows 10 April 2018
-	* 49 8B 87 58 40 00 00                 mov     rax, [r15+4058h]
-	* 39 98 C0 53 00 00                    cmp     [rax+53C0h], ebx
-	* 75 12                                jnz     short loc_1800A7FEC
-	* 48 8D 15 7F B6 09 00                 lea     rdx, addrErrorMsg
-	*
-	* Note: different instructions, last byte skipped due to MAX_CMP_SIZE
-	*/
+	 * Windows 10 April 2018
+	 * 49 8B 87 58 40 00 00                 mov     rax, [r15+4058h]
+	 * 39 98 C0 53 00 00                    cmp     [rax+53C0h], ebx
+	 * 75 12                                jnz     short loc_1800A7FEC
+	 * 48 8D 15 7F B6 09 00                 lea     rdx, addrErrorMsg
+	 *
+	 * Note: different instructions, last byte skipped due to MAX_CMP_SIZE
+	 */
 	{0x48, 0x8B, 0x80, 0x00, 0x00, 0x00, 0x00, 0x39, 0x80, 0x00, 0x00,
 	 0x00, 0x00, 0x75, 0x00, 0x48, 0x8D, 0x00, 0x00, 0x00, 0x00}};
 
@@ -144,31 +144,31 @@ static const uint8_t mask[][MAX_CMP_SIZE] = {
 
 static const uint8_t mask_cmp[][MAX_CMP_SIZE] = {
 	/*
-	* Windows 7+
-	* 8B 83 E8 29 00 00      mov     eax, [ebx+29E8h]
-	* 39 B0 80 4B 00 00      cmp     [eax+4B80h], esi
-	* 75 14                  jnz     short loc_754CD9E1
-	* 68 F9 19 00 00         push    19F9h
-	*/
+	 * Windows 7+
+	 * 8B 83 E8 29 00 00      mov     eax, [ebx+29E8h]
+	 * 39 B0 80 4B 00 00      cmp     [eax+4B80h], esi
+	 * 75 14                  jnz     short loc_754CD9E1
+	 * 68 F9 19 00 00         push    19F9h
+	 */
 	{0x8B, 0x80, 0x00, 0x00, 0x00, 0x00, 0x39, 0x80, 0x00, 0x00, 0x00, 0x00,
 	 0x75, 0x00, 0x68, 0x00, 0x00, 0x00, 0x00},
 
 	/* Windows 10 Creator's Update+
-	* 8B 86 F8 2B 00 00      mov     eax, [esi+2BF8h]
-	* 83 B8 00 4D 00 00 00   cmp     dword ptr [eax+4D00h], 0
-	* 75 0F                  jnz     short loc_100D793C
-	* 68 C3 1A 00 00         push    1AC3h
-	*/
+	 * 8B 86 F8 2B 00 00      mov     eax, [esi+2BF8h]
+	 * 83 B8 00 4D 00 00 00   cmp     dword ptr [eax+4D00h], 0
+	 * 75 0F                  jnz     short loc_100D793C
+	 * 68 C3 1A 00 00         push    1AC3h
+	 */
 	{0x8B, 0x80, 0x00, 0x00, 0x00, 0x00, 0x83, 0x80, 0x00, 0x00,
 	 0x00, 0x00, 0x00, 0x75, 0x00, 0x68, 0x00, 0x00, 0x00, 0x00},
 
 	/*
-	* Windows 10 April 2018 Update
-	* 8B 86 68 2B 00 00         mov     eax, [esi+2B68h]
-	* 83 B8 F4 4D 00 00 00      cmp     dword ptr [eax+4DF4h], 0
-	* 75 0F                     jnz     short loc_100D9A9C
-	* BA 08 71 01 10            mov     edx, offset errMsg
-	*/
+	 * Windows 10 April 2018 Update
+	 * 8B 86 68 2B 00 00         mov     eax, [esi+2B68h]
+	 * 83 B8 F4 4D 00 00 00      cmp     dword ptr [eax+4DF4h], 0
+	 * 75 0F                     jnz     short loc_100D9A9C
+	 * BA 08 71 01 10            mov     edx, offset errMsg
+	 */
 	{0x8B, 0x80, 0x00, 0x00, 0x00, 0x00, 0x83, 0x80, 0x00, 0x00,
 	 0x00, 0x00, 0x00, 0x75, 0x00, 0xBA, 0x00, 0x00, 0x00, 0x00}};
 
@@ -228,9 +228,9 @@ void get_d3d9_offsets(struct d3d9_offsets *offsets)
 				if (off1 > 0xFFFF || off2 > 0xFFFF)
 					break;
 
-					/* check to make sure offsets actually point
-				 * toward expected data */
 #ifdef _MSC_VER
+				/* check to make sure offsets actually point
+				 * toward expected data */
 				__try {
 					uint8_t *ptr = (uint8_t *)(info.device);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix indent of 2nd line and later for multiline comment blocks.

The most frequent comment indentation style is as below. I followed this style to update comments.
- Indent the first line of a comment with tab(s).
- Indent remaining lines with the same amount of tab(s) + one space so that the first `*` is vertically aligned.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Some comment blocks are ugly indented like below. `clang-format` did not touch the indent of comments.
https://github.com/obsproject/obs-studio/blob/a82bbb416f84461172224ac33d59d281668e17e0/libobs/obs-source.c#L1508-L1513

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
`git show -w` shows nothing was changed.
Ran `./CI/check-format.sh` and the updated indent is not modified on Fedora 34.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
