### PR TITLE
UI: Fix Yami list widget hover color

### DIFF
--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -201,7 +201,11 @@ SourceTree::item:selected:hover {
 }
 
 QListWidget::item:disabled,
-QListWidget::item:hover {
+QListWidget::item:disabled:hover,
+SourceTree::item:disabled,
+SourceTree::item:disabled:hover,
+SceneTree::item:disabled,
+SceneTree::item:disabled:hover {
     background: transparent;
     color: rgb(153,153,153);
 }


### PR DESCRIPTION
### Description
With Yami, when hovering a list widget (ie. scenes/settings), the
background wouldn't change like the sources list.

### Motivation and Context
Fix Yami bugs

### How Has This Been Tested?
Hovered over list widgets

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
