### PR TITLE
UI: Fix grid mode spacing with Yami

### DIFF
--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -1278,14 +1278,15 @@ OBSBasic {
 /* Scene Tree Grid Mode */
 
 SceneTree {
-    qproperty-gridItemWidth: 150;
-    qproperty-gridItemHeight: 27;
+    qproperty-gridItemWidth: 154;
+    qproperty-gridItemHeight: 31;
 }
 
 *[gridMode="true"] SceneTree::item {
     color: palette(text);
     background-color: palette(button);
     border-radius: 4px;
+    margin: 2px;
 }
 
 *[gridMode="true"] SceneTree::item:selected {


### PR DESCRIPTION
### Description
In the scenes grid mode, the buttons would be squished together in
the Yami theme.

Before:
![Screenshot from 2022-08-10 01-27-23](https://user-images.githubusercontent.com/19962531/183831275-c9b7c04a-9afc-4e58-b2cf-28aae7ecd91c.png)

After:
![Screenshot from 2022-08-10 01-25-54](https://user-images.githubusercontent.com/19962531/183831304-68c13c3a-5942-4074-bb3e-6d77fe2ffe92.png)

### Motivation and Context
Fix Yami bugs

### How Has This Been Tested?
Used grid mode to make sure buttons were spaced properly

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
