### PR TITLE
UI: Improve exponential backoff reconnect on disconnect

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1457,8 +1457,8 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_bool(basicConfig, "Output", "DelayPreserve", true);
 
 	config_set_default_bool(basicConfig, "Output", "Reconnect", true);
-	config_set_default_uint(basicConfig, "Output", "RetryDelay", 10);
-	config_set_default_uint(basicConfig, "Output", "MaxRetries", 20);
+	config_set_default_uint(basicConfig, "Output", "RetryDelay", 2);
+	config_set_default_uint(basicConfig, "Output", "MaxRetries", 25);
 
 	config_set_default_string(basicConfig, "Output", "BindIP", "default");
 	config_set_default_bool(basicConfig, "Output", "NewSocketLoopEnable",

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1027,7 +1027,8 @@ struct obs_output {
 	int reconnect_retry_sec;
 	int reconnect_retry_max;
 	int reconnect_retries;
-	int reconnect_retry_cur_sec;
+	uint64_t reconnect_retry_cur_msec;
+	float reconnect_retry_exp;
 	pthread_t reconnect_thread;
 	os_event_t *reconnect_stop_event;
 	volatile bool reconnecting;


### PR DESCRIPTION
### Description
- Changes the default base exponent value to 1.5 from 2.0
- Applies a random skew of +-0.05 to the exponent to lessen the "water hammer" effect caused by predictable backoff techniques
- Fixes the logging associated with exponential backoff to log the true reconnect delay value
- Changes the default reconnect delay to 2 seconds from 10
- Changes the default max retries to 25 from 20

### Motivation and Context
The default delay of 10 seconds is arguably quite excessive given that it already implements exponential backoff.

Depending on how a given stream is disconnected, it's likely that the RTMP server is already ready to accept the publisher again by the time the reconnect process even starts. If it's not ready, then that's why exponential backoff is there in the first place.

Total average reconnect time before abandon is now 2.75 hours, from an original 3.4 hours.

### How Has This Been Tested?
Ubuntu 20.04: Works

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
