### PR TITLE
obs-qsv11: Do not apply limits if CPU generation is unknown

### DIFF
--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -212,7 +212,8 @@ bool QSV_Encoder_Internal::InitParams(qsv_param_t *pParams)
 	m_mfxEncParams.mfx.GopRefDist = pParams->nbFrames + 1;
 
 	enum qsv_cpu_platform qsv_platform = qsv_get_cpu_platform();
-	if ((qsv_platform >= QSV_CPU_PLATFORM_ICL) &&
+	if ((qsv_platform >= QSV_CPU_PLATFORM_ICL ||
+	     qsv_platform == QSV_CPU_PLATFORM_UNKNOWN) &&
 	    (pParams->nbFrames == 0) &&
 	    (m_ver.Major == 1 && m_ver.Minor >= 31)) {
 		m_mfxEncParams.mfx.LowPower = MFX_CODINGOPTION_ON;

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -188,7 +188,8 @@ static inline void add_strings(obs_property_t *list, const char *const *strings)
 static inline bool is_skl_or_greater_platform()
 {
 	enum qsv_cpu_platform plat = qsv_get_cpu_platform();
-	return (plat >= QSV_CPU_PLATFORM_SKL);
+	return (plat >= QSV_CPU_PLATFORM_SKL ||
+		plat == QSV_CPU_PLATFORM_UNKNOWN);
 }
 
 static bool update_latency(obs_data_t *settings)
@@ -313,7 +314,8 @@ static bool profile_modified(obs_properties_t *ppts, obs_property_t *p,
 	const char *profile = obs_data_get_string(settings, "profile");
 	enum qsv_cpu_platform plat = qsv_get_cpu_platform();
 	bool bVisible = ((astrcmpi(profile, "high") == 0) &&
-			 (plat >= QSV_CPU_PLATFORM_ICL));
+			 (plat >= QSV_CPU_PLATFORM_ICL ||
+			  plat == QSV_CPU_PLATFORM_UNKNOWN));
 	p = obs_properties_get(ppts, "CQM");
 	obs_property_set_visible(p, bVisible);
 	return true;
@@ -324,7 +326,9 @@ static inline void add_rate_controls(obs_property_t *list,
 {
 	enum qsv_cpu_platform plat = qsv_get_cpu_platform();
 	while (rc->name) {
-		if (!rc->haswell_or_greater || plat >= QSV_CPU_PLATFORM_HSW)
+		if (!rc->haswell_or_greater ||
+		    (plat >= QSV_CPU_PLATFORM_HSW ||
+		     plat == QSV_CPU_PLATFORM_UNKNOWN))
 			obs_property_list_add_string(list, rc->name, rc->name);
 		rc++;
 	}
@@ -796,7 +800,8 @@ static inline void cap_resolution(obs_encoder_t *encoder,
 	info->height = height;
 	info->width = width;
 
-	if (qsv_platform <= QSV_CPU_PLATFORM_IVB) {
+	if (qsv_platform <= QSV_CPU_PLATFORM_IVB &&
+	    qsv_platform != QSV_CPU_PLATFORM_UNKNOWN) {
 		if (width > 1920) {
 			info->width = 1920;
 		}


### PR DESCRIPTION

### Description

Do not restrict QSV resolution if CPU ID lookup returns "Unknown".

This should be removed and replaced with a proper check once the encoder implementation gets reworked for OneAPI-VPL and AV1 support.

### Motivation and Context

Users with Intel dGPU (Arc) and AMD CPU would find themselves restricted to 1200p for no reason.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
