### PR TITLE
libobs: Fix gpu thread termination when additional video mixes are added

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -294,8 +294,8 @@ struct obs_core_video_mix {
 	enum obs_scale_type scale_type;
 };
 
-extern int obs_init_video_mix(struct obs_video_info *ovi,
-			      struct obs_core_video_mix *video);
+extern struct obs_core_video_mix *
+obs_create_video_mix(struct obs_video_info *ovi);
 extern void obs_free_video_mix(struct obs_core_video_mix *video);
 
 struct obs_core_video {
@@ -345,7 +345,7 @@ struct obs_core_video {
 	struct circlebuf tasks;
 
 	pthread_mutex_t mixes_mutex;
-	DARRAY(struct obs_core_video_mix) mixes;
+	DARRAY(struct obs_core_video_mix *) mixes;
 	struct obs_core_video_mix *main_mix;
 };
 

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -828,7 +828,7 @@ static inline void video_sleep(struct obs_core_video *video, uint64_t *p_time,
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
-		struct obs_core_video_mix *video = obs->video.mixes.array + i;
+		struct obs_core_video_mix *video = obs->video.mixes.array[i];
 		bool raw_active = video->raw_was_active;
 		bool gpu_active = video->gpu_was_active;
 
@@ -902,10 +902,11 @@ static inline void output_frames(void)
 {
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
-		struct obs_core_video_mix *mix = obs->video.mixes.array + i;
+		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
 		if (mix->view) {
 			output_frame(mix);
 		} else {
+			obs->video.mixes.array[i] = NULL;
 			obs_free_video_mix(mix);
 			da_erase(obs->video.mixes, i);
 			i--;
@@ -1075,7 +1076,7 @@ static inline void update_active_states(void)
 {
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++)
-		update_active_state(obs->video.mixes.array + i);
+		update_active_state(obs->video.mixes.array[i]);
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 }
 
@@ -1085,7 +1086,7 @@ static inline bool stop_requested(void)
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++)
-		if (!video_output_stopped(obs->video.mixes.array[i].video))
+		if (!video_output_stopped(obs->video.mixes.array[i]->video))
 			success = false;
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -578,8 +578,8 @@ static inline void set_video_matrix(struct obs_core_video_mix *video,
 	memcpy(video->color_matrix, &mat, sizeof(float) * 16);
 }
 
-int obs_init_video_mix(struct obs_video_info *ovi,
-		       struct obs_core_video_mix *video)
+static int obs_init_video_mix(struct obs_video_info *ovi,
+			      struct obs_core_video_mix *video)
 {
 	struct video_output_info vi;
 
@@ -618,6 +618,17 @@ int obs_init_video_mix(struct obs_video_info *ovi,
 	gs_leave_context();
 
 	return OBS_VIDEO_SUCCESS;
+}
+
+struct obs_core_video_mix *obs_create_video_mix(struct obs_video_info *ovi)
+{
+	struct obs_core_video_mix *video =
+		bzalloc(sizeof(struct obs_core_video_mix));
+	if (obs_init_video_mix(ovi, video) != OBS_VIDEO_SUCCESS) {
+		bfree(video);
+		video = NULL;
+	}
+	return video;
 }
 
 static int obs_init_video(struct obs_video_info *ovi)
@@ -659,7 +670,7 @@ static void stop_video(void)
 {
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++)
-		video_output_stop(obs->video.mixes.array[i].video);
+		video_output_stop(obs->video.mixes.array[i]->video);
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 
 	struct obs_core_video *video = &obs->video;
@@ -748,6 +759,7 @@ void obs_free_video_mix(struct obs_core_video_mix *video)
 		video->gpu_encoder_active = 0;
 		video->cur_texture = 0;
 	}
+	bfree(video);
 }
 
 static void obs_free_video(void)
@@ -756,8 +768,10 @@ static void obs_free_video(void)
 	size_t num = obs->video.mixes.num;
 	if (num)
 		blog(LOG_WARNING, "%d views remain at shutdown", num);
-	for (size_t i = 0; i < num; i++)
-		obs_free_video_mix(obs->video.mixes.array + i);
+	for (size_t i = 0; i < num; i++) {
+		obs_free_video_mix(obs->video.mixes.array[i]);
+		obs->video.mixes.array[i] = NULL;
+	}
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 
 	pthread_mutex_destroy(&obs->video.mixes_mutex);
@@ -2715,7 +2729,7 @@ struct obs_core_video_mix *get_mix_for_video(video_t *v)
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
-		struct obs_core_video_mix *mix = obs->video.mixes.array + i;
+		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
 
 		if (v == mix->video) {
 			result = mix;
@@ -2866,7 +2880,7 @@ bool obs_video_active(void)
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
-		struct obs_core_video_mix *video = obs->video.mixes.array + i;
+		struct obs_core_video_mix *video = obs->video.mixes.array[i];
 
 		if (os_atomic_load_long(&video->raw_active) > 0 ||
 		    os_atomic_load_long(&video->gpu_encoder_active) > 0) {


### PR DESCRIPTION
### Description
Fixes a bug where enabling the new virtual camera when GPU encoding had already started (for streaming or recording) would cause the GPU thread to exit early. This early exit would result in the output getting stuck in the stopping state later.

### Motivation and Context
Fixes bug reported in v28 beta 2

### How Has This Been Tested?
Repro steps:
- Start recording or streaming with a GPU encoder
- Start he virtual camera (this silently stops the GPU encoder thread)
- Stop the virtual camera (optional)
- Stop the recording or stream -> causes the UI to get stuck in a "Stopping..." state

Re-tested after the fix and was no longer able to reproduce.

The source of the bug was a DARRAY of video mixes containing structs rather than struct pointers. The GPU encoder thread holds a pointer to one of these structs which is invalidated when the DARRAY is reallocated to append a new video mix (which happens when the virtual camera is enabled). This appears to be the only place a pointer to this array is held outside of the mutex so the bug can only be observed when the GPU encoder is running and a new video mix is added causing a realloc.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
