### PR TITLE
UI: Use correct terminology for Program in Studio Mode

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -255,12 +255,12 @@ Updater.GameCaptureActive.Title="Game capture active"
 Updater.GameCaptureActive.Text="Game capture hook library is currently in use. Please close any games/programs being captured (or restart Windows) and try again."
 
 # quick transitions
-QuickTransitions.SwapScenes="Swap Preview/Output Scenes After Transitioning"
-QuickTransitions.SwapScenesTT="Swaps the preview and output scenes after transitioning (if the output's original scene still exists).\nThis will not undo any changes that may have been made to the output's original scene."
+QuickTransitions.SwapScenes="Swap Preview/Program Scenes After Transitioning"
+QuickTransitions.SwapScenesTT="Swaps the preview and program scenes after transitioning (if the program's original scene still exists).\nThis will not undo any changes that may have been made to the program's original scene."
 QuickTransitions.DuplicateScene="Duplicate Scene"
-QuickTransitions.DuplicateSceneTT="When editing the same scene, allows editing transform/visibility of sources without modifying the output.\nTo edit properties of sources without modifying the output, enable 'Duplicate Sources'.\nChanging this value will reset the current output scene (if it still exists)."
+QuickTransitions.DuplicateSceneTT="When editing the same scene, allows editing transform/visibility of sources without modifying the program output.\nTo edit properties of sources without modifying the program output, enable 'Duplicate Sources'.\nChanging this value will reset the current program scene (if it still exists)."
 QuickTransitions.EditProperties="Duplicate Sources"
-QuickTransitions.EditPropertiesTT="When editing the same scene, allows editing properties of sources without modifying the output.\nThis can only be used if 'Duplicate Scene' is enabled.\nCertain sources (such as capture or media sources) do not support this and cannot be edited separately.\nChanging this value will reset the current output scene (if it still exists).\n\nWarning: Because sources will be duplicated, this may require extra system or video resources."
+QuickTransitions.EditPropertiesTT="When editing the same scene, allows editing properties of sources without modifying the program output.\nThis can only be used if 'Duplicate Scene' is enabled.\nCertain sources (such as capture or media sources) do not support this and cannot be edited separately.\nChanging this value will reset the current program scene (if it still exists).\n\nWarning: Because sources will be duplicated, this may require extra system or video resources."
 QuickTransitions.HotkeyName="Quick Transition: %1"
 
 # transitions


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes transition settings from being called "Swap Preview/Output Scenes After Transitioning" to "Swap Preview/Program Scenes After Transitioning", as well as tooltip strings.

In the tooltips, there are instances of "output" left which I *think* are appropriate, but it would be great to have a native English speaker to chime in on this.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
It's called "Preview/Program" everywhere else, so that's the terminology we should use.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
N/A, string change.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
