### PR TITLE
libobs: Use nal_ref_idc for H.264 priority

### DIFF
--- a/libobs/obs-avc.c
+++ b/libobs/obs-avc.c
@@ -55,16 +55,12 @@ static int compute_avc_keyframe_priority(const uint8_t *nal_start,
 					 bool *is_keyframe, int priority)
 {
 	const int type = nal_start[0] & 0x1F;
-
-	switch (type) {
-	case OBS_NAL_SLICE:
-		if (priority < OBS_NAL_PRIORITY_HIGH)
-			priority = OBS_NAL_PRIORITY_HIGH;
-		break;
-	case OBS_NAL_SLICE_IDR:
+	if (type == OBS_NAL_SLICE_IDR)
 		*is_keyframe = true;
-		priority = OBS_NAL_PRIORITY_HIGHEST;
-	}
+
+	const int new_priority = nal_start[0] >> 5;
+	if (priority < new_priority)
+		priority = new_priority;
 
 	return priority;
 }


### PR DESCRIPTION
### Description
H.264 spec only mentions zero/non-zero, but RFC 6184 uses 0/1/2/3 values
for prioritization. Go back to reading packet field for priority.

### Motivation and Context
Want better packet loss behavior.

### How Has This Been Tested?
Logged type/keyframe/priority values, and they looked reasonable.

Regular Twitch stream worked okay.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.