### PR TITLE
obs-ffmpeg: Improve dialog text for NVENC errors

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc-helpers.c
+++ b/plugins/obs-ffmpeg/jim-nvenc-helpers.c
@@ -10,6 +10,26 @@ NV_CREATE_INSTANCE_FUNC nv_create_instance = NULL;
 
 #define error(format, ...) blog(LOG_ERROR, "[jim-nvenc] " format, ##__VA_ARGS__)
 
+bool nv_fail(obs_encoder_t *encoder, const char *format, ...)
+{
+	struct dstr message = {0};
+	struct dstr error_message = {0};
+
+	va_list args;
+	va_start(args, format);
+	dstr_vprintf(&message, format, args);
+	va_end(args);
+
+	dstr_printf(&error_message, "NVENC Error: %s", message.array);
+	obs_encoder_set_last_error(encoder, error_message.array);
+	error("%s", error_message.array);
+
+	dstr_free(&error_message);
+	dstr_free(&message);
+
+	return true;
+}
+
 bool nv_failed(obs_encoder_t *encoder, NVENCSTATUS err, const char *func,
 	       const char *call)
 {

--- a/plugins/obs-ffmpeg/jim-nvenc.h
+++ b/plugins/obs-ffmpeg/jim-nvenc.h
@@ -13,5 +13,6 @@ extern const char *nv_error_name(NVENCSTATUS err);
 extern NV_ENCODE_API_FUNCTION_LIST nv;
 extern NV_CREATE_INSTANCE_FUNC nv_create_instance;
 extern bool init_nvenc(obs_encoder_t *encoder);
+bool nv_fail(obs_encoder_t *encoder, const char *format, ...);
 bool nv_failed(obs_encoder_t *encoder, NVENCSTATUS err, const char *func,
 	       const char *call);


### PR DESCRIPTION
### Description
Add dialog messages for lack of 10-bit support, and exceeding the
hardware B-frame limit. Also move code around to test these just once.

### Motivation and Context
Previous dialog messages for these failures were quite cryptic.

### How Has This Been Tested?
Verified both dialog messages appear as desired. Also verified I was able to record SDR H.264/HEVC & HDR HEVC videos successfully if the checks passed.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
