### PR TITLE
libobs-opengl: Fix Mac projector color space

### DIFF
--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -197,7 +197,8 @@ struct gl_windowinfo *gl_windowinfo_create(const struct gs_init_data *info)
 	struct gl_windowinfo *wi = bzalloc(sizeof(struct gl_windowinfo));
 
 	wi->view = info->window.view;
-	[info->window.view setWantsBestResolutionOpenGLSurface:YES];
+	wi->view.window.colorSpace = NSColorSpace.sRGBColorSpace;
+	wi->view.wantsBestResolutionOpenGLSurface = YES;
 
 	return wi;
 }


### PR DESCRIPTION
### Description
Use sRGB instead of native display color space for correctness.

### Motivation and Context
Projector colors should match main preview colors.

### How Has This Been Tested?
Verified windowed and multiview projectors were incorrect before change, and correct after with Digital Color Meter.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.