### PR TITLE
obs-frontend-api: Add function for manual file splitting

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -320,6 +320,23 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		return os_atomic_load_bool(&recording_paused);
 	}
 
+	bool obs_frontend_recording_split_file(void) override
+	{
+		if (os_atomic_load_bool(&recording_active) &&
+		    !os_atomic_load_bool(&recording_paused)) {
+			proc_handler_t *ph = obs_output_get_proc_handler(
+				main->outputHandler->fileOutput);
+			uint8_t stack[128];
+			calldata cd;
+			calldata_init_fixed(&cd, stack, sizeof(stack));
+			proc_handler_call(ph, "split_file", &cd);
+			bool result = calldata_bool(&cd, "split_file_enabled");
+			return result;
+		} else {
+			return false;
+		}
+	}
+
 	void obs_frontend_replay_buffer_start(void) override
 	{
 		QMetaObject::invokeMethod(main, "StartReplayBuffer");

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -279,6 +279,12 @@ bool obs_frontend_recording_paused(void)
 	return !!callbacks_valid() ? c->obs_frontend_recording_paused() : false;
 }
 
+bool obs_frontend_recording_split_file(void)
+{
+	return !!callbacks_valid() ? c->obs_frontend_recording_split_file()
+				   : false;
+}
+
 void obs_frontend_replay_buffer_start(void)
 {
 	if (callbacks_valid())

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -177,6 +177,7 @@ EXPORT void obs_frontend_recording_stop(void);
 EXPORT bool obs_frontend_recording_active(void);
 EXPORT void obs_frontend_recording_pause(bool pause);
 EXPORT bool obs_frontend_recording_paused(void);
+EXPORT bool obs_frontend_recording_split_file(void);
 
 EXPORT void obs_frontend_replay_buffer_start(void);
 EXPORT void obs_frontend_replay_buffer_save(void);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -52,6 +52,7 @@ struct obs_frontend_callbacks {
 	virtual bool obs_frontend_recording_active(void) = 0;
 	virtual void obs_frontend_recording_pause(bool pause) = 0;
 	virtual bool obs_frontend_recording_paused(void) = 0;
+	virtual bool obs_frontend_recording_split_file(void) = 0;
 
 	virtual void obs_frontend_replay_buffer_start(void) = 0;
 	virtual void obs_frontend_replay_buffer_save(void) = 0;

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -553,6 +553,17 @@ Functions
 
 ---------------------------------------
 
+.. function:: bool obs_frontend_recording_split_file(void)
+
+   Asks OBS to split the current recording file.
+
+   :return: *true* if splitting was successfully requested (this
+            does not mean that splitting has finished or guarantee that it
+            split successfully), *false* if recording is inactive or paused
+            or if file splitting is disabled.
+
+---------------------------------------
+
 .. function:: void obs_frontend_replay_buffer_start(void)
 
    Starts the replay buffer.

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
@@ -43,6 +43,7 @@ struct ffmpeg_muxer {
 	int64_t video_pts_offset;
 	int64_t audio_dts_offsets[MAX_AUDIO_MIXES];
 	bool split_file_ready;
+	volatile bool manual_split;
 
 	/* these are accessed both by replay buffer and by HLS */
 	pthread_t mux_thread;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a function (`obs_frontend_recording_split_file()`) to the Frontend API that makes file splitting split the file when called, without waiting for the limit (size of time).
When called, the limits are reset. For example, if the limit is 15 minutes and the function is called after 6 minutes, the second split will occur after another 15 minutes (at the 21 minutes mark), so there's one file of 6 minutes and another file of 15 minutes.
This function will still require "Automatic File Splitting" to be enabled in the settings.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Asked for in Discord ideas channel.
Will allow for UI integration for splitting files manually (with button and/or hotkey),
however preliminary discussion has shown that this could be a bit more controversial
in terms of how it will be implemented, so that will follow in a separate PR.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13
Hijacked browser source properties to call `obs_frontend_recording_split_file()`.
Tested with both a size and length limit. Made sure it only works when the checkbox for "Automatic File Splitting" is enabled.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
