### PR TITLE
obs-filters: Add HDR support to Crop/Pad

### DIFF
--- a/plugins/obs-filters/crop-filter.c
+++ b/plugins/obs-filters/crop-filter.c
@@ -7,6 +7,7 @@ struct crop_filter_data {
 	gs_effect_t *effect;
 	gs_eparam_t *param_mul;
 	gs_eparam_t *param_add;
+	gs_eparam_t *param_multiplier;
 
 	int left;
 	int right;
@@ -50,6 +51,8 @@ static void *crop_filter_create(obs_data_t *settings, obs_source_t *context)
 		gs_effect_get_param_by_name(filter->effect, "mul_val");
 	filter->param_add =
 		gs_effect_get_param_by_name(filter->effect, "add_val");
+	filter->param_multiplier =
+		gs_effect_get_param_by_name(filter->effect, "multiplier");
 
 	obs_source_update(context, settings);
 	return filter;
@@ -182,26 +185,87 @@ static void crop_filter_tick(void *data, float seconds)
 	UNUSED_PARAMETER(seconds);
 }
 
+static const char *
+get_tech_name_and_multiplier(enum gs_color_space current_space,
+			     enum gs_color_space source_space,
+			     float *multiplier)
+{
+	const char *tech_name = "Draw";
+	*multiplier = 1.f;
+
+	switch (source_space) {
+	case GS_CS_SRGB:
+	case GS_CS_SRGB_16F:
+		switch (current_space) {
+		case GS_CS_709_SCRGB:
+			tech_name = "DrawMultiply";
+			*multiplier = obs_get_video_sdr_white_level() / 80.0f;
+		}
+		break;
+	case GS_CS_709_EXTENDED:
+		switch (current_space) {
+		case GS_CS_SRGB:
+		case GS_CS_SRGB_16F:
+			tech_name = "DrawTonemap";
+			break;
+		case GS_CS_709_SCRGB:
+			tech_name = "DrawMultiply";
+			*multiplier = obs_get_video_sdr_white_level() / 80.0f;
+		}
+		break;
+	case GS_CS_709_SCRGB:
+		switch (current_space) {
+		case GS_CS_SRGB:
+		case GS_CS_SRGB_16F:
+			tech_name = "DrawMultiplyTonemap";
+			*multiplier = 80.0f / obs_get_video_sdr_white_level();
+			break;
+		case GS_CS_709_EXTENDED:
+			tech_name = "DrawMultiply";
+			*multiplier = 80.0f / obs_get_video_sdr_white_level();
+		}
+	}
+
+	return tech_name;
+}
+
 static void crop_filter_render(void *data, gs_effect_t *effect)
 {
+	UNUSED_PARAMETER(effect);
+
 	struct crop_filter_data *filter = data;
 
-	if (!obs_source_process_filter_begin(filter->context, GS_RGBA,
-					     OBS_NO_DIRECT_RENDERING))
-		return;
+	const enum gs_color_space preferred_spaces[] = {
+		GS_CS_SRGB,
+		GS_CS_SRGB_16F,
+		GS_CS_709_EXTENDED,
+	};
 
-	gs_effect_set_vec2(filter->param_mul, &filter->mul_val);
-	gs_effect_set_vec2(filter->param_add, &filter->add_val);
+	const enum gs_color_space source_space = obs_source_get_color_space(
+		obs_filter_get_parent(filter->context),
+		OBS_COUNTOF(preferred_spaces), preferred_spaces);
+	float multiplier;
+	const char *technique = get_tech_name_and_multiplier(
+		gs_get_color_space(), source_space, &multiplier);
+	const enum gs_color_format format =
+		gs_get_format_from_space(source_space);
+	if (obs_source_process_filter_begin_with_color_space(
+		    filter->context, format, source_space,
+		    OBS_NO_DIRECT_RENDERING)) {
+		gs_effect_set_vec2(filter->param_mul, &filter->mul_val);
+		gs_effect_set_vec2(filter->param_add, &filter->add_val);
+		gs_effect_set_float(filter->param_multiplier, multiplier);
 
-	gs_blend_state_push();
-	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+		gs_blend_state_push();
+		gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
-	obs_source_process_filter_end(filter->context, filter->effect,
-				      filter->width, filter->height);
+		obs_source_process_filter_tech_end(filter->context,
+						   filter->effect,
+						   filter->width,
+						   filter->height, technique);
 
-	gs_blend_state_pop();
-
-	UNUSED_PARAMETER(effect);
+		gs_blend_state_pop();
+	}
 }
 
 static uint32_t crop_filter_width(void *data)
@@ -214,6 +278,31 @@ static uint32_t crop_filter_height(void *data)
 {
 	struct crop_filter_data *crop = data;
 	return (uint32_t)crop->height;
+}
+
+static enum gs_color_space
+crop_filter_get_color_space(void *data, size_t count,
+			    const enum gs_color_space *preferred_spaces)
+{
+	const enum gs_color_space potential_spaces[] = {
+		GS_CS_SRGB,
+		GS_CS_SRGB_16F,
+		GS_CS_709_EXTENDED,
+	};
+
+	struct crop_filter_data *const filter = data;
+	const enum gs_color_space source_space = obs_source_get_color_space(
+		obs_filter_get_parent(filter->context),
+		OBS_COUNTOF(potential_spaces), potential_spaces);
+
+	enum gs_color_space space = source_space;
+	for (size_t i = 0; i < count; ++i) {
+		space = preferred_spaces[i];
+		if (space == source_space)
+			break;
+	}
+
+	return space;
 }
 
 struct obs_source_info crop_filter = {
@@ -230,4 +319,5 @@ struct obs_source_info crop_filter = {
 	.video_render = crop_filter_render,
 	.get_width = crop_filter_width,
 	.get_height = crop_filter_height,
+	.video_get_color_space = crop_filter_get_color_space,
 };

--- a/plugins/obs-filters/data/color.effect
+++ b/plugins/obs-filters/data/color.effect
@@ -1,0 +1,26 @@
+float3 rec709_to_rec2020(float3 v)
+{
+	float r = dot(v, float3(0.62740389593469914, 0.32928303837788397, 0.043313065687417190));
+	float g = dot(v, float3(0.069097289358232047, 0.91954039507545904, 0.011362315566309173));
+	float b = dot(v, float3(0.016391438875150235, 0.088013307877225860, 0.89559525324762468));
+	return float3(r, g, b);
+}
+
+float3 rec2020_to_rec709(float3 v)
+{
+	float r = dot(v, float3(1.6604910021084343, -0.58764113878854973, -0.072849863319884745));
+	float g = dot(v, float3(-0.12455047452159063, 1.1328998971259603, -0.0083494226043695080));
+	float b = dot(v, float3(-0.018150763354905199, -0.10057889800800746, 1.1187296613629123));
+	return float3(r, g, b);
+}
+
+float reinhard_channel(float x)
+{
+	return x / (x + 1.);
+}
+
+float3 reinhard(float3 rgb)
+{
+	return float3(reinhard_channel(rgb.r), reinhard_channel(rgb.g), reinhard_channel(rgb.b));
+}
+

--- a/plugins/obs-filters/data/crop_filter.effect
+++ b/plugins/obs-filters/data/crop_filter.effect
@@ -1,8 +1,11 @@
+#include "color.effect"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
 
 uniform float2 mul_val;
 uniform float2 add_val;
+uniform float multiplier;
 
 sampler_state textureSampler {
 	Filter    = Linear;
@@ -29,11 +32,64 @@ float4 PSCrop(VertData v_in) : TARGET
 	return image.Sample(textureSampler, v_in.uv);
 }
 
+float4 PSCropMultiply(VertData v_in) : TARGET
+{
+	float4 rgba = image.Sample(textureSampler, v_in.uv);
+	rgba.rgb *= multiplier;
+	return rgba;
+}
+
+float4 PSCropTonemap(VertData v_in) : TARGET
+{
+	float4 rgba = image.Sample(textureSampler, v_in.uv);
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
+float4 PSCropMultiplyTonemap(VertData v_in) : TARGET
+{
+	float4 rgba = image.Sample(textureSampler, v_in.uv);
+	rgba.rgb *= multiplier;
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
 technique Draw
 {
 	pass
 	{
 		vertex_shader = VSCrop(v_in);
 		pixel_shader  = PSCrop(v_in);
+	}
+}
+
+technique DrawMultiply
+{
+	pass
+	{
+		vertex_shader = VSCrop(v_in);
+		pixel_shader  = PSCropMultiply(v_in);
+	}
+}
+
+technique DrawTonemap
+{
+	pass
+	{
+		vertex_shader = VSCrop(v_in);
+		pixel_shader  = PSCropTonemap(v_in);
+	}
+}
+
+technique DrawMultiplyTonemap
+{
+	pass
+	{
+		vertex_shader = VSCrop(v_in);
+		pixel_shader  = PSCropMultiplyTonemap(v_in);
 	}
 }


### PR DESCRIPTION
### Description
Add support for Crop/Pad of HDR frames.

### Motivation and Context
No reason we shouldn't be able to support crop/pad of HDR frames.

### How Has This Been Tested?
- [x] SRGB on SRGB
- [x] SRGB on SRGB16F
- [x] SRGB on EDR
- [x] SRGB on SCRGB
- [x] SRGB16F on SRGB
- [x] SRGB16F on SRGB16F
- [x] SRGB16F on EDR
- [x] SRGB16F on SCRGB
- [x] EDR on SRGB
- [x] EDR on SRGB16F
- [x] EDR on EDR
- [x] EDR on SCRGB
- [x] SCRGB on SRGB
- [x] SCRGB on SRGB16F
- [x] SCRGB on EDR
- [x] SCRGB on SCRGB

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.