### PR TITLE
media-playback: Fix crash on free

### DIFF
--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -251,11 +251,11 @@ void mp_decode_clear_packets(struct mp_decode *d)
 
 void mp_decode_free(struct mp_decode *d)
 {
-	av_packet_free(&d->pkt);
-	av_packet_free(&d->orig_pkt);
-
 	mp_decode_clear_packets(d);
 	circlebuf_free(&d->packets);
+
+	av_packet_free(&d->pkt);
+	av_packet_free(&d->orig_pkt);
 
 	if (d->hw_frame) {
 		av_frame_unref(d->hw_frame);


### PR DESCRIPTION
### Description
Need to call mp_decode_clear_packets before destroying orig_pkt in case
packet_pending is true.

### Motivation and Context
Don't want to crash.

### How Has This Been Tested?
Verified mp_decode_free doesn't crash for both packet_pending is true and false cases.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.