### PR TITLE
obs-x264: Restore video encoder name to log

### DIFF
--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -30,10 +30,15 @@
 
 #include <x264.h>
 
+#define do_log_enc(level, encoder, format, ...)     \
+	blog(level, "[x264 encoder: '%s'] " format, \
+	     obs_encoder_get_name(encoder), ##__VA_ARGS__)
 #define do_log(level, format, ...) \
-	blog(level, "[x264 encoder] " format, ##__VA_ARGS__)
+	do_log_enc(level, obsx264->encoder, format, ##__VA_ARGS__)
 
 #define warn(format, ...) do_log(LOG_WARNING, format, ##__VA_ARGS__)
+#define warn_enc(encoder, format, ...) \
+	do_log_enc(LOG_WARNING, encoder, format, ##__VA_ARGS__)
 #define info(format, ...) do_log(LOG_INFO, format, ##__VA_ARGS__)
 #define debug(format, ...) do_log(LOG_DEBUG, format, ##__VA_ARGS__)
 
@@ -696,7 +701,8 @@ static void *obs_x264_create(obs_data_t *settings, obs_encoder_t *encoder)
 	switch (voi->colorspace) {
 	case VIDEO_CS_2100_PQ:
 	case VIDEO_CS_2100_HLG:
-		warn("OBS does not support using x264 with Rec. 2100");
+		warn_enc(encoder,
+			 "OBS does not support using x264 with Rec. 2100");
 		return NULL;
 	}
 


### PR DESCRIPTION
### Description
Thought the encoder name was redundant when I removed it, but it's a different meaning of encoder.

### Motivation and Context
Want logging to be as good as it was.

### How Has This Been Tested?
Verified warn and warn_enc macros work properly.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.