### PR TITLE
UI: Fix color format warning

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2583,13 +2583,13 @@ void OBSBasicSettings::LoadAudioSettings()
 
 void OBSBasicSettings::UpdateColorFormatSpaceWarning()
 {
-	const QString text = ui->colorFormat->currentText();
+	const QString format = ui->colorFormat->currentData().toString();
 	switch (ui->colorSpace->currentIndex()) {
 	case 3: /* Rec.2100 (PQ) */
 	case 4: /* Rec.2100 (HLG) */
-		if (text == "P010") {
+		if (format == "P010") {
 			ui->advancedMsg2->clear();
-		} else if (text == "I010") {
+		} else if (format == "I010") {
 			ui->advancedMsg2->setText(
 				QTStr("Basic.Settings.Advanced.FormatWarning"));
 		} else {
@@ -2598,9 +2598,9 @@ void OBSBasicSettings::UpdateColorFormatSpaceWarning()
 		}
 		break;
 	default:
-		if (text == "NV12") {
+		if (format == "NV12") {
 			ui->advancedMsg2->clear();
-		} else if ((text == "I010") || (text == "P010")) {
+		} else if ((format == "I010") || (format == "P010")) {
 			ui->advancedMsg2->setText(QTStr(
 				"Basic.Settings.Advanced.FormatWarning10BitSdr"));
 		} else {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

bbeafeabdd1c00affa73657a0ac992dd9295fc15 change how the combobox is filled.

And `UpdateColorFormatSpaceWarning` did not get the required change to use the combobox data rather than the text.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fix this issue where the warning should not be shown:


![ColorFormatWarning](https://user-images.githubusercontent.com/17492366/178776842-d2603a59-5380-4e02-8685-a55e8831cd3a.png)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Change color format and see if warnings are shown only when needed.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
