### PR TITLE
UI: Use Shift instead of Alt for Copy/Paste Transform

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1676,7 +1676,7 @@
     <string>Basic.MainMenu.Edit.Transform.CopyTransform</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+C</string>
+    <string>Ctrl+Shift+C</string>
    </property>
   </action>
   <action name="actionPasteTransform">
@@ -1687,7 +1687,7 @@
     <string>Basic.MainMenu.Edit.Transform.PasteTransform</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Alt+V</string>
+    <string>Ctrl+Shift+V</string>
    </property>
   </action>
   <action name="actionRotate90CW">


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the shortcut for Copy/Paste Transform from `Ctrl/Cmd+Alt+C/V` to `Ctrl/Cmd+Shift+C/V`.
Being introduced in #6038 this shortcut has not yet been shipped in production, so it can safely be changed.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I wasn't aware at the time of the original PR, but it appears to be general consensus that Shift should be used as a secondary modifier, with Alt being a tertiary (or not used at all). Both the UX guidelines of Apple and Microsoft agree on this, we should adhere to that principle as well.

[Apple](https://developer.apple.com/design/human-interface-guidelines/macos/user-interaction/keyboard/):
> - Prefer the Shift key as a secondary modifier when a shortcut complements another shortcut. [...]
> - Use the Option [Alt] key as a modifier sparingly. If a third, less-common command is related to a pair of commands that use Command and Shift-Command, you can use Option-Command in the third command’s shortcut. [...]

[Microsoft](https://docs.microsoft.com/de-de/previous-versions/windows/desktop/dnacc/guidelines-for-keyboard-user-interface-design?redirectedfrom=MSDN#atg_keyboardshortcuts_creating_shortcut_keys_and_access_keys):
> - Use the SHIFT+key combination for actions that extend or complement the actions of the standard shortcut key. [...]
> - Avoid ALT+letter combinations because they may conflict with access keys. In addition, the system uses many specific key combinations for specialized input; for example, ALT+~ invokes an input editor for the Japanese language.
> - Avoid CTRL+ALT combinations because the system interprets this combination in some language versions as an ALTGR key, which generates alphanumeric characters.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.4 Beta 4, compiled and run
Cmd+Shift+C now correctly copies the Transform, and Cmd+Shift+V pastes it.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
