### PR TITLE
UI: Enforce Fusion Qt style on Linux

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2078,8 +2078,14 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 	}
 #endif
 
-#if !defined(_WIN32) && !defined(__APPLE__) && defined(USE_XDG) && \
-	defined(ENABLE_WAYLAND)
+#if !defined(_WIN32) && !defined(__APPLE__)
+	/* NOTE: The Breeze Qt style plugin adds frame arround QDockWidget with
+	 * QPainter which can not be modifed. To avoid this the base style is
+	 * enforce to the Qt default style on Linux: Fusion. */
+
+	setenv("QT_STYLE_OVERRIDE", "Fusion", false);
+
+#if defined(ENABLE_WAYLAND) && defined(USE_XDG)
 	/* NOTE: Qt doesn't use the Wayland platform on GNOME, so we have to
 	 * force it using the QT_QPA_PLATFORM env var. It's still possible to
 	 * use other QPA platforms using this env var, or the -platform command
@@ -2088,6 +2094,7 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 	const char *session_type = getenv("XDG_SESSION_TYPE");
 	if (session_type && strcmp(session_type, "wayland") == 0)
 		setenv("QT_QPA_PLATFORM", "wayland", false);
+#endif
 #endif
 
 	OBSApp program(argc, argv, profilerNameStore.get());


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Found the issue on Linux, the Plasma default theme Breeze also provide a Qt style plugin.
This plugin add a frame to QDockWidget.
Those frames are not stylable with QSS because those are drawn with QPainter.
- https://github.com/KDE/breeze/blob/4222e8e83ae870ffb1ccc3c02775681322f62b88/kstyle/breezestyle.cpp#L1555
- https://github.com/KDE/breeze/blob/4222e8e83ae870ffb1ccc3c02775681322f62b88/kstyle/breezehelper.cpp#L457

Flatpak install is always affected because the KDE Runtime provide Breeze, and Linux systems with Breeze installed are also affected for non-Flatpak install

So to avoid this the base style is enforce to the Qt default style on Linux: Fusion.

Screenshot made with #2778 

Without the PR:
![Thanks_Qt_and_Breeze](https://user-images.githubusercontent.com/17492366/175991774-c3429578-53cb-4c74-8f8a-0d60b1ff2016.png)

With the PR:
![Thanks_Fusion](https://user-images.githubusercontent.com/17492366/175991818-63e11622-8e11-4e72-b9b1-4cefaf8a4d81.png)


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I want Yami to be nice on Linux and Qt doesn't want me to be happy.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Run without the commit: frames around docks
- Run with the commit: no frames around docks

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
