### PR TITLE
libobs: Add support for reading I420 PQ

### DIFF
--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -477,6 +477,19 @@ float3 PSPlanar420_Reverse(VertTexPos frag_in) : TARGET
 	return rgb;
 }
 
+float4 PSPlanar420_PQ_Reverse(VertTexPos frag_in) : TARGET
+{
+	float y = image.Load(int3(frag_in.pos.xy, 0)).x;
+	int3 xy0_chroma = int3(frag_in.uv, 0);
+	float cb = image1.Load(xy0_chroma).x;
+	float cr = image2.Load(xy0_chroma).x;
+	float3 yuv = float3(y, cb, cr);
+	float3 pq = YUV_to_RGB(yuv);
+	float3 hdr2020 = st2084_to_linear(pq) * maximum_over_sdr_white_nits;
+	float3 rgb = rec2020_to_rec709(hdr2020);
+	return float4(rgb, 1.);
+}
+
 float4 PSPlanar420A_Reverse(VertTexPos frag_in) : TARGET
 {
 	int3 xy0_luma = int3(frag_in.pos.xy, 0);
@@ -511,7 +524,7 @@ float4 PSPlanar422_10LE_Reverse(FragPosWide frag_in) : TARGET
 	yuv *= 65535. / 1023.;
 	float3 rgb = YUV_to_RGB(yuv);
 	rgb = srgb_nonlinear_to_linear(rgb);
-	return float4(rgb, 1.0);
+	return float4(rgb, 1.);
 }
 
 float4 PSPlanar422A_Reverse(FragPosWide frag_in) : TARGET
@@ -548,7 +561,7 @@ float4 PSPlanar444_12LE_Reverse(FragPos frag_in) : TARGET
 	yuv *= 65535. / 4095.;
 	float3 rgb = YUV_to_RGB(yuv);
 	rgb = srgb_nonlinear_to_linear(rgb);
-	return float4(rgb, 1.0);
+	return float4(rgb, 1.);
 }
 
 float4 PSPlanar444A_Reverse(FragPos frag_in) : TARGET
@@ -603,7 +616,7 @@ float4 PSI010_SRGB_Reverse(VertTexPos frag_in) : TARGET
 	float3 yuv = float3(y, cb, cr);
 	float3 rgb = YUV_to_RGB(yuv);
 	rgb = srgb_nonlinear_to_linear(rgb);
-	return float4(rgb, 1.0);
+	return float4(rgb, 1.);
 }
 
 float4 PSI010_PQ_2020_709_Reverse(VertTexPos frag_in) : TARGET
@@ -617,7 +630,7 @@ float4 PSI010_PQ_2020_709_Reverse(VertTexPos frag_in) : TARGET
 	float3 pq = YUV_to_RGB(yuv);
 	float3 hdr2020 = st2084_to_linear(pq) * maximum_over_sdr_white_nits;
 	float3 rgb = rec2020_to_rec709(hdr2020);
-	return float4(rgb, 1.0);
+	return float4(rgb, 1.);
 }
 
 float4 PSI010_HLG_2020_709_Reverse(VertTexPos frag_in) : TARGET
@@ -631,7 +644,7 @@ float4 PSI010_HLG_2020_709_Reverse(VertTexPos frag_in) : TARGET
 	float3 hlg = YUV_to_RGB(yuv);
 	float3 hdr2020 = hlg_to_linear(hlg, hlg_exponent) * maximum_over_sdr_white_nits;
 	float3 rgb = rec2020_to_rec709(hdr2020);
-	return float4(rgb, 1.0);
+	return float4(rgb, 1.);
 }
 
 float4 PSP010_SRGB_Reverse(VertTexPos frag_in) : TARGET
@@ -641,7 +654,7 @@ float4 PSP010_SRGB_Reverse(VertTexPos frag_in) : TARGET
 	float3 yuv = float3(y, cbcr);
 	float3 rgb = YUV_to_RGB(yuv);
 	rgb = srgb_nonlinear_to_linear(rgb);
-	return float4(rgb, 1.0);
+	return float4(rgb, 1.);
 }
 
 float4 PSP010_PQ_2020_709_Reverse(VertTexPos frag_in) : TARGET
@@ -652,7 +665,7 @@ float4 PSP010_PQ_2020_709_Reverse(VertTexPos frag_in) : TARGET
 	float3 pq = YUV_to_RGB(yuv);
 	float3 hdr2020 = st2084_to_linear(pq) * maximum_over_sdr_white_nits;
 	float3 rgb = rec2020_to_rec709(hdr2020);
-	return float4(rgb, 1.0);
+	return float4(rgb, 1.);
 }
 
 float4 PSP010_HLG_2020_709_Reverse(VertTexPos frag_in) : TARGET
@@ -663,7 +676,7 @@ float4 PSP010_HLG_2020_709_Reverse(VertTexPos frag_in) : TARGET
 	float3 hlg = YUV_to_RGB(yuv);
 	float3 hdr2020 = hlg_to_linear(hlg, hlg_exponent) * maximum_over_sdr_white_nits;
 	float3 rgb = rec2020_to_rec709(hdr2020);
-	return float4(rgb, 1.0);
+	return float4(rgb, 1.);
 }
 
 float3 PSY800_Limited(FragPos frag_in) : TARGET
@@ -940,6 +953,15 @@ technique I420_Reverse
 	{
 		vertex_shader = VSTexPosHalfHalf_Reverse(id);
 		pixel_shader  = PSPlanar420_Reverse(frag_in);
+	}
+}
+
+technique I420_PQ_Reverse
+{
+	pass
+	{
+		vertex_shader = VSTexPosHalfHalf_Reverse(id);
+		pixel_shader  = PSPlanar420_PQ_Reverse(frag_in);
 	}
 }
 

--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -503,15 +503,15 @@ float3 PSPlanar422_Reverse(FragPosWide frag_in) : TARGET
 
 float4 PSPlanar422_10LE_Reverse(FragPosWide frag_in) : TARGET
 {
-    float y = image.Load(int3(frag_in.pos_wide.xz, 0)).x;
-    int3 xy0_chroma = int3(frag_in.pos_wide.yz, 0);
-    float cb = image1.Load(xy0_chroma).x;
-    float cr = image2.Load(xy0_chroma).x;
-    float3 yuv = float3(y, cb, cr);
-    yuv *= 65535. / 1023.;
-    float3 rgb = YUV_to_RGB(yuv);
-    rgb = srgb_nonlinear_to_linear(rgb);
-    return float4(rgb, 1.0);
+	float y = image.Load(int3(frag_in.pos_wide.xz, 0)).x;
+	int3 xy0_chroma = int3(frag_in.pos_wide.yz, 0);
+	float cb = image1.Load(xy0_chroma).x;
+	float cr = image2.Load(xy0_chroma).x;
+	float3 yuv = float3(y, cb, cr);
+	yuv *= 65535. / 1023.;
+	float3 rgb = YUV_to_RGB(yuv);
+	rgb = srgb_nonlinear_to_linear(rgb);
+	return float4(rgb, 1.0);
 }
 
 float4 PSPlanar422A_Reverse(FragPosWide frag_in) : TARGET
@@ -540,15 +540,15 @@ float3 PSPlanar444_Reverse(FragPos frag_in) : TARGET
 
 float4 PSPlanar444_12LE_Reverse(FragPos frag_in) : TARGET
 {
-    int3 xy0 = int3(frag_in.pos.xy, 0);
-    float y = image.Load(xy0).x;
-    float cb = image1.Load(xy0).x;
-    float cr = image2.Load(xy0).x;
-    float3 yuv = float3(y, cb, cr);
-    yuv *= 65535. / 4095.;
-    float3 rgb = YUV_to_RGB(yuv);
-    rgb = srgb_nonlinear_to_linear(rgb);
-    return float4(rgb, 1.0);
+	int3 xy0 = int3(frag_in.pos.xy, 0);
+	float y = image.Load(xy0).x;
+	float cb = image1.Load(xy0).x;
+	float cr = image2.Load(xy0).x;
+	float3 yuv = float3(y, cb, cr);
+	yuv *= 65535. / 4095.;
+	float3 rgb = YUV_to_RGB(yuv);
+	rgb = srgb_nonlinear_to_linear(rgb);
+	return float4(rgb, 1.0);
 }
 
 float4 PSPlanar444A_Reverse(FragPos frag_in) : TARGET
@@ -565,16 +565,16 @@ float4 PSPlanar444A_Reverse(FragPos frag_in) : TARGET
 
 float4 PSPlanar444A_12LE_Reverse(FragPos frag_in) : TARGET
 {
-    int3 xy0 = int3(frag_in.pos.xy, 0);
-    float y = image.Load(xy0).x;
-    float cb = image1.Load(xy0).x;
-    float cr = image2.Load(xy0).x;
-    float alpha = image3.Load(xy0).x * 16.;
-    float3 yuv = float3(y, cb, cr);
-    yuv *= 65535. / 4095.;
-    float3 rgb = YUV_to_RGB(yuv);
-    rgb = srgb_nonlinear_to_linear(rgb);
-    return float4(rgb, alpha);
+	int3 xy0 = int3(frag_in.pos.xy, 0);
+	float y = image.Load(xy0).x;
+	float cb = image1.Load(xy0).x;
+	float cr = image2.Load(xy0).x;
+	float alpha = image3.Load(xy0).x * 16.;
+	float3 yuv = float3(y, cb, cr);
+	yuv *= 65535. / 4095.;
+	float3 rgb = YUV_to_RGB(yuv);
+	rgb = srgb_nonlinear_to_linear(rgb);
+	return float4(rgb, alpha);
 }
 
 float4 PSAYUV_Reverse(FragPos frag_in) : TARGET
@@ -963,11 +963,11 @@ technique I422_Reverse
 
 technique I210_Reverse
 {
-    pass
-    {
-        vertex_shader = VSPosWide_Reverse(id);
-        pixel_shader  = PSPlanar422_10LE_Reverse(frag_in);
-    }
+	pass
+	{
+		vertex_shader = VSPosWide_Reverse(id);
+		pixel_shader  = PSPlanar422_10LE_Reverse(frag_in);
+	}
 }
 
 technique I42A_Reverse
@@ -990,11 +990,11 @@ technique I444_Reverse
 
 technique I412_Reverse
 {
-    pass
-    {
-        vertex_shader = VSPos(id);
-        pixel_shader  = PSPlanar444_12LE_Reverse(frag_in);
-    }
+	pass
+	{
+		vertex_shader = VSPos(id);
+		pixel_shader  = PSPlanar444_12LE_Reverse(frag_in);
+	}
 }
 
 technique YUVA_Reverse
@@ -1008,11 +1008,11 @@ technique YUVA_Reverse
 
 technique YA2L_Reverse
 {
-    pass
-    {
-        vertex_shader = VSPos(id);
-        pixel_shader  = PSPlanar444A_12LE_Reverse(frag_in);
-    }
+	pass
+	{
+		vertex_shader = VSPos(id);
+		pixel_shader  = PSPlanar444A_12LE_Reverse(frag_in);
+	}
 }
 
 technique AYUV_Reverse

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -879,25 +879,31 @@ static inline bool frame_out_of_bounds(const obs_source_t *source, uint64_t ts)
 }
 
 static inline enum gs_color_format
-convert_video_format(enum video_format format)
+convert_video_format(enum video_format format, enum video_trc trc)
 {
-	switch (format) {
-	case VIDEO_FORMAT_RGBA:
-		return GS_RGBA;
-	case VIDEO_FORMAT_BGRA:
-	case VIDEO_FORMAT_I40A:
-	case VIDEO_FORMAT_I42A:
-	case VIDEO_FORMAT_YUVA:
-	case VIDEO_FORMAT_AYUV:
-		return GS_BGRA;
-	case VIDEO_FORMAT_I010:
-	case VIDEO_FORMAT_P010:
-	case VIDEO_FORMAT_I210:
-	case VIDEO_FORMAT_I412:
-	case VIDEO_FORMAT_YA2L:
+	switch (trc) {
+	case VIDEO_TRC_PQ:
+	case VIDEO_TRC_HLG:
 		return GS_RGBA16F;
 	default:
-		return GS_BGRX;
+		switch (format) {
+		case VIDEO_FORMAT_RGBA:
+			return GS_RGBA;
+		case VIDEO_FORMAT_BGRA:
+		case VIDEO_FORMAT_I40A:
+		case VIDEO_FORMAT_I42A:
+		case VIDEO_FORMAT_YUVA:
+		case VIDEO_FORMAT_AYUV:
+			return GS_BGRA;
+		case VIDEO_FORMAT_I010:
+		case VIDEO_FORMAT_P010:
+		case VIDEO_FORMAT_I210:
+		case VIDEO_FORMAT_I412:
+		case VIDEO_FORMAT_YA2L:
+			return GS_RGBA16F;
+		default:
+			return GS_BGRX;
+		}
 	}
 }
 
@@ -905,7 +911,7 @@ static inline enum gs_color_space convert_video_space(enum video_format format,
 						      enum video_trc trc)
 {
 	enum gs_color_space space = GS_CS_SRGB;
-	if (convert_video_format(format) == GS_RGBA16F) {
+	if (convert_video_format(format, trc) == GS_RGBA16F) {
 		space = (trc == VIDEO_TRC_SRGB) ? GS_CS_SRGB_16F
 						: GS_CS_709_EXTENDED;
 	}

--- a/libobs/obs-source-deinterlace.c
+++ b/libobs/obs-source-deinterlace.c
@@ -234,7 +234,7 @@ void deinterlace_process_last_frame(obs_source_t *s, uint64_t sys_time)
 void set_deinterlace_texture_size(obs_source_t *source)
 {
 	const enum gs_color_format format =
-		convert_video_format(source->async_format);
+		convert_video_format(source->async_format, source->async_trc);
 
 	if (source->async_gpu_conversion) {
 		source->async_prev_texrender =


### PR DESCRIPTION
### Description
Not normally a valid combination, but Xbox writes 8-bit HDR videos.

### Motivation and Context
Want to view Xbox HDR videos with "proper" colors.

### How Has This Been Tested?
Verified Xbox HDR video matches VLC playback. Also checked real HDR and SDR videos for regressions.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.