### PR TITLE
libobs: Fix missing pair of GS_DEBUG_MARKER

### DIFF
--- a/libobs/obs-display.c
+++ b/libobs/obs-display.c
@@ -250,10 +250,10 @@ void render_display(struct obs_display *display)
 
 		render_display_end();
 
-		GS_DEBUG_MARKER_END();
-
 		gs_present();
 	}
+
+	GS_DEBUG_MARKER_END();
 }
 
 void obs_display_set_enabled(obs_display_t *display, bool enable)


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Call `GS_DEBUG_MARKER_END` outside the conditional block.
Order of `GS_DEBUG_MARKER_END` and `gs_present` is swapped, I think this is not a significant difference.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The conditional branch added by obsproject/obs-studio/6942 resulted `GS_DEBUG_MARKER_END` is not called when the branch condition is failed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 35.

Started OBS and checked displays show contents.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
