### PR TITLE
obs-ffmpeg: Fix media resetting to 0x0 when finished

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -1004,3 +1004,13 @@ void mp_media_seek_to(mp_media_t *m, int64_t pos)
 
 	os_sem_post(m->sem);
 }
+
+uint32_t mp_media_get_width(mp_media_t *m)
+{
+	return m->v.decoder ? (uint32_t)m->v.decoder->width : 0;
+}
+
+uint32_t mp_media_get_height(mp_media_t *m)
+{
+	return m->v.decoder ? (uint32_t)m->v.decoder->height : 0;
+}

--- a/deps/media-playback/media-playback/media.h
+++ b/deps/media-playback/media-playback/media.h
@@ -138,6 +138,9 @@ extern void mp_media_play_pause(mp_media_t *media, bool pause);
 extern int64_t mp_get_current_time(mp_media_t *m);
 extern void mp_media_seek_to(mp_media_t *m, int64_t pos);
 
+extern uint32_t mp_media_get_width(mp_media_t *m);
+extern uint32_t mp_media_get_height(mp_media_t *m);
+
 /* #define DETAILED_DEBUG_INFO */
 
 #ifdef __cplusplus

--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -795,6 +795,18 @@ static obs_missing_files_t *ffmpeg_source_missingfiles(void *data)
 	return files;
 }
 
+static uint32_t ffmpeg_source_get_width(void *data)
+{
+	struct ffmpeg_source *s = data;
+	return mp_media_get_width(&s->media);
+}
+
+static uint32_t ffmpeg_source_get_height(void *data)
+{
+	struct ffmpeg_source *s = data;
+	return mp_media_get_height(&s->media);
+}
+
 struct obs_source_info ffmpeg_source = {
 	.id = "ffmpeg_source",
 	.type = OBS_SOURCE_TYPE_INPUT,
@@ -819,4 +831,6 @@ struct obs_source_info ffmpeg_source = {
 	.media_get_time = ffmpeg_source_get_time,
 	.media_set_time = ffmpeg_source_set_time,
 	.media_get_state = ffmpeg_source_get_state,
+	.get_width = ffmpeg_source_get_width,
+	.get_height = ffmpeg_source_get_height,
 };


### PR DESCRIPTION
### Description
This remembers the previous media size when finished, so
the source size in the preview / transform dialog stays
constant.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/2310

### How Has This Been Tested?
Played a media source and made sure the size didn't reset when finished.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
