### PR TITLE
.gitignore: Add "install_temp" folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ GeneratedFiles/
 /UI/obs.rc
 .vscode/
 /CI/include/*.lock.json
+install_temp/
 
 /other/
 


### PR DESCRIPTION
### Description
We don't want this folder to be searched, as it's just a temp folder.
See `.github/workflows/main.yml:444` and `CI/windows/03_package_obs.ps1:37`

### Motivation and Context
It's annoying to have it show up as untracked files in git.

### How Has This Been Tested?
Tested with git CLI and the fork client. The folder and its contents no longer show up.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
