### PR TITLE
obs-ffmpeg: Set 1000 nits for HLG metadata

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -163,10 +163,9 @@ static void add_video_encoder_params(struct ffmpeg_muxer *stream,
 						: AVCOL_RANGE_MPEG;
 
 	const int max_luminance =
-		((trc == AVCOL_TRC_SMPTE2084) ||
-		 (trc == AVCOL_TRC_ARIB_STD_B67))
+		(trc == AVCOL_TRC_SMPTE2084)
 			? (int)obs_get_video_hdr_nominal_peak_level()
-			: 0;
+			: ((trc == AVCOL_TRC_ARIB_STD_B67) ? 1000 : 0);
 
 	dstr_catf(cmd, "%s %d %d %d %d %d %d %d %d %d %d ",
 		  obs_encoder_get_codec(vencoder), bitrate,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -223,10 +223,13 @@ static bool create_video_stream(struct ffmpeg_data *data)
 			data->config.video_encoder))
 		return false;
 
-	if ((data->config.color_trc == AVCOL_TRC_SMPTE2084) ||
-	    (data->config.color_trc == AVCOL_TRC_ARIB_STD_B67)) {
+	const enum AVColorTransferCharacteristic trc = data->config.color_trc;
+	const bool pq = trc == AVCOL_TRC_SMPTE2084;
+	const bool hlg = trc == AVCOL_TRC_ARIB_STD_B67;
+	if (pq || hlg) {
 		const int hdr_nominal_peak_level =
-			(int)obs_get_video_hdr_nominal_peak_level();
+			pq ? (int)obs_get_video_hdr_nominal_peak_level()
+			   : (hlg ? 1000 : 0);
 
 		size_t content_size;
 		AVContentLightMetadata *const content =


### PR DESCRIPTION
### Description
OBS always renders HLG for 1000 nits, so reflect that in the metadata even though metadata technically isn't supposed to be needed for HLG.

### Motivation and Context
Hopefully better metadata leads to more accurate playback.

### How Has This Been Tested?
For obs-ffmpeg-mux.c, checked output videos for PQ 400/1000/2000, and HLG 400/1000/2000, and got back 400/1000/2000, and 1000/1000/1000.

For obs-ffmpeg-output.c, just checked values were correct in debugger.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation