### PR TITLE
aja: Only allow output formats matching OBS framerate

### DIFF
--- a/plugins/aja/aja-common.hpp
+++ b/plugins/aja/aja-common.hpp
@@ -42,7 +42,7 @@ extern void populate_io_selection_output_list(const std::string &cardID,
 extern void
 populate_video_format_list(NTV2DeviceID deviceID, obs_property_t *list,
 			   NTV2VideoFormat genlockFormat = NTV2_FORMAT_UNKNOWN,
-			   bool want4KHFR = false);
+			   bool want4KHFR = false, bool matchFPS = false);
 extern void populate_pixel_format_list(NTV2DeviceID deviceID,
 				       obs_property_t *list);
 extern void populate_sdi_transport_list(obs_property_t *list,

--- a/plugins/aja/aja-output.cpp
+++ b/plugins/aja/aja-output.cpp
@@ -19,6 +19,8 @@
 // Log AJA Output video/audio delay and av-sync
 // #define AJA_OUTPUT_STATS
 
+#define MATCH_OBS_FRAMERATE true
+
 static constexpr uint32_t kNumCardFrames = 3;
 static const int64_t kDefaultStatPeriod = 3000000000;
 static const int64_t kAudioSyncAdjust = 20000;
@@ -849,7 +851,7 @@ bool aja_output_device_changed(void *data, obs_properties_t *props,
 
 	obs_property_list_clear(vid_fmt_list);
 	populate_video_format_list(deviceID, vid_fmt_list, videoFormatChannel1,
-				   false);
+				   false, MATCH_OBS_FRAMERATE);
 
 	obs_property_list_clear(pix_fmt_list);
 	populate_pixel_format_list(deviceID, pix_fmt_list);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR causes the AJA Output plugin UI to only show video formats in the list if their underlying frame rate matches the current OBS canvas frame rate. The setting is placed behind an ifdef so that we can eventually add and test an algorithm to support incongruous frame rates.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The current AJA Output plugin can handle small frame rate discrepancies but larger differences would require adding an algorithm to drop or dupe frames when needed.

Additionally, the DeckLink plugin has the same behavior, so this change also adds some UI consistency between similar features.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested by selecting all OBS frame rates, and ensuring that the AJA output video format list either shows an empty list when a rate is selected for which there is no available AJA format, or we show the AJA formats which match the selected frame rate.
For example, if 29.97 is selected, we show:
```
NTSC
1080i29.97
1080p29.97
1080sF29.97
2Kp29.97
2KsF29.97
UHDp29.97
4Kp29.97
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
