### PR TITLE
UI: Fix crash on macOS if no python path is set in configuration

### DIFF
--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -653,15 +653,18 @@ extern "C" void InitScripts()
 		config_get_string(config, "Python", "Path" ARCH_NAME);
 
 #ifdef __APPLE__
-	std::string _python_path(python_path);
-	std::size_t pos = _python_path.find("/Python.framework/Versions");
+	if (python_path && *python_path) {
+		std::string _python_path(python_path);
+		std::size_t pos =
+			_python_path.find("/Python.framework/Versions");
 
-	if (pos != std::string::npos) {
-		std::string _temp = _python_path.substr(0, pos);
-		config_set_string(config, "Python", "Path" ARCH_NAME,
-				  _temp.c_str());
-		config_save(config);
-		python_path = _temp.c_str();
+		if (pos != std::string::npos) {
+			std::string _temp = _python_path.substr(0, pos);
+			config_set_string(config, "Python", "Path" ARCH_NAME,
+					  _temp.c_str());
+			config_save(config);
+			python_path = _temp.c_str();
+		}
 	}
 #endif
 


### PR DESCRIPTION
### Description
Obvious fix guarding against calling the std::string constructor with a NULL pointer.

### Motivation and Context
Fix OBS crashing on macOS without preconfigured Python path.

### How Has This Been Tested?
Tested on macOS with clean config and config without available Python configuration.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
