### PR TITLE
obs-filters: Add HDR bypass for sharpen

### DIFF
--- a/plugins/obs-filters/sharpness-filter.c
+++ b/plugins/obs-filters/sharpness-filter.c
@@ -75,35 +75,56 @@ static void *sharpness_create(obs_data_t *settings, obs_source_t *context)
 
 static void sharpness_render(void *data, gs_effect_t *effect)
 {
+	UNUSED_PARAMETER(effect);
+
 	struct sharpness_data *filter = data;
 
-	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
-					     OBS_ALLOW_DIRECT_RENDERING))
-		return;
+	const enum gs_color_space preferred_spaces[] = {
+		GS_CS_SRGB,
+		GS_CS_SRGB_16F,
+		GS_CS_709_EXTENDED,
+	};
 
-	filter->texwidth = (float)obs_source_get_width(
-		obs_filter_get_target(filter->context));
-	filter->texheight = (float)obs_source_get_height(
-		obs_filter_get_target(filter->context));
+	const enum gs_color_space source_space = obs_source_get_color_space(
+		obs_filter_get_parent(filter->context),
+		OBS_COUNTOF(preferred_spaces), preferred_spaces);
+	if (source_space == GS_CS_709_EXTENDED) {
+		obs_source_skip_video_filter(filter->context);
+	} else {
+		const enum gs_color_format format =
+			gs_get_format_from_space(source_space);
+		if (obs_source_process_filter_begin_with_color_space(
+			    filter->context, format, source_space,
+			    OBS_ALLOW_DIRECT_RENDERING)) {
+			filter->texwidth = (float)obs_source_get_width(
+				obs_filter_get_target(filter->context));
+			filter->texheight = (float)obs_source_get_height(
+				obs_filter_get_target(filter->context));
 
-	gs_effect_set_float(filter->sharpness_param, filter->sharpness);
-	gs_effect_set_float(filter->texture_width, filter->texwidth);
-	gs_effect_set_float(filter->texture_height, filter->texheight);
+			gs_effect_set_float(filter->sharpness_param,
+					    filter->sharpness);
+			gs_effect_set_float(filter->texture_width,
+					    filter->texwidth);
+			gs_effect_set_float(filter->texture_height,
+					    filter->texheight);
 
-	gs_blend_state_push();
-	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+			gs_blend_state_push();
+			gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
-	obs_source_process_filter_end(filter->context, filter->effect, 0, 0);
+			obs_source_process_filter_end(filter->context,
+						      filter->effect, 0, 0);
 
-	gs_blend_state_pop();
-
-	UNUSED_PARAMETER(effect);
+			gs_blend_state_pop();
+		}
+	}
 }
 
 static obs_properties_t *sharpness_properties(void *data)
 {
 	obs_properties_t *props = obs_properties_create();
 
+	obs_properties_add_text(props, "sdr_only_info",
+				obs_module_text("SdrOnlyInfo"), OBS_TEXT_INFO);
 	obs_properties_add_float_slider(props, "sharpness",
 					obs_module_text("Sharpness"), 0.0, 1.0,
 					0.01);
@@ -115,6 +136,24 @@ static obs_properties_t *sharpness_properties(void *data)
 static void sharpness_defaults(obs_data_t *settings)
 {
 	obs_data_set_default_double(settings, "sharpness", 0.08);
+}
+
+static enum gs_color_space
+sharpness_get_color_space(void *data, size_t count,
+			  const enum gs_color_space *preferred_spaces)
+{
+	const enum gs_color_space potential_spaces[] = {
+		GS_CS_SRGB,
+		GS_CS_SRGB_16F,
+		GS_CS_709_EXTENDED,
+	};
+
+	struct sharpness_data *const filter = data;
+	const enum gs_color_space source_space = obs_source_get_color_space(
+		obs_filter_get_parent(filter->context),
+		OBS_COUNTOF(potential_spaces), potential_spaces);
+
+	return source_space;
 }
 
 struct obs_source_info sharpness_filter = {
@@ -142,4 +181,5 @@ struct obs_source_info sharpness_filter_v2 = {
 	.video_render = sharpness_render,
 	.get_properties = sharpness_properties,
 	.get_defaults = sharpness_defaults,
+	.video_get_color_space = sharpness_get_color_space,
 };


### PR DESCRIPTION
### Description
Not sure how to implement controls for HDR, so skip unless SDR for now.

### Motivation and Context
Don't want to apply SDR color processing on HDR video.

### How Has This Been Tested?
Checked sharpen settings work on SDR input, but passes HDR input through.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.