### PR TITLE
obs-ffmpeg: Prevent invalid NVENC combinations

### DIFF
--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -33,6 +33,8 @@ NVENC.LookAhead.ToolTip="Enables dynamic B-frames.\n\nIf disabled, the encoder w
 NVENC.PsychoVisualTuning="Psycho Visual Tuning"
 NVENC.PsychoVisualTuning.ToolTip="Enables encoder settings that optimize the use of bitrate for increased perceived visual quality,\nespecially in situations with high motion, at the cost of increased GPU utilization."
 NVENC.CQLevel="CQ Level"
+NVENC.8bitUnsupportedHdr="OBS does not support 8-bit output of Rec. 2100."
+NVENC.I010Unsupported="NVENC does not support I010. Use P010 instead."
 NVENC.10bitUnsupported="Cannot perform 10-bit encode on this encoder."
 NVENC.TooManyBFrames="Max B-frames setting (%d) is more than encoder supports (%d)."
 

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -982,6 +982,21 @@ static bool init_encoder(struct nvenc_data *enc, bool hevc,
 		return false;
 	}
 
+	video_t *video = obs_encoder_video(enc->encoder);
+	const struct video_output_info *voi = video_output_get_info(video);
+	switch (voi->format) {
+	case VIDEO_FORMAT_I010:
+	case VIDEO_FORMAT_P010:
+		break;
+	default:
+		switch (voi->colorspace) {
+		case VIDEO_CS_2100_PQ:
+		case VIDEO_CS_2100_HLG:
+			NV_FAIL(obs_module_text("NVENC.8bitUnsupportedHdr"));
+			return false;
+		}
+	}
+
 	if (bf > bf_max) {
 		NV_FAIL(obs_module_text("NVENC.TooManyBFrames"), bf, bf_max);
 		return false;


### PR DESCRIPTION
### Description
Don't want to silently generate lossy video.

### Motivation and Context
Don't want invalid videos out there.

### How Has This Been Tested?
Verified 8-bit HDR fails with dialog on H.264 & HEVC.

Verified 10-bit fails with dialog on H.264.

Verified I010 fails with dialog on HEVC.

Verified 8-bit SDR, 10-bit SDR, and 10-bit HDR videos still record successfully.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.