### PR TITLE
libobs: Clamp audio NaN to 0.0f

### DIFF
--- a/libobs/media-io/audio-io.c
+++ b/libobs/media-io/audio-io.c
@@ -145,6 +145,7 @@ static inline void clamp_audio_output(struct audio_output *audio, size_t bytes)
 
 			while (mix_data < mix_end) {
 				float val = *mix_data;
+				val = (val == val) ? val : 0.0f;
 				val = (val > 1.0f) ? 1.0f : val;
 				val = (val < -1.0f) ? -1.0f : val;
 				*(mix_data++) = val;


### PR DESCRIPTION
### Description

Rearrange comparison order so that NaN is caught.
Comparisons with NaN always result in false.
NaNs cause problems later in audio encoder.

### Motivation and Context

When a NaN (not a number) audio sample is fed to OBS, it immediately stops both streaming and recording because ffmpeg audio encoder doesn't like it.

See #4885, which this patch should theoretically fix, if compiler obeys IEEE semantics (no `-ffast-math` or so).

### How Has This Been Tested?

I have not tested yet.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
