### PR TITLE
libobs: Trigger bindings injected by Qt directly

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -1289,8 +1289,14 @@ static inline bool inject_hotkey(void *data, size_t idx,
 			    event->strict_modifiers)) {
 		bool pressed = binding->key.key == event->hotkey.key &&
 			       event->pressed;
-		handle_binding(binding, event->hotkey.modifiers, false,
-			       event->strict_modifiers, &pressed);
+		if (binding->key.key == OBS_KEY_NONE)
+			pressed = true;
+
+		if (pressed) {
+			binding->modifiers_match = true;
+			if (!binding->pressed)
+				press_released_binding(binding);
+		}
 	}
 
 	return true;


### PR DESCRIPTION
### Description
Fixes hotkey functionality in macOS, simplify handling of Qt-injected hotkeys.

### Motivation and Context
Instead of lettings the hotkey thread handle bindings triggered by Qt, call the callback directly.

By this point, Qt has resolved the modifier state (so no need for the hotkey thread to do the same), the pressed state is set as well, the branch takes care of matching the pressed keys.

This also fixes the issue with the hotkey changes introduced by #3914, which only inject key events when OBS is _not_ in focus (and as such modifier states are never updated).

### How Has This Been Tested?
Tested on macOS and Windows with OBS in foreground as well as background.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
