### PR TITLE
libobs/util: Add function to get Rosetta translation status

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2173,7 +2173,7 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		}
 
 #ifdef __APPLE__
-		bool rosettaTranslated = ProcessIsRosettaTranslated();
+		bool rosettaTranslated = os_get_emulation_status();
 		blog(LOG_INFO, "Rosetta translation used: %s",
 		     rosettaTranslated ? "true" : "false");
 #endif

--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -202,19 +202,6 @@ void EnableOSXDockIcon(bool enable)
 				NSApplicationActivationPolicyProhibited];
 }
 
-bool ProcessIsRosettaTranslated()
-{
-#ifdef __aarch64__
-	return false;
-#else
-	int ret = 0;
-	size_t size = sizeof(ret);
-	if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1)
-		return false;
-	return ret == 1;
-#endif
-}
-
 // Not implemented yet
 void TaskbarOverlayInit() {}
 void TaskbarOverlaySetStatus(TaskbarOverlayStatus) {}

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -85,5 +85,4 @@ void EnableOSXDockIcon(bool enable);
 bool isInBundle();
 void InstallNSApplicationSubclass();
 void disableColorSpaceConversion(QWidget *window);
-bool ProcessIsRosettaTranslated();
 #endif

--- a/docs/sphinx/reference-libobs-util-platform.rst
+++ b/docs/sphinx/reference-libobs-util-platform.rst
@@ -478,3 +478,12 @@ Other Functions
 .. function:: uint64_t os_get_proc_virtual_size(void)
 
    Returns the virtual memory size of the current process.
+
+---------------------
+
+.. function:: bool os_get_emulation_status(void)
+
+   Returns true if the current process is a x64 binary and is being emulated or translated
+   by the host operating system. On macOS, it returns true when a x64 binary is 
+   being translated by Rosetta and running on Apple Silicon Macs. This function is not yet
+   implemented on Windows and Linux and will always return false on those platforms.

--- a/libobs/util/platform-cocoa.m
+++ b/libobs/util/platform-cocoa.m
@@ -319,6 +319,21 @@ static int physical_cores = 0;
 static int logical_cores = 0;
 static bool core_count_initialized = false;
 
+bool os_get_emulation_status(void)
+{
+#ifdef __aarch64__
+	return false;
+#else
+	int rosettaTranslated = 0;
+	size_t size = sizeof(rosettaTranslated);
+	if (sysctlbyname("sysctl.proc_translated", &rosettaTranslated, &size,
+			 NULL, 0) == -1)
+		return false;
+
+	return rosettaTranslated == 1;
+#endif
+}
+
 static void os_get_cores_internal(void)
 {
 	if (core_count_initialized)

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -401,6 +401,11 @@ char *os_get_executable_path_ptr(const char *name)
 	return path.array;
 }
 
+bool os_get_emulation_status(void)
+{
+	return false;
+}
+
 #endif
 
 bool os_file_exists(const char *path)

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -992,6 +992,11 @@ bool is_64_bit_windows(void)
 #endif
 }
 
+bool os_get_emulation_status(void)
+{
+	return false;
+}
+
 void get_reg_dword(HKEY hkey, LPCWSTR sub_key, LPCWSTR value_name,
 		   struct reg_dword *info)
 {

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -123,6 +123,8 @@ EXPORT char *os_get_abs_path_ptr(const char *path);
 
 EXPORT const char *os_get_path_extension(const char *path);
 
+EXPORT bool os_get_emulation_status(void);
+
 struct os_dir;
 typedef struct os_dir os_dir_t;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add function to get Rosetta translation status
Pruned from #5738.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
As per @gxalpha's request

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
 - New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
