### PR TITLE
CI: Update FreeBSD Cirrus-CI configuration

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,21 +1,27 @@
 # $FreeBSD$
 
 freebsd_instance:
-  image: freebsd-12-1-release-amd64
+  image: freebsd-13-1-release-amd64
 
 env:
   CIRRUS_CLONE_DEPTH: 1
+  CIRRUS_CLONE_SUBMODULES: true
 
 task:
   install_script:
   - pkg install -y
     v4l_compat swig ffmpeg curl dbus fdk-aac fontconfig
     freetype2 jackit jansson luajit mbedtls pulseaudio speexdsp
-    libsysinfo libudev-devd libv4l libx264 cmake ninja
+    libpci librist libsysinfo libudev-devd libv4l libx264 cmake ninja
     mesa-libs lua52 pkgconf
+    srt
     qt5-svg qt5-qmake qt5-buildtools qt5-x11extras qt5-xml
   script:
   - mkdir build
   - cd build
-  - cmake -DUNIX_STRUCTURE=1 -GNinja ..
+  - cmake
+      -DUNIX_STRUCTURE=1
+      -DENABLE_AJA=OFF
+      -DENABLE_ALSA=OFF
+      -GNinja ..
   - ninja


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
- Clone submodules too (for obs-websocket)
- Disable ALSA and AJA
- Add new deps (srt, librist, and libpci packages)
- Bump OS to most recent release, FreeBSD 13.1
- 
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Restore FreeBSD CI build to green
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Cirrus-CI run: https://cirrus-ci.com/build/5105257410723840

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
