### PR TITLE
libobs: Fix crash handler noreturn compiler warning

### DIFF
--- a/deps/obs-scripting/obslua/obslua.i
+++ b/deps/obs-scripting/obslua/obslua.i
@@ -55,6 +55,7 @@ static inline void wrap_blog(int log_level, const char *message)
 %ignore blog;
 %ignore blogva;
 %ignore bcrash;
+%ignore base_set_crash_handler;
 %ignore obs_source_info;
 %ignore obs_register_source_s(const struct obs_source_info *info, size_t size);
 %ignore obs_output_set_video(obs_output_t *output, video_t *video);

--- a/deps/obs-scripting/obspython/obspython.i
+++ b/deps/obs-scripting/obspython/obspython.i
@@ -64,6 +64,7 @@ static inline void wrap_blog(int log_level, const char *message)
 %ignore blog;
 %ignore blogva;
 %ignore bcrash;
+%ignore base_set_crash_handler;
 %ignore obs_source_info;
 %ignore obs_register_source_s(const struct obs_source_info *info, size_t size);
 %ignore obs_output_set_video(obs_output_t *output, video_t *video);

--- a/libobs/util/base.c
+++ b/libobs/util/base.c
@@ -103,6 +103,7 @@ OBS_NORETURN void bcrash(const char *format, ...)
 	va_start(args, format);
 	crash_handler(format, args, crash_param);
 	va_end(args);
+	exit(0);
 }
 
 void blogva(int log_level, const char *format, va_list args)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes a `Function declared 'noreturn' should not return` warning in `bcrash()`.
Compiler: Apple clang version 14.0.0 (clang-1400.0.28.1)
Compiler didn't know that `crash_handler()` doesn't return, so it assumed it did, in which case the entire function would return.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't like warnings.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled (macOS 13).
One less warning (186->185).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
