### PR TITLE
obs-filters: Fix NVIDIA greenscreen issues

### DIFF
--- a/plugins/obs-filters/data/rtx_greenscreen.effect
+++ b/plugins/obs-filters/data/rtx_greenscreen.effect
@@ -11,24 +11,27 @@ sampler_state texSampler {
 };
 
 struct VertData {
+	float2 uv  : TEXCOORD0;
 	float4 pos : POSITION;
+};
+
+struct FragData {
 	float2 uv  : TEXCOORD0;
 };
 
 VertData VSDefault(VertData v_in)
 {
 	VertData v_out;
-	v_out.pos = mul(float4(v_in.pos.xyz, 1.0), ViewProj);
 	v_out.uv = v_in.uv;
+	v_out.pos = mul(float4(v_in.pos.xyz, 1.), ViewProj);
 	return v_out;
 }
 
-float4 PSMask(VertData v2_in) : TARGET
+float4 PSMask(FragData f_in) : TARGET
 {
-	float4 pix;
-	pix.rgb = image.Sample(texSampler, v2_in.uv).rgb;
-	pix.a = smoothstep(threshold - 0.1,threshold,mask.Sample(texSampler, v2_in.uv).a);
-	return pix;
+	float4 rgba = image.Sample(texSampler, f_in.uv);
+	rgba *= smoothstep(threshold - 0.1,threshold,mask.Sample(texSampler, f_in.uv).a);
+	return rgba;
 }
 
 technique Draw
@@ -36,6 +39,6 @@ technique Draw
 	pass
 	{
 		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSMask(v2_in);
+		pixel_shader  = PSMask(f_in);
 	}
 }


### PR DESCRIPTION
### Description
Fix non-async sources, make sure math is linear-correct, preserve
incoming alpha, and allow the filter to work in previews.

### Motivation and Context
Improve color correctness.

### How Has This Been Tested?
Verified main preview and filter preview look reasonable.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.