### PR TITLE
UI: Remove disable_high_dpi_scaling option on Qt 6

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -88,7 +88,9 @@ bool opt_start_virtualcam = false;
 bool opt_minimize_tray = false;
 bool opt_allow_opengl = false;
 bool opt_always_on_top = false;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 bool opt_disable_high_dpi_scaling = false;
+#endif
 bool opt_disable_updater = false;
 bool opt_disable_missing_files_check = false;
 string opt_starting_collection;
@@ -2053,7 +2055,8 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 
 	ScopeProfiler prof{run_program_init};
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)) && \
+	(QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 	QGuiApplication::setAttribute(opt_disable_high_dpi_scaling
 					      ? Qt::AA_DisableHighDpiScaling
 					      : Qt::AA_EnableHighDpiScaling);
@@ -2847,10 +2850,11 @@ int main(int argc, char *argv[])
 				  nullptr)) {
 			opt_disable_missing_files_check = true;
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 		} else if (arg_is(argv[i], "--disable-high-dpi-scaling",
 				  nullptr)) {
 			opt_disable_high_dpi_scaling = true;
-
+#endif
 		} else if (arg_is(argv[i], "--help", "-h")) {
 			std::string help =
 				"--help, -h: Get list of available commands.\n\n"
@@ -2871,7 +2875,10 @@ int main(int argc, char *argv[])
 				"--unfiltered_log: Make log unfiltered.\n\n"
 				"--disable-updater: Disable built-in updater (Windows/Mac only)\n\n"
 				"--disable-missing-files-check: Disable the missing files dialog which can appear on startup.\n\n"
-				"--disable-high-dpi-scaling: Disable automatic high-DPI scaling\n\n";
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+				"--disable-high-dpi-scaling: Disable automatic high-DPI scaling\n\n"
+#endif
+				;
 
 #ifdef _WIN32
 			MessageBoxA(NULL, help.c_str(), "Help",

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -240,6 +240,8 @@ extern bool opt_minimize_tray;
 extern bool opt_studio_mode;
 extern bool opt_allow_opengl;
 extern bool opt_always_on_top;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 extern bool opt_disable_high_dpi_scaling;
+#endif
 extern std::string opt_starting_scene;
 extern bool restart;


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
With Qt 6, high dpi scaling is always enabled and the AA_DisableHighDpiScaling becomes no-op. As such, we can remove the command line argument.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Less warnings in Qt 6.
By no means all (there are quite a few), but you gotta start somewhere.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled and run on both Qt 5 and Qt 6.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
