### PR TITLE
obs-libfdk: Enable 7.1 channel surround for Linux

### DIFF
--- a/plugins/obs-libfdk/obs-libfdk.c
+++ b/plugins/obs-libfdk/obs-libfdk.c
@@ -132,14 +132,9 @@ static void *libfdk_create(obs_data_t *settings, obs_encoder_t *encoder)
 		mode = MODE_1_2_2_1;
 		break;
 
-		/* lib_fdk-aac > 1.3 required for 7.1 surround;
-         * uncomment if available on linux build
-         */
-#ifndef __linux__
 	case 8:
 		mode = MODE_7_1_REAR_SURROUND;
 		break;
-#endif
 
 	default:
 		blog(LOG_ERROR, "Invalid channel count");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Remove `#ifndef __linux__` below.
https://github.com/obsproject/obs-studio/blob/7eb36eadb13c7581dd942377945cf71912e0f552/plugins/obs-libfdk/obs-libfdk.c#L138-L142

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The surround audio was introduced by bbac3280c1 but 7.1 channel audio was disabled since libfdk-aac >= 0.1.3 is required. Now the minimum Ubuntu version is 18.04, which provide libfdk-aac 0.1.5. It is not necessary to exclude Linux now.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Fedora 34.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
