### PR TITLE
Fix CMake Warning and tweak Linux install_headers

### DIFF
--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -47,7 +47,11 @@ function(setup_binary_target target)
             EXCLUDE_FROM_ALL
     LIBRARY DESTINATION ${OBS_LIBRARY_DESTINATION}
             COMPONENT obs_${target}
-            EXCLUDE_FROM_ALL)
+            EXCLUDE_FROM_ALL
+    PUBLIC_HEADER
+      DESTINATION ${OBS_INCLUDE_DESTINATION}
+      COMPONENT obs_${target}
+      EXCLUDE_FROM_ALL)
 
   add_custom_command(
     TARGET ${target}

--- a/cmake/Modules/ObsHelpers_Linux.cmake
+++ b/cmake/Modules/ObsHelpers_Linux.cmake
@@ -93,20 +93,23 @@ function(install_headers target)
       FILES
         "${CMAKE_CURRENT_SOURCE_DIR}/audio-monitoring/pulse/pulseaudio-wrapper.h"
       DESTINATION "${OBS_INCLUDE_DESTINATION}/audio-monitoring/pulse/"
-      COMPONENT obs_libraries)
+      COMPONENT obs_libraries
+      EXCLUDE_FROM_ALL)
   endif()
 
   if(ENABLE_HEVC)
     install(
       FILES "${CMAKE_CURRENT_SOURCE_DIR}/obs-hevc.h"
       DESTINATION "${OBS_INCLUDE_DESTINATION}"
-      COMPONENT obs_libraries)
+      COMPONENT obs_libraries
+      EXCLUDE_FROM_ALL)
   endif()
 
   if(NOT EXISTS "${OBS_INCLUDE_DESTINATION}/obsconfig.h")
     install(
       FILES "${CMAKE_BINARY_DIR}/config/obsconfig.h"
       DESTINATION "${OBS_INCLUDE_DESTINATION}"
-      COMPONENT obs_libraries)
+      COMPONENT obs_libraries
+      EXCLUDE_FROM_ALL)
   endif()
 endfunction()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix this warning:
```
CMake Warning (dev) at cmake/Modules/ObsHelpers.cmake:43 (install):
  Target obs-frontend-api has PUBLIC_HEADER files but no PUBLIC_HEADER
  DESTINATION.
Call Stack (most recent call first):
  cmake/Modules/ObsHelpers_Linux.cmake:10 (_setup_binary_target)
  UI/obs-frontend-api/CMakeLists.txt:39 (setup_binary_target)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

And add EXCLUDE_FROM_ALL to Linux install_headers, because even without it we still need to run `cmake --install . --component obs_libraries`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fix a warning, and tweak something.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Try to build a `-git` package (with my own PKGBUILD) which use `cmake --install . --component obs_libraries`, header are there.

And Cmake no longer throw the warning.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
