### PR TITLE
linux-capture: Check da_erase target is valid

### DIFF
--- a/plugins/linux-capture/xcomposite-input.c
+++ b/plugins/linux-capture/xcomposite-input.c
@@ -610,10 +610,13 @@ void watcher_unregister(xcb_connection_t *conn, struct xcompcap *s)
 			sizeof(struct reg_item), &watcher_registry.da, i);
 
 		if (item->src == s) {
+			idx = i;
 			win = item->win;
 			break;
 		}
 	}
+	if (idx == DARRAY_INVALID)
+		goto done;
 
 	da_erase(watcher_registry, idx);
 
@@ -636,6 +639,7 @@ void watcher_unregister(xcb_connection_t *conn, struct xcompcap *s)
 					     vals);
 	}
 
+done:
 	pthread_mutex_unlock(&watcher_lock);
 }
 


### PR DESCRIPTION

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This was leftover from the cpp conversion where the delete would not
fail, but for darray we need to skip da_erase if its unneeded.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
fixes #6532

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
