### PR TITLE
obs-ffmpeg: Several fixes allowing support of FFmpeg 5

### DIFF
--- a/libobs/media-io/media-remux.c
+++ b/libobs/media-io/media-remux.c
@@ -22,7 +22,9 @@
 #include "../util/platform.h"
 
 #include <libavformat/avformat.h>
-
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 20, 100)
+#include <libavcodec/version.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -495,6 +495,7 @@ static void create_audio_stream(struct ffmpeg_mux *ffm, int idx)
 	context->time_base = stream->time_base;
 	context->extradata = extradata;
 	context->extradata_size = ffm->audio_header[idx].size;
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)
 	context->channel_layout =
 		av_get_default_channel_layout(context->channels);
 	//avutil default channel layout for 4 channels is 4.0 ; fix for quad
@@ -503,6 +504,12 @@ static void create_audio_stream(struct ffmpeg_mux *ffm, int idx)
 	//avutil default channel layout for 5 channels is 5.0 ; fix for 4.1
 	if (context->channels == 5)
 		context->channel_layout = av_get_channel_layout("4.1");
+#else
+	av_channel_layout_default(&context->ch_layout, context->channels);
+	//avutil default channel layout for 5 channels is 5.0 ; fix for 4.1
+	if (context->channels == 5)
+		context->ch_layout = (AVChannelLayout)AV_CHANNEL_LAYOUT_4POINT1;
+#endif
 	if (ffm->output->oformat->flags & AVFMT_GLOBALHEADER)
 		context->flags |= CODEC_FLAG_GLOBAL_H;
 

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -498,9 +498,6 @@ static void create_audio_stream(struct ffmpeg_mux *ffm, int idx)
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)
 	context->channel_layout =
 		av_get_default_channel_layout(context->channels);
-	//avutil default channel layout for 4 channels is 4.0 ; fix for quad
-	if (context->channels == 4)
-		context->channel_layout = av_get_channel_layout("quad");
 	//avutil default channel layout for 5 channels is 5.0 ; fix for 4.1
 	if (context->channels == 5)
 		context->channel_layout = av_get_channel_layout("4.1");

--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
@@ -57,6 +57,7 @@ struct enc_encoder {
 	int frame_size_bytes;
 };
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)
 static inline uint64_t convert_speaker_layout(enum speaker_layout layout)
 {
 	switch (layout) {
@@ -81,30 +82,7 @@ static inline uint64_t convert_speaker_layout(enum speaker_layout layout)
 	/* shouldn't get here */
 	return 0;
 }
-
-static inline enum speaker_layout
-convert_ff_channel_layout(uint64_t channel_layout)
-{
-	switch (channel_layout) {
-	case AV_CH_LAYOUT_MONO:
-		return SPEAKERS_MONO;
-	case AV_CH_LAYOUT_STEREO:
-		return SPEAKERS_STEREO;
-	case AV_CH_LAYOUT_SURROUND:
-		return SPEAKERS_2POINT1;
-	case AV_CH_LAYOUT_4POINT0:
-		return SPEAKERS_4POINT0;
-	case AV_CH_LAYOUT_4POINT1:
-		return SPEAKERS_4POINT1;
-	case AV_CH_LAYOUT_5POINT1_BACK:
-		return SPEAKERS_5POINT1;
-	case AV_CH_LAYOUT_7POINT1:
-		return SPEAKERS_7POINT1;
-	}
-
-	/* shouldn't get here */
-	return SPEAKERS_UNKNOWN;
-}
+#endif
 
 static const char *aac_getname(void *unused)
 {
@@ -157,7 +135,11 @@ static bool initialize_codec(struct enc_encoder *enc)
 	}
 	enc->aframe->format = enc->context->sample_fmt;
 	enc->aframe->channels = enc->context->channels;
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)
 	enc->aframe->channel_layout = enc->context->channel_layout;
+#else
+	enc->aframe->ch_layout = enc->context->ch_layout;
+#endif
 	enc->aframe->sample_rate = enc->context->sample_rate;
 
 	enc->frame_size = enc->context->frame_size;
@@ -235,7 +217,15 @@ static void *enc_create(obs_data_t *settings, obs_encoder_t *encoder,
 	const struct audio_output_info *aoi;
 	aoi = audio_output_get_info(audio);
 	enc->context->channels = (int)audio_output_get_channels(audio);
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)
 	enc->context->channel_layout = convert_speaker_layout(aoi->speakers);
+#else
+	av_channel_layout_default(&enc->context->ch_layout,
+				  enc->context->channels);
+	if (aoi->speakers == SPEAKERS_4POINT1)
+		enc->context->ch_layout =
+			(AVChannelLayout)AV_CHANNEL_LAYOUT_4POINT1;
+#endif
 	enc->context->sample_rate = audio_output_get_sample_rate(audio);
 	enc->context->sample_fmt = enc->codec->sample_fmts
 					   ? enc->codec->sample_fmts[0]
@@ -264,11 +254,18 @@ static void *enc_create(obs_data_t *settings, obs_encoder_t *encoder,
 		av_opt_set(enc->context->priv_data, "aac_coder", "fast", 0);
 	}
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)
 	info("bitrate: %" PRId64 ", channels: %d, channel_layout: %x\n",
 	     (int64_t)enc->context->bit_rate / 1000,
 	     (int)enc->context->channels,
 	     (unsigned int)enc->context->channel_layout);
-
+#else
+	char buf[256];
+	av_channel_layout_describe(&enc->context->ch_layout, buf, 256);
+	info("bitrate: %" PRId64 ", channels: %d, channel_layout: %s\n",
+	     (int64_t)enc->context->bit_rate / 1000,
+	     (int)enc->context->channels, buf);
+#endif
 	init_sizes(enc, audio);
 
 	/* enable experimental FFmpeg encoder if the only one available */
@@ -306,7 +303,9 @@ static bool do_encode(struct enc_encoder *enc, struct encoder_packet *packet,
 	enc->aframe->pts = av_rescale_q(
 		enc->total_samples, (AVRational){1, enc->context->sample_rate},
 		enc->context->time_base);
-
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 24, 100)
+	enc->aframe->ch_layout = enc->context->ch_layout;
+#endif
 	ret = avcodec_fill_audio_frame(
 		enc->aframe, enc->context->channels, enc->context->sample_fmt,
 		enc->samples[0], enc->frame_size_bytes * enc->context->channels,
@@ -394,8 +393,10 @@ static void enc_audio_info(void *data, struct audio_convert_info *info)
 	struct enc_encoder *enc = data;
 	info->format = convert_ffmpeg_sample_format(enc->context->sample_fmt);
 	info->samples_per_sec = (uint32_t)enc->context->sample_rate;
-	info->speakers =
-		convert_ff_channel_layout(enc->context->channel_layout);
+	if (enc->context->channels != 7 && enc->context->channels <= 8)
+		info->speakers = (enum speaker_layout)(enc->context->channels);
+	else
+		info->speakers = SPEAKERS_UNKNOWN;
 }
 
 static size_t enc_frame_size(void *data)


### PR DESCRIPTION
### Description
The upgrade to FFmpeg master introduces
several issues:
- avcodec/version.h is no longer included in codec.h; avformat.h
doesn't carry the avcodec version any more.
- the new channel layout APIbreaks obs-ffmpeg-audio-encoders,
obs-ffmpeg-mux & obs-ffmpeg-output.

### Motivation and Context
Allow for a later upgrade to FFmpeg 5.

**Note:**
- I removed the convert_ff_channel_layout which is not compatible with
the new API; it is replaced by code which has compatibility with both
old and new channel layout API.
- I added an ffmpeg-mux fix for 4.0 channel layout.

### How Has This Been Tested?
obs-studio compiles (on win 10 x64, vs2019).
The FFmpeg audio encoders work (tested with streaming and recording).
The obs-ffmpeg-output works too.
FFmpeg version tested: 
- master branch on commit https://github.com/FFmpeg/FFmpeg/commit/944b8c96c90ae050606e638f77a15d6292209b91
(from April 25th 2022).
- This was also tested to work on ArchLinux and Manjaro (thx to @tytan652 ).

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.