### PR TITLE
UI: Don't hardcode margins in lineedit-autoresize

### DIFF
--- a/UI/lineedit-autoresize.cpp
+++ b/UI/lineedit-autoresize.cpp
@@ -74,7 +74,8 @@ void LineEditAutoResize::keyPressEvent(QKeyEvent *event)
 
 void LineEditAutoResize::resizeVertically(const QSizeF &newSize)
 {
-	setMaximumHeight(newSize.height() + 7);
+	QMargins margins = contentsMargins();
+	setMaximumHeight(newSize.height() + margins.top() + margins.bottom());
 }
 
 QString LineEditAutoResize::text()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Not sure why they were hardcoded in the first place. Different themes have different margins, the size should respect these.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed that in some themes, the chat box would have a scrollbar. Which is bad, it shouldn't have that.
I don't like introducing bugs and then not fixing them.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13
Neither Yami, Dark, nor system theme have a scrollbar, and the box isn't visibly larger than it needs to be (meaning its size is exactly right).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
