### PR TITLE
decklink-output-ui: Fix crash when stopping preview

### DIFF
--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
@@ -124,7 +124,6 @@ void preview_output_stop()
 {
 	obs_output_stop(context.output);
 	obs_output_release(context.output);
-	video_output_stop(context.video_queue);
 
 	obs_remove_main_render_callback(render_preview_source, &context);
 	obs_frontend_remove_event_callback(on_preview_scene_changed, &context);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removing the first call to `video_output_stop` prevents the `data_mutex` field in `struct video_output` from being destroyed while still in use. The `render_preview_source` function will call `video_output_lock_frame` upon that mutex and encounter a NULL pointer exception.

Co-authored-by: @paulh-aja 

Fixes #5832.

----

This change is from #5891, but for Decklink Output UI. In my experience, the problem results in a hang rather than a crash, but either is bad.

Text from #5891:
Stopping the Preview output in the AJA Output UI can lead to a crash.

**Problem**
The function `preview_output_stop` in `UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp` calls `video_output_stop`, which results in a call to `pthread_mutex_destroy`: https://github.com/obsproject/obs-studio/blob/364f102561faf565ae22e5fa0f1f4aabf3e07c48/UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp#L103

This results in the `data_mutex` field of `struct video_output` from being deleted and made `NULL` while still in use by the `render_preview_source` function in aja-ui-main.cpp.

The call to `video_output_close` a few lines after this also results in a call to `video_output_stop` on the same structure. Allowing this call to perform the `video_output` mutex cleanup seems to be the correct action.

https://github.com/obsproject/obs-studio/blob/364f102561faf565ae22e5fa0f1f4aabf3e07c48/libobs/media-io/video-io.c#L267

**Resolution**
Removing the first call to `video_output_stop` appears to fix the crash and not result in any other harmful effects.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Crashes and hangs are bad.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested by spamming Preview Start/Stop, both manually and by holding down the Enter key on Windows to engage/disengage it as fast as the keyboard repeat rate would allow.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
