### PR TITLE
UI: Settings dialog truncate label cleanup/fixes

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -366,7 +366,7 @@ void OBSAdvAudioCtrl::OBSSourceRenamed(void *param, calldata_t *calldata)
 	QString newName = QT_UTF8(calldata_string(calldata, "new_name"));
 
 	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param),
-				  "SetSourceName", Q_ARG(QString &, newName));
+				  "SetSourceName", Q_ARG(QString, newName));
 }
 
 /* ------------------------------------------------------------------------- */
@@ -699,7 +699,7 @@ void OBSAdvAudioCtrl::SetIconVisible(bool visible)
 	visible ? iconLabel->show() : iconLabel->hide();
 }
 
-void OBSAdvAudioCtrl::SetSourceName(QString &newName)
+void OBSAdvAudioCtrl::SetSourceName(QString newName)
 {
 	TruncateLabel(nameLabel, newName);
 }

--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -87,7 +87,7 @@ public slots:
 	void SourceMonitoringTypeChanged(int type);
 	void SourceMixersChanged(uint32_t mixers);
 	void SourceBalanceChanged(int balance);
-	void SetSourceName(QString newNamw);
+	void SetSourceName(QString newName);
 
 	void volumeChanged(double db);
 	void percentChanged(int percent);

--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -87,7 +87,7 @@ public slots:
 	void SourceMonitoringTypeChanged(int type);
 	void SourceMixersChanged(uint32_t mixers);
 	void SourceBalanceChanged(int balance);
-	void SetSourceName(QString &newNamw);
+	void SetSourceName(QString newNamw);
 
 	void volumeChanged(double db);
 	void percentChanged(int percent);

--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -385,7 +385,7 @@ static void SetLabelText(QLabel *label, const QString &newText)
 		label->setText(newText);
 }
 
-void TruncateLabel(QLabel *label, QString &newText, int length)
+void TruncateLabel(QLabel *label, QString newText, int length)
 {
 	if (newText.length() < length) {
 		label->setToolTip(QString());

--- a/UI/qt-wrappers.hpp
+++ b/UI/qt-wrappers.hpp
@@ -120,5 +120,5 @@ QString OpenFile(QWidget *parent, QString title, QString path,
 QStringList OpenFiles(QWidget *parent, QString title, QString path,
 		      QString extensions);
 
-void TruncateLabel(QLabel *label, QString &newText,
+void TruncateLabel(QLabel *label, QString newText,
 		   int length = MAX_LABEL_LENGTH);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2726,8 +2726,6 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	loading = false;
 }
 
-#define TRUNCATE_TEXT_LENGTH 80
-
 template<typename Func>
 static inline void
 LayoutHotkey(OBSBasicSettings *settings, obs_hotkey_id id, obs_hotkey_t *key,
@@ -2738,13 +2736,7 @@ LayoutHotkey(OBSBasicSettings *settings, obs_hotkey_id id, obs_hotkey_t *key,
 	QString text = QT_UTF8(obs_hotkey_get_description(key));
 
 	label->setProperty("fullName", text);
-
-	if (text.length() > TRUNCATE_TEXT_LENGTH) {
-		text = text.left(TRUNCATE_TEXT_LENGTH);
-		text += "...'";
-	}
-
-	label->setText(text);
+	TruncateLabel(label, text);
 
 	OBSHotkeyWidget *hw = nullptr;
 
@@ -2776,14 +2768,7 @@ static QLabel *makeLabel(const OBSSource &source, Func &&)
 	OBSSourceLabel *label = new OBSSourceLabel(source);
 	label->setStyleSheet("font-weight: bold;");
 	QString name = QT_UTF8(obs_source_get_name(source));
-
-	if (name.length() > TRUNCATE_TEXT_LENGTH) {
-		label->setToolTip(name);
-		name = name.left(TRUNCATE_TEXT_LENGTH);
-		name += "...";
-	}
-
-	label->setText(name);
+	TruncateLabel(label, name);
 
 	return label;
 }

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2477,6 +2477,7 @@ void OBSBasicSettings::LoadAudioSources()
 					  pttCB, pttSB);
 
 		auto label = new OBSSourceLabel(source);
+		TruncateLabel(label, label->text());
 		label->setMinimumSize(QSize(170, 0));
 		label->setAlignment(Qt::AlignRight | Qt::AlignTrailing |
 				    Qt::AlignVCenter);


### PR DESCRIPTION
### Description
Commit 1: Update hotkeys to use new truncate label function
Commit 2: Truncate push-to-mute / push-to-talk source name labels

### Motivation and Context
Wanted to use new function introduced with https://github.com/obsproject/obs-studio/commit/0d0b65e8c82d29e4b7068153c86b1745ac7adcfb

Also noticed push-to-* hotkey labels weren't truncated.

### How Has This Been Tested?
Gave a source a really long name and made sure it rendered correctly in the settings dialog.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
