### PR TITLE
CI: Build ALSA support on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,6 +10,7 @@ env:
 task:
   install_script:
   - pkg install -y
+    alsa-lib
     v4l_compat swig ffmpeg curl dbus fdk-aac fontconfig
     freetype2 jackit jansson luajit mbedtls pulseaudio speexdsp
     libpci librist libsysinfo libudev-devd libv4l libx264 cmake ninja
@@ -21,6 +22,5 @@ task:
   - cd build
   - cmake
       -DENABLE_AJA=OFF
-      -DENABLE_ALSA=OFF
       -GNinja ..
   - ninja


### PR DESCRIPTION



<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
FreeBSD provides an ALSA compatibility library.  Install it, and leave ALSA support enabled as default.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Desire to test the FreeBSD build with as much functionality enabled as possible.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
FreeBSD CI via Cirrus-CI is green with this change: https://cirrus-ci.com/task/5783415617224704

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
