### PR TITLE
UI: Restore portable mode on Windows

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2347,9 +2347,15 @@ static void load_debug_privilege(void)
 
 #define CONFIG_PATH BASE_PATH "/config"
 
+#if defined(LINUX_PORTABLE) || defined(_WIN32)
+#define ALLOW_PORTABLE_MODE 1
+#else
+#define ALLOW_PORTABLE_MODE 0
+#endif
+
 int GetConfigPath(char *path, size_t size, const char *name)
 {
-#ifdef LINUX_PORTABLE
+#if ALLOW_PORTABLE_MODE
 	if (portable_mode) {
 		if (name && *name) {
 			return snprintf(path, size, CONFIG_PATH "/%s", name);
@@ -2366,7 +2372,7 @@ int GetConfigPath(char *path, size_t size, const char *name)
 
 char *GetConfigPathPtr(const char *name)
 {
-#ifdef LINUX_PORTABLE
+#if ALLOW_PORTABLE_MODE
 	if (portable_mode) {
 		char path[512];
 
@@ -2882,7 +2888,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-#if defined(LINUX_PORTABLE)
+#if ALLOW_PORTABLE_MODE
 	if (!portable_mode) {
 		portable_mode =
 			os_file_exists(BASE_PATH "/portable_mode") ||


### PR DESCRIPTION
### Description
Fixed portable mode regression.

### Motivation and Context
Portable mode is useful for testing.

### How Has This Been Tested?
Verified portable mode on Windows is enabled with text file, and disabled without.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.