### PR TITLE
AMD AMF Encoder Improvements

### DIFF
--- a/plugins/obs-ffmpeg/obs-amf-test/obs-amf-test.cpp
+++ b/plugins/obs-ffmpeg/obs-amf-test/obs-amf-test.cpp
@@ -85,11 +85,34 @@ static bool get_adapter_caps(IDXGIFactory *factory, uint32_t adapter_idx)
 	return true;
 }
 
+DWORD WINAPI TimeoutThread(LPVOID param)
+{
+	HANDLE hMainThread = (HANDLE)param;
+
+	DWORD ret = WaitForSingleObject(hMainThread, 2500);
+	if (ret == WAIT_TIMEOUT)
+		TerminateProcess(GetCurrentProcess(), STATUS_TIMEOUT);
+
+	CloseHandle(hMainThread);
+
+	return 0;
+}
+
 int main(void)
 try {
 	ComPtr<IDXGIFactory> factory;
 	AMF_RESULT res;
 	HRESULT hr;
+
+	HANDLE hMainThread;
+	DuplicateHandle(GetCurrentProcess(), GetCurrentThread(),
+			GetCurrentProcess(), &hMainThread, 0, FALSE,
+			DUPLICATE_SAME_ACCESS);
+	DWORD threadId;
+	HANDLE hThread;
+	hThread =
+		CreateThread(NULL, 0, TimeoutThread, hMainThread, 0, &threadId);
+	CloseHandle(hThread);
 
 	/* --------------------------------------------------------- */
 	/* try initializing amf, I guess                             */

--- a/plugins/obs-ffmpeg/texture-amf-opts.hpp
+++ b/plugins/obs-ffmpeg/texture-amf-opts.hpp
@@ -237,12 +237,12 @@ static void amf_apply_opt(amf_base *enc, obs_option *opt)
 		int val = atoi(opt->value);
 		set_hevc_property(enc, MAX_QP_I, val);
 
-	} else if (hevc && strcmp(opt->name, "min_qp_i") == 0) {
+	} else if (hevc && strcmp(opt->name, "min_qp_p") == 0) {
 
 		int val = atoi(opt->value);
 		set_hevc_property(enc, MIN_QP_P, val);
 
-	} else if (hevc && strcmp(opt->name, "max_qp_i") == 0) {
+	} else if (hevc && strcmp(opt->name, "max_qp_p") == 0) {
 
 		int val = atoi(opt->value);
 		set_hevc_property(enc, MAX_QP_P, val);

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -633,6 +633,8 @@ static buf_t alloc_buf(amf_fallback *enc)
 		size = enc->linesize * enc->cy * 4;
 	} else if (enc->amf_format == AMF_SURFACE_P010) {
 		size = enc->linesize * enc->cy * 2 * 2;
+	} else {
+		throw "Invalid amf_format";
 	}
 
 	buf.resize(size);
@@ -713,6 +715,11 @@ try {
 	amf_fallback *enc = (amf_fallback *)data;
 	error("%s: %s: %ls", __FUNCTION__, err.str,
 	      amf_trace->GetResultText(err.res));
+	*received_packet = false;
+	return false;
+} catch (const char *err) {
+	amf_fallback *enc = (amf_fallback *)data;
+	error("%s: %s", __FUNCTION__, err);
 	*received_packet = false;
 	return false;
 }

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -682,12 +682,7 @@ try {
 	if (!enc->linesize)
 		enc->linesize = frame->linesize[0];
 
-	if (enc->available_buffers.size()) {
-		buf = std::move(enc->available_buffers.back());
-		enc->available_buffers.pop_back();
-	} else {
-		buf = alloc_buf(enc);
-	}
+	buf = get_buf(enc);
 
 	copy_frame_data(enc, buf, frame);
 

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1602,10 +1602,15 @@ static void register_hevc()
 extern "C" void amf_load(void)
 try {
 	AMF_RESULT res;
+	HMODULE amf_module_test;
 
-	amf_module = LoadLibraryW(AMF_DLL_NAME);
-	if (!amf_module)
+	/* Check if the DLL is present before running the more expensive */
+	/* obs-amf-test.exe, but load it as data so it can't crash us    */
+	amf_module_test =
+		LoadLibraryExW(AMF_DLL_NAME, nullptr, LOAD_LIBRARY_AS_DATAFILE);
+	if (!amf_module_test)
 		throw "No AMF library";
+	FreeLibrary(amf_module_test);
 
 	/* ----------------------------------- */
 	/* Check for AVC/HEVC support          */
@@ -1666,6 +1671,10 @@ try {
 
 	/* ----------------------------------- */
 	/* Init AMF                            */
+
+	amf_module = LoadLibraryW(AMF_DLL_NAME);
+	if (!amf_module)
+		throw "AMF library failed to load";
 
 	AMFInit_Fn init =
 		(AMFInit_Fn)GetProcAddress(amf_module, AMF_INIT_FUNCTION_NAME);


### PR DESCRIPTION
### Description
- Avoid loading the AMF DLL before running the test process.
- Add timeout for the AMF test process in case it freezes.
- Fix typo causing min_qp_p / max_qp_p not to function.
- Use `get_ buf` function to ensure mutex is properly locked.
- Throw in `get_buf` if amf_format is invalid to fix possible uninitialized variable warning.

### Motivation and Context
Make loading of the new AMD AMF encoder safer. Fix some small bugs.

### How Has This Been Tested?
Not at all as I don't have AMF.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
