### PR TITLE
UI: Add support for theme meta, parent theme palette

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -1,3 +1,8 @@
+OBSThemeMeta {
+    dark: 'true';
+    author: 'Warchamp7';
+}
+
 /* OBSTheme, main QApplication palette and QML values */
 OBSTheme {
     window: rgb(24,24,25);

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -28,6 +28,10 @@
 /* rgb(11,10,11); /* veryVeryDark */
 /* rgb(42,130,218); /* blue */
 
+OBSThemeMeta {
+    dark: 'true';
+    author: 'Warchamp7';
+}
 
 /* Custom theme information.  This will set the application's QPalette, as
  * well as pass to QML via the OBSTheme object.

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -44,6 +44,11 @@
 /* ---- Main Theme ---- */
 /************************/
 
+OBSThemeMeta {
+	dark: 'true';
+	author: 'Fenrir';
+}
+
 OBSTheme {
 	window: rgb(49, 54, 59); /* Blue-gray */
 	windowText: rgb(239, 240, 241); /* White */

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -8,6 +8,9 @@
 /* Dark Theme is a good place to start if you need */
 /* a template. */
 
+OBSThemeMeta {
+    dark: 'false';
+}
 
 /* We need to set back the icons, or the preview wont stick. */
 

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -19,6 +19,11 @@
 
 /* Colors */
 
+OBSThemeMeta {
+    dark: 'true';
+    author: 'Warchamp7';
+}
+
 /* Custom theme information.  This will set the application's QPalette, as
  * well as pass to QML via the OBSTheme object.
  * Can also use OBSTheme::disabled, OBSTheme::active, and OBSTheme::inactive.

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -68,6 +68,12 @@ public:
 
 typedef std::function<void()> VoidFunc;
 
+struct OBSThemeMeta {
+	bool dark;
+	std::string parent;
+	std::string author;
+};
+
 class OBSApp : public QApplication {
 	Q_OBJECT
 
@@ -75,6 +81,7 @@ private:
 	std::string locale;
 	std::string theme;
 	QString defaultStyleSheet;
+	OBSThemeMeta *themeMeta = nullptr;
 	bool themeDarkMode = true;
 	ConfigFile globalConfig;
 	TextLookup textLookup;
@@ -103,6 +110,7 @@ private:
 	QPalette defaultPalette;
 
 	void ParseExtraThemeData(const char *path);
+	static OBSThemeMeta *ParseThemeMeta(const char *path);
 	void AddExtraThemeColor(QPalette &pal, int group, const char *name,
 				uint32_t color);
 
@@ -130,6 +138,8 @@ public:
 	inline const char *GetLocale() const { return locale.c_str(); }
 
 	inline const char *GetTheme() const { return theme.c_str(); }
+	std::string GetTheme(std::string name, std::string path);
+	std::string SetParentTheme(std::string name);
 	bool SetTheme(std::string name, std::string path = "");
 	inline bool IsThemeDark() const { return themeDarkMode; };
 


### PR DESCRIPTION
### Description

This enhances the existing theme loading system with Theme Meta, which allows individual themes to provide additional information to OBS.

The primarily goal is for a theme to define a "parent", allowing to extend existing themes with additional attributes, including extending/replacing an existing theme's palette.

### Motivation and Context

Warchamp expressed he would like the ability to provide "palatte swaps" of a single theme - such as dark/light variants, without having to clone the entire QSS file.

While I've updated existing themes to include metadata, I'm leaving creation of palette swaps to Warchamp.

A future version of this will allow for additional QSS, but that requires other changes, so I'm submitting this separately first.

### How Has This Been Tested?

Create a new theme file `YamiChild.qss` with the following contents and load it. It should contain all Yami styling but with yellow text.

```css

OBSThemeMeta {
    parent: 'Yami';
    dark: 'true';
    author: 'WizardCM';
}

OBSTheme {
    text: rgb(234, 255, 0);
}
```

![image](https://user-images.githubusercontent.com/941350/178103442-5a58e181-620e-4d33-a9e1-01938588bf2d.png)


### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
