### PR TITLE
aja: Fix 8ch audio capture offset by a channel

### DIFF
--- a/plugins/aja/aja-source.cpp
+++ b/plugins/aja/aja-source.cpp
@@ -276,7 +276,7 @@ void AJASource::CaptureThread(AJAThread *thread, void *data)
 		}
 
 		card->ReadAudioLastIn(offsets.currentAddress, audioSystem);
-		offsets.currentAddress &= ~0x3; // Force DWORD alignment
+		offsets.currentAddress += 1;
 		offsets.currentAddress += offsets.readOffset;
 		if (offsets.currentAddress < offsets.lastAddress) {
 			offsets.bytesRead =


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Increment the value read from the card via `CNTV2Card::ReadAudioLastIn` (AKA `currentAddress` in the code) by 1 to ensure capturing the correct range of 8ch of audio samples. The current code alters the `currentAddress` value by performing `currentAddress &= ~0x3`. This code was taken from the AJA demo app called `ntv2llburn` and was purported to "Force DWORD alignment". This effectively causes the start of the range of 8ch worth of samples to start ahead of where it should be in the card's audio ring.

After talking to several AJA engineers it was found that this computation is probably some legacy code that was left in the demo. The card's audio de-embedder always writes audio to the card's audio ring in 512 byte chunks, starting at 0 and e nding on the 511th byte. Adding 1 to the `currentAddress` value ensures that the audio capture algorithm as currently written will capture all 8 channels of audio from the card, in the correct order.

Using the current code in the plugin, OBS receives the 8ch of audio from the card ordered as channels "7-1-2-3-4-5-6-7-8" but this fix produces the correct range of channels each frame "1-2-3-4-5-6-7-8".

The `ntv2llburn` demo behaves the same with either computation performed on the "ReadAudioLastIn" address, as the demo is essentially just passing the audio through from the audio input ring to the output ring, at the same positions in memory.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
AJA QA found that, while capturing a stereo signal in the AJA capture plugin, the audio levels of the two channels in OBS were different, even when the same signal (i.e. a 1KHz test tone) was sent to both channels. Investigation into this issue found that the plugin was capturing 8ch of audio from the card but starting from the wrong channel, thus sending the wrong order of channels to OBS. Because the plugin is currently hard-coded to use the speaker layout `SPEAKERS_7POINT1`, OBS takes the 8ch of audio from the card and mixes it into 7.1 audio. Due to the incorrect channel order entering OBS from the AJA card, a stereo signal is being treated as channels 2 and 3 of the 7.1 mix, rather than channels 1 and 2, leading to the volume level discrepancy.

I am currently working on a separate pull request to add UI options and audio repacking code to properly handle all of the OBS speaker layouts: https://github.com/paulh-aja/obs-studio/tree/aja-audio-repacker

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows with AJA io4K+ and ioX3 cards with a source supplying 8ch of audio. Verified that all 8 channels of audio are now captured properly and in the correct order. This was partially verified by checking that stereo sources had the correct equal volume levels with a 1KHz test tone, as well as testing with a full 8ch source in my WIP branch which adds support for the additional speaker layouts.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
