### PR TITLE
obs-ffmpeg: Add b-frame logging for the AMD encoder

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1123,6 +1123,7 @@ static bool amf_avc_init(void *data, obs_data_t *settings)
 		warn("B-Frames set to %lld but b-frames are not "
 		     "supported by this device",
 		     bf);
+		bf = 0;
 	}
 
 	int rc = get_avc_rate_control(rc_str);
@@ -1161,11 +1162,12 @@ static bool amf_avc_init(void *data, obs_data_t *settings)
 	     "\tkeyint:       %d\n"
 	     "\tpreset:       %s\n"
 	     "\tprofile:      %s\n"
+	     "\tb-frames:     %d\n"
 	     "\twidth:        %d\n"
 	     "\theight:       %d\n"
 	     "\tparams:       %s",
-	     rc_str, bitrate, qp, gop_size, preset, profile, enc->cx, enc->cy,
-	     ffmpeg_opts);
+	     rc_str, bitrate, qp, gop_size, preset, profile, bf, enc->cx,
+	     enc->cy, ffmpeg_opts);
 
 	return true;
 }


### PR DESCRIPTION
### Description
Adds b-frame value to the log file. After moving this option to the UI there would be no other way to know what b-frame value the user has set.

When checking for b-frame support, also set bf=0 so the log will reflect the actual value.

### Motivation and Context
It is important for support purposes to know the b-frame value, as well as useful for users to know the when checking logs.

### How Has This Been Tested?
Tested on Windows 11, built, recorded with both h264 and HEVC. Recordings are fine, and log output is what is expected.

### Types of changes
- Tweak (non-breaking change to improve existing functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
