### PR TITLE
graphics-hook: Avoid conflict between Vulkan and DXGI Present

### DIFF
--- a/plugins/win-capture/graphics-hook/dxgi-capture.cpp
+++ b/plugins/win-capture/graphics-hook/dxgi-capture.cpp
@@ -198,6 +198,13 @@ static void update_mismatch_count(bool match)
 static HRESULT STDMETHODCALLTYPE hook_present(IDXGISwapChain *swap,
 					      UINT sync_interval, UINT flags)
 {
+	if (should_passthrough()) {
+		dxgi_presenting = true;
+		const HRESULT hr = RealPresent(swap, sync_interval, flags);
+		dxgi_presenting = false;
+		return hr;
+	}
+
 	const bool capture_overlay = global_hook_info->capture_overlay;
 	const bool test_draw = (flags & DXGI_PRESENT_TEST) != 0;
 
@@ -255,6 +262,14 @@ static HRESULT STDMETHODCALLTYPE
 hook_present1(IDXGISwapChain1 *swap, UINT sync_interval, UINT flags,
 	      const DXGI_PRESENT_PARAMETERS *params)
 {
+	if (should_passthrough()) {
+		dxgi_presenting = true;
+		const HRESULT hr =
+			RealPresent1(swap, sync_interval, flags, params);
+		dxgi_presenting = false;
+		return hr;
+	}
+
 	const bool capture_overlay = global_hook_info->capture_overlay;
 	const bool test_draw = (flags & DXGI_PRESENT_TEST) != 0;
 

--- a/plugins/win-capture/graphics-hook/graphics-hook.h
+++ b/plugins/win-capture/graphics-hook/graphics-hook.h
@@ -248,6 +248,19 @@ static inline bool capture_should_init(void)
 	return should_init;
 }
 
+#if COMPILE_VULKAN_HOOK
+extern __declspec(thread) int vk_presenting;
+#endif
+
+static inline bool should_passthrough()
+{
+#if COMPILE_VULKAN_HOOK
+	return vk_presenting > 0;
+#else
+	return false;
+#endif
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/plugins/win-capture/graphics-hook/vulkan-capture.c
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.c
@@ -115,6 +115,8 @@ struct vk_data {
 	ID3D11DeviceContext *d3d11_context;
 };
 
+__declspec(thread) int vk_presenting = 0;
+
 /* ------------------------------------------------------------------------- */
 
 static void *vk_alloc(const VkAllocationCallbacks *ac, size_t size,
@@ -1216,7 +1218,14 @@ static VkResult VKAPI_CALL OBS_QueuePresentKHR(VkQueue queue,
 		vk_capture(data, queue, info);
 	}
 
-	return funcs->QueuePresentKHR(queue, info);
+	if (vk_presenting != 0) {
+		flog("non-zero vk_presenting: %d", vk_presenting);
+	}
+
+	vk_presenting++;
+	VkResult res = funcs->QueuePresentKHR(queue, info);
+	vk_presenting--;
+	return res;
 }
 
 /* ======================================================================== */


### PR DESCRIPTION
### Description
Skip DXGI interception when called as a result of a Vulkan "Present" call.

### Motivation and Context
Some Vulkan apps for Windows use a DXGI backend, which is called by the Vk "Present" API call. That makes OBS double-hooked during the same call, first by the Vulkan hook, which then call its native implementation, which then calls the DXGI hook in return.

That makes the Vulkan call to capture_should_init true, then the D3D11 call to capture_should_init false, causing the d3d11_capture method to call d3d11_shmem_capture (as data.using_shtex still having its default "false" value), which in turn uses an unititialized mutex as the d3d11_init method has not been called, and leads to a crash.

### How Has This Been Tested?
This was tested on Windows 10 20H2, on a RTX 2070 Super with driver version 516.40, with the project at the last tagged revision (27.2.4).
Tests were done with the stock version of the graphics-hook64.dll for comparison, and with Debug versions for development. Final tests were done back with a RelWithDebug version to confirm the fix.
Verified using the Vulkan build of Rainbow Six Siege.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
