### PR TITLE
libobs: Fix pulseaudio crash

### DIFF
--- a/libobs/audio-monitoring/pulse/pulseaudio-wrapper.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-wrapper.c
@@ -50,7 +50,7 @@ void get_default_id(char **id)
 		(pa_server_info_cb_t)pulseaudio_default_devices, (void *)pdo);
 
 	if (!pdo->default_sink_name || !*pdo->default_sink_name) {
-		*id = NULL;
+		*id = bzalloc(1);
 	} else {
 		*id = bzalloc(strlen(pdo->default_sink_name) + 9);
 		strcat(*id, pdo->default_sink_name);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Change the default value of `get_default_id` from `NULL` to `bzalloc(1)` in order to be consistent with other place mentioned by https://github.com/obsproject/obs-studio/issues/6460#issuecomment-1183958912

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fixes #6460 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Reproduce this situation, and NO crash happen.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
