### PR TITLE
cmake: Remove prefix suppression for scripting plugins.

### DIFF
--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -102,8 +102,6 @@ endfunction()
 
 # Helper function to set up OBS scripting plugin targets
 function(setup_script_plugin_target target)
-  set_target_properties(${target} PROPERTIES PREFIX "")
-
   install(
     TARGETS ${target}
     LIBRARY DESTINATION ${OBS_SCRIPT_PLUGIN_DESTINATION}


### PR DESCRIPTION
### Description
Fixes OBSHelpers overwriting the prefix set up by UseSWIG for scripting libraries.

### Motivation and Context
SWIG uses the prefix target property to prefix generated Python libraries with an underscore (so that obspython.py is loaded first, which acts as a shim for the actual _obspython.pyd library on Windows).

Usually the prefix is set to an empty string on Windows (to avoid the automatic "lib" prefix used by CMake), but this also removed the necessary underscore prefix required for the Python library.

### How Has This Been Tested?
Tested with obslua and obspython on Windows 11.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
