### PR TITLE
UI: Save virtual camera config outside of the modules object

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -729,6 +729,8 @@ void OBSBasic::Save(const char *file)
 	obs_data_set_double(saveData, "scaling_off_y",
 			    ui->preview->GetScrollY());
 
+	OBSBasicVCamConfig::SaveData(saveData, true);
+
 	if (api) {
 		OBSDataAutoRelease moduleObj = obs_data_create();
 		api->on_save(moduleObj);
@@ -1140,6 +1142,8 @@ retryScene:
 	}
 	ui->preview->SetFixedScaling(fixedScaling);
 	emit ui->preview->DisplayResized();
+
+	OBSBasicVCamConfig::SaveData(data, false);
 
 	/* ---------------------- */
 

--- a/UI/window-basic-vcam-config.cpp
+++ b/UI/window-basic-vcam-config.cpp
@@ -133,7 +133,7 @@ void OBSBasicVCamConfig::Save()
 		UpdateOutputSource();
 }
 
-static void SaveCallback(obs_data_t *data, bool saving, void *)
+void OBSBasicVCamConfig::SaveData(obs_data_t *data, bool saving)
 {
 	if (saving) {
 		OBSDataAutoRelease obj = obs_data_create();
@@ -189,7 +189,6 @@ void OBSBasicVCamConfig::Init()
 
 	vCamConfig = &staticConfig;
 
-	obs_frontend_add_save_callback(SaveCallback, nullptr);
 	obs_frontend_add_event_callback(EventCallback, nullptr);
 }
 

--- a/UI/window-basic-vcam-config.hpp
+++ b/UI/window-basic-vcam-config.hpp
@@ -17,6 +17,7 @@ public:
 	static void DestroyView();
 
 	static void UpdateOutputSource();
+	static void SaveData(obs_data_t *data, bool saving);
 
 	explicit OBSBasicVCamConfig(QWidget *parent = 0);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

The `modules` object is more meant for plugins using the frontend API.

So this PR made the virtual camera configuration saved outside of the modules object in the Scene Collection.

This need to be merge before 28 is released, or it will become a breaking change.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

This should be saved outside of the `modules` object.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

My virtual camera config is kept between sessions and scene collections changes.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
