### PR TITLE
obs-ffmpeg: Prevent invalid AMF combinations, and fix leaks

### DIFF
--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -81,6 +81,8 @@ Encoder.Timeout="Encoder %1 is taking too long to encode (timeout: %2 seconds)"
 
 AMF.Error="Failed to open AMF codec: %1"
 AMF.GenericError="Check your video drivers are up to date. Try closing other recording software which might be using the AMD encoder such as the Radeon Software or Windows 10 Game DVR."
+AMF.8bitUnsupportedHdr="OBS does not support 8-bit output of Rec. 2100."
+AMF.10bitUnsupportedAvc="Cannot perform 10-bit encode on AMD H.264 encoder."
 
 NVENC.Error="Failed to open NVENC codec: %1"
 NVENC.GenericError="Check your video drivers are up to date. Try closing other recording software which might be using NVENC such as NVIDIA Shadowplay or Windows 10 Game DVR."

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1231,15 +1231,15 @@ static void *amf_avc_create_texencode(obs_data_t *settings,
 try {
 	check_texture_encode_capability(encoder, false);
 
-	amf_texencode *enc = new amf_texencode;
+	std::unique_ptr<amf_texencode> enc = std::make_unique<amf_texencode>();
 	enc->encoder = encoder;
 	enc->encoder_str = "texture-amf-h264";
 
-	if (!amf_init_d3d11(enc))
+	if (!amf_init_d3d11(enc.get()))
 		throw "Failed to create D3D11";
 
-	amf_avc_create_internal(enc, settings);
-	return enc;
+	amf_avc_create_internal(enc.get(), settings);
+	return enc.release();
 
 } catch (const amf_error &err) {
 	blog(LOG_ERROR, "[texture-amf-h264] %s: %s: %ls", __FUNCTION__, err.str,
@@ -1254,12 +1254,12 @@ try {
 static void *amf_avc_create_fallback(obs_data_t *settings,
 				     obs_encoder_t *encoder)
 try {
-	amf_fallback *enc = new amf_fallback;
+	std::unique_ptr<amf_fallback> enc = std::make_unique<amf_fallback>();
 	enc->encoder = encoder;
 	enc->encoder_str = "fallback-amf-h264";
 
-	amf_avc_create_internal(enc, settings);
-	return enc;
+	amf_avc_create_internal(enc.get(), settings);
+	return enc.release();
 
 } catch (const amf_error &err) {
 	blog(LOG_ERROR, "[texture-amf-h264] %s: %s: %ls", __FUNCTION__, err.str,
@@ -1541,15 +1541,15 @@ static void *amf_hevc_create_texencode(obs_data_t *settings,
 try {
 	check_texture_encode_capability(encoder, true);
 
-	amf_texencode *enc = new amf_texencode;
+	std::unique_ptr<amf_texencode> enc = std::make_unique<amf_texencode>();
 	enc->encoder = encoder;
 	enc->encoder_str = "texture-amf-h265";
 
-	if (!amf_init_d3d11(enc))
+	if (!amf_init_d3d11(enc.get()))
 		throw "Failed to create D3D11";
 
-	amf_hevc_create_internal(enc, settings);
-	return enc;
+	amf_hevc_create_internal(enc.get(), settings);
+	return enc.release();
 
 } catch (const amf_error &err) {
 	blog(LOG_ERROR, "[texture-amf-h265] %s: %s: %ls", __FUNCTION__, err.str,
@@ -1564,12 +1564,12 @@ try {
 static void *amf_hevc_create_fallback(obs_data_t *settings,
 				      obs_encoder_t *encoder)
 try {
-	amf_fallback *enc = new amf_fallback;
+	std::unique_ptr<amf_fallback> enc = std::make_unique<amf_fallback>();
 	enc->encoder = encoder;
 	enc->encoder_str = "fallback-amf-h265";
 
-	amf_hevc_create_internal(enc, settings);
-	return enc;
+	amf_hevc_create_internal(enc.get(), settings);
+	return enc.release();
 
 } catch (const amf_error &err) {
 	blog(LOG_ERROR, "[texture-amf-h265] %s: %s: %ls", __FUNCTION__, err.str,


### PR DESCRIPTION
### Description
Don't want to silently generate lossy video.

### Motivation and Context
Don't want invalid videos out there. Leaks are bad.

### How Has This Been Tested?
Verified AMF H.264 can no longer record 8-bit HDR, and the error message looks as expected.

Verified AMF H.264 can no longer record 10-bit anything, and the error message looks as expected.

Verified AMF HEVC can no longer record 8-bit HDR, and the error message looks as expected.

Lots of debugger breakpoints to verify that the encoder destructors are called as expected in error situations for all code paths.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.