### PR TITLE
UI: Fix crash when hiding audio mixer item

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3301,7 +3301,14 @@ void OBSBasic::HideAudioControl()
 
 	if (!SourceMixerHidden(source)) {
 		SetSourceMixerHidden(source, true);
-		DeactivateAudioSource(source);
+
+		/* Due to a bug with QT 6.2.4, the version that's in the Ubuntu
+		* 22.04 ppa, hiding the audio mixer causes a crash, so defer to
+		* the next event loop to hide it. Doesn't seem to be a problem
+		* with newer versions of QT. */
+		QMetaObject::invokeMethod(this, "DeactivateAudioSource",
+					  Qt::QueuedConnection,
+					  Q_ARG(OBSSource, OBSSource(source)));
 	}
 }
 


### PR DESCRIPTION
### Description
This crash is suspected to be a QT bug that happens in 6.2.4, as
it only happens in this version. This is the QT version that is in
the Ubuntu 22.04 ppa, so this fix is a necessary evil as it affects
Ubuntu users.

This fixes the crash by deferring the hiding of the audio mixer
item to the next event loop.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/7031

### How Has This Been Tested?
Hid mixer item and noticed crashing was gone.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
