### PR TITLE
UI: Add audioProcessOutputIcon to Yami

### DIFF
--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -1234,6 +1234,7 @@ OBSBasic {
     qproperty-groupIcon: url(./Dark/sources/group.svg);
     qproperty-sceneIcon: url(./Dark/sources/scene.svg);
     qproperty-defaultIcon: url(./Dark/sources/default.svg);
+    qproperty-audioProcessOutputIcon: url(./Dark/sources/windowaudio.svg);
 }
 
 /* Scene Tree Grid Mode */


### PR DESCRIPTION
### Description
Icon added to Yami theme.

### Motivation and Context
Icon is missing if launching with Yami theme.

### How Has This Been Tested?
Icon appears when launching with Yami theme.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.