### PR TITLE
Fix unused-parameter warnings, unnecessary unused attributes

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -97,8 +97,6 @@ static void OBSStopRecording(void *data, calldata_t *params)
 	QMetaObject::invokeMethod(output->main, "RecordingStop",
 				  Q_ARG(int, code),
 				  Q_ARG(QString, arg_last_error));
-
-	UNUSED_PARAMETER(params);
 }
 
 static void OBSRecordStopping(void *data, calldata_t *params)
@@ -143,8 +141,6 @@ static void OBSStopReplayBuffer(void *data, calldata_t *params)
 	os_atomic_set_bool(&replaybuf_active, false);
 	QMetaObject::invokeMethod(output->main, "ReplayBufferStop",
 				  Q_ARG(int, code));
-
-	UNUSED_PARAMETER(params);
 }
 
 static void OBSReplayBufferStopping(void *data, calldata_t *params)
@@ -182,8 +178,6 @@ static void OBSStopVirtualCam(void *data, calldata_t *params)
 	os_atomic_set_bool(&virtualcam_active, false);
 	QMetaObject::invokeMethod(output->main, "OnVirtualCamStop",
 				  Q_ARG(int, code));
-
-	UNUSED_PARAMETER(params);
 }
 
 /* ------------------------------------------------------------------------ */

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -1852,7 +1852,6 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *scene,
 	GS_DEBUG_MARKER_END();
 
 	UNUSED_PARAMETER(scene);
-	UNUSED_PARAMETER(param);
 	return true;
 }
 

--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -362,7 +362,6 @@ void OBSBasicStatusBar::OBSOutputReconnect(void *data, calldata_t *params)
 
 	int seconds = (int)calldata_int(params, "timeout_sec");
 	QMetaObject::invokeMethod(statusBar, "Reconnect", Q_ARG(int, seconds));
-	UNUSED_PARAMETER(params);
 }
 
 void OBSBasicStatusBar::OBSOutputReconnectSuccess(void *data,

--- a/libobs-opengl/gl-egl-common.c
+++ b/libobs-opengl/gl-egl-common.c
@@ -178,7 +178,7 @@ create_dmabuf_egl_image(EGLDisplay egl_display, unsigned int width,
 }
 
 struct gs_texture *gl_egl_create_texture_from_eglimage(
-	EGLDisplay egl_display, uint32_t width, uint32_t height,
+	EGLDisplay egl_display OBS_UNUSED, uint32_t width, uint32_t height,
 	enum gs_color_format color_format, EGLint target, EGLImage image)
 {
 	UNUSED_PARAMETER(target);

--- a/libobs-opengl/gl-nix.c
+++ b/libobs-opengl/gl-nix.c
@@ -120,7 +120,8 @@ extern void device_present(gs_device_t *device)
 	gl_vtable->device_present(device);
 }
 
-extern bool device_is_monitor_hdr(gs_device_t *device, void *monitor)
+extern bool device_is_monitor_hdr(gs_device_t *device OBS_UNUSED,
+				  void *monitor OBS_UNUSED)
 {
 	return false;
 }

--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -1202,9 +1202,9 @@ void device_flush(gs_device_t *device)
 		glFlush();
 #else
 	glFlush();
-#endif
 
 	UNUSED_PARAMETER(device);
+#endif
 }
 
 void device_set_cull_mode(gs_device_t *device, enum gs_cull_mode mode)

--- a/libobs-opengl/gl-wayland-egl.c
+++ b/libobs-opengl/gl-wayland-egl.c
@@ -384,8 +384,10 @@ static bool gl_wayland_egl_device_query_dmabuf_modifiers_for_format(
 }
 
 static struct gs_texture *gl_wayland_egl_device_texture_create_from_pixmap(
-	gs_device_t *device, uint32_t width, uint32_t height,
-	enum gs_color_format color_format, uint32_t target, void *pixmap)
+	gs_device_t *device OBS_UNUSED, uint32_t width OBS_UNUSED,
+	uint32_t height OBS_UNUSED,
+	enum gs_color_format color_format OBS_UNUSED,
+	uint32_t target OBS_UNUSED, void *pixmap OBS_UNUSED)
 {
 	return NULL;
 }

--- a/libobs-opengl/gl-x11-egl.c
+++ b/libobs-opengl/gl-x11-egl.c
@@ -266,7 +266,6 @@ gl_x11_egl_windowinfo_create(const struct gs_init_data *info)
 
 static void gl_x11_egl_windowinfo_destroy(struct gl_windowinfo *info)
 {
-	UNUSED_PARAMETER(info);
 	bfree(info);
 }
 

--- a/libobs/audio-monitoring/osx/coreaudio-output.c
+++ b/libobs/audio-monitoring/osx/coreaudio-output.c
@@ -61,8 +61,6 @@ static void on_audio_playback(void *param, obs_source_t *source,
 	float vol = source->user_volume;
 	uint32_t bytes;
 
-	UNUSED_PARAMETER(source);
-
 	if (!os_atomic_load_bool(&monitor->active)) {
 		return;
 	}

--- a/libobs/obs-audio-controls.c
+++ b/libobs/obs-audio-controls.c
@@ -551,8 +551,6 @@ static void volmeter_source_data_received(void *vptr, obs_source_t *source,
 	pthread_mutex_unlock(&volmeter->mutex);
 
 	signal_levels_updated(volmeter, magnitude, peak, input_peak);
-
-	UNUSED_PARAMETER(source);
 }
 
 obs_fader_t *obs_fader_create(enum obs_fader_type type)

--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -302,7 +302,6 @@ static void set_fixed_audio_buffering(struct obs_core_audio *audio,
 {
 	struct ts_info new_ts;
 	size_t total_ms;
-	size_t ms;
 	int ticks;
 
 	if (audio_buffering_maxed(audio))
@@ -314,7 +313,6 @@ static void set_fixed_audio_buffering(struct obs_core_audio *audio,
 	ticks = audio->max_buffering_ticks - audio->total_buffering_ticks;
 	audio->total_buffering_ticks += ticks;
 
-	ms = ticks * AUDIO_OUTPUT_FRAMES * 1000 / sample_rate;
 	total_ms = audio->total_buffering_ticks * AUDIO_OUTPUT_FRAMES * 1000 /
 		   sample_rate;
 

--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -593,7 +593,6 @@ static inline bool find_pair_id(obs_hotkey_pair_id id, size_t *idx)
 static inline bool pair_pointer_fixup_func(size_t idx, obs_hotkey_pair_t *pair,
 					   void *data)
 {
-	UNUSED_PARAMETER(idx);
 	UNUSED_PARAMETER(data);
 
 	if (find_id(pair->id[0], &idx))

--- a/libobs/obs-nix-wayland.c
+++ b/libobs/obs-nix-wayland.c
@@ -216,7 +216,6 @@ static void platform_registry_handler(void *data, struct wl_registry *registry,
 				      uint32_t id, const char *interface,
 				      uint32_t version)
 {
-	UNUSED_PARAMETER(version);
 	obs_hotkeys_platform_t *plat = (obs_hotkeys_platform_t *)data;
 
 	if (strcmp(interface, wl_seat_interface.name) == 0) {

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -2353,7 +2353,6 @@ bool save_transform_states(obs_scene_t *scene, obs_sceneitem_t *item,
 		obs_data_array_release(nids);
 	}
 
-	UNUSED_PARAMETER(scene);
 	return true;
 }
 

--- a/libobs/util/bmem.c
+++ b/libobs/util/bmem.c
@@ -162,4 +162,6 @@ void *bmemdup(const void *ptr, size_t size)
 	return out;
 }
 
-OBS_DEPRECATED void base_set_allocator(struct base_allocator *defs) {}
+OBS_DEPRECATED void base_set_allocator(struct base_allocator *defs OBS_UNUSED)
+{
+}

--- a/plugins/aja/aja-common.cpp
+++ b/plugins/aja/aja-common.cpp
@@ -241,8 +241,6 @@ void populate_sdi_4k_transport_list(obs_property_t *list)
 bool aja_video_format_changed(obs_properties_t *props, obs_property_t *list,
 			      obs_data_t *settings)
 {
-	UNUSED_PARAMETER(list);
-
 	auto vid_fmt = static_cast<NTV2VideoFormat>(
 		obs_data_get_int(settings, kUIPropVideoFormatSelect.id));
 	size_t itemCount = obs_property_list_item_count(list);

--- a/plugins/aja/aja-output.cpp
+++ b/plugins/aja/aja-output.cpp
@@ -868,8 +868,6 @@ bool aja_output_device_changed(void *data, obs_properties_t *props,
 bool aja_output_dest_changed(obs_properties_t *props, obs_property_t *list,
 			     obs_data_t *settings)
 {
-	UNUSED_PARAMETER(props);
-
 	blog(LOG_DEBUG, "AJA Output Dest Changed");
 
 	const char *cardID = obs_data_get_string(settings, kUIPropDevice.id);

--- a/plugins/image-source/color-source.c
+++ b/plugins/image-source/color-source.c
@@ -31,8 +31,6 @@ static void color_source_update(void *data, obs_data_t *settings)
 
 static void *color_source_create(obs_data_t *settings, obs_source_t *source)
 {
-	UNUSED_PARAMETER(source);
-
 	struct color_source *context = bzalloc(sizeof(struct color_source));
 	context->src = source;
 

--- a/plugins/linux-capture/xcomposite-input.c
+++ b/plugins/linux-capture/xcomposite-input.c
@@ -382,7 +382,8 @@ static enum gs_color_format gs_format_from_tex()
 	}
 }
 
-static int silence_x11_errors(Display *display, XErrorEvent *err)
+static int silence_x11_errors(Display *display OBS_UNUSED,
+			      XErrorEvent *err OBS_UNUSED)
 {
 	return 0;
 }

--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -710,7 +710,6 @@ static void on_state_changed_cb(void *user_data, enum pw_stream_state old,
 				enum pw_stream_state state, const char *error)
 {
 	UNUSED_PARAMETER(old);
-	UNUSED_PARAMETER(error);
 
 	obs_pipewire_data *obs_pw = user_data;
 
@@ -736,8 +735,6 @@ static void on_core_info_cb(void *user_data, const struct pw_core_info *info)
 static void on_core_error_cb(void *user_data, uint32_t id, int seq, int res,
 			     const char *message)
 {
-	UNUSED_PARAMETER(seq);
-
 	obs_pipewire_data *obs_pw = user_data;
 
 	blog(LOG_ERROR, "[pipewire] Error id:%u seq:%d res:%d (%s): %s", id,

--- a/plugins/linux-pipewire/screencast-portal.c
+++ b/plugins/linux-pipewire/screencast-portal.c
@@ -600,7 +600,6 @@ init_screencast_capture(struct screencast_portal_capture *capture)
 {
 	GDBusConnection *connection;
 	GDBusProxy *proxy;
-	char *aux;
 
 	capture->cancellable = g_cancellable_new();
 	connection = portal_get_dbus_connection();

--- a/plugins/mac-capture/mac-display-capture.m
+++ b/plugins/mac-capture/mac-display-capture.m
@@ -150,7 +150,6 @@ static inline void display_stream_update(struct display_capture *dc,
 					 CGDisplayStreamUpdateRef update_ref)
 {
 	UNUSED_PARAMETER(display_time);
-	UNUSED_PARAMETER(update_ref);
 
 	if (status == kCGDisplayStreamFrameStatusStopped) {
 		os_event_signal(dc->disp_finished);
@@ -251,9 +250,6 @@ void load_crop(struct display_capture *dc, obs_data_t *settings);
 
 static void *display_capture_create(obs_data_t *settings, obs_source_t *source)
 {
-	UNUSED_PARAMETER(source);
-	UNUSED_PARAMETER(settings);
-
 	struct display_capture *dc = bzalloc(sizeof(struct display_capture));
 
 	dc->source = source;

--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -451,8 +451,6 @@ static inline void syphon_destroy_internal(syphon_t s);
 
 static void *syphon_create_internal(obs_data_t *settings, obs_source_t *source)
 {
-	UNUSED_PARAMETER(source);
-
 	syphon_t s = bzalloc(sizeof(struct syphon));
 	if (!s)
 		return s;
@@ -1039,8 +1037,6 @@ static inline void tick_inject_state(syphon_t s, float seconds)
 
 static void syphon_video_tick(void *data, float seconds)
 {
-	UNUSED_PARAMETER(seconds);
-
 	syphon_t s = data;
 
 	if (s->inject_active && !s->inject_server_found)

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -917,7 +917,6 @@ static void replay_buffer_hotkey(void *data, obs_hotkey_id id,
 {
 	UNUSED_PARAMETER(id);
 	UNUSED_PARAMETER(hotkey);
-	UNUSED_PARAMETER(pressed);
 
 	if (!pressed)
 		return;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -128,7 +128,6 @@ static obs_properties_t *ffmpeg_source_getproperties(void *data)
 	struct ffmpeg_source *s = data;
 	struct dstr filter = {0};
 	struct dstr path = {0};
-	UNUSED_PARAMETER(data);
 
 	obs_properties_t *props = obs_properties_create();
 
@@ -611,8 +610,6 @@ static void ffmpeg_source_stop_hotkey(void *data, obs_hotkey_id id,
 
 static void *ffmpeg_source_create(obs_data_t *settings, obs_source_t *source)
 {
-	UNUSED_PARAMETER(settings);
-
 	struct ffmpeg_source *s = bzalloc(sizeof(struct ffmpeg_source));
 	s->source = source;
 

--- a/plugins/obs-filters/color-grade-filter.c
+++ b/plugins/obs-filters/color-grade-filter.c
@@ -413,7 +413,6 @@ static obs_properties_t *color_grade_filter_properties(void *data)
 	dstr_free(&filter_str);
 	dstr_free(&path);
 
-	UNUSED_PARAMETER(data);
 	return props;
 }
 

--- a/plugins/obs-filters/compressor-filter.c
+++ b/plugins/obs-filters/compressor-filter.c
@@ -533,7 +533,6 @@ static obs_properties_t *compressor_properties(void *data)
 	struct sidechain_prop_info info = {sources, parent};
 	obs_enum_sources(add_sources, &info);
 
-	UNUSED_PARAMETER(data);
 	return props;
 }
 

--- a/plugins/obs-filters/noise-suppress-filter.c
+++ b/plugins/obs-filters/noise-suppress-filter.c
@@ -334,8 +334,8 @@ failure:
 }
 
 static inline void alloc_channel(struct noise_suppress_data *ng,
-				 uint32_t sample_rate OBS_UNUSED,
-				 size_t channel, size_t frames)
+				 uint32_t sample_rate, size_t channel,
+				 size_t frames)
 {
 #ifdef LIBSPEEXDSP_ENABLED
 	ng->spx_states[channel] =

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -775,10 +775,6 @@ static bool obs_qsv_sei(void *data, uint8_t **sei, size_t *size)
 	if (!obsqsv->context)
 		return false;
 
-	/* (Jim) Unused */
-	UNUSED_PARAMETER(sei);
-	UNUSED_PARAMETER(size);
-
 	*sei = obsqsv->sei;
 	*size = obsqsv->sei_size;
 	return true;

--- a/plugins/obs-transitions/transition-luma-wipe.c
+++ b/plugins/obs-transitions/transition-luma-wipe.c
@@ -64,8 +64,6 @@ static void luma_wipe_update(void *data, obs_data_t *settings)
 
 	bfree(file);
 	dstr_free(&path);
-
-	UNUSED_PARAMETER(settings);
 }
 
 static void luma_wipe_get_list(void *data)

--- a/plugins/obs-transitions/transition-swipe.c
+++ b/plugins/obs-transitions/transition-swipe.c
@@ -48,7 +48,6 @@ static void *swipe_create(obs_data_t *settings, obs_source_t *source)
 
 	obs_source_update(source, settings);
 
-	UNUSED_PARAMETER(settings);
 	return swipe;
 }
 

--- a/plugins/rtmp-services/rtmp-custom.c
+++ b/plugins/rtmp-services/rtmp-custom.c
@@ -115,8 +115,6 @@ static const char *rtmp_custom_password(void *data)
 static void rtmp_custom_apply_settings(void *data, obs_data_t *video_settings,
 				       obs_data_t *audio_settings)
 {
-	UNUSED_PARAMETER(audio_settings);
-
 	struct rtmp_custom *service = data;
 	if (service->server != NULL && video_settings != NULL &&
 	    strncmp(service->server, RTMP_PROTOCOL, strlen(RTMP_PROTOCOL)) !=

--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -446,8 +446,6 @@ static unsigned vlcs_video_format(void **p_data, char *chroma, unsigned *width,
 	enum video_format new_format;
 	enum video_range_type range;
 	bool new_range;
-	unsigned new_width = 0;
-	unsigned new_height = 0;
 	size_t i = 0;
 
 	new_format = convert_vlc_video_format(chroma, &new_range);

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -460,8 +460,6 @@ static void duplicator_capture_tick(void *data, float seconds)
 
 	if (!capture->showing)
 		capture->showing = true;
-
-	UNUSED_PARAMETER(seconds);
 }
 
 static uint32_t duplicator_capture_width(void *data)

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -2420,7 +2420,6 @@ static obs_properties_t *game_capture_properties(void *data)
 	obs_property_list_add_string(p, TEXT_RGBA10A2_SPACE_2100PQ,
 				     RGBA10A2_SPACE_2100PQ);
 
-	UNUSED_PARAMETER(data);
 	return ppts;
 }
 

--- a/plugins/win-dshow/win-dshow-encoder.cpp
+++ b/plugins/win-dshow/win-dshow-encoder.cpp
@@ -161,7 +161,6 @@ static inline void *CreateDShowEncoder(obs_data_t *settings,
 		     obs_encoder_get_name(context), error);
 	}
 
-	UNUSED_PARAMETER(settings);
 	return encoder;
 }
 

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -1953,7 +1953,6 @@ static bool DeviceIntervalChanged(obs_properties_t *props, obs_property_t *p,
 	UpdateVideoFormats(device, format, cx, cy, val, props);
 	UpdateFPS(device, format, val, cx, cy, props);
 
-	UNUSED_PARAMETER(p);
 	return true;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
- Add `OBS_UNUSED` attribute to unused function parameters.
- Remove `UNUSED_PARAMETER` from used parameters
- Remove `OBS_UNUSED` from a used parameter

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't want to see warnings.
Don't want to see unnecessary `UNUSED_PARAMETER`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Reviewed code to ensure the changes are just touching `OBS_UNUSED` and `UNUSED_PARAMETER`.
- Checked warnings built on Linux, macOS, and Windows.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
