### PR TITLE
libobs: Ensure active copy surfaces are active

### DIFF
--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -392,21 +392,24 @@ stage_output_texture(struct obs_core_video *video, int cur_texture,
 
 	if (!video->gpu_conversion) {
 		gs_stagesurf_t *copy = copy_surfaces[0];
-		if (copy) {
+		if (copy)
 			gs_stage_texture(copy, video->output_texture);
-			video->active_copy_surfaces[cur_texture][0] = copy;
-		}
+		video->active_copy_surfaces[cur_texture][0] = copy;
+
+		for (size_t i = 1; i < NUM_CHANNELS; ++i)
+			video->active_copy_surfaces[cur_texture][i] = NULL;
 
 		video->textures_copied[cur_texture] = true;
 	} else if (video->texture_converted) {
 		for (size_t i = 0; i < channel_count; i++) {
 			gs_stagesurf_t *copy = copy_surfaces[i];
-			if (copy) {
+			if (copy)
 				gs_stage_texture(copy, convert_textures[i]);
-				video->active_copy_surfaces[cur_texture][i] =
-					copy;
-			}
+			video->active_copy_surfaces[cur_texture][i] = copy;
 		}
+
+		for (size_t i = channel_count; i < NUM_CHANNELS; ++i)
+			video->active_copy_surfaces[cur_texture][i] = NULL;
 
 		video->textures_copied[cur_texture] = true;
 	}


### PR DESCRIPTION
### Description
Stale surfaces can cause improper downloads from GPU, and lead to video
corruption in certain cases.

### Motivation and Context
Corrupt video when streaming NV12 with x264, and recording with NVENC.

### How Has This Been Tested?
Streamed NV12 with x264, and recorded with NVENC. Corruption before change; fixed after.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.