### PR TITLE
UI: Fix spacer lines not using accessibility color

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -629,7 +629,6 @@ private:
 	QColor cropColor;
 	QColor hoverColor;
 
-	QColor GetSelectionColor() const;
 	QColor GetCropColor() const;
 	QColor GetHoverColor() const;
 
@@ -980,6 +979,8 @@ public:
 	void UpdateEditMenu();
 
 	void SetDisplayAffinity(QWindow *window);
+
+	QColor GetSelectionColor() const;
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -2352,6 +2352,8 @@ static void DrawLabel(OBSSource source, vec3 &pos, vec3 &viewport)
 
 static void DrawSpacingLine(vec3 &start, vec3 &end, vec3 &viewport)
 {
+	OBSBasic *main = OBSBasic::Get();
+
 	matrix4 transform;
 	matrix4_identity(&transform);
 	transform.x.x = viewport.x;
@@ -2360,8 +2362,11 @@ static void DrawSpacingLine(vec3 &start, vec3 &end, vec3 &viewport)
 	gs_effect_t *solid = obs_get_base_effect(OBS_EFFECT_SOLID);
 	gs_technique_t *tech = gs_effect_get_technique(solid, "Solid");
 
+	QColor selColor = main->GetSelectionColor();
 	vec4 color;
-	vec4_set(&color, 1.0f, 0.0f, 0.0f, 1.0f);
+	vec4_set(&color, selColor.redF(), selColor.greenF(), selColor.blueF(),
+		 1.0f);
+
 	gs_effect_set_vec4(gs_effect_get_param_by_name(solid, "color"), &color);
 
 	gs_technique_begin(tech);


### PR DESCRIPTION
### Description
The spacer helper lines would not use the selection color set in the
accessibility settings.

### Motivation and Context
Noticed the lines weren't using the selection color

### How Has This Been Tested?
Selected source to make sure it displayed the right color

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
