### PR TITLE
deps/obs-scripting: Log script load/unload

### DIFF
--- a/deps/obs-scripting/obs-scripting-lua.c
+++ b/deps/obs-scripting/obs-scripting-lua.c
@@ -1107,8 +1107,11 @@ bool obs_lua_script_load(obs_script_t *s)
 	struct obs_lua_script *data = (struct obs_lua_script *)s;
 	if (!data->base.loaded) {
 		data->base.loaded = load_lua_script(data);
-		if (data->base.loaded)
+		if (data->base.loaded) {
+			blog(LOG_INFO, "[obs-scripting]: Loaded lua script: %s",
+			     data->base.file.array);
 			obs_lua_script_update(s, NULL);
+		}
 	}
 
 	return data->base.loaded;
@@ -1225,6 +1228,9 @@ void obs_lua_script_unload(obs_script_t *s)
 
 	lua_close(script);
 	s->loaded = false;
+
+	blog(LOG_INFO, "[obs-scripting]: Unloaded lua script: %s",
+	     data->base.file.array);
 }
 
 void obs_lua_script_destroy(obs_script_t *s)

--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -1273,8 +1273,12 @@ bool obs_python_script_load(obs_script_t *s)
 		data->base.loaded = load_python_script(data);
 		unlock_python();
 
-		if (data->base.loaded)
+		if (data->base.loaded) {
+			blog(LOG_INFO,
+			     "[obs-scripting]: Loaded python script: %s",
+			     data->base.file.array);
 			obs_python_script_update(s, NULL);
+		}
 	}
 
 	return data->base.loaded;
@@ -1317,6 +1321,8 @@ obs_script_t *obs_python_script_create(const char *path, obs_data_t *settings)
 	add_to_python_path(data->dir.array);
 	data->base.loaded = load_python_script(data);
 	if (data->base.loaded) {
+		blog(LOG_INFO, "[obs-scripting]: Loaded python script: %s",
+		     data->base.file.array);
 		cur_python_script = data;
 		obs_python_script_update(&data->base, NULL);
 		cur_python_script = NULL;
@@ -1396,6 +1402,9 @@ void obs_python_script_unload(obs_script_t *s)
 	unlock_python();
 
 	s->loaded = false;
+
+	blog(LOG_INFO, "[obs-scripting]: Unloaded python script: %s",
+	     data->base.file.array);
 }
 
 void obs_python_script_destroy(obs_script_t *s)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Logs when a script gets loaded and unloaded

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Requested for support, since scripts can mess up things real bad and currently there's no way to know if a script is active.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13 Beta 2

When starting OBS, both python and lua scripts get logged like this:
<img width="476" alt="image" src="https://user-images.githubusercontent.com/59806498/177016949-1ec8dffc-ea96-426b-a15b-37bf00e4d8aa.png">
When refreshing, first "loaded" and then "unloaded" shows up.
When adding or removing, it shows as loaded or unloaded.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
