### PR TITLE
Check return value of obs_encoder_get_extra_data

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -638,7 +638,8 @@ static bool send_audio_headers(struct ffmpeg_muxer *stream,
 	struct encoder_packet packet = {
 		.type = OBS_ENCODER_AUDIO, .timebase_den = 1, .track_idx = idx};
 
-	obs_encoder_get_extra_data(aencoder, &packet.data, &packet.size);
+	if (!obs_encoder_get_extra_data(aencoder, &packet.data, &packet.size))
+		return false;
 	return write_packet(stream, &packet);
 }
 
@@ -649,7 +650,8 @@ static bool send_video_headers(struct ffmpeg_muxer *stream)
 	struct encoder_packet packet = {.type = OBS_ENCODER_VIDEO,
 					.timebase_den = 1};
 
-	obs_encoder_get_extra_data(vencoder, &packet.data, &packet.size);
+	if (!obs_encoder_get_extra_data(vencoder, &packet.data, &packet.size))
+		return false;
 	return write_packet(stream, &packet);
 }
 

--- a/plugins/obs-outputs/flv-output.c
+++ b/plugins/obs-outputs/flv-output.c
@@ -119,7 +119,8 @@ static void write_audio_header(struct flv_output *stream)
 	struct encoder_packet packet = {.type = OBS_ENCODER_AUDIO,
 					.timebase_den = 1};
 
-	obs_encoder_get_extra_data(aencoder, &packet.data, &packet.size);
+	if (!obs_encoder_get_extra_data(aencoder, &packet.data, &packet.size))
+		return;
 	write_packet(stream, &packet, true);
 }
 
@@ -133,7 +134,8 @@ static void write_video_header(struct flv_output *stream)
 	struct encoder_packet packet = {
 		.type = OBS_ENCODER_VIDEO, .timebase_den = 1, .keyframe = true};
 
-	obs_encoder_get_extra_data(vencoder, &header, &size);
+	if (!obs_encoder_get_extra_data(vencoder, &header, &size))
+		return;
 	packet.size = obs_parse_avc_header(&packet.data, header, size);
 	write_packet(stream, &packet, true);
 	bfree(packet.data);

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -553,7 +553,8 @@ static bool send_video_header(struct ftl_stream *stream, int64_t dts_usec)
 					.keyframe = true,
 					.dts_usec = dts_usec};
 
-	obs_encoder_get_extra_data(vencoder, &header, &size);
+	if (!obs_encoder_get_extra_data(vencoder, &header, &size))
+		return false;
 	packet.size = obs_parse_avc_header(&packet.data, header, size);
 	return send_packet(stream, &packet, true) >= 0;
 }

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -795,7 +795,8 @@ static bool send_audio_header(struct rtmp_stream *stream, size_t idx,
 		return true;
 	}
 
-	obs_encoder_get_extra_data(aencoder, &header, &packet.size);
+	if (!obs_encoder_get_extra_data(aencoder, &header, &packet.size))
+		return false;
 	packet.data = bmemdup(header, packet.size);
 	return send_packet(stream, &packet, true, idx) >= 0;
 }
@@ -810,7 +811,8 @@ static bool send_video_header(struct rtmp_stream *stream)
 	struct encoder_packet packet = {
 		.type = OBS_ENCODER_VIDEO, .timebase_den = 1, .keyframe = true};
 
-	obs_encoder_get_extra_data(vencoder, &header, &size);
+	if (!obs_encoder_get_extra_data(vencoder, &header, &size))
+		return false;
 	packet.size = obs_parse_avc_header(&packet.data, header, size);
 	return send_packet(stream, &packet, true, 0) >= 0;
 }


### PR DESCRIPTION
### Description
`obs_encoder_get_extra_data` was called in many places without checking the return value. If the encoder was invalid, the input fields would be left as-is with uninitialized memory, resulting in a crash when they were used later.

This was found in obs-outputs where the send_thread can be in the process of (re)connecting but the encoder was shut down in the meantime, all other instances were fixed for consistency even if they weren't susceptible to race conditions.

### Motivation and Context
Crashing is bad.

### How Has This Been Tested?
I was not able to reproduce the race condition, but tracing the code shows that this should correctly pass the error back up the stack instead of crashing.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
