### PR TITLE
UI: Add initialization to ensure compat between pthread and NSThread

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2070,6 +2070,7 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 
 #if __APPLE__
 	InstallNSApplicationSubclass();
+	InstallNSThreadLocks();
 
 	if (!isInBundle()) {
 		blog(LOG_ERROR,

--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -230,6 +230,15 @@ void TaskbarOverlaySetStatus(TaskbarOverlayStatus) {}
 }
 @end
 
+void InstallNSThreadLocks()
+{
+	[[NSThread new] start];
+
+	if ([NSThread isMultiThreaded] != 1) {
+		abort();
+	}
+}
+
 void InstallNSApplicationSubclass()
 {
 	[OBSApplication sharedApplication];

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -84,5 +84,6 @@ void EnableOSXVSync(bool enable);
 void EnableOSXDockIcon(bool enable);
 bool isInBundle();
 void InstallNSApplicationSubclass();
+void InstallNSThreadLocks();
 void disableColorSpaceConversion(QWidget *window);
 #endif


### PR DESCRIPTION
### Description
Ensures that Cocoa knows that we intend to use multiple threads, per https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html#//apple_ref/doc/uid/10000057i-CH15-SW21.


### Motivation and Context
This change had been introduced in https://github.com/obsproject/obs-studio/pull/5680 to ensure that Cocoa frameworks are properly multithreaded (per Apple's documentation, see above).

The original PR was merged accidentally, then reverted, with some beneficial changes merged in a later PR. This PR takes the proposed change and adds it to the application initialisation, to ensure stability and multi-threaded performance interplay between core OBS functionality (which uses POSIX threads) and CoreFramework functions which use NSThreads. This should benefit all code that uses multithreaded Cocoa functionality, even if not explicitly initialised by macOS-specific plugins.

### How Has This Been Tested?
Tested on macOS 12.4.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
