### PR TITLE
cmake: Fix plugin RPATH entry on Linux

### DIFF
--- a/cmake/Modules/ObsDefaults_Linux.cmake
+++ b/cmake/Modules/ObsDefaults_Linux.cmake
@@ -94,7 +94,7 @@ macro(setup_obs_project)
 
     set(OBS_SCRIPT_PLUGIN_PATH "../../${OBS_SCRIPT_PLUGIN_DESTINATION}")
     set(CMAKE_INSTALL_RPATH "$ORIGIN/"
-                            "${ORIGIN}/../../${OBS_LIBRARY_DESTINATION}")
+                            "$ORIGIN/../../${OBS_LIBRARY_DESTINATION}")
   endif()
 
   if(BUILD_FOR_PPA)


### PR DESCRIPTION
### Description
Fixes RPATH setting on Linux to use the correct variable notation.

### Motivation and Context
The `$ORIGIN` variable for RPATHs on Linux has been erroneously using CMake's variable notation, which will obviously not work for Linux' library loader.

This PR fixes the issue by using the proper notation.

### How Has This Been Tested?
Tested on Ubuntu 22.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
