### PR TITLE
obs-scripting: Switch Python support to use the Py3 stable ABI

### DIFF
--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -652,6 +652,19 @@ extern "C" void InitScripts()
 	const char *python_path =
 		config_get_string(config, "Python", "Path" ARCH_NAME);
 
+#ifdef __APPLE__
+	std::string _python_path(python_path);
+	std::size_t pos = _python_path.find("/Python.framework/Versions");
+
+	if (pos != std::string::npos) {
+		std::string _temp = _python_path.substr(0, pos);
+		config_set_string(config, "Python", "Path" ARCH_NAME,
+				  _temp.c_str());
+		config_save(config);
+		python_path = _temp.c_str();
+	}
+#endif
+
 	if (!obs_scripting_python_loaded() && python_path && *python_path)
 		obs_scripting_load_python(python_path);
 #endif

--- a/cmake/Modules/FindPythonWindows.cmake
+++ b/cmake/Modules/FindPythonWindows.cmake
@@ -20,7 +20,7 @@ find_path(
 
 find_library(
   PYTHON_LIB
-  NAMES ${_PYTHON_LIBRARIES} python36
+  NAMES ${_PYTHON_LIBRARIES} python3
   HINTS ${_PYTHON_LIBRARY_DIRS}
   PATH_SUFFIXES
     lib${_lib_suffix}

--- a/cmake/Modules/ObsDefaults_Linux.cmake
+++ b/cmake/Modules/ObsDefaults_Linux.cmake
@@ -93,8 +93,8 @@ macro(setup_obs_project)
     set(OBS_DATA_PATH "../../${OBS_DATA_DESTINATION}")
 
     set(OBS_SCRIPT_PLUGIN_PATH "../../${OBS_SCRIPT_PLUGIN_DESTINATION}")
-    set(CMAKE_INSTALL_RPATH
-        "$ORIGIN/" "${CMAKE_INSTALL_PREFIX}/${OBS_LIBRARY_DESTINATION}")
+    set(CMAKE_INSTALL_RPATH "$ORIGIN/"
+                            "${ORIGIN}/../../${OBS_LIBRARY_DESTINATION}")
   endif()
 
   if(BUILD_FOR_PPA)

--- a/deps/obs-scripting/CMakeLists.txt
+++ b/deps/obs-scripting/CMakeLists.txt
@@ -125,8 +125,10 @@ if(TARGET Python::Python)
     OUTPUT swig/swigpyrun.h
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} -E env "SWIG_LIB=${SWIG_DIR}" ${SWIG_EXECUTABLE}
-            -python -external-runtime swig/swigpyrun.h
+    COMMAND
+      ${CMAKE_COMMAND} -E env "SWIG_LIB=${SWIG_DIR}" ${SWIG_EXECUTABLE} -python
+      $<IF:$<BOOL:${OS_LINUX}>,-py3,-py3-stable-abi> -external-runtime
+      swig/swigpyrun.h
     COMMENT "obs-scripting - generating Python 3 SWIG interface headers")
 
   set_source_files_properties(swig/swigpyrun.h PROPERTIES GENERATED ON)

--- a/deps/obs-scripting/obs-scripting-python-import.h
+++ b/deps/obs-scripting/obs-scripting-python-import.h
@@ -44,7 +44,6 @@
 #endif
 
 #if RUNTIME_LINK
-
 #ifdef NO_REDEFS
 #define PY_EXTERN
 #else
@@ -262,7 +261,7 @@ static inline void Import__Py_XDECREF(PyObject *op)
 
 #undef Py_XDECREF
 #define Py_XDECREF(op) Import__Py_XDECREF(_PyObject_CAST(op))
-#endif
+#endif // PY_VERSION_HEX >= 0x030800f0
 
 #if PY_VERSION_HEX >= 0x030900b0
 static inline int Import_PyType_HasFeature(PyTypeObject *type,
@@ -271,8 +270,7 @@ static inline int Import_PyType_HasFeature(PyTypeObject *type,
 	return ((PyType_GetFlags(type) & feature) != 0);
 }
 #define PyType_HasFeature(t, f) Import_PyType_HasFeature(t, f)
-#endif
+#endif // PY_VERSION_HEX >= 0x030900b0
 
-#endif
-
-#endif
+#endif // NO_REDEFS
+#endif // RUNTIME_LINK

--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -1624,8 +1624,17 @@ bool obs_scripting_load_python(const char *python_path)
 		return false;
 
 	if (python_path && *python_path) {
+#ifdef __APPLE__
+		char temp[PATH_MAX];
+		sprintf(temp, "%s/Python.framework/Versions/Current",
+			python_path);
+		os_utf8_to_wcs(temp, 0, home_path, PATH_MAX);
+		Py_SetPythonHome(home_path);
+#else
+
 		os_utf8_to_wcs(python_path, 0, home_path, 1024);
 		Py_SetPythonHome(home_path);
+#endif
 #if 0
 		dstr_copy(&old_path, getenv("PATH"));
 		_putenv("PYTHONPATH=");

--- a/deps/obs-scripting/obspython/CMakeLists.txt
+++ b/deps/obs-scripting/obspython/CMakeLists.txt
@@ -21,7 +21,9 @@ endif()
 include(UseSWIG)
 
 set_source_files_properties(
-  obspython.i PROPERTIES USE_TARGET_INCLUDE_DIRECTORIES TRUE SWIG_FLAGS "-py3")
+  obspython.i
+  PROPERTIES USE_TARGET_INCLUDE_DIRECTORIES TRUE
+             SWIG_FLAGS "$<IF:$<BOOL:${OS_LINUX}>,-py3,-py3-stable-abi>")
 
 swig_add_library(
   obspython


### PR DESCRIPTION
### Description
Changes the Python module of obs-scripting to use the Python 3 stable ABI and also allows OBS to load several different recent Python 3 versions (any possible version between 3.6 and 3.10 will be loaded, if available).

Also changes the macOS UI to just require the base path a `Python.framework` is placed in (instead of requiring users to dive into the Framework to find the library path).

**Note:** This PR implements the changes introduced by https://github.com/obsproject/obs-studio/pull/6696 to pull the swig binaries compiled on CI with stable Abu support.

### Motivation and Context
In theory these changes should allow users to run Python scripts in OBS with a wider range of available Python versions installed on the host system, independent from the version used to compile OBS.

Caveats: While the obspython module uses the stable ABI, obs-scripting itself cannot do the same, as OBS uses C-API methods not available in the stable ABI. As the use of these methods is overseen by OBS development, additional care can be put into their implementation, ensuring that only methods available/unchanged in respective Python versions are used.

The stable ABI itself does not contain many C-API methods that _should_ be contained, for the simple reason of not being as actively maintained/updated as Python itself. Hence why we chose a "better is the enemy of good" approach.

### How Has This Been Tested?
Compiled and ran OBS with Python scripts on:
* Windows (Python 3.6 and 3.9)
* Linux (Python 3.10)
* macOS (Python 3.9 and Python 3.10)

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
