### PR TITLE
libobs-winrt: Support window transparency for WGC

### DIFF
--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -661,13 +661,15 @@ extern "C" EXPORT void winrt_capture_render(struct winrt_capture *capture)
 		}
 
 		gs_effect_t *const effect =
-			obs_get_base_effect(OBS_EFFECT_OPAQUE);
+			obs_get_base_effect(OBS_EFFECT_DEFAULT);
 		gs_technique_t *tech =
 			gs_effect_get_technique(effect, tech_name);
 
 		const bool previous = gs_framebuffer_srgb_enabled();
 		gs_enable_framebuffer_srgb(true);
-		gs_enable_blending(false);
+
+		gs_blend_state_push();
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
 		gs_texture_t *const texture = capture->texture;
 		gs_effect_set_texture_srgb(
@@ -686,7 +688,8 @@ extern "C" EXPORT void winrt_capture_render(struct winrt_capture *capture)
 		}
 		gs_technique_end(tech);
 
-		gs_enable_blending(true);
+		gs_blend_state_pop();
+
 		gs_enable_framebuffer_srgb(previous);
 	}
 }


### PR DESCRIPTION
### Description
WGC capture is at the compositor level, so it's less quirky than the
BitBlt path would be.

Rounded corners in Windows 11 work. LiveSplit shenanigans do not.

### Motivation and Context
Want to support transparency without making the behavior too weird.

### How Has This Been Tested?
WGC window and display capture still work, and window corners respect transparency.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.