### PR TITLE
UI: Hide reset-timestamp property for file splitting

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1022,7 +1022,6 @@ Basic.Settings.Output.SplitFile.TypeSize="Split by Size"
 Basic.Settings.Output.SplitFile.TypeManual="Only split manually"
 Basic.Settings.Output.SplitFile.Time="Split Time"
 Basic.Settings.Output.SplitFile.Size="Split Size"
-Basic.Settings.Output.SplitFile.ResetTimestamps="Reset timestamps at the beginning of each split file"
 
 # Screenshot
 Screenshot="Screenshot Output"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -3018,16 +3018,6 @@
                                  </property>
                                 </widget>
                                </item>
-                               <item row="10" column="1">
-                                <widget class="QCheckBox" name="advOutSplitFileRstTS">
-                                 <property name="text">
-                                  <string>Basic.Settings.Output.SplitFile.ResetTimestamps</string>
-                                 </property>
-                                 <property name="checked">
-                                  <bool>true</bool>
-                                 </property>
-                                </widget>
-                               </item>
                               </layout>
                              </widget>
                             </item>
@@ -7573,7 +7563,6 @@
   <tabstop>advOutSplitFileType</tabstop>
   <tabstop>advOutSplitFileTime</tabstop>
   <tabstop>advOutSplitFileSize</tabstop>
-  <tabstop>advOutSplitFileRstTS</tabstop>
   <tabstop>advOutTrack1Bitrate</tabstop>
   <tabstop>advOutTrack1Name</tabstop>
   <tabstop>advOutTrack2Bitrate</tabstop>

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1950,7 +1950,6 @@ bool AdvancedOutput::StartRecording()
 					 splitFileTime * 60);
 			obs_data_set_int(settings, "max_size_mb",
 					 splitFileSize);
-			obs_data_set_bool(settings, "reset_timestamps", true);
 		}
 
 		obs_output_update(fileOutput, settings);

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1883,7 +1883,6 @@ bool AdvancedOutput::StartRecording()
 	const char *splitFileType;
 	int splitFileTime;
 	int splitFileSize;
-	bool splitFileResetTimestamps;
 
 	if (!useStreamEncoder) {
 		if (!ffmpegOutput) {
@@ -1940,9 +1939,6 @@ bool AdvancedOutput::StartRecording()
 							 "AdvOut",
 							 "RecSplitFileSize")
 					: 0;
-			splitFileResetTimestamps =
-				config_get_bool(main->Config(), "AdvOut",
-						"RecSplitFileResetTimestamps");
 			obs_data_set_string(settings, "directory", path);
 			obs_data_set_string(settings, "format", filenameFormat);
 			obs_data_set_string(settings, "extension", recFormat);
@@ -1954,8 +1950,7 @@ bool AdvancedOutput::StartRecording()
 					 splitFileTime * 60);
 			obs_data_set_int(settings, "max_size_mb",
 					 splitFileSize);
-			obs_data_set_bool(settings, "reset_timestamps",
-					  splitFileResetTimestamps);
+			obs_data_set_bool(settings, "reset_timestamps", true);
 		}
 
 		obs_output_update(fileOutput, settings);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1437,8 +1437,6 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_uint(basicConfig, "AdvOut", "RecSplitFileTime", 15);
 	config_set_default_uint(basicConfig, "AdvOut", "RecSplitFileSize",
 				2048);
-	config_set_default_bool(basicConfig, "AdvOut",
-				"RecSplitFileResetTimestamps", true);
 
 	config_set_default_bool(basicConfig, "AdvOut", "RecRB", false);
 	config_set_default_uint(basicConfig, "AdvOut", "RecRBTime", 20);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -462,7 +462,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->advOutSplitFileType,  COMBO_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->advOutSplitFileTime,  SCROLL_CHANGED, OUTPUTS_CHANGED);
 	HookWidget(ui->advOutSplitFileSize,  SCROLL_CHANGED, OUTPUTS_CHANGED);
-	HookWidget(ui->advOutSplitFileRstTS, CHECK_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->advOutRecTrack1,      CHECK_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->advOutRecTrack2,      CHECK_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->advOutRecTrack3,      CHECK_CHANGED,  OUTPUTS_CHANGED);
@@ -1962,8 +1961,6 @@ void OBSBasicSettings::LoadAdvOutputRecordingSettings()
 		config_get_int(main->Config(), "AdvOut", "RecSplitFileTime");
 	int splitFileSize =
 		config_get_int(main->Config(), "AdvOut", "RecSplitFileSize");
-	bool splitFileResetTimestamps = config_get_bool(
-		main->Config(), "AdvOut", "RecSplitFileResetTimestamps");
 
 	int typeIndex = (astrcmpi(type, "FFmpeg") == 0) ? 1 : 0;
 	ui->advOutRecType->setCurrentIndex(typeIndex);
@@ -1993,7 +1990,6 @@ void OBSBasicSettings::LoadAdvOutputRecordingSettings()
 	ui->advOutSplitFileType->setCurrentIndex(idx);
 	ui->advOutSplitFileTime->setValue(splitFileTime);
 	ui->advOutSplitFileSize->setValue(splitFileSize);
-	ui->advOutSplitFileRstTS->setChecked(splitFileResetTimestamps);
 
 	switch (flvTrack) {
 	case 1:
@@ -3586,8 +3582,6 @@ void OBSBasicSettings::SaveOutputSettings()
 		SplitFileTypeFromIdx(ui->advOutSplitFileType->currentIndex()));
 	SaveSpinBox(ui->advOutSplitFileTime, "AdvOut", "RecSplitFileTime");
 	SaveSpinBox(ui->advOutSplitFileSize, "AdvOut", "RecSplitFileSize");
-	SaveCheckBox(ui->advOutSplitFileRstTS, "AdvOut",
-		     "RecSplitFileResetTimestamps");
 
 	config_set_int(
 		main->Config(), "AdvOut", "RecTracks",
@@ -4612,7 +4606,6 @@ void OBSBasicSettings::AdvOutSplitFileChanged()
 	ui->advOutSplitFileTime->setVisible(splitFileType == 0);
 	ui->advOutSplitFileSizeLabel->setVisible(splitFileType == 1);
 	ui->advOutSplitFileSize->setVisible(splitFileType == 1);
-	ui->advOutSplitFileRstTS->setVisible(splitFile);
 }
 
 void OBSBasicSettings::AdvOutRecCheckWarnings()

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
@@ -61,7 +61,6 @@ struct ffmpeg_muxer {
 
 	bool is_network;
 	bool split_file;
-	bool reset_timestamps;
 	bool allow_overwrite;
 };
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR hide `Reset timestamps at the beginning of each split file` from the automatic split file when the format is other than MPEG-TS (`ts`).
When setting other than MPEG-TS, the setting will be overwritten to reset the timestamp.

Also invert the checkbox by changing the text.
- Old text: `Reset timestamps at the beginning of each split file`
- Revised text: `Preserve timestamps at the beginning of each split file`

The property marked by an orange box won't show unless user select MPEG-TS.
![Recording Settings](https://user-images.githubusercontent.com/780600/185788616-4c20b205-ba3e-4b65-8e0d-ec938b410d58.png)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The option was originally provided for ease of debugging and also for some containers that support timestamp not starting from zero. However, some users could turn the option off even though the current container requires the timestamp starting from zero. In such case, user experiences the recording contents do not start from the beginning of the video file for the 2nd and later files.

For example, a user reported an issue.
- https://obsproject.com/forum/threads/obs-studio-28-0-release-candidate.158248/post-580393
> if you have Reset Time-Stamp off, the recording continues onto a new file while also producing a black screen for 30m untill the 2nd actually starts.

In this case, the user set the container to MOV so that this is as expected behavior.

To avoid confusion like this, the option should be removed from the settings dialog so that the user cannot change it easily.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

1. Start OBS with clean configuration.
2. Set automatic file splitting.
3. Start recording and wait until the 1st split happens.
4. Check the PTS of the 2nd file is starting from zero.

OS: Fedora 35.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

Even though it is a breaking change, I believe the feature is not required for the majority of the users.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
