### PR TITLE
libobs: Remove display GPU markers without draws

### DIFF
--- a/libobs/obs-display.c
+++ b/libobs/obs-display.c
@@ -220,8 +220,6 @@ void render_display(struct obs_display *display)
 	if (!display || !display->enabled)
 		return;
 
-	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DISPLAY, "obs_display");
-
 	/* -------------------------------------------- */
 
 	pthread_mutex_lock(&display->draw_info_mutex);
@@ -237,6 +235,8 @@ void render_display(struct obs_display *display)
 	/* -------------------------------------------- */
 
 	if (render_display_begin(display, cx, cy, update_color_space)) {
+		GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DISPLAY, "obs_display");
+
 		pthread_mutex_lock(&display->draw_callbacks_mutex);
 
 		for (size_t i = 0; i < display->draw_callbacks.num; i++) {
@@ -250,10 +250,10 @@ void render_display(struct obs_display *display)
 
 		render_display_end();
 
+		GS_DEBUG_MARKER_END();
+
 		gs_present();
 	}
-
-	GS_DEBUG_MARKER_END();
 }
 
 void obs_display_set_enabled(obs_display_t *display, bool enable)


### PR DESCRIPTION
### Description
Don't mark up display draws if there aren't going to be any.

### Motivation and Context
Don't need markers for empty draws.

### How Has This Been Tested?
Verified markers are still getting through to RenderDoc.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.