### PR TITLE
Remove allProjectors list from window-projector.cpp

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -106,11 +106,10 @@ OBSProjector::~OBSProjector()
 	if (source)
 		obs_source_dec_showing(source);
 
-	if (isMultiview)
+	if (isMultiview) {
 		delete multiview;
-
-	if (type == ProjectorType::Multiview)
 		multiviewProjectors.removeAll(this);
+	}
 
 	App()->DecrementSleepInhibition();
 

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -11,7 +11,6 @@
 #include "multiview.hpp"
 
 static QList<OBSProjector *> multiviewProjectors;
-static QList<OBSProjector *> allProjectors;
 
 static bool updatingMultiview = false, mouseSwitching, transitionOnDoubleClick;
 
@@ -88,8 +87,6 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 
 	if (source)
 		obs_source_inc_showing(source);
-
-	allProjectors.push_back(this);
 
 	ready = true;
 
@@ -300,8 +297,6 @@ void OBSProjector::EscapeTriggered()
 {
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 	main->DeleteProjector(this);
-
-	allProjectors.removeAll(this);
 }
 
 void OBSProjector::UpdateMultiview()


### PR DESCRIPTION
### Description
Removes the `allProjectors` list from `window-projector.cpp`. It was reported that projectors were not being removed from this list on destruction, which resulted in a memory leak. However the list doesn't appear to be used at all, so we may as well get rid of it entirely unless it has some purpose I am missing? Also simplifies the multiview projector cleanup code.

### Motivation and Context
Fix memory leak. Code simplification.

### How Has This Been Tested?
Ran OBS, verified projectors still behaved as expected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
