### PR TITLE
UI: Qt 6 deprecations

### DIFF
--- a/UI/media-slider.cpp
+++ b/UI/media-slider.cpp
@@ -22,7 +22,8 @@ MediaSlider::MediaSlider(QWidget *parent) : SliderIgnoreScroll(parent)
 
 void MediaSlider::mouseMoveEvent(QMouseEvent *event)
 {
-	int val = minimum() + ((maximum() - minimum()) * event->x()) / width();
+	int val = minimum() +
+		  ((maximum() - minimum()) * event->pos().x()) / width();
 
 	if (val > maximum())
 		val = maximum();

--- a/UI/menu-button.cpp
+++ b/UI/menu-button.cpp
@@ -24,7 +24,7 @@ void MenuButton::keyPressEvent(QKeyEvent *event)
 void MenuButton::mousePressEvent(QMouseEvent *event)
 {
 	if (menu()) {
-		if (width() - event->x() <= 30)
+		if (width() - event->pos().x() <= 30)
 			showMenu();
 		else
 			setDown(true);

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2122,16 +2122,15 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 				QMessageBox::Yes | QMessageBox::Cancel);
 			QMessageBox mb(QMessageBox::Question,
 				       QTStr("AlreadyRunning.Title"),
-				       QTStr("AlreadyRunning.Text"), buttons,
-				       nullptr);
-			mb.setButtonText(QMessageBox::Yes,
-					 QTStr("AlreadyRunning.LaunchAnyway"));
-			mb.setButtonText(QMessageBox::Cancel, QTStr("Cancel"));
-			mb.setDefaultButton(QMessageBox::Cancel);
+				       QTStr("AlreadyRunning.Text"));
+			mb.addButton(QTStr("AlreadyRunning.LaunchAnyway"),
+				     QMessageBox::YesRole);
+			QPushButton *cancelButton = mb.addButton(
+				QTStr("Cancel"), QMessageBox::NoRole);
+			mb.setDefaultButton(cancelButton);
 
-			QMessageBox::StandardButton button;
-			button = (QMessageBox::StandardButton)mb.exec();
-			cancel_launch = button == QMessageBox::Cancel;
+			mb.exec();
+			cancel_launch = mb.clickedButton() == cancelButton;
 		}
 
 		if (cancel_launch)

--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -29,6 +29,7 @@
 #include <QFileDialog>
 #include <QStandardItemModel>
 #include <QLabel>
+#include <QPushButton>
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 #include <obs-nix-platform.h>
@@ -60,55 +61,61 @@ OBSMessageBox::question(QWidget *parent, const QString &title,
 			QMessageBox::StandardButtons buttons,
 			QMessageBox::StandardButton defaultButton)
 {
-	QMessageBox mb(QMessageBox::Question, title, text, buttons, parent);
+	QMessageBox mb(QMessageBox::Question, title, text,
+		       QMessageBox::NoButton, parent);
 	mb.setDefaultButton(defaultButton);
-	if (buttons & QMessageBox::Ok)
-		mb.setButtonText(QMessageBox::Ok, QTStr("OK"));
-#define translate_button(x)           \
-	if (buttons & QMessageBox::x) \
-		mb.setButtonText(QMessageBox::x, QTStr(#x));
-	translate_button(Open);
-	translate_button(Save);
-	translate_button(Cancel);
-	translate_button(Close);
-	translate_button(Discard);
-	translate_button(Apply);
-	translate_button(Reset);
-	translate_button(Yes);
-	translate_button(No);
-	translate_button(Abort);
-	translate_button(Retry);
-	translate_button(Ignore);
-#undef translate_button
+
+	if (buttons & QMessageBox::Ok) {
+		QPushButton *button = mb.addButton(QMessageBox::Ok);
+		button->setText(QTStr("OK"));
+	}
+#define add_button(x)                                               \
+	if (buttons & QMessageBox::x) {                             \
+		QPushButton *button = mb.addButton(QMessageBox::x); \
+		button->setText(QTStr(#x));                         \
+	}
+	add_button(Open);
+	add_button(Save);
+	add_button(Cancel);
+	add_button(Close);
+	add_button(Discard);
+	add_button(Apply);
+	add_button(Reset);
+	add_button(Yes);
+	add_button(No);
+	add_button(Abort);
+	add_button(Retry);
+	add_button(Ignore);
+#undef add_button
 	return (QMessageBox::StandardButton)mb.exec();
 }
 
 void OBSMessageBox::information(QWidget *parent, const QString &title,
 				const QString &text)
 {
-	QMessageBox mb(QMessageBox::Information, title, text, QMessageBox::Ok,
-		       parent);
-	mb.setButtonText(QMessageBox::Ok, QTStr("OK"));
+	QMessageBox mb(QMessageBox::Information, title, text,
+		       QMessageBox::NoButton, parent);
+	mb.addButton(QTStr("OK"), QMessageBox::AcceptRole);
 	mb.exec();
 }
 
 void OBSMessageBox::warning(QWidget *parent, const QString &title,
 			    const QString &text, bool enableRichText)
 {
-	QMessageBox mb(QMessageBox::Warning, title, text, QMessageBox::Ok,
+	QMessageBox mb(QMessageBox::Warning, title, text, QMessageBox::NoButton,
 		       parent);
 	if (enableRichText)
 		mb.setTextFormat(Qt::RichText);
-	mb.setButtonText(QMessageBox::Ok, QTStr("OK"));
+	mb.addButton(QTStr("OK"), QMessageBox::AcceptRole);
 	mb.exec();
 }
 
 void OBSMessageBox::critical(QWidget *parent, const QString &title,
 			     const QString &text)
 {
-	QMessageBox mb(QMessageBox::Critical, title, text, QMessageBox::Ok,
-		       parent);
-	mb.setButtonText(QMessageBox::Ok, QTStr("OK"));
+	QMessageBox mb(QMessageBox::Critical, title, text,
+		       QMessageBox::NoButton, parent);
+	mb.addButton(QTStr("OK"), QMessageBox::AcceptRole);
 	mb.exec();
 }
 

--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -124,7 +124,11 @@ void SceneTree::dropEvent(QDropEvent *event)
 
 		float wid = contentsRect().width() - scrollWid - 1;
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		QPoint point = event->position().toPoint();
+#else
 		QPoint point = event->pos();
+#endif
 
 		int x = (float)point.x() / wid * ceil(wid / maxWidth);
 		int y = point.y() / itemHeight;
@@ -157,7 +161,11 @@ void SceneTree::RepositionGrid(QDragMoveEvent *event)
 	float wid = contentsRect().width() - scrollWid - 1;
 
 	if (event) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		QPoint point = event->position().toPoint();
+#else
 		QPoint point = event->pos();
+#endif
 
 		int x = (float)point.x() / wid * ceil(wid / maxWidth);
 		int y = point.y() / itemHeight;

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -1186,7 +1186,14 @@ void SourceTree::dropEvent(QDropEvent *event)
 	QModelIndexList indices = selectedIndexes();
 
 	DropIndicatorPosition indicator = dropIndicatorPosition();
-	int row = indexAt(event->pos()).row();
+	int row = indexAt(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+			  event->position().toPoint()
+#else
+			  event->pos()
+#endif
+				  )
+			  .row();
 	bool emptyDrop = row == -1;
 
 	if (emptyDrop) {

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -956,7 +956,7 @@ void OBSBasicFilters::CustomContextMenu(const QPoint &pos, bool async)
 		QAction *copyAction = new QAction(QTStr("Copy"));
 		connect(copyAction, SIGNAL(triggered()), this,
 			SLOT(CopyFilter()));
-		copyAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_C));
+		copyAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_C));
 		ui->effectWidget->addAction(copyAction);
 		ui->asyncWidget->addAction(copyAction);
 		popup.addAction(copyAction);
@@ -965,7 +965,7 @@ void OBSBasicFilters::CustomContextMenu(const QPoint &pos, bool async)
 	QAction *pasteAction = new QAction(QTStr("Paste"));
 	pasteAction->setEnabled(main->copyFilter);
 	connect(pasteAction, SIGNAL(triggered()), this, SLOT(PasteFilter()));
-	pasteAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_V));
+	pasteAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_V));
 	ui->effectWidget->addAction(pasteAction);
 	ui->asyncWidget->addAction(pasteAction);
 	popup.addAction(pasteAction);

--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -319,8 +319,9 @@ bool OBSBasicInteraction::HandleMouseClickEvent(QMouseEvent *event)
 	//if (event->flags().testFlag(Qt::MouseEventCreatedDoubleClick))
 	//	clickCount = 2;
 
-	bool insideSource = GetSourceRelativeXY(event->x(), event->y(),
-						mouseEvent.x, mouseEvent.y);
+	QPoint pos = event->pos();
+	bool insideSource = GetSourceRelativeXY(pos.x(), pos.y(), mouseEvent.x,
+						mouseEvent.y);
 
 	if (mouseUp || insideSource)
 		obs_source_send_mouse_click(source, &mouseEvent, button,
@@ -337,7 +338,8 @@ bool OBSBasicInteraction::HandleMouseMoveEvent(QMouseEvent *event)
 
 	if (!mouseLeave) {
 		mouseEvent.modifiers = TranslateQtMouseEventModifiers(event);
-		mouseLeave = !GetSourceRelativeXY(event->x(), event->y(),
+		QPoint pos = event->pos();
+		mouseLeave = !GetSourceRelativeXY(pos.x(), pos.y(),
 						  mouseEvent.x, mouseEvent.y);
 	}
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -376,7 +376,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 #endif
 
 #ifdef __linux__
-	ui->actionE_xit->setShortcut(Qt::CTRL + Qt::Key_Q);
+	ui->actionE_xit->setShortcut(Qt::CTRL | Qt::Key_Q);
 #endif
 
 	auto addNudge = [this](const QKeySequence &seq, const char *s) {
@@ -391,10 +391,10 @@ OBSBasic::OBSBasic(QWidget *parent)
 	addNudge(Qt::Key_Down, SLOT(NudgeDown()));
 	addNudge(Qt::Key_Left, SLOT(NudgeLeft()));
 	addNudge(Qt::Key_Right, SLOT(NudgeRight()));
-	addNudge(Qt::SHIFT + Qt::Key_Up, SLOT(NudgeUpFar()));
-	addNudge(Qt::SHIFT + Qt::Key_Down, SLOT(NudgeDownFar()));
-	addNudge(Qt::SHIFT + Qt::Key_Left, SLOT(NudgeLeftFar()));
-	addNudge(Qt::SHIFT + Qt::Key_Right, SLOT(NudgeRightFar()));
+	addNudge(Qt::SHIFT | Qt::Key_Up, SLOT(NudgeUpFar()));
+	addNudge(Qt::SHIFT | Qt::Key_Down, SLOT(NudgeDownFar()));
+	addNudge(Qt::SHIFT | Qt::Key_Left, SLOT(NudgeLeftFar()));
+	addNudge(Qt::SHIFT | Qt::Key_Right, SLOT(NudgeRightFar()));
 
 	assignDockToggle(ui->scenesDock, ui->toggleScenes);
 	assignDockToggle(ui->sourcesDock, ui->toggleSources);
@@ -404,10 +404,10 @@ OBSBasic::OBSBasic(QWidget *parent)
 	assignDockToggle(statsDock, ui->toggleStats);
 
 	// Register shortcuts for Undo/Redo
-	ui->actionMainUndo->setShortcut(Qt::CTRL + Qt::Key_Z);
+	ui->actionMainUndo->setShortcut(Qt::CTRL | Qt::Key_Z);
 	QList<QKeySequence> shrt;
-	shrt << QKeySequence((Qt::CTRL | Qt::SHIFT) + Qt::Key_Z)
-	     << QKeySequence(Qt::CTRL + Qt::Key_Y);
+	shrt << QKeySequence((Qt::CTRL | Qt::SHIFT) | Qt::Key_Z)
+	     << QKeySequence(Qt::CTRL | Qt::Key_Y);
 	ui->actionMainRedo->setShortcuts(shrt);
 
 	ui->actionMainUndo->setShortcutContext(Qt::ApplicationShortcut);

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -39,10 +39,10 @@ vec2 OBSBasicPreview::GetMouseEventPos(QMouseEvent *event)
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 	float pixelRatio = main->devicePixelRatioF();
 	float scale = pixelRatio / main->previewScale;
+	QPoint qtPos = event->pos();
 	vec2 pos;
-	vec2_set(&pos,
-		 (float(event->x()) - main->previewX / pixelRatio) * scale,
-		 (float(event->y()) - main->previewY / pixelRatio) * scale);
+	vec2_set(&pos, (qtPos.x() - main->previewX / pixelRatio) * scale,
+		 (qtPos.y() - main->previewY / pixelRatio) * scale);
 
 	return pos;
 }
@@ -499,11 +499,17 @@ void OBSBasicPreview::wheelEvent(QWheelEvent *event)
 
 void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	QPointF pos = event->position();
+#else
+	QPointF pos = event->localPos();
+#endif
+
 	if (scrollMode && IsFixedScaling() &&
 	    event->button() == Qt::LeftButton) {
 		setCursor(Qt::ClosedHandCursor);
-		scrollingFrom.x = event->x();
-		scrollingFrom.y = event->y();
+		scrollingFrom.x = pos.x();
+		scrollingFrom.y = pos.x();
 		return;
 	}
 
@@ -519,8 +525,8 @@ void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 	float pixelRatio = main->devicePixelRatioF();
-	float x = float(event->x()) - main->previewX / pixelRatio;
-	float y = float(event->y()) - main->previewY / pixelRatio;
+	float x = pos.x() - main->previewX / pixelRatio;
+	float y = pos.y() - main->previewY / pixelRatio;
 	Qt::KeyboardModifiers modifiers = QGuiApplication::keyboardModifiers();
 	bool altDown = (modifiers & Qt::AltModifier);
 	bool shiftDown = (modifiers & Qt::ShiftModifier);
@@ -1459,11 +1465,17 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 {
 	changed = true;
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	QPointF qtPos = event->position();
+#else
+	QPointF qtPos = event->localPos();
+#endif
+
 	if (scrollMode && event->buttons() == Qt::LeftButton) {
-		scrollingOffset.x += event->x() - scrollingFrom.x;
-		scrollingOffset.y += event->y() - scrollingFrom.y;
-		scrollingFrom.x = event->x();
-		scrollingFrom.y = event->y();
+		scrollingOffset.x += qtPos.x() - scrollingFrom.x;
+		scrollingOffset.y += qtPos.y() - scrollingFrom.y;
+		scrollingFrom.x = qtPos.x();
+		scrollingFrom.y = qtPos.y();
 		emit DisplayResized();
 		return;
 	}
@@ -1537,8 +1549,8 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 			OBSBasic *main = reinterpret_cast<OBSBasic *>(
 				App()->GetMainWindow());
 			float scale = main->devicePixelRatioF();
-			float x = float(event->x()) - main->previewX / scale;
-			float y = float(event->y()) - main->previewY / scale;
+			float x = qtPos.x() - main->previewX / scale;
+			float y = qtPos.y() - main->previewY / scale;
 			vec2_set(&startPos, x, y);
 			updateCursor = true;
 		}

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -232,8 +232,9 @@ void OBSProjector::mouseDoubleClickEvent(QMouseEvent *event)
 		return;
 
 	if (event->button() == Qt::LeftButton) {
+		QPoint pos = event->pos();
 		OBSSource src =
-			multiview->GetSourceByPosition(event->x(), event->y());
+			multiview->GetSourceByPosition(pos.x(), pos.y());
 		if (!src)
 			return;
 
@@ -283,8 +284,9 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 		return;
 
 	if (event->button() == Qt::LeftButton) {
+		QPoint pos = event->pos();
 		OBSSource src =
-			multiview->GetSourceByPosition(event->x(), event->y());
+			multiview->GetSourceByPosition(pos.x(), pos.y());
 		if (!src)
 			return;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes deprecations for Qt.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Less deprecations.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
First commit:
- Undo/Redo hotkeys still work
- Moving items in the preview with arrow keys still works (with shift as well)

Second commit:
- Context Bar Media Slider (MediaSlider)
- Quick Transitions Button (MenuButton)
- Drag and Drop in Sources Dock and Scenes Dock (SourceTree and SceneTree)
- Interact Menu on Browser Source, with pointerpointer.com and webgl aquarium (OBSBasicInteraction)
- In preview, moving the mouse over items correctly highlights the item where the mouse is. When dragging a selection, that selection is in the correct place
- In multiview, clicking a scene correctly selects it for the preview. With "Transition to scene when double-clicked" enabled, double clicking a scene selects and transitions to it.

Third commit:
- Raised a sample information, warning, and critical message box
- Raised several question dialogs in OBS, like closing the properties window without saving or selecting lossless mode, and made sure the buttons have the intended effect.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
