### PR TITLE
UI: Fix crash when pausing/unpausing recording

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -9851,7 +9851,8 @@ void OBSBasic::PauseRecording()
 
 		os_atomic_set_bool(&recording_paused, true);
 
-		auto replay = replayBufferButton->second();
+		auto replay = replayBufferButton ? replayBufferButton->second()
+						 : nullptr;
 		if (replay)
 			replay->setEnabled(false);
 
@@ -9896,7 +9897,8 @@ void OBSBasic::UnpauseRecording()
 
 		os_atomic_set_bool(&recording_paused, false);
 
-		auto replay = replayBufferButton->second();
+		auto replay = replayBufferButton ? replayBufferButton->second()
+						 : nullptr;
 		if (replay)
 			replay->setEnabled(true);
 


### PR DESCRIPTION
### Description
Fix a crash introduced by the virtual camera UI changes. As part of that work the replay buffer button was refactored to be a reusable split button. This introduced an additional level of indirection which led to an incorrect null check when pausing or unpausing recording.

### Motivation and Context
Fixes a crash when pausing or unpausing recording when the replay buffer is disabled (`replayBufferButton` is null).

### How Has This Been Tested?
Verified the bug before fixing, and lack of bug after the fix.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
