### PR TITLE
EGL fixups

### DIFF
--- a/libobs-opengl/gl-egl-common.c
+++ b/libobs-opengl/gl-egl-common.c
@@ -252,7 +252,7 @@ gl_egl_create_texture_from_pixmap(EGLDisplay egl_display, uint32_t width,
 					EGL_NATIVE_PIXMAP_KHR, pixmap,
 					pixmap_attrs);
 	if (image == EGL_NO_IMAGE) {
-		blog(LOG_ERROR, "Cannot create EGLImage: %s",
+		blog(LOG_DEBUG, "Cannot create EGLImage: %s",
 		     gl_egl_error_to_string(eglGetError()));
 		return NULL;
 	}

--- a/plugins/linux-capture/xcomposite-input.c
+++ b/plugins/linux-capture/xcomposite-input.c
@@ -1,6 +1,7 @@
 #include <obs-module.h>
 #include <obs-nix-platform.h>
 #include <glad/glad.h>
+#include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xlib-xcb.h>
 #include <xcb/xcb.h>
@@ -381,6 +382,11 @@ static enum gs_color_format gs_format_from_tex()
 	}
 }
 
+static int silence_x11_errors(Display *display, XErrorEvent *err)
+{
+	return 0;
+}
+
 void xcomp_create_pixmap(xcb_connection_t *conn, struct xcompcap *s,
 			 int log_level)
 {
@@ -422,9 +428,11 @@ void xcomp_create_pixmap(xcb_connection_t *conn, struct xcompcap *s,
 		return;
 	}
 
+	XErrorHandler prev = XSetErrorHandler(silence_x11_errors);
 	s->gltex = gs_texture_create_from_pixmap(s->width, s->height,
 						 GS_BGRA_UNORM, GL_TEXTURE_2D,
 						 (void *)s->pixmap);
+	XSetErrorHandler(prev);
 }
 
 struct reg_item {

--- a/plugins/linux-capture/xcomposite-input.c
+++ b/plugins/linux-capture/xcomposite-input.c
@@ -615,7 +615,7 @@ static void xcompcap_video_tick(void *data, float seconds)
 
 	// Reacquire window after interval or immediately if reconfigured.
 	s->window_check_time += seconds;
-	bool window_lost = !xcomp_window_exists(conn, s->win);
+	bool window_lost = !xcomp_window_exists(conn, s->win) || !s->gltex;
 	if ((window_lost && s->window_check_time > FIND_WINDOW_INTERVAL) ||
 	    s->window_changed) {
 		watcher_unregister(conn, s);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes capture retry not working for xcomposite on EGL.
Fixes log spam when we are waiting for the user to remap a window (move to the right workspace, unminimize window, etc).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
capture regressed from glx. Log spam regressed as well.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
It works on my machine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
