### PR TITLE
UI: Fix reset ui warning showing on first start

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1980,12 +1980,12 @@ void OBSBasic::OBSInit()
 		App()->GlobalConfig(), "BasicWindow", "DockState");
 
 	if (!dockStateStr) {
-		on_resetDocks_triggered();
+		on_resetDocks_triggered(true);
 	} else {
 		QByteArray dockState =
 			QByteArray::fromBase64(QByteArray(dockStateStr));
 		if (!restoreState(dockState))
-			on_resetDocks_triggered();
+			on_resetDocks_triggered(true);
 	}
 
 	bool pre23Defaults = config_get_bool(App()->GlobalConfig(), "General",
@@ -8781,7 +8781,7 @@ int OBSBasic::GetProfilePath(char *path, size_t size, const char *file) const
 	return snprintf(path, size, "%s/%s/%s", profiles_path, profile, file);
 }
 
-void OBSBasic::on_resetDocks_triggered()
+void OBSBasic::on_resetDocks_triggered(bool force)
 {
 	/* prune deleted extra docks */
 	for (int i = extraDocks.size() - 1; i >= 0; i--) {
@@ -8790,7 +8790,7 @@ void OBSBasic::on_resetDocks_triggered()
 		}
 	}
 
-	if (extraDocks.size()) {
+	if (extraDocks.size() && !force) {
 		QMessageBox::StandardButton button = QMessageBox::question(
 			this, QTStr("ResetUIWarning.Title"),
 			QTStr("ResetUIWarning.Text"));

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1083,7 +1083,7 @@ private slots:
 	void on_stats_triggered();
 
 	void on_resetUI_triggered();
-	void on_resetDocks_triggered();
+	void on_resetDocks_triggered(bool force = false);
 	void on_lockDocks_toggled(bool lock);
 
 	void PauseToggled();


### PR DESCRIPTION
### Description
If a plugin adds a dock and the program is run for the
first time, the reset ui warning would show up.

### Motivation and Context
Found when making plugin that uses an extra dock.

### How Has This Been Tested?
Loaded plugin and made sure the dialog didn't show up.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
