### PR TITLE
mac-virtualcam: Avoid conversion of P010

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -116,6 +116,8 @@ FourCharCode convert_video_format_to_mac(enum video_format format)
 		return kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange;
 	case VIDEO_FORMAT_UYVY:
 		return kCVPixelFormatType_422YpCbCr8;
+	case VIDEO_FORMAT_P010:
+		return kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange;
 	default:
 		// Zero indicates that the format is not supported on macOS
 		// Note that some formats do have an associated constant, but


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds the P010 enum case to the list of video formats that do not need to get converted to
NV12 as they are supported directly. This avoids an unnecessary performance penalty.

Importantly, this does NOT add any kind of HDR support to the virtualcam. If one of the
Rec. 2100 color spaces is selected, the image looked washed out before and still does. However,
now it's smooth instead of what looked like ~3fps (on my somewhat powerful Mac).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I actually noticed this when running across a crash when stopping the virtualcam, where when
one of the color formats that need to be converted (meaning I444, P010, I010; but not RBG which
seems to be a bit random in that regard) was combined with one of the color spaces Rec. 601,
Rec. 2100 PQ, Rec. 2100 HLG, it would crash.

This PR *does not fix the cause of the crash* (though P010 doesn't crash anymore since it's no
longer converted), it's intended to lower the performance hit when using P010. For me, that was
"only" a significantly lower CPU load when using SDR color spaces, but when using HDR color
spaces I now have a usable virtualcam (ignoring the fact that it's still washed out of course).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13
When having the P010 color format selected, I no longer get any crashes. As mentioned before, the
CPU load drops significantly with SDR spaces, and using HDR the virtual now is smooth whereas
before it was a slideshow (tested in Chrome).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) (since the virtualcam no longer crashes on stop when using P010 with the aforementioned color spaces)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
