### PR TITLE
UI: Add rename signal to adv audio dialog

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -68,6 +68,7 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 			     this);
 	balChangedSignal.Connect(handler, "audio_balance",
 				 OBSSourceBalanceChanged, this);
+	renameSignal.Connect(handler, "rename", OBSSourceRenamed, this);
 
 	hlayout = new QHBoxLayout();
 	hlayout->setContentsMargins(0, 0, 0, 0);
@@ -95,7 +96,7 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	iconLabel->setFixedSize(16, 16);
 	iconLabel->setStyleSheet("background: none");
 
-	nameLabel->setText(sourceName);
+	SetSourceName(sourceName);
 	nameLabel->setAlignment(Qt::AlignVCenter);
 
 	bool isActive = obs_source_active(source);
@@ -358,6 +359,15 @@ void OBSAdvAudioCtrl::OBSSourceBalanceChanged(void *param, calldata_t *calldata)
 	int balance = (float)calldata_float(calldata, "balance") * 100.0f;
 	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param),
 				  "SourceBalanceChanged", Q_ARG(int, balance));
+}
+
+void OBSAdvAudioCtrl::OBSSourceRenamed(void *param, calldata_t *calldata)
+{
+	QString newName = QT_UTF8(calldata_string(calldata, "new_name"));
+
+	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param),
+				  "SetSourceName",
+				  Q_ARG(const QString &, newName));
 }
 
 /* ------------------------------------------------------------------------- */
@@ -688,4 +698,10 @@ void OBSAdvAudioCtrl::SetVolumeWidget(VolumeType type)
 void OBSAdvAudioCtrl::SetIconVisible(bool visible)
 {
 	visible ? iconLabel->show() : iconLabel->hide();
+}
+
+void OBSAdvAudioCtrl::SetSourceName(const QString &newName)
+{
+	if (nameLabel->text() != newName)
+		nameLabel->setText(newName);
 }

--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -56,6 +56,7 @@ private:
 	OBSSignal activateSignal;
 	OBSSignal deactivateSignal;
 	OBSSignal balChangedSignal;
+	OBSSignal renameSignal;
 
 	static void OBSSourceActivated(void *param, calldata_t *calldata);
 	static void OBSSourceDeactivated(void *param, calldata_t *calldata);
@@ -66,6 +67,7 @@ private:
 						   calldata_t *calldata);
 	static void OBSSourceMixersChanged(void *param, calldata_t *calldata);
 	static void OBSSourceBalanceChanged(void *param, calldata_t *calldata);
+	static void OBSSourceRenamed(void *param, calldata_t *calldata);
 
 public:
 	OBSAdvAudioCtrl(QGridLayout *layout, obs_source_t *source_);
@@ -85,6 +87,7 @@ public slots:
 	void SourceMonitoringTypeChanged(int type);
 	void SourceMixersChanged(uint32_t mixers);
 	void SourceBalanceChanged(int balance);
+	void SetSourceName(const QString &newNamw);
 
 	void volumeChanged(double db);
 	void percentChanged(int percent);


### PR DESCRIPTION
### Description
The names wouldn't be updated in the advanced audio dialog
when the source is renamed.

### Motivation and Context
Noticed named weren't being updated.

### How Has This Been Tested?
Renamed source and made sure the name was updated in the dialog.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
