### PR TITLE
libobs: Add support for multiple video mixes

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -103,6 +103,7 @@ target_sources(
           forms/OBSBasicSettings.ui
           forms/OBSBasicSourceSelect.ui
           forms/OBSBasicTransform.ui
+          forms/OBSBasicVCamConfig.ui
           forms/OBSExtraBrowsers.ui
           forms/OBSImporter.ui
           forms/OBSLogReply.ui
@@ -257,6 +258,8 @@ target_sources(
           window-basic-transform.cpp
           window-basic-transform.hpp
           window-basic-preview.hpp
+          window-basic-vcam-config.cpp
+          window-basic-vcam-config.hpp
           window-dock.cpp
           window-dock.hpp
           window-importer.cpp

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -700,6 +700,17 @@ Basic.Main.Ungroup="Ungroup"
 Basic.Main.GridMode="Grid Mode"
 Basic.Main.ListMode="List Mode"
 
+# virtual camera configuration
+Basic.Main.VirtualCamConfig="Configure Virtual Camera"
+Basic.VCam.VirtualCamera="Virtual Camera"
+Basic.VCam.OutputType="Output Type"
+Basic.VCam.OutputSelection="Output Selection"
+Basic.VCam.Internal="Internal"
+Basic.VCam.InternalDefault="Program Output (Default)"
+Basic.VCam.InternalPreview="Preview Output"
+Basic.VCam.Start="Start"
+Basic.VCam.Update="Update"
+
 # basic mode file menu
 Basic.MainMenu.File="&File"
 Basic.MainMenu.File.Export="&Export"

--- a/UI/forms/OBSBasicVCamConfig.ui
+++ b/UI/forms/OBSBasicVCamConfig.ui
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OBSBasicVCamConfig</class>
+ <widget class="QDialog" name="OBSBasicVCamConfig">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>170</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Basic.VCam.VirtualCamera</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="outputTypeLabel">
+     <property name="text">
+      <string>Basic.VCam.OutputType</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="outputType">
+     <item>
+      <property name="text">
+       <string>Basic.VCam.Internal</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Basic.Scene</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Basic.Main.Source</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="outputSelectionLabel">
+     <property name="text">
+      <string>Basic.VCam.OutputSelection</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="outputSelection"/>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>OBSBasicVCamConfig</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>OBSBasicVCamConfig</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/UI/record-button.cpp
+++ b/UI/record-button.cpp
@@ -18,19 +18,143 @@ void RecordButton::resizeEvent(QResizeEvent *event)
 	event->accept();
 }
 
-void ReplayBufferButton::resizeEvent(QResizeEvent *event)
+static QWidget *firstWidget(QLayoutItem *item)
+{
+	auto widget = item->widget();
+	if (widget)
+		return widget;
+
+	auto layout = item->layout();
+	if (!layout)
+		return nullptr;
+
+	auto n = layout->count();
+	for (auto i = 0, n = layout->count(); i < n; i++) {
+		widget = firstWidget(layout->itemAt(i));
+		if (widget)
+			return widget;
+	}
+	return nullptr;
+}
+
+static QWidget *lastWidget(QLayoutItem *item)
+{
+	auto widget = item->widget();
+	if (widget)
+		return widget;
+
+	auto layout = item->layout();
+	if (!layout)
+		return nullptr;
+
+	auto n = layout->count();
+	for (auto i = layout->count(); i > 0; i--) {
+		widget = lastWidget(layout->itemAt(i - 1));
+		if (widget)
+			return widget;
+	}
+	return nullptr;
+}
+
+static QWidget *getNextWidget(QBoxLayout *container, QLayoutItem *item)
+{
+	for (auto i = 1, n = container->count(); i < n; i++) {
+		if (container->itemAt(i - 1) == item)
+			return firstWidget(container->itemAt(i));
+	}
+	return nullptr;
+}
+
+ControlsSplitButton::ControlsSplitButton(const QString &text,
+					 const QVariant &themeID,
+					 void (OBSBasic::*clicked)())
+	: QHBoxLayout(OBSBasic::Get())
+{
+	button.reset(new QPushButton(text));
+	button->setCheckable(true);
+	button->setProperty("themeID", themeID);
+
+	button->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+	button->installEventFilter(this);
+
+	OBSBasic *main = OBSBasic::Get();
+	connect(button.data(), &QPushButton::clicked, main, clicked);
+
+	addWidget(button.data());
+}
+
+void ControlsSplitButton::addIcon(const QString &name, const QVariant &themeID,
+				  void (OBSBasic::*clicked)())
+{
+	icon.reset(new QPushButton());
+	icon->setAccessibleName(name);
+	icon->setToolTip(name);
+	icon->setChecked(false);
+	icon->setProperty("themeID", themeID);
+
+	QSizePolicy sp;
+	sp.setHeightForWidth(true);
+	icon->setSizePolicy(sp);
+
+	OBSBasic *main = OBSBasic::Get();
+	connect(icon.data(), &QAbstractButton::clicked, main, clicked);
+
+	addWidget(icon.data());
+	QWidget::setTabOrder(button.data(), icon.data());
+
+	auto next = getNextWidget(main->ui->buttonsVLayout, this);
+	if (next)
+		QWidget::setTabOrder(icon.data(), next);
+}
+
+void ControlsSplitButton::removeIcon()
+{
+	icon.reset();
+}
+
+void ControlsSplitButton::insert(int index)
 {
 	OBSBasic *main = OBSBasic::Get();
-	if (!main->replay)
-		return;
+	auto count = main->ui->buttonsVLayout->count();
+	if (index < 0)
+		index = 0;
+	else if (index > count)
+		index = count;
 
-	QSize replaySize = main->replay->size();
-	int height = main->ui->recordButton->size().height();
+	main->ui->buttonsVLayout->insertLayout(index, this);
 
-	if (replaySize.height() != height || replaySize.width() != height) {
-		main->replay->setMinimumSize(height, height);
-		main->replay->setMaximumSize(height, height);
+	QWidget *prev = button.data();
+
+	if (index > 0) {
+		prev = lastWidget(main->ui->buttonsVLayout->itemAt(index - 1));
+		if (prev)
+			QWidget::setTabOrder(prev, button.data());
+		prev = button.data();
 	}
 
-	event->accept();
+	if (icon) {
+		QWidget::setTabOrder(button.data(), icon.data());
+		prev = icon.data();
+	}
+
+	if (index < count) {
+		auto next = firstWidget(
+			main->ui->buttonsVLayout->itemAt(index + 1));
+		if (next)
+			QWidget::setTabOrder(prev, next);
+	}
+}
+
+bool ControlsSplitButton::eventFilter(QObject *obj, QEvent *event)
+{
+	if (event->type() == QEvent::Resize && icon) {
+		QSize iconSize = icon->size();
+		int height = button->height();
+
+		if (iconSize.height() != height || iconSize.width() != height) {
+			icon->setMinimumSize(height, height);
+			icon->setMaximumSize(height, height);
+		}
+	}
+	return QObject::eventFilter(obj, event);
 }

--- a/UI/record-button.hpp
+++ b/UI/record-button.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <QPushButton>
+#include <QBoxLayout>
+#include <QScopedPointer>
 
 class RecordButton : public QPushButton {
 	Q_OBJECT
@@ -11,15 +13,27 @@ public:
 	virtual void resizeEvent(QResizeEvent *event) override;
 };
 
-class ReplayBufferButton : public QPushButton {
+class OBSBasic;
+
+class ControlsSplitButton : public QHBoxLayout {
 	Q_OBJECT
 
 public:
-	inline ReplayBufferButton(const QString &text,
-				  QWidget *parent = nullptr)
-		: QPushButton(text, parent)
-	{
-	}
+	ControlsSplitButton(const QString &text, const QVariant &themeID,
+			    void (OBSBasic::*clicked)());
 
-	virtual void resizeEvent(QResizeEvent *event) override;
+	void addIcon(const QString &name, const QVariant &themeID,
+		     void (OBSBasic::*clicked)());
+	void removeIcon();
+	void insert(int index);
+
+	inline QPushButton *first() { return button.data(); }
+	inline QPushButton *second() { return icon.data(); }
+
+protected:
+	virtual bool eventFilter(QObject *obj, QEvent *event) override;
+
+private:
+	QScopedPointer<QPushButton> button;
+	QScopedPointer<QPushButton> icon;
 };

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -5,6 +5,7 @@
 #include "audio-encoders.hpp"
 #include "window-basic-main.hpp"
 #include "window-basic-main-outputs.hpp"
+#include "window-basic-vcam-config.hpp"
 
 using namespace std;
 
@@ -178,6 +179,9 @@ static void OBSStopVirtualCam(void *data, calldata_t *params)
 	os_atomic_set_bool(&virtualcam_active, false);
 	QMetaObject::invokeMethod(output->main, "OnVirtualCamStop",
 				  Q_ARG(int, code));
+
+	obs_output_set_media(output->virtualCam, nullptr, nullptr);
+	OBSBasicVCamConfig::StopVideo();
 }
 
 /* ------------------------------------------------------------------------ */
@@ -226,8 +230,11 @@ inline BasicOutputHandler::BasicOutputHandler(OBSBasic *main_) : main(main_)
 bool BasicOutputHandler::StartVirtualCam()
 {
 	if (main->vcamEnabled) {
-		obs_output_set_media(virtualCam, obs_get_video(),
-				     obs_get_audio());
+		video_t *video = OBSBasicVCamConfig::StartVideo();
+		if (!video)
+			return false;
+
+		obs_output_set_media(virtualCam, video, obs_get_audio());
 		if (!Active())
 			SetupOutputs();
 

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -21,6 +21,7 @@
 #include <QMessageBox>
 #include <util/dstr.hpp>
 #include "window-basic-main.hpp"
+#include "window-basic-vcam-config.hpp"
 #include "display-helpers.hpp"
 #include "window-namedialog.hpp"
 #include "menu-button.hpp"
@@ -283,6 +284,9 @@ void OBSBasic::OverrideTransition(OBSSource transition)
 		obs_transition_swap_begin(transition, oldTransition);
 		obs_set_output_source(0, transition);
 		obs_transition_swap_end(transition, oldTransition);
+
+		// Transition overrides don't raise an event so we need to call update directly
+		OBSBasicVCamConfig::UpdateOutputSource();
 	}
 }
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -52,6 +52,7 @@
 #include "window-basic-main.hpp"
 #include "window-basic-stats.hpp"
 #include "window-basic-main-outputs.hpp"
+#include "window-basic-vcam-config.hpp"
 #include "window-log-reply.hpp"
 #include "window-projector.hpp"
 #include "window-remux.hpp"
@@ -1622,16 +1623,15 @@ void OBSBasic::ReplayBufferClicked()
 
 void OBSBasic::AddVCamButton()
 {
-	vcamButton = new ReplayBufferButton(QTStr("Basic.Main.StartVirtualCam"),
-					    this);
-	vcamButton->setCheckable(true);
-	connect(vcamButton.data(), &QPushButton::clicked, this,
-		&OBSBasic::VCamButtonClicked);
+	OBSBasicVCamConfig::Init();
 
-	vcamButton->setProperty("themeID", "vcamButton");
-	ui->buttonsVLayout->insertWidget(2, vcamButton);
-	setTabOrder(ui->recordButton, vcamButton);
-	setTabOrder(vcamButton, ui->modeSwitch);
+	vcamButton = new ControlsSplitButton(
+		QTStr("Basic.Main.StartVirtualCam"), "vcamButton",
+		&OBSBasic::VCamButtonClicked);
+	vcamButton->addIcon(QTStr("Basic.Main.VirtualCamConfig"),
+			    QStringLiteral("configIconSmall"),
+			    &OBSBasic::VCamConfigButtonClicked);
+	vcamButton->insert(2);
 }
 
 void OBSBasic::ResetOutputs()
@@ -1647,28 +1647,13 @@ void OBSBasic::ResetOutputs()
 					   : CreateSimpleOutputHandler(this));
 
 		delete replayBufferButton;
-		delete replayLayout;
 
 		if (outputHandler->replayBuffer) {
-			replayBufferButton = new ReplayBufferButton(
-				QTStr("Basic.Main.StartReplayBuffer"), this);
-			replayBufferButton->setCheckable(true);
-			connect(replayBufferButton.data(),
-				&QPushButton::clicked, this,
+			replayBufferButton = new ControlsSplitButton(
+				QTStr("Basic.Main.StartReplayBuffer"),
+				"replayBufferButton",
 				&OBSBasic::ReplayBufferClicked);
-
-			replayBufferButton->setSizePolicy(QSizePolicy::Ignored,
-							  QSizePolicy::Fixed);
-
-			replayLayout = new QHBoxLayout(this);
-			replayLayout->addWidget(replayBufferButton);
-
-			replayBufferButton->setProperty("themeID",
-							"replayBufferButton");
-			ui->buttonsVLayout->insertLayout(2, replayLayout);
-			setTabOrder(ui->recordButton, replayBufferButton);
-			setTabOrder(replayBufferButton,
-				    ui->buttonsVLayout->itemAt(3)->widget());
+			replayBufferButton->insert(2);
 		}
 
 		if (sysTrayReplayBuffer)
@@ -7257,19 +7242,19 @@ void OBSBasic::StartReplayBuffer()
 		return;
 
 	if (!UIValidation::NoSourcesConfirmation(this)) {
-		replayBufferButton->setChecked(false);
+		replayBufferButton->first()->setChecked(false);
 		return;
 	}
 
 	if (!OutputPathValid()) {
 		OutputPathInvalidMessage();
-		replayBufferButton->setChecked(false);
+		replayBufferButton->first()->setChecked(false);
 		return;
 	}
 
 	if (LowDiskSpace()) {
 		DiskSpaceMessage();
-		replayBufferButton->setChecked(false);
+		replayBufferButton->first()->setChecked(false);
 		return;
 	}
 
@@ -7279,7 +7264,7 @@ void OBSBasic::StartReplayBuffer()
 	SaveProject();
 
 	if (!outputHandler->StartReplayBuffer()) {
-		replayBufferButton->setChecked(false);
+		replayBufferButton->first()->setChecked(false);
 	} else if (os_atomic_load_bool(&recording_paused)) {
 		ShowReplayBufferPauseWarning();
 	}
@@ -7290,10 +7275,12 @@ void OBSBasic::ReplayBufferStopping()
 	if (!outputHandler || !outputHandler->replayBuffer)
 		return;
 
-	replayBufferButton->setText(QTStr("Basic.Main.StoppingReplayBuffer"));
+	replayBufferButton->first()->setText(
+		QTStr("Basic.Main.StoppingReplayBuffer"));
 
 	if (sysTrayReplayBuffer)
-		sysTrayReplayBuffer->setText(replayBufferButton->text());
+		sysTrayReplayBuffer->setText(
+			replayBufferButton->first()->text());
 
 	replayBufferStopping = true;
 	if (api)
@@ -7318,11 +7305,13 @@ void OBSBasic::ReplayBufferStart()
 	if (!outputHandler || !outputHandler->replayBuffer)
 		return;
 
-	replayBufferButton->setText(QTStr("Basic.Main.StopReplayBuffer"));
-	replayBufferButton->setChecked(true);
+	replayBufferButton->first()->setText(
+		QTStr("Basic.Main.StopReplayBuffer"));
+	replayBufferButton->first()->setChecked(true);
 
 	if (sysTrayReplayBuffer)
-		sysTrayReplayBuffer->setText(replayBufferButton->text());
+		sysTrayReplayBuffer->setText(
+			replayBufferButton->first()->text());
 
 	replayBufferStopping = false;
 	if (api)
@@ -7375,11 +7364,13 @@ void OBSBasic::ReplayBufferStop(int code)
 	if (!outputHandler || !outputHandler->replayBuffer)
 		return;
 
-	replayBufferButton->setText(QTStr("Basic.Main.StartReplayBuffer"));
-	replayBufferButton->setChecked(false);
+	replayBufferButton->first()->setText(
+		QTStr("Basic.Main.StartReplayBuffer"));
+	replayBufferButton->first()->setChecked(false);
 
 	if (sysTrayReplayBuffer)
-		sysTrayReplayBuffer->setText(replayBufferButton->text());
+		sysTrayReplayBuffer->setText(
+			replayBufferButton->first()->text());
 
 	blog(LOG_INFO, REPLAY_BUFFER_STOP);
 
@@ -7428,7 +7419,7 @@ void OBSBasic::StartVirtualCam()
 	SaveProject();
 
 	if (!outputHandler->StartVirtualCam()) {
-		vcamButton->setChecked(false);
+		vcamButton->first()->setChecked(false);
 	}
 }
 
@@ -7450,10 +7441,10 @@ void OBSBasic::OnVirtualCamStart()
 	if (!outputHandler || !outputHandler->virtualCam)
 		return;
 
-	vcamButton->setText(QTStr("Basic.Main.StopVirtualCam"));
+	vcamButton->first()->setText(QTStr("Basic.Main.StopVirtualCam"));
 	if (sysTrayVirtualCam)
 		sysTrayVirtualCam->setText(QTStr("Basic.Main.StopVirtualCam"));
-	vcamButton->setChecked(true);
+	vcamButton->first()->setChecked(true);
 
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_VIRTUALCAM_STARTED);
@@ -7468,10 +7459,10 @@ void OBSBasic::OnVirtualCamStop(int)
 	if (!outputHandler || !outputHandler->virtualCam)
 		return;
 
-	vcamButton->setText(QTStr("Basic.Main.StartVirtualCam"));
+	vcamButton->first()->setText(QTStr("Basic.Main.StartVirtualCam"));
 	if (sysTrayVirtualCam)
 		sysTrayVirtualCam->setText(QTStr("Basic.Main.StartVirtualCam"));
-	vcamButton->setChecked(false);
+	vcamButton->first()->setChecked(false);
 
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_VIRTUALCAM_STOPPED);
@@ -7623,12 +7614,18 @@ void OBSBasic::VCamButtonClicked()
 		StopVirtualCam();
 	} else {
 		if (!UIValidation::NoSourcesConfirmation(this)) {
-			vcamButton->setChecked(false);
+			vcamButton->first()->setChecked(false);
 			return;
 		}
 
 		StartVirtualCam();
 	}
+}
+
+void OBSBasic::VCamConfigButtonClicked()
+{
+	OBSBasicVCamConfig config(this);
+	config.exec();
 }
 
 void OBSBasic::on_settingsButton_clicked()
@@ -9757,6 +9754,7 @@ void OBSBasic::PauseRecording()
 
 		os_atomic_set_bool(&recording_paused, true);
 
+		auto replay = replayBufferButton->second();
 		if (replay)
 			replay->setEnabled(false);
 
@@ -9801,6 +9799,7 @@ void OBSBasic::UnpauseRecording()
 
 		os_atomic_set_bool(&recording_paused, false);
 
+		auto replay = replayBufferButton->second();
 		if (replay)
 			replay->setEnabled(true);
 
@@ -9877,28 +9876,13 @@ void OBSBasic::UpdateReplayBuffer(bool activate)
 {
 	if (!activate || !outputHandler ||
 	    !outputHandler->ReplayBufferActive()) {
-		replay.reset();
+		replayBufferButton->removeIcon();
 		return;
 	}
 
-	replay.reset(new QPushButton());
-	replay->setAccessibleName(QTStr("Basic.Main.SaveReplay"));
-	replay->setToolTip(QTStr("Basic.Main.SaveReplay"));
-	replay->setChecked(false);
-	replay->setProperty("themeID",
-			    QVariant(QStringLiteral("replayIconSmall")));
-
-	QSizePolicy sp;
-	sp.setHeightForWidth(true);
-	replay->setSizePolicy(sp);
-
-	connect(replay.data(), &QAbstractButton::clicked, this,
-		&OBSBasic::ReplayBufferSave);
-	replayLayout->addWidget(replay.data());
-	setTabOrder(replayLayout->itemAt(0)->widget(),
-		    replayLayout->itemAt(1)->widget());
-	setTabOrder(replayLayout->itemAt(1)->widget(),
-		    ui->buttonsVLayout->itemAt(3)->widget());
+	replayBufferButton->addIcon(QTStr("Basic.Main.SaveReplay"),
+				    QStringLiteral("replayIconSmall"),
+				    &OBSBasic::ReplayBufferSave);
 }
 
 #define MBYTE (1024ULL * 1024ULL)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -178,7 +178,7 @@ class OBSBasic : public OBSMainWindow {
 	friend class AutoConfig;
 	friend class AutoConfigStreamPage;
 	friend class RecordButton;
-	friend class ReplayBufferButton;
+	friend class ControlsSplitButton;
 	friend class ExtraBrowsersModel;
 	friend class ExtraBrowsersDelegate;
 	friend class DeviceCaptureToolbar;
@@ -298,12 +298,10 @@ private:
 	QPointer<QMenu> startStreamMenu;
 
 	QPointer<QPushButton> transitionButton;
-	QPointer<QPushButton> replayBufferButton;
-	QPointer<QHBoxLayout> replayLayout;
+	QPointer<ControlsSplitButton> replayBufferButton;
 	QScopedPointer<QPushButton> pause;
-	QScopedPointer<QPushButton> replay;
 
-	QPointer<QPushButton> vcamButton;
+	QPointer<ControlsSplitButton> vcamButton;
 	bool vcamEnabled = false;
 
 	QScopedPointer<QSystemTrayIcon> trayIcon;
@@ -1038,6 +1036,7 @@ private slots:
 	void on_streamButton_clicked();
 	void on_recordButton_clicked();
 	void VCamButtonClicked();
+	void VCamConfigButtonClicked();
 	void on_settingsButton_clicked();
 	void Screenshot(OBSSource source_ = nullptr);
 	void ScreenshotSelectedSource();

--- a/UI/window-basic-vcam-config.cpp
+++ b/UI/window-basic-vcam-config.cpp
@@ -1,0 +1,264 @@
+#include "window-basic-vcam-config.hpp"
+#include "window-basic-main.hpp"
+#include "qt-wrappers.hpp"
+#include "remote-text.hpp"
+#include <util/util.hpp>
+#include <util/platform.h>
+#include <platform.hpp>
+#include <mutex>
+
+using namespace std;
+
+enum class VCamOutputType {
+	Internal,
+	Scene,
+	Source,
+};
+
+enum class VCamInternalType {
+	Default,
+	Preview,
+};
+
+struct VCamConfig {
+	VCamOutputType type = VCamOutputType::Internal;
+	VCamInternalType internal = VCamInternalType::Default;
+	string scene;
+	string source;
+};
+
+static VCamConfig *vCamConfig = nullptr;
+
+OBSBasicVCamConfig::OBSBasicVCamConfig(QWidget *parent)
+	: QDialog(parent), ui(new Ui::OBSBasicVCamConfig)
+{
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+	ui->setupUi(this);
+
+	auto type = (int)vCamConfig->type;
+	ui->outputType->setCurrentIndex(type);
+	OutputTypeChanged(type);
+	connect(ui->outputType,
+		static_cast<void (QComboBox::*)(int)>(
+			&QComboBox::currentIndexChanged),
+		this, &OBSBasicVCamConfig::OutputTypeChanged);
+
+	auto start = ui->buttonBox->button(QDialogButtonBox::Ok);
+	if (!obs_frontend_virtualcam_active())
+		start->setText(QTStr("Basic.VCam.Start"));
+	else
+		start->setText(QTStr("Basic.VCam.Update"));
+	connect(start, &QPushButton::clicked, this,
+		&OBSBasicVCamConfig::SaveAndStart);
+}
+
+void OBSBasicVCamConfig::OutputTypeChanged(int type)
+{
+	auto list = ui->outputSelection;
+	list->clear();
+
+	switch ((VCamOutputType)type) {
+	case VCamOutputType::Internal:
+		list->addItem(QTStr("Basic.VCam.InternalDefault"));
+		list->addItem(QTStr("Basic.VCam.InternalPreview"));
+		list->setCurrentIndex((int)vCamConfig->internal);
+		break;
+
+	case VCamOutputType::Scene: {
+		// Scenes in default order
+		BPtr<char *> scenes = obs_frontend_get_scene_names();
+		int idx = 0;
+		for (char **temp = scenes; *temp; temp++) {
+			list->addItem(*temp);
+
+			if (vCamConfig->scene.compare(*temp) == 0)
+				list->setCurrentIndex(list->count() - 1);
+		}
+		break;
+	}
+
+	case VCamOutputType::Source: {
+		// Sources in alphabetical order
+		vector<string> sources;
+		auto AddSource = [&](obs_source_t *source) {
+			auto name = obs_source_get_name(source);
+			auto flags = obs_source_get_output_flags(source);
+
+			if (!(obs_source_get_output_flags(source) &
+			      OBS_SOURCE_VIDEO))
+				return;
+
+			sources.push_back(name);
+		};
+		using AddSource_t = decltype(AddSource);
+
+		obs_enum_sources(
+			[](void *data, obs_source_t *source) {
+				auto &AddSource =
+					*static_cast<AddSource_t *>(data);
+				if (!obs_source_removed(source))
+					AddSource(source);
+				return true;
+			},
+			static_cast<void *>(&AddSource));
+
+		// Sort and select current item
+		sort(sources.begin(), sources.end());
+		for (auto &&source : sources) {
+			list->addItem(source.c_str());
+
+			if (vCamConfig->source == source)
+				list->setCurrentIndex(list->count() - 1);
+		}
+		break;
+	}
+	}
+}
+
+void OBSBasicVCamConfig::SaveAndStart()
+{
+	auto type = (VCamOutputType)ui->outputType->currentIndex();
+	auto out = ui->outputSelection;
+	switch (type) {
+	case VCamOutputType::Internal:
+		vCamConfig->internal = (VCamInternalType)out->currentIndex();
+		break;
+	case VCamOutputType::Scene:
+		vCamConfig->scene = out->currentText().toStdString();
+		break;
+	case VCamOutputType::Source:
+		vCamConfig->source = out->currentText().toStdString();
+		break;
+	default:
+		// unknown value, don't save type
+		return;
+	}
+
+	vCamConfig->type = type;
+
+	// Start the vcam if needed, if already running just update the source
+	if (!obs_frontend_virtualcam_active())
+		obs_frontend_start_virtualcam();
+	else
+		UpdateOutputSource();
+}
+
+static void SaveCallback(obs_data_t *data, bool saving, void *)
+{
+	if (saving) {
+		OBSDataAutoRelease obj = obs_data_create();
+
+		obs_data_set_int(obj, "type", (int)vCamConfig->type);
+		obs_data_set_int(obj, "internal", (int)vCamConfig->internal);
+		obs_data_set_string(obj, "scene", vCamConfig->scene.c_str());
+		obs_data_set_string(obj, "source", vCamConfig->source.c_str());
+
+		obs_data_set_obj(data, "virtual-camera", obj);
+	} else {
+		OBSDataAutoRelease obj =
+			obs_data_get_obj(data, "virtual-camera");
+
+		vCamConfig->type =
+			(VCamOutputType)obs_data_get_int(obj, "type");
+		vCamConfig->internal =
+			(VCamInternalType)obs_data_get_int(obj, "internal");
+		vCamConfig->scene = obs_data_get_string(obj, "scene");
+		vCamConfig->source = obs_data_get_string(obj, "source");
+	}
+}
+
+static void EventCallback(enum obs_frontend_event event, void *)
+{
+	if (vCamConfig->type != VCamOutputType::Internal)
+		return;
+
+	// Update output source if the preview scene changes
+	// or if the default transition is changed
+	switch (event) {
+	case OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED:
+		if (vCamConfig->internal != VCamInternalType::Preview)
+			return;
+		break;
+	case OBS_FRONTEND_EVENT_TRANSITION_CHANGED:
+		if (vCamConfig->internal != VCamInternalType::Default)
+			return;
+		break;
+	default:
+		return;
+	}
+
+	OBSBasicVCamConfig::UpdateOutputSource();
+}
+
+void OBSBasicVCamConfig::Init()
+{
+	if (vCamConfig)
+		return;
+
+	vCamConfig = new VCamConfig;
+
+	obs_frontend_add_save_callback(SaveCallback, nullptr);
+	obs_frontend_add_event_callback(EventCallback, nullptr);
+}
+
+static obs_view_t *view = nullptr;
+static video_t *video = nullptr;
+
+video_t *OBSBasicVCamConfig::StartVideo()
+{
+	if (!video) {
+		view = obs_view_create();
+		video = obs_view_add(view);
+	}
+	UpdateOutputSource();
+	return video;
+}
+
+void OBSBasicVCamConfig::StopVideo()
+{
+	if (view) {
+		obs_view_remove(view);
+		obs_view_set_source(view, 0, nullptr);
+		obs_view_destroy(view);
+		view = nullptr;
+	}
+	video = nullptr;
+}
+
+void OBSBasicVCamConfig::UpdateOutputSource()
+{
+	if (!view)
+		return;
+
+	obs_source_t *source = nullptr;
+
+	switch ((VCamOutputType)vCamConfig->type) {
+	case VCamOutputType::Internal:
+		switch (vCamConfig->internal) {
+		case VCamInternalType::Default:
+			source = obs_get_output_source(0);
+			break;
+		case VCamInternalType::Preview:
+			OBSSource s = OBSBasic::Get()->GetCurrentSceneSource();
+			obs_source_get_ref(s);
+			source = s;
+			break;
+		}
+		break;
+
+	case VCamOutputType::Scene:
+		source = obs_get_source_by_name(vCamConfig->scene.c_str());
+		break;
+
+	case VCamOutputType::Source:
+		source = obs_get_source_by_name(vCamConfig->source.c_str());
+		break;
+	}
+
+	auto current = obs_view_get_source(view, 0);
+	if (source != current)
+		obs_view_set_source(view, 0, source);
+	obs_source_release(source);
+	obs_source_release(current);
+}

--- a/UI/window-basic-vcam-config.hpp
+++ b/UI/window-basic-vcam-config.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <obs.hpp>
+#include <QDialog>
+#include <memory>
+
+#include "ui_OBSBasicVCamConfig.h"
+
+class OBSBasicVCamConfig : public QDialog {
+	Q_OBJECT
+
+public:
+	static void Init();
+
+	static video_t *StartVideo();
+	static void StopVideo();
+	static void UpdateOutputSource();
+
+	explicit OBSBasicVCamConfig(QWidget *parent = 0);
+
+private slots:
+	void OutputTypeChanged(int type);
+	void SaveAndStart();
+
+private:
+	std::unique_ptr<Ui::OBSBasicVCamConfig> ui;
+};

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -187,7 +187,7 @@ static inline bool has_scaling(const struct obs_encoder *encoder)
 
 static inline bool gpu_encode_available(const struct obs_encoder *encoder)
 {
-	struct obs_core_video *const video = &obs->video;
+	struct obs_core_video_mix *video = obs->video.main_mix;
 	return (encoder->info.caps & OBS_ENCODER_CAP_PASS_TEXTURE) != 0 &&
 	       (video->using_p010_tex || video->using_nv12_tex);
 }

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -245,8 +245,9 @@ struct obs_task_info {
 	void *param;
 };
 
-struct obs_core_video {
-	graphics_t *graphics;
+struct obs_core_video_mix {
+	struct obs_view *view;
+
 	gs_stagesurf_t *active_copy_surfaces[NUM_TEXTURES][NUM_CHANNELS];
 	gs_stagesurf_t *copy_surfaces[NUM_TEXTURES][NUM_CHANNELS];
 	gs_texture_t *convert_textures[NUM_CHANNELS];
@@ -264,6 +265,41 @@ struct obs_core_video {
 	bool using_p010_tex;
 	struct circlebuf vframe_info_buffer;
 	struct circlebuf vframe_info_buffer_gpu;
+	gs_stagesurf_t *mapped_surfaces[NUM_CHANNELS];
+	int cur_texture;
+	volatile long raw_active;
+	volatile long gpu_encoder_active;
+	bool gpu_was_active;
+	bool raw_was_active;
+	bool was_active;
+	pthread_mutex_t gpu_encoder_mutex;
+	struct circlebuf gpu_encoder_queue;
+	struct circlebuf gpu_encoder_avail_queue;
+	DARRAY(obs_encoder_t *) gpu_encoders;
+	os_sem_t *gpu_encode_semaphore;
+	os_event_t *gpu_encode_inactive;
+	pthread_t gpu_encode_thread;
+	bool gpu_encode_thread_initialized;
+	volatile bool gpu_encode_stop;
+
+	video_t *video;
+
+	bool gpu_conversion;
+	const char *conversion_techs[NUM_CHANNELS];
+	bool conversion_needed;
+	float conversion_width_i;
+	float conversion_height_i;
+
+	float color_matrix[16];
+	enum obs_scale_type scale_type;
+};
+
+extern int obs_init_video_mix(struct obs_video_info *ovi,
+			      struct obs_core_video_mix *video);
+extern void obs_free_video_mix(struct obs_core_video_mix *video);
+
+struct obs_core_video {
+	graphics_t *graphics;
 	gs_effect_t *default_effect;
 	gs_effect_t *default_rect_effect;
 	gs_effect_t *opaque_effect;
@@ -276,42 +312,19 @@ struct obs_core_video {
 	gs_effect_t *bilinear_lowres_effect;
 	gs_effect_t *premultiplied_alpha_effect;
 	gs_samplerstate_t *point_sampler;
-	gs_stagesurf_t *mapped_surfaces[NUM_CHANNELS];
-	int cur_texture;
-	volatile long raw_active;
-	volatile long gpu_encoder_active;
-	pthread_mutex_t gpu_encoder_mutex;
-	struct circlebuf gpu_encoder_queue;
-	struct circlebuf gpu_encoder_avail_queue;
-	DARRAY(obs_encoder_t *) gpu_encoders;
-	os_sem_t *gpu_encode_semaphore;
-	os_event_t *gpu_encode_inactive;
-	pthread_t gpu_encode_thread;
-	bool gpu_encode_thread_initialized;
-	volatile bool gpu_encode_stop;
 
 	uint64_t video_time;
 	uint64_t video_frame_interval_ns;
+	uint64_t video_half_frame_interval_ns;
 	uint64_t video_avg_frame_time_ns;
 	double video_fps;
-	video_t *video;
 	pthread_t video_thread;
 	uint32_t total_frames;
 	uint32_t lagged_frames;
 	bool thread_initialized;
 
-	bool gpu_conversion;
-	const char *conversion_techs[NUM_CHANNELS];
-	bool conversion_needed;
-	float conversion_width_i;
-	float conversion_height_i;
-
-	uint32_t output_width;
-	uint32_t output_height;
 	uint32_t base_width;
 	uint32_t base_height;
-	float color_matrix[16];
-	enum obs_scale_type scale_type;
 
 	gs_texture_t *transparent_texture;
 
@@ -330,6 +343,10 @@ struct obs_core_video {
 
 	pthread_mutex_t task_mutex;
 	struct circlebuf tasks;
+
+	pthread_mutex_t mixes_mutex;
+	DARRAY(struct obs_core_video_mix) mixes;
+	struct obs_core_video_mix *main_mix;
 };
 
 struct audio_monitor;
@@ -463,11 +480,6 @@ struct obs_graphics_context {
 	uint64_t frame_time_total_ns;
 	uint64_t fps_total_ns;
 	uint32_t fps_total_frames;
-#ifdef _WIN32
-	bool gpu_was_active;
-#endif
-	bool raw_was_active;
-	bool was_active;
 	const char *video_thread_name;
 };
 

--- a/libobs/obs-source-deinterlace.c
+++ b/libobs/obs-source-deinterlace.c
@@ -148,7 +148,6 @@ static inline uint64_t uint64_diff(uint64_t ts1, uint64_t ts2)
 static inline void deinterlace_get_closest_frames(obs_source_t *s,
 						  uint64_t sys_time)
 {
-	const struct video_output_info *info;
 	uint64_t half_interval;
 
 	if (s->async_unbuffered && s->deinterlace_offset) {
@@ -169,9 +168,7 @@ static inline void deinterlace_get_closest_frames(obs_source_t *s,
 	if (!s->async_frames.num)
 		return;
 
-	info = video_output_get_info(obs->video.video);
-	half_interval = (uint64_t)info->fps_den * 500000000ULL /
-			(uint64_t)info->fps_num;
+	half_interval = obs->video.video_half_frame_interval_ns;
 
 	if (first_frame(s) || ready_deinterlace_frames(s, sys_time)) {
 		uint64_t offset;

--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -150,7 +150,8 @@ static void *gpu_encode_thread(struct obs_core_video_mix *video)
 bool init_gpu_encoding(struct obs_core_video_mix *video)
 {
 #ifdef _WIN32
-	const struct video_output_info *info = video_output_get_info(video->video);
+	const struct video_output_info *info =
+		video_output_get_info(video->video);
 
 	video->gpu_encode_stop = false;
 
@@ -160,15 +161,13 @@ bool init_gpu_encoding(struct obs_core_video_mix *video)
 		gs_texture_t *tex_uv;
 
 		if (info->format == VIDEO_FORMAT_P010) {
-			gs_texture_create_p010(&tex, &tex_uv, info->width,
-					       info->height,
-					       GS_RENDER_TARGET |
-						       GS_SHARED_KM_TEX);
+			gs_texture_create_p010(
+				&tex, &tex_uv, info->width, info->height,
+				GS_RENDER_TARGET | GS_SHARED_KM_TEX);
 		} else {
-			gs_texture_create_nv12(&tex, &tex_uv, info->width,
-					       info->height,
-					       GS_RENDER_TARGET |
-						       GS_SHARED_KM_TEX);
+			gs_texture_create_nv12(
+				&tex, &tex_uv, info->width, info->height,
+				GS_RENDER_TARGET | GS_SHARED_KM_TEX);
 		}
 		if (!tex) {
 			return false;

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -37,8 +37,7 @@ static uint64_t tick_sources(uint64_t cur_time, uint64_t last_time)
 	float seconds;
 
 	if (!last_time)
-		last_time = cur_time -
-			    obs->video.video_frame_interval_ns;
+		last_time = cur_time - obs->video.video_frame_interval_ns;
 
 	delta_time = cur_time - last_time;
 	seconds = (float)((double)delta_time / 1000000000.0);
@@ -148,8 +147,7 @@ static inline void render_main_texture(struct obs_core_video_mix *video)
 		struct draw_callback *callback;
 		callback = obs->data.draw_callbacks.array + (i - 1);
 
-		callback->draw(callback->param, base_width,
-			       base_height);
+		callback->draw(callback->param, base_width, base_height);
 	}
 
 	pthread_mutex_unlock(&obs->data.draw_callbacks_mutex);
@@ -166,7 +164,8 @@ static inline gs_effect_t *
 get_scale_effect_internal(struct obs_core_video_mix *mix)
 {
 	struct obs_core_video *video = &obs->video;
-	const struct video_output_info *info = video_output_get_info(mix->video);
+	const struct video_output_info *info =
+		video_output_get_info(mix->video);
 
 	/* if the dimension is under half the size of the original image,
 	 * bicubic/lanczos can't sample enough pixels to create an accurate
@@ -219,7 +218,8 @@ static inline gs_effect_t *get_scale_effect(struct obs_core_video_mix *mix,
 }
 
 static const char *render_output_texture_name = "render_output_texture";
-static inline gs_texture_t *render_output_texture(struct obs_core_video_mix *mix)
+static inline gs_texture_t *
+render_output_texture(struct obs_core_video_mix *mix)
 {
 	struct obs_core_video *video = &obs->video;
 	gs_texture_t *texture = mix->render_texture;
@@ -427,7 +427,8 @@ stage_output_texture(struct obs_core_video_mix *video, int cur_texture,
 }
 
 #ifdef _WIN32
-static inline bool queue_frame(struct obs_core_video_mix *video, bool raw_active,
+static inline bool queue_frame(struct obs_core_video_mix *video,
+			       bool raw_active,
 			       struct obs_vframe_info *vframe_info)
 {
 	bool duplicate =
@@ -497,7 +498,8 @@ static inline void encode_gpu(struct obs_core_video_mix *video, bool raw_active,
 }
 
 static const char *output_gpu_encoders_name = "output_gpu_encoders";
-static void output_gpu_encoders(struct obs_core_video_mix *video, bool raw_active)
+static void output_gpu_encoders(struct obs_core_video_mix *video,
+				bool raw_active)
 {
 	profile_start(output_gpu_encoders_name);
 
@@ -519,8 +521,9 @@ end:
 }
 #endif
 
-static inline void render_video(struct obs_core_video_mix *video, bool raw_active,
-				const bool gpu_active, int cur_texture)
+static inline void render_video(struct obs_core_video_mix *video,
+				bool raw_active, const bool gpu_active,
+				int cur_texture)
 {
 	gs_begin_scene();
 
@@ -795,8 +798,7 @@ static inline void output_video_data(struct obs_core_video_mix *video,
 	}
 }
 
-static inline void video_sleep(struct obs_core_video *video,
-			       uint64_t *p_time,
+static inline void video_sleep(struct obs_core_video *video, uint64_t *p_time,
 			       uint64_t interval_ns)
 {
 	struct obs_vframe_info vframe_info;
@@ -830,12 +832,12 @@ static inline void video_sleep(struct obs_core_video *video,
 		bool raw_active = video->raw_was_active;
 		bool gpu_active = video->gpu_was_active;
 
-	if (raw_active)
-		circlebuf_push_back(&video->vframe_info_buffer, &vframe_info,
-				    sizeof(vframe_info));
-	if (gpu_active)
-		circlebuf_push_back(&video->vframe_info_buffer_gpu,
-				    &vframe_info, sizeof(vframe_info));
+		if (raw_active)
+			circlebuf_push_back(&video->vframe_info_buffer,
+					    &vframe_info, sizeof(vframe_info));
+		if (gpu_active)
+			circlebuf_push_back(&video->vframe_info_buffer_gpu,
+					    &vframe_info, sizeof(vframe_info));
 	}
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 }
@@ -1132,8 +1134,7 @@ bool obs_graphics_thread_loop(struct obs_graphics_context *context)
 
 	profile_reenable_thread();
 
-	video_sleep(&obs->video, &obs->video.video_time,
-		    context->interval);
+	video_sleep(&obs->video, &obs->video.video_time, context->interval);
 
 	context->frame_time_total_ns += frame_time_ns;
 	context->fps_total_ns += (obs->video.video_time - context->last_time);

--- a/libobs/obs-view.c
+++ b/libobs/obs-view.c
@@ -139,3 +139,50 @@ void obs_view_render(obs_view_t *view)
 
 	pthread_mutex_unlock(&view->channels_mutex);
 }
+
+static inline size_t find_mix_for_view(obs_view_t *view)
+{
+	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
+		if (obs->video.mixes.array[i].view == view)
+			return i;
+	}
+
+	return DARRAY_INVALID;
+}
+
+static inline void set_main_mix()
+{
+	size_t idx = find_mix_for_view(&obs->data.main_view);
+
+	struct obs_core_video_mix *mix = NULL;
+	if (idx != DARRAY_INVALID)
+		mix = obs->video.mixes.array + idx;
+	obs->video.main_mix = mix;
+}
+
+video_t *obs_view_add(obs_view_t *view)
+{
+	struct obs_core_video_mix mix = {0};
+	mix.view = view;
+	if (obs_init_video_mix(&obs->video.ovi, &mix) != 0) {
+		obs_free_video_mix(&mix);
+		return NULL;
+	}
+
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+	da_push_back(obs->video.mixes, &mix);
+	set_main_mix();
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	return mix.video;
+}
+
+void obs_view_remove(obs_view_t *view)
+{
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+	size_t idx = find_mix_for_view(view);
+	if (idx != DARRAY_INVALID)
+		obs->video.mixes.array[idx].view = NULL;
+	set_main_mix();
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+}

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -46,7 +46,8 @@ static inline void make_video_info(struct video_output_info *vi,
 
 static inline void calc_gpu_conversion_sizes(struct obs_core_video_mix *video)
 {
-	const struct video_output_info *info = video_output_get_info(video->video);
+	const struct video_output_info *info =
+		video_output_get_info(video->video);
 
 	video->conversion_needed = false;
 	video->conversion_techs[0] = NULL;
@@ -117,12 +118,10 @@ static bool obs_init_gpu_conversion(struct obs_core_video_mix *video)
 
 	calc_gpu_conversion_sizes(video);
 
-	video->using_nv12_tex = info->format == VIDEO_FORMAT_NV12
-					? gs_nv12_available()
-					: false;
-	video->using_p010_tex = info->format == VIDEO_FORMAT_P010
-					? gs_p010_available()
-					: false;
+	video->using_nv12_tex =
+		info->format == VIDEO_FORMAT_NV12 ? gs_nv12_available() : false;
+	video->using_p010_tex =
+		info->format == VIDEO_FORMAT_P010 ? gs_p010_available() : false;
 
 	if (!video->conversion_needed) {
 		blog(LOG_INFO, "GPU conversion not available for format: %u",
@@ -152,19 +151,19 @@ static bool obs_init_gpu_conversion(struct obs_core_video_mix *video)
 	video->convert_textures_encode[1] = NULL;
 	video->convert_textures_encode[2] = NULL;
 	if (video->using_nv12_tex) {
-		if (!gs_texture_create_nv12(
-			    &video->convert_textures_encode[0],
-			    &video->convert_textures_encode[1],
-			    info->width, info->height,
-			    GS_RENDER_TARGET | GS_SHARED_KM_TEX)) {
+		if (!gs_texture_create_nv12(&video->convert_textures_encode[0],
+					    &video->convert_textures_encode[1],
+					    info->width, info->height,
+					    GS_RENDER_TARGET |
+						    GS_SHARED_KM_TEX)) {
 			return false;
 		}
 	} else if (video->using_p010_tex) {
-		if (!gs_texture_create_p010(
-			    &video->convert_textures_encode[0],
-			    &video->convert_textures_encode[1],
-			    info->width, info->height,
-			    GS_RENDER_TARGET | GS_SHARED_KM_TEX)) {
+		if (!gs_texture_create_p010(&video->convert_textures_encode[0],
+					    &video->convert_textures_encode[1],
+					    info->width, info->height,
+					    GS_RENDER_TARGET |
+						    GS_SHARED_KM_TEX)) {
 			return false;
 		}
 	}
@@ -175,63 +174,63 @@ static bool obs_init_gpu_conversion(struct obs_core_video_mix *video)
 	switch (info->format) {
 	case VIDEO_FORMAT_I420:
 		video->convert_textures[0] =
-			gs_texture_create(info->width, info->height,
+			gs_texture_create(info->width, info->height, GS_R8, 1,
+					  NULL, GS_RENDER_TARGET);
+		video->convert_textures[1] =
+			gs_texture_create(info->width / 2, info->height / 2,
 					  GS_R8, 1, NULL, GS_RENDER_TARGET);
-		video->convert_textures[1] = gs_texture_create(
-			info->width / 2, info->height / 2, GS_R8, 1,
-			NULL, GS_RENDER_TARGET);
-		video->convert_textures[2] = gs_texture_create(
-			info->width / 2, info->height / 2, GS_R8, 1,
-			NULL, GS_RENDER_TARGET);
+		video->convert_textures[2] =
+			gs_texture_create(info->width / 2, info->height / 2,
+					  GS_R8, 1, NULL, GS_RENDER_TARGET);
 		if (!video->convert_textures[0] ||
 		    !video->convert_textures[1] || !video->convert_textures[2])
 			success = false;
 		break;
 	case VIDEO_FORMAT_NV12:
 		video->convert_textures[0] =
-			gs_texture_create(info->width, info->height,
-					  GS_R8, 1, NULL, GS_RENDER_TARGET);
-		video->convert_textures[1] = gs_texture_create(
-			info->width / 2, info->height / 2, GS_R8G8,
-			1, NULL, GS_RENDER_TARGET);
+			gs_texture_create(info->width, info->height, GS_R8, 1,
+					  NULL, GS_RENDER_TARGET);
+		video->convert_textures[1] =
+			gs_texture_create(info->width / 2, info->height / 2,
+					  GS_R8G8, 1, NULL, GS_RENDER_TARGET);
 		if (!video->convert_textures[0] || !video->convert_textures[1])
 			success = false;
 		break;
 	case VIDEO_FORMAT_I444:
 		video->convert_textures[0] =
-			gs_texture_create(info->width, info->height,
-					  GS_R8, 1, NULL, GS_RENDER_TARGET);
+			gs_texture_create(info->width, info->height, GS_R8, 1,
+					  NULL, GS_RENDER_TARGET);
 		video->convert_textures[1] =
-			gs_texture_create(info->width, info->height,
-					  GS_R8, 1, NULL, GS_RENDER_TARGET);
+			gs_texture_create(info->width, info->height, GS_R8, 1,
+					  NULL, GS_RENDER_TARGET);
 		video->convert_textures[2] =
-			gs_texture_create(info->width, info->height,
-					  GS_R8, 1, NULL, GS_RENDER_TARGET);
+			gs_texture_create(info->width, info->height, GS_R8, 1,
+					  NULL, GS_RENDER_TARGET);
 		if (!video->convert_textures[0] ||
 		    !video->convert_textures[1] || !video->convert_textures[2])
 			success = false;
 		break;
 	case VIDEO_FORMAT_I010:
 		video->convert_textures[0] =
-			gs_texture_create(info->width, info->height,
+			gs_texture_create(info->width, info->height, GS_R16, 1,
+					  NULL, GS_RENDER_TARGET);
+		video->convert_textures[1] =
+			gs_texture_create(info->width / 2, info->height / 2,
 					  GS_R16, 1, NULL, GS_RENDER_TARGET);
-		video->convert_textures[1] = gs_texture_create(
-			info->width / 2, info->height / 2, GS_R16,
-			1, NULL, GS_RENDER_TARGET);
-		video->convert_textures[2] = gs_texture_create(
-			info->width / 2, info->height / 2, GS_R16,
-			1, NULL, GS_RENDER_TARGET);
+		video->convert_textures[2] =
+			gs_texture_create(info->width / 2, info->height / 2,
+					  GS_R16, 1, NULL, GS_RENDER_TARGET);
 		if (!video->convert_textures[0] ||
 		    !video->convert_textures[1] || !video->convert_textures[2])
 			success = false;
 		break;
 	case VIDEO_FORMAT_P010:
 		video->convert_textures[0] =
-			gs_texture_create(info->width, info->height,
-					  GS_R16, 1, NULL, GS_RENDER_TARGET);
-		video->convert_textures[1] = gs_texture_create(
-			info->width / 2, info->height / 2, GS_RG16,
-			1, NULL, GS_RENDER_TARGET);
+			gs_texture_create(info->width, info->height, GS_R16, 1,
+					  NULL, GS_RENDER_TARGET);
+		video->convert_textures[1] =
+			gs_texture_create(info->width / 2, info->height / 2,
+					  GS_RG16, 1, NULL, GS_RENDER_TARGET);
 		if (!video->convert_textures[0] || !video->convert_textures[1])
 			success = false;
 		break;
@@ -256,7 +255,8 @@ static bool obs_init_gpu_conversion(struct obs_core_video_mix *video)
 	return success;
 }
 
-static bool obs_init_gpu_copy_surfaces(struct obs_core_video_mix *video, size_t i)
+static bool obs_init_gpu_copy_surfaces(struct obs_core_video_mix *video,
+				       size_t i)
 {
 	const struct video_output_info *info =
 		video_output_get_info(video->video);
@@ -332,7 +332,8 @@ static bool obs_init_gpu_copy_surfaces(struct obs_core_video_mix *video, size_t 
 
 static bool obs_init_textures(struct obs_core_video_mix *video)
 {
-	const struct video_output_info *info = video_output_get_info(video->video);
+	const struct video_output_info *info =
+		video_output_get_info(video->video);
 
 	bool success = true;
 
@@ -396,15 +397,14 @@ static bool obs_init_textures(struct obs_core_video_mix *video)
 		}
 	}
 
-	video->render_texture = gs_texture_create(obs->video.base_width,
-						  obs->video.base_height, format, 1,
-						  NULL, GS_RENDER_TARGET);
+	video->render_texture =
+		gs_texture_create(obs->video.base_width, obs->video.base_height,
+				  format, 1, NULL, GS_RENDER_TARGET);
 	if (!video->render_texture)
 		success = false;
 
-	video->output_texture = gs_texture_create(info->width,
-						  info->height, format, 1,
-						  NULL, GS_RENDER_TARGET);
+	video->output_texture = gs_texture_create(
+		info->width, info->height, format, 1, NULL, GS_RENDER_TARGET);
 	if (!video->output_texture)
 		success = false;
 
@@ -625,8 +625,10 @@ static int obs_init_video(struct obs_video_info *ovi)
 	struct obs_core_video *video = &obs->video;
 	video->base_width = ovi->base_width;
 	video->base_height = ovi->base_height;
-	video->video_frame_interval_ns = util_mul_div64(1000000000ULL, ovi->fps_den, ovi->fps_num);
-	video->video_half_frame_interval_ns = util_mul_div64(500000000ULL, ovi->fps_den, ovi->fps_num);
+	video->video_frame_interval_ns =
+		util_mul_div64(1000000000ULL, ovi->fps_den, ovi->fps_num);
+	video->video_half_frame_interval_ns =
+		util_mul_div64(500000000ULL, ovi->fps_den, ovi->fps_num);
 
 	if (pthread_mutex_init(&video->task_mutex, NULL) < 0)
 		return OBS_VIDEO_FAIL;
@@ -663,67 +665,64 @@ static void stop_video(void)
 	struct obs_core_video *video = &obs->video;
 	void *thread_retval;
 
-		if (video->thread_initialized) {
-			pthread_join(video->video_thread, &thread_retval);
-			video->thread_initialized = false;
-		}
+	if (video->thread_initialized) {
+		pthread_join(video->video_thread, &thread_retval);
+		video->thread_initialized = false;
+	}
 }
 
 static void obs_free_render_textures(struct obs_core_video_mix *video)
 {
-		if (!obs->video.graphics)
-			return;
+	if (!obs->video.graphics)
+		return;
 
-		gs_enter_context(obs->video.graphics);
+	gs_enter_context(obs->video.graphics);
 
-		for (size_t c = 0; c < NUM_CHANNELS; c++) {
-			if (video->mapped_surfaces[c]) {
-				gs_stagesurface_unmap(
-					video->mapped_surfaces[c]);
-				video->mapped_surfaces[c] = NULL;
-			}
+	for (size_t c = 0; c < NUM_CHANNELS; c++) {
+		if (video->mapped_surfaces[c]) {
+			gs_stagesurface_unmap(video->mapped_surfaces[c]);
+			video->mapped_surfaces[c] = NULL;
 		}
+	}
 
-		for (size_t i = 0; i < NUM_TEXTURES; i++) {
-			for (size_t c = 0; c < NUM_CHANNELS; c++) {
-				if (video->copy_surfaces[i][c]) {
-					gs_stagesurface_destroy(
-						video->copy_surfaces[i][c]);
-					video->copy_surfaces[i][c] = NULL;
-				}
-
-				video->active_copy_surfaces[i][c] = NULL;
-			}
-#ifdef _WIN32
-			if (video->copy_surfaces_encode[i]) {
+	for (size_t i = 0; i < NUM_TEXTURES; i++) {
+		for (size_t c = 0; c < NUM_CHANNELS; c++) {
+			if (video->copy_surfaces[i][c]) {
 				gs_stagesurface_destroy(
-					video->copy_surfaces_encode[i]);
-				video->copy_surfaces_encode[i] = NULL;
+					video->copy_surfaces[i][c]);
+				video->copy_surfaces[i][c] = NULL;
 			}
-#endif
+
+			video->active_copy_surfaces[i][c] = NULL;
 		}
-
-		gs_texture_destroy(video->render_texture);
-
-		for (size_t c = 0; c < NUM_CHANNELS; c++) {
-			if (video->convert_textures[c]) {
-				gs_texture_destroy(video->convert_textures[c]);
-				video->convert_textures[c] = NULL;
-			}
 #ifdef _WIN32
-			if (video->convert_textures_encode[c]) {
-				gs_texture_destroy(
-					video->convert_textures_encode[c]);
-				video->convert_textures_encode[c] = NULL;
-			}
-#endif
+		if (video->copy_surfaces_encode[i]) {
+			gs_stagesurface_destroy(video->copy_surfaces_encode[i]);
+			video->copy_surfaces_encode[i] = NULL;
 		}
+#endif
+	}
 
-		gs_texture_destroy(video->output_texture);
-		video->render_texture = NULL;
-		video->output_texture = NULL;
+	gs_texture_destroy(video->render_texture);
 
-		gs_leave_context();
+	for (size_t c = 0; c < NUM_CHANNELS; c++) {
+		if (video->convert_textures[c]) {
+			gs_texture_destroy(video->convert_textures[c]);
+			video->convert_textures[c] = NULL;
+		}
+#ifdef _WIN32
+		if (video->convert_textures_encode[c]) {
+			gs_texture_destroy(video->convert_textures_encode[c]);
+			video->convert_textures_encode[c] = NULL;
+		}
+#endif
+	}
+
+	gs_texture_destroy(video->output_texture);
+	video->render_texture = NULL;
+	video->output_texture = NULL;
+
+	gs_leave_context();
 }
 
 void obs_free_video_mix(struct obs_core_video_mix *video)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -888,6 +888,12 @@ EXPORT obs_source_t *obs_view_get_source(obs_view_t *view, uint32_t channel);
 /** Renders the sources of this view context */
 EXPORT void obs_view_render(obs_view_t *view);
 
+/** Adds a view to the main render loop */
+EXPORT video_t *obs_view_add(obs_view_t *view);
+
+/** Removes a view from the main render loop */
+EXPORT void obs_view_remove(obs_view_t *view);
+
 /* ------------------------------------------------------------------------- */
 /* Display context */
 


### PR DESCRIPTION
### Description
Add the ability to render multiple "video mixes" where a "video mix" is ultimately a `render_texture` created by compositing scenes and sources that can be fed into one or more video encoders/outputs. 

This implementation splits `obs_core_video` keeping global resources in place and moving per-mix resources to a new `obs_core_video_mix` struct. It then updates the main graphics thread to render each channel of the `main_view` onto a separate `render_texture` / `obs_core_video_mix` rather than rendering them one on top of another on the same `render_texture` (I don't believe this old behavior was actual used since scenes and transitions achieve the same effect with a single `main_view` channel). GPU resource allocation has been deferred until the first render tick when a channel is actually in use for video to avoid re-allocating GPU resources for all 64 available channels.

More details on the design can be found in the [Multiple Video Mixes RFC](https://github.com/chippydip/obs-rfcs/blob/multiple-video-mixes/text/0049-multiple-video-mixes.md) and associated [PR discussion](https://github.com/obsproject/rfcs/pull/49).

### Virtual Camera
While this refactor was designed to support "ISO Recording" as an eventual use-case, the primary motivation was to enable source selection for the Virtual Camera feature. This enables users to export just their webcam (including filters) to be used in a video conference while also streaming/recording a fully composited scene.

Settings have been added to select a source override in both SImple:
![image](https://user-images.githubusercontent.com/552649/173895383-30ce91d1-9d45-4caf-94b4-45ed03c08ab3.png)

and Advanced output modes (in a new Video tab):
![image](https://user-images.githubusercontent.com/552649/173895454-80f807fd-a40f-4620-ac68-1ac2e354c7d8.png)

These settings are kept in sync and are used when starting the virtual camera. If an override is specified, then channel 7 is configured with the selected source and used for the virtual camera. Otherwise the default channel 0 is used as normal.

### Reviewing Changes
To make reviewing these changes easier I've separated the PR into a couple of individual diffs:
- [libobs: Add support for multiple video mixes](https://github.com/obsproject/obs-studio/pull/6577/commits/16d65849f33b2df4b3a2bca5a0ac43f4d8d9128d)
- [docs: Update render pipeline descriptions for multiple video mixes](https://github.com/obsproject/obs-studio/pull/6577/commits/2d19894b6e034080902aaad05d67ace92c28ea86)
- [UI: Add Virtual Camera source selector to settings](https://github.com/obsproject/obs-studio/pull/6577/commits/3e6766663bfcdfc74478f579428c953603d2c87d)
- [libobs: Format changes for multiple video mixes](https://github.com/obsproject/obs-studio/pull/6577/commits/6f8583ac499eefda934b34ae90458f4e8a547d68) (clang-format only to remove noise from main commit above)

### Motivation and Context
OBS supports multiple video outputs allowing simultaneous streaming, recording, virtual camera, etc. These outputs, however, must all be derived from a single `render_texture`. This makes it impossible to support [Multiple Video Outputs (Selective Recording, ISO recording)](https://ideas.obsproject.com/posts/41/multiple-video-outputs-selective-recording-iso-recording) or to share just a webcam via virtual camera (to participate in a video conference while streaming) with the current architecture.

While plugins do exist to implement these features, they do so in a roundabout way. They provide a no-op filter which intercepts video from a source for the plugin to process. This completely bypasses the normal output pipeline of OBS.

### How Has This Been Tested?
- Tested that existing recording functionality continues to work as expected
- Added test code to set a webcam source as an additional view and use that for virtual camera output while also recording
- Tested on Win10

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
  - This is technically a breaking change since it modifies how the renderer behaves when multiple `main_view` channels are used for video, but I don't believe this functionality was being used in practice so it should be more of a non-breaking feature addition in practice.
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
