### PR TITLE
libobs: obs-ffmpeg: Use new priority parsing for HLS

### DIFF
--- a/libobs/obs-avc.h
+++ b/libobs/obs-avc.h
@@ -46,6 +46,7 @@ EXPORT const uint8_t *obs_avc_find_startcode(const uint8_t *p,
 					     const uint8_t *end);
 EXPORT void obs_parse_avc_packet(struct encoder_packet *avc_packet,
 				 const struct encoder_packet *src);
+EXPORT int obs_parse_avc_packet_priority(const struct encoder_packet *packet);
 EXPORT size_t obs_parse_avc_header(uint8_t **header, const uint8_t *data,
 				   size_t size);
 EXPORT void obs_extract_avc_headers(const uint8_t *packet, size_t size,

--- a/libobs/obs-hevc.h
+++ b/libobs/obs-hevc.h
@@ -28,6 +28,7 @@ struct encoder_packet;
 EXPORT bool obs_hevc_keyframe(const uint8_t *data, size_t size);
 EXPORT void obs_parse_hevc_packet(struct encoder_packet *hevc_packet,
 				  const struct encoder_packet *src);
+EXPORT int obs_parse_hevc_packet_priority(const struct encoder_packet *packet);
 EXPORT void obs_extract_hevc_headers(const uint8_t *packet, size_t size,
 				     uint8_t **new_packet_data,
 				     size_t *new_packet_size,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
@@ -270,7 +270,6 @@ void ffmpeg_hls_mux_data(void *data, struct encoder_packet *packet)
 {
 	struct ffmpeg_muxer *stream = data;
 	struct encoder_packet new_packet;
-	struct encoder_packet tmp_packet;
 	bool added_packet = false;
 
 	if (!active(stream))
@@ -299,15 +298,13 @@ void ffmpeg_hls_mux_data(void *data, struct encoder_packet *packet)
 		const char *const codec =
 			obs_encoder_get_codec(packet->encoder);
 		if (strcmp(codec, "h264") == 0) {
-			obs_parse_avc_packet(&tmp_packet, packet);
-			packet->drop_priority = tmp_packet.priority;
-			obs_encoder_packet_release(&tmp_packet);
+			packet->drop_priority =
+				obs_parse_avc_packet_priority(packet);
 		}
 #ifdef ENABLE_HEVC
 		else if (strcmp(codec, "hevc") == 0) {
-			obs_parse_hevc_packet(&tmp_packet, packet);
-			packet->drop_priority = tmp_packet.priority;
-			obs_encoder_packet_release(&tmp_packet);
+			packet->drop_priority =
+				obs_parse_hevc_packet_priority(packet);
 		}
 #endif
 	}


### PR DESCRIPTION
### Description
Parsing priority while serializing/discarding packet data is too gross.

### Motivation and Context
Don't like gross code. Should also be a bit faster.

### How Has This Been Tested?
Debugger inspection of AVC/HEVC over HLS, and AVC over RTMP.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.