### PR TITLE
UI: Enforce macOS plugin bundle on M1; don’t load plugin bundles globally

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -178,10 +178,6 @@ static void AddExtraModulePaths()
 
 	string path = base_module_dir;
 #if defined(__APPLE__)
-	/* System Library Search Path */
-	obs_add_module_path((path + ".plugin/Contents/MacOS").c_str(),
-			    (path + ".plugin/Contents/Resources").c_str());
-
 	/* User Application Support Search Path */
 	BPtr<char> config_bin = os_get_config_path_ptr(
 		"obs-studio/plugins/%module%.plugin/Contents/MacOS");

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -185,6 +185,7 @@ static void AddExtraModulePaths()
 		"obs-studio/plugins/%module%.plugin/Contents/Resources");
 	obs_add_module_path(config_bin, config_data);
 
+#ifndef __aarch64__
 	/* Legacy System Library Search Path */
 	obs_add_module_path((path + "/bin").c_str(), (path + "/data").c_str());
 
@@ -194,6 +195,7 @@ static void AddExtraModulePaths()
 	BPtr<char> config_data_legacy =
 		os_get_config_path_ptr("obs-studio/plugins/%module%/data");
 	obs_add_module_path(config_bin_legacy, config_data_legacy);
+#endif
 #else
 #if ARCH_BITS == 64
 	obs_add_module_path((path + "/bin/64bit").c_str(),


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
macOS OBS plugins in following locations/formats will no longer get loaded with this PR:
- The plugin is a `.plugin` bundle, but located in the global application support directory (`/Library/Application Support/obs-studio/plugins`)
- OBS and the plugin have the arm64 architecture and the plugin has the `/bin` and `/data` folder structure (which effectively means it's an `.so` plugin)

This means that plugins are now only loaded if:
- They are a `.plugin` bundle in the user application support directory
- They are an x86_64 `.so` plugin

Important note: None of what got removed got released in a stable OBS release yet.
This does not break any setups just upgrading from 27.2 to 28.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Modern plugins on macOS are `.plugin` bundles.
They live in the user application support directory, so that they don't require admin
permissions to be installed and don't effect other users. (@PatTheMav will still need to
confirm whether this assessment is correct.)

Now is our best shot at preventing any other behaviour, since by introducing it we could
potentially force ourselves into supporting it for a long time.
Any plugin author following the plugintemplate (which most of them need to do anyways
due to Qt 6) will already have the plugin in the correct format and installer will install it into
the correct location.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13
- Tested that a plugin bundle (used [obs-properties-dock](https://github.com/gxalpha/obs-properties-dock) to test) from the global applications support directory gets loaded without my changes, and no longer get loaded with them.
- Tested with CI build that an existing, x86_64-only old-style plugin (used [obs-main-view-source](https://github.com/norihiro/obs-main-view-source) to test) gets loaded successfully from both global and user application support (via running Rosetta). Tested that when running arm64 natively, without this PR (plugin in either location) I get an error (`os_dlopen[...] mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64'`) message in the log (which means that it tries to load the plugin), but with this PR that message doesn't appear (which means that it correctly does not try to load this old-style plugin).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
