### PR TITLE
More HDR metadata work

### DIFF
--- a/libobs/media-io/media-remux.c
+++ b/libobs/media-io/media-remux.c
@@ -96,6 +96,41 @@ static inline bool init_output(media_remux_job_t job, const char *out_filename)
 			return false;
 		}
 
+#if FF_API_BUFFER_SIZE_T
+		int content_size;
+#else
+		size_t content_size;
+#endif
+		const uint8_t *const content_src = av_stream_get_side_data(
+			in_stream, AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+			&content_size);
+		if (content_src) {
+			uint8_t *const content_dst = av_stream_new_side_data(
+				out_stream, AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+				content_size);
+			if (content_dst)
+				memcpy(content_dst, content_src, content_size);
+		}
+
+#if FF_API_BUFFER_SIZE_T
+		int mastering_size;
+#else
+		size_t mastering_size;
+#endif
+		const uint8_t *const mastering_src = av_stream_get_side_data(
+			in_stream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA,
+			&mastering_size);
+		if (mastering_src) {
+			uint8_t *const mastering_dst = av_stream_new_side_data(
+				out_stream,
+				AV_PKT_DATA_MASTERING_DISPLAY_METADATA,
+				mastering_size);
+			if (mastering_dst) {
+				memcpy(mastering_dst, mastering_src,
+				       mastering_size);
+			}
+		}
+
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
 		ret = avcodec_parameters_copy(out_stream->codecpar,
 					      in_stream->codecpar);

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -420,7 +420,17 @@ static void create_video_stream(struct ffmpeg_mux *ffm)
 #endif
 	ffm->video_stream->avg_frame_rate = av_inv_q(context->time_base);
 
-	if (ffm->params.max_luminance > 0) {
+	const int max_luminance = ffm->params.max_luminance;
+	if (max_luminance > 0) {
+		size_t content_size;
+		AVContentLightMetadata *const content =
+			av_content_light_metadata_alloc(&content_size);
+		content->MaxCLL = max_luminance;
+		content->MaxFALL = max_luminance;
+		av_stream_add_side_data(ffm->video_stream,
+					AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+					(uint8_t *)content, content_size);
+
 		AVMasteringDisplayMetadata *const mastering =
 			av_mastering_display_metadata_alloc();
 		mastering->display_primaries[0][0] = av_make_q(17, 25);
@@ -432,8 +442,7 @@ static void create_video_stream(struct ffmpeg_mux *ffm)
 		mastering->white_point[0] = av_make_q(3127, 10000);
 		mastering->white_point[1] = av_make_q(329, 1000);
 		mastering->min_luminance = av_make_q(0, 1);
-		mastering->max_luminance =
-			av_make_q(ffm->params.max_luminance, 1);
+		mastering->max_luminance = av_make_q(max_luminance, 1);
 		mastering->has_primaries = 1;
 		mastering->has_luminance = 1;
 		av_stream_add_side_data(ffm->video_stream,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -225,6 +225,18 @@ static bool create_video_stream(struct ffmpeg_data *data)
 
 	if ((data->config.color_trc == AVCOL_TRC_SMPTE2084) ||
 	    (data->config.color_trc == AVCOL_TRC_ARIB_STD_B67)) {
+		const int hdr_nominal_peak_level =
+			(int)obs_get_video_hdr_nominal_peak_level();
+
+		size_t content_size;
+		AVContentLightMetadata *const content =
+			av_content_light_metadata_alloc(&content_size);
+		content->MaxCLL = hdr_nominal_peak_level;
+		content->MaxFALL = hdr_nominal_peak_level;
+		av_stream_add_side_data(data->video,
+					AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+					(uint8_t *)content, content_size);
+
 		AVMasteringDisplayMetadata *const mastering =
 			av_mastering_display_metadata_alloc();
 		mastering->display_primaries[0][0] = av_make_q(17, 25);
@@ -236,8 +248,7 @@ static bool create_video_stream(struct ffmpeg_data *data)
 		mastering->white_point[0] = av_make_q(3127, 10000);
 		mastering->white_point[1] = av_make_q(329, 1000);
 		mastering->min_luminance = av_make_q(0, 1);
-		mastering->max_luminance = av_make_q(
-			(int)obs_get_video_hdr_nominal_peak_level(), 1);
+		mastering->max_luminance = av_make_q(hdr_nominal_peak_level, 1);
 		mastering->has_primaries = 1;
 		mastering->has_luminance = 1;
 		av_stream_add_side_data(data->video,


### PR DESCRIPTION
### Description
Add content light levels (MaxCLL/MaxFALL) to video streams. Should note that we're not computing these; we're just assuming worst case from user setting.

Also update remux to preserve content light levels and mastering display metadata from input video stream.

### Motivation and Context
YouTube wants the content light levels, and more metadata is probably useful for compatibility in general.

### How Has This Been Tested?
Verified MKV in mkvtoolnix, and mastering display metadata from remux with ffprobe. ffprobe does not appear to print the content light levels, but I verified that in a binary diff with Beyond Compare. FFmpeg output was tested a little lax, I just stepped through the code in a debugger.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.