### PR TITLE
obs-ffmpeg: Block 8-bit HDR for AV1 encoders

### DIFF
--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -90,4 +90,6 @@ NVENC.UnsupportedDevice="NVENC Error: Unsupported device. Check your video card 
 NVENC.TooManySessions="NVENC Error: Too many concurrent sessions. Try closing other recording software which might be using NVENC such as NVIDIA Shadowplay or Windows 10 Game DVR."
 NVENC.CheckDrivers="Please check your video drivers are up to date."
 
+AV1.8bitUnsupportedHdr="OBS does not support 8-bit output of Rec. 2100."
+
 ReconnectDelayTime="Reconnect Delay"


### PR DESCRIPTION
### Description
Don't want to silently generate lossy video.

### Motivation and Context
Don't want invalid videos out there.

### How Has This Been Tested?
Verified 8-bit HDR fails with dialog for AOM and SVT.

Verified 8-bit SDR, 10-bit SDR, and 10-bit HDR videos still record successfully for AOM and SVT.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.