### PR TITLE
UI: Fix undo stack uninitialized ui warning

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -818,7 +818,6 @@ private:
 	OBSSource prevFTBSource = nullptr;
 
 public:
-	undo_stack undo_s;
 	OBSSource GetProgramSource();
 	OBSScene GetCurrentScene();
 
@@ -1150,7 +1149,14 @@ public slots:
 	void UpdateContextBarDeferred(bool force = false);
 	void UpdateContextBarVisibility();
 
+private:
+	std::unique_ptr<Ui::OBSBasic> ui;
+
 public:
+	/* `undo_s` needs to be declared after `ui` to prevent an uninitialized
+	 * warning for `ui` while initializing `undo_s`. */
+	undo_stack undo_s;
+
 	explicit OBSBasic(QWidget *parent = 0);
 	virtual ~OBSBasic();
 
@@ -1162,9 +1168,6 @@ public:
 				   const char *file) const override;
 
 	static void InitBrowserPanelSafeBlock();
-
-private:
-	std::unique_ptr<Ui::OBSBasic> ui;
 };
 
 class SceneRenameDelegate : public QStyledItemDelegate {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix this warning by ~~turning~~ moving `undo_s` after `ui` in the class definition. ~~into a pointer and initialized it inside `OBSBasic` constructor~~.

```
obs-studio/UI/window-basic-main.cpp: In constructor ‘OBSBasic::OBSBasic(QWidget*)’:
OBS/obs-studio/UI/window-basic-main.cpp:231:41: warning: member ‘OBSBasic::ui’ is used uninitialized [-Wuninitialized]
  231 |         : OBSMainWindow(parent), undo_s(ui), ui(new Ui::OBSBasic)
      |                                         ^~

```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Just remembered that this warning was there and wanted to get rid of it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tried to use Undo/Redo feature and no issue.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
