### PR TITLE
flatpak: Install CMake config files

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -444,6 +444,7 @@
         "-DYOUTUBE_SECRET_HASH=$YOUTUBE_SECRET_HASH"
       ],
       "post-install": [
+        "cmake --install . --component obs_libraries",
         "install -d /app/plugins",
         "install -d /app/extensions/Plugins"
       ],


### PR DESCRIPTION
### Description

Add a post-install command to the OBS module that installs the `obs_libraries` component, which provides CMake config files.

### Motivation and Context

CMake config files are required for building OBS plugins with the Flatpak as a runtime.

Builds from the `master` branch stopped shipping the `LibObsConfig.cmake` file, and never shipped the `obs-frontend-apiConfig.cmake` file.

Fixes #6556 

### How Has This Been Tested?

Built locally, the resulting Flatpak ships the following CMake config files:

- `/app/lib/cmake/libobs/libobsConfig.cmake`
- `/app/lib/cmake/libobs/libobsConfigVersion.cmake`
- `/app/lib/cmake/libobs/libobsTargets.cmake`
- `/app/lib/cmake/libobs/libobsTargets-release.cmake`
- `/app/lib/cmake/obs-frontend-api/obs-frontend-apiConfig.cmake`
- `/app/lib/cmake/obs-frontend-api/obs-frontend-apiConfigVersion.cmake`
- `/app/lib/cmake/obs-frontend-api/obs-frontend-apiTargets.cmake`
- `/app/lib/cmake/obs-frontend-api/obs-frontend-apiTargets-release.cmake`


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
