### PR TITLE
libobs: Should not free audio_output before clearing view->channels

### DIFF
--- a/libobs/media-io/audio-io.h
+++ b/libobs/media-io/audio-io.h
@@ -203,6 +203,8 @@ static inline uint64_t ns_to_audio_frames(size_t sample_rate, uint64_t frames)
 	return util_mul_div64(frames, sample_rate, 1000000000ULL);
 }
 
+void stop_audio_thread(audio_t *audio);
+
 #define AUDIO_OUTPUT_SUCCESS 0
 #define AUDIO_OUTPUT_INVALIDPARAM -1
 #define AUDIO_OUTPUT_FAIL -2

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -803,8 +803,8 @@ static void stop_audio(void)
 	struct obs_core_audio *audio = &obs->audio;
 
 	if (audio->audio) {
-		audio_output_close(audio->audio);
-		audio->audio = NULL;
+		/* Here we just exit audio_thread, and won't free related memory because there are alive channel sources */
+		stop_audio_thread(audio->audio);
 	}
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When `stop_audio()` is called,  `view->channels` has not been cleared yet, where maybe storage global output/input audio source.
So variables related with audio should not be deleted in stop_audio().

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
fix possible crash

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
enable global desktop audio, exit OBS

### Types of changes
Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -  -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
