### PR TITLE
UI: Make transform dialog spinboxes consistant

### DIFF
--- a/UI/forms/OBSBasicTransform.ui
+++ b/UI/forms/OBSBasicTransform.ui
@@ -76,6 +76,12 @@
             <height>0</height>
            </size>
           </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
           <property name="accessibleName">
            <string>Basic.TransformWindow.PositionX</string>
           </property>
@@ -99,6 +105,12 @@
            <size>
             <width>100</width>
             <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
            </size>
           </property>
           <property name="accessibleName">
@@ -143,6 +155,12 @@
         <size>
          <width>100</width>
          <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
         </size>
        </property>
        <property name="accessibleName">
@@ -201,6 +219,12 @@
             <height>0</height>
            </size>
           </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
           <property name="accessibleName">
            <string>Basic.TransformWindow.Width</string>
           </property>
@@ -227,6 +251,12 @@
            <size>
             <width>100</width>
             <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
            </size>
           </property>
           <property name="accessibleName">
@@ -492,6 +522,12 @@
             <height>0</height>
            </size>
           </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
           <property name="accessibleName">
            <string>Basic.TransformWindow.BoundsWidth</string>
           </property>
@@ -518,6 +554,12 @@
            <size>
             <width>100</width>
             <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
            </size>
           </property>
           <property name="accessibleName">
@@ -575,8 +617,14 @@
          </property>
          <property name="minimumSize">
           <size>
-           <width>70</width>
+           <width>100</width>
            <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="accessibleName">
@@ -600,8 +648,14 @@
          </property>
          <property name="minimumSize">
           <size>
-           <width>70</width>
+           <width>100</width>
            <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="accessibleName">
@@ -651,8 +705,14 @@
          </property>
          <property name="minimumSize">
           <size>
-           <width>70</width>
+           <width>100</width>
            <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="accessibleName">
@@ -676,8 +736,14 @@
          </property>
          <property name="minimumSize">
           <size>
-           <width>70</width>
+           <width>100</width>
            <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>16777215</height>
           </size>
          </property>
          <property name="accessibleName">


### PR DESCRIPTION
### Description
The spinboxes in the transform dialog were different sizes.

Before:
![2022-06-08 06_18_12-Edit Transform for 'Color Source'](https://user-images.githubusercontent.com/19962531/172603957-83554e34-c3e5-48a8-b8d9-c9886f9b49b4.png)

After:
![2022-06-08 06_11_27-Edit Transform for 'Color Source'](https://user-images.githubusercontent.com/19962531/172604005-67342c50-c96f-41b6-89b4-9ac103c2dcdd.png)

### Motivation and Context
Makes the dialog look better

### How Has This Been Tested?
Looked at dialog to see if it looked better.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
