### PR TITLE
mac-virtualcam: Fix IOSurface memory leak

### DIFF
--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
@@ -397,7 +397,10 @@
 	}
 
 	err = CMSimpleQueueEnqueue(self.queue, sampleBuffer);
+
 	if (err != noErr) {
+		CFRelease(sampleBuffer);
+
 		DLog(@"CMSimpleQueueEnqueue err %d", err);
 		return;
 	}


### PR DESCRIPTION
This change fixes a memory leak in the mac-virtualcam plugin that causes OBS to not release the CVPixelBuffers (and underlying IOSurfaces) it emits to the virtual camera consumers.

### Description
I have found that the plugin is leaking Mach ports associated with IOSurfaces, preventing them from being re-used. The previous approach using `NSMachPort` does not seem to properly release the Mach port allocated via `CVPixelBufferGetIOSurface` and `IOSurfaceLookupFromMachPort`. Instead, we must explicitly deallocate the port using `mach_port_deallocate`.

### Motivation and Context
Pull request https://github.com/obsproject/obs-studio/pull/6573 (Avoid transcoding where possible) updated the mac-virtualcam plugin to share the virtual camera feed with other processes via IOSurfaces.

Although the changes work correctly, users have observed that OBS memory usage keeps increasing when the virtual camera is active until OBS runs out of memory or the consuming application is closed.
See the report by @SciTechNick for more information: https://github.com/obsproject/obs-studio/pull/6573#issuecomment-1161979765

### How Has This Been Tested?
I have tested the changes on a Macbook Pro (M1) running macOS Monterey with Google Chrome, Zoom, and Cameo. OBS shows no signs of memory leakage after multiple minutes.

### Types of changes
Bug fix

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
