### PR TITLE
decklink: Support different frame rate on decklink output

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4436,7 +4436,7 @@ bool OBSBasic::ResetAudio()
 {
 	ProfileScope("OBSBasic::ResetAudio");
 
-	struct obs_audio_info ai;
+	struct obs_audio_info2 ai;
 	ai.samples_per_sec =
 		config_get_uint(basicConfig, "Audio", "SampleRate");
 
@@ -4458,7 +4458,10 @@ bool OBSBasic::ResetAudio()
 	else
 		ai.speakers = SPEAKERS_STEREO;
 
-	return obs_reset_audio(&ai);
+	ai.fixed_buffering = true;
+	ai.max_buffering_ms = 1;
+
+	return obs_reset_audio2(&ai);
 }
 
 extern char *get_new_source_name(const char *name, const char *format);

--- a/plugins/decklink/DecklinkOutput.hpp
+++ b/plugins/decklink/DecklinkOutput.hpp
@@ -16,7 +16,6 @@ protected:
 public:
 	const char *deviceHash;
 	long long modeID;
-	uint64_t start_timestamp;
 	uint32_t audio_samplerate;
 	size_t audio_planes;
 	size_t audio_size;

--- a/plugins/decklink/decklink-device-instance.hpp
+++ b/plugins/decklink/decklink-device-instance.hpp
@@ -3,6 +3,8 @@
 #define LOG(level, message, ...) \
 	blog(level, "%s: " message, "decklink", ##__VA_ARGS__)
 
+#include <atomic>
+
 #include <obs-module.h>
 #include <media-io/video-scaler.h>
 #include "decklink-device.hpp"
@@ -11,8 +13,7 @@
 class AudioRepacker;
 class DecklinkBase;
 
-class DeckLinkDeviceInstance : public IDeckLinkVideoOutputCallback,
-			       public IDeckLinkInputCallback {
+class DeckLinkDeviceInstance : public IDeckLinkVideoOutputCallback, public IDeckLinkInputCallback {
 protected:
 	struct obs_source_frame2 currentFrame;
 	struct obs_source_audio currentPacket;
@@ -37,10 +38,14 @@ protected:
 	speaker_layout channelFormat = SPEAKERS_STEREO;
 	bool swap;
 	bool allow10Bit;
-	BMDTimeValue outputFrameDuration = 0;
-	BMDTimeScale outputTimeScale = 0;
-	int64_t outputInitialScheduleOffset = 1000000000;
-	int64_t outputDriftOffset = 0;
+
+	uint64_t frameLength = 0;
+	std::atomic<uint64_t> hardwareStartTime = 0;
+	std::atomic<uint64_t> systemStartTime = 0;
+	std::atomic<uint64_t> bufferSize = 100000000;
+	std::atomic<int64_t> timestampOffset = 0;
+
+	uint32_t maxSamples = 0;
 
 	OBSVideoFrame *convertFrame = nullptr;
 	ComPtr<IDeckLinkMutableVideoFrame> decklinkOutputFrame;
@@ -57,10 +62,8 @@ public:
 	DeckLinkDeviceInstance(DecklinkBase *decklink, DeckLinkDevice *device);
 	virtual ~DeckLinkDeviceInstance();
 
-	virtual HRESULT STDMETHODCALLTYPE
-	ScheduledFrameCompleted(IDeckLinkVideoFrame *completedFrame,
-				BMDOutputFrameCompletionResult result);
-	virtual HRESULT STDMETHODCALLTYPE ScheduledPlaybackHasStopped();
+	virtual HRESULT STDMETHODCALLTYPE	ScheduledFrameCompleted (IDeckLinkVideoFrame* completedFrame, BMDOutputFrameCompletionResult result);
+	virtual HRESULT STDMETHODCALLTYPE	ScheduledPlaybackHasStopped ();
 
 	inline DeckLinkDevice *GetDevice() const { return device; }
 	inline long long GetActiveModeId() const

--- a/plugins/decklink/decklink-device-instance.hpp
+++ b/plugins/decklink/decklink-device-instance.hpp
@@ -11,7 +11,8 @@
 class AudioRepacker;
 class DecklinkBase;
 
-class DeckLinkDeviceInstance : public IDeckLinkInputCallback {
+class DeckLinkDeviceInstance : public IDeckLinkVideoOutputCallback,
+			       public IDeckLinkInputCallback {
 protected:
 	struct obs_source_frame2 currentFrame;
 	struct obs_source_audio currentPacket;
@@ -36,6 +37,10 @@ protected:
 	speaker_layout channelFormat = SPEAKERS_STEREO;
 	bool swap;
 	bool allow10Bit;
+	BMDTimeValue outputFrameDuration = 0;
+	BMDTimeScale outputTimeScale = 0;
+	int64_t outputInitialScheduleOffset = 1000000000;
+	int64_t outputDriftOffset = 0;
 
 	OBSVideoFrame *convertFrame = nullptr;
 	ComPtr<IDeckLinkMutableVideoFrame> decklinkOutputFrame;
@@ -51,6 +56,11 @@ protected:
 public:
 	DeckLinkDeviceInstance(DecklinkBase *decklink, DeckLinkDevice *device);
 	virtual ~DeckLinkDeviceInstance();
+
+	virtual HRESULT STDMETHODCALLTYPE
+	ScheduledFrameCompleted(IDeckLinkVideoFrame *completedFrame,
+				BMDOutputFrameCompletionResult result);
+	virtual HRESULT STDMETHODCALLTYPE ScheduledPlaybackHasStopped();
 
 	inline DeckLinkDevice *GetDevice() const { return device; }
 	inline long long GetActiveModeId() const

--- a/plugins/decklink/decklink-device-instance.hpp
+++ b/plugins/decklink/decklink-device-instance.hpp
@@ -49,9 +49,11 @@ protected:
 
 	// Output
 	bool playbackStarted = false;
+	uint32_t frameDuplication = 1;
 	uint64_t frameLength = 0;
 	uint64_t hardwareStartTime = 0;
 	uint64_t systemStartTime = 0;
+	uint64_t nextVideoTime = 0;
 
 	RollingAverage driftAverage;
 	int64_t clockAdjustment = 0;

--- a/plugins/decklink/decklink-device-mode.cpp
+++ b/plugins/decklink/decklink-device-mode.cpp
@@ -68,20 +68,6 @@ const std::string &DeckLinkDeviceMode::GetName(void) const
 	return name;
 }
 
-bool DeckLinkDeviceMode::IsEqualFrameRate(int64_t num, int64_t den)
-{
-	bool equal = false;
-
-	if (mode) {
-		BMDTimeValue frameDuration;
-		BMDTimeScale timeScale;
-		if (SUCCEEDED(mode->GetFrameRate(&frameDuration, &timeScale)))
-			equal = timeScale * den == frameDuration * num;
-	}
-
-	return equal;
-}
-
 void DeckLinkDeviceMode::SetMode(IDeckLinkDisplayMode *mode_)
 {
 	mode = mode_;

--- a/plugins/decklink/decklink-device-mode.cpp
+++ b/plugins/decklink/decklink-device-mode.cpp
@@ -28,6 +28,12 @@ BMDDisplayMode DeckLinkDeviceMode::GetDisplayMode(void) const
 	return bmdModeUnknown;
 }
 
+void DeckLinkDeviceMode::GetFrameRate(/* out */ BMDTimeValue *frameDuration,
+				      /* out */ BMDTimeScale *timeScale)
+{
+	mode->GetFrameRate(frameDuration, timeScale);
+}
+
 int DeckLinkDeviceMode::GetWidth()
 {
 	if (mode != nullptr)

--- a/plugins/decklink/decklink-device-mode.hpp
+++ b/plugins/decklink/decklink-device-mode.hpp
@@ -21,7 +21,6 @@ public:
 	BMDDisplayModeFlags GetDisplayModeFlags(void) const;
 	long long GetId(void) const;
 	const std::string &GetName(void) const;
-	bool IsEqualFrameRate(int64_t num, int64_t den);
 
 	void SetMode(IDeckLinkDisplayMode *mode);
 

--- a/plugins/decklink/decklink-device-mode.hpp
+++ b/plugins/decklink/decklink-device-mode.hpp
@@ -27,4 +27,6 @@ public:
 
 	int GetWidth();
 	int GetHeight();
+
+	void GetFrameRate(BMDTimeValue *frameDuration, BMDTimeScale *timeScale);
 };

--- a/plugins/decklink/decklink-device.cpp
+++ b/plugins/decklink/decklink-device.cpp
@@ -110,6 +110,10 @@ bool DeckLinkDevice::Init()
 	attributes->GetFlag(BMDDeckLinkSupportsInternalKeying,
 			    &supportsInternalKeyer);
 
+	// get clock adjustment support
+	attributes->GetFlag(BMDDeckLinkSupportsClockTimingAdjustment,
+				&supportsClockAdjustment);
+
 	// Sub Device Counts
 	attributes->GetInt(BMDDeckLinkSubDeviceIndex, &subDeviceIndex);
 	attributes->GetInt(BMDDeckLinkNumberOfSubDevices, &numSubDevices);
@@ -243,6 +247,11 @@ bool DeckLinkDevice::GetSupportsExternalKeyer(void) const
 bool DeckLinkDevice::GetSupportsInternalKeyer(void) const
 {
 	return supportsInternalKeyer;
+}
+
+bool DeckLinkDevice::GetSupportsClockAdjustment(void) const
+{
+	return supportsClockAdjustment;
 }
 
 int64_t DeckLinkDevice::GetSubDeviceCount()

--- a/plugins/decklink/decklink-device.cpp
+++ b/plugins/decklink/decklink-device.cpp
@@ -114,6 +114,10 @@ bool DeckLinkDevice::Init()
 	attributes->GetFlag(BMDDeckLinkSupportsClockTimingAdjustment,
 				&supportsClockAdjustment);
 
+	// get minimum preroll frames
+	attributes->GetInt(BMDDeckLinkMinimumPrerollFrames,
+				&minimumPrerollFrames);
+
 	// Sub Device Counts
 	attributes->GetInt(BMDDeckLinkSubDeviceIndex, &subDeviceIndex);
 	attributes->GetInt(BMDDeckLinkNumberOfSubDevices, &numSubDevices);
@@ -252,6 +256,11 @@ bool DeckLinkDevice::GetSupportsInternalKeyer(void) const
 bool DeckLinkDevice::GetSupportsClockAdjustment(void) const
 {
 	return supportsClockAdjustment;
+}
+
+int64_t DeckLinkDevice::GetMinimumPrerollFrames(void) const
+{
+	return minimumPrerollFrames;
 }
 
 int64_t DeckLinkDevice::GetSubDeviceCount()

--- a/plugins/decklink/decklink-device.hpp
+++ b/plugins/decklink/decklink-device.hpp
@@ -19,6 +19,7 @@ class DeckLinkDevice {
 	int32_t maxChannel = 0;
 	decklink_bool_t supportsExternalKeyer = false;
 	decklink_bool_t supportsInternalKeyer = false;
+	decklink_bool_t supportsClockAdjustment = false;
 	int64_t subDeviceIndex = 0;
 	int64_t numSubDevices = 0;
 	int64_t supportedVideoInputConnections = -1;
@@ -47,6 +48,7 @@ public:
 	int64_t GetAudioInputConnections();
 	bool GetSupportsExternalKeyer(void) const;
 	bool GetSupportsInternalKeyer(void) const;
+	bool GetSupportsClockAdjustment(void) const;
 	int64_t GetSubDeviceCount();
 	int64_t GetSubDeviceIndex();
 	int GetKeyerMode(void);

--- a/plugins/decklink/decklink-device.hpp
+++ b/plugins/decklink/decklink-device.hpp
@@ -20,6 +20,7 @@ class DeckLinkDevice {
 	decklink_bool_t supportsExternalKeyer = false;
 	decklink_bool_t supportsInternalKeyer = false;
 	decklink_bool_t supportsClockAdjustment = false;
+	int64_t minimumPrerollFrames = 0;
 	int64_t subDeviceIndex = 0;
 	int64_t numSubDevices = 0;
 	int64_t supportedVideoInputConnections = -1;
@@ -49,6 +50,7 @@ public:
 	bool GetSupportsExternalKeyer(void) const;
 	bool GetSupportsInternalKeyer(void) const;
 	bool GetSupportsClockAdjustment(void) const;
+	int64_t GetMinimumPrerollFrames(void) const;
 	int64_t GetSubDeviceCount();
 	int64_t GetSubDeviceIndex();
 	int GetKeyerMode(void);

--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -55,8 +55,6 @@ static bool decklink_output_start(void *data)
 	decklink->audio_size =
 		get_audio_size(AUDIO_FORMAT_16BIT, aoi.speakers, 1);
 
-	decklink->start_timestamp = 0;
-
 	ComPtr<DeckLinkDevice> device;
 
 	device.Set(deviceEnum->FindByHash(decklink->deviceHash));
@@ -123,15 +121,13 @@ static void decklink_output_raw_video(void *data, struct video_data *frame)
 {
 	auto *decklink = (DeckLinkOutput *)data;
 
-	if (!decklink->start_timestamp)
-		decklink->start_timestamp = frame->timestamp;
-
 	decklink->DisplayVideoFrame(frame);
 }
 
 static void decklink_output_raw_audio(void *data, struct audio_data *frames)
 {
 	auto *decklink = (DeckLinkOutput *)data;
+
 	decklink->WriteAudio(frames);
 }
 

--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -64,18 +64,6 @@ static bool decklink_output_start(void *data)
 
 	DeckLinkDeviceMode *mode = device->FindOutputMode(decklink->modeID);
 
-	struct obs_video_info ovi;
-	if (!obs_get_video_info(&ovi)) {
-		LOG(LOG_ERROR,
-		    "Start failed: could not retrieve obs_video_info!");
-		return false;
-	}
-
-	if (!mode->IsEqualFrameRate(ovi.fps_num, ovi.fps_den)) {
-		LOG(LOG_ERROR, "Start failed: FPS mismatch!");
-		return false;
-	}
-
 	decklink->SetSize(mode->GetWidth(), mode->GetHeight());
 
 	struct video_scale_info to = {};
@@ -173,17 +161,11 @@ static bool decklink_output_device_changed(obs_properties_t *props,
 		const std::vector<DeckLinkDeviceMode *> &modes =
 			device->GetOutputModes();
 
-		struct obs_video_info ovi;
-		if (obs_get_video_info(&ovi)) {
-			for (DeckLinkDeviceMode *mode : modes) {
-				if (mode->IsEqualFrameRate(ovi.fps_num,
-							   ovi.fps_den)) {
-					obs_property_list_add_int(
-						modeList,
-						mode->GetName().c_str(),
-						mode->GetId());
-				}
-			}
+		for (DeckLinkDeviceMode *mode : modes) {
+			obs_property_list_add_int(
+				modeList,
+				mode->GetName().c_str(),
+				mode->GetId());
 		}
 
 		obs_property_list_add_int(keyerList, "Disabled", 0);

--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -129,49 +129,10 @@ static void decklink_output_raw_video(void *data, struct video_data *frame)
 	decklink->DisplayVideoFrame(frame);
 }
 
-static bool prepare_audio(DeckLinkOutput *decklink,
-			  const struct audio_data *frame,
-			  struct audio_data *output)
-{
-	*output = *frame;
-
-	if (frame->timestamp < decklink->start_timestamp) {
-		uint64_t duration = util_mul_div64(frame->frames, 1000000000ULL,
-						   decklink->audio_samplerate);
-		uint64_t end_ts = frame->timestamp + duration;
-		uint64_t cutoff;
-
-		if (end_ts <= decklink->start_timestamp)
-			return false;
-
-		cutoff = decklink->start_timestamp - frame->timestamp;
-		output->timestamp += cutoff;
-
-		cutoff = util_mul_div64(cutoff, decklink->audio_samplerate,
-					1000000000ULL);
-
-		for (size_t i = 0; i < decklink->audio_planes; i++)
-			output->data[i] +=
-				decklink->audio_size * (uint32_t)cutoff;
-
-		output->frames -= (uint32_t)cutoff;
-	}
-
-	return true;
-}
-
 static void decklink_output_raw_audio(void *data, struct audio_data *frames)
 {
 	auto *decklink = (DeckLinkOutput *)data;
-	struct audio_data in;
-
-	if (!decklink->start_timestamp)
-		return;
-
-	if (!prepare_audio(decklink, frames, &in))
-		return;
-
-	decklink->WriteAudio(&in);
+	decklink->WriteAudio(frames);
 }
 
 static bool decklink_output_device_changed(obs_properties_t *props,

--- a/plugins/decklink/util.cpp
+++ b/plugins/decklink/util.cpp
@@ -41,3 +41,39 @@ const char *bmd_audio_connection_to_name(BMDAudioConnection connection)
 		return "Unknown";
 	}
 }
+
+RollingAverage::RollingAverage(size_t capacity) :
+	capacity(capacity),
+	size(0),
+	sum(0)
+{
+	samples = {0};
+
+	//circlebuf_reserve(&samples, sizeof(int64_t) * capacity);
+}
+
+RollingAverage::~RollingAverage()
+{
+	circlebuf_free(&samples);
+}
+
+void RollingAverage::SubmitSample(int64_t sample)
+{
+	if (size == capacity) {
+		int64_t out = 0;
+		circlebuf_pop_front(&samples, &out, sizeof(out));
+
+		size--;
+		sum -= out;
+	}
+
+	circlebuf_push_back(&samples, &sample, sizeof(sample));
+
+	size++;
+	sum += sample;
+}
+
+int64_t RollingAverage::GetAverage()
+{
+	return size ? (sum / (int64_t)size) : 0;
+}

--- a/plugins/decklink/util.hpp
+++ b/plugins/decklink/util.hpp
@@ -1,7 +1,36 @@
 #pragma once
 
+#include <util/circlebuf.h>
+
 #include "decklink-device.hpp"
 
 const char *bmd_video_connection_to_name(BMDVideoConnection connection);
 
 const char *bmd_audio_connection_to_name(BMDAudioConnection connection);
+
+class RollingAverage {
+	public:
+		RollingAverage(size_t capacity = 2048);
+		~RollingAverage();
+
+		void SubmitSample(int64_t sample);
+		int64_t GetAverage();
+
+		inline size_t GetCapacity()
+		{
+			return capacity;
+		}
+
+		inline size_t GetSize()
+		{
+			return size;
+		}
+
+	private:
+		size_t capacity;
+		size_t size;
+
+		int64_t sum;
+
+		struct circlebuf samples;
+};


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Support different video frame rates on Decklink output.

- When the frame rate of decklink output is larger than that of OBS, frames will be duplicated to output enough frames.
- When the frame rate of decklink output is smaller than that of OBS, frames will be decimated.

This PR is based on the other PR #1865. The PR #1865 should be merged earlier than this PR.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I want to set different frame rate on decklink output than OBS's frame rate.

On Intensity Pro 4K, it is required to set `525i59.94` for analog composite output but different sampling rate is required for streaming.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

- Set 720p50 on decklink output, set OBS's frame rate to 30 fps, confirmed there is no `Late Frame` log message.
- Set 1080p24 on decklink output, set OBS's frame rate to 30 fps, confirmed the number of `buffered video frames` does not increase.
- Set 1080p30 on decklink output, set OBS's frame rate to 30 fps, confirmed one frame is output for every OBS's frame.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
