### PR TITLE
obs-ffmpeg: Remove codec property from VAAPI encoder

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -77,7 +77,7 @@ struct vaapi_encoder {
 static const char *vaapi_getname(void *unused)
 {
 	UNUSED_PARAMETER(unused);
-	return "FFMPEG VAAPI";
+	return "FFMPEG VAAPI H.264";
 }
 
 static inline bool valid_format(enum video_format format)
@@ -351,11 +351,7 @@ static void *vaapi_create(obs_data_t *settings, obs_encoder_t *encoder)
 	enc = bzalloc(sizeof(*enc));
 	enc->encoder = encoder;
 
-	int vaapi_codec = (int)obs_data_get_int(settings, "vaapi_codec");
-
-	if (vaapi_codec == AV_CODEC_ID_H264) {
-		enc->vaapi = avcodec_find_encoder_by_name("h264_vaapi");
-	}
+	enc->vaapi = avcodec_find_encoder_by_name("h264_vaapi");
 
 	enc->first_packet = true;
 
@@ -517,7 +513,6 @@ static void vaapi_defaults(obs_data_t *settings)
 {
 	obs_data_set_default_string(settings, "vaapi_device",
 				    "/dev/dri/renderD128");
-	obs_data_set_default_int(settings, "vaapi_codec", AV_CODEC_ID_H264);
 	obs_data_set_default_int(settings, "profile",
 				 FF_PROFILE_H264_CONSTRAINED_BASELINE);
 	obs_data_set_default_int(settings, "level", 40);
@@ -646,13 +641,6 @@ static obs_properties_t *vaapi_properties(void *unused)
 			}
 		}
 	}
-
-	list = obs_properties_add_list(props, "vaapi_codec",
-				       obs_module_text("VAAPI.Codec"),
-				       OBS_COMBO_TYPE_LIST,
-				       OBS_COMBO_FORMAT_INT);
-
-	obs_property_list_add_int(list, "H.264 (default)", AV_CODEC_ID_H264);
 
 	list = obs_properties_add_list(props, "profile",
 				       obs_module_text("Profile"),


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Encoders have only one codec so this property is not needed.

Also rename the encoder to "FFMPEG VAAPI H.264".

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Cleanup

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Try to encode with VAAPI H.264 and it worked.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
