### PR TITLE
CI: Ping authors of failed services in removal PR

### DIFF
--- a/.github/workflows/services-json.yml
+++ b/.github/workflows/services-json.yml
@@ -67,14 +67,7 @@ jobs:
 
       - name: Check Services
         id: check
-        run: |
-           python3.9 -u CI/check-services.py
-           # if there are changes, run the PR step
-           if ! git diff --quiet; then
-             echo "::set-output name=make_pr::true"
-           else
-             echo "::set-output name=make_pr::false"
-           fi
+        run: python3.9 -u CI/check-services.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_RUN_ID: ${{ github.run_id }}
@@ -93,5 +86,5 @@ jobs:
           commit-message: "rtmp-services: Remove defunct servers/services"
           title: "rtmp-services: Remove defunct servers/services"
           branch: "automated/clean-services"
-          body: "Automatic PR to remove dead servers\nCreated by workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          body: ${{ fromJSON(steps.check.outputs.pr_message) }}
           delete-branch: true


### PR DESCRIPTION
### Description

Pings people responsible for modifying affected service entries in the `services.json` file.

Looks like this: https://github.com/derrod/obs-studio/pull/8 (The "@" was ommited for this test to avoid pinging people).

### Motivation and Context

Give service owners an opportunity to fix their entry or servers.

### How Has This Been Tested?

Ran on my fork: https://github.com/derrod/obs-studio/runs/6541019315?check_suite_focus=true

### Types of changes
- New feature (non-breaking change which adds functionality) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
