### PR TITLE
libobs: Default 10-bit video to sRGB instead of PQ

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -912,8 +912,15 @@ static inline enum gs_color_space convert_video_space(enum video_format format,
 {
 	enum gs_color_space space = GS_CS_SRGB;
 	if (convert_video_format(format, trc) == GS_RGBA16F) {
-		space = (trc == VIDEO_TRC_SRGB) ? GS_CS_SRGB_16F
-						: GS_CS_709_EXTENDED;
+		switch (trc) {
+		case VIDEO_TRC_DEFAULT:
+		case VIDEO_TRC_SRGB:
+			space = GS_CS_SRGB_16F;
+			break;
+		case VIDEO_TRC_PQ:
+		case VIDEO_TRC_HLG:
+			space = GS_CS_709_EXTENDED;
+		}
 	}
 
 	return space;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1560,12 +1560,8 @@ enum convert_type {
 	CONVERT_800,
 	CONVERT_RGB_LIMITED,
 	CONVERT_BGR3,
-	CONVERT_I010_SRGB,
-	CONVERT_I010_PQ_2020_709,
-	CONVERT_I010_HLG_2020_709,
-	CONVERT_P010_SRGB,
-	CONVERT_P010_PQ_2020_709,
-	CONVERT_P010_HLG_2020_709,
+	CONVERT_I010,
+	CONVERT_P010,
 };
 
 static inline enum convert_type get_convert_type(enum video_format format,
@@ -1617,27 +1613,11 @@ static inline enum convert_type get_convert_type(enum video_format format,
 	case VIDEO_FORMAT_AYUV:
 		return CONVERT_444_A_PACK;
 
-	case VIDEO_FORMAT_I010: {
-		switch (trc) {
-		case VIDEO_TRC_SRGB:
-			return CONVERT_I010_SRGB;
-		case VIDEO_TRC_HLG:
-			return CONVERT_I010_HLG_2020_709;
-		default:
-			return CONVERT_I010_PQ_2020_709;
-		}
-	}
+	case VIDEO_FORMAT_I010:
+		return CONVERT_I010;
 
-	case VIDEO_FORMAT_P010: {
-		switch (trc) {
-		case VIDEO_TRC_SRGB:
-			return CONVERT_P010_SRGB;
-		case VIDEO_TRC_HLG:
-			return CONVERT_P010_HLG_2020_709;
-		default:
-			return CONVERT_P010_PQ_2020_709;
-		}
-	}
+	case VIDEO_FORMAT_P010:
+		return CONVERT_P010;
 	}
 
 	return CONVERT_NONE;
@@ -1979,14 +1959,10 @@ static inline bool init_gpu_conversion(struct obs_source *source,
 	case CONVERT_444_A_PACK:
 		return set_packed444_alpha_sizes(source, frame);
 
-	case CONVERT_I010_SRGB:
-	case CONVERT_I010_PQ_2020_709:
-	case CONVERT_I010_HLG_2020_709:
+	case CONVERT_I010:
 		return set_i010_sizes(source, frame);
 
-	case CONVERT_P010_SRGB:
-	case CONVERT_P010_PQ_2020_709:
-	case CONVERT_P010_HLG_2020_709:
+	case CONVERT_P010:
 		return set_p010_sizes(source, frame);
 
 	case CONVERT_NONE:
@@ -2079,12 +2055,8 @@ static void upload_raw_frame(gs_texture_t *tex[MAX_AV_PLANES],
 	case CONVERT_444_A:
 	case CONVERT_444P12LE_A:
 	case CONVERT_444_A_PACK:
-	case CONVERT_I010_SRGB:
-	case CONVERT_I010_PQ_2020_709:
-	case CONVERT_I010_HLG_2020_709:
-	case CONVERT_P010_SRGB:
-	case CONVERT_P010_PQ_2020_709:
-	case CONVERT_P010_HLG_2020_709:
+	case CONVERT_I010:
+	case CONVERT_P010:
 		for (size_t c = 0; c < MAX_AV_PLANES; c++) {
 			if (tex[c])
 				gs_texture_set_image(tex[c], frame->data[c],
@@ -2153,23 +2125,23 @@ static const char *select_conversion_technique(enum video_format format,
 
 	case VIDEO_FORMAT_I010: {
 		switch (trc) {
-		case VIDEO_TRC_SRGB:
-			return "I010_SRGB_Reverse";
+		case VIDEO_TRC_PQ:
+			return "I010_PQ_2020_709_Reverse";
 		case VIDEO_TRC_HLG:
 			return "I010_HLG_2020_709_Reverse";
 		default:
-			return "I010_PQ_2020_709_Reverse";
+			return "I010_SRGB_Reverse";
 		}
 	}
 
 	case VIDEO_FORMAT_P010: {
 		switch (trc) {
-		case VIDEO_TRC_SRGB:
-			return "P010_SRGB_Reverse";
+		case VIDEO_TRC_PQ:
+			return "P010_PQ_2020_709_Reverse";
 		case VIDEO_TRC_HLG:
 			return "P010_HLG_2020_709_Reverse";
 		default:
-			return "P010_PQ_2020_709_Reverse";
+			return "P010_SRGB_Reverse";
 		}
 	}
 


### PR DESCRIPTION
### Description
Matches how VLC operates. HDR is only in effect with proper metadata.

### Motivation and Context
Want to behave like other popular programs when no default is specified.

### How Has This Been Tested?
Tested 10-bit video file without video metadata now appears like VLC. PQ and HLG videos still render fine.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.