### PR TITLE
Fix compiler warnings in several modules

### DIFF
--- a/UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp
+++ b/UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp
@@ -220,7 +220,8 @@ void populate_multi_view_audio_sources(obs_property_t *list, NTV2DeviceID id)
 }
 
 bool on_misc_device_selected(void *data, obs_properties_t *props,
-			     obs_property_t *list, obs_data_t *settings)
+			     obs_property_t *list OBS_UNUSED,
+			     obs_data_t *settings)
 {
 	const char *cardID = obs_data_get_string(settings, kUIPropDevice.id);
 	if (!cardID || !cardID[0])
@@ -450,7 +451,7 @@ static void OBSEvent(enum obs_frontend_event event, void *)
 	}
 }
 
-static void aja_loaded(void *data, calldata_t *calldata)
+static void aja_loaded(void *data OBS_UNUSED, calldata_t *calldata)
 {
 	// Receive CardManager pointer from the main AJA plugin
 	calldata_get_ptr(calldata, "card_manager", &cardManager);

--- a/deps/libcaption/CMakeLists.txt
+++ b/deps/libcaption/CMakeLists.txt
@@ -25,7 +25,13 @@ target_sources(
 
 target_compile_definitions(
   caption PRIVATE __STDC_CONSTANT_MACROS
-                  "$<$<BOOL:${OS_WINDOWS}>:_CRT_SECURE_NO_WARNINGS>")
+                  $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>)
+
+target_compile_options(
+  caption
+  PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wno-unused-but-set-parameter>
+)
 
 target_include_directories(
   caption

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -258,7 +258,12 @@ target_compile_definitions(
 
 target_compile_features(libobs PRIVATE cxx_alias_templates)
 
-target_compile_options(libobs PUBLIC ${ARCH_SIMD_FLAGS})
+target_compile_options(
+  libobs
+  PUBLIC ${ARCH_SIMD_FLAGS}
+  PRIVATE
+    $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:GNU>>:-Wno-switch>
+)
 
 target_include_directories(
   libobs PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/libobs/graphics/graphics-ffmpeg.c
+++ b/libobs/graphics/graphics-ffmpeg.c
@@ -152,7 +152,7 @@ static void *ffmpeg_image_copy_data_straight(struct ffmpeg_image *info,
 	return data;
 }
 
-static inline size_t get_dst_position(size_t src, const size_t w,
+static inline size_t get_dst_position(size_t src OBS_UNUSED, const size_t w,
 				      const size_t h, const size_t x,
 				      const size_t y, int orient)
 {

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1499,12 +1499,10 @@ static bool scene_audio_render(void *data, uint64_t *ts_out,
 	return true;
 }
 
-enum gs_color_space
-scene_video_get_color_space(void *data, size_t count,
-			    const enum gs_color_space *preferred_spaces)
+enum gs_color_space scene_video_get_color_space(
+	void *data OBS_UNUSED, size_t count OBS_UNUSED,
+	const enum gs_color_space *preferred_spaces OBS_UNUSED)
 {
-	UNUSED_PARAMETER(data);
-
 	enum gs_color_space space = GS_CS_SRGB;
 	struct obs_video_info ovi;
 	if (obs_get_video_info(&ovi)) {
@@ -2062,7 +2060,7 @@ static inline bool source_has_audio(obs_source_t *source)
 static obs_sceneitem_t *obs_scene_add_internal(obs_scene_t *scene,
 					       obs_source_t *source,
 					       obs_sceneitem_t *insert_after,
-					       bool create_texture)
+					       bool create_texture OBS_UNUSED)
 {
 	struct obs_scene_item *last;
 	struct obs_scene_item *item;

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -599,7 +599,7 @@ static const uint8_t *set_gpu_converted_plane(uint32_t width, uint32_t height,
 	return in;
 }
 
-static void set_gpu_converted_data(struct obs_core_video *video,
+static void set_gpu_converted_data(struct obs_core_video *video OBS_UNUSED,
 				   struct video_frame *output,
 				   const struct video_data *input,
 				   const struct video_output_info *info)

--- a/plugins/aja/aja-common.cpp
+++ b/plugins/aja/aja-common.cpp
@@ -201,7 +201,8 @@ void populate_pixel_format_list(NTV2DeviceID deviceID, obs_property_t *list)
 	}
 }
 
-void populate_sdi_transport_list(obs_property_t *list, IOSelection io,
+void populate_sdi_transport_list(obs_property_t *list,
+				 IOSelection io OBS_UNUSED,
 				 NTV2DeviceID deviceID, bool capture)
 {
 	if (capture) {
@@ -1019,7 +1020,7 @@ inline bool IsStandard1080p(NTV2Standard standard)
 	return false;
 }
 
-VPIDStandard DetermineVPIDStandard(NTV2DeviceID id, IOSelection io,
+VPIDStandard DetermineVPIDStandard(NTV2DeviceID id OBS_UNUSED, IOSelection io,
 				   NTV2VideoFormat vf, NTV2PixelFormat pf,
 				   SDITransport trx, SDITransport4K t4k)
 {

--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -331,9 +331,9 @@ static obs_missing_files_t *image_source_missingfiles(void *data)
 	return files;
 }
 
-static enum gs_color_space
-image_source_get_color_space(void *data, size_t count,
-			     const enum gs_color_space *preferred_spaces)
+static enum gs_color_space image_source_get_color_space(
+	void *data, size_t count OBS_UNUSED,
+	const enum gs_color_space *preferred_spaces OBS_UNUSED)
 {
 	struct image_source *const s = data;
 	gs_image_file4_t *const if4 = &s->if4;

--- a/plugins/obs-ffmpeg/CMakeLists.txt
+++ b/plugins/obs-ffmpeg/CMakeLists.txt
@@ -56,6 +56,11 @@ endif()
 
 set_target_properties(obs-ffmpeg PROPERTIES FOLDER "plugins/obs-ffmpeg" PREFIX
                                                                         "")
+target_compile_options(
+  obs-ffmpeg
+  PRIVATE
+    $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:GNU>>:-Wno-switch>
+)
 
 if(OS_WINDOWS)
   if(MSVC)

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -290,6 +290,8 @@ static void *nvenc_create_internal(obs_data_t *settings, obs_encoder_t *encoder,
 					       on_init_error, on_first_packet))
 			goto fail;
 	} else
+#else
+	UNUSED_PARAMETER(hevc);
 #endif
 	{
 		if (!ffmpeg_video_encoder_init(&enc->ffve, enc, settings,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-video-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-video-encoders.c
@@ -142,9 +142,9 @@ void ffmpeg_video_encoder_free(struct ffmpeg_video_encoder *enc)
 }
 
 bool ffmpeg_video_encoder_init(struct ffmpeg_video_encoder *enc, void *parent,
-			       obs_data_t *settings, obs_encoder_t *encoder,
-			       const char *enc_lib, const char *enc_lib2,
-			       const char *enc_name,
+			       obs_data_t *settings OBS_UNUSED,
+			       obs_encoder_t *encoder, const char *enc_lib,
+			       const char *enc_lib2, const char *enc_name,
 			       init_error_cb on_init_error,
 			       first_packet_cb on_first_packet)
 {

--- a/plugins/obs-filters/CMakeLists.txt
+++ b/plugins/obs-filters/CMakeLists.txt
@@ -157,6 +157,12 @@ target_include_directories(
 
 target_link_libraries(obs-filters PRIVATE OBS::libobs)
 
+target_compile_options(
+  obs-filters
+  PRIVATE
+    $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:GNU>>:-Wno-switch>
+)
+
 set_target_properties(obs-filters PROPERTIES FOLDER "plugins" PREFIX "")
 
 if(OS_WINDOWS)

--- a/plugins/obs-x264/CMakeLists.txt
+++ b/plugins/obs-x264/CMakeLists.txt
@@ -16,6 +16,12 @@ target_link_libraries(obs-x264 PRIVATE LIBX264::LIBX264 OBS::opts-parser)
 
 set_target_properties(obs-x264 PROPERTIES FOLDER "plugins" PREFIX "")
 
+target_compile_options(
+  obs-x264
+  PRIVATE
+    $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:GNU>>:-Wno-switch>
+)
+
 if(OS_WINDOWS)
   set(MODULE_DESCRIPTION "OBS x264 encoder")
   configure_file(${CMAKE_SOURCE_DIR}/cmake/bundle/windows/obs-module.rc.in


### PR DESCRIPTION
### Description
Fixes and/or suppresses compiler warnings in several modules. Main fixes are:

* Suppress warnings about non-exhaustive `switch` cases (fixed via compiler flags)
* Suppress warnings about unused variables (fixed via `OBS_UNUSED` macro)
* Fix warning about a function marked as no_return supposedly returning (fixed by applying the macro to all aliased function signatures as well)

### Motivation and Context
Fixing warnings removes clutter in build output and allows maintainers to focus on actual (or new) warnings and errors.

### How Has This Been Tested?
* OBS built and tested locally on macOS

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
