### PR TITLE
obs-ffmpeg: Make muxers respect ENABLE_HEVC 

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
@@ -319,7 +319,11 @@ struct obs_output_info ffmpeg_hls_muxer = {
 	.id = "ffmpeg_hls_muxer",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_MULTI_TRACK |
 		 OBS_OUTPUT_SERVICE,
+#ifdef ENABLE_HEVC
 	.encoded_video_codecs = "h264;hevc",
+#else
+	.encoded_video_codecs = "h264",
+#endif
 	.encoded_audio_codecs = "aac",
 	.get_name = ffmpeg_hls_mux_getname,
 	.create = ffmpeg_hls_mux_create,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -156,8 +156,13 @@ static bool create_video_stream(struct ffmpeg_output *stream,
 	}
 	if (!new_stream(data, &data->video, name))
 		return false;
-	if ((data->config.color_trc == AVCOL_TRC_SMPTE2084) ||
-	    (data->config.color_trc == AVCOL_TRC_ARIB_STD_B67)) {
+	const bool pq = data->config.color_trc == AVCOL_TRC_SMPTE2084;
+	const bool hlg = data->config.color_trc == AVCOL_TRC_ARIB_STD_B67;
+	if (pq || hlg) {
+		const int hdr_nominal_peak_level =
+			pq ? (int)obs_get_video_hdr_nominal_peak_level()
+			   : (hlg ? 1000 : 0);
+
 		AVMasteringDisplayMetadata *const mastering =
 			av_mastering_display_metadata_alloc();
 		mastering->display_primaries[0][0] = av_make_q(17, 25);
@@ -169,8 +174,7 @@ static bool create_video_stream(struct ffmpeg_output *stream,
 		mastering->white_point[0] = av_make_q(3127, 10000);
 		mastering->white_point[1] = av_make_q(329, 1000);
 		mastering->min_luminance = av_make_q(0, 1);
-		mastering->max_luminance = av_make_q(
-			(int)obs_get_video_hdr_nominal_peak_level(), 1);
+		mastering->max_luminance = av_make_q(hdr_nominal_peak_level, 1);
 		mastering->has_primaries = 1;
 		mastering->has_luminance = 1;
 		av_stream_add_side_data(data->video,
@@ -1226,7 +1230,11 @@ struct obs_output_info ffmpeg_mpegts_muxer = {
 	.id = "ffmpeg_mpegts_muxer",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_MULTI_TRACK |
 		 OBS_OUTPUT_SERVICE,
+#ifdef ENABLE_HEVC
 	.encoded_video_codecs = "h264;hevc;av1",
+#else
+	.encoded_video_codecs = "h264;av1",
+#endif
 	.encoded_audio_codecs = "aac",
 	.get_name = ffmpeg_mpegts_getname,
 	.create = ffmpeg_mpegts_create,


### PR DESCRIPTION
### Description
The encoded_video_codecs field doesn't seem to be used though.

Also update HDR luminance to match pattern.

### Motivation and Context
Demonstrate good ENABLE_HEVC usage, and output desired metadata.

### How Has This Been Tested?
Both muxers work on HEVC even without string, so there's that.

Debugger inspection for HDR luminance.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.