### PR TITLE
plugins: Fix decklink gradual audio desync

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4436,7 +4436,7 @@ bool OBSBasic::ResetAudio()
 {
 	ProfileScope("OBSBasic::ResetAudio");
 
-	struct obs_audio_info ai;
+	struct obs_audio_info2 ai;
 	ai.samples_per_sec =
 		config_get_uint(basicConfig, "Audio", "SampleRate");
 
@@ -4458,7 +4458,10 @@ bool OBSBasic::ResetAudio()
 	else
 		ai.speakers = SPEAKERS_STEREO;
 
-	return obs_reset_audio(&ai);
+	ai.fixed_buffering = true;
+	ai.max_buffering_ms = 1;
+
+	return obs_reset_audio2(&ai);
 }
 
 extern char *get_new_source_name(const char *name, const char *format);

--- a/plugins/decklink/DecklinkOutput.cpp
+++ b/plugins/decklink/DecklinkOutput.cpp
@@ -62,6 +62,10 @@ bool DeckLinkOutput::Activate(DeckLinkDevice *device, long long modeId)
 		return false;
 	}
 
+	card_start = 0;
+	system_start = 0;
+	compensated_drift = 0;
+
 	os_atomic_inc_long(&activateRefs);
 	return true;
 }
@@ -106,4 +110,14 @@ int DeckLinkOutput::GetWidth()
 int DeckLinkOutput::GetHeight()
 {
 	return height;
+}
+
+uint64_t DeckLinkOutput::GetHardwareClock()
+{
+	return instance->GetHardwareClock();
+}
+
+uint32_t DeckLinkOutput::GetBufferedAudioSamples()
+{
+	return instance->GetBufferedAudioSamples();
 }

--- a/plugins/decklink/DecklinkOutput.hpp
+++ b/plugins/decklink/DecklinkOutput.hpp
@@ -33,4 +33,11 @@ public:
 	void SetSize(int width, int height);
 	int GetWidth();
 	int GetHeight();
+
+	uint64_t GetHardwareClock();
+	uint32_t GetBufferedAudioSamples();
+
+	uint64_t card_start;
+	uint64_t system_start;
+	uint64_t compensated_drift;
 };

--- a/plugins/decklink/decklink-device-instance.cpp
+++ b/plugins/decklink/decklink-device-instance.cpp
@@ -729,3 +729,22 @@ ULONG STDMETHODCALLTYPE DeckLinkDeviceInstance::Release(void)
 
 	return newRefCount;
 }
+
+uint64_t DeckLinkDeviceInstance::GetHardwareClock(void)
+{
+	BMDTimeValue hardwareTime;
+	BMDTimeValue timeInFrame;
+	BMDTimeValue ticksPerFrame;
+
+	HRESULT ret = output->GetHardwareReferenceClock(1000000000, &hardwareTime, &timeInFrame, &ticksPerFrame);
+
+	return hardwareTime;
+}
+
+uint32_t DeckLinkDeviceInstance::GetBufferedAudioSamples(void)
+{
+	uint32_t buffered = 0;
+	output->GetBufferedAudioSampleFrameCount(&buffered);
+
+	return buffered;
+}

--- a/plugins/decklink/decklink-device-instance.hpp
+++ b/plugins/decklink/decklink-device-instance.hpp
@@ -110,4 +110,7 @@ public:
 	void WriteAudio(audio_data *frames);
 	void HandleCaptionPacket(IDeckLinkAncillaryPacket *packet,
 				 const uint64_t timestamp);
+
+	uint64_t GetHardwareClock(void);
+	uint32_t GetBufferedAudioSamples(void);
 };


### PR DESCRIPTION
### Description
Fixes desync with Decklink output by dropping audio frames when the card's audio buffer grows too large as a result of clock drift.

### Motivation and Context
All my homies hate clock drift.

### How Has This Been Tested?
Ubuntu 20.04:
- Load OBS
- Run an AV sync test mp4 and record it using a known-good reference recorder
- Wait as long as you want (hours or days)
- Check it again, AV should have the same amount of desync as the original test

It needs to be noted that this fix is not meant to make decklink perfect, it's just meant to fix *one of many* problems causing desync. The point is to prevent desync caused by clock drift from growing over time.

IF YOU WANT TO TEST, download the latest CI artifact from this PR. You should perform the steps above to validate that desync does not get worse than when you first started. Log messages are posted every time audio frames are dropped to compensate for desync. `Total drift offset` should be the amount of time that audio would lag further behind video without this fix.

I used another computer with a Mini Recorder 4k and Media Express to record the raw frames coming from a duo2, and played the audio slowed down to determine how large the delay got.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
