### PR TITLE
UI: Fix double scrollbar in settings

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -938,6 +938,9 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 
 	UpdateAudioWarnings();
 	UpdateAdvNetworkGroup();
+
+	connect(App(), &OBSApp::StyleChanged, this,
+		&OBSBasicSettings::UpdatePropertiesViewSizing);
 }
 
 OBSBasicSettings::~OBSBasicSettings()
@@ -1899,6 +1902,8 @@ OBSBasicSettings::CreateEncoderPropertyView(const char *encoder,
 	view->setFrameShape(QFrame::NoFrame);
 	view->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
 	view->setProperty("changed", QVariant(changed));
+	view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+	view->setWidgetResizable(true);
 	QObject::connect(view, SIGNAL(Changed()), this, SLOT(OutputsChanged()));
 
 	return view;
@@ -5437,4 +5442,12 @@ void OBSBasicSettings::UpdateAdvNetworkGroup()
 	ui->enableNewSocketLoop->setVisible(enabled);
 	ui->enableLowLatencyMode->setVisible(enabled);
 #endif
+}
+
+void OBSBasicSettings::UpdatePropertiesViewSizing()
+{
+	QList<OBSPropertiesView *> list = findChildren<OBSPropertiesView *>();
+
+	foreach(OBSPropertiesView * view, list)
+		view->setFixedHeight(view->size().height());
 }

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -466,6 +466,7 @@ private slots:
 	void SetAdvancedIcon(const QIcon &icon);
 
 	void UseStreamKeyAdvClicked();
+	void UpdatePropertiesViewSizing();
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;


### PR DESCRIPTION
### Description
The settings would sometimes show a scrollbar with the
properties view (ie. encoder section).

### Motivation and Context
Reported here: https://github.com/obsproject/obs-studio/pull/5174#issuecomment-1200128285

### How Has This Been Tested?
It doesn't break anything. I have never been able to reproduce this, but at least in theory it should fix the problem.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
