### PR TITLE
mac-virtualcam: Don't convert color space when converting color format

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -176,6 +176,8 @@ static bool virtualcam_output_start(void *data)
 		conversion.format = VIDEO_FORMAT_NV12;
 		conversion.width = vcam->videoInfo.output_width;
 		conversion.height = vcam->videoInfo.output_height;
+		conversion.colorspace = vcam->videoInfo.colorspace;
+		conversion.range = vcam->videoInfo.range;
 		obs_output_set_video_conversion(vcam->output, &conversion);
 
 		video_format = convert_video_format_to_mac(conversion.format);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Converting the color space was likely accidental as it isn't explicitly
set. Unfortunately, not setting it means that it gets set to the
default, which is Rec. 709 and thus a conversion takes place when having
any other space. This conversion leads to a massive performance penalty
that isn't necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When looking at the crash mentioned in #7034, I noticed a pattern where it would crash only
when converting the color format *and* having a non-default color space set. There, I stumbled
across the fact that the color space indeed isn't set and thus VIDEO_CS_DEFAULT is used which
when converting means Rec. 709. This is not good as it brings a performance penalty (which is
especially massive if you're using HDR), and we're fine using whatever color space (as seen with
any color format that doesn't get converted). And while we're at it, let's also make sure the color
range doesn't get changed implicitly.

I still don't think that this is the root cause of the crashes (there shouldn't be a crash just because
an output has a color space conversion set), but it no longer crashes (except with RGB, as I said
that seems to be a bit random), plus performance is much better now.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13
*Massively* better virtualcam performance when both a color format is set that gets converted (I444,
P010 until #7034, I010) and a non-709 color space is selected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
