### PR TITLE
aja: Increment aja-source version for buffering setting

### DIFF
--- a/plugins/aja/aja-output.cpp
+++ b/plugins/aja/aja-output.cpp
@@ -1289,7 +1289,7 @@ static void aja_output_defaults(obs_data_t *settings)
 		static_cast<long long>(kDefaultAJASDITransport4K));
 }
 
-struct obs_output_info create_aja_output_info()
+void register_aja_output_info()
 {
 	struct obs_output_info aja_output_info = {};
 
@@ -1305,5 +1305,5 @@ struct obs_output_info create_aja_output_info()
 	aja_output_info.update = aja_output_update;
 	aja_output_info.get_defaults = aja_output_defaults;
 	aja_output_info.get_properties = aja_output_get_properties;
-	return aja_output_info;
+	obs_register_output(&aja_output_info);
 }

--- a/plugins/aja/aja-source.cpp
+++ b/plugins/aja/aja-source.cpp
@@ -1127,7 +1127,12 @@ void aja_source_get_defaults(obs_data_t *settings)
 		static_cast<long long>(SDITransport4K::TwoSampleInterleave));
 	obs_data_set_default_bool(settings, kUIPropDeactivateWhenNotShowing.id,
 				  false);
-	obs_data_set_default_bool(settings, kUIPropBuffering.id, false);
+}
+
+static void aja_source_get_defaults_v1(obs_data_t *settings)
+{
+	aja_source_get_defaults(settings);
+	obs_data_set_default_bool(settings, kUIPropBuffering.id, true);
 }
 
 void aja_source_save(void *data, obs_data_t *settings)
@@ -1161,14 +1166,14 @@ void aja_source_save(void *data, obs_data_t *settings)
 	}
 }
 
-struct obs_source_info create_aja_source_info()
+void register_aja_source_info()
 {
 	struct obs_source_info aja_source_info = {};
 	aja_source_info.id = kUIPropCaptureModule.id;
 	aja_source_info.type = OBS_SOURCE_TYPE_INPUT;
-	aja_source_info.output_flags = OBS_SOURCE_ASYNC_VIDEO |
-				       OBS_SOURCE_AUDIO |
-				       OBS_SOURCE_DO_NOT_DUPLICATE;
+	aja_source_info.output_flags =
+		OBS_SOURCE_ASYNC_VIDEO | OBS_SOURCE_AUDIO |
+		OBS_SOURCE_DO_NOT_DUPLICATE | OBS_SOURCE_CAP_OBSOLETE;
 	aja_source_info.get_name = aja_source_get_name;
 	aja_source_info.create = aja_source_create;
 	aja_source_info.destroy = aja_source_destroy;
@@ -1178,8 +1183,13 @@ struct obs_source_info create_aja_source_info()
 	aja_source_info.activate = aja_source_activate;
 	aja_source_info.deactivate = aja_source_deactivate;
 	aja_source_info.get_properties = aja_source_get_properties;
-	aja_source_info.get_defaults = aja_source_get_defaults;
+	aja_source_info.get_defaults = aja_source_get_defaults_v1;
 	aja_source_info.save = aja_source_save;
 	aja_source_info.icon_type = OBS_ICON_TYPE_CAMERA;
-	return aja_source_info;
+	obs_register_source(&aja_source_info);
+
+	aja_source_info.version = 2;
+	aja_source_info.output_flags &= ~OBS_SOURCE_CAP_OBSOLETE;
+	aja_source_info.get_defaults = aja_source_get_defaults;
+	obs_register_source(&aja_source_info);
 }

--- a/plugins/aja/main.cpp
+++ b/plugins/aja/main.cpp
@@ -10,11 +10,8 @@ MODULE_EXPORT const char *obs_module_description(void)
 	return "aja";
 }
 
-extern struct obs_source_info create_aja_source_info();
-struct obs_source_info aja_source_info;
-
-extern struct obs_output_info create_aja_output_info();
-struct obs_output_info aja_output_info;
+extern void register_aja_source_info();
+extern void register_aja_output_info();
 
 bool obs_module_load(void)
 {
@@ -28,11 +25,9 @@ bool obs_module_load(void)
 
 	aja::CardManager::Instance().EnumerateCards();
 
-	aja_source_info = create_aja_source_info();
-	obs_register_source(&aja_source_info);
+	register_aja_source_info();
 
-	aja_output_info = create_aja_output_info();
-	obs_register_output(&aja_output_info);
+	register_aja_output_info();
 
 	return true;
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add aja-source version 2 to differentiate buffering settings, which is implemented in a255b0f74.
- Version 1: buffering is enabled by default
- Version 2: buffering is disabled by default

To register two versions, remove to return obs_source_info and register the source inside aja-source.cpp. Also revise aja-output.cpp to register aja-output to keep consistency of function type.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Requested by @paulh-aja at https://github.com/obsproject/obs-studio/pull/6621#issuecomment-1180152631.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Before this modification,
  - added aja-source.
- With this modification,
  - checked the aja-source has enabled buffer.
  - added another aja-source and checked it's buffer is disabled.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
