### PR TITLE
UI: handle theme file names with "." characters

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1215,7 +1215,7 @@ void OBSBasicSettings::LoadThemeList()
 				QDir::Files);
 		while (it.hasNext()) {
 			it.next();
-			QString name = it.fileName().section(".", 0, 0);
+			QString name = it.fileInfo().completeBaseName();
 			ui->theme->addItem(name);
 			uniqueSet.insert(name);
 		}
@@ -1231,7 +1231,7 @@ void OBSBasicSettings::LoadThemeList()
 			 QDir::Files);
 	while (uIt.hasNext()) {
 		uIt.next();
-		QString name = uIt.fileName().section(".", 0, 0);
+		QString name = uIt.fileInfo().completeBaseName();
 
 		if (name == DEFAULT_THEME)
 			name = defaultTheme;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
The Settings dialog derives theme names from names of the theme files, nominally by removing the ".qss" extension. However, the current code parses the name as "everything left of the first '.'" rather than "everything left of the LAST '.'"

Thus, if there is a file with a name such as "Dark-V27.2.4.qss" in the themes directory, the Settings dialog will show it as "Dark-V27", and an attempt to select the theme will cause an error. This PR corrects the parsing.
<!--- If this change includes UI elements, please include screenshots. -->
![files](https://user-images.githubusercontent.com/31324355/172673452-3b5b13a4-95e7-42fd-9a5b-9040424c27ff.png)
Theme directory including theme file with "." characters

![Ver27 2 4-composite](https://user-images.githubusercontent.com/31324355/172674664-ddb7c58a-df95-4e60-bedd-34aa72550be3.png)
Setting dialog in 27.2.4 truncates at first "." Selecting the truncated name shows an error, since file can't be loaded.

![Fix](https://user-images.githubusercontent.com/31324355/172673511-bc212d81-7a50-4fe7-983a-1de236dee0f8.png)
Fix correctly shows the name up to the .qss extension.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes a bug in parsing of theme filenames which prevented some valid names from being used.
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows 10.

- Rename a theme file to include one or several "." characters before the extension. For example, make a copy of Dark.qss and call it "Dark27.2.4.qss"
- Open the OBS Settings dialog and drop the "Themes" list. Verify correct or incorrect parsing of the theme filename
- Select the theme in question and verify that it is loaded correctly
- Close the Settings dialog and exit OBS
- Run OBS and verify that it correctly loads the selected theme

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
