### PR TITLE
CI: Restore output of cmake configuration on Windows with Qt version

### DIFF
--- a/CI/include/build_support_windows.ps1
+++ b/CI/include/build_support_windows.ps1
@@ -101,6 +101,43 @@ function Ensure-Directory {
     Set-Location -Path $Directory
 }
 
+function Invoke-External {
+    <#
+        .SYNOPSIS
+            Invokes a non-PowerShell command.
+        .DESCRIPTION
+            Runs a non-PowerShell command, and captures its return code.
+            Throws an exception if the command returns non-zero.
+        .EXAMPLE
+            Invoke-External 7z x $MyArchive
+    #>
+
+    if ( $args.Count -eq 0 ) {
+        throw 'Invoke-External called without arguments.'
+    }
+
+    $Command = $args[0]
+    $CommandArgs = @()
+
+    if ( $args.Count -gt 1) {
+        $CommandArgs = $args[1..($args.Count - 1)]
+    }
+
+    $_EAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+
+    Write-Debug "Invoke-External: ${Command} ${CommandArgs}"
+
+    & $command $commandArgs
+    $Result = $LASTEXITCODE
+
+    $ErrorActionPreference = $_EAP
+
+    if ( $Result -ne 0 ) {
+        throw "${Command} ${CommandArgs} exited with non-zero code ${Result}."
+    }
+}
+
 $BuildDirectory = "$(if (Test-Path Env:BuildDirectory) { $env:BuildDirectory } else { $BuildDirectory })"
 $BuildConfiguration = "$(if (Test-Path Env:BuildConfiguration) { $env:BuildConfiguration } else { $BuildConfiguration })"
 $BuildArch = "$(if (Test-Path Env:BuildArch) { $env:BuildArch } else { $BuildArch })"

--- a/CI/windows/02_build_obs.ps1
+++ b/CI/windows/02_build_obs.ps1
@@ -43,7 +43,7 @@ function Build-OBS {
 
     $BuildDirectoryActual = "${BuildDirectory}$(if (${BuildArch} -eq "x64") { "64" } else { "32" })"
 
-    Invoke-Expression "cmake --build ${BuildDirectoryActual} --config ${BuildConfiguration}"
+    Invoke-External cmake --build "${BuildDirectoryActual}" --config ${BuildConfiguration}
 }
 
 function Configure-OBS {
@@ -64,8 +64,7 @@ function Configure-OBS {
     $GeneratorPlatform = "$(if (${BuildArch} -eq "x64") { "x64" } else { "Win32" })"
 
     $CmakeCommand = @(
-        "-S . -B `"${BuildDirectoryActual}`"",
-        "-G `"${CmakeGenerator}`"",
+        "-G", ${CmakeGenerator}
         "-DCMAKE_GENERATOR_PLATFORM=`"${GeneratorPlatform}`"",
         "-DCMAKE_SYSTEM_VERSION=`"${CmakeSystemVersion}`"",
         "-DCMAKE_PREFIX_PATH:PATH=`"${CmakePrefixPath}`"",
@@ -90,7 +89,7 @@ function Configure-OBS {
         "$(if (Test-Path Variable:$Quiet) { "-Wno-deprecated -Wno-dev --log-level=ERROR" })"
     )
 
-    Invoke-Expression "cmake ${CmakeCommand}"
+    Invoke-External cmake -S . -B  "${BuildDirectoryActual}" @CmakeCommand
 
     Ensure-Directory ${CheckoutDir}
 }

--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -368,6 +368,7 @@ macro(find_qt)
           6
           CACHE INTERNAL "")
     endif()
+    obs_status(STATUS "Qt version: ${_QT_VERSION}")
   elseif(NOT _QT_VERSION)
     if(TARGET Qt${QT_VERSION}::Core)
       set(_QT_VERSION
@@ -390,6 +391,7 @@ macro(find_qt)
             CACHE INTERNAL "")
       endif()
     endif()
+    obs_status(STATUS "Qt version: ${_QT_VERSION}")
   endif()
 
   set(QT_NO_CREATE_VERSIONLESS_TARGETS OFF)


### PR DESCRIPTION
### Description
Restores the configuration output of CMake on Windows and adds the selected Qt version.

### Motivation and Context
Allows better insight into how the Windows build is configured on CI and also enables quicker check for the Qt version selected for a build.

### How Has This Been Tested?
Needs to be tested on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
