### PR TITLE
UI/installer: Install Media Foundation if missing

### DIFF
--- a/UI/installer/mp-installer.nsi
+++ b/UI/installer/mp-installer.nsi
@@ -187,6 +187,23 @@ Function PreReqCheck
 	dxOK:
 	ClearErrors
 
+	; Media Foundation (win N) Check
+	ClearErrors
+	GetDLLVersion "mfplat.dll" $R0 $R1
+	IfErrors mfMissing mfOK
+	mfMissing:
+	IfSilent +1 +3
+		SetErrorLevel 4
+		Quit
+	MessageBox MB_YESNO|MB_ICONEXCLAMATION "Your system is missing Media Foundation components that ${APPNAME} requires. Would you like to install it?" IDYES mftrue IDNO mffalse
+	mftrue:
+	ExecWait 'powershell -ExecutionPolicy bypass -Command ""add-windowsCapability -Online -Name Media.MediaFeaturePack~~~~0.0.1.0"" '
+	MessageBox MB_OK|MB_ICONEXCLAMATION "Media Foundation installation requires you to reboot the computer. Please do so, and run the installer again"
+	mffalse:
+	Quit
+	mfOK:
+	ClearErrors
+
 	; Check previous instance
 	check32BitRunning:
 	OBSInstallerUtils::IsProcessRunning "obs32.exe"


### PR DESCRIPTION
Checks for mfplat.dll, and offers user to install Media Foundation. If accepted, Powershell installs it, and installer informs user of  required reboot.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
If the installer detects mfplat.dll is missing, you get the following message and offer.
![vmconnect_9F90Kfuk6m](https://user-images.githubusercontent.com/50419942/168987253-320ea3e9-4a8e-42fa-980f-075bf32a3b28.png)
Yes triggers the powershell installer. No exits the installer.

Upon yes, a powershell window is spawned with a progress bar. Window closes automatically when done
![vmconnect_1gcUtCsI5I](https://user-images.githubusercontent.com/50419942/168987367-4e626407-65fc-4b4f-881e-ab1b6a0d3529.png)

Once the powershell script is done, the user is informed a reboot is required (it really is, as far as I can tell).
![vmconnect_8DJ1TDcbRI](https://user-images.githubusercontent.com/50419942/168987517-08a3eebe-e615-4fca-bf59-db26800909cc.png)
A bit unfortunate that the mfplat.dll does not exist as far as the check can tell until the reboot is done.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
A few versions back we bumped FFMPEG to a version that requires Media Foundation. For the time being, I'm not sure this requirement will be removed.

For Windows 10/11 "N" versions, which ships without Media Foundatino installed, it will completely prevent the user from running OBS Studio.

Manually installing this can be quite confusing and difficult for a lot of users.
This installation method *should* work for most supported Win10/11 builds.
I believe this installation method is valid for Windows 10, version 1903, and later (no manual download required)
Have not personally tested on the older builds (only on 21H2), and it's probably worthwhile to test on at least one more build, like 20H2 (still enterprise support).

A fairly large number of users run Windows N are coming by the support channels asking for help. A majority of people are not able to successfully get Media Foundation installed correctly on the first try. I would prefer preReqs were handled for them in an easier way (equivalent to vcredist).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built the installer successfully. Ran the installer on a clean Win10 21H2 VM, multiple times (uninstall mfplat, retry, re-install OBS). I can provide the installer if that makes it easier for others to test.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
