### PR TITLE
add header ../obs-ffmpeg-compat.h for ffmpeg version compatibility

### DIFF
--- a/libobs/media-io/media-remux.c
+++ b/libobs/media-io/media-remux.c
@@ -25,6 +25,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include "../obs-ffmpeg-compat.h"
 
 #if LIBAVCODEC_VERSION_MAJOR >= 58
 #define CODEC_FLAG_GLOBAL_H AV_CODEC_FLAG_GLOBAL_HEADER


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
Add `#include "../obs-ffmpeg-compat.h"` into file `libobs/media-io/media-remux.c`, specifically for the cmpatability of ffmpeg5 with this particular file.
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
specifically for the cmpatability of ffmpeg5 with file `libobs/media-io/media-remux.c` .
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
