### PR TITLE
obs-ffmpeg: Change AMF bitrate logging to kbps

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1095,13 +1095,13 @@ try {
 		return true;
 	}
 
-	int64_t bitrate = obs_data_get_int(settings, "bitrate") * 1000;
+	int64_t bitrate = obs_data_get_int(settings, "bitrate");
 	int64_t qp = obs_data_get_int(settings, "cqp");
 	const char *rc_str = obs_data_get_string(settings, "rate_control");
 	int rc = get_avc_rate_control(rc_str);
 	AMF_RESULT res;
 
-	amf_avc_update_data(enc, rc, bitrate, qp);
+	amf_avc_update_data(enc, rc, bitrate * 1000, qp);
 
 	res = enc->amf_encoder->ReInit(enc->cx, enc->cy);
 	if (res != AMF_OK)
@@ -1120,7 +1120,7 @@ static bool amf_avc_init(void *data, obs_data_t *settings)
 {
 	amf_base *enc = (amf_base *)data;
 
-	int64_t bitrate = obs_data_get_int(settings, "bitrate") * 1000;
+	int64_t bitrate = obs_data_get_int(settings, "bitrate");
 	int64_t qp = obs_data_get_int(settings, "cqp");
 	const char *preset = obs_data_get_string(settings, "preset");
 	const char *profile = obs_data_get_string(settings, "profile");
@@ -1145,7 +1145,7 @@ static bool amf_avc_init(void *data, obs_data_t *settings)
 	set_avc_property(enc, RATE_CONTROL_METHOD, rc);
 	set_avc_property(enc, ENABLE_VBAQ, true);
 
-	amf_avc_update_data(enc, rc, bitrate, qp);
+	amf_avc_update_data(enc, rc, bitrate * 1000, qp);
 
 	set_avc_property(enc, ENFORCE_HRD, true);
 	set_avc_property(enc, HIGH_MOTION_QUALITY_BOOST_ENABLE, false);
@@ -1399,13 +1399,13 @@ try {
 		return true;
 	}
 
-	int64_t bitrate = obs_data_get_int(settings, "bitrate") * 1000;
+	int64_t bitrate = obs_data_get_int(settings, "bitrate");
 	int64_t qp = obs_data_get_int(settings, "cqp");
 	const char *rc_str = obs_data_get_string(settings, "rate_control");
 	int rc = get_hevc_rate_control(rc_str);
 	AMF_RESULT res;
 
-	amf_hevc_update_data(enc, rc, bitrate, qp);
+	amf_hevc_update_data(enc, rc, bitrate * 1000, qp);
 
 	res = enc->amf_encoder->ReInit(enc->cx, enc->cy);
 	if (res != AMF_OK)
@@ -1424,7 +1424,7 @@ static bool amf_hevc_init(void *data, obs_data_t *settings)
 {
 	amf_base *enc = (amf_base *)data;
 
-	int64_t bitrate = obs_data_get_int(settings, "bitrate") * 1000;
+	int64_t bitrate = obs_data_get_int(settings, "bitrate");
 	int64_t qp = obs_data_get_int(settings, "cqp");
 	const char *preset = obs_data_get_string(settings, "preset");
 	const char *profile = obs_data_get_string(settings, "profile");
@@ -1434,7 +1434,7 @@ static bool amf_hevc_init(void *data, obs_data_t *settings)
 	set_hevc_property(enc, RATE_CONTROL_METHOD, rc);
 	set_hevc_property(enc, ENABLE_VBAQ, true);
 
-	amf_hevc_update_data(enc, rc, bitrate, qp);
+	amf_hevc_update_data(enc, rc, bitrate * 1000, qp);
 
 	set_hevc_property(enc, ENFORCE_HRD, true);
 	set_hevc_property(enc, HIGH_MOTION_QUALITY_BOOST_ENABLE, false);


### PR DESCRIPTION
### Description
Move multiplication to when its passed to the encoder, so that bitrate
is kept in kbps. Changed for both for H264 and HEVC. Other encoders (x264 and NVENC) already display kbps in the log,
so it makes sense to mimic this with AMF. It's difficult to tell the exact bitrate with bps.

```
01:10:56.878: 	rate_control: VBR
01:10:56.878: 	bitrate:      25000
```

### Motivation and Context
It's difficult to tell the exact bitrate with bps. Helps support volunteers and users who are used to seeing kbps in other encoders. I believe it's important to have units (kbps) as it reduces confusion, especially with AMF which has been displaying bps since its inception.

### How Has This Been Tested?
Tested on Win11, both texture-amf and fallback-amf, using H.264 and HEVC. Records fine, log output is as expected for all 4 variations.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
