### PR TITLE
CMake headers installation fix with HEVC include fix

### DIFF
--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -295,28 +295,6 @@ function(export_target target)
     EXCLUDE_FROM_ALL)
 endfunction()
 
-# Helper function to install header files
-function(install_headers target)
-  install(
-    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
-    DESTINATION ${OBS_INCLUDE_DESTINATION}
-    COMPONENT obs_libraries
-    EXCLUDE_FROM_ALL FILES_MATCHING
-    PATTERN "*.h"
-    PATTERN "*.hpp"
-    PATTERN "cmake" EXCLUDE
-    PATTERN "pkgconfig" EXCLUDE
-    PATTERN "data" EXCLUDE)
-
-  if(NOT EXISTS "${OBS_INCLUDE_DESTINATION}/obsconfig.h")
-    install(
-      FILES "${CMAKE_BINARY_DIR}/config/obsconfig.h"
-      DESTINATION "${OBS_INCLUDE_DESTINATION}"
-      COMPONENT obs_libraries
-      EXCLUDE_FROM_ALL)
-  endif()
-endfunction()
-
 # Helper function to define available graphics modules for targets
 function(define_graphic_modules target)
   foreach(_GRAPHICS_API metal d3d11 opengl d3d9)

--- a/cmake/Modules/ObsHelpers_Linux.cmake
+++ b/cmake/Modules/ObsHelpers_Linux.cmake
@@ -61,3 +61,44 @@ function(export_target_pkgconf target)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}.pc"
           DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endfunction()
+
+# Helper function to install header files
+function(install_headers target)
+  install(
+    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+    DESTINATION ${OBS_INCLUDE_DESTINATION}
+    COMPONENT obs_libraries
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp"
+    PATTERN "obs-hevc.h" EXCLUDE
+    PATTERN "*-windows.h" EXCLUDE
+    PATTERN "audio-monitoring" EXCLUDE
+    PATTERN "util/apple" EXCLUDE
+    PATTERN "util/windows" EXCLUDE
+    PATTERN "cmake" EXCLUDE
+    PATTERN "pkgconfig" EXCLUDE
+    PATTERN "data" EXCLUDE)
+
+  if(ENABLE_PULSEAUDIO)
+    install(
+      FILES
+        "${CMAKE_CURRENT_SOURCE_DIR}/audio-monitoring/pulse/pulseaudio-wrapper.h"
+      DESTINATION "${OBS_INCLUDE_DESTINATION}/audio-monitoring/pulse/"
+      COMPONENT obs_libraries)
+  endif()
+
+  if(ENABLE_HEVC)
+    install(
+      FILES "${CMAKE_CURRENT_SOURCE_DIR}/obs-hevc.h"
+      DESTINATION "${OBS_INCLUDE_DESTINATION}"
+      COMPONENT obs_libraries)
+  endif()
+
+  if(NOT EXISTS "${OBS_INCLUDE_DESTINATION}/obsconfig.h")
+    install(
+      FILES "${CMAKE_BINARY_DIR}/config/obsconfig.h"
+      DESTINATION "${OBS_INCLUDE_DESTINATION}"
+      COMPONENT obs_libraries)
+  endif()
+endfunction()

--- a/cmake/Modules/ObsHelpers_Windows.cmake
+++ b/cmake/Modules/ObsHelpers_Windows.cmake
@@ -417,3 +417,40 @@ function(generate_multiarch_installer)
     DESTINATION "."
     USE_SOURCE_PERMISSIONS)
 endfunction()
+
+# Helper function to install header files
+function(install_headers target)
+  install(
+    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+    DESTINATION ${OBS_INCLUDE_DESTINATION}
+    COMPONENT obs_libraries
+    EXCLUDE_FROM_ALL FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp"
+    PATTERN "obs-hevc.h" EXCLUDE
+    PATTERN "obs-nix-*.h" EXCLUDE
+    PATTERN "*-posix.h" EXCLUDE
+    PATTERN "audio-monitoring/null" EXCLUDE
+    PATTERN "audio-monitoring/osx" EXCLUDE
+    PATTERN "audio-monitoring/pulse" EXCLUDE
+    PATTERN "util/apple" EXCLUDE
+    PATTERN "cmake" EXCLUDE
+    PATTERN "pkgconfig" EXCLUDE
+    PATTERN "data" EXCLUDE)
+
+  if(ENABLE_HEVC)
+    install(
+      FILES "${CMAKE_CURRENT_SOURCE_DIR}/obs-hevc.h"
+      DESTINATION "${OBS_INCLUDE_DESTINATION}"
+      COMPONENT obs_libraries
+      EXCLUDE_FROM_ALL)
+  endif()
+
+  if(NOT EXISTS "${OBS_INCLUDE_DESTINATION}/obsconfig.h")
+    install(
+      FILES "${CMAKE_BINARY_DIR}/config/obsconfig.h"
+      DESTINATION "${OBS_INCLUDE_DESTINATION}"
+      COMPONENT obs_libraries
+      EXCLUDE_FROM_ALL)
+  endif()
+endfunction()

--- a/cmake/Modules/ObsHelpers_macOS.cmake
+++ b/cmake/Modules/ObsHelpers_macOS.cmake
@@ -480,9 +480,26 @@ function(install_headers target)
     EXCLUDE_FROM_ALL FILES_MATCHING
     PATTERN "*.h"
     PATTERN "*.hpp"
+    PATTERN "obs-hevc.h" EXCLUDE
+    PATTERN "*-windows.h" EXCLUDE
+    PATTERN "*-x11.h" EXCLUDE
+    PATTERN "*-wayland.h" EXCLUDE
+    PATTERN "audio-monitoring/null" EXCLUDE
+    PATTERN "audio-monitoring/win32" EXCLUDE
+    PATTERN "audio-monitoring/pulse" EXCLUDE
+    PATTERN "util/windows" EXCLUDE
     PATTERN "cmake" EXCLUDE
     PATTERN "pkgconfig" EXCLUDE
     PATTERN "data" EXCLUDE)
+
+  if(ENABLE_HEVC)
+    install(
+      FILES "${CMAKE_CURRENT_SOURCE_DIR}/obs-hevc.h"
+      DESTINATION
+        $<IF:$<BOOL:$<TARGET_PROPERTY:${target},FRAMEWORK>>,Frameworks/$<TARGET_FILE_BASE_NAME:${target}>.framework/Headers,${OBS_INCLUDE_DESTINATION}>
+      COMPONENT obs_libraries
+      EXCLUDE_FROM_ALL)
+  endif()
 
   install(
     FILES "${CMAKE_BINARY_DIR}/config/obsconfig.h"

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -31,8 +31,6 @@ target_sources(
           obs-encoder.c
           obs-encoder.h
           obs-ffmpeg-compat.h
-          obs-hevc.c
-          obs-hevc.h
           obs-hotkey.c
           obs-hotkey.h
           obs-hotkeys.h
@@ -202,6 +200,10 @@ target_sources(
           util/curl/curl-helper.h
           util/darray.h
           util/util.hpp)
+
+if(ENABLE_HEVC)
+  target_sources(libobs PRIVATE obs-hevc.c obs-hevc.h)
+endif()
 
 # Contents of "data" dir already automatically added to bundles on macOS
 if(NOT OS_MACOS)

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -3,12 +3,14 @@
 #include <util/darray.h>
 #include <util/dstr.h>
 #include <obs-avc.h>
-#include <obs-hevc.h>
 #include <libavutil/rational.h>
 #define INITGUID
 #include <dxgi.h>
 #include <d3d11.h>
 #include <d3d11_1.h>
+#ifdef ENABLE_HEVC
+#include <obs-hevc.h>
+#endif
 
 /* ========================================================================= */
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
- Stop including `obs-hevc.{h,c}` in sources target if HEVC is disabled with a fix for `jim-nvenc`
- Headers are now installed per default on Linux
- `obs-hevc.h` is not installed if HEVC is disabled
- OS exclusive headers are no longer installed on the wrong OS

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This needed to be fixed so I fixed it.

The HEVC change was made at the same time since the HEVC header is not required if disabled.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Linux OBS Portable installation have headers without Windows or macOS headers
- OBS build with HEVC disabled or enabled

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
