### PR TITLE
UI: Don't force the user to start virtual camera after configuring it

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -731,8 +731,6 @@ Basic.VCam.OutputSelection="Output Selection"
 Basic.VCam.Internal="Internal"
 Basic.VCam.InternalDefault="Program Output (Default)"
 Basic.VCam.InternalPreview="Preview Output"
-Basic.VCam.Start="Start"
-Basic.VCam.Update="Update"
 
 # basic mode file menu
 Basic.MainMenu.File="&File"

--- a/UI/forms/OBSBasicVCamConfig.ui
+++ b/UI/forms/OBSBasicVCamConfig.ui
@@ -69,7 +69,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/UI/window-basic-vcam-config.cpp
+++ b/UI/window-basic-vcam-config.cpp
@@ -40,13 +40,8 @@ OBSBasicVCamConfig::OBSBasicVCamConfig(QWidget *parent)
 			&QComboBox::currentIndexChanged),
 		this, &OBSBasicVCamConfig::OutputTypeChanged);
 
-	auto start = ui->buttonBox->button(QDialogButtonBox::Ok);
-	if (!obs_frontend_virtualcam_active())
-		start->setText(QTStr("Basic.VCam.Start"));
-	else
-		start->setText(QTStr("Basic.VCam.Update"));
-	connect(start, &QPushButton::clicked, this,
-		&OBSBasicVCamConfig::SaveAndStart);
+	connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
+		&OBSBasicVCamConfig::Save);
 }
 
 void OBSBasicVCamConfig::OutputTypeChanged(int type)
@@ -112,7 +107,7 @@ void OBSBasicVCamConfig::OutputTypeChanged(int type)
 	}
 }
 
-void OBSBasicVCamConfig::SaveAndStart()
+void OBSBasicVCamConfig::Save()
 {
 	auto type = (VCamOutputType)ui->outputType->currentIndex();
 	auto out = ui->outputSelection;
@@ -133,10 +128,8 @@ void OBSBasicVCamConfig::SaveAndStart()
 
 	vCamConfig->type = type;
 
-	// Start the vcam if needed, if already running just update the source
-	if (!obs_frontend_virtualcam_active())
-		obs_frontend_start_virtualcam();
-	else
+	// If already running just update the source
+	if (obs_frontend_virtualcam_active())
 		UpdateOutputSource();
 }
 

--- a/UI/window-basic-vcam-config.cpp
+++ b/UI/window-basic-vcam-config.cpp
@@ -1,13 +1,9 @@
 #include "window-basic-vcam-config.hpp"
 #include "window-basic-main.hpp"
 #include "qt-wrappers.hpp"
-#include "remote-text.hpp"
+
 #include <util/util.hpp>
 #include <util/platform.h>
-#include <platform.hpp>
-#include <mutex>
-
-using namespace std;
 
 enum class VCamOutputType {
 	Internal,
@@ -23,8 +19,8 @@ enum class VCamInternalType {
 struct VCamConfig {
 	VCamOutputType type = VCamOutputType::Internal;
 	VCamInternalType internal = VCamInternalType::Default;
-	string scene;
-	string source;
+	std::string scene;
+	std::string source;
 };
 
 static VCamConfig *vCamConfig = nullptr;
@@ -80,7 +76,7 @@ void OBSBasicVCamConfig::OutputTypeChanged(int type)
 
 	case VCamOutputType::Source: {
 		// Sources in alphabetical order
-		vector<string> sources;
+		std::vector<std::string> sources;
 		auto AddSource = [&](obs_source_t *source) {
 			auto name = obs_source_get_name(source);
 			auto flags = obs_source_get_output_flags(source);

--- a/UI/window-basic-vcam-config.hpp
+++ b/UI/window-basic-vcam-config.hpp
@@ -20,7 +20,7 @@ public:
 
 private slots:
 	void OutputTypeChanged(int type);
-	void SaveAndStart();
+	void Save();
 
 private:
 	std::unique_ptr<Ui::OBSBasicVCamConfig> ui;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

The user could want to configure the virtual camera without starting it.

Also remove unneeded headers and `using namespace`.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Forcing the user to start the virtual camera to save settings is bad UI/UX.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

The dialog no longer start the VCam and the "ISO VCam" still works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
