### PR TITLE
UI: Remove spaces from translation keys

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1720,7 +1720,9 @@ QString OBSTranslator::translate(const char *context, const char *sourceText,
 				 const char *disambiguation, int n) const
 {
 	const char *out = nullptr;
-	if (!App()->TranslateString(sourceText, &out))
+	QString str(sourceText);
+	str.replace(" ", "");
+	if (!App()->TranslateString(QT_TO_UTF8(str), &out))
 		return QString(sourceText);
 
 	UNUSED_PARAMETER(context);


### PR DESCRIPTION
### Description

Qt translation strings use the full English string as an identifier, rather than a standardised key. Meanwhile, .ini files aren't designed
for keys with spaces, so a translation string for "Restore Defaults" won't match unless the ini line is
`"Restore Defaults"="Defaults"`
which is inconsistent, unpleasant and harder to read.

This fixes the "Restore Defaults" button in Filters and Properties to actually be translated using the right key.

### Motivation and Context

In https://github.com/obsproject/obs-studio/commit/dbb063eae6a4b111ef6dabef5aeab5514d4a7b73#diff-fa7b36911cb29093d60306caac7b90c5e9d2d489b8f0ad563c4061be8d18e483R581 I changed the "Defaults" button from a Reset button with a modified label to use the built-in Qt button "Restore Defaults", not realising that the translation key wasn't being applied.

**Alternate solution**: We could simply restore the below code to the dialogs one-by-one, rather than modifying the translation function, which is called every time Qt attempts to render text.

```cpp
	ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)
		->setText(QTStr("Defaults"));
```

Open to feedback on this.

### How Has This Been Tested?

Open the Properties or Filters dialog for a source.

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)
 - Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
