### PR TITLE
UI: JXR screenshots on Windows

### DIFF
--- a/UI/screenshot-obj.hpp
+++ b/UI/screenshot-obj.hpp
@@ -36,6 +36,7 @@ public:
 	OBSWeakSource weakSource;
 	std::string path;
 	QImage image;
+	std::vector<uint8_t> half_bytes;
 	uint32_t cx;
 	uint32_t cy;
 	std::thread th;


### PR DESCRIPTION
### Description
Use JXR for HDR video on Windows. Other operating systems will tonemap
HDR to SDR, and save to PNG. Continue to take PNG screenshots for SDR.
We will probably support EXR for Mac/Linux someday.

### Motivation and Context
Want to be able to take HDR screenshots.

### How Has This Been Tested?
Verified JXR and PNG outputs look correct on Windows.

Verified PNG output on Mac for SDR and HDR.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.