### PR TITLE
Allow updater to delete files specified as removed in manifest

### DIFF
--- a/UI/win-update/updater/hash.cpp
+++ b/UI/win-update/updater/hash.cpp
@@ -59,8 +59,8 @@ bool CalculateFileHash(const wchar_t *path, BYTE *hash)
 
 	for (;;) {
 		DWORD read = 0;
-		if (!ReadFile(handle, &hashBuffer[0], hashBuffer.size(), &read,
-			      nullptr))
+		if (!ReadFile(handle, &hashBuffer[0], (DWORD)hashBuffer.size(),
+			      &read, nullptr))
 			return false;
 
 		if (!read)


### PR DESCRIPTION
### Description

Adds a new `removed_files` array to the manifest which allows to specify files to be deleted.

Originally this was supposed to go further [based on this discussion](https://github.com/obsproject/obs-studio/discussions/3885), but most of that seemed kinda overkill for what we actually need.

I wasn't able to build the updater originally, simply using the zlib package shipped with obs-deps fixed that, but ideally someone should document how it's actually supposed to work.

### Motivation and Context

With the upgrade to Qt6, running the updater would otherwise leave a lot of orphaned `Qt5*.dll` files in the installation directory.

### How Has This Been Tested?

Built updater, ran it with modified manifest that removed the entry for `decklink-ouput.dll` and added the path to `removed_files` like so:
```json
...
  "packages": [
    {
      "removed_files": [
        "obs-plugins/64bit/decklink-ouput-ui.dll"
      ],
      "files": [
...
```
After running the updater the portable OBS install was updated to 27.2, but decklink-**ou**put.dll was gone, yay!

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
