### PR TITLE
obs-scripting: Fix swig runtime header generation for macOS

### DIFF
--- a/deps/obs-scripting/CMakeLists.txt
+++ b/deps/obs-scripting/CMakeLists.txt
@@ -95,7 +95,8 @@ if(TARGET Luajit::Luajit)
     OUTPUT swig/swigluarun.h
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PRE_BUILD
-    COMMAND ${SWIG_EXECUTABLE} -lua -external-runtime swig/swigluarun.h
+    COMMAND ${CMAKE_COMMAND} -E env "SWIG_LIB=${SWIG_DIR}" ${SWIG_EXECUTABLE}
+            -lua -external-runtime swig/swigluarun.h
     COMMENT "obs-scripting - generating Luajit SWIG interface headers")
 
   set_source_files_properties(swig/swigluarun.h PROPERTIES GENERATED ON)
@@ -124,7 +125,8 @@ if(TARGET Python::Python)
     OUTPUT swig/swigpyrun.h
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PRE_BUILD
-    COMMAND ${SWIG_EXECUTABLE} -python -external-runtime swig/swigpyrun.h
+    COMMAND ${CMAKE_COMMAND} -E env "SWIG_LIB=${SWIG_DIR}" ${SWIG_EXECUTABLE}
+            -python -external-runtime swig/swigpyrun.h
     COMMENT "obs-scripting - generating Python 3 SWIG interface headers")
 
   set_source_files_properties(swig/swigpyrun.h PROPERTIES GENERATED ON)


### PR DESCRIPTION
### Description
Fixes swig runtime header generation failing on macOS with updated obs-deps.

### Motivation and Context
Due to swig using a hardcoded swig library path in self-compiled variants, we need to pass our custom swig library path with every invocation of swig on macOS.

CMake's `add_custom_command` function does _not_ inherit the environment variables used during configuration, hence why it needs to be passed explicitly on invocation.

Usage of CMake's "-E env" command module should allow for cross-platform compatible invocation.

### How Has This Been Tested?
* Tested with full OBS-Studio build on macOS
* Tested with full OBS-Studio build on Windows

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
