### PR TITLE
mac-capture: Fix availability on macOS 12.5 and increase code efficiency

### DIFF
--- a/plugins/mac-capture/mac-screen-capture.m
+++ b/plugins/mac-capture/mac-screen-capture.m
@@ -3,10 +3,14 @@
 
 bool is_screen_capture_available(void)
 {
-	return (NSClassFromString(@"SCStream") != NULL);
+	if (@available(macOS 12.5, *)) {
+		return true;
+	} else {
+		return false;
+	}
 }
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120500 // __MAC_12_5
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120300 // __MAC_12_3
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
 

--- a/plugins/mac-capture/mac-screen-capture.m
+++ b/plugins/mac-capture/mac-screen-capture.m
@@ -376,9 +376,15 @@ static bool init_screen_stream(struct screen_capture *sc)
 	case ScreenCaptureDisplayStream: {
 		SCDisplay *target_display = get_target_display();
 
-		content_filter = [[SCContentFilter alloc]
-			 initWithDisplay:target_display
-			excludingWindows:[[NSArray alloc] init]];
+		if (@available(macOS 13.0, *)) {
+			content_filter = [[SCContentFilter alloc]
+				 initWithDisplay:target_display
+				excludingWindows:[[NSArray alloc] init]];
+		} else {
+			content_filter = [[SCContentFilter alloc]
+				 initWithDisplay:target_display
+				includingWindows:sc->shareable_content.windows];
+		}
 
 		set_display_mode(sc, target_display);
 	} break;

--- a/plugins/mac-capture/plugin-main.c
+++ b/plugins/mac-capture/plugin-main.c
@@ -18,7 +18,7 @@ bool obs_module_load(void)
 {
 	obs_register_source(&coreaudio_input_capture_info);
 	obs_register_source(&coreaudio_output_capture_info);
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120500 // __MAC_12_5
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120300 // __MAC_12_3
 	if (is_screen_capture_available()) {
 		extern struct obs_source_info screen_capture_info;
 		obs_register_source(&screen_capture_info);


### PR DESCRIPTION
### Description
Fixes availability of screen capture source on macOS 12.5 and also increases code efficiency when source is initialised and source type is changed.

Also fixes broken desktop capture because of a bug introduced in macOS 12.5.

### Motivation and Context
While the `availability` checks will correctly detect macOS 12.5, the `__MAC_OS_X_VERSION_MAX_ALLOWED` macro is dependent on the platform SDK. The most current platform SDK is 12.3, hence why this version needs to be checked for.

Also reduces the amount of calls to the update callback (and reduces amount of calls to check for available capture content).

Also moves some code to only update data for currently selected capture type.

### How Has This Been Tested?
Tested on macOS 12.5.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
