### PR TITLE
v4l2,scripting: Add more thread names

### DIFF
--- a/deps/obs-scripting/obs-scripting.c
+++ b/deps/obs-scripting/obs-scripting.c
@@ -85,6 +85,7 @@ struct defer_call {
 static void *defer_thread(void *unused)
 {
 	UNUSED_PARAMETER(unused);
+	os_set_thread_name("scripting: defer");
 
 	while (os_sem_wait(defer_call_semaphore) == 0) {
 		struct defer_call info;

--- a/plugins/linux-v4l2/v4l2-udev.c
+++ b/plugins/linux-v4l2/v4l2-udev.c
@@ -115,6 +115,7 @@ static void *udev_event_thread(void *vptr)
 	struct udev_device *dev;
 
 	/* set up udev monitoring */
+	os_set_thread_name("v4l2: udev");
 	udev = udev_new();
 	mon = udev_monitor_new_from_netlink(udev, "udev");
 	udev_monitor_filter_add_match_subsystem_devtype(mon, "video4linux",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This sets some thread names for the scripting backend's defer thread and
the v4l2 udev thread.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
It makes it easier to know I dont have to look at a thread if it's name is not "obs" when debugging.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
