### PR TITLE
CI: Remove 32-bit Windows builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -290,7 +290,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        arch: [x64, x86]
+        arch: [x64]
     env:
       CMAKE_GENERATOR: 'Visual Studio 17 2022'
       CMAKE_SYSTEM_VERSION: '10.0.18363.657'
@@ -433,11 +433,6 @@ jobs:
         with:
           name: 'obs-studio-windows-x64-${{ steps.setup.outputs.commitHash }}'
 
-      - name: 'Download 32-bit artifact'
-        uses: actions/download-artifact@v3
-        with:
-          name: 'obs-studio-windows-x86-${{ steps.setup.outputs.commitHash }}'
-
       - name: 'Unpack Windows build artifacts'
         id: unpack
         run: |
@@ -445,12 +440,11 @@ jobs:
             $null = New-Item -ItemType Directory -Force -Path install_temp
           }
 
-          Expand-Archive -Path "$(Get-ChildItem -filter "obs-studio-*-windows-x86.zip" -File)" -DestinationPath install_temp
           Expand-Archive -Path "$(Get-ChildItem -filter "obs-studio-*-windows-x64.zip" -File)" -Force -DestinationPath install_temp
 
-          CI/windows/03_package_obs.ps1 -CombinedArchs -Package
+          CI/windows/03_package_obs.ps1 -Package
 
-          $ArtifactName = (Get-ChildItem -filter "obs-studio-*-windows-x86+x64.zip" -File).Name
+          $ArtifactName = (Get-ChildItem -filter "obs-studio-*-windows-x64.zip" -File).Name
           Write-Output "::set-output name=filename::${ArtifactName}"
 
       - name: 'Upload build artifact'


### PR DESCRIPTION
### Description
Since 32-bit is no longer supported, remove the 32-bit builds from the github workflow.

### Motivation and Context
Remove unneeded workflow jobs

### How Has This Been Tested?
Building on CI

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
