### PR TITLE
CI: Install Xcode 14 beta for tagged builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,6 +155,10 @@ jobs:
 
           echo "::set-output name=commitHash::$(git rev-parse --short=9 HEAD)"
 
+      - name: 'Install Xcode 14 Beta'
+        if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && env.HAVE_CODESIGN_IDENTITY == 'true' && secrets.XCODE_DOWNLOAD_URL != '' }}
+        run: xcversion install "14 beta 4" --url=${{ secrets.XCODE_DOWNLOAD_URL }}
+
       - name: 'Install dependencies'
         env:
           RESTORED_VLC: ${{ steps.vlc-cache.outputs.cache-hit }}


### PR DESCRIPTION
### Description

Manually install Xcode 14 beta 4 to compile OBS 28.0 with all new macOS features available.

### Motivation and Context

GitHub's runner images do not include Xcode 14 yet. But we need it for macOS 13 specific features that are only in the Xcode 14 SDK.

### How Has This Been Tested?

Build: https://github.com/derrod/obs-studio/actions/runs/2785485502

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
