### PR TITLE
obs-filters: Don't allow HDR max below 5 nits

### DIFF
--- a/plugins/obs-filters/hdr-tonemap-filter.c
+++ b/plugins/obs-filters/hdr-tonemap-filter.c
@@ -117,11 +117,11 @@ static obs_properties_t *hdr_tonemap_filter_properties(void *data)
 	obs_property_int_set_suffix(p, " nits");
 	p = obs_properties_add_int(
 		props, "hdr_input_maximum_nits",
-		obs_module_text("HdrTonemap.HdrInputMaximum"), 0, 10000, 1);
+		obs_module_text("HdrTonemap.HdrInputMaximum"), 5, 10000, 1);
 	obs_property_int_set_suffix(p, " nits");
 	p = obs_properties_add_int(
 		props, "hdr_output_maximum_nits",
-		obs_module_text("HdrTonemap.HdrOutputMaximum"), 0, 10000, 1);
+		obs_module_text("HdrTonemap.HdrOutputMaximum"), 5, 10000, 1);
 	obs_property_int_set_suffix(p, " nits");
 
 	UNUSED_PARAMETER(data);


### PR DESCRIPTION
### Description
That's the lower limit of max_display_mastering_luminance in the spec.

### Motivation and Context
Range sanity

### How Has This Been Tested?
Verified both controls respect the new minimum values.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.