### PR TITLE
graphics-hook: Track DXGI status with counter

### DIFF
--- a/plugins/win-capture/graphics-hook/d3d12-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d12-capture.cpp
@@ -45,7 +45,7 @@ struct d3d12_data {
 
 static struct d3d12_data data = {};
 
-extern thread_local bool dxgi_presenting;
+extern thread_local int dxgi_presenting;
 extern ID3D12CommandQueue *dxgi_possible_swap_queues[8];
 extern size_t dxgi_possible_swap_queue_count;
 extern bool dxgi_present_attempted;
@@ -375,7 +375,7 @@ hook_execute_command_lists(ID3D12CommandQueue *queue, UINT NumCommandLists,
 
 	if (dxgi_possible_swap_queue_count <
 	    _countof(dxgi_possible_swap_queues)) {
-		if (dxgi_presenting &&
+		if ((dxgi_presenting > 0) &&
 		    (queue->GetDesc().Type == D3D12_COMMAND_LIST_TYPE_DIRECT)) {
 			if (try_append_queue_if_unique(queue)) {
 				hlog("Remembering D3D12 queue from present: queue=0x%" PRIX64,

--- a/plugins/win-capture/graphics-hook/dxgi-capture.cpp
+++ b/plugins/win-capture/graphics-hook/dxgi-capture.cpp
@@ -25,7 +25,7 @@ resize_buffers_t RealResizeBuffers = nullptr;
 present_t RealPresent = nullptr;
 present1_t RealPresent1 = nullptr;
 
-thread_local bool dxgi_presenting = false;
+thread_local int dxgi_presenting = 0;
 struct ID3D12CommandQueue *dxgi_possible_swap_queues[8]{};
 size_t dxgi_possible_swap_queue_count;
 bool dxgi_present_attempted = false;
@@ -223,9 +223,9 @@ static HRESULT STDMETHODCALLTYPE hook_present(IDXGISwapChain *swap,
 		}
 	}
 
-	dxgi_presenting = true;
+	++dxgi_presenting;
 	const HRESULT hr = RealPresent(swap, sync_interval, flags);
-	dxgi_presenting = false;
+	--dxgi_presenting;
 	dxgi_present_attempted = true;
 
 	if (capture && capture_overlay) {
@@ -282,9 +282,9 @@ hook_present1(IDXGISwapChain1 *swap, UINT sync_interval, UINT flags,
 		}
 	}
 
-	dxgi_presenting = true;
+	++dxgi_presenting;
 	const HRESULT hr = RealPresent1(swap, sync_interval, flags, params);
-	dxgi_presenting = false;
+	--dxgi_presenting;
 	dxgi_present_attempted = true;
 
 	if (capture && capture_overlay) {


### PR DESCRIPTION
### Description
Previous approach could mark Present exit too early.

### Motivation and Context
Better queue heuristics can lead to more reliable capture.

### How Has This Been Tested?
Verified D3D12HDR sample still captures.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.