### PR TITLE
CI: allow specifying cmake args on Windows

### DIFF
--- a/CI/build-windows.ps1
+++ b/CI/build-windows.ps1
@@ -10,7 +10,8 @@ Param(
     [ValidateSet('x86', 'x64')]
     [String]$BuildArch = ('x86', 'x64')[[System.Environment]::Is64BitOperatingSystem],
     [ValidateSet("Release", "RelWithDebInfo", "MinSizeRel", "Debug")]
-    [String]$BuildConfiguration = "RelWithDebInfo"
+    [String]$BuildConfiguration = "RelWithDebInfo",
+    [String]$CMakeArgs = "CMakeArgs"
 )
 
 ##############################################################################
@@ -36,6 +37,7 @@ Param(
 #   -CombinedArchs          : Create combined packages and installer
 #                             (x86 and x64) - Default: off
 #   -Package                : Prepare folder structure for installer creation
+#   -CMakeArgs              : Additional arguments to CMake
 #
 # Environment Variables (optional):
 #  WindowsDepsVersion       : Pre-compiled Windows dependencies version

--- a/CI/windows/02_build_obs.ps1
+++ b/CI/windows/02_build_obs.ps1
@@ -6,7 +6,8 @@ Param(
     [ValidateSet('x86', 'x64')]
     [String]$BuildArch = $(if (Test-Path variable:BuildArch) { "${BuildArch}" } else { ('x86', 'x64')[[System.Environment]::Is64BitOperatingSystem] }),
     [ValidateSet("Release", "RelWithDebInfo", "MinSizeRel", "Debug")]
-    [String]$BuildConfiguration = $(if (Test-Path variable:BuildConfiguration) { "${BuildConfiguration}" } else { "RelWithDebInfo" })
+    [String]$BuildConfiguration = $(if (Test-Path variable:BuildConfiguration) { "${BuildConfiguration}" } else { "RelWithDebInfo" }),
+    [String]$CMakeArgs = $(if (Test-Path variable:CMakeArgs) { "${CMakeArgs}" } else { "" })
 )
 
 ##############################################################################
@@ -24,7 +25,8 @@ function Build-OBS {
     Param(
         [String]$BuildDirectory = $(if (Test-Path variable:BuildDirectory) { "${BuildDirectory}" }),
         [String]$BuildArch = $(if (Test-Path variable:BuildArch) { "${BuildArch}" }),
-        [String]$BuildConfiguration = $(if (Test-Path variable:BuildConfiguration) { "${BuildConfiguration}" })
+        [String]$BuildConfiguration = $(if (Test-Path variable:BuildConfiguration) { "${BuildConfiguration}" }),
+        [String]$CMakeArgs = $(if (Test-Path variable:CMakeArgs) { "${CMakeArgs}" })
     )
 
     $NumProcessors = (Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors
@@ -87,7 +89,8 @@ function Configure-OBS {
         "-DCOPY_DEPENDENCIES=ON",
         "-DBUILD_FOR_DISTRIBUTION=`"$(if (Test-Path Env:BUILD_FOR_DISTRIBUTION) { "ON" } else { "OFF" })`"",
         "$(if (Test-Path Env:CI) { "-DOBS_BUILD_NUMBER=${Env:GITHUB_RUN_ID}" })",
-        "$(if (Test-Path Variable:$Quiet) { "-Wno-deprecated -Wno-dev --log-level=ERROR" })"
+        "$(if (Test-Path Variable:$Quiet) { "-Wno-deprecated -Wno-dev --log-level=ERROR" })",
+        "${CMakeArgs}"
     )
 
     Invoke-Expression "cmake ${CmakeCommand}"
@@ -115,7 +118,8 @@ function Print-Usage {
         "-Verbose                 : Enable more verbose build process output",
         "-BuildDirectory          : Directory to use for builds - Default: build64 on 64-bit systems, build32 on 32-bit systems",
         "-BuildArch               : Build architecture to use (x86 or x64) - Default: local architecture",
-        "-BuildConfiguration      : Build configuration to use - Default: RelWithDebInfo"
+        "-BuildConfiguration      : Build configuration to use - Default: RelWithDebInfo",
+        "-CMakeArgs               : Additional arguments to CMake"
     )
 
     $Lines | Write-Host


### PR DESCRIPTION
### Description
This adds the ability to specify `-CMakeArgs "arbitrary cmake args"`
on the `./CI/build-windows.ps1` command line.

### Motivation and Context
Some plugins require additional CMake settings to be specified.

### How Has This Been Tested?
Tested a full automated build flow with custom cmake args locally.

### Types of changes
- Tweak (non-breaking change to improve existing functionality) 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
