### PR TITLE
obs-filters: Support HDR AI greenscreen

### DIFF
--- a/plugins/obs-filters/data/color.effect
+++ b/plugins/obs-filters/data/color.effect
@@ -1,3 +1,13 @@
+float srgb_linear_to_nonlinear_channel(float u)
+{
+	return (u <= 0.0031308) ? (12.92 * u) : ((1.055 * pow(u, 1. / 2.4)) - 0.055);
+}
+
+float3 srgb_linear_to_nonlinear(float3 v)
+{
+	return float3(srgb_linear_to_nonlinear_channel(v.r), srgb_linear_to_nonlinear_channel(v.g), srgb_linear_to_nonlinear_channel(v.b));
+}
+
 float3 rec709_to_rec2020(float3 v)
 {
 	float r = dot(v, float3(0.62740389593469914, 0.32928303837788397, 0.043313065687417190));

--- a/plugins/obs-filters/data/rtx_greenscreen.effect
+++ b/plugins/obs-filters/data/rtx_greenscreen.effect
@@ -1,5 +1,8 @@
+#include "color.effect"
+
 uniform float4x4 ViewProj;
 uniform texture2d image;
+uniform float multiplier;
 
 uniform texture2d mask;
 uniform float threshold;
@@ -11,6 +14,11 @@ sampler_state texSampler {
 };
 
 struct VertData {
+	float4 pos : POSITION;
+	float2 uv  : TEXCOORD0;
+};
+
+struct VertInOut {
 	float2 uv  : TEXCOORD0;
 	float4 pos : POSITION;
 };
@@ -19,18 +27,95 @@ struct FragData {
 	float2 uv  : TEXCOORD0;
 };
 
-VertData VSDefault(VertData v_in)
+struct FragPos {
+	float4 pos : POSITION;
+};
+
+VertInOut VSDefault(VertData v_in)
 {
-	VertData v_out;
+	VertInOut v_out;
 	v_out.uv = v_in.uv;
 	v_out.pos = mul(float4(v_in.pos.xyz, 1.), ViewProj);
 	return v_out;
 }
 
-float4 PSMask(FragData f_in) : TARGET
+FragPos VSConvertUnorm(uint id : VERTEXID)
+{
+	float idHigh = float(id >> 1);
+	float idLow = float(id & uint(1));
+
+	float x = idHigh * 4.0 - 1.0;
+	float y = idLow * 4.0 - 1.0;
+
+	FragPos vert_out;
+	vert_out.pos = float4(x, y, 0.0, 1.0);
+	return vert_out;
+}
+
+float4 Mask(FragData f_in)
 {
 	float4 rgba = image.Sample(texSampler, f_in.uv);
 	rgba *= smoothstep(threshold - 0.1,threshold,mask.Sample(texSampler, f_in.uv).a);
+	return rgba;
+}
+
+float4 PSMask(FragData f_in) : TARGET
+{
+	float4 rgba = Mask(f_in);
+	return rgba;
+}
+
+float4 PSMaskMultiply(FragData f_in) : TARGET
+{
+	float4 rgba = Mask(f_in);
+	rgba.rgb *= multiplier;
+	return rgba;
+}
+
+float4 PSMaskTonemap(FragData f_in) : TARGET
+{
+	float4 rgba = Mask(f_in);
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
+float4 PSMaskMultiplyTonemap(FragData f_in) : TARGET
+{
+	float4 rgba = Mask(f_in);
+	rgba.rgb *= multiplier;
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	return rgba;
+}
+
+float4 PSConvertUnorm(FragPos f_in) : TARGET
+{
+	float4 rgba = image.Load(int3(f_in.pos.xy, 0));
+	rgba.rgb = srgb_linear_to_nonlinear(rgba.rgb);
+	return rgba;
+}
+
+float4 PSConvertUnormTonemap(FragPos f_in) : TARGET
+{
+	float4 rgba = image.Load(int3(f_in.pos.xy, 0));
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	rgba.rgb = srgb_linear_to_nonlinear(rgba.rgb);
+	return rgba;
+}
+
+float4 PSConvertUnormMultiplyTonemap(FragPos f_in) : TARGET
+{
+	float4 rgba = image.Load(int3(f_in.pos.xy, 0));
+	rgba.rgb *= multiplier;
+	rgba.rgb = rec709_to_rec2020(rgba.rgb);
+	rgba.rgb = reinhard(rgba.rgb);
+	rgba.rgb = rec2020_to_rec709(rgba.rgb);
+	rgba.rgb = srgb_linear_to_nonlinear(rgba.rgb);
 	return rgba;
 }
 
@@ -40,5 +125,59 @@ technique Draw
 	{
 		vertex_shader = VSDefault(v_in);
 		pixel_shader  = PSMask(f_in);
+	}
+}
+
+technique DrawMultiply
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSMaskMultiply(f_in);
+	}
+}
+
+technique DrawTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSMaskTonemap(f_in);
+	}
+}
+
+technique DrawMultiplyTonemap
+{
+	pass
+	{
+		vertex_shader = VSDefault(v_in);
+		pixel_shader  = PSMaskMultiplyTonemap(f_in);
+	}
+}
+
+technique ConvertUnorm
+{
+	pass
+	{
+		vertex_shader = VSConvertUnorm(id);
+		pixel_shader  = PSConvertUnorm(f_in);
+	}
+}
+
+technique ConvertUnormTonemap
+{
+	pass
+	{
+		vertex_shader = VSConvertUnorm(id);
+		pixel_shader  = PSConvertUnormTonemap(f_in);
+	}
+}
+
+technique ConvertUnormMultiplyTonemap
+{
+	pass
+	{
+		vertex_shader = VSConvertUnorm(id);
+		pixel_shader  = PSConvertUnormMultiplyTonemap(f_in);
 	}
 }


### PR DESCRIPTION
### Description
Add HDR support to AI greenscreen.

### Motivation and Context
More HDR support.

### How Has This Been Tested?
Checked SDR image/camera, and HDR image/video.

Admittedly, I didn't check every color space combination, but the others should be rare, and follow the same pattern as other filters. We can fix bugs if they come up.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.