### PR TITLE
obs-scripting: Fix missing obs-frontend-api bindings for scripting plugins

### DIFF
--- a/deps/obs-scripting/obslua/CMakeLists.txt
+++ b/deps/obs-scripting/obslua/CMakeLists.txt
@@ -30,9 +30,8 @@ swig_add_library(
 
 target_link_libraries(obslua PRIVATE OBS::scripting OBS::libobs Luajit::Luajit)
 
-set_target_properties(
-  obslua PROPERTIES SWIG_COMPILE_DEFINITIONS
-                    "SWIG_TYPE_TABLE=obslua;SWIG_LUA_INTERPRETER_NO_DEBUG")
+list(APPEND _SWIG_DEFINITIONS "SWIG_TYPE_TABLE=obslua"
+     "SWIG_LUA_INTERPRETER_NO_DEBUG")
 
 set_target_properties(
   obslua
@@ -44,10 +43,14 @@ target_compile_definitions(obslua PRIVATE SWIG_TYPE_TABLE=obslua
                                           SWIG_LUA_INTERPRETER_NO_DEBUG)
 
 if(ENABLE_UI)
+  list(APPEND _SWIG_DEFINITIONS "ENABLE_UI")
   target_link_libraries(obslua PRIVATE OBS::frontend-api)
 
   target_compile_definitions(obslua PRIVATE ENABLE_UI)
 endif()
+
+set_target_properties(obslua PROPERTIES SWIG_COMPILE_DEFINITIONS
+                                        "${_SWIG_DEFINITIONS}")
 
 if(OS_WINDOWS)
   if(MSVC)

--- a/deps/obs-scripting/obspython/CMakeLists.txt
+++ b/deps/obs-scripting/obspython/CMakeLists.txt
@@ -32,12 +32,8 @@ swig_add_library(
 
 target_link_libraries(obspython PRIVATE OBS::scripting OBS::libobs)
 
-set_target_properties(
-  obspython
-  PROPERTIES
-    SWIG_COMPILE_DEFINITIONS
-    "SWIG_TYPE_TABLE=obspython;Py_ENABLE_SHARED=1;SWIG_PYTHON_INTERPRETER_NO_DEBUG"
-)
+list(APPEND _SWIG_DEFINITIONS "SWIG_TYPE_TABLE=obspython" "Py_ENABLE_SHARED=1"
+     "SWIG_PYTHON_INTERPRETER_NO_DEBUG")
 
 target_compile_features(obspython PRIVATE cxx_auto_type c_std_11)
 
@@ -46,10 +42,14 @@ target_compile_definitions(
                     SWIG_PYTHON_INTERPRETER_NO_DEBUG)
 
 if(ENABLE_UI)
+  list(APPEND _SWIG_DEFINITIONS "ENABLE_UI")
   target_link_libraries(obspython PRIVATE OBS::frontend-api)
 
   target_compile_definitions(obspython PRIVATE ENABLE_UI)
 endif()
+
+set_target_properties(obspython PROPERTIES SWIG_COMPILE_DEFINITIONS
+                                           "${_SWIG_DEFINITIONS}")
 
 if(OS_WINDOWS)
   set_target_properties(


### PR DESCRIPTION
### Description
Fixes `obs-frontend-api` symbols not being available to scripting environments since merging the rework.

Fixes https://github.com/obsproject/obs-studio/issues/6539

### Motivation and Context
The required preprocessor definition activating support for `obs-frontend-api` within the scripting plugin needs to be set for the actual C/C++ compiler as well as the swig pre-compiler.

These commits ensure that the definition exists if UI is enabled in the project.

### How Has This Been Tested?
* Compiled locally and checked for existing symbols using the Lua file provided in [#6539](https://github.com/obsproject/obs-studio/issues/6539).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
