### PR TITLE
win-capture: Invert destination pixels when drawing monochrome cursors

### DIFF
--- a/plugins/win-capture/cursor-capture.h
+++ b/plugins/win-capture/cursor-capture.h
@@ -15,6 +15,7 @@ struct cursor_data {
 	long x_hotspot;
 	long y_hotspot;
 	bool visible;
+	bool monochrome;
 
 	uint32_t last_cx;
 	uint32_t last_cy;


### PR DESCRIPTION
### Issue / Motivation
Currently all monochrome cursors are always rendered all-black, meaning they are invisible on dark backgrounds (see #6794).

### Description
This updates the blend mode from GS_BLEND_SRCALPHA to GS_BLEND_INVDSTCOLOR when drawing monochrome cursors, so they are visible on both light and dark backgrounds.

The following monochrome cursor rendering requirements are complete: 
- [x] A pixel that is black in both the top and bottom half will always be black in the final image.
- [x] A pixel that is black in the top and white in the bottom will always be white in the final image.
- [x] A pixel that is white in the top and white in the bottom will invert (XOR) the colour underneath it.
- [x] A pixel that is white in the top and black in the bottom is a no-op.

### How Has This Been Tested?
Tested on Windows 10 x64 with all of the baked-in Windows cursors. All color cursors remain unchanged, monochrome cursors (such as the I-Beam and Crosshair) are now rendered inverted instead of black. This should have no impact on any other areas of the code.

### Types of changes
Bug Fix

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.


Maintainer Edit: Fixes #3129, fixes #6794