### PR TITLE
cmake: Fix broken pthread detection on Windows with CMake 3.24

### DIFF
--- a/cmake/Modules/CompilerConfig.cmake
+++ b/cmake/Modules/CompilerConfig.cmake
@@ -15,6 +15,12 @@ if(OS_WINDOWS AND MSVC)
     )
   endif()
 
+  # CMake 3.24 introduces a bug mistakenly interpreting MSVC as supporting
+  # `-pthread`
+  if(${CMAKE_VERSION} VERSION_EQUAL "3.24.0")
+    set(THREADS_HAVE_PTHREAD_ARG OFF)
+  endif()
+
   # Check for Win SDK version 10.0.20348 or above
   obs_status(
     STATUS "Windows API version is ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")


### PR DESCRIPTION
### Description
Fixes CMake mistakenly assuming POSIX threading support in MSVC compilers.

### Motivation and Context
Workaround for CMake issue https://gitlab.kitware.com/cmake/cmake/-/issues/23829.

### How Has This Been Tested?
Needs to be tested by affected reporters.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
