### PR TITLE
Allow HEVC on streaming only if the service is compatible

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -867,6 +867,10 @@ Basic.Settings.Stream.Recommended.MaxVideoBitrate="Maximum Video Bitrate: %1 kbp
 Basic.Settings.Stream.Recommended.MaxAudioBitrate="Maximum Audio Bitrate: %1 kbps"
 Basic.Settings.Stream.Recommended.MaxResolution="Maximum Resolution: %1"
 Basic.Settings.Stream.Recommended.MaxFPS="Maximum FPS: %1"
+Basic.Settings.Stream.ChangeIncompatibleEncoder="The selected encoder is not compatible with the service.\nThe encoder in the output page was changed.\n\nCheck your encoder settings."
+Basic.Settings.Stream.ChangeIncompatibleEncoder.Title="Incompatible encoder changed"
+Basic.Settings.Stream.ChangeIncompatibleEncoder.Simple="The selected encoder is not compatible with the service.\nThe encoder in the output page was changed to its H.264 version."
+Basic.Settings.Stream.ChangeIncompatibleEncoder.ReplaceWithH264="The selected encoder is not compatible with the service.\nThe encoder in the output page was changed to its H.264 version.\n\nCheck your encoder settings."
 
 # basic mode 'output' settings
 Basic.Settings.Output="Output"

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -96,6 +96,11 @@ void OBSBasicSettings::InitStreamPage()
 		SLOT(UpdateResFPSLimits()));
 	connect(ui->service, SIGNAL(currentIndexChanged(int)), this,
 		SLOT(UpdateMoreInfoLink()));
+
+	connect(ui->service, SIGNAL(currentIndexChanged(int)), this,
+		SLOT(UpdateStreamEncoders()));
+	connect(ui->customServer, SIGNAL(editingFinished()), this,
+		SLOT(UpdateStreamEncoders()));
 }
 
 void OBSBasicSettings::LoadStream1Settings()
@@ -1155,3 +1160,17 @@ void OBSBasicSettings::UpdateResFPSLimits()
 	lastIgnoreRecommended = (int)ignoreRecommended;
 	lastServiceIdx = idx;
 }
+
+#ifdef ENABLE_HEVC
+bool OBSBasicSettings::IsServiceSupportHEVC()
+{
+	if (ui->service->currentText() == "YouTube - HLS")
+		return true;
+
+	if (IsCustomService())
+		return ui->customServer->text().startsWith("srt://") ||
+		       ui->customServer->text().startsWith("rist://");
+
+	return false;
+}
+#endif

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -221,7 +221,8 @@ private:
 
 	bool QueryChanges();
 
-	void LoadEncoderTypes();
+	void LoadRecEncoderTypes();
+	void LoadStrEncoderTypes();
 	void LoadColorRanges();
 	void LoadColorSpaces();
 	void LoadColorFormats();
@@ -346,6 +347,10 @@ private:
 
 	OBSService GetStream1Service();
 
+#ifdef ENABLE_HEVC
+	bool IsServiceSupportHEVC();
+#endif
+
 private slots:
 	void on_theme_activated(int idx);
 
@@ -394,6 +399,8 @@ private slots:
 	void AdvancedChangedRestart();
 
 	void UpdateStreamDelayEstimate();
+
+	void UpdateStreamEncoders();
 
 	void UpdateAutomaticReplayBufferCheckboxes();
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
@@ -319,7 +319,7 @@ struct obs_output_info ffmpeg_hls_muxer = {
 	.id = "ffmpeg_hls_muxer",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_MULTI_TRACK |
 		 OBS_OUTPUT_SERVICE,
-	.encoded_video_codecs = "h264",
+	.encoded_video_codecs = "h264;hevc",
 	.encoded_audio_codecs = "aac",
 	.get_name = ffmpeg_hls_mux_getname,
 	.create = ffmpeg_hls_mux_create,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -891,7 +891,7 @@ struct obs_output_info ffmpeg_mpegts_muxer = {
 	.id = "ffmpeg_mpegts_muxer",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_MULTI_TRACK |
 		 OBS_OUTPUT_SERVICE,
-	.encoded_video_codecs = "h264;av1",
+	.encoded_video_codecs = "h264;hevc;av1",
 	.encoded_audio_codecs = "aac",
 	.get_name = ffmpeg_mpegts_mux_getname,
 	.create = ffmpeg_mux_create,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

While the user change his streaming service, if an incompatible encoder was set the user will got this warning explaining that the encoder was changed because of the incompatibility.
![HEVC_Warning](https://user-images.githubusercontent.com/17492366/180148824-160cbcb5-e480-404c-8eb3-cf831e1a9270.png)

The message differ if the encoder was a simple preset or does not have a H264 alternative.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

When HEVC is enabled, HEVC encoder can be used with any service, this PR try to avoid this.
It also add HEVC as supported codec for mpeg-ts based protocols (HLS, RIST, SRT)

Also clear the issue I have with #6617.

This might be refactored afterward because of https://github.com/obsproject/rfcs/pull/45 and https://github.com/obsproject/rfcs/pull/39.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

- Set a service compatible with HEVC
- Set an HEVC encoder (they are not shown if the service is not compatible)
- Change the service for one that does not support HEVC and a warning should show.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
