### PR TITLE
libobs: Prevent D3D11 projectors from tearing

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -821,7 +821,6 @@ struct gs_swap_chain : gs_obj {
 	gs_init_data initData;
 	DXGI_SWAP_CHAIN_DESC swapDesc = {};
 	gs_color_space space;
-	UINT presentFlags = 0;
 
 	gs_texture_2d target;
 	gs_zstencil_buffer zs;

--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -287,6 +287,12 @@ void device_load_swapchain(gs_device_t *device, gs_swapchain_t *swap)
 	}
 }
 
+bool device_is_present_ready(gs_device_t *device)
+{
+	UNUSED_PARAMETER(device);
+	return true;
+}
+
 void device_present(gs_device_t *device)
 {
 	glFlush();

--- a/libobs-opengl/gl-nix.c
+++ b/libobs-opengl/gl-nix.c
@@ -115,6 +115,12 @@ extern void device_load_swapchain(gs_device_t *device, gs_swapchain_t *swap)
 	gl_vtable->device_load_swapchain(device, swap);
 }
 
+extern bool device_is_present_ready(gs_device_t *device)
+{
+	UNUSED_PARAMETER(device);
+	return true;
+}
+
 extern void device_present(gs_device_t *device)
 {
 	gl_vtable->device_present(device);

--- a/libobs-opengl/gl-windows.c
+++ b/libobs-opengl/gl-windows.c
@@ -573,6 +573,12 @@ void device_load_swapchain(gs_device_t *device, gs_swapchain_t *swap)
 	}
 }
 
+bool device_is_present_ready(gs_device_t *device)
+{
+	UNUSED_PARAMETER(device);
+	return true;
+}
+
 void device_present(gs_device_t *device)
 {
 	if (!SwapBuffers(device->cur_swap->wi->hdc)) {

--- a/libobs/graphics/device-exports.h
+++ b/libobs/graphics/device-exports.h
@@ -133,6 +133,7 @@ EXPORT void device_load_swapchain(gs_device_t *device,
 EXPORT void device_clear(gs_device_t *device, uint32_t clear_flags,
 			 const struct vec4 *color, float depth,
 			 uint8_t stencil);
+EXPORT bool device_is_present_ready(gs_device_t *device);
 EXPORT void device_present(gs_device_t *device);
 EXPORT void device_flush(gs_device_t *device);
 EXPORT void device_set_cull_mode(gs_device_t *device, enum gs_cull_mode mode);

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -96,6 +96,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT(device_load_swapchain);
 	GRAPHICS_IMPORT(device_end_scene);
 	GRAPHICS_IMPORT(device_clear);
+	GRAPHICS_IMPORT(device_is_present_ready);
 	GRAPHICS_IMPORT(device_present);
 	GRAPHICS_IMPORT(device_flush);
 	GRAPHICS_IMPORT(device_set_cull_mode);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -133,6 +133,7 @@ struct gs_exports {
 	void (*device_clear)(gs_device_t *device, uint32_t clear_flags,
 			     const struct vec4 *color, float depth,
 			     uint8_t stencil);
+	bool (*device_is_present_ready)(gs_device_t *device);
 	void (*device_present)(gs_device_t *device);
 	void (*device_flush)(gs_device_t *device);
 	void (*device_set_cull_mode)(gs_device_t *device,

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -1943,6 +1943,16 @@ void gs_clear(uint32_t clear_flags, const struct vec4 *color, float depth,
 				       depth, stencil);
 }
 
+bool gs_is_present_ready(void)
+{
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_is_present_ready"))
+		return false;
+
+	return graphics->exports.device_is_present_ready(graphics->device);
+}
+
 void gs_present(void)
 {
 	graphics_t *graphics = thread_graphics;

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -742,6 +742,7 @@ EXPORT void gs_end_scene(void);
 EXPORT void gs_load_swapchain(gs_swapchain_t *swapchain);
 EXPORT void gs_clear(uint32_t clear_flags, const struct vec4 *color,
 		     float depth, uint8_t stencil);
+EXPORT bool gs_is_present_ready(void);
 EXPORT void gs_present(void);
 EXPORT void gs_flush(void);
 


### PR DESCRIPTION
### Description
Some users stream projectors, so don't let them tear. Use the waitable
object to check the flip queue, and only flip if there's space.

Fixes #6936

### Motivation and Context
Want to both have tear-free flip, and avoid stalling the graphics thread.

### How Has This Been Tested?
Used temporary instrumentation to both verify flip/no-flip repeating pattern for 120 Hz video on 60 Hz monitor, and that Present calls normally last 50-60 µs in the new setup.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.