### PR TITLE
libobs, win-wasapi: Handle changes to the default audio monitoring device

### DIFF
--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -540,6 +540,12 @@ Video, Audio, and Graphics
 
 ---------------------
 
+.. function:: void obs_reset_audio_monitoring(void)
+
+   Resets all audio monitoring devices.
+
+---------------------
+
 .. function:: void obs_enum_audio_monitoring_devices(obs_enum_audio_device_cb cb, void *data)
 
    Enumerates audio devices which can be used for audio monitoring.

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -3018,6 +3018,21 @@ bool obs_obj_is_private(void *obj)
 	return context->private;
 }
 
+void obs_reset_audio_monitoring(void)
+{
+	if (!obs_audio_monitoring_available())
+		return;
+
+	pthread_mutex_lock(&obs->audio.monitoring_mutex);
+
+	for (size_t i = 0; i < obs->audio.monitors.num; i++) {
+		struct audio_monitor *monitor = obs->audio.monitors.array[i];
+		audio_monitor_reset(monitor);
+	}
+
+	pthread_mutex_unlock(&obs->audio.monitoring_mutex);
+}
+
 bool obs_set_audio_monitoring_device(const char *name, const char *id)
 {
 	if (!name || !id || !*name || !*id)
@@ -3039,10 +3054,7 @@ bool obs_set_audio_monitoring_device(const char *name, const char *id)
 	obs->audio.monitoring_device_name = bstrdup(name);
 	obs->audio.monitoring_device_id = bstrdup(id);
 
-	for (size_t i = 0; i < obs->audio.monitors.num; i++) {
-		struct audio_monitor *monitor = obs->audio.monitors.array[i];
-		audio_monitor_reset(monitor);
-	}
+	obs_reset_audio_monitoring();
 
 	pthread_mutex_unlock(&obs->audio.monitoring_mutex);
 	return true;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -832,6 +832,8 @@ typedef bool (*obs_enum_audio_device_cb)(void *data, const char *name,
 
 EXPORT bool obs_audio_monitoring_available(void);
 
+EXPORT void obs_reset_audio_monitoring(void);
+
 EXPORT void obs_enum_audio_monitoring_devices(obs_enum_audio_device_cb cb,
 					      void *data);
 

--- a/plugins/win-wasapi/CMakeLists.txt
+++ b/plugins/win-wasapi/CMakeLists.txt
@@ -5,7 +5,8 @@ legacy_check()
 add_library(win-wasapi MODULE)
 add_library(OBS::wasapi ALIAS win-wasapi)
 
-target_sources(win-wasapi PRIVATE enum-wasapi.cpp enum-wasapi.hpp plugin-main.cpp win-wasapi.cpp)
+target_sources(win-wasapi PRIVATE win-wasapi.cpp wasapi-notify.cpp wasapi-notify.hpp enum-wasapi.cpp enum-wasapi.hpp
+                                  plugin-main.cpp)
 
 configure_file(cmake/windows/obs-module.rc.in win-wasapi.rc)
 target_sources(win-wasapi PRIVATE win-wasapi.rc)

--- a/plugins/win-wasapi/plugin-main.cpp
+++ b/plugins/win-wasapi/plugin-main.cpp
@@ -1,9 +1,12 @@
+#include "wasapi-notify.hpp"
+
 #include <obs-module.h>
 
 #include <util/windows/win-version.h>
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("win-wasapi", "en-US")
+
 MODULE_EXPORT const char *obs_module_description(void)
 {
 	return "Windows WASAPI audio input/output sources";
@@ -12,6 +15,26 @@ MODULE_EXPORT const char *obs_module_description(void)
 void RegisterWASAPIInput();
 void RegisterWASAPIDeviceOutput();
 void RegisterWASAPIProcessOutput();
+
+WASAPINotify *notify = nullptr;
+
+static void default_device_changed_callback(EDataFlow flow, ERole, LPCWSTR)
+{
+	const char *id;
+	obs_get_audio_monitoring_device(nullptr, &id);
+
+	if (!id || strcmp(id, "default") != 0)
+		return;
+
+	if (flow != eRender)
+		return;
+
+	auto task = [](void *) {
+		obs_reset_audio_monitoring();
+	};
+
+	obs_queue_task(OBS_TASK_UI, task, nullptr, false);
+}
 
 bool obs_module_load(void)
 {
@@ -30,5 +53,23 @@ bool obs_module_load(void)
 	RegisterWASAPIDeviceOutput();
 	if (process_filter_supported)
 		RegisterWASAPIProcessOutput();
+
+	notify = new WASAPINotify();
+	notify->AddDefaultDeviceChangedCallback(
+		obs_current_module(), default_device_changed_callback);
+
 	return true;
+}
+
+void obs_module_unload(void)
+{
+	if (notify) {
+		delete notify;
+		notify = nullptr;
+	}
+}
+
+WASAPINotify *GetNotify()
+{
+	return notify;
 }

--- a/plugins/win-wasapi/wasapi-notify.cpp
+++ b/plugins/win-wasapi/wasapi-notify.cpp
@@ -1,0 +1,121 @@
+#include "wasapi-notify.hpp"
+
+#include <windows.h>
+#include <assert.h>
+
+#include <util/threading.h>
+
+class NotificationClient : public IMMNotificationClient {
+	volatile long refs = 1;
+	WASAPINotifyDefaultDeviceChangedCallback cb;
+
+public:
+	NotificationClient(WASAPINotifyDefaultDeviceChangedCallback cb) : cb(cb)
+	{
+		assert(cb);
+	}
+
+	STDMETHODIMP_(ULONG) AddRef()
+	{
+		return (ULONG)os_atomic_inc_long(&refs);
+	}
+
+	STDMETHODIMP_(ULONG) STDMETHODCALLTYPE Release()
+	{
+		long val = os_atomic_dec_long(&refs);
+		if (val == 0)
+			delete this;
+		return (ULONG)val;
+	}
+
+	STDMETHODIMP QueryInterface(REFIID riid, void **ptr)
+	{
+		if (riid == IID_IUnknown) {
+			*ptr = (IUnknown *)this;
+		} else if (riid == __uuidof(IMMNotificationClient)) {
+			*ptr = (IMMNotificationClient *)this;
+		} else {
+			*ptr = nullptr;
+			return E_NOINTERFACE;
+		}
+
+		InterlockedIncrement(&refs);
+		return S_OK;
+	}
+
+	STDMETHODIMP OnDeviceAdded(LPCWSTR) { return S_OK; }
+
+	STDMETHODIMP OnDeviceRemoved(LPCWSTR) { return S_OK; }
+
+	STDMETHODIMP OnDeviceStateChanged(LPCWSTR, DWORD) { return S_OK; }
+
+	STDMETHODIMP OnPropertyValueChanged(LPCWSTR, const PROPERTYKEY)
+	{
+		return S_OK;
+	}
+
+	STDMETHODIMP OnDefaultDeviceChanged(EDataFlow flow, ERole role,
+					    LPCWSTR id)
+	{
+		if (cb && id)
+			cb(flow, role, id);
+
+		return S_OK;
+	}
+};
+
+WASAPINotify::WASAPINotify()
+{
+	HRESULT res = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr,
+				       CLSCTX_ALL,
+				       __uuidof(IMMDeviceEnumerator),
+				       (LPVOID *)enumerator.Assign());
+	if (SUCCEEDED(res)) {
+		notificationClient = new NotificationClient(
+			std::bind(&WASAPINotify::OnDefaultDeviceChanged, this,
+				  std::placeholders::_1, std::placeholders::_2,
+				  std::placeholders::_3));
+		enumerator->RegisterEndpointNotificationCallback(
+			notificationClient);
+	} else {
+		enumerator.Clear();
+	}
+}
+
+WASAPINotify::~WASAPINotify()
+{
+	if (enumerator) {
+		enumerator->UnregisterEndpointNotificationCallback(
+			notificationClient);
+		enumerator.Clear();
+	}
+
+	notificationClient.Clear();
+}
+
+void WASAPINotify::AddDefaultDeviceChangedCallback(
+	void *handle, WASAPINotifyDefaultDeviceChangedCallback cb)
+{
+	if (!handle)
+		return;
+
+	std::lock_guard<std::mutex> l(mutex);
+	defaultDeviceChangedCallbacks[handle] = cb;
+}
+
+void WASAPINotify::RemoveDefaultDeviceChangedCallback(void *handle)
+{
+	if (!handle)
+		return;
+
+	std::lock_guard<std::mutex> l(mutex);
+	defaultDeviceChangedCallbacks.erase(handle);
+}
+
+void WASAPINotify::OnDefaultDeviceChanged(EDataFlow flow, ERole role,
+					  LPCWSTR id)
+{
+	std::lock_guard<std::mutex> l(mutex);
+	for (const auto &cb : defaultDeviceChangedCallbacks)
+		cb.second(flow, role, id);
+}

--- a/plugins/win-wasapi/wasapi-notify.hpp
+++ b/plugins/win-wasapi/wasapi-notify.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <util/windows/ComPtr.hpp>
+#include <Mmdeviceapi.h>
+
+#include <unordered_map>
+#include <functional>
+#include <mutex>
+
+typedef std::function<void(EDataFlow, ERole, LPCWSTR)>
+	WASAPINotifyDefaultDeviceChangedCallback;
+
+class NotificationClient;
+
+class WASAPINotify {
+public:
+	WASAPINotify();
+	~WASAPINotify();
+
+	void AddDefaultDeviceChangedCallback(
+		void *handle, WASAPINotifyDefaultDeviceChangedCallback cb);
+	void RemoveDefaultDeviceChangedCallback(void *handle);
+
+private:
+	void OnDefaultDeviceChanged(EDataFlow flow, ERole role, LPCWSTR id);
+
+	std::mutex mutex;
+
+	ComPtr<IMMDeviceEnumerator> enumerator;
+	ComPtr<NotificationClient> notificationClient;
+
+	std::unordered_map<void *, WASAPINotifyDefaultDeviceChangedCallback>
+		defaultDeviceChangedCallbacks;
+};


### PR DESCRIPTION
### Description
Changes win-wasapi to reset audio monitoring when the default output device changes.

Fixes #4463
Closes #5398 

### Motivation and Context
When the default Windows output changes, OBS should switch to the new one if it is configured to use default.

### How Has This Been Tested?
- Enable audio monitoring with default device
- Change default output device: OBS responds [ok]
- Change default input device: OBS does not respond [ok]
- Set audio monitoring to non-default device
- Change default input/output devices: OBS does not respond [ok]

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Documentation (a change to documentation pages)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
