### PR TITLE
aja: Fix frame duplication in output plugin

### DIFF
--- a/plugins/aja/aja-output.hpp
+++ b/plugins/aja/aja-output.hpp
@@ -62,7 +62,8 @@ public:
 	void ClearConnections();
 
 	void GenerateTestPattern(NTV2VideoFormat vf, NTV2PixelFormat pf,
-				 NTV2TestPatternSelect pattern);
+				 NTV2TestPatternSelect pattern,
+				 uint32_t frameNum);
 
 	void QueueVideoFrame(struct video_data *frame, size_t size);
 	void QueueAudioFrames(struct audio_data *frames, size_t size);
@@ -71,7 +72,8 @@ public:
 	size_t VideoQueueSize();
 	size_t AudioQueueSize();
 
-	void DMAAudioFromQueue(NTV2AudioSystem audioSys);
+	void DMAAudioFromQueue(NTV2AudioSystem audioSys, uint32_t channels,
+			       uint32_t sampleRate, uint32_t sampleSize);
 	void DMAVideoFromQueue();
 
 	void CreateThread(bool enable = false);
@@ -87,11 +89,10 @@ public:
 	uint32_t mAudioPlayCursor;
 	uint32_t mAudioWriteCursor;
 	uint32_t mAudioWrapAddress;
-	uint32_t mAudioRate;
 
-	uint64_t mAudioQueueSamples;
-	uint64_t mAudioWriteSamples;
-	uint64_t mAudioPlaySamples;
+	uint64_t mAudioQueueBytes;
+	uint64_t mAudioWriteBytes;
+	uint64_t mAudioPlayBytes;
 
 	uint32_t mNumCardFrames;
 	uint32_t mFirstCardFrame;
@@ -126,13 +127,12 @@ public:
 #endif
 
 private:
+	void reset_frame_counts();
 	void calculate_card_frame_indices(uint32_t numFrames, NTV2DeviceID id,
 					  NTV2Channel channel,
 					  NTV2VideoFormat vf,
 					  NTV2PixelFormat pf);
-
-	uint32_t get_frame_count();
-
+	uint32_t get_card_play_count();
 	void dma_audio_samples(NTV2AudioSystem audioSys, uint32_t *data,
 			       size_t size);
 

--- a/plugins/aja/aja-output.hpp
+++ b/plugins/aja/aja-output.hpp
@@ -111,9 +111,14 @@ public:
 	uint64_t mLastVideoTS;
 	uint64_t mLastAudioTS;
 
+	int64_t mOutputDelay;
+	int64_t mVideoMax;
 	int64_t mVideoDelay;
+	int64_t mVideoSync;
+	int64_t mVideoAdjust;
+	int64_t mAudioMax;
 	int64_t mAudioDelay;
-	int64_t mAudioVideoSync;
+	int64_t mAudioSync;
 	int64_t mAudioAdjust;
 	int64_t mLastStatTime;
 #ifdef AJA_WRITE_DEBUG_WAV


### PR DESCRIPTION
This PR augments the existing audio delay algorithm in the output plugin to dynamically adjust both the video and audio delays, rather than just the audio delay, in order to maintain sync with the card's current output rate. The PR also increases the number of card frame buffers to a maximum of 8, increased from the current 2 frames, and tries to maintain a buffer level of 4 frames of video and audio at the current output rate.

_NOTE: I am submitting this PR on behalf of my co-worker, David S., who wrote both the existing audio delay algorithm and the new video delay algorithm code in this PR. If there are questions that I cannot answer, I will relay them to David and ask him to comment here, as I am not sure if he gets Github notifications._

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
- Added a video delay algorithm to the current code, similar to the existing audio delay algorithm. The algorithm attempts to maintain sync with the card's current output rate when writing frames to the card.
- Adjusted video/audio delay algorithm to try to maintain a hardware buffer level of 4 frames of video and audio instead of the current 2 frames of buffering
- Tweaked the AV sync detection to check for de-sync every 2 seconds instead of 3 seconds, and adjust video/audio delay if 3 de-sync events occur in a row, rather than 5 in a row.
- Increased maximum hardware video buffer level to 8 frames.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Both AJA QA and two AJA customers reported that the AJA Output plugin was exhibiting video frame duplication. This was found to be due to the fact that the output plugin needed to allocate more hardware frames of buffering, and also dynamically adjust the delay of the video on the fly to remain in sync with the audio, which was already being dynamically delayed. The frame duplication would sometimes arise when the plugin could not write frames to the card fast enough, or wrote frames too fast, resulting in the same frame playing out of the SDI multiple times in a row.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with an AJA io4K+ outputting with 1080p29.97, 1080p30, 1080p59.94 and 1080p60. AJA QA is going to do some additional testing with 4K, which was already known to be outputting with poor performance at high framerates (i.e. UHD/4Kp60), to see if this fix improved performance.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
