### PR TITLE
cmake: Fix cmake package export templates for CMake 3.24

### DIFF
--- a/deps/w32-pthreads/cmake/w32-pthreadsConfig.cmake.in
+++ b/deps/w32-pthreads/cmake/w32-pthreadsConfig.cmake.in
@@ -2,5 +2,3 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")
-
-set(LIBOBS_LIBRARIES w32-pthreads)

--- a/libobs/cmake/libobsConfig.cmake.in
+++ b/libobs/cmake/libobsConfig.cmake.in
@@ -1,13 +1,14 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
-check_required_components("@PROJECT_NAME@")
+include(CMakeFindDependencyMacro)
 
 if(MSVC)
-  find_package(w32-pthreads REQUIRED)
+  find_dependency(w32-pthreads REQUIRED)
 endif()
+find_dependency(Threads REQUIRED)
 
-find_package(Threads REQUIRED)
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")
 
 set(LIBOBS_PLUGIN_DESTINATION "@PACKAGE_OBS_PLUGIN_DESTINATION@")
 set(LIBOBS_PLUGIN_DATA_DESTINATION "@PACKAGE_OBS_DATA_DESTINATION@/obs-plugins")


### PR DESCRIPTION
### Description
Moves dependency imports for libobs above the target definition in the exported CMake package definition file.

### Motivation and Context
CMake 3.24 implemented changes that break dependency discovery of the exported libraries build by OBS.

Specifically, without this fix, building obs-plugintemplate with CMake 3.24.0 will break.

This bug is _present_ on all other OSes as well, but because macOS and Linux supply POSIX threads as a static library, it is only resolved at project generation (much later step) and is not required by `libobsTargets.cmake` during creation of the `libobs` target.

On Windows `libobs` is linked against the shared library `w32-pthreads` and thus needs to be resolved at link-time and is added to the `IMPORTED_LINK_DEPENDENT_LIBRARIES` target property automatically. As such, the dependency needs to be resolved _before_ that.

### How Has This Been Tested?
Tested with CMake 3.24 on Windows 11.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
