### PR TITLE
UI: Restore color format/space warning

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2656,8 +2656,6 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	ui->autoRemux->setChecked(autoRemux);
 	ui->dynBitrate->setChecked(dynBitrate);
 
-	UpdateColorFormatSpaceWarning();
-
 	SetComboByValue(ui->colorFormat, videoColorFormat);
 	SetComboByValue(ui->colorSpace, videoColorSpace);
 	SetComboByValue(ui->colorRange, videoColorRange);
@@ -4117,12 +4115,12 @@ void OBSBasicSettings::on_advOutFFType_currentIndexChanged(int idx)
 	ui->advOutFFNoSpace->setHidden(idx != 0);
 }
 
-void OBSBasicSettings::on_colorFormat_currentIndexChanged(const QString &)
+void OBSBasicSettings::on_colorFormat_currentIndexChanged(int)
 {
 	UpdateColorFormatSpaceWarning();
 }
 
-void OBSBasicSettings::on_colorSpace_currentIndexChanged(const QString &)
+void OBSBasicSettings::on_colorSpace_currentIndexChanged(int)
 {
 	UpdateColorFormatSpaceWarning();
 }

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -395,8 +395,8 @@ private slots:
 	void on_advOutFFVEncoder_currentIndexChanged(int idx);
 	void on_advOutFFType_currentIndexChanged(int idx);
 
-	void on_colorFormat_currentIndexChanged(const QString &text);
-	void on_colorSpace_currentIndexChanged(const QString &text);
+	void on_colorFormat_currentIndexChanged(int idx);
+	void on_colorSpace_currentIndexChanged(int idx);
 
 	void on_filenameFormatting_textEdited(const QString &text);
 	void on_outputResolution_editTextChanged(const QString &text);


### PR DESCRIPTION
### Description
Callbacks had the wrong signature.

### Motivation and Context
Want warning to be visible.

### How Has This Been Tested?
Warning works again.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.