### PR TITLE
UI: Add suffixes to transform dialog

### DIFF
--- a/UI/forms/OBSBasicTransform.ui
+++ b/UI/forms/OBSBasicTransform.ui
@@ -79,6 +79,9 @@
           <property name="accessibleName">
            <string>Basic.TransformWindow.PositionX</string>
           </property>
+          <property name="suffix">
+           <string> px</string>
+          </property>
           <property name="decimals">
            <number>4</number>
           </property>
@@ -100,6 +103,9 @@
           </property>
           <property name="accessibleName">
            <string>Basic.TransformWindow.PositionY</string>
+          </property>
+          <property name="suffix">
+           <string> px</string>
           </property>
           <property name="decimals">
            <number>4</number>
@@ -141,6 +147,9 @@
        </property>
        <property name="accessibleName">
         <string>Basic.TransformWindow.Rotation</string>
+       </property>
+       <property name="suffix">
+        <string>°</string>
        </property>
        <property name="minimum">
         <double>-360.000000000000000</double>
@@ -195,6 +204,9 @@
           <property name="accessibleName">
            <string>Basic.TransformWindow.Width</string>
           </property>
+          <property name="suffix">
+           <string> px</string>
+          </property>
           <property name="decimals">
            <number>4</number>
           </property>
@@ -219,6 +231,9 @@
           </property>
           <property name="accessibleName">
            <string>Basic.TransformWindow.Height</string>
+          </property>
+          <property name="suffix">
+           <string> px</string>
           </property>
           <property name="decimals">
            <number>4</number>
@@ -480,6 +495,9 @@
           <property name="accessibleName">
            <string>Basic.TransformWindow.BoundsWidth</string>
           </property>
+          <property name="suffix">
+           <string> px</string>
+          </property>
           <property name="decimals">
            <number>4</number>
           </property>
@@ -504,6 +522,9 @@
           </property>
           <property name="accessibleName">
            <string>Basic.TransformWindow.BoundsHeight</string>
+          </property>
+          <property name="suffix">
+           <string> px</string>
           </property>
           <property name="decimals">
            <number>4</number>
@@ -561,6 +582,9 @@
          <property name="accessibleName">
           <string>Basic.TransformWindow.CropLeft</string>
          </property>
+         <property name="suffix">
+          <string> px</string>
+         </property>
          <property name="maximum">
           <number>100000</number>
          </property>
@@ -582,6 +606,9 @@
          </property>
          <property name="accessibleName">
           <string>Basic.TransformWindow.CropRight</string>
+         </property>
+         <property name="suffix">
+          <string> px</string>
          </property>
          <property name="maximum">
           <number>100000</number>
@@ -631,6 +658,9 @@
          <property name="accessibleName">
           <string>Basic.TransformWindow.CropTop</string>
          </property>
+         <property name="suffix">
+          <string> px</string>
+         </property>
          <property name="maximum">
           <number>100000</number>
          </property>
@@ -652,6 +682,9 @@
          </property>
          <property name="accessibleName">
           <string>Basic.TransformWindow.CropBottom</string>
+         </property>
+         <property name="suffix">
+          <string> px</string>
          </property>
          <property name="maximum">
           <number>100000</number>


### PR DESCRIPTION
### Description
This makes it easier to understand what the
values in the dialog mean.

![after](https://user-images.githubusercontent.com/19962531/170163549-b6b9b112-93ba-4cf7-b378-6ef5ce42e0ac.PNG)

### Motivation and Context
Makes UI better.

### How Has This Been Tested?
Opened dialog to see if the suffixes were correct.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
