### PR TITLE
vlc-video: Fix video rotation and aspect ratio

### DIFF
--- a/plugins/vlc-video/vlc-video-plugin.c
+++ b/plugins/vlc-video/vlc-video-plugin.c
@@ -24,8 +24,10 @@ LIBVLC_MEDIA_NEW_PATH libvlc_media_new_path_;
 LIBVLC_MEDIA_NEW_LOCATION libvlc_media_new_location_;
 LIBVLC_MEDIA_ADD_OPTION libvlc_media_add_option_;
 LIBVLC_MEDIA_RELEASE libvlc_media_release_;
-LIBVLC_MEDIA_RELEASE libvlc_media_retain_;
+LIBVLC_MEDIA_RETAIN libvlc_media_retain_;
 LIBVLC_MEDIA_GET_META libvlc_media_get_meta_;
+LIBVLC_MEDIA_TRACKS_GET libvlc_media_tracks_get_;
+LIBVLC_MEDIA_TRACKS_RELEASE libvlc_media_tracks_release_;
 
 /* libvlc media player */
 LIBVLC_MEDIA_PLAYER_NEW libvlc_media_player_new_;
@@ -104,6 +106,8 @@ static bool load_vlc_funcs(void)
 	LOAD_VLC_FUNC(libvlc_media_release);
 	LOAD_VLC_FUNC(libvlc_media_retain);
 	LOAD_VLC_FUNC(libvlc_media_get_meta);
+	LOAD_VLC_FUNC(libvlc_media_tracks_get);
+	LOAD_VLC_FUNC(libvlc_media_tracks_release);
 
 	/* libvlc media player */
 	LOAD_VLC_FUNC(libvlc_media_player_new);

--- a/plugins/vlc-video/vlc-video-plugin.h
+++ b/plugins/vlc-video/vlc-video-plugin.h
@@ -38,6 +38,10 @@ typedef void (*LIBVLC_MEDIA_RETAIN)(libvlc_media_t *p_md);
 typedef void (*LIBVLC_MEDIA_RELEASE)(libvlc_media_t *p_md);
 typedef char *(*LIBVLC_MEDIA_GET_META)(libvlc_media_t *p_md,
 				       libvlc_meta_t e_meta);
+typedef unsigned (*LIBVLC_MEDIA_TRACKS_GET)(libvlc_media_t *p_md,
+					    libvlc_media_track_t ***pp_es);
+typedef void (*LIBVLC_MEDIA_TRACKS_RELEASE)(libvlc_media_track_t **p_tracks,
+					    unsigned i_count);
 
 /* libvlc media player */
 typedef libvlc_media_player_t *(*LIBVLC_MEDIA_PLAYER_NEW)(
@@ -125,6 +129,8 @@ extern LIBVLC_MEDIA_ADD_OPTION libvlc_media_add_option_;
 extern LIBVLC_MEDIA_RELEASE libvlc_media_release_;
 extern LIBVLC_MEDIA_RETAIN libvlc_media_retain_;
 extern LIBVLC_MEDIA_GET_META libvlc_media_get_meta_;
+extern LIBVLC_MEDIA_TRACKS_GET libvlc_media_tracks_get_;
+extern LIBVLC_MEDIA_TRACKS_RELEASE libvlc_media_tracks_release_;
 
 /* libvlc media player */
 extern LIBVLC_MEDIA_PLAYER_NEW libvlc_media_player_new_;


### PR DESCRIPTION
### Description
Fixes rotation and aspect ratio of VLC Video Source videos. Only works for local video files - video streams will still be incorrect (https://github.com/obsproject/obs-studio/issues/2933) and will need to be dealt with separately.

Cause: previously, the buffer size passed from libvlc was being used as the video size, but this was often incorrect as the buffer size could be rounded up to the next multiple of 32. This was then "fixed" by getting the pixel size of the original video file, however it didn't take into account rotation or aspect ratio attributes. This PR addresses this.

#### Before
![image](https://user-images.githubusercontent.com/18594548/132258767-5c5e10f5-7ff5-4f8f-a284-b2341cb59948.png)
#### After
![image](https://user-images.githubusercontent.com/18594548/132389383-bb205624-2b3a-498a-9c54-9062dcc45c54.png)

### Motivation and Context
Fixes #5250 - portrait videos (e.g. from phones) being rendered with incorrect aspect ratio.
Also fixes #3843

### How Has This Been Tested?
Tested on macOS 11.5.2 on Intel and 12.3.1 on Apple silicon. Ran several videos of different dimensions and rotations through VLC Video Source and aspect ratio is now correct for all of them.

Test videos generated with:

```
ffmpeg -f lavfi -i "testsrc=duration=10,drawtext=text='rotation 180':fontcolor=white,transpose=clock,transpose=clock" -c libx264 -f mpegts - | ffmpeg -i - -c copy -metadata:s:v rotate=180 rotation180.mp4
ffmpeg -f lavfi -i "testsrc=duration=10,drawtext=text='rotation 270':fontcolor=white,transpose=clock" -c libx264 -f mpegts - | ffmpeg -i - -c copy -metadata:s:v rotate=90 rotation270.mp4
ffmpeg -f lavfi -i "testsrc=duration=10,drawtext=text='rotation 90':fontcolor=white,transpose=cclock" -c libx264 -f mpegts - | ffmpeg -i - -c copy -metadata:s:v rotate=270 rotation90.mp4
ffmpeg -f lavfi -i "testsrc=duration=10,drawtext=text='aspect ratio':fontcolor=white,scale=iw*2:ih,setsar=1/2" aspect.mp4
```

Add to VLC Video Source - these should all render the same size:

https://user-images.githubusercontent.com/18594548/166231717-7b57e1b7-4ae6-4e7d-bd10-35d24841e975.mp4

https://user-images.githubusercontent.com/18594548/166231721-3f56123d-9012-479b-870a-4ce18c8c0143.mp4

https://user-images.githubusercontent.com/18594548/166231722-e8d1a670-4291-48a6-86ab-ebbb2cce433e.mp4

https://user-images.githubusercontent.com/18594548/166231723-8cab08c4-32cc-462e-ae42-2ba739484ec1.mp4

Other example videos:

https://user-images.githubusercontent.com/18594548/132258725-4ef35599-fab2-44c3-8262-60d5914ea876.MOV

https://user-images.githubusercontent.com/18594548/166114798-722719c5-d38f-4f07-af25-d920d8c957f3.mov

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
