### PR TITLE
mac-capture: Don't exclude desktop windows in SCK window capture

### DIFF
--- a/plugins/mac-capture/mac-screen-capture.m
+++ b/plugins/mac-capture/mac-screen-capture.m
@@ -947,17 +947,6 @@ static bool build_application_list(struct screen_capture *sc,
 	return true;
 }
 
-static bool content_changed(struct screen_capture *sc, obs_properties_t *props)
-{
-	screen_capture_build_content_list(sc);
-
-	build_display_list(sc, props);
-	build_window_list(sc, props);
-	build_application_list(sc, props);
-
-	return true;
-}
-
 static bool content_settings_changed(void *data, obs_properties_t *props,
 				     obs_property_t *list
 				     __attribute__((unused)),
@@ -1006,7 +995,12 @@ static bool content_settings_changed(void *data, obs_properties_t *props,
 	sc->show_hidden_windows =
 		obs_data_get_bool(settings, "show_hidden_windows");
 
-	return content_changed(sc, props);
+	screen_capture_build_content_list(sc);
+	build_display_list(sc, props);
+	build_window_list(sc, props);
+	build_application_list(sc, props);
+
+	return true;
 }
 
 static obs_properties_t *screen_capture_properties(void *data)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When looking for content, we exclude the desktop windows (mainly wallpaper) to keep the list in window capture smaller.
However, due to a bug with SCK on macOS 12 we have to use this same list to populate the display.
This means that we need to exclude them when the user has Window Capture selected, but include them for Display Capture so that they appears on screen there.

This PR assumes that the only reason that they are excluded is the window capture list length. @PatTheMav will still need to confirm this. Should there be other reasons for the exclusion this PR might not be a good idea.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes the desktop wallpaper missing on Display Capture on macOS 12

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13
Changed the guard to macOS 14 so that I used the same method to capture the display as macOS 12 would. Without this change, the wallpaper is missing, with the change it exists.
Confirmed window list for window capture still doesn't show them.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
