### PR TITLE
linux-v4l2: Correct udev fd poll event test

### DIFF
--- a/plugins/linux-v4l2/v4l2-udev.c
+++ b/plugins/linux-v4l2/v4l2-udev.c
@@ -140,7 +140,7 @@ static void *udev_event_thread(void *vptr)
 		if (poll(fds, 2, 1000) <= 0)
 			continue;
 
-		if (!fds[0].revents & POLLIN)
+		if (!(fds[0].revents & POLLIN))
 			continue;
 
 		dev = udev_monitor_receive_device(mon);


### PR DESCRIPTION

Fixes:		91f986ec9969 ("linux-v4l2: Check udev fd events")

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Parentheses are needed due to operator precedence (although the previous
code happened to work because POLLIN has the value 1).

### Motivation and Context
Fix bug in my previous change 91f986ec9969

### How Has This Been Tested?
OBS still exits successfully on FreeBSD here.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
