### PR TITLE
obs-ffmpeg: Fix build with latest ffmpeg

### DIFF
--- a/libobs/media-io/media-remux.c
+++ b/libobs/media-io/media-remux.c
@@ -16,6 +16,7 @@
 ******************************************************************************/
 
 #include "media-remux.h"
+#include "../obs-ffmpeg-compat.h"
 
 #include "../util/base.h"
 #include "../util/bmem.h"


### PR DESCRIPTION
### Description

The build was failing with the following, e.g.:

```
.../obs-studio/libobs/media-io/media-remux.c: In function ‘init_output’:
.../obs-studio/libobs/media-io/media-remux.c:91:49: error: ‘AVStream’ has no member named ‘codec’
   91 |                         job->ofmt_ctx, in_stream->codec->codec);
      |                                                 ^~
```

Adding this compat header seems to fix for me. Not sure if it's the
right solution though.

ffmpeg version info:

```
ffmpeg version N-106925-gb90341d1d5 Copyright (c) 2000-2022 the FFmpeg developers
built with gcc 11 (Debian 11.3.0-1)
configuration: --enable-libass --enable-libcaca --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libmp3lame --enable-libopus --enable-libpulse --enable-libspeex --enable-libv4l2 --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-gpl --enable-libaom --enable-gnutls --enable-pic --enable-shared --enable-libcdio
libavutil      57. 24.101 / 57. 24.101
libavcodec     59. 28.100 / 59. 28.100
libavformat    59. 24.100 / 59. 24.100
libavdevice    59.  6.100 / 59.  6.100
libavfilter     8. 38.100 /  8. 38.100
libswscale      6.  6.100 /  6.  6.100
libswresample   4.  6.100 /  4.  6.100
libpostproc    56.  5.100 / 56.  5.100
```

### Motivation and Context
Build fix

### How Has This Been Tested?
Successful build on Debian testing with latest ffmpeg

### Types of changes
Build fix

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
