### PR TITLE
UI: Remove compatibility for QT < 5.10

### DIFF
--- a/UI/auth-youtube.cpp
+++ b/UI/auth-youtube.cpp
@@ -7,9 +7,7 @@
 #include <QDesktopServices>
 #include <QHBoxLayout>
 #include <QUrl>
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
 #include <QRandomGenerator>
-#endif
 
 #ifdef WIN32
 #include <windows.h>
@@ -200,7 +198,6 @@ void YoutubeAuth::ResetChat()
 
 QString YoutubeAuth::GenerateState()
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
 	char state[YOUTUBE_API_STATE_LENGTH + 1];
 	QRandomGenerator *rng = QRandomGenerator::system();
 	int i;
@@ -210,17 +207,6 @@ QString YoutubeAuth::GenerateState()
 	state[i] = 0;
 
 	return state;
-#else
-	std::uniform_int_distribution<> distr(0, allowedCount);
-	std::string result;
-	result.reserve(YOUTUBE_API_STATE_LENGTH);
-	std::generate_n(std::back_inserter(result), YOUTUBE_API_STATE_LENGTH,
-			[&] {
-				return static_cast<char>(
-					allowedChars[distr(randomSeed)]);
-			});
-	return result.c_str();
-#endif
 }
 
 // Static.

--- a/UI/auth-youtube.hpp
+++ b/UI/auth-youtube.hpp
@@ -40,7 +40,6 @@ class YoutubeAuth : public OAuthStreamKey {
 	Q_OBJECT
 
 	bool uiLoaded = false;
-	std::mt19937 randomSeed;
 	std::string section;
 
 #ifdef BROWSER_AVAILABLE

--- a/UI/obs-proxy-style.cpp
+++ b/UI/obs-proxy-style.cpp
@@ -82,10 +82,8 @@ int OBSIgnoreWheelProxyStyle::styleHint(StyleHint hint,
 					const QWidget *widget,
 					QStyleHintReturn *returnData) const
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 	if (hint == SH_ComboBox_AllowWheelScrolling)
 		return 0;
-#endif
 
 	return QProxyStyle::styleHint(hint, option, widget, returnData);
 }

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -269,11 +269,7 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
 
 	if (type == OBS_TEXT_MULTILINE) {
 		QPlainTextEdit *edit = new QPlainTextEdit(QT_UTF8(val));
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 		edit->setTabStopDistance(40);
-#else
-		edit->setTabStopWidth(40);
-#endif
 		if (monospace) {
 			QFont f("Courier");
 			f.setStyleHint(QFont::Monospace);


### PR DESCRIPTION
### Description

Remove old ifdefs for compatibility with Qt versions prior to 5.10.

### Motivation and Context

Ubuntu 18.04 is dead (to us), long live not having to support an ancient Qt version.

### How Has This Been Tested?

Still compiles with Qt 5.15.

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
