### PR TITLE
mac-syphon: Fix issues on modern macOS versions

### DIFF
--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -885,9 +885,11 @@ static void show_syphon_license_internal(void)
 	if (@available(macOS 11.0, *)) {
 		NSURL *url = [NSURL
 			URLWithString:
-				[NSString
-					stringWithCString:path
-						 encoding:NSUTF8StringEncoding]];
+				[@"file://"
+					stringByAppendingString:
+						[NSString
+							stringWithCString:path
+								 encoding:NSUTF8StringEncoding]]];
 		[ws openURL:url];
 	} else {
 #pragma clang diagnostic push


### PR DESCRIPTION
### Description
Fixes broken license button on macOS 11+ (introduced via deprecation fix recently) and also remove all injection functionality for macOS 10.15+ (which is blocked by macOS anyway).

### Motivation and Context
Fix broken functionality and also remove errors in log occurring by normal use of the source.

### How Has This Been Tested?
Tested on macOS 12.4.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
