### PR TITLE
UI: Fix extra browsers trash icon

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -1169,6 +1169,8 @@ VisibilityCheckBox::indicator:unchecked:hover {
 
 QPushButton#extraPanelDelete {
     background-color: palette(mid);
+    margin: 0;
+    padding: 0;
 }
 
 QPushButton#extraPanelDelete:hover {

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -1158,6 +1158,8 @@ VisibilityCheckBox::indicator:unchecked:hover {
 
 QPushButton#extraPanelDelete {
     background-color: palette(mid);
+    margin: 0;
+    padding: 0;
 }
 
 QPushButton#extraPanelDelete:hover {

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -1158,6 +1158,8 @@ VisibilityCheckBox::indicator:unchecked:hover {
 
 QPushButton#extraPanelDelete {
     background-color: palette(mid);
+    margin: 0;
+    padding: 0;
 }
 
 QPushButton#extraPanelDelete:hover {

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -1162,6 +1162,8 @@ VisibilityCheckBox::indicator:unchecked:hover {
 
 QPushButton#extraPanelDelete {
     background-color: palette(mid);
+    margin: 0;
+    padding: 0;
 }
 
 QPushButton#extraPanelDelete:hover {

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -1162,6 +1162,8 @@ VisibilityCheckBox::indicator:unchecked:hover {
 
 QPushButton#extraPanelDelete {
     background-color: palette(mid);
+    margin: 0;
+    padding: 0;
 }
 
 QPushButton#extraPanelDelete:hover {


### PR DESCRIPTION
### Description
The trash icon in the extra browsers dock would be rendered
incorrectly with the Yami based themes.

Before:
![Screenshot from 2022-08-21 00-00-42](https://user-images.githubusercontent.com/19962531/185776450-3c7fe97e-ff4e-4ddb-a599-fe5bd29b4c77.png)

After:
![Screenshot from 2022-08-21 00-11-27](https://user-images.githubusercontent.com/19962531/185776484-22699197-a83f-4c45-b0d4-e676f4b01001.png)

### Motivation and Context
Fix theme bugs.

### How Has This Been Tested?
Opened dock and made sure button looked good.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
