### PR TITLE
vlc-source: Fix surround sound not properly downmixed

### DIFF
--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -458,10 +458,13 @@ static int vlcs_audio_setup(void **p_data, char *format, unsigned *rate,
 {
 	struct vlc_source *c = *p_data;
 	enum audio_format new_audio_format;
+	struct obs_audio_info aoi;
+	obs_get_audio_info(&aoi);
+	int out_channels = (int)get_audio_channels(aoi.speakers);
 
 	new_audio_format = convert_vlc_audio_format(format);
-	if (*channels > 8)
-		*channels = 8;
+	if (*channels > out_channels)
+		*channels = out_channels;
 
 	/* don't free audio data if the data is the same format */
 	if (c->audio.format == new_audio_format &&


### PR DESCRIPTION
### Description
This fixes issue https://github.com/obsproject/obs-studio/issues/6295 .
libvlc does some downmixing/upmixing when the number of channels
requested is less than the number of channels of the source.
We take advantage of that feature to avoid doing it with swresample
because we're missing info that libvlc is not giving (the exact channel
layout of the source).

### Motivation and Context
Fixes a bug.

**Important Note**

- surprisingly libvlc does not provide any speaker layout info about a source it decodes. I checked with ePirat. This is a real bummer because this means we can't let swresample do its usual task of downmixing or upmixing to the output speaker layout.
- the libvlc audio callback has however an interesting feature which I haven't seen documented, which is if we request less channels than the original audio soruce has, then vlc will downmix it.
- That's the feature we take advantage of in this PR. A 5.1 source will be then properly downmixed to stereo.
- However a 5.1(side) source won't be touched at all and since obs default corresponds to 5.1(back) (default speaker layout for aac), there will be some channels which are swapped in the wrong positions. That's not something as easy to solve and is beyond the scope of this PR. A solution would be to have the user select a speaker layout and that the plugin calls swresample. That's not something I want to implement at the moment, but maybe in the future.

### How Has This Been Tested?
Fixes the issue https://github.com/obsproject/obs-studio/issues/6295 


### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
