### PR TITLE
obs-scripting: Fix loading of scripting libraries with runtime lookup

### DIFF
--- a/deps/obs-scripting/obs-scripting-python-import.c
+++ b/deps/obs-scripting/obs-scripting-python-import.c
@@ -113,6 +113,9 @@ bool import_python(const char *python_path)
 	IMPORT_FUNC(PyDict_GetItemString);
 	IMPORT_FUNC(PyDict_SetItemString);
 	IMPORT_FUNC(PyCFunction_NewEx);
+#if PY_VERSION_HEX > 0x030900b0
+	IMPORT_FUNC(PyCMethod_New);
+#endif
 	IMPORT_FUNC(PyModule_GetDict);
 	IMPORT_FUNC(PyModule_GetNameObject);
 	IMPORT_FUNC(PyModule_AddObject);

--- a/deps/obs-scripting/obs-scripting-python-import.h
+++ b/deps/obs-scripting/obs-scripting-python-import.h
@@ -100,6 +100,10 @@ PY_EXTERN int (*Import_PyDict_SetItemString)(PyObject *dp, const char *key,
 					     PyObject *item);
 PY_EXTERN PyObject *(*Import_PyCFunction_NewEx)(PyMethodDef *, PyObject *,
 						PyObject *);
+#if PY_VERSION_HEX > 0x030900b0
+PY_EXTERN PyObject *(*Import_PyCMethod_New)(PyMethodDef *, PyObject *,
+					    PyObject *, PyTypeObject *);
+#endif
 PY_EXTERN PyObject *(*Import_PyModule_GetDict)(PyObject *);
 PY_EXTERN PyObject *(*Import_PyModule_GetNameObject)(PyObject *);
 PY_EXTERN int (*Import_PyModule_AddObject)(PyObject *, const char *,
@@ -193,7 +197,11 @@ extern bool import_python(const char *python_path);
 #define PyDict_New Import_PyDict_New
 #define PyDict_GetItemString Import_PyDict_GetItemString
 #define PyDict_SetItemString Import_PyDict_SetItemString
+#if PY_VERSION_HEX < 0x030900b0
 #define PyCFunction_NewEx Import_PyCFunction_NewEx
+#else
+#define PyCMethod_New Import_PyCMethod_New
+#endif
 #define PyModule_GetDict Import_PyModule_GetDict
 #define PyModule_GetNameObject Import_PyModule_GetNameObject
 #define PyModule_AddObject Import_PyModule_AddObject

--- a/deps/obs-scripting/obs-scripting-python-import.h
+++ b/deps/obs-scripting/obs-scripting-python-import.h
@@ -193,9 +193,7 @@ extern bool import_python(const char *python_path);
 #define PyDict_New Import_PyDict_New
 #define PyDict_GetItemString Import_PyDict_GetItemString
 #define PyDict_SetItemString Import_PyDict_SetItemString
-#if PY_VERSION_HEX < 0x030900b0
 #define PyCFunction_NewEx Import_PyCFunction_NewEx
-#endif
 #define PyModule_GetDict Import_PyModule_GetDict
 #define PyModule_GetNameObject Import_PyModule_GetNameObject
 #define PyModule_AddObject Import_PyModule_AddObject


### PR DESCRIPTION
### Description
Fixes `frontend-tools` not being loaded on macOS when Python scripting is enabled.

### Motivation and Context
Issue was introduced in 4c1687901ecfc99b1fd0d810e86e9deff5497b2d in an attempt to remove compiler warnings.

### How Has This Been Tested?
* Tested with enabled Python scripting on local macOS builds.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
