### PR TITLE
obs-scripting: Fix SWIG flags for non-macOS POSIX

### DIFF
--- a/deps/obs-scripting/CMakeLists.txt
+++ b/deps/obs-scripting/CMakeLists.txt
@@ -127,8 +127,8 @@ if(TARGET Python::Python)
     PRE_BUILD
     COMMAND
       ${CMAKE_COMMAND} -E env "SWIG_LIB=${SWIG_DIR}" ${SWIG_EXECUTABLE} -python
-      $<IF:$<BOOL:${OS_LINUX}>,-py3,-py3-stable-abi> -external-runtime
-      swig/swigpyrun.h
+      $<IF:$<AND:$<BOOL:${OS_POSIX}>,$<NOT:$<BOOL:${OS_MACOS}>>>,-py3,-py3-stable-abi>
+      -external-runtime swig/swigpyrun.h
     COMMENT "obs-scripting - generating Python 3 SWIG interface headers")
 
   set_source_files_properties(swig/swigpyrun.h PROPERTIES GENERATED ON)

--- a/deps/obs-scripting/obspython/CMakeLists.txt
+++ b/deps/obs-scripting/obspython/CMakeLists.txt
@@ -22,8 +22,11 @@ include(UseSWIG)
 
 set_source_files_properties(
   obspython.i
-  PROPERTIES USE_TARGET_INCLUDE_DIRECTORIES TRUE
-             SWIG_FLAGS "$<IF:$<BOOL:${OS_LINUX}>,-py3,-py3-stable-abi>")
+  PROPERTIES
+    USE_TARGET_INCLUDE_DIRECTORIES TRUE
+    SWIG_FLAGS
+    "$<IF:$<AND:$<BOOL:${OS_POSIX}>,$<NOT:$<BOOL:${OS_MACOS}>>>,-py3,-py3-stable-abi>"
+)
 
 swig_add_library(
   obspython


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixes #6946 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Avoid SWIG Python ABI flag on non-macOS POSIX rather than just Linux.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Work on my Arch Linux.

Need a sanity check for the macOS build.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
