### PR TITLE
obs-outputs: Rework RTMP context init/deinit

### DIFF
--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -420,7 +420,7 @@ RTMP_TLS_Init(RTMP *r)
 
 void
 RTMP_TLS_Free(RTMP *r) {
-#ifdef USE_MBEDTLS
+#if defined(CRYPTO) && defined(USE_MBEDTLS)
 
     if (!r->RTMP_TLS_ctx)
         return;
@@ -451,9 +451,7 @@ RTMP_Alloc()
 void
 RTMP_Free(RTMP *r)
 {
-#if defined(CRYPTO) && defined(USE_MBEDTLS)
     RTMP_TLS_Free(r);
-#endif
     free(r);
 }
 
@@ -463,11 +461,7 @@ RTMP_Init(RTMP *r)
     memset(r, 0, sizeof(RTMP));
     r->m_sb.sb_socket = -1;
     RTMP_Reset(r);
-
-#ifdef CRYPTO
     RTMP_TLS_Init(r);
-#endif
-
 }
 
 void

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -154,7 +154,6 @@ static void *rtmp_stream_create(obs_data_t *settings, obs_output_t *output)
 	pthread_mutex_init_value(&stream->packets_mutex);
 
 	RTMP_LogSetCallback(log_rtmp);
-	RTMP_Init(&stream->rtmp);
 	RTMP_LogSetLevel(RTMP_LOGWARNING);
 
 	if (pthread_mutex_init(&stream->packets_mutex, NULL) != 0)
@@ -1050,19 +1049,10 @@ static int try_connect(struct rtmp_stream *stream)
 
 	info("Connecting to RTMP URL %s...", stream->path.array);
 
-	// on reconnect we need to reset the internal variables of librtmp
-	// otherwise the data sent/received will not parse correctly on the other end
-	RTMP_Reset(&stream->rtmp);
-
-	// apparently TLS will not properly persist through connections
+	// free any existing RTMP TLS context
 	RTMP_TLS_Free(&stream->rtmp);
-	RTMP_TLS_Init(&stream->rtmp);
 
-	// since we don't call RTMP_Init above, there's no other good place
-	// to reset this as doing it in RTMP_Close breaks the ugly RTMP
-	// authentication system
-	memset(&stream->rtmp.Link, 0, sizeof(stream->rtmp.Link));
-	stream->rtmp.last_error_code = 0;
+	RTMP_Init(&stream->rtmp);
 
 	if (!RTMP_SetupURL(&stream->rtmp, stream->path.array))
 		return OBS_OUTPUT_BAD_PATH;


### PR DESCRIPTION
### Description
This commit fixes what is arguably a long-winded series of previous commits that have possibly caused just as many problems as they have fixed.

This provides a slight enhancement by removing the `RTMP_Init` call in `rtmp_stream_create()`, since it effectively just initializes TLS just for `try_connect` to deinitialize it before it is even used.

This also fixes the current `SO_RCVTIMEO` timeout functionality by making sure that `RTMP_Reset` is called last.

### Motivation and Context
I'll spare the details, but basically, there's no reason that any of the RTMP object should ever be used across socket sessions. It's best just to zero out the RTMP context and initialize TLS each time we connect, than to do a bunch of things to only reset parts of it.

### How Has This Been Tested?
Ubuntu 20.04:
- RTMPS streaming - ok
- Standard RTMP streaming - ok
- Cutting network for RTMP stream and allowing reconnect - ok
- RTMP streaming with user/pass authentication - ok

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
