### PR TITLE
UI: Search combo property item with QVariant type

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -541,30 +541,30 @@ static void AddComboItem(QComboBox *combo, obs_property_t *prop,
 template<long long get_int(obs_data_t *, const char *),
 	 double get_double(obs_data_t *, const char *),
 	 const char *get_string(obs_data_t *, const char *)>
-static string from_obs_data(obs_data_t *data, const char *name,
-			    obs_combo_format format)
+static QVariant from_obs_data(obs_data_t *data, const char *name,
+			      obs_combo_format format)
 {
 	switch (format) {
 	case OBS_COMBO_FORMAT_INT:
-		return to_string(get_int(data, name));
+		return QVariant::fromValue(get_int(data, name));
 	case OBS_COMBO_FORMAT_FLOAT:
-		return to_string(get_double(data, name));
+		return QVariant::fromValue(get_double(data, name));
 	case OBS_COMBO_FORMAT_STRING:
-		return get_string(data, name);
+		return QByteArray(get_string(data, name));
 	default:
-		return "";
+		return QVariant();
 	}
 }
 
-static string from_obs_data(obs_data_t *data, const char *name,
-			    obs_combo_format format)
+static QVariant from_obs_data(obs_data_t *data, const char *name,
+			      obs_combo_format format)
 {
 	return from_obs_data<obs_data_get_int, obs_data_get_double,
 			     obs_data_get_string>(data, name, format);
 }
 
-static string from_obs_data_autoselect(obs_data_t *data, const char *name,
-				       obs_combo_format format)
+static QVariant from_obs_data_autoselect(obs_data_t *data, const char *name,
+					 obs_combo_format format)
 {
 	return from_obs_data<obs_data_get_autoselect_int,
 			     obs_data_get_autoselect_double,
@@ -590,13 +590,13 @@ QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 	combo->setMaxVisibleItems(40);
 	combo->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 
-	string value = from_obs_data(settings, name, format);
+	QVariant value = from_obs_data(settings, name, format);
 
 	if (format == OBS_COMBO_FORMAT_STRING &&
 	    type == OBS_COMBO_TYPE_EDITABLE) {
-		combo->lineEdit()->setText(QT_UTF8(value.c_str()));
+		combo->lineEdit()->setText(value.toString());
 	} else {
-		idx = combo->findData(QByteArray(value.c_str()));
+		idx = combo->findData(value);
 	}
 
 	if (type == OBS_COMBO_TYPE_EDITABLE)
@@ -607,9 +607,9 @@ QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 		combo->setCurrentIndex(idx);
 
 	if (obs_data_has_autoselect_value(settings, name)) {
-		string autoselect =
+		QVariant autoselect =
 			from_obs_data_autoselect(settings, name, format);
-		int id = combo->findData(QT_UTF8(autoselect.c_str()));
+		int id = combo->findData(autoselect);
 
 		if (id != -1 && id != idx) {
 			QString actual = combo->itemText(id);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

When finding current item for a combobox on properties view, use `QVariant` type to hold current values instead of converting all types into string.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

A combobox created with `OBS_COMBO_FORMAT_FLOAT` cannot show the current item. When a modified callback for another item on the properties view returns true, the combobox is initialized again and the selection goes to the top item even though another item is selected.

When adding items into the combobox, `userData` is generated in the code below.
https://github.com/obsproject/obs-studio/blob/e3f416f3fc72db49d1ba71b8423454d053a9d6bf/UI/properties-view.cpp#L505-L523

| OBS's type | `userData` generation function |
| ---------- | --------- |
| `OBS_COMBO_FORMAT_INT`    | `QVariant::fromValue<long long>(long long)` |
| `OBS_COMBO_FORMAT_FLOAT`  | `QVariant::fromValue<double>(double)` |
| `OBS_COMBO_FORMAT_STRING` | `QByteArray(const char *)` |

I'm implementing a plugin on norihiro/obs-color-monitor#54 and found this bug.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 35
Qt version: 5.15.2-31.fc35 and 6.2.3-2.fc35 (I checked with both versions.)

Checked these steps for `xshm_input` (using `OBS_COMBO_FORMAT_INT`) and `slideshow` (using `OBS_COMBO_FORMAT_STRING`).
- Create a source.
- Open it's properties view.
- Choose another item in combobox.
- Close the properties view and open it again.
- Check the combobox shows the same item.
  - Before this bugfix, the top item is always selected at this step for the combobox with `OBS_COMBO_FORMAT_FLOAT`.

Also checked another source under development using `OBS_COMBO_FORMAT_FLOAT`.

Need to check autoselect functionality but only available on two sources `av_capture_input` on macOS and `dshow_input` on Windows.

I've checked the signature and description of `QComboBox::findData` are same in between Qt5 and Qt6.
Qt5: https://doc.qt.io/qt-5/qcombobox.html#findData
Qt6: https://doc.qt.io/qt-6/qcombobox.html#findData

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
  - I didn't test autoselect functionality.
  - I didn't test on Windows though especially the behavior of `QT_UTF8` is different on Windows.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
