### PR TITLE
UI: Revert transitions dock redesign

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1159,20 +1159,106 @@
          <number>0</number>
         </property>
         <item>
+         <widget class="QComboBox" name="transitions">
+          <property name="minimumSize">
+           <size>
+            <width>120</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="accessibleName">
+           <string>Transition</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_4">
           <property name="spacing">
            <number>4</number>
           </property>
           <item>
-           <widget class="QComboBox" name="transitions">
-            <property name="minimumSize">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Expanding</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
              <size>
-              <width>120</width>
-              <height>0</height>
+              <width>40</width>
+              <height>20</height>
              </size>
             </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="transitionAdd">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>22</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Basic.AddTransition</string>
+            </property>
             <property name="accessibleName">
-             <string>Transition</string>
+             <string>Basic.AddTransition</string>
+            </property>
+            <property name="text">
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset>
+              <normaloff>:/res/images/add.png</normaloff>:/res/images/add.png</iconset>
+            </property>
+            <property name="flat">
+             <bool>true</bool>
+            </property>
+            <property name="themeID" stdset="0">
+             <string notr="true">addIconSmall</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="transitionRemove">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>22</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Basic.RemoveTransition</string>
+            </property>
+            <property name="accessibleName">
+             <string>Basic.RemoveTransition</string>
+            </property>
+            <property name="text">
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset>
+              <normaloff>:/res/images/list_remove.png</normaloff>:/res/images/list_remove.png</iconset>
+            </property>
+            <property name="flat">
+             <bool>true</bool>
+            </property>
+            <property name="themeID" stdset="0">
+             <string notr="true">removeIconSmall</string>
             </property>
            </widget>
           </item>

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1172,6 +1172,51 @@
          </widget>
         </item>
         <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="transitionDurationLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Basic.TransitionDuration</string>
+            </property>
+            <property name="buddy">
+             <cstring>transitionDuration</cstring>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="transitionDuration">
+            <property name="accessibleName">
+             <string>Basic.TransitionDuration</string>
+            </property>
+            <property name="suffix">
+             <string> ms</string>
+            </property>
+            <property name="minimum">
+             <number>50</number>
+            </property>
+            <property name="maximum">
+             <number>20000</number>
+            </property>
+            <property name="singleStep">
+             <number>50</number>
+            </property>
+            <property name="value">
+             <number>300</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_4">
           <property name="spacing">
            <number>4</number>
@@ -1294,51 +1339,6 @@
             </property>
             <property name="themeID" stdset="0">
              <string notr="true">configIconSmall</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <property name="spacing">
-           <number>4</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="transitionDurationLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Basic.TransitionDuration</string>
-            </property>
-            <property name="buddy">
-             <cstring>transitionDuration</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="transitionDuration">
-            <property name="accessibleName">
-             <string>Basic.TransitionDuration</string>
-            </property>
-            <property name="suffix">
-             <string> ms</string>
-            </property>
-            <property name="minimum">
-             <number>50</number>
-            </property>
-            <property name="maximum">
-             <number>20000</number>
-            </property>
-            <property name="singleStep">
-             <number>50</number>
-            </property>
-            <property name="value">
-             <number>300</number>
             </property>
            </widget>
           </item>

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -101,9 +101,11 @@ void OBSBasic::InitDefaultTransitions()
 	ui->transitions->blockSignals(false);
 }
 
-int OBSBasic::TransitionCount()
+int OBSBasic::AddTransitionBeforeSeparator(const QString &name,
+					   obs_source_t *source)
 {
-	int idx = 0;
+	int idx = -1;
+
 	for (int i = 0; i < ui->transitions->count(); i++) {
 		QVariant v = ui->transitions->itemData(i);
 		if (!v.toString().isEmpty()) {
@@ -112,21 +114,11 @@ int OBSBasic::TransitionCount()
 		}
 	}
 
-	/* should always have at least fade and cut due to them being
-	 * defaults */
-	assert(idx != 0);
-	return idx - 1; /* remove separator from equation */
-}
-
-int OBSBasic::AddTransitionBeforeSeparator(const QString &name,
-					   obs_source_t *source)
-{
-	int idx = TransitionCount();
 	ui->transitions->blockSignals(true);
-	ui->transitions->insertItem(idx, name,
+	ui->transitions->insertItem(idx - 1, name,
 				    QVariant::fromValue(OBSSource(source)));
 	ui->transitions->blockSignals(false);
-	return idx;
+	return idx - 1;
 }
 
 void OBSBasic::AddQuickTransitionHotkey(QuickTransition *qt)
@@ -578,15 +570,7 @@ void OBSBasic::on_transitionRemove_clicked()
 		}
 	}
 
-	ui->transitions->blockSignals(true);
 	ui->transitions->removeItem(idx);
-	ui->transitions->setCurrentIndex(-1);
-	ui->transitions->blockSignals(false);
-
-	int bottomIdx = TransitionCount() - 1;
-	if (idx > bottomIdx)
-		idx = bottomIdx;
-	ui->transitions->setCurrentIndex(idx);
 
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_TRANSITION_LIST_CHANGED);

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -72,11 +72,8 @@ void OBSBasic::InitDefaultTransitions()
 			else if (strcmp(id, "cut_transition") == 0)
 				cutTransition = tr;
 		} else {
-			QString addString = QTStr("Add") +
-					    QStringLiteral(": ") +
-					    QT_UTF8(name);
 			ui->transitions->addItem(
-				addString,
+				QTStr("Add ") + QT_UTF8(name),
 				QVariant::fromValue(QString(QT_UTF8(id))));
 		}
 	}

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -51,14 +51,8 @@ static inline QString MakeQuickTransitionText(QuickTransition *qt)
 
 void OBSBasic::InitDefaultTransitions()
 {
-	struct AddTransitionVal {
-		QString id;
-		QString name;
-	};
-
 	ui->transitions->blockSignals(true);
 	std::vector<OBSSource> transitions;
-	std::vector<AddTransitionVal> addables;
 	size_t idx = 0;
 	const char *id;
 
@@ -78,26 +72,22 @@ void OBSBasic::InitDefaultTransitions()
 			else if (strcmp(id, "cut_transition") == 0)
 				cutTransition = tr;
 		} else {
-			AddTransitionVal val;
-			val.name = QTStr("Add") + QStringLiteral(": ") +
-				   QT_UTF8(name);
-			val.id = QT_UTF8(id);
-			addables.push_back(val);
+			QString addString = QTStr("Add") +
+					    QStringLiteral(": ") +
+					    QT_UTF8(name);
+			ui->transitions->addItem(
+				addString,
+				QVariant::fromValue(QString(QT_UTF8(id))));
 		}
 	}
+
+	if (ui->transitions->count())
+		ui->transitions->insertSeparator(ui->transitions->count());
 
 	for (OBSSource &tr : transitions) {
 		ui->transitions->addItem(QT_UTF8(obs_source_get_name(tr)),
 					 QVariant::fromValue(OBSSource(tr)));
 	}
-
-	if (addables.size())
-		ui->transitions->insertSeparator(ui->transitions->count());
-
-	for (AddTransitionVal &val : addables) {
-		ui->transitions->addItem(val.name, QVariant::fromValue(val.id));
-	}
-
 	ui->transitions->blockSignals(false);
 }
 

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -556,7 +556,7 @@ void OBSBasic::AddTransition(QString id)
 	}
 }
 
-void OBSBasic::RemoveTransitionClicked()
+void OBSBasic::on_transitionRemove_clicked()
 {
 	OBSSource tr = GetCurrentTransition();
 
@@ -660,7 +660,7 @@ void OBSBasic::on_transitionProps_clicked()
 
 	action = new QAction(QTStr("Remove"), &menu);
 	connect(action, SIGNAL(triggered()), this,
-		SLOT(RemoveTransitionClicked()));
+		SLOT(on_transitionRemove_clicked()));
 	menu.addAction(action);
 
 	action = new QAction(QTStr("Properties"), &menu);

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -101,26 +101,6 @@ void OBSBasic::InitDefaultTransitions()
 	ui->transitions->blockSignals(false);
 }
 
-int OBSBasic::AddTransitionBeforeSeparator(const QString &name,
-					   obs_source_t *source)
-{
-	int idx = -1;
-
-	for (int i = 0; i < ui->transitions->count(); i++) {
-		QVariant v = ui->transitions->itemData(i);
-		if (!v.toString().isEmpty()) {
-			idx = i;
-			break;
-		}
-	}
-
-	ui->transitions->blockSignals(true);
-	ui->transitions->insertItem(idx - 1, name,
-				    QVariant::fromValue(OBSSource(source)));
-	ui->transitions->blockSignals(false);
-	return idx - 1;
-}
-
 void OBSBasic::AddQuickTransitionHotkey(QuickTransition *qt)
 {
 	DStr hotkeyId;
@@ -530,9 +510,10 @@ void OBSBasic::AddTransition(QString id)
 		source = obs_source_create_private(QT_TO_UTF8(id), name.c_str(),
 						   NULL);
 		InitTransition(source);
-		int idx = AddTransitionBeforeSeparator(QT_UTF8(name.c_str()),
-						       source);
-		ui->transitions->setCurrentIndex(idx);
+		ui->transitions->addItem(
+			QT_UTF8(name.c_str()),
+			QVariant::fromValue(OBSSource(source)));
+		ui->transitions->setCurrentIndex(ui->transitions->count() - 1);
 		CreatePropertiesWindow(source);
 		obs_source_release(source);
 
@@ -1817,9 +1798,10 @@ void OBSBasic::LoadTransitions(obs_data_array_t *transitions,
 			obs_source_create_private(id, name, settings);
 		if (!obs_obj_invalid(source)) {
 			InitTransition(source);
-			AddTransitionBeforeSeparator(QT_UTF8(name), source);
-			if (cb)
-				cb(private_data, source);
+
+			ui->transitions->addItem(
+				QT_UTF8(name),
+				QVariant::fromValue(OBSSource(source)));
 		}
 	}
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -701,7 +701,7 @@ private slots:
 
 	void ProcessHotkey(obs_hotkey_id id, bool pressed);
 
-	void AddTransition(QString id);
+	void AddTransition();
 	void RenameTransition();
 	void TransitionClicked();
 	void TransitionStopped();
@@ -1063,6 +1063,7 @@ private slots:
 	void on_toggleSourceIcons_toggled(bool visible);
 
 	void on_transitions_currentIndexChanged(int index);
+	void on_transitionAdd_clicked();
 	void on_transitionRemove_clicked();
 	void on_transitionProps_clicked();
 	void on_transitionDuration_valueChanged(int value);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1066,7 +1066,7 @@ private slots:
 	void on_toggleSourceIcons_toggled(bool visible);
 
 	void on_transitions_currentIndexChanged(int index);
-	void RemoveTransitionClicked();
+	void on_transitionRemove_clicked();
 	void on_transitionProps_clicked();
 	void on_transitionDuration_valueChanged(int value);
 	void on_tbar_position_valueChanged(int value);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -446,8 +446,6 @@ private:
 
 	void CreateProgramDisplay();
 	void CreateProgramOptions();
-	int AddTransitionBeforeSeparator(const QString &name,
-					 obs_source_t *source);
 	void AddQuickTransitionId(int id);
 	void AddQuickTransition();
 	void AddQuickTransitionHotkey(QuickTransition *qt);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -446,7 +446,6 @@ private:
 
 	void CreateProgramDisplay();
 	void CreateProgramOptions();
-	int TransitionCount();
 	int AddTransitionBeforeSeparator(const QString &name,
 					 obs_source_t *source);
 	void AddQuickTransitionId(int id);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Reverts the redesign of the transitions dock (and a few related follow-up commits)
originally introduced in #2961 which moved adding transitions to the dropdown
menu and the remove function to the settings gear icon.

<img width="180" alt="image" src="https://user-images.githubusercontent.com/59806498/169292285-474d5c00-1a5f-4877-b0ba-6177c19c6a8c.png">

Most reverts applied cleanly, some had to be manually adjusted (like for RAII).
I left the commits separate to make it easier to follow what got changed, but feel
free to "Squash and Merge" should one commit be desired.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The original change had the intention of increasing discoverability, however it
achieved the opposite (see #3631 as well as the support channels on Discord). While
other things like sources and scenes have a standard +/- configuration for adding and
removing, for transitions you need to select the dropdown to add transitions.
Besides being inconsistent, this is not intuitive and not how comboboxes should be
used. Many people have complained about it.

Closes #3631

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.4

Tested:
- Adding new transitions
- Removing transitions (except the default ones that can't be removed, obviously)
- Renaming transitions
- Changing properties
- Changing duration of duration-based transitions

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate (**See note in Description**).
- [x] I have included updates to all appropriate documentation.
