### PR TITLE
UI: Yami font adjustments

### DIFF
--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -77,7 +77,6 @@ QWidget {
     selection-background-color: rgb(40,76,184);
     selection-color: palette(text);
     font-size: 10pt;
-    font-family: 'Open Sans', Helvetica, Arial, sans-serif;
 }
 
 QWidget:disabled {
@@ -204,6 +203,7 @@ SourceTree QLineEdit {
     padding-bottom: 0px;
     padding-right: 0;
     padding-left: 2px;
+    margin: -3px;
     border: none;
     border-radius: none;
 }
@@ -252,7 +252,7 @@ OBSDock QPushButton {
 }
 
 QDockWidget {
-    font-size: 14px;
+    font-size: 10.5pt;
     font-weight: bold;
 
     titlebar-close-icon: url('./Dark/Close.svg');
@@ -963,12 +963,12 @@ QLabel#errorLabel {
 /* About dialog */
 
 * [themeID="aboutName"] {
-    font-size: 36px;
+    font-size: 26pt;
     font-weight: bold;
 }
 
 * [themeID="aboutVersion"] {
-    font-size: 16px;
+    font-size: 12pt;
     margin-bottom: 20px;
 }
 


### PR DESCRIPTION
### Description
Removes font-family definition for now, and changes
other font sizes to pt units instead of px

Also adds a margin to the SceneTree/SourceTree line
edits to fix qss padding weirdness

### Motivation and Context
Until we can ship fonts as part the resource file, we should stick to using the existing system fonts

### How Has This Been Tested?
Compared font sizes before and after this change.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
