### PR TITLE
obs-ffmpeg: Add HDR and HEVC to VA-API encoder

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -44,7 +44,10 @@ extern struct obs_encoder_info svt_av1_encoder_info;
 extern struct obs_encoder_info aom_av1_encoder_info;
 
 #ifdef LIBAVUTIL_VAAPI_AVAILABLE
-extern struct obs_encoder_info vaapi_encoder_info;
+extern struct obs_encoder_info h264_vaapi_encoder_info;
+#ifdef ENABLE_HEVC
+extern struct obs_encoder_info hevc_vaapi_encoder_info;
+#endif
 #endif
 
 #ifndef __APPLE__
@@ -336,6 +339,19 @@ static bool h264_vaapi_supported(void)
 	 * that support H264. */
 	return vaapi_get_h264_default_device() != NULL;
 }
+#ifdef ENABLE_HEVC
+static bool hevc_vaapi_supported(void)
+{
+	const AVCodec *vaenc = avcodec_find_encoder_by_name("hevc_vaapi");
+
+	if (!vaenc)
+		return false;
+
+	/* NOTE: If default device is NULL, it means there is no device
+	 * that support HEVC. */
+	return vaapi_get_hevc_default_device() != NULL;
+}
+#endif
 #endif
 
 #ifdef _WIN32
@@ -423,10 +439,19 @@ bool obs_module_load(void)
 
 	if (h264_vaapi_supported()) {
 		blog(LOG_INFO, "FFmpeg VAAPI H264 encoding supported");
-		obs_register_encoder(&vaapi_encoder_info);
+		obs_register_encoder(&h264_vaapi_encoder_info);
 	} else {
 		blog(LOG_INFO, "FFmpeg VAAPI H264 encoding not supported");
 	}
+
+#ifdef ENABLE_HEVC
+	if (hevc_vaapi_supported()) {
+		blog(LOG_INFO, "FFmpeg VAAPI HEVC encoding supported");
+		obs_register_encoder(&hevc_vaapi_encoder_info);
+	} else {
+		blog(LOG_INFO, "FFmpeg VAAPI HEVC encoding not supported");
+	}
+#endif
 #endif
 #endif
 

--- a/plugins/obs-ffmpeg/vaapi-utils.c
+++ b/plugins/obs-ffmpeg/vaapi-utils.c
@@ -260,3 +260,64 @@ const char *vaapi_get_h264_default_device()
 
 	return default_h264_device;
 }
+
+#ifdef ENABLE_HEVC
+
+bool vaapi_display_hevc_supported(VADisplay dpy, const char *device_path)
+{
+	bool ret = false;
+
+	CHECK_PROFILE(ret, VAProfileHEVCMain, dpy, device_path);
+	CHECK_PROFILE(ret, VAProfileHEVCMain10, dpy, device_path);
+
+	if (!ret) {
+		CHECK_PROFILE_LP(ret, VAProfileHEVCMain, dpy, device_path);
+		CHECK_PROFILE_LP(ret, VAProfileHEVCMain10, dpy, device_path);
+	}
+
+	return ret;
+}
+
+bool vaapi_device_hevc_supported(const char *device_path)
+{
+	bool ret = false;
+	VADisplay va_dpy;
+
+	int drm_fd = -1;
+
+	va_dpy = vaapi_open_device(&drm_fd, device_path,
+				   "vaapi_device_hevc_supported");
+	if (!va_dpy)
+		return false;
+
+	ret = vaapi_display_hevc_supported(va_dpy, device_path);
+
+	vaapi_close_device(&drm_fd, va_dpy);
+
+	return ret;
+}
+
+const char *vaapi_get_hevc_default_device()
+{
+	static const char *default_hevc_device = NULL;
+
+	if (!default_hevc_device) {
+		bool ret = false;
+		char path[32] = "/dev/dri/renderD1";
+		for (int i = 28;; i++) {
+			sprintf(path, "/dev/dri/renderD1%d", i);
+			if (access(path, F_OK) != 0)
+				break;
+
+			ret = vaapi_device_hevc_supported(path);
+			if (ret) {
+				default_hevc_device = strdup(path);
+				break;
+			}
+		}
+	}
+
+	return default_hevc_device;
+}
+
+#endif // #ifdef ENABLE_HEVC

--- a/plugins/obs-ffmpeg/vaapi-utils.h
+++ b/plugins/obs-ffmpeg/vaapi-utils.h
@@ -16,7 +16,11 @@ bool vaapi_device_rc_supported(VAProfile profile, VADisplay dpy, uint32_t rc,
 			       const char *device_path);
 
 bool vaapi_display_h264_supported(VADisplay dpy, const char *device_path);
-
 bool vaapi_device_h264_supported(const char *device_path);
-
 const char *vaapi_get_h264_default_device(void);
+
+#ifdef ENABLE_HEVC
+bool vaapi_display_hevc_supported(VADisplay dpy, const char *device_path);
+bool vaapi_device_hevc_supported(const char *device_path);
+const char *vaapi_get_hevc_default_device(void);
+#endif


### PR DESCRIPTION
### Description
Add HEVC support to create HDR videos using FFmpeg VA-API on Linux.

EDIT (jpark37): I have reworked the changes to add NV12 back to support narrow SDR again. I've also consolidated the files, so no new files are added.

### Motivation and Context
HDR streaming.

### How Has This Been Tested?
- HDR video was recorded using "FFmpeg HEVC VAAPI" encoder with AMD hardware device selected. Video parameters were tested using the `ffprobe` tool. The recorded video was played using `mpv`.
- HDR Video was streamed to YouTube using "FFmpeg HEVC VAAPI" encoder with AMD hardware device selected. Video parameters were tested using the `Stats for nerds` YouTube feature. The streamed video was viewed using `chrome web browser`.

AMD Ryzen 7 5700U with Radeon Graphics

EDIT (jpark37): I've tested recordings with these combinations on my Rocket Lake on Ubuntu 22.10.

- H.264, Rec. 709, NV12
- HEVC, Rec. 709, NV12
- HEVC, Rec. 2100 (PQ), P010
- HEVC, Rec. 2100 (HLG), P010
- ENABLE_HEVC=OFF builds, and the encoders are removed

I was unable to test streaming because we seem to require CBR, and the Intel HEVC encoder reports that it only supports CQP (for me at least).

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.