### PR TITLE
UI: Qt 6 deprecations, Part 2

### DIFF
--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -29,6 +29,7 @@
 #include <QFileDialog>
 #include <QStandardItemModel>
 #include <QLabel>
+#include <QPushButton>
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 #include <obs-nix-platform.h>
@@ -60,26 +61,32 @@ OBSMessageBox::question(QWidget *parent, const QString &title,
 			QMessageBox::StandardButtons buttons,
 			QMessageBox::StandardButton defaultButton)
 {
-	QMessageBox mb(QMessageBox::Question, title, text, buttons, parent);
+	QMessageBox mb(QMessageBox::Question, title, text,
+		       QMessageBox::NoButton, parent);
 	mb.setDefaultButton(defaultButton);
-	if (buttons & QMessageBox::Ok)
-		mb.setButtonText(QMessageBox::Ok, QTStr("OK"));
-#define translate_button(x)           \
-	if (buttons & QMessageBox::x) \
-		mb.setButtonText(QMessageBox::x, QTStr(#x));
-	translate_button(Open);
-	translate_button(Save);
-	translate_button(Cancel);
-	translate_button(Close);
-	translate_button(Discard);
-	translate_button(Apply);
-	translate_button(Reset);
-	translate_button(Yes);
-	translate_button(No);
-	translate_button(Abort);
-	translate_button(Retry);
-	translate_button(Ignore);
-#undef translate_button
+
+	if (buttons & QMessageBox::Ok) {
+		QPushButton *button = mb.addButton(QMessageBox::Ok);
+		button->setText(QTStr("OK"));
+	}
+#define add_button(x)                                               \
+	if (buttons & QMessageBox::x) {                             \
+		QPushButton *button = mb.addButton(QMessageBox::x); \
+		button->setText(QTStr(#x));                         \
+	}
+	add_button(Open);
+	add_button(Save);
+	add_button(Cancel);
+	add_button(Close);
+	add_button(Discard);
+	add_button(Apply);
+	add_button(Reset);
+	add_button(Yes);
+	add_button(No);
+	add_button(Abort);
+	add_button(Retry);
+	add_button(Ignore);
+#undef add_button
 	return (QMessageBox::StandardButton)mb.exec();
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes more Qt 6 deprecations.
To keep things in chronological order, this should be merged after #6770 (and will stay draft until then).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Deprecations are warnings, and warnings are build failures (or at least will be with Qt 6).

When I made #6770, I expected this part to be a change much bigger than what it actually is, which is why I didn't include it the first PR. To keep PR scopes narrow and not suddenly add more changes to what @RytoEX might have tested already, I decided to still make this a separate PR. However, I could combine them if asked to.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Raised several question dialogs in OBS, like closing the properties window without saving or selecting lossless mode, and made sure the buttons have the intended effect.
Deprecation warnings are gone.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
