### PR TITLE
Treat warnings as errors on Clang and GNU GCC

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/obsproject/obs-amd-encoder.git
 [submodule "plugins/obs-browser"]
 	path = plugins/obs-browser
-	url = https://github.com/obsproject/obs-browser.git
+	url = https://github.com/tytan652/obs-browser.git
 [submodule "plugins/obs-vst"]
 	path = plugins/obs-vst
 	url = https://github.com/obsproject/obs-vst.git

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -818,7 +818,6 @@ private:
 	OBSSource prevFTBSource = nullptr;
 
 public:
-	undo_stack undo_s;
 	OBSSource GetProgramSource();
 	OBSScene GetCurrentScene();
 
@@ -1150,7 +1149,12 @@ public slots:
 	void UpdateContextBarDeferred(bool force = false);
 	void UpdateContextBarVisibility();
 
+private:
+	std::unique_ptr<Ui::OBSBasic> ui;
+
 public:
+	undo_stack undo_s;
+
 	explicit OBSBasic(QWidget *parent = 0);
 	virtual ~OBSBasic();
 
@@ -1162,9 +1166,6 @@ public:
 				   const char *file) const override;
 
 	static void InitBrowserPanelSafeBlock();
-
-private:
-	std::unique_ptr<Ui::OBSBasic> ui;
 };
 
 class SceneRenameDelegate : public QStyledItemDelegate {

--- a/cmake/Modules/CompilerConfig.cmake
+++ b/cmake/Modules/CompilerConfig.cmake
@@ -82,10 +82,14 @@ else()
   endif()
 
   add_compile_options(
+    -Werror
     -Wextra
     -Wvla
+    -Wformat
+    -Wformat-security
     -Wno-unused-function
     -Wno-missing-field-initializers
+    -Wno-error=deprecated-declarations
     -fno-strict-aliasing
     "$<$<COMPILE_LANGUAGE:C>:-Werror-implicit-function-declaration;-Wno-missing-braces>"
     "$<$<BOOL:${USE_LIBCXX}>:-stdlib=libc++>"

--- a/deps/jansson/CMakeLists.txt
+++ b/deps/jansson/CMakeLists.txt
@@ -701,5 +701,11 @@ set(JANSSON_LIBRARIES
     jansson
     CACHE STRING "Jansson libraries")
 
+if (UNIX)
+  target_compile_options(jansson PUBLIC
+    -Wno-format-truncation
+    -Wno-implicit-fallthrough)
+endif()
+
 target_include_directories(jansson PUBLIC src
                                           "${CMAKE_CURRENT_BINARY_DIR}/include")

--- a/deps/obs-scripting/obslua/CMakeLists.txt
+++ b/deps/obs-scripting/obslua/CMakeLists.txt
@@ -61,4 +61,10 @@ elseif(OS_MACOS)
                                           MACHO_COMPATIBILITY_VERSION 0)
 endif()
 
+if(NOT OS_WINDOWS
+   AND CMAKE_C_COMPILER_ID STREQUAL "GNU"
+   AND SWIG_VERSION VERSION_LESS "4.1")
+  target_compile_options(obslua PRIVATE -Wno-maybe-uninitialized)
+endif()
+
 setup_script_plugin_target(obslua)

--- a/deps/obs-scripting/obslua/obslua.i
+++ b/deps/obs-scripting/obslua/obslua.i
@@ -55,6 +55,7 @@ static inline void wrap_blog(int log_level, const char *message)
 %ignore blog;
 %ignore blogva;
 %ignore bcrash;
+%ignore base_set_crash_handler;
 %ignore obs_source_info;
 %ignore obs_register_source_s(const struct obs_source_info *info, size_t size);
 %ignore obs_output_set_video(obs_output_t *output, video_t *video);

--- a/deps/obs-scripting/obspython/obspython.i
+++ b/deps/obs-scripting/obspython/obspython.i
@@ -64,6 +64,7 @@ static inline void wrap_blog(int log_level, const char *message)
 %ignore blog;
 %ignore blogva;
 %ignore bcrash;
+%ignore base_set_crash_handler;
 %ignore obs_source_info;
 %ignore obs_register_source_s(const struct obs_source_info *info, size_t size);
 %ignore obs_output_set_video(obs_output_t *output, video_t *video);

--- a/libobs/media-io/media-remux.c
+++ b/libobs/media-io/media-remux.c
@@ -34,6 +34,10 @@
 #define CODEC_FLAG_GLOBAL_H CODEC_FLAG_GLOBAL_HEADER
 #endif
 
+#ifndef FF_API_BUFFER_SIZE_T
+#define FF_API_BUFFER_SIZE_T (LIBAVUTIL_VERSION_MAJOR < 57)
+#endif
+
 struct media_remux_job {
 	int64_t in_size;
 	AVFormatContext *ifmt_ctx, *ofmt_ctx;

--- a/libobs/util/base.c
+++ b/libobs/util/base.c
@@ -64,6 +64,9 @@ OBS_NORETURN static void def_crash_handler(const char *format, va_list args,
 }
 
 static log_handler_t log_handler = def_log_handler;
+#if !defined(_MSC_VER) && !defined(SWIG)
+OBS_NORETURN
+#endif
 static void (*crash_handler)(const char *, va_list, void *) = def_crash_handler;
 
 void base_get_log_handler(log_handler_t *handler, void **param)
@@ -83,8 +86,12 @@ void base_set_log_handler(log_handler_t handler, void *param)
 	log_handler = handler;
 }
 
-void base_set_crash_handler(void (*handler)(const char *, va_list, void *),
-			    void *param)
+void base_set_crash_handler(
+#if !defined(_MSC_VER) && !defined(SWIG)
+	OBS_NORETURN
+#endif
+	void (*handler)(const char *, va_list, void *),
+	void *param)
 {
 	crash_param = param;
 	crash_handler = handler;

--- a/libobs/util/base.h
+++ b/libobs/util/base.h
@@ -72,9 +72,12 @@ typedef void (*log_handler_t)(int lvl, const char *msg, va_list args, void *p);
 EXPORT void base_get_log_handler(log_handler_t *handler, void **param);
 EXPORT void base_set_log_handler(log_handler_t handler, void *param);
 
-EXPORT void base_set_crash_handler(void (*handler)(const char *, va_list,
-						   void *),
-				   void *param);
+EXPORT void base_set_crash_handler(
+#if !defined(_MSC_VER) && !defined(SWIG)
+	OBS_NORETURN
+#endif
+	void (*handler)(const char *, va_list, void *),
+	void *param);
 
 EXPORT void blogva(int log_level, const char *format, va_list args);
 

--- a/libobs/util/bmem.c
+++ b/libobs/util/bmem.c
@@ -162,4 +162,6 @@ void *bmemdup(const void *ptr, size_t size)
 	return out;
 }
 
-OBS_DEPRECATED void base_set_allocator(struct base_allocator *defs) {}
+OBS_DEPRECATED void base_set_allocator(OBS_UNUSED struct base_allocator *defs)
+{
+}

--- a/plugins/aja/aja-output.cpp
+++ b/plugins/aja/aja-output.cpp
@@ -759,8 +759,8 @@ void AJAOutput::OutputThread(AJAThread *thread, void *ctx)
 	ajaOutput->mAudioStarted = false;
 
 	blog(LOG_INFO,
-	     "AJAOutput::OutputThread: Thread stopped. Played %lld video frames",
-	     ajaOutput->mVideoQueueFrames);
+	     "AJAOutput::OutputThread: Thread stopped. Played %llu video frames",
+	     (unsigned long long)ajaOutput->mVideoQueueFrames);
 }
 
 void populate_output_device_list(obs_property_t *list)

--- a/plugins/aja/aja-source.cpp
+++ b/plugins/aja/aja-source.cpp
@@ -13,7 +13,9 @@
 #include <ajantv2/includes/ntv2card.h>
 #include <ajantv2/includes/ntv2utils.h>
 
+#ifndef NSEC_PER_SEC
 #define NSEC_PER_SEC 1000000000LL
+#endif
 #define NTV2_AUDIOSIZE_MAX (401 * 1024)
 
 AJASource::AJASource(obs_source_t *source)

--- a/plugins/linux-capture/xshm-input.c
+++ b/plugins/linux-capture/xshm-input.c
@@ -352,7 +352,7 @@ static bool xshm_server_changed(obs_properties_t *props, obs_property_t *p,
 
 	for (int_fast32_t i = 0; i < count; ++i) {
 		char *name;
-		char name_tmp[12];
+		char name_tmp[20];
 		int_fast32_t x, y, w, h;
 		x = y = w = h = 0;
 

--- a/plugins/mac-avcapture/av-capture.mm
+++ b/plugins/mac-avcapture/av-capture.mm
@@ -604,7 +604,7 @@ static inline bool update_audio(obs_source_audio *audio,
 {
 	size_t requiredSize;
 	OSStatus status = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(
-		sample_buffer, &requiredSize, nullptr, NULL, nullptr, nullptr,
+		sample_buffer, &requiredSize, nullptr, 0, nullptr, nullptr,
 		kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment,
 		nullptr);
 

--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -1082,12 +1082,15 @@ bool obs_module_load(void)
 		VT_DICTSTR(kVTVideoEncoderList_EncoderID, id);
 		VT_DICTSTR(kVTVideoEncoderList_DisplayName, disp_name);
 
-		CFBooleanRef hardware_ref = CFDictionaryGetValue(
-			encoder_dict,
-			kVTVideoEncoderList_IsHardwareAccelerated);
 		bool hardware_accelerated = false;
-		if (hardware_ref)
-			hardware_accelerated = CFBooleanGetValue(hardware_ref);
+		if (__builtin_available(macOS 10.14, *)) {
+			CFBooleanRef hardware_ref = CFDictionaryGetValue(
+				encoder_dict,
+				kVTVideoEncoderList_IsHardwareAccelerated);
+			if (hardware_ref)
+				hardware_accelerated =
+					CFBooleanGetValue(hardware_ref);
+		}
 
 		info.id = id;
 		struct vt_encoder_type_data *type_data =

--- a/plugins/obs-outputs/CMakeLists.txt
+++ b/plugins/obs-outputs/CMakeLists.txt
@@ -178,6 +178,22 @@ elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ftl-sdk/CMakeLists.txt")
       obs-outputs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ftl-sdk/libftl/posix)
   endif()
 
+  if(NOT OS_WINDOWS)
+    target_compile_options(
+      obs-outputs
+      PRIVATE
+        -Wno-error=extra
+        -Wno-error=sign-compare
+        -Wno-error=incompatible-pointer-types
+        -Wno-error=int-conversion
+        "$<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=maybe-uninitialized>"
+        "$<$<COMPILE_LANG_AND_ID:C,AppleClang,Clang>:-Wno-error=pointer-sign>")
+    if((NOT CMAKE_C_COMPILER_ID STREQUAL "GNU") OR CMAKE_C_COMPILER_VERSION
+                                                   VERSION_GREATER_EQUAL "10")
+      target_compile_options(obs-outputs PRIVATE -Wno-error=enum-conversion)
+    endif()
+  endif()
+
   target_compile_definitions(obs-outputs PRIVATE FTL_FOUND)
 endif()
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Depends on:
- #6720
- #6750
- https://github.com/obsproject/obs-browser/pull/368

Once those are merged some commits will be removed.

Turn every warning into errors except:
- deprecations
- jansson (warning are silenced)
- some of obs-outputs because of FTL

All the errors made by this changed are fixed in this PR.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Do the same as #6723.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

- Flatpak local build.
- Build on Arch Linux (need some change related to FFmpeg 5).
- And CI from a PR on my fork.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
