### PR TITLE
UI: Add toolButton style property for transitions dock

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -336,12 +336,27 @@ QToolBar {
 	margin-top: 4px;
 }
 
+QPushButton[toolButton="true"],
+QToolButton {
+	background: transparent;
+	border: none;
+    padding: 4px 6px;
+    margin: 0px 2px;
+}
+
+QPushButton[toolButton="true"]:last-child,
+QToolButton:last-child {
+    margin-right: 0px;
+}
+
+QPushButton[toolButton="true"]:hover,
 QToolButton:hover {
 	background-color: rgb(42,58,117);
 	border: 1px solid rgb(35,49,102);
 	border-radius: none;
 }
 
+QPushButton[toolButton="true"]:pressed,
 QToolButton:pressed {
 	background-color: rgb(22,31,65);
 	border-radius: none;

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -245,11 +245,26 @@ QToolBar {
     border: none;
 }
 
+QPushButton[toolButton="true"],
+QToolButton {
+	background: transparent;
+	border: none;
+    padding: 1px;
+    margin: 1px;
+}
+
+QPushButton[toolButton="true"]:last-child,
+QToolButton:last-child {
+    margin-right: 0px;
+}
+
+QPushButton[toolButton="true"]:hover,
 QToolButton:hover {
     background-color: rgb(122,121,122); /* light */
     border-radius: none;
 }
 
+QPushButton[toolButton="true"]:pressed,
 QToolButton:pressed {
     background-color: palette(base);
     border-radius: none;

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -474,11 +474,26 @@ QToolBar {
 	border: none;
 }
 
+QPushButton[toolButton="true"],
+QToolButton {
+	background: transparent;
+	border: none;
+    padding: 1px;
+    margin: 1px;
+}
+
+QPushButton[toolButton="true"]:last-child,
+QToolButton:last-child {
+    margin-right: 0px;
+}
+
+QPushButton[toolButton="true"]:hover,
 QToolButton:hover {
 	background-color: rgba(240, 98, 146, 0.5); /* Pink (Secondary) */
 	border-radius: 2px;
 }
 
+QPushButton[toolButton="true"]:pressed,
 QToolButton:pressed {
 	background-color: rgb(240, 98, 146); /* Pink (Secondary) */
 	border-radius: 2px;

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -412,13 +412,15 @@ QToolBar {
     margin: 4px 0px;
 }
 
+QPushButton[toolButton="true"],
 QToolButton {
-    background-color: rgb(60,64,75);
+    background-color: rgb(160,64,75);
     padding: 4px 6px;
     margin: 0px 2px;
     border-radius: 2px;
 }
 
+QPushButton[toolButton="true"]:last-child,
 QToolButton:last-child {
     margin-right: 0px;
 }

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1279,6 +1279,9 @@
             <property name="themeID" stdset="0">
              <string notr="true">addIconSmall</string>
             </property>
+            <property name="toolButton" stdset="0">
+             <bool>true</bool>
+            </property>
            </widget>
           </item>
           <item>
@@ -1308,6 +1311,9 @@
             <property name="themeID" stdset="0">
              <string notr="true">removeIconSmall</string>
             </property>
+            <property name="toolButton" stdset="0">
+             <bool>true</bool>
+            </property>
            </widget>
           </item>
           <item>
@@ -1336,6 +1342,9 @@
             </property>
             <property name="themeID" stdset="0">
              <string notr="true">menuIconSmall</string>
+            </property>
+            <property name="toolButton" stdset="0">
+             <string notr="true">true</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
### Description
Allows making QPushButtons use the QToolButton styling.
Current usage is for transitions dock buttons.

May be unneeded after #6756 but doesn't hurt to have for elsewhere

### Motivation and Context
Makes transitions dock buttons look like the other toolbars

![image](https://user-images.githubusercontent.com/1554753/180831059-bdae2dcd-be54-4084-a158-09bb37afc836.png)


### How Has This Been Tested?
I looked with my special eyes

### Types of changes
- Tweak (non-breaking change to improve existing functionality)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
