### PR TITLE
UI: Disable default path setting when file path is selected

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -1743,7 +1743,11 @@ bool WidgetInfo::PathChanged(const char *setting)
 	const char *desc = obs_property_description(property);
 	obs_path_type type = obs_property_path_type(property);
 	const char *filter = obs_property_path_filter(property);
-	const char *default_path = obs_property_path_default_path(property);
+	const char *last_path = obs_data_get_string(view->settings, setting);
+	const char *default_path =
+		(last_path && *last_path)
+			? NULL
+			: obs_property_path_default_path(property);
 	QString path;
 
 	if (type == OBS_PATH_DIRECTORY)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Add path value check (whether empty) when open path/file selecting dialog, to achive only using `default_path` when path value is empty.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fixes #6777
In most cases, the `default_path` setting should only work when the path is empty, but in current situation, it looks not work well when the path is changed to other directory or is set from empty. Beacuse the `properties view` (default_path argument) is not updated after changing the path.

https://github.com/obsproject/obs-studio/blob/e3f416f3fc72db49d1ba71b8423454d053a9d6bf/plugins/obs-filters/color-grade-filter.c#L392-L399

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

in Ubuntu20
reproduce the steps mentioned in issue, it works.
and other behaviors link to this `WidgetInfo::PathChanged` function works fine as usual.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
