### PR TITLE
obs-ffmpeg: Fix NVENC HEVC fallback being H.264

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -1024,7 +1024,12 @@ static void *nvenc_create_h264_hevc(bool hevc, obs_data_t *settings,
 	}
 
 reroute:
-	return obs_encoder_create_rerouted(encoder, "ffmpeg_nvenc");
+	const char *fallback_name = "ffmpeg_nvenc";
+#ifdef ENABLE_HEVC
+	if (hevc)
+		fallback_name = "ffmpeg_hevc_nvenc";
+#endif
+	return obs_encoder_create_rerouted(encoder, fallback_name);
 }
 
 static void *h264_nvenc_create(obs_data_t *settings, obs_encoder_t *encoder)


### PR DESCRIPTION
### Description
Fix NVENC HEVC fallback routing.

### Motivation and Context
Don't want unexpected H.264.

### How Has This Been Tested?
Verified video metadata for H.264 and HEVC fallback paths forced by moving instruction pointer in debugger.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.