### PR TITLE
CI: Don't install Qt5 if Qt6 is available

### DIFF
--- a/CI/linux/01_install_dependencies.sh
+++ b/CI/linux/01_install_dependencies.sh
@@ -37,7 +37,10 @@ install_qt5-deps() {
     status "Install Qt5 dependencies"
     trap "caught_error 'install_qt5-deps'" ERR
 
-    sudo apt-get install -y $@
+    _QT6_AVAILABLE="$(sudo apt-cache madison ${1})"
+    if [ ! "${_QT6_AVAILABLE}" ]; then
+        sudo apt-get install -y $@
+    fi
 }
 
 install_qt6-deps() {


### PR DESCRIPTION
### Description
In the Linux install dependencies script, qt5 and qt6 would both
be installed.

### Motivation and Context
Don't install unnecessary deps

### How Has This Been Tested?
Ran script to make sure qt5 wasn't installed

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
