### PR TITLE
obs-ffmpeg: Fix crash when retrying init encoder for NVENC

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -997,7 +997,10 @@ static bool init_encoder(struct nvenc_data *enc, bool hevc,
 
 		blog(LOG_WARNING, "[jim-nvenc] init_specific_encoder failed, "
 				  "trying again without Psycho Visual Tuning");
-		if (!init_specific_encoder(enc, hevc, settings, encoder, bf,
+		nv.nvEncDestroyEncoder(enc->session);
+		enc->session = NULL;
+		if (!init_session(enc) ||
+		    !init_specific_encoder(enc, hevc, settings, encoder, bf,
 					   false)) {
 			return false;
 		}

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -949,11 +949,8 @@ static bool init_textures(struct nvenc_data *enc)
 static void nvenc_destroy(void *data);
 
 static bool init_specific_encoder(struct nvenc_data *enc, bool hevc,
-				  obs_data_t *settings, obs_encoder_t *encoder,
-				  int bf, bool psycho_aq)
+				  obs_data_t *settings, int bf, bool psycho_aq)
 {
-	bool init = false;
-
 #ifdef ENABLE_HEVC
 	if (hevc)
 		return init_encoder_hevc(enc, settings, bf, psycho_aq);
@@ -963,7 +960,7 @@ static bool init_specific_encoder(struct nvenc_data *enc, bool hevc,
 }
 
 static bool init_encoder(struct nvenc_data *enc, bool hevc,
-			 obs_data_t *settings, obs_encoder_t *encoder)
+			 obs_data_t *settings)
 {
 	const int bf = (int)obs_data_get_int(settings, "bf");
 	const bool psycho_aq = obs_data_get_bool(settings, "psycho_aq");
@@ -990,8 +987,7 @@ static bool init_encoder(struct nvenc_data *enc, bool hevc,
 		return false;
 	}
 
-	if (!init_specific_encoder(enc, hevc, settings, encoder, bf,
-				   psycho_aq)) {
+	if (!init_specific_encoder(enc, hevc, settings, bf, psycho_aq)) {
 		if (!psycho_aq)
 			return false;
 
@@ -1000,8 +996,7 @@ static bool init_encoder(struct nvenc_data *enc, bool hevc,
 		nv.nvEncDestroyEncoder(enc->session);
 		enc->session = NULL;
 		if (!init_session(enc) ||
-		    !init_specific_encoder(enc, hevc, settings, encoder, bf,
-					   false)) {
+		    !init_specific_encoder(enc, hevc, settings, bf, false)) {
 			return false;
 		}
 	}
@@ -1029,7 +1024,7 @@ static void *nvenc_create_internal(bool hevc, obs_data_t *settings,
 	if (!init_session(enc)) {
 		goto fail;
 	}
-	if (!init_encoder(enc, hevc, settings, encoder)) {
+	if (!init_encoder(enc, hevc, settings)) {
 		goto fail;
 	}
 	if (!init_bitstreams(enc)) {

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -998,7 +998,7 @@ static bool init_encoder(struct nvenc_data *enc, bool hevc,
 		blog(LOG_WARNING, "[jim-nvenc] init_specific_encoder failed, "
 				  "trying again without Psycho Visual Tuning");
 		if (!init_specific_encoder(enc, hevc, settings, encoder, bf,
-					   psycho_aq)) {
+					   false)) {
 			return false;
 		}
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

1. Correctly assign argument psycho_aq to false when retrying again without Psycho Visual Tuning.
2. Reinit encode session before retrying init encoder to fix crash
3. Code cleanup

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

1. notice that the argument `psycho_aq` was assigned unexpectedly when debugging
2. fixes #6911 
3. code cleanup mentioned by @jpark37 

the diff between 28 and 27.2.4(doesnt crash in this version mentioned by issue) https://github.com/obsproject/obs-studio/commit/699e89d8596e8f96c3d7d4448998ca73d2efac87
move the retrying code segments, and then in this way pass the `nvenc_destroy(enc)` and `init_session(enc)` procedure.

https://github.com/obsproject/obs-studio/blob/1444ead8123a3947ea12f1f515afd5741ee5936e/plugins/obs-ffmpeg/jim-nvenc.c#L689-L696

https://github.com/obsproject/obs-studio/blob/1444ead8123a3947ea12f1f515afd5741ee5936e/plugins/obs-ffmpeg/jim-nvenc.c#L629-L664


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Win10 with Nvidia GTX 1050 Ti max-Q Design (Laptop version), Thinkpad X1e 1gen

retry these steps in *Steps to Reproduce*
with settings `X264(new)`/`HEVC(new)`, `Rescale Output(disable)` and `Lossless`

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

Bug fix (non-breaking change which fixes an issue)
Code cleanup (non-breaking change which makes code smaller or more readable)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
