### PR TITLE
obs-scripting: Fix issues between runtime and compile-time versions

### DIFF
--- a/deps/obs-scripting/obs-scripting-python-import.h
+++ b/deps/obs-scripting/obs-scripting-python-import.h
@@ -50,6 +50,11 @@
 #define PY_EXTERN extern
 #endif
 
+typedef struct python_version {
+	int major;
+	int minor;
+} python_version_t;
+
 PY_EXTERN int (*Import_PyType_Ready)(PyTypeObject *);
 PY_EXTERN PyObject *(*Import_PyObject_GenericGetAttr)(PyObject *, PyObject *);
 PY_EXTERN int (*Import_PyObject_IsTrue)(PyObject *);
@@ -99,10 +104,8 @@ PY_EXTERN int (*Import_PyDict_SetItemString)(PyObject *dp, const char *key,
 					     PyObject *item);
 PY_EXTERN PyObject *(*Import_PyCFunction_NewEx)(PyMethodDef *, PyObject *,
 						PyObject *);
-#if PY_VERSION_HEX > 0x030900b0
 PY_EXTERN PyObject *(*Import_PyCMethod_New)(PyMethodDef *, PyObject *,
 					    PyObject *, PyTypeObject *);
-#endif
 PY_EXTERN PyObject *(*Import_PyModule_GetDict)(PyObject *);
 PY_EXTERN PyObject *(*Import_PyModule_GetNameObject)(PyObject *);
 PY_EXTERN int (*Import_PyModule_AddObject)(PyObject *, const char *,
@@ -139,23 +142,17 @@ PY_EXTERN PyObject *(*Import_PyLong_FromUnsignedLongLong)(unsigned long long);
 PY_EXTERN int (*Import_PyArg_VaParse)(PyObject *, const char *, va_list);
 PY_EXTERN PyObject(*Import__Py_NoneStruct);
 PY_EXTERN PyObject *(*Import_PyTuple_New)(Py_ssize_t size);
-#if PY_VERSION_HEX >= 0x030900b0
 PY_EXTERN int (*Import_PyType_GetFlags)(PyTypeObject *o);
-#endif
 #if defined(Py_DEBUG) || PY_VERSION_HEX >= 0x030900b0
 PY_EXTERN void (*Import__Py_Dealloc)(PyObject *obj);
 #endif
 
-extern bool import_python(const char *python_path);
+extern bool import_python(const char *python_path,
+			  python_version_t *python_version);
 
 #ifndef NO_REDEFS
 #define PyType_Ready Import_PyType_Ready
-#if PY_VERSION_HEX >= 0x030900b0
 #define PyType_GetFlags Import_PyType_GetFlags
-#endif
-#if defined(Py_DEBUG) || PY_VERSION_HEX >= 0x030900b0
-#define _Py_Dealloc Import__Py_Dealloc
-#endif
 #define PyObject_GenericGetAttr Import_PyObject_GenericGetAttr
 #define PyObject_IsTrue Import_PyObject_IsTrue
 #define Py_DecRef Import_Py_DecRef
@@ -231,6 +228,9 @@ extern bool import_python(const char *python_path);
 #define PyArg_VaParse Import_PyArg_VaParse
 #define _Py_NoneStruct (*Import__Py_NoneStruct)
 #define PyTuple_New Import_PyTuple_New
+#if defined(Py_DEBUG) || PY_VERSION_HEX >= 0x030900b0
+#define _Py_Dealloc Import__Py_Dealloc
+#endif
 #if PY_VERSION_HEX >= 0x030800f0
 static inline void Import__Py_DECREF(const char *filename, int lineno,
 				     PyObject *op)
@@ -262,7 +262,6 @@ static inline void Import__Py_XDECREF(PyObject *op)
 #undef Py_XDECREF
 #define Py_XDECREF(op) Import__Py_XDECREF(_PyObject_CAST(op))
 #endif // PY_VERSION_HEX >= 0x030800f0
-
 #if PY_VERSION_HEX >= 0x030900b0
 static inline int Import_PyType_HasFeature(PyTypeObject *type,
 					   unsigned long feature)


### PR DESCRIPTION
### Description
Fixes crashing bug when OBS is configured to load Python 3.6.

### Motivation and Context
Calling `PyEval_InitThreads` has been deprecated in Python 3.7 and the function itself will be removed in Python 3.11. The current check guards this function behind a version check that only happens at compile time.

This in turn leads to crashes when run on Python 3.6, as the necessary initialization for `PyEval_ReleaseThread` did not take place.

This commit ensures the manual initialization takes place based on the runtime version of Python and avoids loading the associated symbols on Python 3.9 or later.

**Note:** Once Python 3.11 is out officially, we probably have to drop support for Python 3.6, as the corresponding symbols are not available anymore.

### How Has This Been Tested?
Compiled and ran OBS with Python 3.6.2, 3.8.10, and 3.9.6 on Windows and 3.9.13 on macOS.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
