### PR TITLE
UI: Fix color select buttons with Yami

### DIFF
--- a/UI/forms/ColorSelect.ui
+++ b/UI/forms/ColorSelect.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>98</width>
-    <height>61</height>
+    <width>126</width>
+    <height>70</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,9 +20,7 @@
    <string>Form</string>
   </property>
   <property name="styleSheet">
-   <string notr="true">QPushButton {
-	border: 1px solid black;
-}</string>
+   <string notr="true">QPushButton { border: 1px solid black; margin: 0; padding: 0; }</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
@@ -37,14 +35,14 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="styleSheet">
@@ -68,14 +66,14 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="text">
@@ -96,14 +94,14 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="text">
@@ -124,14 +122,14 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="text">
@@ -152,14 +150,14 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="text">
@@ -180,14 +178,14 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="text">
@@ -208,14 +206,14 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="text">
@@ -236,14 +234,14 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>16</width>
-         <height>16</height>
+         <width>22</width>
+         <height>22</height>
         </size>
        </property>
        <property name="text">


### PR DESCRIPTION
### Description
The color select buttons would not be rendered properly with the Yami based themes.

Before:
![Screenshot from 2022-08-09 07-33-15](https://user-images.githubusercontent.com/19962531/183648132-d3a0bb56-9c7f-47f1-bdb6-747c4b1b24df.png)

After:
![Screenshot from 2022-08-09 07-26-50](https://user-images.githubusercontent.com/19962531/183648171-f52bf456-3cc1-4d50-adfc-768b431a49f4.png)

### Motivation and Context
Found bug when using color select

### How Has This Been Tested?
Set source color to make sure the buttons looked good

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
