### PR TITLE
obs-scripting: Fix crashes introduced by Swig update to 4.1.0

### DIFF
--- a/deps/obs-scripting/obspython/CMakeLists.txt
+++ b/deps/obs-scripting/obspython/CMakeLists.txt
@@ -21,8 +21,7 @@ endif()
 include(UseSWIG)
 
 set_source_files_properties(
-  obspython.i PROPERTIES USE_TARGET_INCLUDE_DIRECTORIES TRUE SWIG_FLAGS
-                                                             "-builtin;-py3")
+  obspython.i PROPERTIES USE_TARGET_INCLUDE_DIRECTORIES TRUE SWIG_FLAGS "-py3")
 
 swig_add_library(
   obspython
@@ -53,11 +52,8 @@ set_target_properties(obspython PROPERTIES SWIG_COMPILE_DEFINITIONS
 
 if(OS_WINDOWS)
   set_target_properties(
-    obspython
-    PROPERTIES
-      SWIG_COMPILE_DEFINITIONS
-      "SWIG_TYPE_TABLE=obspython;Py_ENABLE_SHARED=1;SWIG_PYTHON_INTERPRETER_NO_DEBUG;MS_NO_COREDLL"
-  )
+    obspython PROPERTIES SWIG_COMPILE_DEFINITIONS
+                         "${_SWIG_DEFINITIONS};MS_NO_COREDLL")
 
   target_link_libraries(obspython PRIVATE Python::Python)
 


### PR DESCRIPTION
### Description
Fixes issues introduced by https://github.com/swig/swig/pull/2238. As obs-scripting is not compatible with the SWIGPYTHON_BUILTIN, obspython needs to disable this feature.

### Motivation and Context
Fix crash issues introduced by possible swig/obs-deps update.

### How Has This Been Tested?
Tested locally with updated obs-deps and Python test script.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
