### PR TITLE
UI: Fix menu icons not showing up

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -379,6 +379,10 @@ QToolButton:pressed {
 	qproperty-icon: url(./Dark/media-pause.svg);
 }
 
+* [themeID="menuIconSmall"] {
+	qproperty-icon: url(./Dark/dots-vert.svg);
+}
+
 /* Tab Widget */
 
 QTabWidget::pane { /* The tab widget frame */

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -287,6 +287,9 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/media-pause.svg);
 }
 
+* [themeID="menuIconSmall"] {
+    qproperty-icon: url(./Dark/dots-vert.svg);
+}
 
 /* Tab Widget */
 

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -516,6 +516,10 @@ QToolButton:pressed {
 	qproperty-icon: url(./Dark/media-pause.svg);
 }
 
+* [themeID="menuIconSmall"] {
+	qproperty-icon: url(./Dark/dots-vert.svg);
+}
+
 /***********************/
 /* --- Combo boxes --- */
 /***********************/

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -43,6 +43,10 @@
     qproperty-icon: url(:/res/images/media-pause.svg);
 }
 
+* [themeID="menuIconSmall"] {
+    qproperty-icon: url(:res/images/dots-vert.svg);
+}
+
 MuteCheckBox {
     outline: none;
 }


### PR DESCRIPTION
### Description
The menu icon was set only in the Yami theme.

### Motivation and Context
New theme Yami broke existing themes.

### How Has This Been Tested?
Ran program to make sure the icons showed up as expected.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
