### PR TITLE
mac-syphon: Fix usage of methods deprecated since macOS 11.0

### DIFF
--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -2,6 +2,7 @@
 #import <ScriptingBridge/ScriptingBridge.h>
 #import "syphon-framework/Syphon.h"
 #include <obs-module.h>
+#include <AvailabilityMacros.h>
 
 #define LOG(level, message, ...)                                    \
 	blog(level, "%s: " message, obs_source_get_name(s->source), \
@@ -621,7 +622,19 @@ static inline NSString *get_inject_application_path()
 {
 	static NSString *ident = @"zakk.lol.SyphonInject";
 	NSWorkspace *ws = [NSWorkspace sharedWorkspace];
+#if (__MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0)
+	if (@available(macOS 11.0, *)) {
+		NSURL *url = [ws URLForApplicationWithBundleIdentifier:ident];
+		return [url absoluteString];
+	} else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+		return [ws absolutePathForAppBundleWithIdentifier:ident];
+#pragma clang diagnostic pop
+	}
+#else
 	return [ws absolutePathForAppBundleWithIdentifier:ident];
+#endif
 }
 
 static inline bool is_inject_available_in_lib_dir(NSFileManager *fm, NSURL *url)
@@ -865,7 +878,24 @@ static void show_syphon_license_internal(void)
 		return;
 
 	NSWorkspace *ws = [NSWorkspace sharedWorkspace];
+
+#if (__MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0)
+	if (@available(macOS 11.0, *)) {
+		NSURL *url = [NSURL
+			URLWithString:
+				[NSString
+					stringWithCString:path
+						 encoding:NSUTF8StringEncoding]];
+		[ws openURL:url];
+	} else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+		[ws openFile:@(path)];
+#pragma clang diagnostic pop
+	}
+#else
 	[ws openFile:@(path)];
+#endif
 	bfree(path);
 }
 


### PR DESCRIPTION
### Description
`absolutePathForAppBundleWithIdentifier` and `openFile` have both been deprecated since macOS 11.0. 

This implements the correct modern APIs when OBS is compiled for macOS 11.0 or more recent and falls back to the legacy APIs when either compiled against or run on older macOS versions.

### Motivation and Context
Ensure compatibility with future versions of macOS.

### How Has This Been Tested?
* Still needs to be tested with a proper Syphon setup

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
