### PR TITLE
cmake: Fix handling of optional debug wrapper libraries for obs-browser

### DIFF
--- a/cmake/Modules/FindCEF.cmake
+++ b/cmake/Modules/FindCEF.cmake
@@ -125,10 +125,8 @@ if(NOT TARGET CEF::Wrapper)
                                                   ${CEF_LIBRARY})
 
     if(DEFINED CEFWRAPPER_LIBRARY_DEBUG)
-      add_library(CEF::Wrapper_Debug UNKNOWN IMPORTED)
-      set_target_properties(
-        CEF::Wrapper_Debug PROPERTIES IMPORTED_LOCATION
-                                      ${CEFWRAPPER_LIBRARY_DEBUG})
+      set_target_properties(CEF::Wrapper PROPERTIES IMPORTED_LOCATION_DEBUG
+                                                    ${CEFWRAPPER_LIBRARY_DEBUG})
     endif()
   else()
     add_library(CEF::Wrapper INTERFACE IMPORTED)
@@ -141,10 +139,8 @@ if(NOT TARGET CEF::Wrapper)
                                                   ${CEF_LIBRARY})
 
     if(DEFINED CEFWRAPPER_LIBRARY_DEBUG)
-      add_library(CEF::Wrapper_Debug INTERFACE IMPORTED)
-      set_target_properties(
-        CEF::Wrapper_Debug PROPERTIES IMPORTED_LIBNAME
-                                      ${CEFWRAPPER_LIBRARY_DEBUG})
+      set_target_properties(CEF::Wrapper PROPERTIES IMPORTED_LIBNAME_DEBUG
+                                                    ${CEFWRAPPER_LIBRARY_DEBUG})
     endif()
   endif()
 
@@ -153,10 +149,4 @@ if(NOT TARGET CEF::Wrapper)
 
   set_target_properties(CEF::Library PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
                                                 "${CEF_INCLUDE_DIR}")
-
-  if(DEFINED CEFWRAPPER_LIBRARY_DEBUG)
-    set_target_properties(
-      CEF::Wrapper_Debug PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-                                    "${CEF_INCLUDE_DIR}")
-  endif()
 endif()


### PR DESCRIPTION
### Description
This is a companion-PR to https://github.com/obsproject/obs-browser/pull/362.

Modern CMake can handle multiple different build configurations per target by setting suffixed target properties. In this case setting `_DEBUG` variants of the `IMPORTED_LIBNAME` allows CMake to pick up the debug variant.

### Motivation and Context
Simplifies handling of different actual library files for different build configurations. CMake will pick up the appropriate file (if specified) and depending targets don't have to link to separate targets just for specific configs.

### How Has This Been Tested?
Needs to be tested manually by pulling the companion PR into the same branch as this PR, building OBS in debug configuration on Windows (the only platform with separate wrapper libraries so far).

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
