### PR TITLE
Fix I010/P010 video saving as 8-bit for old NVENC

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -547,9 +547,16 @@ void SimpleOutput::Update()
 	video_t *video = obs_get_video();
 	enum video_format format = video_output_get_format(video);
 
-	if (format != VIDEO_FORMAT_NV12 && format != VIDEO_FORMAT_I420)
+	switch (format) {
+	case VIDEO_FORMAT_I420:
+	case VIDEO_FORMAT_NV12:
+	case VIDEO_FORMAT_I010:
+	case VIDEO_FORMAT_P010:
+		break;
+	default:
 		obs_encoder_set_preferred_video_format(h264Streaming,
 						       VIDEO_FORMAT_NV12);
+	}
 
 	obs_encoder_update(h264Streaming, h264Settings);
 	obs_encoder_update(aacStreaming, aacSettings);
@@ -1352,9 +1359,16 @@ void AdvancedOutput::UpdateStreamSettings()
 	video_t *video = obs_get_video();
 	enum video_format format = video_output_get_format(video);
 
-	if (format != VIDEO_FORMAT_NV12 && format != VIDEO_FORMAT_I420)
+	switch (format) {
+	case VIDEO_FORMAT_I420:
+	case VIDEO_FORMAT_NV12:
+	case VIDEO_FORMAT_I010:
+	case VIDEO_FORMAT_P010:
+		break;
+	default:
 		obs_encoder_set_preferred_video_format(h264Streaming,
 						       VIDEO_FORMAT_NV12);
+	}
 
 	obs_encoder_update(h264Streaming, settings);
 }

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -57,8 +57,16 @@ static const char *hevc_nvenc_getname(void *unused)
 
 static inline bool valid_format(enum video_format format)
 {
-	return format == VIDEO_FORMAT_I420 || format == VIDEO_FORMAT_NV12 ||
-	       format == VIDEO_FORMAT_I444;
+	switch (format) {
+	case VIDEO_FORMAT_I420:
+	case VIDEO_FORMAT_NV12:
+	case VIDEO_FORMAT_I444:
+	case VIDEO_FORMAT_I010:
+	case VIDEO_FORMAT_P010:
+		return true;
+	default:
+		return false;
+	}
 }
 
 static void nvenc_video_info(void *data, struct video_scale_info *info)


### PR DESCRIPTION
### Description
Some format checks were causing 10-bit videos to save as 8-bit when using old NVENC, and just needed updating.

### Motivation and Context
8-bit HDR is a bad look.

### How Has This Been Tested?
Verified video metadata comparison with ffprobe, and banding reduction visually.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.