### PR TITLE
UI: Fix padding with vertical volume meters

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -20,6 +20,9 @@ using namespace std;
 // Size of the audio indicator in pixels
 #define INDICATOR_THICKNESS 3
 
+// Padding on top and bottom of vertical meters
+#define METER_PADDING 1
+
 QWeakPointer<VolumeMeterTimer> VolumeMeter::updateTimer;
 
 void VolControl::OBSVolumeChanged(void *data, float db)
@@ -1035,7 +1038,7 @@ void VolumeMeter::paintVTicks(QPainter &painter, int x, int y, int height)
 
 	// Draw major tick lines and numeric indicators.
 	for (int i = 0; i >= minimumLevel; i -= 5) {
-		int position = y + int(i * scale);
+		int position = y + int(i * scale) + METER_PADDING;
 		QString str = QString::number(i);
 
 		// Center the number on the tick, but don't overflow
@@ -1054,7 +1057,7 @@ void VolumeMeter::paintVTicks(QPainter &painter, int x, int y, int height)
 	// Draw minor tick lines.
 	painter.setPen(minorTickColor);
 	for (int i = 0; i >= minimumLevel; i--) {
-		int position = y + int(i * scale);
+		int position = y + int(i * scale) + METER_PADDING;
 		if (i % 5 != 0)
 			painter.drawLine(x, position, x + 1, position);
 	}
@@ -1304,6 +1307,9 @@ void VolumeMeter::paintEvent(QPaintEvent *event)
 
 	QPainter painter(this);
 
+	if (vertical)
+		height -= METER_PADDING * 2;
+
 	// timerEvent requests update of the bar(s) only, so we can avoid the
 	// overhead of repainting the scale and labels.
 	if (event->region().boundingRect() != getBarRect()) {
@@ -1332,7 +1338,7 @@ void VolumeMeter::paintEvent(QPaintEvent *event)
 
 	if (vertical) {
 		// Invert the Y axis to ease the math
-		painter.translate(0, height);
+		painter.translate(0, height + METER_PADDING);
 		painter.scale(1, -1);
 	}
 


### PR DESCRIPTION
### Description
Since Yami uses a different font, the 0 dB mark at the top of the
vertical meters would be cut off. This adds a 1px padding to the top
and bottom of the volume meters, when in vertical mode.

Before:
![Screenshot from 2022-08-10 11-31-28](https://user-images.githubusercontent.com/19962531/183964293-e2d53252-d3c4-4e8c-a099-4e7d7f50138d.png)

After:
![Screenshot from 2022-08-10 11-29-58](https://user-images.githubusercontent.com/19962531/183964339-6b53ee94-398d-4c49-a6b6-fbba6a38c1da.png)

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/6961

### How Has This Been Tested?
Put volume meters in vertical mode to see if the 0 dB mark was cut off or not.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
