### PR TITLE
macOS branding change and code cleanup

### DIFF
--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -23,7 +23,6 @@
 #include "obs-app.hpp"
 
 #include <unistd.h>
-#include <sys/sysctl.h>
 
 #import <AppKit/AppKit.h>
 

--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -141,7 +141,7 @@ static bool using_10_15_or_above = true;
 static void log_os(void)
 {
 	NSProcessInfo *pi = [NSProcessInfo processInfo];
-	blog(LOG_INFO, "OS Name: Mac OS X");
+	blog(LOG_INFO, "OS Name: macOS");
 	blog(LOG_INFO, "OS Version: %s",
 	     [[pi operatingSystemVersionString] UTF8String]);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Apple have used the "macOS" branding instead of the "Mac OS X" branding for a long time. 
The `sysctl` header used by first attempt of Rosetta detection is unused and to be removed.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
https://github.com/obsproject/obs-studio/pull/5738#pullrequestreview-1037130964
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
These 2 commits are cherry-picked from #5738, which itself have these 2 commits.
Change of string should not cause a problem, same goes for remove unused header file.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
 - Code cleanup (non-breaking change which makes code smaller or more readable) 
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
