### PR TITLE
UI: Free virtual cam memory on shutdown

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2731,6 +2731,8 @@ OBSBasic::~OBSBasic()
 	delete cef;
 	cef = nullptr;
 #endif
+
+	OBSBasicVCamConfig::DestroyView();
 }
 
 void OBSBasic::SaveProjectNow()

--- a/UI/window-basic-vcam-config.hpp
+++ b/UI/window-basic-vcam-config.hpp
@@ -14,6 +14,8 @@ public:
 
 	static video_t *StartVideo();
 	static void StopVideo();
+	static void DestroyView();
+
 	static void UpdateOutputSource();
 
 	explicit OBSBasicVCamConfig(QWidget *parent = 0);

--- a/libobs/obs-view.c
+++ b/libobs/obs-view.c
@@ -162,6 +162,9 @@ static inline void set_main_mix()
 
 video_t *obs_view_add(obs_view_t *view)
 {
+	if (!view)
+		return NULL;
+
 	struct obs_core_video_mix *mix = obs_create_video_mix(&obs->video.ovi);
 	if (!mix) {
 		return NULL;
@@ -178,6 +181,9 @@ video_t *obs_view_add(obs_view_t *view)
 
 void obs_view_remove(obs_view_t *view)
 {
+	if (!view)
+		return;
+
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	size_t idx = find_mix_for_view(view);
 	if (idx != DARRAY_INVALID)


### PR DESCRIPTION
### Description
Fix a memory leak on shutdown if the virtual camera is still active. Also fixes an untracked memory leak (C++ new/delete) of the `vCamConfig` by making it statically allocated.

### How Has This Been Tested?
- Reproduced leak on shutdown, implemented fix and tested that leak was gone.
- Added `new`/`delete` overrides to `VCamConfig` so that leak was tracked, fixed and then tested again that leak was gone before removing the overrides.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
