### PR TITLE
obs-ffmpeg: Remove duplicate "FFmpeg Options" locale

### DIFF
--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -2,6 +2,7 @@ FFmpegOutput="FFmpeg Output"
 FFmpegAAC="FFmpeg Default AAC Encoder"
 FFmpegOpus="FFmpeg Opus Encoder"
 FFmpegOpts="FFmpeg Options"
+FFmpegOpts.ToolTip.Source="Allows you to set FFmpeg options. This only accepts options in the option=value format.\nMultiple options can be set by separating them with a space.\nExample: rtsp_transport=tcp rtsp_flags=prefer_tcp"
 Bitrate="Bitrate"
 MaxBitrate="Max Bitrate"
 Preset="Preset"
@@ -61,9 +62,6 @@ MediaFileFilter.AllFiles="All Files"
 
 ReplayBuffer="Replay Buffer"
 ReplayBuffer.Save="Save Replay"
-
-FFmpeg.Options="FFmpeg Options"
-FFmpeg.Options.Tooltip="Allows you to set FFmpeg options. This only accepts options in the option=value format.\nMultiple options can be set by separating them with a space.\nExample: rtsp_transport=tcp rtsp_flags=prefer_tcp"
 
 HelperProcessFailed="Unable to start the recording helper process. Check that OBS files have not been blocked or removed by any 3rd party antivirus / security software."
 UnableToWritePath="Unable to write to %1. Make sure you're using a recording path which your user account is allowed to write to and that there is sufficient disk space."

--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -223,10 +223,10 @@ static obs_properties_t *ffmpeg_source_getproperties(void *data)
 	obs_properties_add_bool(props, "seekable", obs_module_text("Seekable"));
 
 	prop = obs_properties_add_text(props, "ffmpeg_options",
-				       obs_module_text("FFmpeg.Options"),
+				       obs_module_text("FFmpegOpts"),
 				       OBS_TEXT_DEFAULT);
 	obs_property_set_long_description(
-		prop, obs_module_text("FFmpeg.Options.Tooltip"));
+		prop, obs_module_text("FFmpegOpts.ToolTip.Source"));
 
 	return props;
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
There are two separate locales for "FFmpeg Options", now there is only one.
Also moves the tooltip up to where the other source options are.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Duplicate locales only cause extra code and work for translators.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.4
Made sure for the source both the name and tooltip of the property are shown.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
