### PR TITLE
CI: remove UNIX_STRUCTURE from FreeBSD Cirrus-CI config

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,6 @@ task:
   - mkdir build
   - cd build
   - cmake
-      -DUNIX_STRUCTURE=1
       -DENABLE_AJA=OFF
       -DENABLE_ALSA=OFF
       -GNinja ..


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Update FreeBSD .cirrus.yml to stop setting UNIX_STRUCTURE.

### Motivation and Context
UNIX_STRUCTURE was deprecated in df94b0207563.

### How Has This Been Tested?
Cirrus-CI run: https://cirrus-ci.com/task/4900659664257024

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
