### PR TITLE
CI: Switch to included Xcode 14 Beta

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,6 @@ jobs:
       BLOCKED_FORMULAS: 'speexdsp curl php composer'
       CODESIGN_IDENT: '-'
       HAVE_CODESIGN_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY != '' && secrets.MACOS_SIGNING_CERT != '' }}
-      HAVE_XCODE_URL: ${{ secrets.XCODE_DOWNLOAD_URL != '' }}
     defaults:
       run:
         shell: bash
@@ -156,9 +155,8 @@ jobs:
 
           echo "::set-output name=commitHash::$(git rev-parse --short=9 HEAD)"
 
-      - name: 'Install Xcode 14 Beta'
-        if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && env.HAVE_CODESIGN_IDENTITY == 'true' && env.HAVE_XCODE_URL == 'true' }}
-        run: xcversion install "14 beta 4" --url=${{ secrets.XCODE_DOWNLOAD_URL }}
+      - name: 'Switch to Xcode 14 Beta'
+        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
 
       - name: 'Install dependencies'
         env:


### PR DESCRIPTION
### Description

Set Xcode 14 Beta as the active version on CI.

### Motivation and Context

GitHub updated the runner image to include the 14 beta, so we no longer need to manually install it, saving us about 30 minutes of build time.

### How Has This Been Tested?

CI ran successfully.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
