### PR TITLE
UI: Clean up source right-click menu

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1196,11 +1196,6 @@ AddUrl.Title="Add Source via URL"
 AddUrl.Text="You have dragged a URL into OBS. This will automatically add the link as a source. Continue?"
 AddUrl.Text.Url="URL: %1"
 
-# Dynamic output size
-ResizeOutputSizeOfSource="Resize output (source size)"
-ResizeOutputSizeOfSource.Text="The base and output resolutions will be resized to the size of the current source."
-ResizeOutputSizeOfSource.Continue="Do you want to continue?"
-
 PreviewTransition="Preview Transition"
 
 # Import Dialog

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5601,18 +5601,6 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 			popup.addSeparator();
 		}
 
-		QAction *resizeOutput =
-			popup.addAction(QTStr("ResizeOutputSizeOfSource"), this,
-					SLOT(ResizeOutputSizeOfSource()));
-
-		int width = obs_source_get_width(source);
-		int height = obs_source_get_height(source);
-
-		resizeOutput->setEnabled(!obs_video_active());
-
-		if (width < 8 || height < 8)
-			resizeOutput->setEnabled(false);
-
 		scaleFilteringMenu = new QMenu(QTStr("ScaleFiltering"));
 		popup.addMenu(
 			AddScaleFilteringMenu(scaleFilteringMenu, sceneItem));
@@ -9624,40 +9612,6 @@ void OBSBasic::on_actionShowAbout_triggered()
 	about->show();
 
 	about->setAttribute(Qt::WA_DeleteOnClose, true);
-}
-
-void OBSBasic::ResizeOutputSizeOfSource()
-{
-	if (obs_video_active())
-		return;
-
-	QMessageBox resize_output(this);
-	resize_output.setText(QTStr("ResizeOutputSizeOfSource.Text") + "\n\n" +
-			      QTStr("ResizeOutputSizeOfSource.Continue"));
-	QAbstractButton *Yes =
-		resize_output.addButton(QTStr("Yes"), QMessageBox::YesRole);
-	resize_output.addButton(QTStr("No"), QMessageBox::NoRole);
-	resize_output.setIcon(QMessageBox::Warning);
-	resize_output.setWindowTitle(QTStr("ResizeOutputSizeOfSource"));
-	resize_output.exec();
-
-	if (resize_output.clickedButton() != Yes)
-		return;
-
-	OBSSource source = obs_sceneitem_get_source(GetCurrentSceneItem());
-
-	int width = obs_source_get_width(source);
-	int height = obs_source_get_height(source);
-
-	config_set_uint(basicConfig, "Video", "BaseCX", width);
-	config_set_uint(basicConfig, "Video", "BaseCY", height);
-	config_set_uint(basicConfig, "Video", "OutputCX", width);
-	config_set_uint(basicConfig, "Video", "OutputCY", height);
-
-	ResetVideo();
-	ResetOutputs();
-	config_save_safe(basicConfig, "tmp", nullptr);
-	on_actionFitToScreen_triggered();
 }
 
 QAction *OBSBasic::AddDockWidget(QDockWidget *dock)

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5559,7 +5559,6 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		bool isAsyncVideo = (flags & OBS_SOURCE_ASYNC_VIDEO) ==
 				    OBS_SOURCE_ASYNC_VIDEO;
 		bool hasAudio = (flags & OBS_SOURCE_AUDIO) == OBS_SOURCE_AUDIO;
-		QAction *action;
 
 		colorMenu = new QMenu(QTStr("ChangeBG"));
 		colorWidgetAction = new QWidgetAction(colorMenu);
@@ -5623,14 +5622,12 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		popup.addMenu(CreateVisibilityTransitionMenu(false));
 		popup.addSeparator();
 
-		action = popup.addAction(QTStr("Interact"), this,
-					 SLOT(on_actionInteract_triggered()));
-
-		action->setEnabled(obs_source_get_output_flags(source) &
-				   OBS_SOURCE_INTERACTION);
+		if (flags & OBS_SOURCE_INTERACTION)
+			popup.addAction(QTStr("Interact"), this,
+					SLOT(on_actionInteract_triggered()));
 
 		popup.addAction(QTStr("Filters"), this, SLOT(OpenFilters()));
-		action = popup.addAction(
+		QAction *action = popup.addAction(
 			QTStr("Properties"), this,
 			SLOT(on_actionSourceProperties_triggered()));
 		action->setEnabled(obs_source_configurable(source));

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5570,18 +5570,9 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		popup.addAction(QTStr("Remove"), this,
 				SLOT(on_actionRemoveSource_triggered()));
 		popup.addSeparator();
+
 		popup.addMenu(ui->orderMenu);
-
 		popup.addMenu(ui->transformMenu);
-
-		sourceProjector = new QMenu(QTStr("SourceProjector"));
-		AddProjectorMenuMonitors(sourceProjector, this,
-					 SLOT(OpenSourceProjector()));
-
-		QAction *sourceWindow = popup.addAction(
-			QTStr("SourceWindow"), this, SLOT(OpenSourceWindow()));
-
-		popup.addAction(sourceWindow);
 
 		popup.addSeparator();
 
@@ -5591,35 +5582,36 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 						SLOT(ToggleHideMixer()));
 			actionHideMixer->setCheckable(true);
 			actionHideMixer->setChecked(SourceMixerHidden(source));
-		}
-
-		if (isAsyncVideo) {
-			deinterlaceMenu = new QMenu(QTStr("Deinterlacing"));
-			popup.addMenu(
-				AddDeinterlacingMenu(deinterlaceMenu, source));
 			popup.addSeparator();
 		}
 
 		scaleFilteringMenu = new QMenu(QTStr("ScaleFiltering"));
 		popup.addMenu(
 			AddScaleFilteringMenu(scaleFilteringMenu, sceneItem));
-		popup.addSeparator();
-
+		blendingModeMenu = new QMenu(QTStr("BlendingMode"));
+		popup.addMenu(AddBlendingModeMenu(blendingModeMenu, sceneItem));
 		blendingMethodMenu = new QMenu(QTStr("BlendingMethod"));
 		popup.addMenu(
 			AddBlendingMethodMenu(blendingMethodMenu, sceneItem));
-		blendingModeMenu = new QMenu(QTStr("BlendingMode"));
-		popup.addMenu(AddBlendingModeMenu(blendingModeMenu, sceneItem));
-		popup.addSeparator();
-
-		popup.addMenu(sourceProjector);
-		popup.addAction(sourceWindow);
-		popup.addAction(QTStr("Screenshot.Source"), this,
-				SLOT(ScreenshotSelectedSource()));
+		if (isAsyncVideo) {
+			deinterlaceMenu = new QMenu(QTStr("Deinterlacing"));
+			popup.addMenu(
+				AddDeinterlacingMenu(deinterlaceMenu, source));
+		}
 		popup.addSeparator();
 
 		popup.addMenu(CreateVisibilityTransitionMenu(true));
 		popup.addMenu(CreateVisibilityTransitionMenu(false));
+		popup.addSeparator();
+
+		sourceProjector = new QMenu(QTStr("SourceProjector"));
+		AddProjectorMenuMonitors(sourceProjector, this,
+					 SLOT(OpenSourceProjector()));
+		popup.addMenu(sourceProjector);
+		popup.addAction(QTStr("SourceWindow"), this,
+				SLOT(OpenSourceWindow()));
+		popup.addAction(QTStr("Screenshot.Source"), this,
+				SLOT(ScreenshotSelectedSource()));
 		popup.addSeparator();
 
 		if (flags & OBS_SOURCE_INTERACTION)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1139,8 +1139,6 @@ private slots:
 
 	void StackedMixerAreaContextMenuRequested();
 
-	void ResizeOutputSizeOfSource();
-
 public slots:
 	void on_actionResetTransform_triggered();
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. --> 
Cleans up the source right click menu mostly according to a mockup and requests from @Warchamp7.

Old menu (source has async video / no audio):
<img width="200" alt="image" src="https://user-images.githubusercontent.com/59806498/169189333-3b7bb225-8829-40dd-ab9f-97a1061b5326.png">

New menu (source has async video / no audio):
<img width="200" alt="image" src="https://user-images.githubusercontent.com/59806498/169189013-77ca1c0e-3edf-449d-b3f8-2ca14cf028ce.png">

Mockup: 
<img width="200" src="https://cdn.discordapp.com/attachments/940868766345084928/965560926768091187/unknown.png">

New menu (no video / with audio):
<img width="200" alt="image" src="https://user-images.githubusercontent.com/59806498/169189543-af87b0fe-4a87-4124-989c-75657b16ef55.png">

Detailed overview:
- Removed "Resize output (source size)" menu
- Only shows "Interact" menu when source can be interacted with, instead of always showing the menu, but disabling it with most sources
- Grouped Scale Filtering, Blending Mode & Method, and Deinterlacing together
- Moved Projector menus down
- "Hide in mixer" has its own group. This is the only change that doesn't comply with the mockup (and the notes), since just up removing it would remove functionality and a better place for it has yet to be found. This can come at a later point.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
List is very long. List can be shorter.

Changes to it were requested many times by multiple people, this follows Warchamps mockup and notes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.4
Made sure the menus still work and appear when they are supposed to.
See screenshots above.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

Closes #4968 
Closes #4969