### PR TITLE
obs-scripting: add studio mode functions

### DIFF
--- a/deps/obs-scripting/obs-scripting-lua-frontend.c
+++ b/deps/obs-scripting/obs-scripting-lua-frontend.c
@@ -81,6 +81,33 @@ static int set_current_scene(lua_State *script)
 	return 0;
 }
 
+static int get_current_preview_scene(lua_State *script)
+{
+	obs_source_t *source = obs_frontend_get_current_preview_scene();
+	ls_push_libobs_obj(obs_source_t, source, false);
+	return 1;
+}
+
+static int set_current_preview_scene(lua_State *script)
+{
+	obs_source_t *source = NULL;
+	ls_get_libobs_obj(obs_source_t, 1, &source);
+	obs_frontend_set_current_preview_scene(source);
+	return 0;
+}
+
+static int preview_program_mode_active(lua_State *script)
+{
+	lua_pushboolean(script, obs_frontend_preview_program_mode_active());
+	return 1;
+}
+
+static int set_preview_program_mode(lua_State *script)
+{
+	obs_frontend_set_preview_program_mode(lua_toboolean(script, 1) != 0);
+	return 0;
+}
+
 static int get_transitions(lua_State *script)
 {
 	struct obs_frontend_source_list list = {0};
@@ -312,6 +339,10 @@ void add_lua_frontend_funcs(lua_State *script)
 	add_func(get_scenes);
 	add_func(get_current_scene);
 	add_func(set_current_scene);
+	add_func(get_current_preview_scene);
+	add_func(set_current_preview_scene);
+	add_func(preview_program_mode_active);
+	add_func(set_preview_program_mode);
 	add_func(get_transitions);
 	add_func(get_current_transition);
 	add_func(set_current_transition);

--- a/deps/obs-scripting/obs-scripting-python-frontend.c
+++ b/deps/obs-scripting/obs-scripting-python-frontend.c
@@ -106,6 +106,58 @@ static PyObject *set_current_scene(PyObject *self, PyObject *args)
 	return python_none();
 }
 
+static PyObject *get_current_preview_scene(PyObject *self, PyObject *args)
+{
+	obs_source_t *source = obs_frontend_get_current_preview_scene();
+
+	PyObject *py_source;
+	if (!libobs_to_py(obs_source_t, source, false, &py_source)) {
+		obs_source_release(source);
+		return python_none();
+	}
+
+	UNUSED_PARAMETER(self);
+	UNUSED_PARAMETER(args);
+	return py_source;
+}
+
+static PyObject *set_current_preview_scene(PyObject *self, PyObject *args)
+{
+	PyObject *py_source;
+	obs_source_t *source = NULL;
+
+	if (!parse_args(args, "O", &py_source))
+		return python_none();
+	if (!py_to_libobs(obs_source_t, py_source, &source))
+		return python_none();
+
+	UNUSED_PARAMETER(self);
+
+	obs_frontend_set_current_preview_scene(source);
+	return python_none();
+}
+
+static PyObject *preview_program_mode_active(PyObject *self, PyObject *args)
+{
+	if (obs_frontend_preview_program_mode_active()) {
+		Py_RETURN_TRUE;
+	}
+	UNUSED_PARAMETER(self);
+	UNUSED_PARAMETER(args);
+	Py_RETURN_FALSE;
+}
+
+static PyObject *set_preview_program_mode(PyObject *self, PyObject *args)
+{
+	UNUSED_PARAMETER(self);
+	int enabled;
+	if (!parse_args(args, "i", &enabled))
+		return python_none();
+
+	obs_frontend_set_preview_program_mode(enabled != 0);
+	return python_none();
+}
+
 static PyObject *get_transitions(PyObject *self, PyObject *args)
 {
 	struct obs_frontend_source_list list = {0};
@@ -432,6 +484,10 @@ void add_python_frontend_funcs(PyObject *module)
 		DEF_FUNC(get_scenes),
 		DEF_FUNC(get_current_scene),
 		DEF_FUNC(set_current_scene),
+		DEF_FUNC(get_current_preview_scene),
+		DEF_FUNC(set_current_preview_scene),
+		DEF_FUNC(preview_program_mode_active),
+		DEF_FUNC(set_preview_program_mode),
 		DEF_FUNC(get_transitions),
 		DEF_FUNC(get_current_transition),
 		DEF_FUNC(set_current_transition),


### PR DESCRIPTION
### Description
add studio mode functions to scripting
obs_frontend_get_current_preview_scene
obs_frontend_set_current_preview_scene
obs_frontend_preview_program_mode_active
obs_frontend_set_preview_program_mode

### Motivation and Context
they are missing

### How Has This Been Tested?
On windows 64 bits with a lua script

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality) 
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
