### PR TITLE
mac-capture: Set (extended) sRBG for SCK Display/App capture

### DIFF
--- a/plugins/mac-capture/mac-screen-capture.m
+++ b/plugins/mac-capture/mac-screen-capture.m
@@ -366,6 +366,13 @@ static bool init_screen_stream(struct screen_capture *sc)
 		[sc->stream_properties
 			setHeight:CGDisplayModeGetPixelHeight(display_mode)];
 		CGDisplayModeRelease(display_mode);
+		CGColorSpaceRef colorspace =
+			CGDisplayCopyColorSpace(target_display.displayID);
+		bool wide = CGColorSpaceIsWideGamutRGB(colorspace);
+		[sc->stream_properties
+			setColorSpaceName:wide ? kCGColorSpaceExtendedSRGB
+					       : kCGColorSpaceSRGB];
+		CGColorSpaceRelease(colorspace);
 	};
 
 	switch (sc->capture_type) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Sets the color space of SCK sources manually, since the default sometimes
seems to yield bad results.

Before:
<img width="500" alt="without patch" src="https://user-images.githubusercontent.com/59806498/185700097-95928208-f100-4ef7-8f21-eb102ad2547f.png">

After:
<img width="500" alt="with patch" src="https://user-images.githubusercontent.com/59806498/185700100-cebf6b15-5a73-41a3-a30c-9bae4dc2be24.png">

Fixes #7139 for ScreenCaptureKit.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Washed out colors look bad.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13
Tested on an P3 and a standard color Display.
Previously it would look washed out (on the standard one interestingly), now both are fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
