### PR TITLE
libobs: Read /etc/os-release on FreeBSD

### DIFF
--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -261,7 +261,7 @@ static void log_kernel_version(void)
 	blog(LOG_INFO, "Kernel Version: %s %s", info.sysname, info.release);
 }
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
 static void log_distribution_info(void)
 {
 	FILE *fp;
@@ -322,7 +322,7 @@ void log_system_info(void)
 	log_processor_cores();
 	log_memory_info();
 	log_kernel_version();
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
 	log_distribution_info();
 	log_desktop_session_info();
 #endif


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Previously FreeBSD had an optional port that installed /etc/os-release
so it was already available on many FreeBSD systems, but os-release is
now provided by the base system and will be universally available.

### Motivation and Context
Improved diagnostic/error reporting, and consistency with Linux.

### How Has This Been Tested?
Running locally, I see "Distribution" in the log:
```
17:01:02.771: Using EGL/X11
17:01:02.771: CPU Name: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
17:01:02.771: CPU Speed: 2000.00MHz
17:01:02.774: Physical Cores: 4, Logical Cores: 8
17:01:02.777: Physical Memory: 15678MB Total, 7362MB Free
17:01:02.777: Kernel Version: FreeBSD 14.0-CURRENT
17:01:02.777: Distribution: FreeBSD 13.0
17:01:02.777: Window System: X11.0, Vendor: The X.Org Foundation, Version: 1.20.14
17:01:02.778: Qt Version: 5.15.2 (runtime), 5.15.2 (compiled)
17:01:02.778: Portable mode: false
17:01:02.844: OBS 28.0.0-beta2-52-g4615326cc-modified (freebsd)
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
