### PR TITLE
CI: Fix Sparkle cache location for local macOS CI build

### DIFF
--- a/CI/macos/01_install_dependencies.sh
+++ b/CI/macos/01_install_dependencies.sh
@@ -70,7 +70,7 @@ install_sparkle() {
 
     if [ "${CI}" -a "${RESTORED_SPARKLE}" ]; then
         _SKIP=TRUE
-    elif [ -d "${DEPS_BUILD_DIR}/obs-deps/Frameworks/Sparkle.framework" -a -f "${DEPS_BUILD_DIR}/obs-deps/Frameworks/Sparkle.framework/Sparkle" ]; then
+    elif [ -d "${DEPS_BUILD_DIR}/obs-deps/lib/Sparkle.framework" -a -f "${DEPS_BUILD_DIR}/obs-deps/lib/Sparkle.framework/Sparkle" ]; then
         _SKIP=TRUE
     fi
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Fixes the Sparkle cache location for the local macOS CI build, by changing it from `"${DEPS_BUILD_DIR}/obs-deps/Frameworks/Sparkle.framework` to `${DEPS_BUILD_DIR}/obs-deps/lib/Sparkle.framework`.

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context

I've been building OBS Studio a lot from source recently using `./CI/build-macOS.sh --bundle`, and whilst the first build works successfully, the second build fails with the following error:

```
[OBS-Studio] Set up dependency Sparkle v1.26.0
  + Download...
  + Sparkle-1.26.0.tar.xz exists and passed hash check
  + Unpack...
cp: cannot overwrite directory /Users/carrot/git/obs-studio/../obs-build-dependencies/obs-deps/lib/Sparkle.framework/PrivateHeaders with non-directory /Users/carrot/git/obs-studio/../obs-build-dependencies/sparkle/Sparkle.framework/PrivateHeaders
cp: cannot overwrite directory /Users/carrot/git/obs-studio/../obs-build-dependencies/obs-deps/lib/Sparkle.framework/Resources with non-directory /Users/carrot/git/obs-studio/../obs-build-dependencies/sparkle/Sparkle.framework/Resources
cp: cannot overwrite directory /Users/carrot/git/obs-studio/../obs-build-dependencies/obs-deps/lib/Sparkle.framework/Versions/Current with non-directory /Users/carrot/git/obs-studio/../obs-build-dependencies/sparkle/Sparkle.framework/Versions/Current
cp: cannot overwrite directory /Users/carrot/git/obs-studio/../obs-build-dependencies/obs-deps/lib/Sparkle.framework/Headers with non-directory /Users/carrot/git/obs-studio/../obs-build-dependencies/sparkle/Sparkle.framework/Headers
cp: cannot overwrite directory /Users/carrot/git/obs-studio/../obs-build-dependencies/obs-deps/lib/Sparkle.framework/Modules with non-directory /Users/carrot/git/obs-studio/../obs-build-dependencies/sparkle/Sparkle.framework/Modules
  + ERROR during build step: sparkle
```

This is because the "skip check" looked in the wrong location, so Sparkle has already been extracted in to the location where it's attempting to unpack it, resulting in an error. The `Frameworks` folder the CI script references doesn't exist, so I suspect it's just a hangover from the changes in https://github.com/obsproject/obs-studio/pull/5155

Without this patch, I had to run this between builds: `rm -rf ~/git/obs-build-dependencies/obs-deps/lib/Sparkle.framework`.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?

I tested the change with a fresh clone (and removing the `../obs-dependencies` folder), running `./CI/build-macOS.sh --bundle`, and then doing a second `./CI/build-macOS.sh --bundle`.

Before the patch, the second build would fail with the error noted above.

After the patch, it works successfully and builds a new bundle:
```
[OBS-Studio] Set up dependency Sparkle v1.26.0
  + Found existing Sparkle Framework...
```

I'm running macOS 12.5 on a Mac Studio.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.