### PR TITLE
libobs: Ignore lower six bits for P010 sources

### DIFF
--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -651,7 +651,9 @@ float4 PSP010_SRGB_Reverse(VertTexPos frag_in) : TARGET
 {
 	float y = image.Load(int3(frag_in.pos.xy, 0)).x;
 	float2 cbcr = image1.Load(int3(frag_in.uv, 0)).xy;
-	float3 yuv = float3(y, cbcr);
+	float3 yuv_65535 = floor(float3(y, cbcr) * 65535. + 0.5);
+	float3 yuv_1023 = floor(yuv_65535 * 0.015625);
+	float3 yuv = yuv_1023 / 1023.;
 	float3 rgb = YUV_to_RGB(yuv);
 	rgb = srgb_nonlinear_to_linear(rgb);
 	return float4(rgb, 1.);
@@ -661,7 +663,9 @@ float4 PSP010_PQ_2020_709_Reverse(VertTexPos frag_in) : TARGET
 {
 	float y = image.Load(int3(frag_in.pos.xy, 0)).x;
 	float2 cbcr = image1.Load(int3(frag_in.uv, 0)).xy;
-	float3 yuv = float3(y, cbcr);
+	float3 yuv_65535 = floor(float3(y, cbcr) * 65535. + 0.5);
+	float3 yuv_1023 = floor(yuv_65535 * 0.015625);
+	float3 yuv = yuv_1023 / 1023.;
 	float3 pq = YUV_to_RGB(yuv);
 	float3 hdr2020 = st2084_to_linear(pq) * maximum_over_sdr_white_nits;
 	float3 rgb = rec2020_to_rec709(hdr2020);
@@ -672,7 +676,9 @@ float4 PSP010_HLG_2020_709_Reverse(VertTexPos frag_in) : TARGET
 {
 	float y = image.Load(int3(frag_in.pos.xy, 0)).x;
 	float2 cbcr = image1.Load(int3(frag_in.uv, 0)).xy;
-	float3 yuv = float3(y, cbcr);
+	float3 yuv_65535 = floor(float3(y, cbcr) * 65535. + 0.5);
+	float3 yuv_1023 = floor(yuv_65535 * 0.015625);
+	float3 yuv = yuv_1023 / 1023.;
 	float3 hlg = YUV_to_RGB(yuv);
 	float3 hdr2020 = hlg_to_linear(hlg, hlg_exponent) * maximum_over_sdr_white_nits;
 	float3 rgb = rec2020_to_rec709(hdr2020);


### PR DESCRIPTION
### Description
Need to truncate 16 bits to 10 bits for accuracy.

### Motivation and Context
Want accurate colors.

### How Has This Been Tested?
Inspected shader math in RenderDoc debugger for all three pixel shaders.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.