### PR TITLE
cmake: Fix cURL library handling for updated dependencies

### DIFF
--- a/cmake/Modules/CopyMSVCBins.cmake
+++ b/cmake/Modules/CopyMSVCBins.cmake
@@ -131,6 +131,11 @@ file(
   "${SSL_INCLUDE_DIR}/bin/ssleay32*.dll"
   "${SSL_INCLUDE_DIR}/bin/libeay32*.dll")
 
+if(NOT DEFINED CURL_INCLUDE_DIR AND TARGET CURL::libcurl)
+  get_target_property(CURL_INCLUDE_DIR CURL::libcurl
+                      INTERFACE_INCLUDE_DIRECTORIES)
+endif()
+
 file(
   GLOB
   CURL_BIN_FILES


### PR DESCRIPTION
### Description
Fixes functionality in `CopyMSVCBins` when cURL is imported as a CMake package (instead of being discovered using a "finder" module).

### Motivation and Context
Soon to be updated obs-deps built on CI will retain CMake package files created while building dependencies. When CMake uses packages, the usual triplet of variables from finders are not set. `CopyMSVCBins` relies on one such variable.

This PR sets the `CURL_INCLUDE_DIR` if the cURL target is present, but apparently imported as a CMake package, to ensure prior functionality is restored.

### How Has This Been Tested?
* Recent obs-deps from rework PR set up for building OBS
* Purged contents of "additional_install_files" directory
* Purged "rundir" inside OBS build directory
* Purged "cURL"-related cache variables in CMake cache
* Reconfigured and built OBS
* Ran OBS successfully

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
