### PR TITLE
libobs: Clear low bits when writing P010

### DIFF
--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -202,32 +202,32 @@ float PS_Y(FragPos frag_in) : TARGET
 	return y;
 }
 
-float PS_PQ_Y_709_2020(FragPos frag_in) : TARGET
+float PS_P010_PQ_Y_709_2020(FragPos frag_in) : TARGET
 {
 	float3 rgb = image.Load(int3(frag_in.pos.xy, 0)).rgb * sdr_white_nits_over_maximum;
 	rgb = rec709_to_rec2020(rgb);
 	rgb = linear_to_st2084(rgb);
 	float y = dot(color_vec0.xyz, rgb) + color_vec0.w;
-	y = (65472. / 65535.) * y + (32. / 65535.); // set up truncation to 10 bits
+	y = floor(saturate(y) * 1023. + 0.5) * (64. / 65535.);
 	return y;
 }
 
-float PS_HLG_Y_709_2020(FragPos frag_in) : TARGET
+float PS_P010_HLG_Y_709_2020(FragPos frag_in) : TARGET
 {
 	float3 rgb = image.Load(int3(frag_in.pos.xy, 0)).rgb * sdr_white_nits_over_maximum;
 	rgb = rec709_to_rec2020(rgb);
 	rgb = linear_to_hlg(rgb, hdr_lw);
 	float y = dot(color_vec0.xyz, rgb) + color_vec0.w;
-	y = (65472. / 65535.) * y + (32. / 65535.); // set up truncation to 10 bits
+	y = floor(saturate(y) * 1023. + 0.5) * (64. / 65535.);
 	return y;
 }
 
-float PS_SRGB_Y(FragPos frag_in) : TARGET
+float PS_P010_SRGB_Y(FragPos frag_in) : TARGET
 {
 	float3 rgb = image.Load(int3(frag_in.pos.xy, 0)).rgb;
 	rgb = srgb_linear_to_nonlinear(rgb);
 	float y = dot(color_vec0.xyz, rgb) + color_vec0.w;
-	y = (65472. / 65535.) * y + (32. / 65535.); // set up truncation to 10 bits
+	y = floor(saturate(y) * 1023. + 0.5) * (64. / 65535.);
 	return y;
 }
 
@@ -267,7 +267,7 @@ float2 PS_UV_Wide(FragTexWide frag_in) : TARGET
 	return float2(u, v);
 }
 
-float2 PS_PQ_UV_709_2020_WideWide(FragTexWideWide frag_in) : TARGET
+float2 PS_P010_PQ_UV_709_2020_WideWide(FragTexWideWide frag_in) : TARGET
 {
 	float3 rgb_topleft = image.Sample(def_sampler, frag_in.uuvv.xz).rgb;
 	float3 rgb_topright = image.Sample(def_sampler, frag_in.uuvv.yz).rgb;
@@ -279,11 +279,11 @@ float2 PS_PQ_UV_709_2020_WideWide(FragTexWideWide frag_in) : TARGET
 	float u = dot(color_vec1.xyz, rgb) + color_vec1.w;
 	float v = dot(color_vec2.xyz, rgb) + color_vec2.w;
 	float2 uv = float2(u, v);
-	uv = (65472. / 65535.) * uv + (32. / 65535.); // set up truncation to 10 bits
+	uv = floor(saturate(uv) * 1023. + 0.5) * (64. / 65535.);
 	return uv;
 }
 
-float2 PS_HLG_UV_709_2020_WideWide(FragTexWideWide frag_in) : TARGET
+float2 PS_P010_HLG_UV_709_2020_WideWide(FragTexWideWide frag_in) : TARGET
 {
 	float3 rgb_topleft = image.Sample(def_sampler, frag_in.uuvv.xz).rgb;
 	float3 rgb_topright = image.Sample(def_sampler, frag_in.uuvv.yz).rgb;
@@ -295,11 +295,11 @@ float2 PS_HLG_UV_709_2020_WideWide(FragTexWideWide frag_in) : TARGET
 	float u = dot(color_vec1.xyz, rgb) + color_vec1.w;
 	float v = dot(color_vec2.xyz, rgb) + color_vec2.w;
 	float2 uv = float2(u, v);
-	uv = (65472. / 65535.) * uv + (32. / 65535.); // set up truncation to 10 bits
+	uv = floor(saturate(uv) * 1023. + 0.5) * (64. / 65535.);
 	return uv;
 }
 
-float2 PS_SRGB_UV_WideWide(FragTexWideWide frag_in) : TARGET
+float2 PS_P010_SRGB_UV_WideWide(FragTexWideWide frag_in) : TARGET
 {
 	float3 rgb_topleft = image.Sample(def_sampler, frag_in.uuvv.xz).rgb;
 	float3 rgb_topright = image.Sample(def_sampler, frag_in.uuvv.yz).rgb;
@@ -310,7 +310,7 @@ float2 PS_SRGB_UV_WideWide(FragTexWideWide frag_in) : TARGET
 	float u = dot(color_vec1.xyz, rgb) + color_vec1.w;
 	float v = dot(color_vec2.xyz, rgb) + color_vec2.w;
 	float2 uv = float2(u, v);
-	uv = (65472. / 65535.) * uv + (32. / 65535.); // set up truncation to 10 bits
+	uv = floor(saturate(uv) * 1023. + 0.5) * (64. / 65535.);
 	return uv;
 }
 
@@ -878,7 +878,7 @@ technique P010_PQ_Y
 	pass
 	{
 		vertex_shader = VSPos(id);
-		pixel_shader  = PS_PQ_Y_709_2020(frag_in);
+		pixel_shader  = PS_P010_PQ_Y_709_2020(frag_in);
 	}
 }
 
@@ -887,7 +887,7 @@ technique P010_HLG_Y
 	pass
 	{
 		vertex_shader = VSPos(id);
-		pixel_shader  = PS_HLG_Y_709_2020(frag_in);
+		pixel_shader  = PS_P010_HLG_Y_709_2020(frag_in);
 	}
 }
 
@@ -896,7 +896,7 @@ technique P010_SRGB_Y
 	pass
 	{
 		vertex_shader = VSPos(id);
-		pixel_shader  = PS_SRGB_Y(frag_in);
+		pixel_shader  = PS_P010_SRGB_Y(frag_in);
 	}
 }
 
@@ -905,7 +905,7 @@ technique P010_PQ_UV
 	pass
 	{
 		vertex_shader = VSTexPos_TopLeft(id);
-		pixel_shader  = PS_PQ_UV_709_2020_WideWide(frag_in);
+		pixel_shader  = PS_P010_PQ_UV_709_2020_WideWide(frag_in);
 	}
 }
 
@@ -914,7 +914,7 @@ technique P010_HLG_UV
 	pass
 	{
 		vertex_shader = VSTexPos_TopLeft(id);
-		pixel_shader  = PS_HLG_UV_709_2020_WideWide(frag_in);
+		pixel_shader  = PS_P010_HLG_UV_709_2020_WideWide(frag_in);
 	}
 }
 
@@ -923,7 +923,7 @@ technique P010_SRGB_UV
 	pass
 	{
 		vertex_shader = VSTexPos_TopLeft(id);
-		pixel_shader  = PS_SRGB_UV_WideWide(frag_in);
+		pixel_shader  = PS_P010_SRGB_UV_WideWide(frag_in);
 	}
 }
 


### PR DESCRIPTION
### Description
Don't want to rely on consumer to ignore those bits.

### Motivation and Context
Paranoia.

### How Has This Been Tested?
- [x] Verified color values appeared to be multiples of 0x40 (64), and that test videos looked about right.
- [x] Verified P010_PQ_Y used in RenderDoc.
- [x] Verified P010_PQ_UV used in RenderDoc.
- [x] Verified P010_HLG_Y used in RenderDoc.
- [x] Verified P010_HLG_UV used in RenderDoc.
- [x] Verified P010_SRGB_Y used in RenderDoc.
- [x] Verified P010_SRGB_UV used in RenderDoc.
- [x] Verified OpenGL on Windows still works.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.