### PR TITLE
libobs: Deprecate obs_hotkey_enable_strict_modifiers

### DIFF
--- a/libobs/obs-hotkey.h
+++ b/libobs/obs-hotkey.h
@@ -277,7 +277,7 @@ EXPORT void obs_hotkey_inject_event(obs_key_combination_t hotkey, bool pressed);
 
 EXPORT void obs_hotkey_enable_background_press(bool enable);
 
-EXPORT void obs_hotkey_enable_strict_modifiers(bool enable);
+OBS_DEPRECATED EXPORT void obs_hotkey_enable_strict_modifiers(bool enable);
 
 /* hotkey callback routing (trigger callbacks through e.g. a UI thread) */
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
As discussed, deprecates `obs_hotkey_enable_strict_modifiers` so that we can get rid of it later.
I would probably push to master but
a) I'm too scared and
b) I don't actually know how

- Follow-up to #5095

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This got changed in the UI and we don't need it for developers either.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Calling it will now warn that it's deprecated.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable) I guess? Or at least in the future it will
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
