### PR TITLE
Fix discarded-qualifiers warnings with FFmpeg 5

### DIFF
--- a/deps/libff/libff/ff-util.c
+++ b/deps/libff/libff/ff-util.c
@@ -66,7 +66,7 @@ void ff_init()
 
 const char *ff_codec_name_from_id(int codec_id)
 {
-	AVCodec *codec = avcodec_find_encoder(codec_id);
+	const AVCodec *codec = avcodec_find_encoder(codec_id);
 	if (codec != NULL)
 		return codec->name;
 	else
@@ -159,7 +159,7 @@ static void add_codec_to_list(const struct ff_format_desc *format_desc,
 	d->name = codec->name;
 	d->long_name = codec->long_name;
 	d->id = codec->id;
-	AVCodec *base_codec = avcodec_find_encoder(codec->id);
+	const AVCodec *base_codec = avcodec_find_encoder(codec->id);
 	if (strcmp(base_codec->name, codec->name) != 0) {
 		d->alias = true;
 		d->base_name = base_codec->name;
@@ -415,7 +415,7 @@ ff_format_desc_next(const struct ff_format_desc *format_desc)
 static const char *get_encoder_name(const struct ff_format_desc *format_desc,
                                     enum AVCodecID codec_id)
 {
-	AVCodec *codec = avcodec_find_encoder(codec_id);
+	const AVCodec *codec = avcodec_find_encoder(codec_id);
 	if (codec == NULL && codec_id == AV_CODEC_ID_NONE)
 		return NULL;
 	else if (codec == NULL)

--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -31,7 +31,7 @@ enum AVHWDeviceType hw_priority[] = {
 	AV_HWDEVICE_TYPE_NONE,
 };
 
-static bool has_hw_type(AVCodec *c, enum AVHWDeviceType type,
+static bool has_hw_type(const AVCodec *c, enum AVHWDeviceType type,
 			enum AVPixelFormat *hw_format)
 {
 	for (int i = 0;; i++) {

--- a/deps/media-playback/media-playback/decode.h
+++ b/deps/media-playback/media-playback/decode.h
@@ -53,7 +53,7 @@ struct mp_decode {
 
 	AVCodecContext *decoder;
 	AVBufferRef *hw_ctx;
-	AVCodec *codec;
+	const AVCodec *codec;
 
 	int64_t last_duration;
 	int64_t frame_pts;

--- a/libobs/graphics/graphics-ffmpeg.c
+++ b/libobs/graphics/graphics-ffmpeg.c
@@ -39,7 +39,8 @@ static bool ffmpeg_image_open_decoder_context(struct ffmpeg_image *info)
 	AVStream *const stream = fmt_ctx->streams[ret];
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
 	AVCodecParameters *const codecpar = stream->codecpar;
-	AVCodec *const decoder = avcodec_find_decoder(codecpar->codec_id);
+	const AVCodec *const decoder = avcodec_find_decoder(
+		codecpar->codec_id); // fix discarded-qualifiers
 #else
 	AVCodecContext *const decoder_ctx = stream->codec;
 	AVCodec *const decoder = avcodec_find_decoder(decoder_ctx->codec_id);

--- a/plugins/linux-v4l2/v4l2-decoder.h
+++ b/plugins/linux-v4l2/v4l2-decoder.h
@@ -29,7 +29,7 @@ extern "C" {
  * Data structure for decoder
  */
 struct v4l2_decoder {
-	AVCodec *codec;
+	const AVCodec *codec;
 	AVCodecContext *context;
 	AVPacket *packet;
 	AVFrame *frame;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
@@ -41,7 +41,7 @@ struct enc_encoder {
 
 	const char *type;
 
-	AVCodec *codec;
+	const AVCodec *codec;
 	AVCodecContext *context;
 
 	uint8_t *samples[MAX_AV_PLANES];

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -79,7 +79,8 @@ void ffmpeg_log_error(int log_level, struct ffmpeg_data *data,
 }
 
 static bool new_stream(struct ffmpeg_data *data, AVStream **stream,
-		       AVCodec **codec, enum AVCodecID id, const char *name)
+		       const AVCodec **codec, enum AVCodecID id,
+		       const char *name)
 {
 	*codec = (!!name && *name) ? avcodec_find_encoder_by_name(name)
 				   : avcodec_find_encoder(id);
@@ -418,7 +419,7 @@ static bool create_audio_stream(struct ffmpeg_data *data, int idx)
 
 static inline bool init_streams(struct ffmpeg_data *data)
 {
-	AVOutputFormat *format = data->output->oformat;
+	const AVOutputFormat *format = data->output->oformat;
 
 	if (format->video_codec != AV_CODEC_ID_NONE)
 		if (!create_video_stream(data))
@@ -439,7 +440,7 @@ static inline bool init_streams(struct ffmpeg_data *data)
 
 static inline bool open_output_file(struct ffmpeg_data *data)
 {
-	AVOutputFormat *format = data->output->oformat;
+	const AVOutputFormat *format = data->output->oformat;
 	int ret;
 
 	AVDictionary *dict = NULL;
@@ -566,7 +567,7 @@ static inline const char *safe_str(const char *s)
 
 static enum AVCodecID get_codec_id(const char *name, int id)
 {
-	AVCodec *codec;
+	const AVCodec *codec;
 
 	if (id != 0)
 		return (enum AVCodecID)id;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.h
@@ -43,8 +43,8 @@ struct ffmpeg_data {
 	AVStream *video;
 	AVCodecContext *video_ctx;
 	struct ffmpeg_audio_info *audio_infos;
-	AVCodec *acodec;
-	AVCodec *vcodec;
+	const AVCodec *acodec;
+	const AVCodec *vcodec;
 	AVFormatContext *output;
 	struct SwsContext *swscale;
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -54,7 +54,7 @@ struct vaapi_encoder {
 	AVBufferRef *vadevice_ref;
 	AVBufferRef *vaframes_ref;
 
-	AVCodec *vaapi;
+	const AVCodec *vaapi;
 	AVCodecContext *context;
 
 	AVPacket *packet;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-video-encoders.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-video-encoders.h
@@ -21,7 +21,7 @@ struct ffmpeg_video_encoder {
 	obs_encoder_t *encoder;
 	const char *enc_name;
 
-	AVCodec *avcodec;
+	const AVCodec *avcodec;
 	AVCodecContext *context;
 	int64_t start_ts;
 	bool first_packet;

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -230,7 +230,7 @@ extern bool load_nvenc_lib(void);
 
 static bool nvenc_codec_exists(const char *name, const char *fallback)
 {
-	AVCodec *nvenc = avcodec_find_encoder_by_name(name);
+	const AVCodec *nvenc = avcodec_find_encoder_by_name(name);
 	if (!nvenc)
 		nvenc = avcodec_find_encoder_by_name(fallback);
 
@@ -286,7 +286,7 @@ static bool nvenc_supported(bool *out_h264, bool *out_hevc)
 #ifdef LIBAVUTIL_VAAPI_AVAILABLE
 static bool vaapi_supported(void)
 {
-	AVCodec *vaenc = avcodec_find_encoder_by_name("h264_vaapi");
+	const AVCodec *vaenc = avcodec_find_encoder_by_name("h264_vaapi");
 	return !!vaenc;
 }
 #endif
@@ -304,7 +304,7 @@ extern void obs_ffmpeg_unload_logging(void);
 static void register_encoder_if_available(struct obs_encoder_info *info,
 					  const char *id)
 {
-	AVCodec *c = avcodec_find_encoder_by_name(id);
+	const AVCodec *c = avcodec_find_encoder_by_name(id);
 	if (c) {
 		obs_register_encoder(info);
 	}

--- a/plugins/win-dshow/ffmpeg-decode.c
+++ b/plugins/win-dshow/ffmpeg-decode.c
@@ -34,7 +34,7 @@ enum AVHWDeviceType hw_priority[] = {
 	AV_HWDEVICE_TYPE_NONE,
 };
 
-static bool has_hw_type(AVCodec *c, enum AVHWDeviceType type)
+static bool has_hw_type(const AVCodec *c, enum AVHWDeviceType type)
 {
 	for (int i = 0;; i++) {
 		const AVCodecHWConfig *config = avcodec_get_hw_config(c, i);

--- a/plugins/win-dshow/ffmpeg-decode.h
+++ b/plugins/win-dshow/ffmpeg-decode.h
@@ -39,7 +39,7 @@ extern "C" {
 struct ffmpeg_decode {
 	AVBufferRef *hw_device_ctx;
 	AVCodecContext *decoder;
-	AVCodec *codec;
+	const AVCodec *codec;
 
 	AVFrame *hw_frame;
 	AVFrame *frame;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Avoid breaking building OBS with a newer version of FFmpeg with #6759.
No additional warning if built with FFmpeg 4.4.1.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Avoid breaking building OBS with a newer version of FFmpeg with #6759 (and maybe #6723).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Builds fine on my ArchLinux.

**Needs testing**, I don't consider myself has a good tester.

Following tests are made with a Flatpak build (FFmpeg 4.4.1) and a ArchLinux build (FFmpeg 5.0.1):
- Custom Output (FFmpeg) UI (libff changes) does not seem to have issue on both builds.
- Media Source with local MP4 file does not seem to have issue on both builds.
- Drawing Overflow on the Preview (graphics-ffmpeg.c changes) does not seem to have issue on both builds.
- V4L2 input with MJPEG does not seem to have issue on both builds.
- NVENC and VAAPI are shown in the settings on both builds.
- NVENC, ~~aac~~ and SRT output does not seem to have issue on both builds.
- VAAPI, ~~aac~~ and RIST output does not seem to have issue on both builds.

Yikes, I forgot that I may rely on libfdk-aac

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
