### PR TITLE
mac-capture: Use cleaner render patterns

### DIFF
--- a/plugins/mac-capture/mac-screen-capture.m
+++ b/plugins/mac-capture/mac-screen-capture.m
@@ -43,10 +43,8 @@ typedef enum {
 struct screen_capture {
 	obs_source_t *source;
 
-	gs_samplerstate_t *sampler;
 	gs_effect_t *effect;
 	gs_texture_t *tex;
-	gs_vertbuffer_t *vertbuf;
 
 	NSRect frame;
 	bool hide_cursor;
@@ -129,11 +127,6 @@ static void screen_capture_destroy(void *data)
 	obs_enter_graphics();
 
 	destroy_screen_stream(sc);
-
-	if (sc->sampler)
-		gs_samplerstate_destroy(sc->sampler);
-	if (sc->vertbuf)
-		gs_vertexbuffer_destroy(sc->vertbuf);
 
 	obs_leave_graphics();
 
@@ -544,28 +537,6 @@ static bool init_screen_stream(struct screen_capture *sc)
 	return did_stream_start;
 }
 
-bool init_vertbuf_screen_capture(struct screen_capture *sc)
-{
-	struct gs_vb_data *vb_data = gs_vbdata_create();
-	vb_data->num = 4;
-	vb_data->points = bzalloc(sizeof(struct vec3) * 4);
-	if (!vb_data->points)
-		return false;
-
-	vb_data->num_tex = 1;
-	vb_data->tvarray = bzalloc(sizeof(struct gs_tvertarray));
-	if (!vb_data->tvarray)
-		return false;
-
-	vb_data->tvarray[0].width = 2;
-	vb_data->tvarray[0].array = bzalloc(sizeof(struct vec2) * 4);
-	if (!vb_data->tvarray[0].array)
-		return false;
-
-	sc->vertbuf = gs_vertexbuffer_create(vb_data, GS_DYNAMIC);
-	return sc->vertbuf != NULL;
-}
-
 static void screen_capture_build_content_list(struct screen_capture *sc,
 					      bool display_capture)
 {
@@ -625,24 +596,6 @@ static void *screen_capture_create(obs_data_t *settings, obs_source_t *source)
 	if (!sc->effect)
 		goto fail;
 
-	obs_enter_graphics();
-
-	struct gs_sampler_info info = {
-		.filter = GS_FILTER_LINEAR,
-		.address_u = GS_ADDRESS_CLAMP,
-		.address_v = GS_ADDRESS_CLAMP,
-		.address_w = GS_ADDRESS_CLAMP,
-		.max_anisotropy = 1,
-	};
-	sc->sampler = gs_samplerstate_create(&info);
-	if (!sc->sampler)
-		goto fail;
-
-	if (!init_vertbuf_screen_capture(sc))
-		goto fail;
-
-	obs_leave_graphics();
-
 	sc->display = obs_data_get_int(settings, "display");
 	sc->application_id = [[NSString alloc]
 		initWithUTF8String:obs_data_get_string(settings,
@@ -658,27 +611,6 @@ fail:
 	obs_leave_graphics();
 	screen_capture_destroy(sc);
 	return NULL;
-}
-
-static void build_sprite(struct gs_vb_data *data, float fcx, float fcy,
-			 float start_u, float end_u, float start_v, float end_v)
-{
-	struct vec2 *tvarray = data->tvarray[0].array;
-
-	vec3_set(data->points + 1, fcx, 0.0f, 0.0f);
-	vec3_set(data->points + 2, 0.0f, fcy, 0.0f);
-	vec3_set(data->points + 3, fcx, fcy, 0.0f);
-	vec2_set(tvarray, start_u, start_v);
-	vec2_set(tvarray + 1, end_u, start_v);
-	vec2_set(tvarray + 2, start_u, end_v);
-	vec2_set(tvarray + 3, end_u, end_v);
-}
-
-static inline void build_sprite_rect(struct gs_vb_data *data, float origin_x,
-				     float origin_y, float end_x, float end_y)
-{
-	build_sprite(data, fabs(end_x - origin_x), fabs(end_y - origin_y),
-		     origin_x, end_x, origin_y, end_y);
 }
 
 static void screen_capture_video_tick(void *data,
@@ -701,13 +633,7 @@ static void screen_capture_video_tick(void *data,
 	if (prev_prev == sc->prev)
 		return;
 
-	CGPoint origin = {0.f, 0.f};
-	CGPoint end = {sc->frame.size.width, sc->frame.size.height};
-
 	obs_enter_graphics();
-	build_sprite_rect(gs_vertexbuffer_get_data(sc->vertbuf), origin.x,
-			  origin.y, end.x, end.y);
-
 	if (sc->tex)
 		gs_texture_rebind_iosurface(sc->tex, sc->prev);
 	else
@@ -733,23 +659,14 @@ static void screen_capture_video_render(void *data, gs_effect_t *effect
 	const bool previous = gs_framebuffer_srgb_enabled();
 	gs_enable_framebuffer_srgb(linear_srgb);
 
-	gs_vertexbuffer_flush(sc->vertbuf);
-	gs_load_vertexbuffer(sc->vertbuf);
-	gs_load_indexbuffer(NULL);
-	gs_load_samplerstate(sc->sampler, 0);
-	gs_technique_t *tech = gs_effect_get_technique(sc->effect, "Draw");
 	gs_eparam_t *param = gs_effect_get_param_by_name(sc->effect, "image");
 	if (linear_srgb)
 		gs_effect_set_texture_srgb(param, sc->tex);
 	else
 		gs_effect_set_texture(param, sc->tex);
-	gs_technique_begin(tech);
-	gs_technique_begin_pass(tech, 0);
 
-	gs_draw(GS_TRISTRIP, 0, 4);
-
-	gs_technique_end_pass(tech);
-	gs_technique_end(tech);
+	while (gs_effect_loop(sc->effect, "Draw"))
+		gs_draw_sprite(sc->tex, false, 0, 0);
 
 	gs_enable_framebuffer_srgb(previous);
 }


### PR DESCRIPTION
### Description
Render code seems unnecessarily custom. Use normal patterns.

### Motivation and Context
Less is more.

### How Has This Been Tested?
Screen capture still works.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.