### PR TITLE
rtmp-services: Enable YouTube dual ingestion

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -211,6 +211,13 @@
                 {
                     "name": "Backup YouTube ingest server",
                     "url": "https://b.upload.youtube.com/http_upload_hls?cid={stream_key}&copy=1&file=out.m3u8"
+                },
+                {
+                    "name": "Both Primary and Backup YouTube ingest servers",
+                    "url": "https://a.upload.youtube.com/http_upload_hls?cid={stream_key}&copy=0&file=out.m3u8",
+                    "backup_urls": [
+                        "https://b.upload.youtube.com/http_upload_hls?cid={stream_key}&copy=1&file=out.m3u8"
+                    ]
                 }
             ],
             "recommended": {
@@ -237,6 +244,13 @@
                 {
                     "name": "Backup YouTube ingest server",
                     "url": "rtmps://b.rtmps.youtube.com:443/live2?backup=1"
+                },
+                {
+                    "name": "Both Primary & Backup YouTube ingest servers",
+                    "url": "rtmps://a.rtmps.youtube.com:443/live2",
+                    "backup_urls": [
+                        "rtmps://b.rtmps.youtube.com:443/live2?backup=1"
+                    ]
                 },
                 {
                     "name": "Primary YouTube ingest server (legacy RTMP)",


### PR DESCRIPTION
### Description
Enable YouTube dual ingestion.
This pull request enables the redundant stream feature implemented in https://github.com/obsproject/obs-studio/pull/6445

### Motivation and Context
To enable dual ingestion in YouTube.

### How Has This Been Tested?
This can be tested with the backup streams [pull request](https://github.com/obsproject/obs-studio/pull/6445) by selecting YouTube in the services drop down.

### Types of changes
New feature (non-breaking change which adds functionality)

### Checklist:
- [ x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ x] My code is not on the master branch.
- [ x] The code has been tested.
- [ x] All commit messages are properly formatted and commits squashed where appropriate.
- [ x] I have included updates to all appropriate documentation.
