### PR TITLE
UI: Fix multithread-unsafe GetCurrentScene

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -735,6 +735,7 @@ void OBSBasic::SetCurrentScene(OBSSource scene, bool force)
 
 			if (source == scene) {
 				ui->scenes->blockSignals(true);
+				currentScene = itemScene.Get();
 				ui->scenes->setCurrentItem(item);
 				ui->scenes->blockSignals(false);
 				if (api)

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2769,8 +2769,7 @@ OBSSource OBSBasic::GetProgramSource()
 
 OBSScene OBSBasic::GetCurrentScene()
 {
-	QListWidgetItem *item = ui->scenes->currentItem();
-	return item ? GetOBSRef<OBSScene>(item) : nullptr;
+	return currentScene.load();
 }
 
 OBSSceneItem OBSBasic::GetSceneItem(QListWidgetItem *item)
@@ -3960,6 +3959,7 @@ void OBSBasic::RemoveSelectedScene()
 		QListWidgetItem *item = ui->scenes->takeItem(curIndex);
 		ui->scenes->insertItem(savedIndex, item);
 		ui->scenes->setCurrentRow(savedIndex);
+		currentScene = scene.Get();
 		ui->scenes->blockSignals(false);
 	};
 
@@ -4964,6 +4964,10 @@ void OBSBasic::on_scenes_currentItemChanged(QListWidgetItem *current,
 
 		scene = GetOBSRef<OBSScene>(current);
 		source = obs_scene_get_source(scene);
+
+		currentScene = scene;
+	} else {
+		currentScene = NULL;
 	}
 
 	SetCurrentScene(source);
@@ -5227,6 +5231,7 @@ void OBSBasic::ChangeSceneIndex(bool relative, int offset, int invalidIdx)
 	ui->scenes->insertItem(idx + offset, item);
 	ui->scenes->setCurrentRow(idx + offset);
 	item->setSelected(true);
+	currentScene = GetOBSRef<OBSScene>(item).Get();
 	ui->scenes->blockSignals(false);
 
 	OBSProjector::UpdateMultiviewProjectors();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -332,6 +332,8 @@ private:
 	QScopedPointer<QThread> patronJsonThread;
 	std::string patronJson;
 
+	std::atomic<obs_scene_t *> currentScene = nullptr;
+
 	void UpdateMultiviewProjectorMenu();
 
 	void DrawBackdrop(float cx, float cy);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Store current scene into a pointer variable in `OBSBasic` class.
When current scene is requested, return the saved pointer instead of querying `scenes` object, which is not multithread-safe.

`OBSBasic::GetCurrentScene()` is modified to return the stored pointer to the current scene instead of querying the `scenes` object. There can be a discussion not change the function and implement a new function for the purpose of multithread safe, then use it from the rendering routine and frontend-api.

~~New functions `os_atomic_store_ptr` and `os_atomic_load_ptr` are added to safely store the pointer to the current scene and load from any threads.~~ Reverted.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The function `OBSBasic::GetCurrentScene()` is also called from the graphics thread when rendering the preview and the multiview projectors.

https://github.com/obsproject/obs-studio/blob/5e696cdaa8152292570648b5345a22dbb109fdb1/UI/window-basic-main.cpp#L4186
https://github.com/obsproject/obs-studio/blob/5e696cdaa8152292570648b5345a22dbb109fdb1/UI/window-projector.cpp#L258
https://github.com/obsproject/obs-studio/blob/5e696cdaa8152292570648b5345a22dbb109fdb1/UI/window-projector.cpp#L644

Below is a back trace at a segmentation fault happened on Fedora 34, several minutes after modifying the list of the scene, which is very rare to catch.
The fault happened with a plugin [Color Monitor](https://github.com/norihiro/obs-color-monitor), which acquires the preview source at every `video_tick` callback on a source. However, The obs-studio would have the same concern because `GetCurrentScene()` is called inside the graphics thread.
```
(gdb) bt
#0  0x0000000000007f8f in  ()
#1  0x00007f8f3d6235fe in QMetaObject::cast(QObject const*) const () at /lib64/libQt5Core.so.5
#2  0x00007f8f3e4abb72 in QListWidget::currentItem() const () at /lib64/libQt5Widgets.so.5
#3  0x000000000049fe2d in OBSBasic::GetCurrentScene() (this=<optimized out>) at /home/user/repo/obs-studio/UI/window-basic-main.cpp:2747
#4  0x0000000000497867 in OBSBasic::GetCurrentSceneSource() (this=<optimized out>) at /home/user/repo/obs-studio/UI/window-basic-main.hpp:828
#5  OBSStudioAPI::obs_frontend_get_current_preview_scene() (this=<optimized out>) at /home/user/repo/obs-studio/UI/api-interface.cpp:546
#6  0x00007f8f18034b00 in cm_tick (data=data@entry=0x39563c0, unused=<optimized out>) at /home/user/repo/obs-color-monitor/src/common.c:303
#7  0x00007f8f18032908 in roi_tick (data=0x39563c0, unused=<optimized out>) at /home/user/repo/obs-color-monitor/src/roi.c:611
#8  0x00007f8f3dfb66b3 in obs_source_video_tick (source=0x3952280, seconds=0.0166833326) at /home/user/repo/obs-studio/libobs/obs-source.c:1280
#9  0x00007f8f3dff0ede in tick_sources (last_time=<optimized out>, cur_time=554321390081104) at /home/user/repo/obs-studio/libobs/obs-video.c:68
#10 obs_graphics_thread_loop (context=0x7f8ed3ffeb90) at /home/user/repo/obs-studio/libobs/obs-video.c:1003
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
These operations are checked while monitoring current-scene with obs-websocket and also monitoring the current scene on OBS Studio by eyes.

- Add, remove a scene, and undo/redo that operation.
- Change the current scene from obs-websocket using `SetPreviewScene`.

OS: Fedora 34

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
