### PR TITLE
CI: Fix Steam workflow for APFS DMGs

### DIFF
--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -194,7 +194,6 @@ jobs:
 
         echo "::group::Extract macOS (x86)"
         mkdir -p steam-macos/x86
-        mkdir steam-macos
         # CI builds are zipped
         if [[ -f ../mac_x86.dmg.zip ]]; then
             unzip ../mac_x86.dmg.zip
@@ -206,7 +205,11 @@ jobs:
             7zz x ../mac_x86.dmg -otmp_x86 || true
         fi
 
-        mv tmp_x86/*/OBS.app steam-macos/x86
+        if [ -d tmp_x86/OBS.app ]; then
+            mv tmp_x86/OBS.app steam-macos/x86
+        else
+            mv tmp_x86/*/OBS.app steam-macos/x86
+        fi
         echo "::endgroup::"
 
         echo "::group::Extract and prepare macOS (arm64)"
@@ -219,7 +222,11 @@ jobs:
             7zz x ../mac_arm64.dmg -otmp_arm64 || true
         fi
 
-        mv tmp_arm64/*/OBS.app steam-macos/arm64
+        if [ -d tmp_arm64/OBS.app ]; then
+            mv tmp_arm64/OBS.app steam-macos/arm64
+        else
+            mv tmp_arm64/*/OBS.app steam-macos/arm64
+        fi
 
         cp ../source/CI/steam/scripts_macos/launch.sh steam-macos/launch.sh
         echo "::endgroup::"


### PR DESCRIPTION
### Description

Our new DMGs no longer have a subfolder that contains the `.app` apparently (at least when extracted this way). So this adjusts the paths.

### Motivation and Context

Stop CI from failing and me from crying.

### How Has This Been Tested?

On my fork: https://github.com/derrod/obs-studio/runs/7643611723?check_suite_focus=true

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
