### PR TITLE
cmake: Fix M1-based OBS.app appearing as an "iOS" app

### DIFF
--- a/cmake/bundle/macOS/Info.plist.in
+++ b/cmake/bundle/macOS/Info.plist.in
@@ -18,6 +18,10 @@
 	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
 	<key>CFBundleVersion</key>
 	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>CFBundleSupportedPlatforms</key>
+  	<array>
+  		<string>MacOSX</string>
+  	</array>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
### Description
Fix OBS.app appearing as an "iOS" app in macOS' system information overview of programmes available on the local machine.

### Motivation and Context
MacOS' system information checks the CFBundleSupportedPlatforms value in the app's property list file for the type. This was correctly set for plugin bundles, but not binary bundles so far.

### How Has This Been Tested?
OBS built locally and checked in system information.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
