### PR TITLE
UI: Fix use-after-free in properties view

### DIFF
--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -61,7 +61,6 @@ public:
 			update_timer->stop();
 			QMetaObject::invokeMethod(update_timer, "timeout");
 			update_timer->deleteLater();
-			obs_data_release(old_settings_cache);
 		}
 	}
 


### PR DESCRIPTION
### Description
I experienced a random crash under a debugger with heap validation active when changing items in the settings window. Further investigation showed that we're calling `obs_data_release` on an `OBSData` class member inside `WidgetInfo`, which I believe is incorrect behavior since `OBSData` will automatically call `obs_data_release` on destruction. This caused a double `obs_data_release` call when destroying `WidgetInfo`, which in the unlikely event of the `WidgetInfo` having an `update_timer` assigned AND the freed heap memory having `ref = 1`, would trigger a double-free crash.

### Motivation and Context
Crashing bad.

### How Has This Been Tested?
Confirmed fixed the crashing for me. Additional eyes on this to make sure this is correct use of `OBSData` would be nice.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
