### PR TITLE
libobs/media-io: Sleep to next audio time accurately

### DIFF
--- a/docs/sphinx/reference-libobs-util-platform.rst
+++ b/docs/sphinx/reference-libobs-util-platform.rst
@@ -194,6 +194,13 @@ Sleep/Time Functions
 
 ---------------------
 
+.. function:: bool os_sleepto_ns_fast(uint64_t time_target)
+
+   Sleeps to a specific time without high precision, in nanoseconds.
+   The function won't return until reaching the specific time.
+
+---------------------
+
 .. function:: void os_sleep_ms(uint32_t duration)
 
    Sleeps for a specific number of milliseconds.

--- a/libobs/media-io/audio-io.c
+++ b/libobs/media-io/audio-io.c
@@ -213,10 +213,6 @@ static void *audio_thread(void *param)
 	uint64_t samples = 0;
 	uint64_t start_time = os_gettime_ns();
 	uint64_t prev_time = start_time;
-	uint64_t audio_time = prev_time;
-	uint32_t audio_wait_time =
-		(uint32_t)(audio_frames_to_ns(rate, AUDIO_OUTPUT_FRAMES) /
-			   1000000);
 
 	os_set_thread_name("audio-io: audio thread");
 
@@ -225,21 +221,16 @@ static void *audio_thread(void *param)
 				   "audio_thread(%s)", audio->info.name);
 
 	while (os_event_try(audio->stop_event) == EAGAIN) {
-		uint64_t cur_time;
+		samples += AUDIO_OUTPUT_FRAMES;
+		uint64_t audio_time =
+			start_time + audio_frames_to_ns(rate, samples);
 
-		os_sleep_ms(audio_wait_time);
+		os_sleepto_ns_fast(audio_time);
 
 		profile_start(audio_thread_name);
 
-		cur_time = os_gettime_ns();
-		while (audio_time <= cur_time) {
-			samples += AUDIO_OUTPUT_FRAMES;
-			audio_time =
-				start_time + audio_frames_to_ns(rate, samples);
-
-			input_and_output(audio, audio_time, prev_time);
-			prev_time = audio_time;
-		}
+		input_and_output(audio, audio_time, prev_time);
+		prev_time = audio_time;
 
 		profile_end(audio_thread_name);
 

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -180,6 +180,23 @@ bool os_sleepto_ns(uint64_t time_target)
 	return true;
 }
 
+bool os_sleepto_ns_fast(uint64_t time_target)
+{
+	uint64_t current = os_gettime_ns();
+	if (time_target < current)
+		return false;
+
+	do {
+		uint64_t remain_us = (time_target - current + 999) / 1000;
+		useconds_t us = remain_us >= 1000000 ? 999999 : remain_us;
+		usleep(us);
+
+		current = os_gettime_ns();
+	} while (time_target > current);
+
+	return true;
+}
+
 void os_sleep_ms(uint32_t duration)
 {
 	usleep(duration * 1000);

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -360,6 +360,24 @@ bool os_sleepto_ns(uint64_t time_target)
 	return stall;
 }
 
+bool os_sleepto_ns_fast(uint64_t time_target)
+{
+	uint64_t current = os_gettime_ns();
+	if (time_target < current)
+		return false;
+
+	do {
+		uint64_t remain_ms = (time_target - current) / 1000000;
+		if (!remain_ms)
+			remain_ms = 1;
+		Sleep((DWORD)remain_ms);
+
+		current = os_gettime_ns();
+	} while (time_target > current);
+
+	return true;
+}
+
 void os_sleep_ms(uint32_t duration)
 {
 	/* windows 8+ appears to have decreased sleep precision */

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -103,6 +103,7 @@ EXPORT void os_end_high_performance(os_performance_token_t *);
  * Returns false if already at or past target time.
  */
 EXPORT bool os_sleepto_ns(uint64_t time_target);
+EXPORT bool os_sleepto_ns_fast(uint64_t time_target);
 EXPORT void os_sleep_ms(uint32_t duration);
 
 EXPORT uint64_t os_gettime_ns(void);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR implements a new function `os_sleepto_ns_fast`, which sleeps in a low precision but won't return until reaching the specific time.
This change introduces `os_sleepto_ns_fast` to the audio thread so that the audio packets will be periodically output.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Prior to this change, the audio thread roughly waits the time of `AUDIO_OUTPUT_FRAMES`, which is hard coded `1024`, and consecutively processes twice or more if the latency is accumulated. This behavior caused fluctuation of timing to output audio packets and affects audio buffering in decklink output.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

The amount of audio buffer is monitored with a temporary commit db923d1f3b5eacae79275b489e0758af09aaa451, which is one more commit ahead of #1865 for logging purpose.
The buffer size in decklink is monitored at just before sending new audio frames. The buffer size is plotted and checked the buffer size is constant. (The buffer is gradually increasing, which is another issue to be fixed in the future.)

![deckout-data-comp-os_sleepto_ns_fast-WriteAudio](https://user-images.githubusercontent.com/780600/166496496-87cf7d66-d419-404d-ab81-19dd5b2cb815.png)
Audio buffer for the decklink-output device. This figure is taken with Intensity Pro 4K and Fedora 34. The buffer size is monitored at every 6.4 seconds.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
