### PR TITLE
UI: Reintroduce faster theme switching

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1205,6 +1205,8 @@ bool OBSApp::SetTheme(std::string name, std::string path)
 	path = GetTheme(name, path);
 	if (path.empty())
 		return false;
+
+	setStyleSheet("");
 	unique_ptr<OBSThemeMeta> themeMeta;
 	themeMeta.reset(ParseThemeMeta(path.c_str()));
 	string parentPath;


### PR DESCRIPTION
### Description
Based on (was reverted):
https://github.com/obsproject/obs-studio/commit/08cee21158c1f43956210418dd99ab763a90d2a2

This simplifies the faster switching code, as setting an empty
stylesheet resets it to default.

### Motivation and Context
Faster theme switching is a much better experience.

Simplifies https://github.com/obsproject/obs-studio/commit/08cee21158c1f43956210418dd99ab763a90d2a2

### How Has This Been Tested?
Tested on Ubuntu 22.04, with QT 6.2.4.

Switch themes and made sure things were indeed faster. Also tested with #7116 

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
