### PR TITLE
deps/media-playback: Fix metadata for hw_accel

### DIFF
--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -346,9 +346,15 @@ static int decode_packet(struct mp_decode *d, int *got_frame)
 		}
 
 		int err = av_hwframe_transfer_data(d->sw_frame, d->hw_frame, 0);
-		if (err != 0) {
+		if (err) {
 			ret = 0;
 			*got_frame = false;
+		} else {
+			d->sw_frame->color_range = d->hw_frame->color_range;
+			d->sw_frame->color_primaries =
+				d->hw_frame->color_primaries;
+			d->sw_frame->color_trc = d->hw_frame->color_trc;
+			d->sw_frame->colorspace = d->hw_frame->colorspace;
 		}
 	}
 #endif


### PR DESCRIPTION
### Description
av_hwframe_transfer_data doesn't seem to transfer metadata, so do it
manually.

### Motivation and Context
Want to display video correctly.

### How Has This Been Tested?
HDR video displayed incorrectly before, correctly after.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.