### PR TITLE
UI: Add eventFilter to media slider

### DIFF
--- a/UI/media-slider.cpp
+++ b/UI/media-slider.cpp
@@ -4,6 +4,7 @@
 
 MediaSlider::MediaSlider(QWidget *parent) : SliderIgnoreScroll(parent)
 {
+	installEventFilter(this);
 	setMouseTracking(true);
 
 	QString styleName = style()->objectName();
@@ -31,4 +32,21 @@ void MediaSlider::mouseMoveEvent(QMouseEvent *event)
 	emit mediaSliderHovered(val);
 	event->accept();
 	QSlider::mouseMoveEvent(event);
+}
+
+bool MediaSlider::eventFilter(QObject *obj, QEvent *event)
+{
+	if (event->type() == QEvent::KeyPress) {
+		QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+
+		if (keyEvent->key() == Qt::Key_Up ||
+		    keyEvent->key() == Qt::Key_Down) {
+			return true;
+		}
+	}
+
+	if (event->type() == QEvent::Wheel)
+		return true;
+
+	return QSlider::eventFilter(obj, event);
 }

--- a/UI/media-slider.hpp
+++ b/UI/media-slider.hpp
@@ -14,4 +14,5 @@ signals:
 
 protected:
 	virtual void mouseMoveEvent(QMouseEvent *event) override;
+	virtual bool eventFilter(QObject *obj, QEvent *event) override;
 };


### PR DESCRIPTION
### Description
When pressing the up and down arrows or moving the mouse wheel
for the media slider, the slider would move.

### Motivation and Context
Noticed the slider would move when using the up/down arrow keys or the mouse wheel.
In the future we could use the mouse wheel for seeking.

### How Has This Been Tested?
Made sure the slider didn't move.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
