### PR TITLE
libobs,UI: Replace `obs_hotkey_inject_event` with "external" hotkeys

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -639,13 +639,10 @@ void OBSBasicPreview::ProcessClick(const vec2 &pos)
 
 void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 {
+	OBSQTDisplay::mouseReleaseEvent(event);
+
 	if (scrollMode)
 		setCursor(Qt::OpenHandCursor);
-
-	if (locked) {
-		OBSQTDisplay::mouseReleaseEvent(event);
-		return;
-	}
 
 	if (mouseDown) {
 		vec2 pos = GetMouseEventPos(event);

--- a/libobs/obs-hotkey.h
+++ b/libobs/obs-hotkey.h
@@ -273,7 +273,12 @@ EXPORT void obs_enum_hotkey_bindings(obs_hotkey_binding_enum_func func,
 
 /* hotkey event control */
 
-EXPORT void obs_hotkey_inject_event(obs_key_combination_t hotkey, bool pressed);
+OBS_DEPRECATED EXPORT void obs_hotkey_inject_event(obs_key_combination_t hotkey,
+						   bool pressed);
+/* Use for manually triggering hotkeys when the platform hotkeys aren't used,
+ * like when focused on a frontend */
+EXPORT void obs_hotkey_external_set_pressed(obs_key_t key, bool pressed);
+EXPORT void obs_hotkey_external_release_all();
 
 EXPORT void obs_hotkey_enable_background_press(bool enable);
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -169,6 +169,7 @@ bool obs_hotkeys_platform_init(struct obs_core_hotkeys *hotkeys);
 void obs_hotkeys_platform_free(struct obs_core_hotkeys *hotkeys);
 bool obs_hotkeys_platform_is_pressed(obs_hotkeys_platform_t *context,
 				     obs_key_t key);
+bool obs_hotkeys_external_is_pressed(obs_key_t key);
 
 const char *obs_get_hotkey_translation(obs_key_t key, const char *def);
 
@@ -400,6 +401,7 @@ struct obs_core_hotkeys {
 	bool thread_disable_press;
 	bool strict_modifiers;
 	bool reroute_hotkeys;
+	DARRAY(obs_key_t) external_keys;
 	DARRAY(obs_hotkey_binding_t) bindings;
 
 	obs_hotkey_callback_router_func router_func;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Replaces the existing method of injecting hotkeys from the UI (and other
places) with one that doesn't rely on the platform implementation at all.
The new method programatically more closely resembles the platform
implementation and shouldn't cause bugs like the one described under
motivation and context.
A UI for example can set an "external" key to be pressed or released. Libobs
remembers the state of these external keys and looks them up like it would
look up native platform keys when querying hotkeys.

The existing `inject_event` keeps working for now to not break the API,
but should this PR get merged it would only make sense to remove it in the
future, especially since it still has the issues below. I marked it as deprecated
as part of this PR.

This PR should not conflict with #5095 and #3914.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The existing `obs_hotkey_inject_event` method is a bit problematic since
it partly relies on the injected key combination, but also partly on the
native platform implementation. This is because it not only checks for
the modifiers passed in the key combination, but through an `is_pressed`
call in `query_hotkeys` it also check for modifiers on the platform
implementation. If the platform implementation now either doesn't work
at all (like currently on macOS) or is completely disabled when not in
focus (like with the upcoming macOS implementation), hotkeys injected
with modifiers will fail.

You can reproduce the macOS behaviour on Windows by forcing the
native Windows implementation to always return false on
`obs_hotkeys_platform_is_pressed`.
I made [these](https://github.com/gxalpha/obs-studio/actions/runs/2401073563) CI builds for that.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 12.5 Beta:
Triggering hotkeys with modifiers from the UI now works.
Tested:
- Modifierless hotkeys
- Hotkeys with a single modifier, making sure to both work non-strictly as well as strictly with #5095 applied
- Hotkeys with multiple modifiers -> made sure they don't work with modifiers missing
- Modifier-only hotkeys

Windows 11, tested the same as above with CI builds:
- from the UI
- outside the UI (focus on another window)

I tested as well as I could, but it would be great to see other people test
as well.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable)-->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
