### PR TITLE
libobs: Lock scene to video color space

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1505,21 +1505,14 @@ scene_video_get_color_space(void *data, size_t count,
 {
 	UNUSED_PARAMETER(data);
 
-	enum gs_color_space canvas_space = GS_CS_SRGB;
+	enum gs_color_space space = GS_CS_SRGB;
 	struct obs_video_info ovi;
 	if (obs_get_video_info(&ovi)) {
 		switch (ovi.colorspace) {
 		case VIDEO_CS_2100_PQ:
 		case VIDEO_CS_2100_HLG:
-			canvas_space = GS_CS_709_EXTENDED;
+			space = GS_CS_709_EXTENDED;
 		}
-	}
-
-	enum gs_color_space space = canvas_space;
-	for (size_t i = 0; i < count; ++i) {
-		space = preferred_spaces[i];
-		if (space == canvas_space)
-			break;
 	}
 
 	return space;


### PR DESCRIPTION
### Description
Fixes studio mode preview on SDR monitor for HDR canvas rendering SDR
source into SDR swap chain. Needs to render SDR source into HDR render
target, and then tonemap into SDR swap chain for preview.

### Motivation and Context
Want Studio Mode preview and program views to match colors.

### How Has This Been Tested?
Checked SDR on SDR, SDR on HDR, HDR on SDR, and HDR on HDR for both sides of studio mode.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.