### PR TITLE
cmake: Fix frontend-api built when ENABLE_UI=OFF

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -1,5 +1,3 @@
-add_subdirectory(obs-frontend-api)
-
 option(ENABLE_UI "Enable building with UI (requires Qt)" ON)
 if(NOT ENABLE_UI)
   obs_status(DISABLED "OBS UI")
@@ -12,6 +10,8 @@ if(NOT QT_VERSION)
       CACHE STRING "OBS Qt version [5, 6]" FORCE)
   set_property(CACHE QT_VERSION PROPERTY STRINGS 5 6)
 endif()
+
+add_subdirectory(obs-frontend-api)
 
 project(obs)
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Moved the add_subdirectory call in the UI CMakeLists.txt to after the check
for it ENABLE_UI is set to off

### Motivation and Context
Currently the obs-frontend-api is still being built even when ENABLE_UI
is off and there is no frontend being built

### How Has This Been Tested?
I built it and confirmed the frontent-api isn't being built

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
