### PR TITLE
libobs: Fix reserved word in variable names

### DIFF
--- a/libobs/data/color.effect
+++ b/libobs/data/color.effect
@@ -46,8 +46,8 @@ float3 reinhard(float3 rgb)
 
 float linear_to_st2084_channel(float x)
 {
-	float common = pow(abs(x), 0.1593017578);
-	return pow((0.8359375 + 18.8515625 * common) / (1. + 18.6875 * common), 78.84375);
+	float c = pow(abs(x), 0.1593017578);
+	return pow((0.8359375 + 18.8515625 * c) / (1. + 18.6875 * c), 78.84375);
 }
 
 float3 linear_to_st2084(float3 rgb)
@@ -57,8 +57,8 @@ float3 linear_to_st2084(float3 rgb)
 
 float st2084_to_linear_channel(float u)
 {
-	float common = pow(abs(u), 1. / 78.84375);
-	return pow(abs(max(common - 0.8359375, 0.) / (18.8515625 - 18.6875 * common)), 1. / 0.1593017578);
+	float c = pow(abs(u), 1. / 78.84375);
+	return pow(abs(max(c - 0.8359375, 0.) / (18.8515625 - 18.6875 * c)), 1. / 0.1593017578);
 }
 
 float3 st2084_to_linear(float3 v)


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Replace `common` with `c` in `color.effect`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
After the commit 0f53dc28b, OBS Studio fails to initialize. The use of the reserved name caused initialization failure on Linux with log lines as below.
```
Error compiling shader:
0:37(8): error: illegal use of reserved word `common'
0:37(8): error: syntax error, unexpected ERROR_TOK, expecting ',' or ';'
```
https://obsproject.com/logs/WU5thNosIFxNkekN

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Fedora 34.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
