### PR TITLE
libobs: Fix the crash when Async Delay Filter on

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -744,7 +744,6 @@ struct obs_source {
 	bool async_flip;
 	bool async_linear_alpha;
 	bool async_active;
-	bool async_update_texture;
 	bool async_unbuffered;
 	bool async_decoupled;
 	struct obs_source_frame *async_preload_frame;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1206,10 +1206,6 @@ static void async_tick(obs_source_t *source)
 
 	source->last_sys_timestamp = sys_time;
 	pthread_mutex_unlock(&source->async_mutex);
-
-	if (source->cur_async_frame)
-		source->async_update_texture =
-			set_async_texture_size(source, source->cur_async_frame);
 }
 
 void obs_source_video_tick(obs_source_t *source, float seconds)
@@ -1975,9 +1971,6 @@ static inline bool init_gpu_conversion(struct obs_source *source,
 bool set_async_texture_size(struct obs_source *source,
 			    const struct obs_source_frame *frame)
 {
-	enum convert_type cur =
-		get_convert_type(frame->format, frame->full_range, frame->trc);
-
 	if (source->async_width == frame->width &&
 	    source->async_height == frame->height &&
 	    source->async_format == frame->format &&
@@ -2007,7 +2000,9 @@ bool set_async_texture_size(struct obs_source *source,
 
 	const enum gs_color_format format =
 		convert_video_format(frame->format, frame->trc);
-	const bool async_gpu_conversion = (cur != CONVERT_NONE) &&
+	const enum convert_type type =
+		get_convert_type(frame->format, frame->full_range, frame->trc);
+	const bool async_gpu_conversion = (type != CONVERT_NONE) &&
 					  init_gpu_conversion(source, frame);
 	source->async_gpu_conversion = async_gpu_conversion;
 	if (async_gpu_conversion) {
@@ -2382,6 +2377,9 @@ static void obs_source_update_async_video(obs_source_t *source)
 
 		source->async_rendered = true;
 		if (frame) {
+			const bool async_update_texture =
+				set_async_texture_size(source, frame);
+
 			check_to_swap_bgrx_bgra(source, frame);
 
 			if (!source->async_decoupled ||
@@ -2391,11 +2389,10 @@ static void obs_source_update_async_video(obs_source_t *source)
 				source->timing_set = true;
 			}
 
-			if (source->async_update_texture) {
+			if (async_update_texture) {
 				update_async_textures(source, frame,
 						      source->async_textures,
 						      source->async_texrender);
-				source->async_update_texture = false;
 			}
 
 			obs_source_release_frame(source, frame);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

~~1. Add function to limit texture filling size to avoid memcpy overflow in memcpy~~

Correctly set the async texture size,
based on the frame to be rendered on this loop,
rather than the newest frame from encoder when async delay filter on.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

1. Fixes #6188
2. And fixes crash when preload frame remain but the source texture changed
(by media file changed or other situation, found in debugging other issues)

When using Video Delay filter, after the source media changed(especially when the media dimension size get bigger),
the frame pop from the delay filter with the old size, but the texture is changed by the newest frame.

https://github.com/obsproject/obs-studio/blob/bad54448ceb65b015a3b2c812a40920f6f78d8b1/libobs/obs-source.c#L2377-L2381

When occurs the mismatch between frame and texture, the crash happens.

The `set_async_texture_size` should be called after the old deleyed frame popped.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Win10
Reproduce those steps mentioned on issue, no crash happen.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

Bug fix (non-breaking change which fixes an issue)
Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
