### PR TITLE
libobs: Fix memory leak when load_module_exports failed

### DIFF
--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -126,8 +126,11 @@ int obs_open_module(obs_module_t **module, const char *path,
 	}
 
 	errorcode = load_module_exports(&mod, path);
-	if (errorcode != MODULE_SUCCESS)
+	if (errorcode != MODULE_SUCCESS) {
+		blog(LOG_WARNING, "Module '%s' missing exports", path);
+		os_dlclose(mod.module);
 		return errorcode;
+	}
 
 	mod.bin_path = bstrdup(path);
 	mod.file = strrchr(mod.bin_path, '/');


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Release `mod.module` when an error is detected after the module was successfully opened.

Also add a warning message that the module is failed to load exports.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

When reading plugin files and `load_module_exports` failed, the object should be released before returning an error code but was not released. This is a memory leak.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Added a random shared object into the plugin directory and checked the module is released.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
