### PR TITLE
docs: Fix encoder .get_defaults2 arguments

### DIFF
--- a/docs/sphinx/reference-encoders.rst
+++ b/docs/sphinx/reference-encoders.rst
@@ -77,7 +77,7 @@ Encoder Definition Structure (obs_encoder_info)
             number would be 1024
 
 .. member:: void (*obs_encoder_info.get_defaults)(obs_data_t *settings)
-            void (*obs_encoder_info.get_defaults2)(void *type_data, obs_data_t *settings)
+            void (*obs_encoder_info.get_defaults2)(obs_data_t *settings, void *type_data)
 
    Sets the default settings for this encoder.
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The order of the arguments as called is first the settings, then the type data:

https://github.com/obsproject/obs-studio/blob/2dd1a3fc6f3a3c5139290e09eebff60d7ee4f6e2/libobs/obs-encoder.c#L70-L71

https://github.com/obsproject/obs-studio/blob/2dd1a3fc6f3a3c5139290e09eebff60d7ee4f6e2/libobs/obs-encoder.h#L250

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed when referring to the docs and getting crashes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Hasn't, besides seeing that it renders correctly on GitHub.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
