### PR TITLE
Various NVENC B-frame improvements

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -364,6 +364,13 @@ static bool init_encoder_h264(struct nvenc_data *enc, obs_data_t *settings,
 	bool vbr = astrcmpi(rc, "VBR") == 0;
 	NVENCSTATUS err;
 
+	const int bf_max = nv_get_cap_h264(enc, NV_ENC_CAPS_NUM_MAX_BFRAMES);
+	if (bf > bf_max) {
+		error("Max B-frames setting (%d) is more than GPU supports (%d)",
+		      bf, bf_max);
+		return false;
+	}
+
 	video_t *video = obs_encoder_video(enc->encoder);
 	const struct video_output_info *voi = video_output_get_info(video);
 
@@ -636,6 +643,13 @@ static bool init_encoder_hevc(struct nvenc_data *enc, obs_data_t *settings,
 	int bf = (int)obs_data_get_int(settings, "bf");
 	bool vbr = astrcmpi(rc, "VBR") == 0;
 	NVENCSTATUS err;
+
+	const int bf_max = nv_get_cap_hevc(enc, NV_ENC_CAPS_NUM_MAX_BFRAMES);
+	if (bf > bf_max) {
+		error("Max B-frames setting (%d) is more than GPU supports (%d)",
+		      bf, bf_max);
+		return false;
+	}
 
 	video_t *video = obs_encoder_video(enc->encoder);
 	const struct video_output_info *voi = video_output_get_info(video);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -163,6 +163,8 @@ static bool nvenc_update(struct nvenc_encoder *enc, obs_data_t *settings,
 
 	set_psycho_aq(enc, psycho_aq);
 
+	enc->ffve.context->max_b_frames = bf;
+
 	const char *ffmpeg_opts = obs_data_get_string(settings, "ffmpeg_opts");
 	ffmpeg_video_encoder_update(&enc->ffve, bitrate, keyint_sec, voi, &info,
 				    ffmpeg_opts);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -373,7 +373,7 @@ void hevc_nvenc_defaults(obs_data_t *settings)
 	obs_data_set_default_string(settings, "profile", "main");
 	obs_data_set_default_bool(settings, "psycho_aq", true);
 	obs_data_set_default_int(settings, "gpu", 0);
-	obs_data_set_default_int(settings, "bf", 2);
+	obs_data_set_default_int(settings, "bf", 0);
 	obs_data_set_default_bool(settings, "repeat_headers", false);
 }
 #endif


### PR DESCRIPTION
### Description
See individual commit descriptions for details.

### Motivation and Context
Correctness and user-friendliness.

### How Has This Been Tested?
- [x] Verified both error cases in logging using debugger inspection.
- [x] Verified old NVENC Max B-frames setting is being used again by testing valid and invalid values, and getting success and failure respectively.
- [x] Verified 0 is the new HEVC Max B-frames default with a fresh profile.
- [x] Tested on GTX 1080 (Pascal) that HEVC Max B-frames 0 works, and 2 doesn't.
- [x] Tested on GTX 1080 (Ampere) that HEVC Max B-frames 2 works. Reports that 5 is allowed.


### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.