### PR TITLE
mac-avcapture: Make "High" preset default

### DIFF
--- a/plugins/mac-avcapture/av-capture.mm
+++ b/plugins/mac-avcapture/av-capture.mm
@@ -1415,19 +1415,24 @@ static NSString *preset_names(NSString *preset)
 	return [NSString stringWithFormat:@"Unknown (%@)", preset];
 }
 
-inline static void av_capture_defaults(obs_data_t *settings, bool enable_audio)
+inline static void av_capture_defaults(obs_data_t *settings,
+				       bool enable_audio_and_high_preset)
 {
 	obs_data_set_default_string(settings, "uid", "");
 	obs_data_set_default_bool(settings, "use_preset", true);
 
-	obs_data_set_default_string(settings, "preset",
-				    AVCaptureSessionPreset1280x720.UTF8String);
+	obs_data_set_default_string(
+		settings, "preset",
+		enable_audio_and_high_preset
+			? AVCaptureSessionPresetHigh.UTF8String
+			: AVCaptureSessionPreset1280x720.UTF8String);
 
 	obs_data_set_default_int(settings, "input_format", INPUT_FORMAT_AUTO);
 	obs_data_set_default_int(settings, "color_space", COLOR_SPACE_AUTO);
 	obs_data_set_default_int(settings, "video_range", VIDEO_RANGE_AUTO);
 
-	obs_data_set_default_bool(settings, "enable_audio", enable_audio);
+	obs_data_set_default_bool(settings, "enable_audio",
+				  enable_audio_and_high_preset);
 }
 
 static void av_capture_defaults_v1(obs_data_t *settings)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the default camera preset from 720p to [High](https://developer.apple.com/documentation/avfoundation/avcapturesessionpresethigh).
High is the maximum resolution that the camera provides.
Does not need v3 since v2 has not yet been deployed in production.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Users often don't change defaults and then are stuck on 720p
even if their webcam supports 1080p or more.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Created source on 27.2 and tested that it stays on 720 on the new build.
Created source on new build and confirmed it defaults to High, resulting in
1080p on my internal MacBook facecam.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
