### PR TITLE
decklink: Avoid sending 0x0 frame to libobs

### DIFF
--- a/plugins/decklink/decklink-device-instance.cpp
+++ b/plugins/decklink/decklink-device-instance.cpp
@@ -187,6 +187,9 @@ void DeckLinkDeviceInstance::HandleVideoFrame(
 	currentFrame.height = (uint32_t)frame->GetHeight();
 	currentFrame.timestamp = timestamp;
 
+	if (currentFrame.width == 0 || currentFrame.height == 0)
+		return;
+
 	obs_source_output_video2(
 		static_cast<DeckLinkInput *>(decklink)->GetSource(),
 		&currentFrame);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When the width or height is zero, avoid calling `obs_source_output_video2`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When opening a decklink source without plugging its input device, these error messages are shown for each frame.
```
error: glMapBuffer failed, glGetError returned GL_INVALID_OPERATION(0x502)
error: gs_texture_map (GL) failed
```
Debugging the code, I found the API sometimes send frames with 0x0 size when the mode is set to auto. Without filtering such frames, which causes libobs to output error messages.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: Fedora 34
Device: Decklink Quad
Settings of the decklink source is `Mode` = `Auto`.

Preparation
1. Configure decklink-source with `Mode` = `Auto`.

Run these steps several times.
1. Restart OBS.
2. Check stdout or log file.

Note that this changes minor behavior at the time the source becomes inactive. Prior to this change, the size of the source sometimes become 0x0 when the input cable of the source is disconnected. With this change, the last frame will be displayed at such a case.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
