### PR TITLE
UI: Fix crash if missing module in context bar

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -229,9 +229,8 @@ void AudioCaptureToolbar::Init()
 
 	obs_module_t *mod =
 		get_os_module("win-wasapi", "mac-capture", "linux-pulseaudio");
-	if (!mod) {
+	if (!mod)
 		return;
-	}
 
 	const char *device_str =
 		get_os_text(mod, "Device", "CoreAudio.Device", "Device");
@@ -254,6 +253,9 @@ void WindowCaptureToolbar::Init()
 
 	obs_module_t *mod =
 		get_os_module("win-capture", "mac-capture", "linux-capture");
+	if (!mod)
+		return;
+
 	const char *device_str = get_os_text(mod, "WindowCapture.Window",
 					     "WindowUtils.Window", "Window");
 	ui->deviceLabel->setText(device_str);
@@ -283,6 +285,9 @@ void DisplayCaptureToolbar::Init()
 
 	obs_module_t *mod =
 		get_os_module("win-capture", "mac-capture", "linux-capture");
+	if (!mod)
+		return;
+
 	const char *device_str =
 		get_os_text(mod, "Monitor", "DisplayCapture.Display", "Screen");
 	ui->deviceLabel->setText(device_str);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When a module is not found, immediately return from the `Init()` function. This is same change as 41367bb2b but fixes window-capture and display-capture. See also #3485.

Also removes an unnecessary pair of braces.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
If a module is not found in context bar, it crashed when resolving source type name.

The situation could happen in such cases below.
- The OBS Studio is built by a user who does not have enough dependencies to build the required module for the context bar such as `linux-capture` but the source is instantiated from imported configuration from other machine.
- User might remove the module.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Fedora 34. Log shows `xshm_input` is not found. Then choose the source for `xshm_input` and ensure the OBS won't crash.
```
Source ID 'xshm_input' not found
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
