### PR TITLE
UI: Truncate names in advanced audio dialog

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -366,8 +366,7 @@ void OBSAdvAudioCtrl::OBSSourceRenamed(void *param, calldata_t *calldata)
 	QString newName = QT_UTF8(calldata_string(calldata, "new_name"));
 
 	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param),
-				  "SetSourceName",
-				  Q_ARG(const QString &, newName));
+				  "SetSourceName", Q_ARG(QString &, newName));
 }
 
 /* ------------------------------------------------------------------------- */
@@ -700,8 +699,7 @@ void OBSAdvAudioCtrl::SetIconVisible(bool visible)
 	visible ? iconLabel->show() : iconLabel->hide();
 }
 
-void OBSAdvAudioCtrl::SetSourceName(const QString &newName)
+void OBSAdvAudioCtrl::SetSourceName(QString &newName)
 {
-	if (nameLabel->text() != newName)
-		nameLabel->setText(newName);
+	TruncateLabel(nameLabel, newName);
 }

--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -87,7 +87,7 @@ public slots:
 	void SourceMonitoringTypeChanged(int type);
 	void SourceMixersChanged(uint32_t mixers);
 	void SourceBalanceChanged(int balance);
-	void SetSourceName(const QString &newNamw);
+	void SetSourceName(QString &newNamw);
 
 	void volumeChanged(double db);
 	void percentChanged(int percent);

--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -28,6 +28,7 @@
 #include <QKeyEvent>
 #include <QFileDialog>
 #include <QStandardItemModel>
+#include <QLabel>
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 #include <obs-nix-platform.h>
@@ -377,4 +378,25 @@ QStringList OpenFiles(QWidget *parent, QString title, QString path,
 		QFileDialog::getOpenFileNames(parent, title, path, extensions);
 
 	return files;
+}
+
+static void SetLabelText(QLabel *label, const QString &newText)
+{
+	if (label->text() != newText)
+		label->setText(newText);
+}
+
+void TruncateLabel(QLabel *label, QString &newText, int length)
+{
+	if (newText.length() < length) {
+		label->setToolTip(QString());
+		SetLabelText(label, newText);
+		return;
+	}
+
+	label->setToolTip(newText);
+	newText.truncate(length);
+	newText += "...";
+
+	SetLabelText(label, newText);
 }

--- a/UI/qt-wrappers.hpp
+++ b/UI/qt-wrappers.hpp
@@ -30,6 +30,7 @@
 
 #define QT_UTF8(str) QString::fromUtf8(str, -1)
 #define QT_TO_UTF8(str) str.toUtf8().constData()
+#define MAX_LABEL_LENGTH 80
 
 class QDataStream;
 class QComboBox;
@@ -37,6 +38,7 @@ class QWidget;
 class QLayout;
 class QString;
 struct gs_window;
+class QLabel;
 
 class OBSMessageBox {
 public:
@@ -117,3 +119,6 @@ QString OpenFile(QWidget *parent, QString title, QString path,
 		 QString extensions);
 QStringList OpenFiles(QWidget *parent, QString title, QString path,
 		      QString extensions);
+
+void TruncateLabel(QLabel *label, QString &newText,
+		   int length = MAX_LABEL_LENGTH);


### PR DESCRIPTION
### Description
This limits the length of the name label in the advanced audio
dialog to 80 characters, so the dialog doesn't get too wide. If the
name is truncated, "..." are added at the end of the label, and the
label's tooltip is set to the full name of the source.

### Motivation and Context
Prevents really long source names from making the dialog look bad.

### How Has This Been Tested?
Made sure long names were truncated in the dialog.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
