### PR TITLE
UI: close display before native surfaces

### DIFF
--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -42,6 +42,9 @@ protected:
 			else
 				mTimerId = startTimer(67); // Arbitrary
 			break;
+		case QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed:
+			display->DestroyDisplay();
+			break;
 		case QEvent::Expose:
 			createOBSDisplay();
 			break;
@@ -52,7 +55,10 @@ protected:
 		return result;
 	}
 
-	void timerEvent(QTimerEvent *) { createOBSDisplay(true); }
+	void timerEvent(QTimerEvent *)
+	{
+		createOBSDisplay(display->isVisible());
+	}
 
 private:
 	void createOBSDisplay(bool force = false)

--- a/UI/qt-display.hpp
+++ b/UI/qt-display.hpp
@@ -43,6 +43,7 @@ public:
 	void SetDisplayBackgroundColor(const QColor &color);
 	void UpdateDisplayBackgroundColor();
 	void CreateDisplay(bool force = false);
+	void DestroyDisplay() { display = nullptr; };
 
 	void OnMove();
 	void OnDisplayChange();

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4707,6 +4707,10 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 
 	delete extraBrowsers;
 
+	ui->preview->DestroyDisplay();
+	if (program)
+		program->DestroyDisplay();
+
 	config_set_string(App()->GlobalConfig(), "BasicWindow", "DockState",
 			  saveState().toBase64().constData());
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This hooks the platform specific events in order to close the obs
display more accurately. Earlier attempts on hooking visiblity in Qt
, but Qt does not ensure that visibility is changed before the surface is
destroyed. So we ended up racing with the egl driver, and on some
drivers if you lose the race they hang.

Also force closure of the main preview window earlier to avoid similar
ordering issues in qt.

Finally only force display creation if the display is actually visible.
When a source type is not video/drawable (or is missing) this would
force the display to be created for the blank window and also hang.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
People prefer if obs doesnt hang on their favorite proprietary drivers. Mostly resolves #6466 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Repeatedly opening and closing source and filter properties worked. Opening xcomposite source properties on wayland also didn't hang the render thread.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
