### PR TITLE
libobs: Use system header notation for pthread.h include

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -313,7 +313,7 @@ if(OS_WINDOWS)
   target_link_libraries(libobs PRIVATE Avrt Dwmapi winmm)
 
   if(MSVC)
-    target_link_libraries(libobs PRIVATE OBS::w32-pthreads)
+    target_link_libraries(libobs PUBLIC OBS::w32-pthreads)
 
     target_compile_options(libobs PRIVATE "$<$<COMPILE_LANGUAGE:C>:/EHc->"
                                           "$<$<COMPILE_LANGUAGE:CXX>:/EHc->")

--- a/libobs/util/threading.h
+++ b/libobs/util/threading.h
@@ -26,12 +26,10 @@
 
 #include "c99defs.h"
 
-#ifdef _MSC_VER
-#include "../../deps/w32-pthreads/pthread.h"
-#else
+#ifndef _MSC_VER
 #include <errno.h>
-#include <pthread.h>
 #endif
+#include <pthread.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Description
Using a relative path for the pthread.h header by w32-pthreads breaks compilation of plugins which include threading.h from libobs (as w32-pthreads will exist at a different location relative to the libobs header).

As w32-pthreads (and its include directory) is added to the libobs target by CMake, the pthread.h header will be found even when using system header notation.

Fixes https://github.com/obsproject/obs-studio/issues/7155

### Motivation and Context
Fixes an oversight in libobs' threading.h header that was designed to be used within the obi-studio source tree, but is not compatible when used by plugins built out-of-tree (as desired and expected by the updated obs-plugintmmplate).

### How Has This Been Tested?
Built obs-studio on Windows 11 with updated header.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
