### PR TITLE
obs-qsv11: Add HEVC support

### DIFF
--- a/plugins/obs-qsv11/QSV_Encoder.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder.cpp
@@ -363,3 +363,13 @@ enum qsv_cpu_platform qsv_get_cpu_platform()
 	//assume newer revisions are at least as capable as Haswell
 	return QSV_CPU_PLATFORM_INTEL;
 }
+
+int qsv_hevc_encoder_headers(qsv_t *pContext, uint8_t **pVPS, uint8_t **pSPS,
+			     uint8_t **pPPS, uint16_t *pnVPS, uint16_t *pnSPS,
+			     uint16_t *pnPPS)
+{
+	QSV_Encoder_Internal *pEncoder = (QSV_Encoder_Internal *)pContext;
+	pEncoder->GetVpsSpsPps(pVPS, pSPS, pPPS, pnVPS, pnSPS, pnPPS);
+
+	return 0;
+}

--- a/plugins/obs-qsv11/QSV_Encoder.h
+++ b/plugins/obs-qsv11/QSV_Encoder.h
@@ -80,6 +80,7 @@ static const struct qsv_rate_control_info qsv_av1_ratecontrols[] =
 
 static const char *const qsv_profile_names[] = {"high", "main", "baseline", 0};
 static const char *const qsv_profile_names_av1[] = {"main", 0};
+static const char *const qsv_profile_names_hevc[] = {"main", "main10", 0};
 static const char *const qsv_usage_names[] = {"quality",  "balanced", "speed",
 					      "veryslow", "slower",   "slow",
 					      "medium",   "fast",     "faster",
@@ -92,11 +93,13 @@ struct adapter_info {
 	bool is_intel;
 	bool is_dgpu;
 	bool supports_av1;
+	bool supports_hevc;
 };
 
 enum qsv_codec {
 	QSV_CODEC_AVC,
 	QSV_CODEC_AV1,
+	QSV_CODEC_HEVC,
 };
 
 #define MAX_ADAPTERS 10
@@ -178,6 +181,10 @@ int qsv_encoder_headers(qsv_t *, uint8_t **pSPS, uint8_t **pPPS,
 			uint16_t *pnSPS, uint16_t *pnPPS);
 enum qsv_cpu_platform qsv_get_cpu_platform();
 bool prefer_igpu_enc(int *iGPUIndex);
+
+int qsv_hevc_encoder_headers(qsv_t *pContext, uint8_t **vVPS, uint8_t **pSPS,
+			     uint8_t **pPPS, uint16_t *pnVPS, uint16_t *pnSPS,
+			     uint16_t *pnPPS);
 
 #ifdef __cplusplus
 }

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.h
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.h
@@ -67,6 +67,8 @@ public:
 	mfxStatus Open(qsv_param_t *pParams, enum qsv_codec codec);
 	void GetSPSPPS(mfxU8 **pSPSBuf, mfxU8 **pPPSBuf, mfxU16 *pnSPSBuf,
 		       mfxU16 *pnPPSBuf);
+	void GetVpsSpsPps(mfxU8 **pVPSBuf, mfxU8 **pSPSBuf, mfxU8 **pPPSBuf,
+			  mfxU16 *pnVPSBuf, mfxU16 *pnSPSBuf, mfxU16 *pnPPSBuf);
 	mfxStatus Encode(uint64_t ts, uint8_t *pDataY, uint8_t *pDataUV,
 			 uint32_t strideY, uint32_t strideUV,
 			 mfxBitstream **pBS);
@@ -81,7 +83,7 @@ public:
 protected:
 	mfxStatus InitParams(qsv_param_t *pParams, enum qsv_codec codec);
 	mfxStatus AllocateSurfaces();
-	mfxStatus GetVideoParam();
+	mfxStatus GetVideoParam(enum qsv_codec codec);
 	mfxStatus InitBitstream();
 	mfxStatus LoadNV12(mfxFrameSurface1 *pSurface, uint8_t *pDataY,
 			   uint8_t *pDataUV, uint32_t strideY,
@@ -102,14 +104,17 @@ private:
 	mfxFrameSurface1 **m_pmfxSurfaces;
 	mfxU16 m_nSurfNum;
 	MFXVideoENCODE *m_pmfxENC;
+	mfxU8 m_VPSBuffer[1024];
 	mfxU8 m_SPSBuffer[1024];
 	mfxU8 m_PPSBuffer[1024];
+	mfxU16 m_nVPSBufferSize;
 	mfxU16 m_nSPSBufferSize;
 	mfxU16 m_nPPSBufferSize;
 	mfxVideoParam m_parameter;
 	mfxExtCodingOption3 m_co3;
 	mfxExtCodingOption2 m_co2;
 	mfxExtCodingOption m_co;
+	mfxExtHEVCParam m_ExtHEVCParam{};
 	mfxExtVideoSignalInfo m_ExtVideoSignalInfo{};
 	mfxExtChromaLocInfo m_ExtChromaLocInfo{};
 	mfxExtMasteringDisplayColourVolume m_ExtMasteringDisplayColourVolume{};

--- a/plugins/obs-qsv11/obs-qsv-test/obs-qsv-test.cpp
+++ b/plugins/obs-qsv11/obs-qsv-test/obs-qsv-test.cpp
@@ -23,6 +23,7 @@ struct adapter_caps {
 	bool is_intel = false;
 	bool is_dgpu = false;
 	bool supports_av1 = false;
+	bool supports_hevc = false;
 };
 
 static std::map<uint32_t, adapter_caps> adapter_info;
@@ -72,6 +73,9 @@ static bool get_adapter_caps(IDXGIFactory *factory, uint32_t adapter_idx)
 	caps.is_intel = true;
 	caps.is_dgpu = dgpu;
 	caps.supports_av1 = has_encoder(impl, MFX_CODEC_AV1);
+#if ENABLE_HEVC
+	caps.supports_hevc = has_encoder(impl, MFX_CODEC_HEVC);
+#endif
 
 	return true;
 }
@@ -80,7 +84,7 @@ DWORD WINAPI TimeoutThread(LPVOID param)
 {
 	HANDLE hMainThread = (HANDLE)param;
 
-	DWORD ret = WaitForSingleObject(hMainThread, 5000);
+	DWORD ret = WaitForSingleObject(hMainThread, 8000);
 	if (ret == WAIT_TIMEOUT)
 		TerminateProcess(GetCurrentProcess(), STATUS_TIMEOUT);
 
@@ -121,6 +125,8 @@ try {
 		printf("is_dgpu=%s\n", caps.is_dgpu ? "true" : "false");
 		printf("supports_av1=%s\n",
 		       caps.supports_av1 ? "true" : "false");
+		printf("supports_hevc=%s\n",
+		       caps.supports_hevc ? "true" : "false");
 	}
 
 	return 0;

--- a/plugins/obs-qsv11/obs-qsv11-plugin-main.c
+++ b/plugins/obs-qsv11/obs-qsv11-plugin-main.c
@@ -73,6 +73,8 @@ extern struct obs_encoder_info obs_qsv_encoder_tex;
 extern struct obs_encoder_info obs_qsv_encoder_tex_v2;
 extern struct obs_encoder_info obs_qsv_av1_encoder_tex;
 extern struct obs_encoder_info obs_qsv_av1_encoder;
+extern struct obs_encoder_info obs_qsv_hevc_encoder_tex;
+extern struct obs_encoder_info obs_qsv_hevc_encoder;
 
 extern bool av1_supported(mfxIMPL impl);
 
@@ -123,6 +125,7 @@ bool obs_module_load(void)
 	adapter_count = config_num_sections(config);
 	bool avc_supported = false;
 	bool av1_supported = false;
+	bool hevc_supported = false;
 
 	if (adapter_count > MAX_ADAPTERS)
 		adapter_count = MAX_ADAPTERS;
@@ -137,9 +140,12 @@ bool obs_module_load(void)
 		adapter->is_dgpu = config_get_bool(config, section, "is_dgpu");
 		adapter->supports_av1 =
 			config_get_bool(config, section, "supports_av1");
+		adapter->supports_hevc =
+			config_get_bool(config, section, "supports_hevc");
 
 		avc_supported |= adapter->is_intel;
 		av1_supported |= adapter->supports_av1;
+		hevc_supported |= adapter->supports_hevc;
 	}
 
 	if (avc_supported) {
@@ -152,6 +158,12 @@ bool obs_module_load(void)
 		obs_register_encoder(&obs_qsv_av1_encoder_tex);
 		obs_register_encoder(&obs_qsv_av1_encoder);
 	}
+#if ENABLE_HEVC
+	if (hevc_supported) {
+		obs_register_encoder(&obs_qsv_hevc_encoder_tex);
+		obs_register_encoder(&obs_qsv_hevc_encoder);
+	}
+#endif
 
 fail:
 	config_close(config);


### PR DESCRIPTION
### Description
- Add Intel HEVC hardware encoder (QSV H.265).
~~- Add *Simple Output Mode* for Intel HEVC hardware encoder.~~

### Motivation and Context
- We should have a way to use Intel HEVC hardware encoder in streaming and recording.
~~- We should have easy way (*Simple Output Mode*) to use Intel HEVC hardware encoder in streaming and recording.~~

### How Has This Been Tested?
MSVC debugger, VLC color/metadata checks
- [x] H.264, NV12, 709 -> Regular
- [x] H.264, NV12, 2100PQ -> HDR on 8-bit fail
- [x] H.264, NV12, 2100HLG -> HDR on 8-bit fail
- [x] H.264, I420, 709 -> NV12 fallback
- [x] H.264, I420, 2100PQ -> HDR on 8-bit fail
- [x] H.264, I420, 2100HLG -> HDR on 8-bit fail
- [x] H.264, I010, 709 -> 10-bit fail
- [x] H.264, I010, 2100PQ -> 10-bit fail
- [x] H.264, I010, 2100HLG -> 10-bit fail
- [x] H.264, P010, 709 -> 10-bit fail
- [x] H.264, P010, 2100PQ -> 10-bit fail
- [x] H.264, P010, 2100HLG -> 10-bit fail
- [x] HEVC, NV12, 709 -> Regular
- [x] HEVC, NV12, 2100PQ -> HDR on 8-bit fail
- [x] HEVC, NV12, 2100HLG -> HDR on 8-bit fail
- [x] HEVC, I420, 709 -> NV12 fallback
- [x] HEVC, I420, 2100PQ -> HDR on 8-bit fail
- [x] HEVC, I420, 2100HLG -> HDR on 8-bit fail
- [x] HEVC, I010, 709 -> P010 fallback
- [x] HEVC, I010, 2100PQ -> P010 fallback
- [x] HEVC, I010, 2100HLG -> P010 fallback
- [x] HEVC, P010, 709 -> Regular
- [x] HEVC, P010, 601 -> Regular
- [x] HEVC, P010, sRGB -> Regular
- [x] HEVC, P010, 2100PQ -> Regular
- [x] HEVC, P010, 2100HLG -> Regular

RenderDoc color check
- [x] H.264, 709, limited vs. full range

MediaInfo metadata checks:
- [x] H.264, 709, Limited range
- [x] H.264, 709, Full range
- [x] HEVC, 709, no display mastering metadata, no content light metadata (garbage content light level, but not our fault)
- [x] HEVC, 601, no display mastering metadata, no content light metadata (garbage content light level, but not our fault)
- [x] HEVC, sRGB, no display mastering metadata, no content light metadata (garbage content light level, but not our fault)
- [x] HEVC, 2100PQ, display mastering metadata, content light metadata (garbage content light level, but not our fault)
- [x] HEVC, 2100HLG, display mastering metadata, content light metadata (garbage content light level, but not our fault)

Compile/UI check:
- [x] Verify HEVC encoder not available when ENABLE_HEVC is disabled

Chrome checks:
- [x] Test HEVC 709 against YouTube streaming
- [x] Test HEVC 2100PQ against YouTube streaming
- [x] Test HEVC 2100HLG against YouTube streaming

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.