### PR TITLE
Treat warnings as errors on MSVC

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -367,6 +367,7 @@ if(OS_WINDOWS)
                 _CRT_NONSTDC_NO_WARNINGS)
 
   if(MSVC)
+    target_link_options(obs PRIVATE "LINKER:/IGNORE:4099")
     target_link_libraries(obs PRIVATE OBS::w32-pthreads)
 
     set_source_files_properties(

--- a/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
@@ -72,6 +72,7 @@ elseif(OS_WINDOWS)
                  aja-output-ui.rc)
   target_sources(aja-output-ui PRIVATE aja-output-ui.rc)
 
+  target_compile_options(aja-output-ui PRIVATE /wd4996)
   target_link_libraries(aja-output-ui PRIVATE ws2_32.lib setupapi.lib Winmm.lib
                                               netapi32.lib Shlwapi.lib)
   target_link_options(aja-output-ui PRIVATE "LINKER:/IGNORE:4099")

--- a/cmake/Modules/CompilerConfig.cmake
+++ b/cmake/Modules/CompilerConfig.cmake
@@ -48,6 +48,7 @@ if(OS_WINDOWS AND MSVC)
   add_compile_options(
     /MP
     /W3
+    /WX
     /wd4127
     /wd4201
     /wd4456
@@ -64,6 +65,7 @@ if(OS_WINDOWS AND MSVC)
 
   add_link_options(
     "LINKER:/OPT:REF"
+    "LINKER:/WX"
     "$<$<NOT:$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>>:LINKER\:/SAFESEH\:NO>"
     "$<$<CONFIG:DEBUG>:LINKER\:/INCREMENTAL\:NO>"
     "$<$<CONFIG:RELWITHDEBINFO>:LINKER\:/INCREMENTAL\:NO;/OPT:ICF>")

--- a/plugins/aja/CMakeLists.txt
+++ b/plugins/aja/CMakeLists.txt
@@ -58,6 +58,7 @@ elseif(OS_WINDOWS)
 
   target_sources(aja PRIVATE win-aja.rc)
 
+  target_compile_options(aja PRIVATE /wd4996)
   target_link_libraries(aja PRIVATE ws2_32.lib setupapi.lib Winmm.lib
                                     netapi32.lib Shlwapi.lib)
   target_link_options(aja PRIVATE "LINKER:/IGNORE:4099")

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -124,7 +124,7 @@ struct audio_info {
 
 struct io_header {
 	uint64_t seek_offset;
-	uint64_t data_length;
+	size_t data_length;
 };
 
 struct io_buffer {

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -12,6 +12,9 @@
 #include <obs-hevc.h>
 #endif
 
+/* TODO: Use new preset scheme */
+#pragma warning(disable : 4996)
+
 /* ========================================================================= */
 
 #define EXTRA_BUFFERS 5

--- a/plugins/obs-filters/CMakeLists.txt
+++ b/plugins/obs-filters/CMakeLists.txt
@@ -29,7 +29,7 @@ else()
 
   if(OS_WINDOWS)
     target_link_options(obs-filters PRIVATE "LINKER:/LTCG"
-                        "LINKER:/IGNORE:4099")
+                        "LINKER:/IGNORE:4098" "LINKER:/IGNORE:4099")
   endif()
 endif()
 

--- a/plugins/obs-outputs/CMakeLists.txt
+++ b/plugins/obs-outputs/CMakeLists.txt
@@ -42,7 +42,8 @@ if(OS_WINDOWS)
 
   if(MSVC)
     target_link_libraries(obs-outputs PRIVATE OBS::w32-pthreads)
-    target_link_options(obs-outputs PRIVATE "LINKER:/IGNORE:4099")
+    target_link_options(obs-outputs PRIVATE "LINKER:/IGNORE:4098"
+                        "LINKER:/IGNORE:4099")
   endif()
 
   target_link_libraries(obs-outputs PRIVATE ws2_32 winmm Iphlpapi)

--- a/plugins/text-freetype2/CMakeLists.txt
+++ b/plugins/text-freetype2/CMakeLists.txt
@@ -27,7 +27,8 @@ if(OS_WINDOWS)
 
   target_sources(text-freetype2 PRIVATE find-font.c find-font-windows.c
                                         text-freetype2.rc)
-  target_link_options(text-freetype2 PRIVATE "LINKER:/IGNORE:4099")
+  target_link_options(text-freetype2 PRIVATE "LINKER:/IGNORE:4098"
+                      "LINKER:/IGNORE:4099")
 
 elseif(OS_MACOS)
   find_package(Iconv REQUIRED)


### PR DESCRIPTION
### Description
Address the remaining warnings, and enable /WX on both MSVC compiler & linker to prevent more from being added.

### Motivation and Context
I hate warnings.

### How Has This Been Tested?
- Verified the warnings were treated as errors when not fixed.
- Verified the warnings are gone after fixing.
- Verified Debug and RelWithDebInfo compiled on my machine.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.