### PR TITLE
libobs: Initialize main_view video mix before video thread

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -646,6 +646,11 @@ static int obs_init_video(struct obs_video_info *ovi)
 	if (pthread_mutex_init(&video->mixes_mutex, NULL) < 0)
 		return OBS_VIDEO_FAIL;
 
+	video->ovi = *ovi;
+
+	if (!obs_view_add(&obs->data.main_view))
+		return OBS_VIDEO_FAIL;
+
 	int errorcode;
 #ifdef __APPLE__
 	errorcode = pthread_create(&video->video_thread, NULL,
@@ -658,10 +663,6 @@ static int obs_init_video(struct obs_video_info *ovi)
 		return OBS_VIDEO_FAIL;
 
 	video->thread_initialized = true;
-	video->ovi = *ovi;
-
-	if (!obs_view_add(&obs->data.main_view))
-		return OBS_VIDEO_FAIL;
 
 	return OBS_VIDEO_SUCCESS;
 }


### PR DESCRIPTION
### Description
Fixes a race condition where the video thread would exit because it sees no active mixes, causing OBS to freeze on startup. Introduced in https://github.com/obsproject/obs-studio/pull/6577.

### Motivation and Context
Bug fix.

### How Has This Been Tested?
@tytan652 tested on Discord and confirmed it fixed the freezing he experienced.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
