### PR TITLE
rnnoise: Use __builtin_trap() instead of *(int*)0=0;

### DIFF
--- a/plugins/obs-filters/rnnoise/src/rnn.c
+++ b/plugins/obs-filters/rnnoise/src/rnn.c
@@ -102,7 +102,7 @@ static void compute_dense(const DenseLayer *layer, float *output, const float *i
       for (i=0;i<N;i++)
          output[i] = relu(output[i]);
    } else {
-     *(int*)0=0;
+     __builtin_trap();
    }
 }
 
@@ -148,7 +148,7 @@ static void compute_gru(const GRULayer *gru, float *state, const float *input)
       if (gru->activation == ACTIVATION_SIGMOID) sum = sigmoid_approx(WEIGHTS_SCALE*sum);
       else if (gru->activation == ACTIVATION_TANH) sum = tansig_approx(WEIGHTS_SCALE*sum);
       else if (gru->activation == ACTIVATION_RELU) sum = relu(WEIGHTS_SCALE*sum);
-      else *(int*)0=0;
+      else __builtin_trap();
       h[i] = z[i]*state[i] + (1-z[i])*sum;
    }
    for (i=0;i<N;i++)


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Compilers may omit `*(int*)0=0` - use `__builtin_trap()` instead. I am not sure if `__builtin_trap()` is available in all compilers relevant to OBS-studio, but will check the CI results.

If `__builtin_trap()` is not available we could use Clang's other suggestion `*(volatile int*)0=0;`, add some `#ifdef`ery, or use `abort()` perhaps.

### Motivation and Context
Building on FreeBSD, the system compiler (Clang 14) emitted a warning:

```
[224/423] Building C object plugins/obs-filters/CMakeFiles/obs-filters.dir/rnnoise/src/rnn.c.o
/home/emaste/src/obs-studio/plugins/obs-filters/rnnoise/src/rnn.c:105:6: warning: indirection of non-volatile null pointer will be deleted, not trap [-Wnull-dereference]
     *(int*)0=0;
     ^~~~~~~~
/home/emaste/src/obs-studio/plugins/obs-filters/rnnoise/src/rnn.c:105:6: note: consider using __builtin_trap() or qualifying pointer with 'volatile'
```

### How Has This Been Tested?
Build tested on FreeBSD.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
