### PR TITLE
CI: Fix packaging scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -440,8 +440,8 @@ jobs:
             $null = New-Item -ItemType Directory -Force -Path install_temp
           }
 
-          Expand-Archive -Path "$(Get-ChildItem -filter "obs-studio-windows-*-x86.zip" -File)" -DestinationPath install_temp
-          Expand-Archive -Path "$(Get-ChildItem -filter "obs-studio-windows-*-x64.zip" -File)" -Force -DestinationPath install_temp
+          Expand-Archive -Path "$(Get-ChildItem -filter "obs-studio-*-windows-x86.zip" -File)" -DestinationPath install_temp
+          Expand-Archive -Path "$(Get-ChildItem -filter "obs-studio-*-windows-x64.zip" -File)" -Force -DestinationPath install_temp
 
           CI/windows/03_package_obs.ps1 -CombinedArchs -Package
 

--- a/CI/linux/03_package_obs.sh
+++ b/CI/linux/03_package_obs.sh
@@ -37,8 +37,10 @@ package-obs-standalone() {
     source "${CHECKOUT_DIR}/CI/include/build_support.sh"
     source "${CHECKOUT_DIR}/CI/include/build_support_linux.sh"
 
-    step "Fetch OBS tags..."
-    git fetch origin --tags
+    if [ -z "${CI}" ]; then
+        step "Fetch OBS tags..."
+        git fetch --tags origin
+    fi
 
     GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
     GIT_HASH=$(git rev-parse --short=9 HEAD)

--- a/CI/macos/03_package_obs.sh
+++ b/CI/macos/03_package_obs.sh
@@ -99,8 +99,10 @@ package-obs-standalone() {
     check_archs
     check_macos_version
 
-    step "Fetch OBS tags..."
-    /usr/bin/git fetch origin --tags
+    if [ -z "${CI}" ]; then
+        step "Fetch OBS tags..."
+        /usr/bin/git fetch --tags origin
+    fi
 
     GIT_BRANCH=$(/usr/bin/git rev-parse --abbrev-ref HEAD)
     GIT_HASH=$(/usr/bin/git rev-parse --short=9 HEAD)

--- a/CI/windows/03_package_obs.ps1
+++ b/CI/windows/03_package_obs.ps1
@@ -107,8 +107,10 @@ function Package-OBS-Standalone {
 
     . ${CheckoutDir}/CI/include/build_support_windows.ps1
 
-    Write-Step "Fetch OBS tags..."
-    $null = git fetch origin --tags
+    if (!(Test-Path Env:CI)) {
+        Write-Step "Fetch OBS tags..."
+        $null = git fetch --tags origin
+    }
 
     Ensure-Directory ${CheckoutDir}
     $GitBranch = git rev-parse --abbrev-ref HEAD


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
On CI, do not fetch tags in packaging scripts. For some reason, the checkout action seems to locally update any new git tags on the runner:

t [tag update]   (commit-hash) -> tag-name

This causes future calls to fetch git tags to fail on CI with:

! [rejected]   tag-name -> tag-name  (would clobber existing tag)

To avoid this, we can simply not fetch tags a second time on CI.

Additionally, fix the Windows Installer job.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We want both CI and locally run scripts to work.

See lines 573-580: https://github.com/obsproject/obs-studio/runs/7618273262?check_suite_focus=true#step:2:578
See lines 43-46: https://github.com/obsproject/obs-studio/runs/7618273262?check_suite_focus=true#step:14:44

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on my fork's CI.
https://github.com/RytoEX/obs-studio/actions/runs/2778324498

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
