### PR TITLE
UI: Remove m3u8 format from simple output mode

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -1769,11 +1769,6 @@
                         <string notr="true">ts</string>
                        </property>
                       </item>
-                      <item>
-                       <property name="text">
-                        <string notr="true">m3u8</string>
-                       </property>
-                      </item>
                      </widget>
                     </item>
                     <item row="4" column="0">


### PR DESCRIPTION
### Description
Removes m3u8 (HLS) as a recording format option in simple output mode.

### Motivation and Context
Many users accidentally select m3u8 and then wonder why they have hundreds of 4 second video files. Anyone who actually needs local HLS output is likely an advanced user and can set it up there.

https://obsproject.com/forum/threads/recording-in-4-second-intervals.128706/
https://obsproject.com/forum/threads/obs-only-records-a-series-of-8-second-clips-instead-of-continuous-file.111192/
https://obsproject.com/forum/threads/my-stream-got-saved-as-tons-of-small-ts-files.106669/
https://obsproject.com/forum/threads/recording-creates-multiple-files.121238/
https://obsproject.com/forum/threads/help-obs-records-many-4-second-files-instead-of-one-big-one-after-update.118353/

### How Has This Been Tested?
- Ran OBS, verified m3u8 didn't show up any more.
- Set OBS to output m3u8, then switched to this branch.  Existing output to m3u8 did not break, though the option no longer appeared in settings. Verified simply looking at settings did not change the option. Only after selecting a different format did it change from m3u8.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
