### PR TITLE
Address shutdown hang on FreeBSD

### DIFF
--- a/plugins/linux-v4l2/v4l2-udev.c
+++ b/plugins/linux-v4l2/v4l2-udev.c
@@ -133,10 +133,14 @@ static void *udev_event_thread(void *vptr)
 
 		fds[0].fd = fd;
 		fds[0].events = POLLIN;
+		fds[0].revents = 0;
 		fds[1].fd = udev_event_fd;
 		fds[1].events = POLLIN;
 
 		if (poll(fds, 2, 1000) <= 0)
+			continue;
+
+		if (!fds[0].revents & POLLIN)
 			continue;
 
 		dev = udev_monitor_receive_device(mon);


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
udev_event_thread calls poll with two fds: the udev fd, and an eventfd
used for shutdown.  On FreeBSD we were hanging on shutdown in
udev_monitor_receive_device after receiving the eventfd event.

Now, if the udev fd reports no events skip the
udev_monitor_receive_device call.

At shutdown the loop will exit via os_event_try().

### Motivation and Context
Avoid shutdown hang.

### How Has This Been Tested?
Tested locally on my FreeBSD laptop

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
