### PR TITLE
obs-filters: Add HDR bypass for various filters

### DIFF
--- a/plugins/obs-filters/chroma-key-filter.c
+++ b/plugins/obs-filters/chroma-key-filter.c
@@ -5,6 +5,7 @@
 
 /* clang-format off */
 
+#define SETTING_SDR_ONLY_INFO          "sdr_only_info"
 #define SETTING_OPACITY                "opacity"
 #define SETTING_CONTRAST               "contrast"
 #define SETTING_BRIGHTNESS             "brightness"
@@ -15,6 +16,7 @@
 #define SETTING_SMOOTHNESS             "smoothness"
 #define SETTING_SPILL                  "spill"
 
+#define TEXT_SDR_ONLY_INFO             obs_module_text("SdrOnlyInfo")
 #define TEXT_OPACITY                   obs_module_text("Opacity")
 #define TEXT_CONTRAST                  obs_module_text("Contrast")
 #define TEXT_BRIGHTNESS                obs_module_text("Brightness")
@@ -365,36 +367,60 @@ static void chroma_key_render_v1(void *data, gs_effect_t *effect)
 
 static void chroma_key_render_v2(void *data, gs_effect_t *effect)
 {
+	UNUSED_PARAMETER(effect);
+
 	struct chroma_key_filter_data_v2 *filter = data;
 	obs_source_t *target = obs_filter_get_target(filter->context);
 	uint32_t width = obs_source_get_base_width(target);
 	uint32_t height = obs_source_get_base_height(target);
 	struct vec2 pixel_size;
 
-	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
-					     OBS_ALLOW_DIRECT_RENDERING))
-		return;
+	const enum gs_color_space preferred_spaces[] = {
+		GS_CS_SRGB,
+		GS_CS_SRGB_16F,
+		GS_CS_709_EXTENDED,
+	};
 
-	vec2_set(&pixel_size, 1.0f / (float)width, 1.0f / (float)height);
+	const enum gs_color_space source_space = obs_source_get_color_space(
+		obs_filter_get_parent(filter->context),
+		OBS_COUNTOF(preferred_spaces), preferred_spaces);
+	if (source_space == GS_CS_709_EXTENDED) {
+		obs_source_skip_video_filter(filter->context);
+	} else {
+		const enum gs_color_format format =
+			gs_get_format_from_space(source_space);
+		if (obs_source_process_filter_begin_with_color_space(
+			    filter->context, format, source_space,
+			    OBS_ALLOW_DIRECT_RENDERING)) {
+			vec2_set(&pixel_size, 1.0f / (float)width,
+				 1.0f / (float)height);
 
-	gs_effect_set_float(filter->opacity_param, filter->opacity);
-	gs_effect_set_float(filter->contrast_param, filter->contrast);
-	gs_effect_set_float(filter->brightness_param, filter->brightness);
-	gs_effect_set_float(filter->gamma_param, filter->gamma);
-	gs_effect_set_vec2(filter->chroma_param, &filter->chroma);
-	gs_effect_set_vec2(filter->pixel_size_param, &pixel_size);
-	gs_effect_set_float(filter->similarity_param, filter->similarity);
-	gs_effect_set_float(filter->smoothness_param, filter->smoothness);
-	gs_effect_set_float(filter->spill_param, filter->spill);
+			gs_effect_set_float(filter->opacity_param,
+					    filter->opacity);
+			gs_effect_set_float(filter->contrast_param,
+					    filter->contrast);
+			gs_effect_set_float(filter->brightness_param,
+					    filter->brightness);
+			gs_effect_set_float(filter->gamma_param, filter->gamma);
+			gs_effect_set_vec2(filter->chroma_param,
+					   &filter->chroma);
+			gs_effect_set_vec2(filter->pixel_size_param,
+					   &pixel_size);
+			gs_effect_set_float(filter->similarity_param,
+					    filter->similarity);
+			gs_effect_set_float(filter->smoothness_param,
+					    filter->smoothness);
+			gs_effect_set_float(filter->spill_param, filter->spill);
 
-	gs_blend_state_push();
-	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+			gs_blend_state_push();
+			gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
-	obs_source_process_filter_end(filter->context, filter->effect, 0, 0);
+			obs_source_process_filter_end(filter->context,
+						      filter->effect, 0, 0);
 
-	gs_blend_state_pop();
-
-	UNUSED_PARAMETER(effect);
+			gs_blend_state_pop();
+		}
+	}
 }
 
 static bool key_type_changed(obs_properties_t *props, obs_property_t *p,
@@ -449,6 +475,9 @@ static obs_properties_t *chroma_key_properties_v1(void *data)
 static obs_properties_t *chroma_key_properties_v2(void *data)
 {
 	obs_properties_t *props = obs_properties_create();
+
+	obs_properties_add_text(props, SETTING_SDR_ONLY_INFO,
+				TEXT_SDR_ONLY_INFO, OBS_TEXT_INFO);
 
 	obs_property_t *p = obs_properties_add_list(props, SETTING_COLOR_TYPE,
 						    TEXT_COLOR_TYPE,
@@ -508,6 +537,24 @@ static void chroma_key_defaults_v2(obs_data_t *settings)
 	obs_data_set_default_int(settings, SETTING_SPILL, 100);
 }
 
+static enum gs_color_space
+chroma_key_get_color_space(void *data, size_t count,
+			   const enum gs_color_space *preferred_spaces)
+{
+	const enum gs_color_space potential_spaces[] = {
+		GS_CS_SRGB,
+		GS_CS_SRGB_16F,
+		GS_CS_709_EXTENDED,
+	};
+
+	struct chroma_key_filter_data_v2 *const filter = data;
+	const enum gs_color_space source_space = obs_source_get_color_space(
+		obs_filter_get_parent(filter->context),
+		OBS_COUNTOF(potential_spaces), potential_spaces);
+
+	return source_space;
+}
+
 struct obs_source_info chroma_key_filter = {
 	.id = "chroma_key_filter",
 	.type = OBS_SOURCE_TYPE_FILTER,
@@ -533,4 +580,5 @@ struct obs_source_info chroma_key_filter_v2 = {
 	.update = chroma_key_update_v2,
 	.get_properties = chroma_key_properties_v2,
 	.get_defaults = chroma_key_defaults_v2,
+	.video_get_color_space = chroma_key_get_color_space,
 };


### PR DESCRIPTION
### Description
Not sure how to implement controls for HDR, so skip unless SDR for now.

### Motivation and Context
Don't want to apply SDR color processing on HDR video.

### How Has This Been Tested?
Verify scenarios:
- [x] Apply LUT, SRGB on SRGB: filter works
- [x] Apply LUT, SRGB on EDR: filter works
- [x] Apply LUT, SRGB on SCRGB: filter works
- [x] Chroma Key, SRGB on SRGB: filter works
- [x] Chroma Key, SRGB on EDR: filter works
- [x] Chroma Key, SRGB on SCRGB: filter works
- [x] Color Key, SRGB on SRGB: filter works
- [x] Color Key, SRGB on EDR: filter works
- [x] Color Key, SRGB on SCRGB: filter works
- [x] Image Mask/Blend, SRGB on SRGB: filter works
- [x] Image Mask/Blend, SRGB on EDR: filter works
- [x] Image Mask/Blend, SRGB on SCRGB: filter works
- [x] Luma Key, SRGB on SRGB: filter works
- [x] Luma Key, SRGB on EDR: filter works
- [x] Luma Key, SRGB on SCRGB: filter works
- [x] Apply LUT, EDR on SRGB: passthrough
- [x] Apply LUT, EDR on EDR: passthrough
- [x] Apply LUT, EDR on SCRGB: passthrough
- [x] Chroma Key, EDR on SRGB: passthrough
- [x] Chroma Key, EDR on EDR: passthrough
- [x] Chroma Key, EDR on SCRGB: passthrough
- [x] Color Key, EDR on SRGB: passthrough
- [x] Color Key, EDR on EDR: passthrough
- [x] Color Key, EDR on SCRGB: passthrough
- [x] Image Mask/Blend, EDR on SRGB: passthrough
- [x] Image Mask/Blend, EDR on EDR: passthrough
- [x] Image Mask/Blend, EDR on SCRGB: passthrough
- [x] Luma Key, EDR on SRGB: passthrough
- [x] Luma Key, EDR on EDR: passthrough
- [x] Luma Key, EDR on SCRGB: passthrough

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.