### PR TITLE
cmake: Specify utf-8 for MSVC builds

### DIFF
--- a/cmake/Modules/CompilerConfig.cmake
+++ b/cmake/Modules/CompilerConfig.cmake
@@ -67,7 +67,8 @@ if(OS_WINDOWS AND MSVC)
     /DUNICODE
     /D_UNICODE
     /D_CRT_SECURE_NO_WARNINGS
-    /D_CRT_NONSTDC_NO_WARNINGS)
+    /D_CRT_NONSTDC_NO_WARNINGS
+    /utf-8)
 
   add_link_options(
     "LINKER:/OPT:REF"


### PR DESCRIPTION
### Description
If there is no BOM, MSVC defaults to the user's code page which can result in errors if UTF-8 characters are present in the source files.

https://docs.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170

### Motivation and Context
Trying to build OBS with a non-standard codepage would fail.

### How Has This Been Tested?
Hasn't.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
