### PR TITLE
UI: Force fixed font in plain text edits

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -186,6 +186,8 @@ target_sources(
           menu-button.cpp
           menu-button.hpp
           mute-checkbox.hpp
+          plain-text-edit.cpp
+          plain-text-edit.hpp
           properties-view.cpp
           properties-view.hpp
           properties-view.moc.hpp

--- a/UI/crash-report.cpp
+++ b/UI/crash-report.cpp
@@ -1,12 +1,12 @@
 #include "crash-report.hpp"
 #include <QApplication>
 #include <QFontDatabase>
-#include <QPlainTextEdit>
 #include <QPushButton>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QClipboard>
 #include "qt-wrappers.hpp"
+#include "plain-text-edit.hpp"
 
 OBSCrashReport::OBSCrashReport(QWidget *parent, const char *text)
 	: QDialog(parent)
@@ -17,10 +17,9 @@ OBSCrashReport::OBSCrashReport(QWidget *parent, const char *text)
 	QPushButton *exitButton = new QPushButton;
 	exitButton->setText("Exit");
 
-	textBox = new QPlainTextEdit;
+	textBox = new OBSPlainTextEdit;
 	textBox->setPlainText(QT_UTF8(text));
 	textBox->setLineWrapMode(QPlainTextEdit::NoWrap);
-	textBox->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 
 	QHBoxLayout *buttonLayout = new QHBoxLayout;
 	buttonLayout->addWidget(copyButton);

--- a/UI/crash-report.hpp
+++ b/UI/crash-report.hpp
@@ -2,12 +2,12 @@
 
 #include <QDialog>
 
-class QPlainTextEdit;
+class OBSPlainTextEdit;
 
 class OBSCrashReport : public QDialog {
 	Q_OBJECT
 
-	QPlainTextEdit *textBox;
+	OBSPlainTextEdit *textBox;
 
 public:
 	OBSCrashReport(QWidget *parent, const char *text);

--- a/UI/forms/OBSLogViewer.ui
+++ b/UI/forms/OBSLogViewer.ui
@@ -27,7 +27,7 @@
     <number>4</number>
    </property>
    <item>
-    <widget class="QPlainTextEdit" name="textArea">
+    <widget class="OBSPlainTextEdit" name="textArea">
      <property name="readOnly">
       <bool>true</bool>
      </property>
@@ -92,6 +92,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>OBSPlainTextEdit</class>
+   <extends>QPlainTextEdit</extends>
+   <header>plain-text-edit.hpp</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="obs.qrc"/>
  </resources>

--- a/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
@@ -44,6 +44,8 @@ target_sources(
           ${CMAKE_SOURCE_DIR}/plugins/aja/aja-widget-io.hpp
           ${CMAKE_SOURCE_DIR}/UI/double-slider.cpp
           ${CMAKE_SOURCE_DIR}/UI/double-slider.hpp
+          ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.hpp
+          ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.cpp
           ${CMAKE_SOURCE_DIR}/UI/properties-view.hpp
           ${CMAKE_SOURCE_DIR}/UI/properties-view.cpp
           ${CMAKE_SOURCE_DIR}/UI/properties-view.moc.hpp

--- a/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
@@ -26,6 +26,8 @@ target_sources(
           decklink-ui-main.h
           ${CMAKE_SOURCE_DIR}/UI/double-slider.cpp
           ${CMAKE_SOURCE_DIR}/UI/double-slider.hpp
+          ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.hpp
+          ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.cpp
           ${CMAKE_SOURCE_DIR}/UI/properties-view.hpp
           ${CMAKE_SOURCE_DIR}/UI/properties-view.cpp
           ${CMAKE_SOURCE_DIR}/UI/properties-view.moc.hpp

--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -38,7 +38,9 @@ target_sources(
           ${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.cpp
           ${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.hpp
           ${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.hpp
-          ${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.cpp)
+          ${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.cpp
+          ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.cpp
+          ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.hpp)
 
 target_compile_features(frontend-tools PRIVATE cxx_std_17)
 

--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -2,9 +2,9 @@
 #include "scripts.hpp"
 #include "../../properties-view.hpp"
 #include "../../qt-wrappers.hpp"
+#include "../../plain-text-edit.hpp"
 
 #include <QFileDialog>
-#include <QPlainTextEdit>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QScrollBar>
@@ -81,18 +81,14 @@ struct ScriptData {
 static ScriptData *scriptData = nullptr;
 static ScriptsTool *scriptsWindow = nullptr;
 static ScriptLogWindow *scriptLogWindow = nullptr;
-static QPlainTextEdit *scriptLogWidget = nullptr;
+static OBSPlainTextEdit *scriptLogWidget = nullptr;
 
 /* ----------------------------------------------------------------- */
 
 ScriptLogWindow::ScriptLogWindow() : QWidget(nullptr)
 {
-	const QFont fixedFont =
-		QFontDatabase::systemFont(QFontDatabase::FixedFont);
-
-	QPlainTextEdit *edit = new QPlainTextEdit();
+	OBSPlainTextEdit *edit = new OBSPlainTextEdit();
 	edit->setReadOnly(true);
-	edit->setFont(fixedFont);
 	edit->setWordWrapMode(QTextOption::NoWrap);
 
 	QHBoxLayout *buttonLayout = new QHBoxLayout();

--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -21,14 +21,6 @@ OBSLogViewer::OBSLogViewer(QWidget *parent)
 
 	ui->setupUi(this);
 
-	const QFont fixedFont =
-		QFontDatabase::systemFont(QFontDatabase::FixedFont);
-
-	ui->textArea->setFont(fixedFont);
-	// Fix display of tabs & multiple spaces
-	ui->textArea->document()->setDefaultStyleSheet(
-		"font { white-space: pre; }");
-
 	bool showLogViewerOnStartup = config_get_bool(
 		App()->GlobalConfig(), "LogViewer", "ShowLogStartup");
 

--- a/UI/plain-text-edit.cpp
+++ b/UI/plain-text-edit.cpp
@@ -1,0 +1,19 @@
+#include "plain-text-edit.hpp"
+#include <QFontDatabase>
+
+OBSPlainTextEdit::OBSPlainTextEdit(QWidget *parent, bool monospace)
+	: QPlainTextEdit(parent)
+{
+	// Fix display of tabs & multiple spaces
+	document()->setDefaultStyleSheet("font { white-space: pre; }");
+
+	if (monospace) {
+		const QFont fixedFont =
+			QFontDatabase::systemFont(QFontDatabase::FixedFont);
+
+		setStyleSheet(
+			QString("font-family: %1; font-size: %2pt;")
+				.arg(fixedFont.family(),
+				     QString::number(fixedFont.pointSize())));
+	}
+}

--- a/UI/plain-text-edit.hpp
+++ b/UI/plain-text-edit.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <QPlainTextEdit>
+
+class OBSPlainTextEdit : public QPlainTextEdit {
+	Q_OBJECT
+
+public:
+	explicit OBSPlainTextEdit(QWidget *parent = nullptr,
+				  bool monospace = true);
+};

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -14,7 +14,6 @@
 #include <QStandardItem>
 #include <QFileDialog>
 #include <QColorDialog>
-#include <QPlainTextEdit>
 #include <QDialogButtonBox>
 #include <QMenu>
 #include <QMessageBox>
@@ -29,6 +28,7 @@
 #include "qt-wrappers.hpp"
 #include "properties-view.hpp"
 #include "properties-view.moc.hpp"
+#include "plain-text-edit.hpp"
 #include "obs-app.hpp"
 
 #include <cstdlib>
@@ -264,17 +264,13 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
 {
 	const char *name = obs_property_name(prop);
 	const char *val = obs_data_get_string(settings, name);
-	const bool monospace = obs_property_text_monospace(prop);
+	bool monospace = obs_property_text_monospace(prop);
 	obs_text_type type = obs_property_text_type(prop);
 
 	if (type == OBS_TEXT_MULTILINE) {
-		QPlainTextEdit *edit = new QPlainTextEdit(QT_UTF8(val));
+		OBSPlainTextEdit *edit = new OBSPlainTextEdit(this, monospace);
+		edit->setPlainText(QT_UTF8(val));
 		edit->setTabStopDistance(40);
-		if (monospace) {
-			QFont f("Courier");
-			f.setStyleHint(QFont::Monospace);
-			edit->setFont(f);
-		}
 		return NewWidget(prop, edit, SIGNAL(textChanged()));
 
 	} else if (type == OBS_TEXT_PASSWORD) {
@@ -1724,7 +1720,8 @@ void WidgetInfo::TextChanged(const char *setting)
 	obs_text_type type = obs_property_text_type(property);
 
 	if (type == OBS_TEXT_MULTILINE) {
-		QPlainTextEdit *edit = static_cast<QPlainTextEdit *>(widget);
+		OBSPlainTextEdit *edit =
+			static_cast<OBSPlainTextEdit *>(widget);
 		obs_data_set_string(view->settings, setting,
 				    QT_TO_UTF8(edit->toPlainText()));
 		return;


### PR DESCRIPTION
### Description
Since the Yami QSS changes the default font for widgets, we need
to force the system fixed font for plain text edits.

### Motivation and Context
Fix Yami bugs

### How Has This Been Tested?
Opened log viewer to make sure it was the right font

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
