### PR TITLE
libobs: Add api to for notifications

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -488,6 +488,8 @@ struct obs_core {
 	os_task_queue_t *destruction_task_thread;
 
 	obs_task_handler_t ui_task_handler;
+
+	volatile long notification_id;
 };
 
 extern struct obs_core *obs;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2617,6 +2617,19 @@ EXPORT void obs_source_frame_copy(struct obs_source_frame *dst,
 /* Get source icon type */
 EXPORT enum obs_icon_type obs_source_get_icon_type(const char *id);
 
+/* ------------------------------------------------------------------------- */
+/* Functions to show notification in main UI */
+enum obs_notify_type {
+	OBS_NOTIFY_TYPE_INFO,
+	OBS_NOTIFY_TYPE_WARNING,
+	OBS_NOTIFY_TYPE_ERROR,
+};
+
+EXPORT uint32_t obs_show_notification(enum obs_notify_type type,
+				      const char *message, bool persist,
+				      void *data);
+EXPORT void obs_close_notification(uint32_t id);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Description
This adds an api to libobs to show a notification in the
main UI. This is only for the libobs changes, as the UI
will be added later.

### Motivation and Context
Split from #1832 

### How Has This Been Tested?
Tested with #1832 

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
