### PR TITLE
UI: Fix settings properties view background

### DIFF
--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -234,6 +234,11 @@ OBSBasicSettings QListWidget::item {
     padding: 6px;
 }
 
+/* Settings properties view */
+OBSBasicSettings #PropertiesContainer {
+    background-color: palette(dark);
+}
+
 /* Dock Widget */
 OBSDock > QWidget {
     background: palette(dark);

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -116,6 +116,7 @@ void OBSPropertiesView::RefreshProperties()
 		widget->deleteLater();
 
 	widget = new QWidget();
+	widget->setObjectName("PropertiesContainer");
 
 	QFormLayout *layout = new QFormLayout;
 	layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);


### PR DESCRIPTION
### Description
In the Yami theme, the background color in the properties view in the
settings dialog would be incorrect.

Before:
![Screenshot from 2022-08-06 22-26-36](https://user-images.githubusercontent.com/19962531/183273931-05a37a61-d90e-4fcc-9ee5-0a168f992396.png)

After:
![Screenshot from 2022-08-06 22-25-49](https://user-images.githubusercontent.com/19962531/183273936-76e90d2f-97d5-4c09-b558-4b09d9dfea15.png)

### Motivation and Context
Fix Yami bugs

### How Has This Been Tested?
Looked at all of the the properties views in the settings to make sure they had the correct background.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
