### PR TITLE
rtmp-services: Add modern-stream service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services",
-    "version": 197,
+    "version": 198,
     "files": [
         {
             "name": "services.json",
-            "version": 197
+            "version": 198
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2633,9 +2633,8 @@
             ],
             "recommended": {
                 "keyint": 2,
-                "x264opts": "tune=zerolatency",
-				"max fps": 30
+                "max fps": 30
             }
-		}
+        }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2622,6 +2622,20 @@
                 "max video bitrate": 5000,
                 "max audio bitrate": 160
             }
-        }
+        },
+        {
+            "name": "Modern Stream",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmps://ingest.modern-stream.com:443/live"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "x264opts": "tune=zerolatency",
+				"max fps": 30
+            }
+		}
     ]
 }


### PR DESCRIPTION
### Description
Added RTMP service for [Modern-stream ](https://www.modern-stream.com/) platform

### Motivation and Context
We built an easy to use streaming platform for sports/Esports events and we want our users to be able to use it more easily with OBS without extra configuration
### How Has This Been Tested?
Manually applied the JSON entry to my local installation.

### Types of changes
New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
