### PR TITLE
UI: Fix ffmpeg path browse button not showing

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -3189,7 +3189,7 @@
                                   </sizepolicy>
                                  </property>
                                  <property name="currentIndex">
-                                  <number>1</number>
+                                  <number>0</number>
                                  </property>
                                  <widget class="QWidget" name="page_7">
                                   <property name="sizePolicy">


### PR DESCRIPTION
### Description
The ffmpeg path browse button would be hidden in the settings.

Before:
![Screenshot from 2022-08-07 03-34-44](https://user-images.githubusercontent.com/19962531/183282469-58b4fd5e-8b04-4e9b-93a1-daedb868f1b3.png)

After:
![Screenshot from 2022-08-07 03-28-00](https://user-images.githubusercontent.com/19962531/183282306-4d109207-f5b3-4973-8402-9d4f5cef7de2.png)

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/6986

### How Has This Been Tested?
Changed to ffmpeg settings to make sure button was there.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
