### PR TITLE
UI, libobs: Add lock aspect ratio to transform dialog

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -626,6 +626,7 @@ Basic.TransformWindow.CropLeft="Crop Left"
 Basic.TransformWindow.CropRight="Crop Right"
 Basic.TransformWindow.CropTop="Crop Top"
 Basic.TransformWindow.CropBottom="Crop Bottom"
+Basic.TransformWindow.LockAspectRatio="Lock Aspect Ratio"
 
 Basic.TransformWindow.Alignment.TopLeft="Top Left"
 Basic.TransformWindow.Alignment.TopCenter="Top Center"

--- a/UI/forms/OBSBasicTransform.ui
+++ b/UI/forms/OBSBasicTransform.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>564</width>
-    <height>313</height>
+    <width>778</width>
+    <height>378</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -246,6 +246,25 @@
           </property>
           <property name="singleStep">
            <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="LockedCheckBox" name="sizeLockAspect">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="accessibleName">
+           <string>Basic.TransformWindow.LockAspectRatio</string>
+          </property>
+          <property name="text">
+           <string>Basic.TransformWindow.LockAspectRatio</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
           </property>
          </widget>
         </item>
@@ -537,6 +556,19 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="LockedCheckBox" name="boundsLockAspect">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="accessibleName">
+           <string>Basic.TransformWindow.LockAspectRatio</string>
+          </property>
+          <property name="text">
+           <string>Basic.TransformWindow.LockAspectRatio</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>
@@ -756,6 +788,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>LockedCheckBox</class>
+   <extends>QCheckBox</extends>
+   <header>locked-checkbox.hpp</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7946,6 +7946,8 @@ void OBSBasic::on_actionEditTransform_triggered()
 	transformWindow = new OBSBasicTransform(this);
 	connect(ui->scenes, &QListWidget::currentItemChanged, transformWindow,
 		&OBSBasicTransform::OnSceneChanged);
+	transformWindow->adjustSize();
+
 	transformWindow->show();
 	transformWindow->setAttribute(Qt::WA_DeleteOnClose, true);
 }
@@ -8021,6 +8023,8 @@ static bool reset_tr(obs_scene_t *scene, obs_sceneitem_t *item, void *param)
 	info.alignment = OBS_ALIGN_TOP | OBS_ALIGN_LEFT;
 	info.bounds_type = OBS_BOUNDS_NONE;
 	info.bounds_alignment = OBS_ALIGN_CENTER;
+	info.lock_size_aspect = false;
+	info.lock_bounds_aspect = false;
 	vec2_set(&info.bounds, 0.0f, 0.0f);
 	obs_sceneitem_set_info(item, &info);
 

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -1209,9 +1209,6 @@ void OBSBasicPreview::ClampAspect(vec3 &tl, vec3 &br, vec2 &size,
 			size.y = size.x / baseAspect * -1.0f;
 	}
 
-	size.x = std::round(size.x);
-	size.y = std::round(size.y);
-
 	if (stretchFlags & ITEM_LEFT)
 		tl.x = br.x - size.x;
 	else if (stretchFlags & ITEM_RIGHT)
@@ -1422,7 +1419,8 @@ void OBSBasicPreview::StretchItem(const vec2 &pos)
 	vec2_set(&size, br.x - tl.x, br.y - tl.y);
 
 	if (boundsType != OBS_BOUNDS_NONE) {
-		if (shiftDown)
+		if (shiftDown ||
+		    obs_sceneitem_bounding_box_aspect_ratio_locked(stretchItem))
 			ClampAspect(tl, br, size, baseSize);
 
 		if (tl.x > br.x)
@@ -1440,7 +1438,8 @@ void OBSBasicPreview::StretchItem(const vec2 &pos)
 		baseSize.x -= float(crop.left + crop.right);
 		baseSize.y -= float(crop.top + crop.bottom);
 
-		if (!shiftDown)
+		if (!shiftDown ||
+		    obs_sceneitem_size_aspect_ratio_locked(stretchItem))
 			ClampAspect(tl, br, size, baseSize);
 
 		vec2_div(&size, &size, &baseSize);

--- a/UI/window-basic-transform.hpp
+++ b/UI/window-basic-transform.hpp
@@ -39,6 +39,9 @@ private:
 	static void OBSSceneItemSelect(void *param, calldata_t *data);
 	static void OBSSceneItemDeselect(void *param, calldata_t *data);
 
+	double sizeAspect = 1.0;
+	double boundsAspect = 1.0;
+
 private slots:
 	void RefreshControls();
 	void SetItemQt(OBSSceneItem newItem);
@@ -46,6 +49,11 @@ private slots:
 	void OnControlChanged();
 	void OnCropChanged();
 	void on_resetButton_clicked();
+
+	void on_sizeX_valueChanged(double value);
+	void on_sizeY_valueChanged(double value);
+	void on_boundsWidth_valueChanged(double value);
+	void on_boundsHeight_valueChanged(double value);
 
 public:
 	OBSBasicTransform(OBSBasic *parent);

--- a/libobs/obs-scene.h
+++ b/libobs/obs-scene.h
@@ -54,6 +54,8 @@ struct obs_scene_item {
 	struct vec2 scale;
 	float rot;
 	uint32_t align;
+	bool lock_size_aspect;
+	bool lock_bounds_aspect;
 
 	/* last width/height of the source, this is used to check whether
 	 * the transform needs updating */

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -163,6 +163,9 @@ struct obs_transform_info {
 	enum obs_bounds_type bounds_type;
 	uint32_t bounds_alignment;
 	struct vec2 bounds;
+
+	bool lock_size_aspect;
+	bool lock_bounds_aspect;
 };
 
 /**
@@ -1793,6 +1796,10 @@ obs_sceneitem_get_bounds_type(const obs_sceneitem_t *item);
 EXPORT uint32_t obs_sceneitem_get_bounds_alignment(const obs_sceneitem_t *item);
 EXPORT void obs_sceneitem_get_bounds(const obs_sceneitem_t *item,
 				     struct vec2 *bounds);
+
+EXPORT bool obs_sceneitem_size_aspect_ratio_locked(const obs_sceneitem_t *item);
+EXPORT bool
+obs_sceneitem_bounding_box_aspect_ratio_locked(const obs_sceneitem_t *item);
 
 EXPORT void obs_sceneitem_get_info(const obs_sceneitem_t *item,
 				   struct obs_transform_info *info);


### PR DESCRIPTION
### Description
This adds the ability to lock the aspect ratio for the size
and bounding box, in the transform dialog.

![2022-06-03 05_35_32-Edit Transform for 'Image Slide Show'](https://user-images.githubusercontent.com/19962531/171838758-0ff0df5d-2e61-4697-86c1-688fad6feddd.png)

### Motivation and Context
https://ideas.obsproject.com/posts/1338/button-to-lock-aspect-ratio-under-transform

### How Has This Been Tested?
Locked the aspect ratio and made sure the width/height changed accordingly.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
