### PR TITLE
UI: Fix source tree item color height

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -189,11 +189,17 @@ SourceTree {
     padding: 3px;
 }
 
+SourceTreeItem,
+QMenu::item,
+SceneTree::item {
+    padding: 6px;
+}
+
+SourceTreeItem,
 QMenu::item,
 SceneTree::item,
 SourceTree::item {
     border-radius: 4px;
-    padding: 6px;
     color: palette(text);
 	border: 0px solid transparent;
 }

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -189,11 +189,17 @@ SourceTree {
     padding: 3px;
 }
 
+SourceTreeItem,
+QMenu::item,
+SceneTree::item {
+    padding: 6px;
+}
+
+SourceTreeItem,
 QMenu::item,
 SceneTree::item,
 SourceTree::item {
     border-radius: 4px;
-    padding: 6px;
     color: palette(text);
 	border: 0px solid transparent;
 }

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -189,11 +189,17 @@ SourceTree {
     padding: 3px;
 }
 
+SourceTreeItem,
+QMenu::item,
+SceneTree::item {
+    padding: 6px;
+}
+
+SourceTreeItem,
 QMenu::item,
 SceneTree::item,
 SourceTree::item {
     border-radius: 4px;
-    padding: 6px;
     color: palette(text);
 	border: 0px solid transparent;
 }

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -191,11 +191,17 @@ SourceTree {
     padding: 3px;
 }
 
+SourceTreeItem,
+QMenu::item,
+SceneTree::item {
+    padding: 6px;
+}
+
+SourceTreeItem,
 QMenu::item,
 SceneTree::item,
 SourceTree::item {
     border-radius: 4px;
-    padding: 6px;
     color: palette(text);
 	border: 0px solid transparent;
 }

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -189,11 +189,17 @@ SourceTree {
     padding: 3px;
 }
 
+SourceTreeItem,
+QMenu::item,
+SceneTree::item {
+    padding: 6px;
+}
+
+SourceTreeItem,
 QMenu::item,
 SceneTree::item,
 SourceTree::item {
     border-radius: 4px;
-    padding: 6px;
     color: palette(text);
 	border: 0px solid transparent;
 }

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -1088,6 +1088,8 @@ SourceTree::SourceTree(QWidget *parent_) : QListView(parent_)
 	connect(App(), &OBSApp::StyleChanged, this,
 		&SourceTree::UpdateNoSourcesMessage);
 	connect(App(), &OBSApp::StyleChanged, this, &SourceTree::UpdateIcons);
+
+	setItemDelegate(new SourceTreeDelegate(this));
 }
 
 void SourceTree::UpdateIcons()
@@ -1742,4 +1744,18 @@ void SourceTree::paintEvent(QPaintEvent *event)
 	} else {
 		QListView::paintEvent(event);
 	}
+}
+
+SourceTreeDelegate::SourceTreeDelegate(QObject *parent)
+	: QStyledItemDelegate(parent)
+{
+}
+
+QSize SourceTreeDelegate::sizeHint(const QStyleOptionViewItem &,
+				   const QModelIndex &index) const
+{
+	SourceTree *tree = qobject_cast<SourceTree *>(parent());
+	QWidget *item = tree->indexWidget(index);
+
+	return (QSize(item->width(), item->height()));
 }

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -8,6 +8,7 @@
 #include <QStaticText>
 #include <QSvgRenderer>
 #include <QAbstractListModel>
+#include <QStyledItemDelegate>
 #include <obs.hpp>
 #include <obs-frontend-api.h>
 
@@ -25,7 +26,7 @@ class SourceTreeSubItemCheckBox : public QCheckBox {
 	Q_OBJECT
 };
 
-class SourceTreeItem : public QWidget {
+class SourceTreeItem : public QFrame {
 	Q_OBJECT
 
 	friend class SourceTree;
@@ -217,4 +218,13 @@ protected:
 	virtual void
 	selectionChanged(const QItemSelection &selected,
 			 const QItemSelection &deselected) override;
+};
+
+class SourceTreeDelegate : public QStyledItemDelegate {
+	Q_OBJECT
+
+public:
+	SourceTreeDelegate(QObject *parent);
+	virtual QSize sizeHint(const QStyleOptionViewItem &option,
+			       const QModelIndex &index) const override;
 };


### PR DESCRIPTION
### Description
Fixes widget inside of source tree item being incorrect height.

Before:
![Screenshot from 2022-08-07 01-47-41](https://user-images.githubusercontent.com/19962531/183279281-937827fb-5756-49cf-a591-f84e2e829fc6.png)

After:
![Screenshot from 2022-08-07 02-11-05](https://user-images.githubusercontent.com/19962531/183279649-9c38d4e0-22ef-420f-affa-bfbdbe9eacbe.png)

### Motivation and Context
Fix theme bugs

### How Has This Been Tested?
Set scene item colors and made sure everything looked good.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
