### PR TITLE
UI: Find Qt WinExtras only in Qt 5

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -72,10 +72,15 @@ find_package(CURL REQUIRED)
 add_subdirectory(frontend-plugins)
 add_executable(obs)
 
+set(UI_COMPONENTS_WIN "")
+if(QT_VERSION EQUAL 5)
+  set(UI_COMPONENTS_WIN "WinExtras")
+endif()
+
 find_qt(
   VERSION ${QT_VERSION}
   COMPONENTS Widgets Network Svg Xml
-  COMPONENTS_WIN WinExtras
+  COMPONENTS_WIN ${UI_COMPONENTS_WIN}
   COMPONENTS_LINUX Gui)
 
 target_link_libraries(obs PRIVATE Qt::Widgets Qt::Svg Qt::Xml Qt::Network)
@@ -338,7 +343,11 @@ if(OS_WINDOWS)
             win-update/win-update-helpers.hpp
             ${CMAKE_BINARY_DIR}/obs.rc)
 
-  target_link_libraries(obs PRIVATE crypt32 OBS::blake2 Qt::WinExtras)
+  if(QT_VERSION EQUAL 5)
+    target_link_libraries(obs PRIVATE crypt32 OBS::blake2 Qt::WinExtras)
+  else()
+    target_link_libraries(obs PRIVATE crypt32 OBS::blake2)
+  endif()
 
   target_compile_features(obs PRIVATE cxx_std_17)
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
WinExtras does not exist in Qt 6. Only try to find it and link against it if using Qt 5.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Maintain compatibility with Qt 5 and Qt 6.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Was able to successfully run cmake locally against Qt 5 and Qt 6.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
