### PR TITLE
UI: Fix sub-item's SpacingHelper render on group

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -2497,6 +2497,23 @@ void OBSBasicPreview::DrawSpacingHelpers()
 	// Seems hacky, probably a better way to do it
 	float rot = oti.rot;
 
+	if (parentGroup) {
+		obs_transform_info groupOti;
+		obs_sceneitem_get_info(parentGroup, &groupOti);
+
+		//Correct the scene item rotation angle
+		rot = oti.rot + groupOti.rot;
+
+		// Correct the scene item box transform
+		// Based on scale, rotation angle, position of parent's group
+		matrix4_scale3f(&boxTransform, &boxTransform, groupOti.scale.x,
+				groupOti.scale.y, 1.0f);
+		matrix4_rotate_aa4f(&boxTransform, &boxTransform, 0.0f, 0.0f,
+				    1.0f, RAD(groupOti.rot));
+		matrix4_translate3f(&boxTransform, &boxTransform,
+				    groupOti.pos.x, groupOti.pos.y, 0.0f);
+	}
+
 	if (rot >= HELPER_ROT_BREAKPONT) {
 		for (float i = HELPER_ROT_BREAKPONT; i <= 360.0f; i += 90.0f) {
 			if (rot < i)

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -2467,6 +2467,12 @@ void OBSBasicPreview::DrawSpacingHelpers()
 	if (itemSize.x == 0.0f || itemSize.y == 0.0f)
 		return;
 
+	obs_sceneitem_t *parentGroup =
+		obs_sceneitem_get_group(main->GetCurrentScene(), item);
+
+	if (parentGroup && obs_sceneitem_locked(parentGroup))
+		return;
+
 	matrix4 boxTransform;
 	obs_sceneitem_get_box_transform(item, &boxTransform);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
in obs28
1. Don't show sub-item SpacingHelper on locked group
Add judgment whether the sub-item's parent group locked or not
2. Correctly draw sub-item SpacingHelper on group
Recalculate the position of the sub-item source sides

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

1. Don't show sub-item SpacingHelper on locked group when sub-item of group source clicked in source list
before:
![Screenshot 2022-08-10 183813](https://user-images.githubusercontent.com/30559085/183891461-5a5281ce-4390-4d5d-808a-539e1309b4bc.png)
after:
![Screenshot 2022-08-10 18-37-31](https://user-images.githubusercontent.com/30559085/183891508-ccb1f0ab-68b6-4e3b-b51f-69231f4fd280.png)

2. Correctly draw sub-item SpacingHelper on group
before:
![Screenshot 2022-08-10 191820](https://user-images.githubusercontent.com/30559085/183891621-3de970ef-ad92-467c-91ac-5582fcd36c4e.png)
after:(with *pos moved*)
![Screenshot 2022-08-10 192050](https://user-images.githubusercontent.com/30559085/183891642-3bbcf05f-9b1e-485c-bc5b-cf89b24f3d60.png)
before:
![Screenshot 2022-08-10 194006](https://user-images.githubusercontent.com/30559085/183892650-c4fa80d5-91be-4186-954f-703bde5d0e7a.png)
after:(with *x and y scaled*, *pos moved*, *angle rotated* )
![Screenshot 2022-08-10 194140](https://user-images.githubusercontent.com/30559085/183892683-f019d1ad-8046-4e33-83ce-1a09e6b37999.png)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

observe those changes

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix (non-breaking change which fixes an issue) 
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
