### PR TITLE
CI: Fix Flathub workflow tag validation

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -35,7 +35,7 @@ jobs:
               echo '::set-output name=valid_tag::${{ toJSON(true) }}'
               echo '::set-output name=matrix::["beta", "stable"]'
               ;;
-            +([0-9]).+([0-9]).+([0-9])-@(beta|rc) )
+            +([0-9]).+([0-9]).+([0-9])-@(beta|rc)*([0-9]) )
               echo '::set-output name=valid_tag::${{ toJSON(true) }}'
               echo '::set-output name=matrix::["beta"]'
               ;;


### PR DESCRIPTION
### Description

Fixes the glob for the relase tag.

### Motivation and Context

No Flathub release = big sad.

### How Has This Been Tested?

Verified it now matches `refs/tags/28.0.0-beta1` and `refs/tags/28.0.0-beta` in a local bash shell.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
