### PR TITLE
obs-ffmpeg: fix USAGE typo

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1176,7 +1176,7 @@ static void amf_avc_create_internal(amf_base *enc, obs_data_t *settings)
 	}
 
 	set_avc_property(enc, FRAMESIZE, AMFConstructSize(enc->cx, enc->cy));
-	set_avc_property(enc, USAGE, AMF_VIDEO_ENCODER_USAGE_TRANSCONDING);
+	set_avc_property(enc, USAGE, AMF_VIDEO_ENCODER_USAGE_TRANSCODING);
 	set_avc_property(enc, QUALITY_PRESET, get_avc_preset(enc, settings));
 	set_avc_property(enc, PROFILE, get_avc_profile(settings));
 	set_avc_property(enc, LOWLATENCY_MODE, false);
@@ -1468,7 +1468,7 @@ static void amf_hevc_create_internal(amf_base *enc, obs_data_t *settings)
 	const bool is_hdr = pq || hlg;
 
 	set_hevc_property(enc, FRAMESIZE, AMFConstructSize(enc->cx, enc->cy));
-	set_hevc_property(enc, USAGE, AMF_VIDEO_ENCODER_USAGE_TRANSCONDING);
+	set_hevc_property(enc, USAGE, AMF_VIDEO_ENCODER_USAGE_TRANSCODING);
 	set_hevc_property(enc, QUALITY_PRESET, get_hevc_preset(enc, settings));
 	set_hevc_property(enc, COLOR_BIT_DEPTH,
 			  is10bit ? AMF_COLOR_BIT_DEPTH_10


### PR DESCRIPTION
### Description
Replace TRANSCONDING with TRANSCODING for both H.264 and HEVC, becuase it is likely that the typo compatibility will be removed in a future AMF header update. This should also minimize confusion and improve search.

See: https://github.com/obsproject/obs-studio/blob/a1e8075fba09f3b56ed43ead64cc3e340dd7a059/plugins/obs-ffmpeg/external/AMF/include/components/VideoEncoderVCE.h#L50-L51

### Motivation and Context
Currently uses an old typo. While currently valid, this could change when AMF headers are updated, so might as well correct it now.

### How Has This Been Tested?
Compiled on windows, recorded using the encoder (both h264 and HEVC), and inspect the outputs.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
