### PR TITLE
CI: Use xcrun notarytool instead of xcnotary

### DIFF
--- a/CI/include/build_support_macos.sh
+++ b/CI/include/build_support_macos.sh
@@ -157,7 +157,7 @@ read_codesign_ident() {
 #   + Your Apple developer ID is needed for notarization
 #   + An app-specific password is necessary for notarization from CLI
 #   + This password will be stored in your macOS keychain under the identifier
-#     'OBS-Codesign-Password' with access Apple's 'altool' only.
+#     'OBS-Codesign-Password' with access Apple's 'notarytool' only.
 ##############################################################################
 
 read_codesign_pass() {
@@ -174,8 +174,8 @@ read_codesign_pass() {
 
     step "Update notarization keychain..."
 
-    echo -n "${COLOR_ORANGE}"
-    /usr/bin/xcrun altool --store-password-in-keychain-item "OBS-Codesign-Password" -u "${CODESIGN_IDENT_USER}" -p "${CODESIGN_IDENT_PASS}"
-    echo -n "${COLOR_RESET}"
     CODESIGN_IDENT_SHORT=$(echo "${CODESIGN_IDENT}" | /usr/bin/sed -En "s/.+\((.+)\)/\1/p")
+    echo -n "${COLOR_ORANGE}"
+    /usr/bin/xcrun notarytool store-credentials "OBS-Codesign-Password" --apple-id "${CODESIGN_IDENT_USER}" --team-id "${CODESIGN_IDENT_SHORT}" --password "${CODESIGN_IDENT_PASS}"
+    echo -n "${COLOR_RESET}"
 }

--- a/CI/macos/03_package_obs.sh
+++ b/CI/macos/03_package_obs.sh
@@ -47,31 +47,21 @@ notarize_obs() {
         exit 1
     fi
 
-    if ! exists xcnotary; then
-        step "Install notarization dependency 'xcnotary'"
-        brew install akeru-inc/tap/xcnotary
-    fi
-
     ensure_dir "${CHECKOUT_DIR}"
 
     if [ "${NOTARIZE_IMAGE}" ]; then
-        trap "_caught_error_xcnotary '${NOTARIZE_IMAGE}'" ERR
+        trap "_caught_error_hdiutil_verify '${NOTARIZE_IMAGE}'" ERR
 
-        step "Attach OBS disk image ${NOTARIZE_IMAGE}..."
-        hdiutil attach -readonly -noverify -noautoopen -quiet "${NOTARIZE_IMAGE}"
+        step "Verify OBS disk image ${NOTARIZE_IMAGE}..."
+        hdiutil verify "${NOTARIZE_IMAGE}"
 
-        VOLUME_NAME=$(hdiutil info -plist | grep "/Volumes/OBS-" | sed 's/<string>\/Volumes\/\([^<]*\)<\/string>/\1/' | sed -e 's/^[[:space:]]*//')
-        PRECHECK="/Volumes/${VOLUME_NAME}/OBS.app"
         NOTARIZE_TARGET="${NOTARIZE_IMAGE}"
     elif [ "${NOTARIZE_BUNDLE}" ]; then
-        PRECHECK="${NOTARIZE_BUNDLE}"
         NOTARIZE_TARGET="${NOTARIZE_BUNDLE}"
     else
         OBS_IMAGE="${BUILD_DIR}/${FILE_NAME}"
 
         if [ -f "${OBS_IMAGE}" ]; then
-            OBS_BUNDLE=$(/usr/bin/find "${BUILD_DIR}/_CPack_Packages" -type d -name "OBS.app")
-            PRECHECK="${OBS_BUNDLE}"
             NOTARIZE_TARGET="${OBS_IMAGE}"
         else
             error "No notarization application bundle ('OBS.app') or disk image ('${NOTARIZE_IMAGE:-${FILE_NAME}}') found"
@@ -79,30 +69,20 @@ notarize_obs() {
         fi
     fi
 
-    step "Run notarization pre-checks on OBS.app..."
-    xcnotary precheck "${PRECHECK}"
-
     if [ "$?" -eq 0 ]; then
         read_codesign_ident
         read_codesign_pass
 
-        step "Run xcnotary with ${NOTARIZE_TARGET}..."
-        xcnotary notarize "${NOTARIZE_TARGET}" --developer-account "${CODESIGN_IDENT_USER}" --developer-password-keychain-item "OBS-Codesign-Password" --provider "${CODESIGN_IDENT_SHORT}"
-    fi
+        step "Notarize ${NOTARIZE_TARGET}..."
+        /usr/bin/xcrun notarytool submit "${NOTARIZE_TARGET}" --keychain-profile "OBS-Codesign-Password" --wait
 
-    if [ "${NOTARIZE_IMAGE}" -a -d "/Volumes/${VOLUME_NAME}" ]; then
-        step "Detach OBS disk image ${NOTARIZE_IMAGE}..."
-        hdiutil detach "/Volumes/${VOLUME_NAME}" -quiet
+        step "Staple the ticket to ${NOTARIZE_TARGET}..."
+        /usr/bin/xcrun stapler staple "${NOTARIZE_TARGET}"
     fi
 }
 
-_caught_error_xcnotary() {
-    error "ERROR during notarization of image '${1}'"
-
-    if [ -d "/Volumes/${1}" ]; then
-        step "Detach OBS disk image ${1}..."
-        hdiutil detach "/Volumes/${1}" -quiet
-    fi
+_caught_error_hdiutil_verify() {
+    error "ERROR during verifying image '${1}'"
 
     cleanup
     exit 1


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR replaces the third party tool `xcnotary` with Apple's `xcrun notarytool`.

The command `xcnotary precheck` implements these check points. However there is no equivalent steps provided by notarytool so that the checks are omitted. Though the checks are omitted, at least some of them are checked on the notarization server so that it should not be a critical issue.
- DeveloperIdCheck
- HardenedRuntimeCheck
- NoGetTaskAllowCheck
- SecureTimestampCheck

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

`xcnotary` is discontinued since Apple now provides `xcrun notarytool`. See their README.md for details.
https://github.com/akeru-inc/xcnotary

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Run the flow with my own credential and confirm the notarization succeeded.
https://github.com/norihiro/obs-studio/actions/runs/2761096817

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
