### PR TITLE
UI: Add hotkey for resize output (source size)

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1231,6 +1231,11 @@ AddUrl.Title="Add Source via URL"
 AddUrl.Text="You have dragged a URL into OBS. This will automatically add the link as a source. Continue?"
 AddUrl.Text.Url="URL: %1"
 
+# Dynamic output size
+ResizeOutputSizeOfSource="Resize output (source size)"
+ResizeOutputSizeOfSource.Text="The base and output resolutions will be resized to the size of the current source."
+ResizeOutputSizeOfSource.Continue="Do you want to continue?"
+
 PreviewTransition="Preview Transition"
 
 # Import Dialog

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5555,6 +5555,18 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 			popup.addSeparator();
 		}
 
+		QAction *resizeOutput =
+			popup.addAction(QTStr("ResizeOutputSizeOfSource"), this,
+					SLOT(ResizeOutputSizeOfSource()));
+
+		int width = obs_source_get_width(source);
+		int height = obs_source_get_height(source);
+
+		resizeOutput->setEnabled(!obs_video_active());
+
+		if (width < 8 || height < 8)
+			resizeOutput->setEnabled(false);
+
 		scaleFilteringMenu = new QMenu(QTStr("ScaleFiltering"));
 		popup.addMenu(
 			AddScaleFilteringMenu(scaleFilteringMenu, sceneItem));
@@ -9623,6 +9635,40 @@ void OBSBasic::on_actionShowAbout_triggered()
 	about->show();
 
 	about->setAttribute(Qt::WA_DeleteOnClose, true);
+}
+
+void OBSBasic::ResizeOutputSizeOfSource()
+{
+	if (obs_video_active())
+		return;
+
+	QMessageBox resize_output(this);
+	resize_output.setText(QTStr("ResizeOutputSizeOfSource.Text") + "\n\n" +
+			      QTStr("ResizeOutputSizeOfSource.Continue"));
+	QAbstractButton *Yes =
+		resize_output.addButton(QTStr("Yes"), QMessageBox::YesRole);
+	resize_output.addButton(QTStr("No"), QMessageBox::NoRole);
+	resize_output.setIcon(QMessageBox::Warning);
+	resize_output.setWindowTitle(QTStr("ResizeOutputSizeOfSource"));
+	resize_output.exec();
+
+	if (resize_output.clickedButton() != Yes)
+		return;
+
+	OBSSource source = obs_sceneitem_get_source(GetCurrentSceneItem());
+
+	int width = obs_source_get_width(source);
+	int height = obs_source_get_height(source);
+
+	config_set_uint(basicConfig, "Video", "BaseCX", width);
+	config_set_uint(basicConfig, "Video", "BaseCY", height);
+	config_set_uint(basicConfig, "Video", "OutputCX", width);
+	config_set_uint(basicConfig, "Video", "OutputCY", height);
+
+	ResetVideo();
+	ResetOutputs();
+	config_save_safe(basicConfig, "tmp", nullptr);
+	on_actionFitToScreen_triggered();
 }
 
 QAction *OBSBasic::AddDockWidget(QDockWidget *dock)

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5555,18 +5555,6 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 			popup.addSeparator();
 		}
 
-		QAction *resizeOutput =
-			popup.addAction(QTStr("ResizeOutputSizeOfSource"), this,
-					SLOT(ResizeOutputSizeOfSource()));
-
-		int width = obs_source_get_width(source);
-		int height = obs_source_get_height(source);
-
-		resizeOutput->setEnabled(!obs_video_active());
-
-		if (width < 8 || height < 8)
-			resizeOutput->setEnabled(false);
-
 		scaleFilteringMenu = new QMenu(QTStr("ScaleFiltering"));
 		popup.addMenu(
 			AddScaleFilteringMenu(scaleFilteringMenu, sceneItem));

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1152,6 +1152,8 @@ private slots:
 
 	void StackedMixerAreaContextMenuRequested();
 
+	void ResizeOutputSizeOfSource();
+
 public slots:
 	void on_actionResetTransform_triggered();
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -500,6 +500,7 @@ private:
 	obs_hotkey_id statsHotkey = 0;
 	obs_hotkey_id screenshotHotkey = 0;
 	obs_hotkey_id sourceScreenshotHotkey = 0;
+	obs_hotkey_id resizeOutputHotkey = 0;
 	int quickTransitionIdCounter = 1;
 	bool overridingTransition = false;
 


### PR DESCRIPTION
### Description
Adds hotkey for resizing the output based on current source size.

### Motivation and Context
https://github.com/obsproject/obs-studio/commit/829e906ac2b15d822173009cde5c90b5ec6c04c1 removed the feature all together, this just removes it from the context menu and changes it to a hotkey

### How Has This Been Tested?
Resized output with the hotkey.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
