### PR TITLE
UI/installer: Require Windows 10 64bit minimum

### DIFF
--- a/UI/installer/mp-installer.nsi
+++ b/UI/installer/mp-installer.nsi
@@ -110,16 +110,17 @@ Function PreReqCheck
 		IfSilent +1 +3
 			SetErrorLevel 3
 			Quit
-		MessageBox MB_OK|MB_ICONSTOP "This version of ${APPNAME} is not compatible with your system. Please use the 32bit (x86) installer."
+		MessageBox MB_OK|MB_ICONSTOP "${APPNAME} is not compatible with your operating system's architecture."
 	${EndIf}
-	; Abort on XP or lower
+	; Abort on 8.1 or lower
 !endif
 
-	${If} ${AtMostWinVista}
+	${If} ${AtLeastWin10}
+	${Else}
 		IfSilent +1 +3
 			SetErrorLevel 3
 			Quit
-		MessageBox MB_OK|MB_ICONSTOP "Due to extensive use of DirectX 10 features, ${APPNAME} requires Windows 7 or higher and cannot be installed on this version of Windows."
+		MessageBox MB_OK|MB_ICONSTOP "${APPNAME} requires Windows 10 or higher and cannot be installed on this version of Windows."
 		Quit
 	${EndIf}
 


### PR DESCRIPTION
### Description

This updates the Windows Vista check to Windows 8.1 and lower.

![image](https://user-images.githubusercontent.com/941350/182612961-bbadd511-1ea8-4ba6-b8f2-ba145ba1e572.png)

This also improves the wording of the 32bit error.

Submitting this as a PR to get feedback on wording, and to determine if more 32bit/64bit code should be removed from the installer script.

### Motivation and Context

With Qt 6, Windows 8.1 and below are no longer supported.

Additionally, 32bit is no longer supported.

### How Has This Been Tested?

* Launch the installer on Windows 8.1.
* Click "Next" to go past the first screen
* See error message

### Types of changes
 - Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
