### PR TITLE
libobs-opengl,UI: Use Metal swap chain for non-blocking vsync

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -6643,7 +6643,7 @@
                     <widget class="QLabel" name="label_30">
                      <property name="minimumSize">
                       <size>
-                       <width>0</width>
+                       <width>170</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -6776,49 +6776,6 @@
                       </widget>
                      </item>
                     </layout>
-                   </item>
-                   <item row="5" column="1">
-                    <layout class="QHBoxLayout" name="horizontalLayout_18">
-                     <property name="leftMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                     <item>
-                      <widget class="QCheckBox" name="disableOSXVSync">
-                       <property name="text">
-                        <string>DisableOSXVSync</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QCheckBox" name="resetOSXVSync">
-                       <property name="text">
-                        <string>ResetOSXVSyncOnExit</string>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </item>
-                   <item row="6" column="0">
-                    <spacer name="horizontalSpacer_12">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>170</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
                    </item>
                   </layout>
                  </widget>
@@ -7522,8 +7479,6 @@
   <tabstop>colorFormat</tabstop>
   <tabstop>colorSpace</tabstop>
   <tabstop>colorRange</tabstop>
-  <tabstop>disableOSXVSync</tabstop>
-  <tabstop>resetOSXVSync</tabstop>
   <tabstop>filenameFormatting</tabstop>
   <tabstop>overwriteIfExists</tabstop>
   <tabstop>autoRemux</tabstop>

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -506,9 +506,6 @@ bool OBSApp::InitGlobalConfigDefaults()
 #ifdef __APPLE__
 	config_set_default_bool(globalConfig, "General", "BrowserHWAccel",
 				true);
-	config_set_default_bool(globalConfig, "Video", "DisableOSXVSync", true);
-	config_set_default_bool(globalConfig, "Video", "ResetOSXVSyncOnExit",
-				true);
 #endif
 
 	config_set_default_bool(globalConfig, "BasicWindow",
@@ -1278,15 +1275,6 @@ OBSApp::~OBSApp()
 		DisableAudioDucking(false);
 #endif
 
-#ifdef __APPLE__
-	bool vsyncDisabled =
-		config_get_bool(globalConfig, "Video", "DisableOSXVSync");
-	bool resetVSync =
-		config_get_bool(globalConfig, "Video", "ResetOSXVSyncOnExit");
-	if (vsyncDisabled && resetVSync)
-		EnableOSXVSync(true);
-#endif
-
 	os_inhibit_sleep_set_active(sleepInhibitor, false);
 	os_inhibit_sleep_destroy(sleepInhibitor);
 
@@ -1418,11 +1406,6 @@ void OBSApp::AppInit()
 		config_get_bool(globalConfig, "Audio", "DisableAudioDucking");
 	if (disableAudioDucking)
 		DisableAudioDucking(true);
-#endif
-
-#ifdef __APPLE__
-	if (config_get_bool(globalConfig, "Video", "DisableOSXVSync"))
-		EnableOSXVSync(false);
 #endif
 
 	UpdateHotkeyFocusSetting(false);

--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -165,37 +165,6 @@ bool SetDisplayAffinitySupported(void)
 	return false;
 }
 
-typedef void (*set_int_t)(int);
-
-void EnableOSXVSync(bool enable)
-{
-	static bool initialized = false;
-	static bool valid = false;
-	static set_int_t set_debug_options = nullptr;
-	static set_int_t deferred_updates = nullptr;
-
-	if (!initialized) {
-		void *quartzCore = dlopen("/System/Library/Frameworks/"
-					  "QuartzCore.framework/QuartzCore",
-					  RTLD_LAZY);
-		if (quartzCore) {
-			set_debug_options = (set_int_t)dlsym(
-				quartzCore, "CGSSetDebugOptions");
-			deferred_updates = (set_int_t)dlsym(
-				quartzCore, "CGSDeferredUpdates");
-
-			valid = set_debug_options && deferred_updates;
-		}
-
-		initialized = true;
-	}
-
-	if (valid) {
-		set_debug_options(enable ? 0 : 0x08000000);
-		deferred_updates(enable ? 1 : 0);
-	}
-}
-
 void EnableOSXDockIcon(bool enable)
 {
 	if (enable)

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -94,7 +94,6 @@ typedef enum {
 	kPermissionAuthorized = 3,
 } MacPermissionStatus;
 
-void EnableOSXVSync(bool enable);
 void EnableOSXDockIcon(bool enable);
 bool isInBundle();
 void InstallNSApplicationSubclass();

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -539,8 +539,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->colorRange,           COMBO_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->sdrWhiteLevel,        SCROLL_CHANGED, ADV_CHANGED);
 	HookWidget(ui->hdrNominalPeakLevel,  SCROLL_CHANGED, ADV_CHANGED);
-	HookWidget(ui->disableOSXVSync,      CHECK_CHANGED,  ADV_CHANGED);
-	HookWidget(ui->resetOSXVSync,        CHECK_CHANGED,  ADV_CHANGED);
 	if (obs_audio_monitoring_available())
 		HookWidget(ui->monitoringDevice,     COMBO_CHANGED,  ADV_CHANGED);
 #ifdef _WIN32
@@ -666,13 +664,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	ui->sourcesGroup = nullptr;
 #endif
 	ui->disableAudioDucking = nullptr;
-#endif
-
-#ifndef __APPLE__
-	delete ui->disableOSXVSync;
-	delete ui->resetOSXVSync;
-	ui->disableOSXVSync = nullptr;
-	ui->resetOSXVSync = nullptr;
 #endif
 
 	connect(ui->streamDelaySec, SIGNAL(valueChanged(int)), this,
@@ -2673,15 +2664,7 @@ void OBSBasicSettings::LoadAdvancedSettings()
 		ui->advancedVideoContainer->setEnabled(false);
 	}
 
-#ifdef __APPLE__
-	bool disableOSXVSync = config_get_bool(App()->GlobalConfig(), "Video",
-					       "DisableOSXVSync");
-	bool resetOSXVSync = config_get_bool(App()->GlobalConfig(), "Video",
-					     "ResetOSXVSyncOnExit");
-	ui->disableOSXVSync->setChecked(disableOSXVSync);
-	ui->resetOSXVSync->setChecked(resetOSXVSync);
-	ui->resetOSXVSync->setEnabled(disableOSXVSync);
-#elif _WIN32
+#ifdef _WIN32
 	bool disableAudioDucking = config_get_bool(
 		App()->GlobalConfig(), "Audio", "DisableAudioDucking");
 	ui->disableAudioDucking->setChecked(disableAudioDucking);
@@ -3338,19 +3321,6 @@ void OBSBasicSettings::SaveAdvancedSettings()
 		config_set_string(App()->GlobalConfig(), "General",
 				  "HotkeyFocusType", QT_TO_UTF8(str));
 	}
-
-#ifdef __APPLE__
-	if (WidgetChanged(ui->disableOSXVSync)) {
-		bool disable = ui->disableOSXVSync->isChecked();
-		config_set_bool(App()->GlobalConfig(), "Video",
-				"DisableOSXVSync", disable);
-		EnableOSXVSync(!disable);
-	}
-	if (WidgetChanged(ui->resetOSXVSync))
-		config_set_bool(App()->GlobalConfig(), "Video",
-				"ResetOSXVSyncOnExit",
-				ui->resetOSXVSync->isChecked());
-#endif
 
 	SaveComboData(ui->colorFormat, "Video", "ColorFormat");
 	SaveComboData(ui->colorSpace, "Video", "ColorSpace");
@@ -5283,16 +5253,6 @@ void OBSBasicSettings::SimpleRecordingQualityLosslessWarning(int idx)
 	}
 
 	lastSimpleRecQualityIdx = idx;
-}
-
-void OBSBasicSettings::on_disableOSXVSync_clicked()
-{
-#ifdef __APPLE__
-	if (!loading) {
-		bool disable = ui->disableOSXVSync->isChecked();
-		ui->resetOSXVSync->setEnabled(disable);
-	}
-#endif
 }
 
 QIcon OBSBasicSettings::GetGeneralIcon() const

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -402,8 +402,6 @@ private slots:
 	void on_outputResolution_editTextChanged(const QString &text);
 	void on_baseResolution_editTextChanged(const QString &text);
 
-	void on_disableOSXVSync_clicked();
-
 	void on_choose1_clicked();
 	void on_choose2_clicked();
 	void on_choose3_clicked();

--- a/libobs-opengl/CMakeLists.txt
+++ b/libobs-opengl/CMakeLists.txt
@@ -38,10 +38,13 @@ if(OS_WINDOWS)
 elseif(OS_MACOS)
   find_library(COCOA Cocoa)
   find_library(IOSURF IOSurface)
+  find_library(METAL Metal)
+  find_library(QUARTZCORE QuartzCore)
 
   target_sources(libobs-opengl PRIVATE gl-cocoa.m)
 
-  target_link_libraries(libobs-opengl PRIVATE ${COCOA} ${IOSURF})
+  target_link_libraries(libobs-opengl PRIVATE ${COCOA} ${IOSURF} ${METAL}
+                                              ${QUARTZCORE})
 
   set_target_properties(libobs-opengl PROPERTIES PREFIX "")
 

--- a/libobs-opengl/gl-nix.c
+++ b/libobs-opengl/gl-nix.c
@@ -44,8 +44,9 @@ static void init_winsys(void)
 }
 
 extern struct gl_windowinfo *
-gl_windowinfo_create(const struct gs_init_data *info)
+gl_windowinfo_create(gs_device_t *device, const struct gs_init_data *info)
 {
+	UNUSED_PARAMETER(device);
 	return gl_vtable->windowinfo_create(info);
 }
 

--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -311,7 +311,7 @@ gs_swapchain_t *device_swapchain_create(gs_device_t *device,
 
 	swap->device = device;
 	swap->info = *info;
-	swap->wi = gl_windowinfo_create(info);
+	swap->wi = gl_windowinfo_create(device, info);
 	if (!swap->wi) {
 		blog(LOG_ERROR, "device_swapchain_create (GL) failed");
 		gs_swapchain_destroy(swap);
@@ -790,7 +790,7 @@ static bool attach_rendertarget(struct fbo_info *fbo, gs_texture_t *tex,
 
 	if (tex->type == GS_TEXTURE_2D) {
 		glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER,
-				       GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+				       GL_COLOR_ATTACHMENT0, tex->gl_target,
 				       tex->texture, 0);
 
 	} else if (tex->type == GS_TEXTURE_CUBE) {

--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -683,7 +683,7 @@ extern bool gl_platform_init_swapchain(struct gs_swap_chain *swap);
 extern void gl_platform_cleanup_swapchain(struct gs_swap_chain *swap);
 
 extern struct gl_windowinfo *
-gl_windowinfo_create(const struct gs_init_data *info);
+gl_windowinfo_create(gs_device_t *device, const struct gs_init_data *info);
 extern void gl_windowinfo_destroy(struct gl_windowinfo *wi);
 
 extern void gl_getclientsize(const struct gs_swap_chain *swap, uint32_t *width,

--- a/libobs-opengl/gl-texture2d.c
+++ b/libobs-opengl/gl-texture2d.c
@@ -135,6 +135,31 @@ fail:
 	return NULL;
 }
 
+gs_texture_t *device_drawable_wrap(gs_device_t *device, GLuint name,
+				   uint32_t width, uint32_t height,
+				   enum gs_color_format color_format)
+{
+	struct gs_texture_2d *tex = bzalloc(sizeof(struct gs_texture_2d));
+	tex->base.device = device;
+	tex->base.type = GS_TEXTURE_2D;
+	tex->base.format = color_format;
+	tex->base.levels = 1;
+	tex->base.gl_format = convert_gs_format(color_format);
+	tex->base.gl_internal_format = convert_gs_internal_format(color_format);
+	tex->base.gl_type = get_gl_format_type(color_format);
+	tex->base.gl_target = GL_TEXTURE_RECTANGLE_ARB;
+	tex->base.is_dynamic = false;
+	tex->base.is_render_target = true;
+	tex->base.is_dummy = false;
+	tex->base.gen_mipmaps = false;
+	tex->width = width;
+	tex->height = height;
+
+	tex->base.texture = name;
+
+	return (gs_texture_t *)tex;
+}
+
 static inline bool is_texture_2d(const gs_texture_t *tex, const char *func)
 {
 	bool is_tex2d = tex->type == GS_TEXTURE_2D;

--- a/libobs-opengl/gl-windows.c
+++ b/libobs-opengl/gl-windows.c
@@ -504,8 +504,11 @@ void gl_platform_cleanup_swapchain(struct gs_swap_chain *swap)
 	UNUSED_PARAMETER(swap);
 }
 
-struct gl_windowinfo *gl_windowinfo_create(const struct gs_init_data *info)
+struct gl_windowinfo *gl_windowinfo_create(gs_device_t *device,
+					   const struct gs_init_data *info)
 {
+	UNUSED_PARAMETER(device);
+
 	struct gl_windowinfo *wi = gl_windowinfo_bare(info);
 	PIXELFORMATDESCRIPTOR pfd;
 	int pixel_format;


### PR DESCRIPTION
### Description
Using the Metal swap chain allows us check when the swap chain is
ready, so the graphics thread won't get stuck waiting on vsync.

There's also dormant HDR code that isn't turned on right now because it causes Qt to flicker like crazy.

### Motivation and Context
Want preview/projectors to not tear, and also not block the graphics thread from making progress.

### How Has This Been Tested?
Preview and projectors seem to work. Resize is fine. Ran temporary instrumentation to test present is skipped alternating for 120 FPS video on 60 Hz refresh.

Vsync settings are gone from Settings dialog, and tested that that a setting change still works.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.