### PR TITLE
UI: Fix text shifting on lineEdits in Yami

### DIFF
--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -199,13 +199,17 @@ QListWidget::item:hover {
 QListWidget QLineEdit,
 SceneTree QLineEdit,
 SourceTree QLineEdit {
-    padding-top: 0px;
-    padding-bottom: 0px;
-    padding-right: 0;
-    padding-left: 2px;
-    margin: -3px;
-    border: none;
-    border-radius: none;
+    padding:  0px;
+    padding-bottom: 2px;
+    margin: 0px;
+    border: 1px solid #FFF;
+    border-radius: 2px;
+}
+
+QListWidget QLineEdit:focus,
+SceneTree QLineEdit:focus,
+SourceTree QLineEdit:focus {
+    border: 1px solid #FFF;
 }
 
 /* Settings QList */
@@ -603,6 +607,7 @@ QLineEdit, QTextEdit, QPlainTextEdit {
     border: none;
     border-radius: 3px;
     padding: 5px 2px 5px 7px;
+    border: 2px solid transparent;
 }
 
 QLineEdit:hover,


### PR DESCRIPTION
### Description
This adds a transparent border to lineEdits in their normal state, so that the :hover and :focus styling does not cause the text to shift.

Also adds some special styling for the QListWidget lineEdits (Scenes list, Sources list) to remove their shifting as well as more clearly show they're in edit mode, as the text highlight color matches the selected item color.

### Motivation and Context
Text shifting doesn't look nice

### How Has This Been Tested?
I used some text boxes

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
