### PR TITLE
Memory allocator cleanups

### DIFF
--- a/libobs/util/bmem.c
+++ b/libobs/util/bmem.c
@@ -91,9 +91,16 @@ static long num_allocs = 0;
 
 void *bmalloc(size_t size)
 {
+	if (!size) {
+		blog(LOG_ERROR,
+		     "bmalloc: Allocating 0 bytes is broken behavior, please "
+		     "fix your code! This will crash in future versions of "
+		     "OBS.");
+		size = 1;
+	}
+
 	void *ptr = a_malloc(size);
-	if (!ptr && !size)
-		ptr = a_malloc(1);
+
 	if (!ptr) {
 		os_breakpoint();
 		bcrash("Out of memory while trying to allocate %lu bytes",
@@ -109,9 +116,16 @@ void *brealloc(void *ptr, size_t size)
 	if (!ptr)
 		os_atomic_inc_long(&num_allocs);
 
+	if (!size) {
+		blog(LOG_ERROR,
+		     "brealloc: Allocating 0 bytes is broken behavior, please "
+		     "fix your code! This will crash in future versions of "
+		     "OBS.");
+		size = 1;
+	}
+
 	ptr = a_realloc(ptr, size);
-	if (!ptr && !size)
-		ptr = a_realloc(ptr, 1);
+
 	if (!ptr) {
 		os_breakpoint();
 		bcrash("Out of memory while trying to allocate %lu bytes",

--- a/libobs/util/bmem.c
+++ b/libobs/util/bmem.c
@@ -87,19 +87,13 @@ static void a_free(void *ptr)
 #endif
 }
 
-static struct base_allocator alloc = {a_malloc, a_realloc, a_free};
 static long num_allocs = 0;
-
-void base_set_allocator(struct base_allocator *defs)
-{
-	memcpy(&alloc, defs, sizeof(struct base_allocator));
-}
 
 void *bmalloc(size_t size)
 {
-	void *ptr = alloc.malloc(size);
+	void *ptr = a_malloc(size);
 	if (!ptr && !size)
-		ptr = alloc.malloc(1);
+		ptr = a_malloc(1);
 	if (!ptr) {
 		os_breakpoint();
 		bcrash("Out of memory while trying to allocate %lu bytes",
@@ -115,9 +109,9 @@ void *brealloc(void *ptr, size_t size)
 	if (!ptr)
 		os_atomic_inc_long(&num_allocs);
 
-	ptr = alloc.realloc(ptr, size);
+	ptr = a_realloc(ptr, size);
 	if (!ptr && !size)
-		ptr = alloc.realloc(ptr, 1);
+		ptr = a_realloc(ptr, 1);
 	if (!ptr) {
 		os_breakpoint();
 		bcrash("Out of memory while trying to allocate %lu bytes",
@@ -131,7 +125,7 @@ void bfree(void *ptr)
 {
 	if (ptr) {
 		os_atomic_dec_long(&num_allocs);
-		alloc.free(ptr);
+		a_free(ptr);
 	}
 }
 
@@ -153,3 +147,5 @@ void *bmemdup(const void *ptr, size_t size)
 
 	return out;
 }
+
+OBS_DEPRECATED void base_set_allocator(struct base_allocator *defs) {}

--- a/libobs/util/bmem.h
+++ b/libobs/util/bmem.h
@@ -31,7 +31,7 @@ struct base_allocator {
 	void (*free)(void *);
 };
 
-EXPORT void base_set_allocator(struct base_allocator *defs);
+OBS_DEPRECATED EXPORT void base_set_allocator(struct base_allocator *defs);
 
 EXPORT void *bmalloc(size_t size);
 EXPORT void *brealloc(void *ptr, size_t size);


### PR DESCRIPTION
### Description
Deprecates `base_set_allocator` and signals removal of support for `bmalloc(0)`.

### Motivation and Context
As libobs has alignment requirements, allowing an app to change our memory allocator from our own aligned implementation with `base_set_allocator` doesn't really make a lot of sense. Presumably nothing ever used this function anyway, and having all allocations go through an indirect function call prevents more aggressive optimizations such as inlining directly to `malloc` at the call site. Also note that `base_set_allocator` was never documented.

I believe `bmalloc(0)` is also a bad thing to support as `malloc(0)` behavior is implementation defined - it either returns NULL or returns a pointer that can never be written or read. We handle it specially in libobs and pretend it was `bmalloc(1)` but I don't believe this is a good practice - any caller trying to allocate 0 bytes is likely doing something very wrong, so let's move away from supporting it. As this behavior may be present in 3rd party plugins, this only logs occurrences for now, but eventually I believe we should assert / crash.

### How Has This Been Tested?
Quick test of OBS with the default set of plugins and didn't find any calls to `bmalloc(0)`. More testing with 3rd party plugins would be good to make sure they aren't calling `bmalloc(0)`.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
