### PR TITLE
UI: Fix close display before native surfaces

### DIFF
--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -33,17 +33,21 @@ protected:
 		case QEvent::PlatformSurface:
 			surfaceEvent =
 				static_cast<QPlatformSurfaceEvent *>(event);
-			if (surfaceEvent->surfaceEventType() !=
-			    QPlatformSurfaceEvent::SurfaceCreated)
-				return result;
 
-			if (display->windowHandle()->isExposed())
-				createOBSDisplay();
-			else
-				mTimerId = startTimer(67); // Arbitrary
-			break;
-		case QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed:
-			display->DestroyDisplay();
+			switch (surfaceEvent->surfaceEventType()) {
+			case QPlatformSurfaceEvent::SurfaceCreated:
+				if (display->windowHandle()->isExposed())
+					createOBSDisplay();
+				else
+					mTimerId = startTimer(67); // Arbitrary
+				break;
+			case QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed:
+				display->DestroyDisplay();
+				break;
+			default:
+				break;
+			}
+
 			break;
 		case QEvent::Expose:
 			createOBSDisplay();
@@ -55,7 +59,7 @@ protected:
 		return result;
 	}
 
-	void timerEvent(QTimerEvent *)
+	void timerEvent(QTimerEvent *) override
 	{
 		createOBSDisplay(display->isVisible());
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

A QPlatformSurfaceEvent constant is used in a switch that only accept
QEvent type.

Meaning that `QPlatformSurfaceEvent::SurfaceAboutToBeDestroyed` (1) is casted to `QEvent::Timer` (1).

timerEvent() is missing the override keyword.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

While I was working on #6759, I decided to try to build with Clang on Linux to check and found warnings related to what this PR is actually fixing.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

With Weston on my GNOME (X11) on my NVIDIA machine, no hang while closing properties and filter windows.

~~Need the Flatpak artifacts to test it on my Wayland machine easily.~~
No issue on my Wayland machine with the Flatpak artifact.

Needs surely same testing as #6487.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
