### PR TITLE
UI: Remove padding on QStackedWidget in Yami

### DIFF
--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -237,10 +237,6 @@ OBSDock QFrame {
     border-bottom-right-radius: 4px;
 }
 
-QStackedWidget {
-    padding: 4px;
-}
-
 #transitionsContainer QPushButton {
     margin: 0px 0px;
     padding: 4px 6px;


### PR DESCRIPTION
### Description
Removes padding from QStackedWidgets

### Motivation and Context
Originally added for the Settings pane itself, this caused issues in other places QStackedWidget is used (Such as the Video tab of settings, for the FPS dropdowns) creating weird misalignment

**Before:**
![image](https://user-images.githubusercontent.com/1554753/180824137-5504c35f-40c3-4e42-9742-8c541ec48307.png)

**After:**
![image](https://user-images.githubusercontent.com/1554753/180824178-826bb629-e0a0-4739-a69a-55737d64915c.png)


### How Has This Been Tested?
Looked through theme for QStackedWidget usages

### Types of changes
- Tweak (non-breaking change to improve existing functionality)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
