### PR TITLE
mac-videotoolbox: Don't manually override color space

### DIFF
--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -789,22 +789,6 @@ bool get_cached_pixel_buffer(struct vt_encoder *enc, CVPixelBufferRef *buf)
 
 	CVPixelBufferRef pixbuf;
 	STATUS_CHECK(CVPixelBufferPoolCreatePixelBuffer(NULL, pool, &pixbuf));
-
-	// Why aren't these already set on the pixel buffer?
-	// I would have expected pixel buffers from the session's
-	// pool to have the correct color space stuff set
-
-	CFStringRef matrix = obs_to_vt_colorspace(enc->colorspace);
-
-	CVBufferSetAttachment(pixbuf, kCVImageBufferYCbCrMatrixKey, matrix,
-			      kCVAttachmentMode_ShouldPropagate);
-	CVBufferSetAttachment(pixbuf, kCVImageBufferColorPrimariesKey,
-			      kCVImageBufferColorPrimaries_ITU_R_709_2,
-			      kCVAttachmentMode_ShouldPropagate);
-	CVBufferSetAttachment(pixbuf, kCVImageBufferTransferFunctionKey,
-			      kCVImageBufferTransferFunction_ITU_R_709_2,
-			      kCVAttachmentMode_ShouldPropagate);
-
 	*buf = pixbuf;
 	return true;
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This was done to work around an issue in 2015 which does not appear to
exist anymore in 2022. Thus, remove it to remove complexity, especially
if we want to explicitly add HDR support (even though that already
mostly works).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Less unnecessary code is better.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13
Confirmed with `CVBufferCopyAttachments` that all of the attributes are already correctly
set on the buffer.
<img width="534" alt="image" src="https://user-images.githubusercontent.com/59806498/183750757-587885d5-07fc-4d9c-8f99-f553c8e2dd4b.png">

Tested with H.264 Software, H.264 Hardware, and HEVC Hardware encoders.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
