### PR TITLE
libobs: Cap HLG video at 1000 nits

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2258,17 +2258,18 @@ static bool update_async_texrender(struct obs_source *source,
 		set_eparam(conv, "height_d2", (float)cy * 0.5f);
 		set_eparam(conv, "width_x2_i", 0.5f / (float)cx);
 
-		const float hdr_nominal_peak_level =
-			obs->video.hdr_nominal_peak_level;
+		/* BT.2408 says higher than 1000 isn't comfortable */
+		float hlg_peak_level = obs->video.hdr_nominal_peak_level;
+		if (hlg_peak_level > 1000.f)
+			hlg_peak_level = 1000.f;
+
 		const float maximum_nits = (frame->trc == VIDEO_TRC_HLG)
-						   ? hdr_nominal_peak_level
+						   ? hlg_peak_level
 						   : 10000.f;
 		set_eparam(conv, "maximum_over_sdr_white_nits",
 			   maximum_nits / obs_get_video_sdr_white_level());
-		const float hlg_gamma =
-			1.2f +
-			(0.42f * log10f(hdr_nominal_peak_level / 1000.f));
-		const float hlg_exponent = hlg_gamma - 1.f;
+		const float hlg_exponent =
+			0.2f + (0.42f * log10f(hlg_peak_level / 1000.f));
 		set_eparam(conv, "hlg_exponent", hlg_exponent);
 
 		struct vec4 vec0, vec1, vec2;


### PR DESCRIPTION
### Description
Follow BT.2408 recommendation and cap HLG at 1000 nits.

### Motivation and Context
Don't want uncomfortably bright HLG video on bright monitors. Parity with future Chromium implementation.

### How Has This Been Tested?
Check 400/1000/2000 nits on PQ for regressions, and they all look the same.
Check 400/1000/2000 nits on HLG, and 2000 used to be brighter, but is now the same as 1000.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.