### PR TITLE
UI: Fix studio mode label not updating

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2068,6 +2068,7 @@ void OBSBasic::OBSInit()
 	}
 #endif
 
+	UpdatePreviewProgramIndicators();
 	OnFirstLoad();
 
 	activateWindow();


### PR DESCRIPTION
### Description
When studio mode is enabled and OBS is first started, the program
scene label would be empty.

### Motivation and Context
Fixes bug I've found

### How Has This Been Tested?
Opened OBS with studio mode enabled and made sure the program label was set properly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
