### PR TITLE
obs-filters: Reset RTX greenscreen on cuda error

### DIFF
--- a/plugins/obs-filters/nvidia-greenscreen-filter.c
+++ b/plugins/obs-filters/nvidia-greenscreen-filter.c
@@ -321,6 +321,8 @@ static bool process_texture_greenscreen(struct nv_greenscreen_data *filter)
 	if (vfxErr != NVCV_SUCCESS) {
 		const char *errString = NvCV_GetErrorStringFromCode(vfxErr);
 		error("Error running the FX; error %i: %s", vfxErr, errString);
+		if (vfxErr == NVCV_ERR_CUDA)
+			nv_greenscreen_filter_reset(filter, NULL);
 	}
 
 	/* 4. Map dst texture before transfer from dst img provided by FX */


### PR DESCRIPTION
### Description
This resets the RTX greenscreen filter if the FX returns a CUDA error.
In case of a CUDA error 1099, the error can keep repeating locking up
the filter which is inoperant. So if such an error is detected we reset
the FX.

### Motivation and Context
Bug fix.
After changing some properties of a webcam source, a lockup of the filter may occur with
a CUDA error 1099 which keeps repeating.
If that occurs, we fix it by resetting NVIDIA FX.

### How Has This Been Tested?
Tested on win 10.
Bug is fixed.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
