### PR TITLE
UI: Add functions to check for and request macOS permissions

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -417,9 +417,12 @@ elseif(OS_MACOS)
   endif()
 
   find_library(APPKIT Appkit)
-  mark_as_advanced(APPKIT)
+  find_library(AVFOUNDATION AVFoundation)
+  find_library(APPLICATIONSERVICES ApplicationServices)
+  mark_as_advanced(APPKIT AVFOUNDATION APPLICATIONSERVICES)
 
-  target_link_libraries(obs PRIVATE ${APPKIT})
+  target_link_libraries(obs PRIVATE ${APPKIT} ${AVFOUNDATION}
+                                    ${APPLICATIONSERVICES})
 
   if(ENABLE_SPARKLE_UPDATER)
     find_library(SPARKLE Sparkle)

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2185,6 +2185,15 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 		}
 
 #ifdef __APPLE__
+		MacPermissionStatus audio_permission =
+			CheckPermission(kAudioDeviceAccess);
+		MacPermissionStatus video_permission =
+			CheckPermission(kVideoDeviceAccess);
+		MacPermissionStatus accessibility_permission =
+			CheckPermission(kAccessibility);
+		MacPermissionStatus screen_permission =
+			CheckPermission(kScreenCapture);
+
 		bool rosettaTranslated = os_get_emulation_status();
 		blog(LOG_INFO, "Rosetta translation used: %s",
 		     rosettaTranslated ? "true" : "false");

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -80,10 +80,29 @@ bool IsRunningOnWine();
 #endif
 
 #ifdef __APPLE__
+typedef enum {
+	kAudioDeviceAccess = 0,
+	kVideoDeviceAccess = 1,
+	kScreenCapture = 2,
+	kAccessibility = 3
+} MacPermissionType;
+
+typedef enum {
+	kPermissionNotDetermined = 0,
+	kPermissionRestricted = 1,
+	kPermissionDenied = 2,
+	kPermissionAuthorized = 3,
+} MacPermissionStatus;
+
 void EnableOSXVSync(bool enable);
 void EnableOSXDockIcon(bool enable);
 bool isInBundle();
 void InstallNSApplicationSubclass();
 void InstallNSThreadLocks();
 void disableColorSpaceConversion(QWidget *window);
+
+MacPermissionStatus CheckPermissionWithPrompt(MacPermissionType type,
+					      bool prompt_for_permission);
+#define CheckPermission(x) CheckPermissionWithPrompt(x, false)
+#define RequestPermission(x) CheckPermissionWithPrompt(x, true)
 #endif


### PR DESCRIPTION
### Description
Adds functions to check and/or request specific macOS permissions (audio device access, video device access, accessibility access, and screen capture access).

By default only audio capture, video capture, and accessibility are requested on launch - the first two have straight-forward "Yes/No" prompts, the latter requires people to enable OBS in the settings application (but is required for hotkey functionality, independent
of scene setups).

### Motivation and Context
Reduce friction to gain necessary permissions on macOS, especially for fixed hotkey functionality.

### How Has This Been Tested?
Yes.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
