### PR TITLE
Misc obs-vst cleanups

### DIFF
--- a/plugins/obs-vst/VSTPlugin.cpp
+++ b/plugins/obs-vst/VSTPlugin.cpp
@@ -96,14 +96,14 @@ void VSTPlugin::createChannelBuffers(size_t count)
 	numChannels = (std::max)((size_t)0, count);
 
 	if (numChannels > 0) {
-		inputs = (float **)malloc(sizeof(float *) * numChannels);
-		outputs = (float **)malloc(sizeof(float *) * numChannels);
-		channelrefs = (float **)malloc(sizeof(float *) * numChannels);
+		inputs = (float **)bmalloc(sizeof(float *) * numChannels);
+		outputs = (float **)bmalloc(sizeof(float *) * numChannels);
+		channelrefs = (float **)bmalloc(sizeof(float *) * numChannels);
 		for (size_t channel = 0; channel < numChannels; channel++) {
 			inputs[channel] =
-				(float *)malloc(sizeof(float) * blocksize);
+				(float *)bmalloc(sizeof(float) * blocksize);
 			outputs[channel] =
-				(float *)malloc(sizeof(float) * blocksize);
+				(float *)bmalloc(sizeof(float) * blocksize);
 		}
 	}
 }
@@ -112,24 +112,24 @@ void VSTPlugin::cleanupChannelBuffers()
 {
 	for (size_t channel = 0; channel < numChannels; channel++) {
 		if (inputs && inputs[channel]) {
-			free(inputs[channel]);
+			bfree(inputs[channel]);
 			inputs[channel] = NULL;
 		}
 		if (outputs && outputs[channel]) {
-			free(outputs[channel]);
+			bfree(outputs[channel]);
 			outputs[channel] = NULL;
 		}
 	}
 	if (inputs) {
-		free(inputs);
+		bfree(inputs);
 		inputs = NULL;
 	}
 	if (outputs) {
-		free(outputs);
+		bfree(outputs);
 		outputs = NULL;
 	}
 	if (channelrefs) {
-		free(channelrefs);
+		bfree(channelrefs);
 		channelrefs = NULL;
 	}
 	numChannels = 0;

--- a/plugins/obs-vst/VSTPlugin.cpp
+++ b/plugins/obs-vst/VSTPlugin.cpp
@@ -135,7 +135,7 @@ void VSTPlugin::cleanupChannelBuffers()
 	numChannels = 0;
 }
 
-void VSTPlugin::loadEffectFromPath(std::string path)
+void VSTPlugin::loadEffectFromPath(const std::string &path)
 {
 	if (this->pluginPath.compare(path) != 0) {
 		unloadEffect();
@@ -309,7 +309,7 @@ void VSTPlugin::unloadEffect()
 
 	unloadLibrary();
 
-	pluginPath = "";
+	pluginPath.clear();
 }
 
 bool VSTPlugin::isEditorOpen()
@@ -403,7 +403,7 @@ std::string VSTPlugin::getChunk()
 	}
 }
 
-void VSTPlugin::setChunk(std::string data)
+void VSTPlugin::setChunk(const std::string &data)
 {
 	if (!effect) {
 		return;

--- a/plugins/obs-vst/headers/VSTPlugin.h
+++ b/plugins/obs-vst/headers/VSTPlugin.h
@@ -88,11 +88,11 @@ class VSTPlugin : public QObject {
 public:
 	VSTPlugin(obs_source_t *sourceContext);
 	~VSTPlugin();
-	void loadEffectFromPath(std::string path);
+	void loadEffectFromPath(const std::string &path);
 	void unloadEffect();
 	std::string getEffectPath();
 	std::string getChunk();
-	void setChunk(std::string data);
+	void setChunk(const std::string &data);
 	void setProgram(const int programNumber);
 	int getProgram();
 	void getSourceNames();

--- a/plugins/obs-vst/obs-vst.cpp
+++ b/plugins/obs-vst/obs-vst.cpp
@@ -105,7 +105,7 @@ static void vst_update(void *data, obs_data_t *settings)
 
 	const char *path = obs_data_get_string(settings, "plugin_path");
 
-	if (strcmp(path, "") == 0) {
+	if (!*path) {
 		vstPlugin->unloadEffect();
 		return;
 	}
@@ -115,10 +115,10 @@ static void vst_update(void *data, obs_data_t *settings)
 	const char *chunkHash = obs_data_get_string(settings, "chunk_hash");
 	const char *chunkData = obs_data_get_string(settings, "chunk_data");
 
-	bool chunkHashesMatch = chunkHash && strlen(chunkHash) > 0 &&
+	bool chunkHashesMatch = chunkHash && *chunkHash &&
 				hash.compare(chunkHash) == 0;
-	if (chunkData && strlen(chunkData) > 0 &&
-	    (chunkHashesMatch || !chunkHash || strlen(chunkHash) == 0)) {
+	if (chunkData && *chunkData &&
+	    (chunkHashesMatch || !chunkHash || !*chunkHash)) {
 		vstPlugin->setChunk(std::string(chunkData));
 	}
 }


### PR DESCRIPTION
### Description
Minor code cleanups for obs-vst. Use libobs memory functions instead of malloc / free  and some misc. string handling improvements.

### Motivation and Context
Improve plugin behavior and clean up some static analysis warnings.

### How Has This Been Tested?
It compiled. I don't have VSTs so no functional testing.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
