### PR TITLE
UI: Deduplicate UI element names

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -5567,7 +5567,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QScrollArea" name="scrollArea_6">
+          <widget class="QScrollArea" name="scrollArea_7">
            <property name="frameShape">
             <enum>QFrame::NoFrame</enum>
            </property>
@@ -5600,7 +5600,7 @@
               <number>9</number>
              </property>
              <item>
-              <layout class="QVBoxLayout" name="verticalLayout_6" stretch="0,0">
+              <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,0">
                <item>
                 <widget class="QGroupBox" name="colorsGroupBox">
                  <property name="sizePolicy">
@@ -5618,7 +5618,7 @@
                  <property name="checked">
                   <bool>false</bool>
                  </property>
-                 <layout class="QFormLayout" name="formLayout_7">
+                 <layout class="QFormLayout" name="formLayout_8">
                   <property name="labelAlignment">
                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                   </property>
@@ -6684,7 +6684,7 @@
                 </widget>
                </item>
                <item>
-                <spacer name="verticalSpacer_4">
+                <spacer name="verticalSpacer_7">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
                  </property>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
UI: Deduplicate UI element names

Prevent some warnings from AutoUIC.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want to avoid warnings. Even if UIC will automatically rename these and these don't prevent compiling, we should just fix them.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled locally. AutoUIC warnings were gone. OBS built and ran fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
