### PR TITLE
obs-transitions: Reduce code duplication

### DIFF
--- a/plugins/obs-transitions/data/fade_transition.effect
+++ b/plugins/obs-transitions/data/fade_transition.effect
@@ -41,27 +41,19 @@ float4 Fade(FragData f_in)
 	float4 a_val = tex_a.Sample(textureSampler, f_in.uv);
 	float4 b_val = tex_b.Sample(textureSampler, f_in.uv);
 	float4 rgba = lerp(a_val, b_val, fade_val);
-	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
 	return rgba;
 }
 
 float4 PSFade(FragData f_in) : TARGET
 {
 	float4 rgba = Fade(f_in);
-	return rgba;
-}
-
-float4 FadeLinear(FragData f_in)
-{
-	float4 a_val = tex_a.Sample(textureSampler, f_in.uv);
-	float4 b_val = tex_b.Sample(textureSampler, f_in.uv);
-	float4 rgba = lerp(a_val, b_val, fade_val);
+	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
 	return rgba;
 }
 
 float4 PSFadeLinear(FragData f_in) : TARGET
 {
-	float4 rgba = FadeLinear(f_in);
+	float4 rgba = Fade(f_in);
 	return rgba;
 }
 


### PR DESCRIPTION
### Description
Simplified fade effect shader code.

### Motivation and Context
Maintainability.

### How Has This Been Tested?
Tested both nonlinear and linear paths still faded correctly.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.