### PR TITLE
mac-capture: Clip gamut to sRGB

### DIFF
--- a/plugins/mac-capture/mac-screen-capture.m
+++ b/plugins/mac-capture/mac-screen-capture.m
@@ -474,6 +474,7 @@ static bool init_screen_stream(struct screen_capture *sc)
 	os_sem_post(sc->shareable_content_available);
 	[sc->stream_properties setQueueDepth:8];
 	[sc->stream_properties setShowsCursor:!sc->hide_cursor];
+	[sc->stream_properties setColorSpaceName:kCGColorSpaceSRGB];
 	[sc->stream_properties setPixelFormat:'BGRA'];
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
 	if (@available(macOS 13.0, *)) {


### PR DESCRIPTION
### Description
Mac likes P3, but OBS only supports sRGB for SDR.

Fixes #7139

### Motivation and Context
Aliasing P3 as sRGB is worse than clipping out of range colors, which shouldn't happen too often given that most SDR content fits in sRGB.

### How Has This Been Tested?
Recursive display capture colors were measured to be stable by Digital Color Meter with changes, and unstable without.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.