### PR TITLE
UI: Fix bugs with missing files refactor

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1765,7 +1765,8 @@ obs_data_array_t *OBSBasic::SaveTransitions()
 	return transitions;
 }
 
-void OBSBasic::LoadTransitions(obs_data_array_t *transitions)
+void OBSBasic::LoadTransitions(obs_data_array_t *transitions,
+			       obs_load_source_cb cb, void *private_data)
 {
 	size_t count = obs_data_array_count(transitions);
 

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1787,6 +1787,8 @@ void OBSBasic::LoadTransitions(obs_data_array_t *transitions,
 				QVariant::fromValue(OBSSource(source)));
 			ui->transitions->setCurrentIndex(
 				ui->transitions->count() - 1);
+			if (cb)
+				cb(private_data, source);
 		}
 	}
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -446,7 +446,8 @@ private:
 	obs_source_t *FindTransition(const char *name);
 	OBSSource GetCurrentTransition();
 	obs_data_array_t *SaveTransitions();
-	void LoadTransitions(obs_data_array_t *transitions);
+	void LoadTransitions(obs_data_array_t *transitions,
+			     obs_load_source_cb cb, void *private_data);
 
 	obs_source_t *fadeTransition;
 	obs_source_t *cutTransition;
@@ -621,6 +622,7 @@ private:
 	bool drawSafeAreas = false;
 
 	void CenterSelectedSceneItems(const CenterType &centerType);
+	void ShowMissingFilesDialog(obs_missing_files_t *files);
 
 public slots:
 	void DeferSaveBegin();


### PR DESCRIPTION
### Description
With https://github.com/obsproject/obs-studio/pull/5148, it was
brought up that the loading of the missing files was not thread
safe, as the missing files were being loaded late in the loading
process. This PR tries to fix that problem, while still simplifying
the original missing files code.

### Motivation and Context
@norihiro brought up in the PR that the code was possibly not thread safe.

### How Has This Been Tested?
Deleted files and made sure the missing files dialog still worked.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
