### PR TITLE
UI: Increase maximum limit of automatic file splitting

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -2953,7 +2953,7 @@
                                   <number>1</number>
                                  </property>
                                  <property name="maximum">
-                                  <number>360</number>
+                                  <number>525600</number>
                                  </property>
                                  <property name="value">
                                   <number>15</number>
@@ -2976,7 +2976,7 @@
                                   <number>20</number>
                                  </property>
                                  <property name="maximum">
-                                  <number>8192</number>
+                                  <number>1073741824</number>
                                  </property>
                                  <property name="value">
                                   <number>2048</number>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Increase maximum limits of time and file size to trigger splitting file.

New upper limits are 1024 TiB for split by size, 525600 minutes (365 days) for split by time. These upper limits should be large enough for any users.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Suggested on Discord.
https://discord.com/channels/348973006581923840/1004146447991709816/1004332982762475520

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

1. Added these change to obs-ffmpeg plugin (not included in this PR).
```patch
diff --git a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
index bf8e15fea..d08bdfd1c 100644
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -403,6 +403,8 @@ static bool ffmpeg_mux_start(void *data)
 		stream->max_size = obs_data_get_int(settings, "max_size_mb") *
 				   (1024 * 1024);
 		stream->split_file = obs_data_get_bool(settings, "split_file");
+		blog(LOG_INFO, "max_size=%f GB", stream->max_size * 1e-9);
+		blog(LOG_INFO, "max_time=%f hours", stream->max_time * (1e-6 / 3600.0));
 		stream->reset_timestamps =
 			obs_data_get_bool(settings, "reset_timestamps");
 		stream->allow_overwrite =
```
2. Set maximum number with Split by Size and checked the log.
```
info: max_size=1125899.906843 GB
```
3. Set maximum number with Split by Time and checked the log.
```
info: max_time=8760.000000 hours
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
