### PR TITLE
cmake: Enable ENABLE_HEVC by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 # Global project options
-option(ENABLE_HEVC "Enable HEVC encoders" OFF)
+option(ENABLE_HEVC "Enable HEVC encoders" ON)
 if(ENABLE_HEVC)
   add_compile_definitions(ENABLE_HEVC)
 endif()


### PR DESCRIPTION
### Description
Enable HEVC code by default.

### Motivation and Context
Widespread hardware encode/decode support.

### How Has This Been Tested?
Verified HEVC was enabled by default in fresh CMake build directory. Was able to make HEVC recording with NVENC.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.