### PR TITLE
libobs: obs-ffmpeg: Fix some chroma locations

### DIFF
--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -299,13 +299,11 @@ float2 PS_P010_HLG_UV_709_2020_WideWide(FragTexWideWide frag_in) : TARGET
 	return uv;
 }
 
-float2 PS_P010_SRGB_UV_WideWide(FragTexWideWide frag_in) : TARGET
+float2 PS_P010_SRGB_UV_Wide(FragTexWide frag_in) : TARGET
 {
-	float3 rgb_topleft = image.Sample(def_sampler, frag_in.uuvv.xz).rgb;
-	float3 rgb_topright = image.Sample(def_sampler, frag_in.uuvv.yz).rgb;
-	float3 rgb_bottomleft = image.Sample(def_sampler, frag_in.uuvv.xw).rgb;
-	float3 rgb_bottomright = image.Sample(def_sampler, frag_in.uuvv.yw).rgb;
-	float3 rgb = (rgb_topleft + rgb_topright + rgb_bottomleft + rgb_bottomright) * 0.25;
+	float3 rgb_left = image.Sample(def_sampler, frag_in.uuv.xz).rgb;
+	float3 rgb_right = image.Sample(def_sampler, frag_in.uuv.yz).rgb;
+	float3 rgb = (rgb_left + rgb_right) * 0.5;
 	rgb = srgb_linear_to_nonlinear(rgb);
 	float u = dot(color_vec1.xyz, rgb) + color_vec1.w;
 	float v = dot(color_vec2.xyz, rgb) + color_vec2.w;
@@ -372,13 +370,11 @@ float PS_I010_HLG_U_709_2020_WideWide(FragTexWideWide frag_in) : TARGET
 	return u * (1023. / 65535.);
 }
 
-float PS_I010_SRGB_U_WideWide(FragTexWideWide frag_in) : TARGET
+float PS_I010_SRGB_U_Wide(FragTexWide frag_in) : TARGET
 {
-	float3 rgb_topleft = image.Sample(def_sampler, frag_in.uuvv.xz).rgb;
-	float3 rgb_topright = image.Sample(def_sampler, frag_in.uuvv.yz).rgb;
-	float3 rgb_bottomleft = image.Sample(def_sampler, frag_in.uuvv.xw).rgb;
-	float3 rgb_bottomright = image.Sample(def_sampler, frag_in.uuvv.yw).rgb;
-	float3 rgb = (rgb_topleft + rgb_topright + rgb_bottomleft + rgb_bottomright) * 0.25;
+	float3 rgb_left = image.Sample(def_sampler, frag_in.uuv.xz).rgb;
+	float3 rgb_right = image.Sample(def_sampler, frag_in.uuv.yz).rgb;
+	float3 rgb = (rgb_left + rgb_right) * 0.5;
 	rgb = srgb_linear_to_nonlinear(rgb);
 	float u = dot(color_vec1.xyz, rgb) + color_vec1.w;
 	return u * (1023. / 65535.);
@@ -410,13 +406,11 @@ float PS_I010_HLG_V_709_2020_WideWide(FragTexWideWide frag_in) : TARGET
 	return v * (1023. / 65535.);
 }
 
-float PS_I010_SRGB_V_WideWide(FragTexWideWide frag_in) : TARGET
+float PS_I010_SRGB_V_Wide(FragTexWide frag_in) : TARGET
 {
-	float3 rgb_topleft = image.Sample(def_sampler, frag_in.uuvv.xz).rgb;
-	float3 rgb_topright = image.Sample(def_sampler, frag_in.uuvv.yz).rgb;
-	float3 rgb_bottomleft = image.Sample(def_sampler, frag_in.uuvv.xw).rgb;
-	float3 rgb_bottomright = image.Sample(def_sampler, frag_in.uuvv.yw).rgb;
-	float3 rgb = (rgb_topleft + rgb_topright + rgb_bottomleft + rgb_bottomright) * 0.25;
+	float3 rgb_left = image.Sample(def_sampler, frag_in.uuv.xz).rgb;
+	float3 rgb_right = image.Sample(def_sampler, frag_in.uuv.yz).rgb;
+	float3 rgb = (rgb_left + rgb_right) * 0.5;
 	rgb = srgb_linear_to_nonlinear(rgb);
 	float v = dot(color_vec2.xyz, rgb) + color_vec2.w;
 	return v * (1023. / 65535.);
@@ -841,8 +835,8 @@ technique I010_SRGB_U
 {
 	pass
 	{
-		vertex_shader = VSTexPos_TopLeft(id);
-		pixel_shader  = PS_I010_SRGB_U_WideWide(frag_in);
+		vertex_shader = VSTexPos_Left(id);
+		pixel_shader  = PS_I010_SRGB_U_Wide(frag_in);
 	}
 }
 
@@ -868,8 +862,8 @@ technique I010_SRGB_V
 {
 	pass
 	{
-		vertex_shader = VSTexPos_TopLeft(id);
-		pixel_shader  = PS_I010_SRGB_V_WideWide(frag_in);
+		vertex_shader = VSTexPos_Left(id);
+		pixel_shader  = PS_I010_SRGB_V_Wide(frag_in);
 	}
 }
 
@@ -922,8 +916,8 @@ technique P010_SRGB_UV
 {
 	pass
 	{
-		vertex_shader = VSTexPos_TopLeft(id);
-		pixel_shader  = PS_P010_SRGB_UV_WideWide(frag_in);
+		vertex_shader = VSTexPos_Left(id);
+		pixel_shader  = PS_P010_SRGB_UV_Wide(frag_in);
 	}
 }
 

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -454,6 +454,10 @@ static void create_video_stream(struct ffmpeg_mux *ffm)
 	context->color_trc = ffm->params.color_trc;
 	context->colorspace = ffm->params.colorspace;
 	context->color_range = ffm->params.color_range;
+	context->chroma_sample_location =
+		(ffm->params.colorspace == AVCOL_SPC_BT2020_NCL)
+			? AVCHROMA_LOC_TOPLEFT
+			: AVCHROMA_LOC_LEFT;
 	context->extradata = extradata;
 	context->extradata_size = ffm->video_header.size;
 	context->time_base =

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -781,11 +781,17 @@ static bool init_encoder_hevc(struct nvenc_data *enc, obs_data_t *settings,
 		vui_params->colourPrimaries = 9;
 		vui_params->transferCharacteristics = 16;
 		vui_params->colourMatrix = 9;
+		vui_params->chromaSampleLocationFlag = 1;
+		vui_params->chromaSampleLocationTop = 2;
+		vui_params->chromaSampleLocationBot = 2;
 		break;
 	case VIDEO_CS_2100_HLG:
 		vui_params->colourPrimaries = 9;
 		vui_params->transferCharacteristics = 18;
 		vui_params->colourMatrix = 9;
+		vui_params->chromaSampleLocationFlag = 1;
+		vui_params->chromaSampleLocationTop = 2;
+		vui_params->chromaSampleLocationBot = 2;
 	}
 
 	enc->bframes = bf;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -193,6 +193,10 @@ static bool create_video_stream(struct ffmpeg_output *stream,
 	context->color_primaries = data->config.color_primaries;
 	context->color_trc = data->config.color_trc;
 	context->colorspace = data->config.colorspace;
+	context->chroma_sample_location =
+		(data->config.colorspace == AVCOL_SPC_BT2020_NCL)
+			? AVCHROMA_LOC_TOPLEFT
+			: AVCHROMA_LOC_LEFT;
 	context->thread_count = 0;
 
 	data->video->time_base = context->time_base;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -152,6 +152,10 @@ static bool open_video_codec(struct ffmpeg_data *data)
 	data->vframe->color_primaries = data->config.color_primaries;
 	data->vframe->color_trc = data->config.color_trc;
 	data->vframe->colorspace = data->config.colorspace;
+	data->vframe->chroma_location =
+		(data->config.colorspace == AVCOL_SPC_BT2020_NCL)
+			? AVCHROMA_LOC_TOPLEFT
+			: AVCHROMA_LOC_LEFT;
 
 	ret = av_frame_get_buffer(data->vframe, base_get_alignment());
 	if (ret < 0) {
@@ -258,6 +262,10 @@ static bool create_video_stream(struct ffmpeg_data *data)
 	context->color_primaries = data->config.color_primaries;
 	context->color_trc = data->config.color_trc;
 	context->colorspace = data->config.colorspace;
+	context->chroma_sample_location =
+		(data->config.colorspace == AVCOL_SPC_BT2020_NCL)
+			? AVCHROMA_LOC_TOPLEFT
+			: AVCHROMA_LOC_LEFT;
 	context->thread_count = 0;
 
 	data->video->time_base = context->time_base;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-video-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-video-encoders.c
@@ -45,8 +45,11 @@ bool ffmpeg_video_encoder_init_codec(struct ffmpeg_video_encoder *enc)
 	enc->vframe->format = enc->context->pix_fmt;
 	enc->vframe->width = enc->context->width;
 	enc->vframe->height = enc->context->height;
-	enc->vframe->colorspace = enc->context->colorspace;
 	enc->vframe->color_range = enc->context->color_range;
+	enc->vframe->color_primaries = enc->context->color_primaries;
+	enc->vframe->color_trc = enc->context->color_trc;
+	enc->vframe->colorspace = enc->context->colorspace;
+	enc->vframe->chroma_location = enc->context->chroma_sample_location;
 
 	ret = av_frame_get_buffer(enc->vframe, base_get_alignment());
 	if (ret < 0) {
@@ -96,11 +99,13 @@ void ffmpeg_video_encoder_update(struct ffmpeg_video_encoder *enc, int bitrate,
 		enc->context->color_primaries = AVCOL_PRI_BT2020;
 		enc->context->color_trc = AVCOL_TRC_SMPTE2084;
 		enc->context->colorspace = AVCOL_SPC_BT2020_NCL;
+		enc->context->chroma_sample_location = AVCHROMA_LOC_TOPLEFT;
 		break;
 	case VIDEO_CS_2100_HLG:
 		enc->context->color_primaries = AVCOL_PRI_BT2020;
 		enc->context->color_trc = AVCOL_TRC_ARIB_STD_B67;
 		enc->context->colorspace = AVCOL_SPC_BT2020_NCL;
+		enc->context->chroma_sample_location = AVCHROMA_LOC_TOPLEFT;
 	}
 
 	if (keyint_sec)


### PR DESCRIPTION
### Description
Update shaders to export 10-bit 4:2:0 SDR video with left chroma instead of top-left.

Update video metadata to indicate top-left chroma for 4:2:0 HDR video.

### Motivation and Context
VLC now indicates correct chroma location for Rec. 2100.

### How Has This Been Tested?
Verified high-precision sRGB video still looks correct.

Verified SDR/HDR videos generated by NVENC has left/top-left locations set in VLC.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.