### PR TITLE
obs-transitions: Add HDR support to stinger

### DIFF
--- a/plugins/obs-transitions/data/stinger_matte_transition.effect
+++ b/plugins/obs-transitions/data/stinger_matte_transition.effect
@@ -33,9 +33,9 @@ float3 srgb_nonlinear_to_linear(float3 v)
 	return float3(srgb_nonlinear_to_linear_channel(v.r), srgb_nonlinear_to_linear_channel(v.g), srgb_nonlinear_to_linear_channel(v.b));
 }
 
-float4 PSStingerMatte(VertData v_in) : TARGET
+float4 StingerMatte(VertData f_in)
 {
-	float2 uv = v_in.uv;
+	float2 uv = f_in.uv;
 	float4 a_color = a_tex.Sample(textureSampler, uv);
 	float4 b_color = b_tex.Sample(textureSampler, uv);
 	float4 matte_color = matte_tex.Sample(textureSampler, uv);
@@ -51,7 +51,19 @@ float4 PSStingerMatte(VertData v_in) : TARGET
 	matte_luma = (invert_matte ? (1.0 - matte_luma) : matte_luma);
 
 	float4 rgba = lerp(a_color, b_color, matte_luma);
+	return rgba;
+}
+
+float4 PSStingerMatte(VertData f_in) : TARGET
+{
+	float4 rgba = StingerMatte(f_in);
 	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
+	return rgba;
+}
+
+float4 PSStingerMatteLinear(VertData f_in) : TARGET
+{
+	float4 rgba = StingerMatte(f_in);
 	return rgba;
 }
 
@@ -60,6 +72,15 @@ technique StingerMatte
 	pass
 	{
 		vertex_shader = VSDefault(v_in);
-		pixel_shader = PSStingerMatte(v_in);
+		pixel_shader = PSStingerMatte(f_in);
+	}
+}
+
+technique StingerMatteLinear
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader = PSStingerMatteLinear(f_in);
 	}
 }


### PR DESCRIPTION
### Description
Allow stinger transitions to work with HDR.

HDR track matte might work, but would take a very carefully crafted video. SDR track matte should work in all situations.

### Motivation and Context
More HDR support.

### How Has This Been Tested?
- [x] SDR/SDR on SDR canvas with SDR stinger, track matte
- [x] SDR/EDR on SDR canvas with SDR stinger, track matte
- [x] EDR/EDR on SDR canvas with SDR stinger, track matte
- [x] SDR/SDR on HDR canvas with SDR stinger, track matte
- [x] SDR/EDR on HDR canvas with SDR stinger, track matte
- [x] EDR/EDR on HDR canvas with SDR stinger, track matte
- [x] SDR/SDR on SDR canvas with SDR stinger, not track matte
- [x] SDR/EDR on SDR canvas with SDR stinger, not track matte
- [x] EDR/EDR on SDR canvas with SDR stinger, not track matte
- [x] SDR/SDR on HDR canvas with SDR stinger, not track matte
- [x] SDR/EDR on HDR canvas with SDR stinger, not track matte
- [x] EDR/EDR on HDR canvas with SDR stinger, not track matte
- [x] SDR/SDR on SDR canvas with HDR stinger, not track matte
- [x] SDR/EDR on SDR canvas with HDR stinger, not track matte
- [x] EDR/EDR on SDR canvas with HDR stinger, not track matte
- [x] SDR/SDR on HDR canvas with HDR stinger, not track matte
- [x] SDR/EDR on HDR canvas with HDR stinger, not track matte
- [x] EDR/EDR on HDR canvas with HDR stinger, not track matte

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.