### PR TITLE
obs-ffmpeg: Replace ftime on *nix platforms and fix incompatible-pointer-types warning

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -1164,7 +1164,7 @@ static bool write_header(struct ffmpeg_output *stream, struct ffmpeg_data *data)
 	return true;
 }
 
-static bool ffmpeg_mpegts_data(void *data, struct encoder_packet *packet)
+static void ffmpeg_mpegts_data(void *data, struct encoder_packet *packet)
 {
 	struct ffmpeg_output *stream = data;
 	struct ffmpeg_data *ff_data = &stream->ff_data;
@@ -1187,28 +1187,27 @@ static bool ffmpeg_mpegts_data(void *data, struct encoder_packet *packet)
 	}
 
 	if (!stream->active)
-		return 0;
+		return;
 
 	/* encoder failure */
 	if (!packet) {
 		obs_output_signal_stop(stream->output, OBS_OUTPUT_ENCODE_ERROR);
 		ffmpeg_mpegts_deactivate(stream);
-		return 0;
+		return;
 	}
 
 	if (stopping(stream)) {
 		if (packet->sys_dts_usec >= (int64_t)stream->stop_ts) {
 			ffmpeg_mpegts_deactivate(stream);
-			return 0;
+			return;
 		}
 	}
 
 	mpegts_write_packet(stream, packet);
-	return 1;
+	return;
 fail:
 	obs_output_signal_stop(stream->output, code);
 	ffmpeg_mpegts_full_stop(stream);
-	return false;
 }
 
 static obs_properties_t *ffmpeg_mpegts_properties(void *unused)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Replace [ftime](https://man7.org/linux/man-pages/man3/ftime.3.html) by [clock_gettime](https://man7.org/linux/man-pages/man2/clock_gettime.2.html) on *nix platforms.

Newer glibc version deprecated it and on macOS in `timeb.h` ftime is qualified as a "Legacy Interface".

Fix an incompatible-pointer-types warning.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

- ftime is deprecated on newer version of glibc.
- incompatible-pointer-types warning looks bad.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Not used to test SRT and mpegts output, feedbacks about how to test are welcome.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
