### PR TITLE
CI: Fix Linux package filename version

### DIFF
--- a/CI/linux/03_package_obs.sh
+++ b/CI/linux/03_package_obs.sh
@@ -44,7 +44,7 @@ package-obs-standalone() {
     GIT_HASH=$(git rev-parse --short=9 HEAD)
     GIT_TAG=$(git describe --tags --abbrev=0)
 
-    if [ "${BUILD_FOR_DISTRIBUTION}" ]; then
+    if [ "${BUILD_FOR_DISTRIBUTION}" = "true" ]; then
         VERSION_STRING="${GIT_TAG}"
     else
         VERSION_STRING="${GIT_TAG}-${GIT_HASH}"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
In [`.github/workflows/main.yml`](https://github.com/obsproject/obs-studio/blob/8af6b79044c2d4176a915884c4c76b9a836828ab/.github/workflows/main.yml), for the linux_build job, the variable BUILD_FOR_DISTRIBUTION is set to the string "true" or "false" on CI. Later, in `CI/linux/03_package_obs.sh`, we perform a boolean check on this variable. However, "false" will evaluate as true, because it is a non-null string. This was causing CI Linux packages to always build as if BUILD_FOR_DISTRIBUTION was enabled, which caused the git commit hash to be omitted from package filenames.

Since we know the expected values, let's just test directly if the variable equals "true" to get the expected behavior.

https://github.com/obsproject/obs-studio/blob/8af6b79044c2d4176a915884c4c76b9a836828ab/.github/workflows/main.yml#L212

https://github.com/obsproject/obs-studio/blob/8af6b79044c2d4176a915884c4c76b9a836828ab/CI/linux/03_package_obs.sh#L47

CI linux_build "Setup build environment" step log:
>      BUILD_FOR_DISTRIBUTION: false
![image](https://user-images.githubusercontent.com/624931/181961427-04b2d9ad-dcb5-4e81-9bf5-2f834fcac2b2.png)


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want predictable behavior from CI.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on an Ubuntu 22.04 VM.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
