### PR TITLE
libobs: Only warn when releasing non-NULL source

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -756,7 +756,7 @@ void obs_source_addref(obs_source_t *source)
 
 void obs_source_release(obs_source_t *source)
 {
-	if (!obs) {
+	if (!obs && source) {
 		blog(LOG_WARNING, "Tried to release a source when the OBS "
 				  "core is shut down!");
 		return;


### PR DESCRIPTION
### Description
Only warn when the pointer provided to obs_source_release() is non-NULL. In some custom usages of libobs, libobs may be freed before OBS* smart pointers (like OBSSource) are destructed, leading to a misleading warning if the pointers have already been cleared with nullptr.

### Motivation and Context
Warnings are being misleading

Previous behavior is basically:
- Clear OBS* pointers with nullptr
- Unload libobs
- Those smart pointers that were cleared will still call obs_source_release() on destruct
- Warning appears

### How Has This Been Tested?
Test with this patch == no more warnings

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
