### PR TITLE
CI: Use static 7zip build instead of PPA

### DIFF
--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -24,6 +24,7 @@ env:
   STEAM_NIGHTLY_BRANCH: nightly
   STEAM_STABLE_BRANCH: staging
   STEAM_BETA_BRANCH: beta_staging
+  SEVENZIP_HASH: 5290409e7bbe2f133d0bd7e7482548678157ea2be276b0f9cb440600f4be9a2d
 
 jobs:
   upload:
@@ -37,12 +38,19 @@ jobs:
       with:
         path: source
 
-    - name: Setup 7-Zip (PPA)
       # The 7-Zip version available in the default ubuntu repos (p7zip) is wildly out-of-date and does not properly support DMG files.
+    - name: Setup 7-Zip
       run: |
-        sudo add-apt-repository -y ppa:spvkgn/sevenzip
-        sudo apt update -y
-        sudo apt install -y 7-zip
+        mkdir 7z && cd 7z
+        curl -s https://www.7-zip.org/a/7z2200-linux-x64.tar.xz -o 7z.tar.xz
+        
+        if [[ '${{ env.SEVENZIP_HASH }}' != "$(sha256sum 7z.tar.xz | cut -d " " -f 1)" ]]; then
+            echo "7-Zip Download hash does not match!"
+            exit 1
+        fi
+        
+        tar -xJf 7z.tar.xz
+        echo "$(pwd)" >> $GITHUB_PATH
 
     - name: Get build information
       id: build-info
@@ -175,9 +183,9 @@ jobs:
             unzip ../mac_x86.dmg.zip
             # 7-Zip will have an exit code of 2 due to the "unsafe" 'Applications' symlink.
             # GitHub treats this as a failure so ignore non-zero exit codes here.
-            7zz x *.dmg -otmp || true
+            7zzs x *.dmg -otmp || true
         else
-            7zz x ../mac_x86.dmg -otmp || true
+            7zzs x ../mac_x86.dmg -otmp || true
         fi
 
         mv tmp/*/OBS.app steam-macos


### PR DESCRIPTION
### Description

Use official static 7zip linux binaries instead of removed PPA.

### Motivation and Context

The PPA has been deleted so the Steam workflow started failing.

### How Has This Been Tested?

Has not been tested, but since this is just reverting the switch to the PPA I don't expect any issues.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
