### PR TITLE
rtmps-services: Add fallback to H264 and some tweaks and fixes

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services",
-    "version": 203,
+    "version": 204,
     "files": [
         {
             "name": "services.json",
-            "version": 203
+            "version": 204
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -6,12 +6,6 @@
             "name": "Twitch",
             "common": true,
             "stream_key_link": "https://dashboard.twitch.tv/settings/stream",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Asia: Hong Kong",
@@ -214,9 +208,6 @@
                 "h264",
                 "hevc"
             ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Primary YouTube ingest server",
@@ -242,12 +233,6 @@
                 "YouTube / YouTube Gaming",
                 "YouTube - RTMP",
                 "YouTube - RTMPS (Beta)"
-            ],
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
             ],
             "servers": [
                 {
@@ -276,12 +261,6 @@
         {
             "name": "Loola.tv",
             "common": false,
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "US East: Virginia",
@@ -315,12 +294,6 @@
         },
         {
             "name": "Lovecast",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -342,12 +315,6 @@
         {
             "name": "Luzento.com - RTMP",
             "stream_key_link": "https://cms.luzento.com/dashboard/stream-key?from=OBS",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Primary",
@@ -368,12 +335,6 @@
         },
         {
             "name": "VIMM",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Europe: Frankfurt",
@@ -393,12 +354,6 @@
         },
         {
             "name": "Mobcrush",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Primary",
@@ -414,12 +369,6 @@
         },
         {
             "name": "Web.TV",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Primary",
@@ -435,12 +384,6 @@
         },
         {
             "name": "GoodGame.ru",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Моscow",
@@ -451,12 +394,6 @@
         {
             "name": "YouStreamer",
             "stream_key_link": "https://www.app.youstreamer.com/stream/",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Moscow",
@@ -466,12 +403,6 @@
         },
         {
             "name": "Vaughn Live / iNSTAGIB",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "US: Chicago, IL",
@@ -514,12 +445,6 @@
         },
         {
             "name": "Breakers.TV",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "US: Chicago, IL",
@@ -564,12 +489,6 @@
             "name": "Facebook Live",
             "common": true,
             "stream_key_link": "https://www.facebook.com/live/producer?ref=OBS",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -640,12 +559,6 @@
             ],
             "common": true,
             "stream_key_link": "https://restream.io/settings/streaming-setup?from=OBS",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Autodetect",
@@ -758,12 +671,6 @@
         },
         {
             "name": "Castr.io",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "US-East (Chicago, IL)",
@@ -856,12 +763,6 @@
         },
         {
             "name": "Boomstream",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -871,12 +772,6 @@
         },
         {
             "name": "Meridix Live Sports Platform",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Primary",
@@ -892,12 +787,6 @@
             "alt_names": [
                 "아프리카TV",
                 "Afreeca.TV"
-            ],
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
             ],
             "servers": [
                 {
@@ -934,12 +823,6 @@
         },
         {
             "name": "CAM4",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "CAM4",
@@ -955,12 +838,6 @@
         },
         {
             "name": "ePlay",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "ePlay Primary",
@@ -976,12 +853,6 @@
         },
         {
             "name": "Picarto",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Autoselect closest server",
@@ -1016,12 +887,6 @@
         },
         {
             "name": "Livestream",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Primary",
@@ -1031,12 +896,6 @@
         },
         {
             "name": "Uscreen",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1051,12 +910,6 @@
         },
         {
             "name": "Stripchat",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Auto",
@@ -1074,12 +927,6 @@
         },
         {
             "name": "CamSoda",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "North America",
@@ -1117,12 +964,6 @@
         },
         {
             "name": "Chaturbate",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Global Main Fastest - Recommended",
@@ -1237,12 +1078,6 @@
             "alt_names": [
                 "Twitter / Periscope"
             ],
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "US West: California",
@@ -1304,12 +1139,6 @@
             "name": "Switchboard Live",
             "alt_names": [
                 "Switchboard Live (Joicaster)"
-            ],
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
             ],
             "servers": [
                 {
@@ -1378,12 +1207,6 @@
         {
             "name": "Looch",
             "common": false,
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Primary Looch ingest server",
@@ -1399,12 +1222,6 @@
         },
         {
             "name": "Eventials",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1420,12 +1237,6 @@
         },
         {
             "name": "EventLive.pro",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1445,12 +1256,6 @@
         },
         {
             "name": "Lahzenegar - StreamG | لحظه‌نگار - استریمجی",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Primary",
@@ -1470,12 +1275,6 @@
         },
         {
             "name": "MyLive",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1495,12 +1294,6 @@
                 "Madcat"
             ],
             "stream_key_link": "https://studio.trovo.live/mychannel/stream",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1516,12 +1309,6 @@
         },
         {
             "name": "Mixcloud",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1546,12 +1333,6 @@
             "alt_names": [
                 "SermonAudio.com"
             ],
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Primary",
@@ -1565,12 +1346,6 @@
         },
         {
             "name": "Vimeo",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1580,12 +1355,6 @@
         },
         {
             "name": "Aparat",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1601,12 +1370,6 @@
         },
         {
             "name": "KakaoTV",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1620,12 +1383,6 @@
         },
         {
             "name": "Piczel.tv",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1641,12 +1398,6 @@
         },
         {
             "name": "STAGE TEN",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "STAGE TEN",
@@ -1662,12 +1413,6 @@
         },
         {
             "name": "DLive",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1682,12 +1427,6 @@
         },
         {
             "name": "Lightcast.com",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "North America / East",
@@ -1726,12 +1465,6 @@
         },
         {
             "name": "Bongacams",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Automatic / Default",
@@ -1760,12 +1493,6 @@
         },
         {
             "name": "Chathostess",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Chathostess - Backup",
@@ -1780,12 +1507,6 @@
         },
         {
             "name": "OnlyFans.com",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "USA",
@@ -1808,9 +1529,6 @@
         {
             "name": "YouNow",
             "common": false,
-            "supported video codecs": [
-                "h264"
-            ],
             "supported audio codecs": [
                 "opus"
             ],
@@ -1832,12 +1550,6 @@
         {
             "name": "Steam",
             "common": false,
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1853,12 +1565,6 @@
         },
         {
             "name": "Konduit.live",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1872,12 +1578,6 @@
         },
         {
             "name": "LOCO",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1890,12 +1590,6 @@
         },
         {
             "name": "niconico, premium member (ニコニコ生放送 プレミアム会員)",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1912,12 +1606,6 @@
         },
         {
             "name": "niconico, free member (ニコニコ生放送 一般会員)",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -1934,12 +1622,6 @@
         },
         {
             "name": "WASD.TV",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Automatic",
@@ -1966,12 +1648,6 @@
         },
         {
             "name": "Nimo TV",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Global:1",
@@ -1994,12 +1670,6 @@
         },
         {
             "name": "XLoveCam.com",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Europe(main)",
@@ -2040,12 +1710,6 @@
         },
         {
             "name": "AngelThump",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Auto",
@@ -2093,12 +1757,6 @@
         },
         {
             "name": "api.video",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -2113,12 +1771,6 @@
         },
         {
             "name": "SHOWROOM",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -2135,12 +1787,6 @@
         },
         {
             "name": "Mux",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Global (RTMPS)",
@@ -2159,12 +1805,6 @@
         },
         {
             "name": "Viloud",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -2179,12 +1819,6 @@
         },
         {
             "name": "MyFreeCams",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Automatic",
@@ -2230,12 +1864,6 @@
         },
         {
             "name": "PolyStreamer.com",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Auto-select closest server",
@@ -2277,9 +1905,6 @@
         {
             "name": "Glimesh",
             "stream_key_link": "https://glimesh.tv/users/settings/stream",
-            "supported video codecs": [
-                "h264"
-            ],
             "supported audio codecs": [
                 "opus"
             ],
@@ -2333,12 +1958,6 @@
         {
             "name": "OPENREC.tv - Premium member (プレミアム会員)",
             "stream_key_link": "https://www.openrec.tv/login?keep_login=true&url=https://www.openrec.tv/dashboard/live?from=obs",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -2355,12 +1974,6 @@
             "name": "nanoStream Cloud / bintu",
             "more_info_link": "https://www.nanocosmos.de/obs",
             "stream_key_link": "https://bintu-cloud-frontend.nanocosmos.de/organisation",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "bintu-stream global ingest (rtmp)",
@@ -2430,12 +2043,6 @@
         },
         {
             "name": "Dacast",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -2452,12 +2059,6 @@
         {
             "name": "Brime Live",
             "stream_key_link": "https://brime.tv/studio",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "North America - Ashburn, VA",
@@ -2485,12 +2086,6 @@
             "alt_names": [
                 "Bilibili Live"
             ],
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default | 默认",
@@ -2501,12 +2096,6 @@
         {
             "name": "Volume.com",
             "stream_key_link": "https://volume.com/b?show_key=1&webrtc=0",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default - Recommended",
@@ -2530,12 +2119,6 @@
         {
             "name": "BoxCast",
             "stream_key_link": "https://dashboard.boxcast.com/#/sources",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "BoxCast",
@@ -2545,12 +2128,6 @@
         },
         {
             "name": "Disciple Media",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -2560,12 +2137,6 @@
         },
         {
             "name": "Jio Games",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Primary",
@@ -2585,12 +2156,6 @@
         {
             "name": "Kuaishou Live",
             "stream_key_link": "https://studio.kuaishou.com/live/list",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -2604,12 +2169,6 @@
         },
         {
             "name": "Utreon",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -2624,12 +2183,6 @@
         },
         {
             "name": "Autistici.org Live",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -2645,12 +2198,6 @@
         {
             "name": "PhoneLiveStreaming",
             "stream_key_link": "https://app.phonelivestreaming.com/media/rtmp",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "PhoneLiveStreaming",
@@ -2665,12 +2212,6 @@
         },
         {
             "name": "ManyVids",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -2703,12 +2244,6 @@
             "name": "Fantasy.Club",
             "stream_key_link": "https://fantasy.club/app/create-content/stream-now",
             "more_info_link": "https://help.fantasy.club/",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "US: East",
@@ -2772,12 +2307,6 @@
         {
             "name": "Shareplay",
             "more_info_link": "https://shareplay.tv",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Default",
@@ -2842,12 +2371,6 @@
         },
         {
             "name": "Sympla",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
             "servers": [
                 {
                     "name": "Sympla RTMP",
@@ -2899,7 +2422,7 @@
                 "max video bitrate": 6000,
                 "max audio bitrate": 160
             }
-        },        
+        },
         {
             "name": "StreamVi",
             "stream_key_link": "https://streamvi.ru/settings",

--- a/plugins/rtmp-services/rtmp-common.c
+++ b/plugins/rtmp-services/rtmp-common.c
@@ -874,20 +874,21 @@ static const char **rtmp_common_get_supported_video_codecs(void *data)
 
 	json_t *json_video_codecs =
 		json_object_get(json_service, "supported video codecs");
-	if (!json_is_array(json_video_codecs)) {
-		goto fail;
-	}
+	if (json_is_array(json_video_codecs)) {
+		size_t index;
+		json_t *item;
 
-	size_t index;
-	json_t *item;
+		json_array_foreach (json_video_codecs, index, item) {
+			char codec[16];
 
-	json_array_foreach (json_video_codecs, index, item) {
-		char codec[16];
-
-		snprintf(codec, sizeof(codec), "%s", json_string_value(item));
-		if (codecs.len)
-			dstr_cat(&codecs, ";");
-		dstr_cat(&codecs, codec);
+			snprintf(codec, sizeof(codec), "%s",
+				 json_string_value(item));
+			if (codecs.len)
+				dstr_cat(&codecs, ";");
+			dstr_cat(&codecs, codec);
+		}
+	} else {
+		dstr_cat(&codecs, "h264;");
 	}
 
 	service->video_codecs = strlist_split(codecs.array, ';', false);

--- a/plugins/rtmp-services/rtmp-common.c
+++ b/plugins/rtmp-services/rtmp-common.c
@@ -860,7 +860,7 @@ static const char **rtmp_common_get_supported_video_codecs(void *data)
 	struct rtmp_common *service = data;
 
 	if (service->video_codecs)
-		return service->video_codecs;
+		return (const char **)service->video_codecs;
 
 	struct dstr codecs = {0};
 	json_t *root = open_services_file();
@@ -895,7 +895,7 @@ static const char **rtmp_common_get_supported_video_codecs(void *data)
 
 fail:
 	json_decref(root);
-	return service->video_codecs;
+	return (const char **)service->video_codecs;
 }
 
 static const char *rtmp_common_username(void *data)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Make optional `supported video codecs` and `supported audio codecs` by adding a fallback to H264 in `rtmp-services`.
`supported audio codecs` is not used for now so no fallback to AAC.

Remove field in the JSON that have only H264 or only AAC.

Opus ones are kept but are not used at all.

Also fixes incompatible-ponter-types warnings.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Some services don't have those fields which cause issue and those should be optional.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Service without those field are now considered compatible only with H264.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
