### PR TITLE
UI: Fix disabled sliders with Yami

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -825,7 +825,7 @@ QSlider::sub-page:horizontal {
 }
 
 QSlider::sub-page:horizontal:disabled {
-    background-color: palette(dark);
+    background-color: palette(window);
     border-radius: 2px;
 }
 
@@ -855,7 +855,7 @@ QSlider::add-page:vertical {
 }
 
 QSlider::add-page:vertical:disabled {
-    background-color: rgb(50,49,50);
+    background-color: palette(window);
     border-radius: 2px;
 }
 

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -815,7 +815,7 @@ QSlider::sub-page:horizontal {
 }
 
 QSlider::sub-page:horizontal:disabled {
-    background-color: palette(dark);
+    background-color: palette(window);
     border-radius: 2px;
 }
 
@@ -845,7 +845,7 @@ QSlider::add-page:vertical {
 }
 
 QSlider::add-page:vertical:disabled {
-    background-color: rgb(50,49,50);
+    background-color: palette(window);
     border-radius: 2px;
 }
 

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -815,7 +815,7 @@ QSlider::sub-page:horizontal {
 }
 
 QSlider::sub-page:horizontal:disabled {
-    background-color: palette(dark);
+    background-color: palette(window);
     border-radius: 2px;
 }
 
@@ -845,7 +845,7 @@ QSlider::add-page:vertical {
 }
 
 QSlider::add-page:vertical:disabled {
-    background-color: rgb(50,49,50);
+    background-color: palette(window);
     border-radius: 2px;
 }
 

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -819,7 +819,7 @@ QSlider::sub-page:horizontal {
 }
 
 QSlider::sub-page:horizontal:disabled {
-    background-color: palette(dark);
+    background-color: palette(window);
     border-radius: 2px;
 }
 
@@ -849,7 +849,7 @@ QSlider::add-page:vertical {
 }
 
 QSlider::add-page:vertical:disabled {
-    background-color: rgb(50,49,50);
+    background-color: palette(window);
     border-radius: 2px;
 }
 

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -819,7 +819,7 @@ QSlider::sub-page:horizontal {
 }
 
 QSlider::sub-page:horizontal:disabled {
-    background-color: palette(dark);
+    background-color: palette(window);
     border-radius: 2px;
 }
 
@@ -849,7 +849,7 @@ QSlider::add-page:vertical {
 }
 
 QSlider::add-page:vertical:disabled {
-    background-color: rgb(50,49,50);
+    background-color: palette(window);
     border-radius: 2px;
 }
 


### PR DESCRIPTION
### Description
The disabled sliders would be the same color as the window background.

Before:
![Screenshot from 2022-08-05 22-48-41](https://user-images.githubusercontent.com/19962531/183232539-d8e4da09-406d-4401-a9d1-a5babee2a583.png)

After:
![Screenshot from 2022-08-21 01-13-36](https://user-images.githubusercontent.com/19962531/185778212-21f67117-8f98-4472-b44d-d21e739f8706.png)

### Motivation and Context
Fix Yami bugs

### How Has This Been Tested?
Locked volume controls to make sure the disabled slider was colored properly

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
