### PR TITLE
cmake: Fix hardcoded SWIG_LIB path on macOS

### DIFF
--- a/cmake/Modules/ObsDefaults_macOS.cmake
+++ b/cmake/Modules/ObsDefaults_macOS.cmake
@@ -46,6 +46,15 @@ if(NOT DEFINED CMAKE_PREFIX_PATH)
   )
 endif()
 
+# SWIG hard codes the directory to its library directory at compile time. As
+# obs-deps need to be relocatable, we need to force SWIG to look for its files
+# in a directory relative to the PREFIX_PATH. The best way to ensure this is to
+# set the SWIG_LIB environment variable.
+
+if(NOT DEFINED ENV{SWIG_LIB} AND EXISTS "${CMAKE_PREFIX_PATH}/bin/swig")
+  set(ENV{SWIG_LIB} "${CMAKE_PREFIX_PATH}/share/swig/CURRENT")
+endif()
+
 macro(setup_obs_project)
   # Set code signing options
   set(OBS_BUNDLE_CODESIGN_IDENTITY


### PR DESCRIPTION
### Description
Sets a dynamic SWIG library path in the environment to allow relocatable swig installations on compilation hosts.

### Motivation and Context
Swig hardcodes its library path at compilation time with Windows being the only platform on which it uses a path relative to its binary. This a deliberate choice by the Swig authors, as UNIX-style operating systems should either use Swig installed system wide (using default library paths) or compiled on the host system (for custom paths).

As we use pre-compiled dependencies via obs-deps, this results in self-built Swig versions that use the library path as present on the GitHub runner at compilation time and thus break on any other system.

This change detects if a obs-deps version with shipped Swig is used and forces it to use a path relative to the `CMAKE_PREFIX_PATH`.

A PR adding Swig with stable ABI support will be added to obs-deps, which will package the dependencies with a symlink named `CURRENT` pointing to the Swig library path for any given version.

The latter change removes the need to update this part of the code for every new Swig version we might release.

### How Has This Been Tested?
Tested with current and updated obs-deps (the former missing self-compiled swig, whereas the latter does contain it) and checked the SWIG_LIB as set by CMake before invoking Swig.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
