### PR TITLE
UI: Fix position of reset filters button

### DIFF
--- a/UI/forms/OBSBasicFilters.ui
+++ b/UI/forms/OBSBasicFilters.ui
@@ -563,19 +563,6 @@
            <enum>QLayout::SetMaximumSize</enum>
           </property>
           <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
            <widget class="QDialogButtonBox" name="buttonBox">
             <property name="standardButtons">
              <set>QDialogButtonBox::Close|QDialogButtonBox::RestoreDefaults</set>


### PR DESCRIPTION
### Description
This removes the horizontal spacer that pushed the filters
reset button to the right.

Before:
![2022-06-08 06_34_07-Filters for 'Color Source'](https://user-images.githubusercontent.com/19962531/172606713-4b45e13b-7ebf-4f1d-b3b2-4babb74c4888.png)

After:
![2022-06-08 06_32_11-Filters for 'Color Source'](https://user-images.githubusercontent.com/19962531/172606450-4d8e6937-2f12-4aa4-9ba0-bf0bfef2fe95.png)

### Motivation and Context
Makes the dialog look better

### How Has This Been Tested?
Looked to see if the button was all the way to the left

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
