### PR TITLE
deps/media-playback: Fix video looping

### DIFF
--- a/deps/media-playback/media-playback/decode.h
+++ b/deps/media-playback/media-playback/decode.h
@@ -68,7 +68,9 @@ struct mp_decode {
 	bool eof;
 	bool hw;
 
+	AVPacket *orig_pkt;
 	AVPacket *pkt;
+	bool packet_pending;
 	struct circlebuf packets;
 };
 


### PR DESCRIPTION
### Description
Previous FFmpeg deprecation fix, and optimization attempt causes short
videos to loop badly. Keep deprecation fix, and fix the rest later.

### Motivation and Context
Want video loop to look nice.

### How Has This Been Tested?
Video loop looks nice again.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.