### PR TITLE
Various tweak/fix related to Flatpak

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -50,7 +50,7 @@ jobs:
     env:
       FLATPAK_BUILD_PATH: flatpak_app/files/share
     container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-5.15-21.08
+      image: bilelmoussaoui/flatpak-github-actions:kde-6.3
       options: --privileged
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -370,7 +370,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-5.15-21.08
+      image: bilelmoussaoui/flatpak-github-actions:kde-6.3
       options: --privileged
     steps:
       - name: 'Check for Github Labels'

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -439,7 +439,6 @@
         "-DYOUTUBE_SECRET_HASH=$YOUTUBE_SECRET_HASH"
       ],
       "post-install": [
-        "cmake --install . --component obs_libraries",
         "install -d /app/plugins",
         "install -d /app/extensions/Plugins"
       ],

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -40,7 +40,6 @@
     }
   },
   "cleanup": [
-    "/lib/pkgconfig",
     "/share/man",
     "*.la"
   ],
@@ -52,7 +51,8 @@
         "--enable-shared"
       ],
       "cleanup": [
-        "/include"
+        "/include",
+        "/lib/pkgconfig"
       ],
       "sources": [
         {
@@ -73,7 +73,8 @@
         "--with-udevdir=/app/lib/udev/"
       ],
       "cleanup": [
-        "/include"
+        "/include",
+        "/lib/pkgconfig"
       ],
       "sources": [
         {
@@ -111,6 +112,7 @@
       ],
       "cleanup": [
         "/include",
+        "/lib/pkgconfig",
         "/bin"
       ],
       "sources": [
@@ -157,7 +159,8 @@
         "-Dbuiltin_cjson=true"
       ],
       "cleanup": [
-        "/include"
+        "/include",
+        "/lib/pkgconfig"
       ],
       "sources": [
         {
@@ -181,7 +184,8 @@
         "-DENABLE_TOOLS=OFF "
       ],
       "cleanup": [
-        "/include"
+        "/include",
+        "/lib/pkgconfig"
       ],
       "sources": [
         {
@@ -205,7 +209,8 @@
         "-DBUILD_TESTING=OFF"
       ],
       "cleanup": [
-        "/include"
+        "/include",
+        "/lib/pkgconfig"
       ],
       "sources": [
         {
@@ -269,6 +274,7 @@
       "cleanup": [
         "/bin",
         "/include",
+        "/lib/pkgconfig",
         "*.a"
       ],
       "sources": [


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

- Update the container image for the Flatpak CI, it just make flatpak-builder avoid installing the required runtime and SDK each time.
- Avoid cleaning libobs, FFmpeg and PipeWire pkgconfig files since plugin could need them to build.
- Revert #6561 because #6934 remove this requirement

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Clean and fix.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

~~CI is required to test this.~~

The CI Flatpak contains the pkgconfig, cmake and headers files as expected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
