### PR TITLE
obs-ffmpeg: Disable audio if no audio in source

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -728,6 +728,9 @@ static bool init_avformat(mp_media_t *m)
 	m->has_video = mp_decode_init(m, AVMEDIA_TYPE_VIDEO, m->hw);
 	m->has_audio = mp_decode_init(m, AVMEDIA_TYPE_AUDIO, m->hw);
 
+	if (m->set_a_cb)
+		m->set_a_cb(m->opaque, m->has_audio);
+
 	if (!m->has_video && !m->has_audio) {
 		blog(LOG_WARNING,
 		     "MP: Could not initialize audio or video: "
@@ -880,6 +883,7 @@ bool mp_media_init(mp_media_t *media, const struct mp_media_info *info)
 	media->v_cb = info->v_cb;
 	media->a_cb = info->a_cb;
 	media->stop_cb = info->stop_cb;
+	media->set_a_cb = info->set_a_cb;
 	media->ffmpeg_options = info->ffmpeg_options;
 	media->v_seek_cb = info->v_seek_cb;
 	media->v_preload_cb = info->v_preload_cb;

--- a/deps/media-playback/media-playback/media.h
+++ b/deps/media-playback/media-playback/media.h
@@ -41,6 +41,7 @@ extern "C" {
 typedef void (*mp_video_cb)(void *opaque, struct obs_source_frame *frame);
 typedef void (*mp_audio_cb)(void *opaque, struct obs_source_audio *audio);
 typedef void (*mp_stop_cb)(void *opaque);
+typedef void (*mp_set_audio_cb)(void *opaque, bool have_audio);
 
 struct mp_media {
 	AVFormatContext *fmt;
@@ -50,6 +51,7 @@ struct mp_media {
 	mp_stop_cb stop_cb;
 	mp_video_cb v_cb;
 	mp_audio_cb a_cb;
+	mp_set_audio_cb set_a_cb;
 	void *opaque;
 
 	char *path;
@@ -116,6 +118,7 @@ struct mp_media_info {
 	mp_video_cb v_seek_cb;
 	mp_audio_cb a_cb;
 	mp_stop_cb stop_cb;
+	mp_set_audio_cb set_a_cb;
 
 	const char *path;
 	const char *format;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -302,6 +302,12 @@ static void media_stopped(void *opaque)
 	obs_source_media_ended(s->source);
 }
 
+static void set_audio(void *opaque, bool have_audio)
+{
+	struct ffmpeg_source *s = opaque;
+	obs_source_set_audio_active(s->source, have_audio);
+}
+
 static void ffmpeg_source_open(struct ffmpeg_source *s)
 {
 	if (s->input && *s->input) {
@@ -311,6 +317,7 @@ static void ffmpeg_source_open(struct ffmpeg_source *s)
 			.v_preload_cb = preload_frame,
 			.v_seek_cb = seek_frame,
 			.a_cb = get_audio,
+			.set_a_cb = set_audio,
 			.stop_cb = media_stopped,
 			.path = s->input,
 			.format = s->input_format,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Disable media source audio output if source doesn't have audio.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Avoid to display audio mixer entry for media source without audio

Partially implement this idea : https://ideas.obsproject.com/posts/1125
And : 
https://ideas.obsproject.com/posts/797

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Mac os 11.6 Intel
Test with media file with and without audio
- File with audio still play audio
- File without audio didn't display audio mixer entry anymore

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
