### PR TITLE
UI: Fix scripts dialog buttons

### DIFF
--- a/UI/frontend-plugins/frontend-tools/forms/scripts.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/scripts.ui
@@ -53,10 +53,16 @@
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <widget class="QPushButton" name="addScripts">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="maximumSize">
               <size>
-               <width>22</width>
-               <height>22</height>
+               <width>16777215</width>
+               <height>16777215</height>
               </size>
              </property>
              <property name="toolTip">
@@ -74,14 +80,23 @@
              <property name="themeID" stdset="0">
               <string notr="true">addIconSmall</string>
              </property>
+             <property name="toolButton" stdset="0">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item>
             <widget class="QPushButton" name="removeScripts">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="maximumSize">
               <size>
-               <width>22</width>
-               <height>22</height>
+               <width>16777215</width>
+               <height>16777215</height>
               </size>
              </property>
              <property name="toolTip">
@@ -99,14 +114,23 @@
              <property name="themeID" stdset="0">
               <string notr="true">removeIconSmall</string>
              </property>
+             <property name="toolButton" stdset="0">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item>
             <widget class="QPushButton" name="reloadScripts">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="maximumSize">
               <size>
-               <width>22</width>
-               <height>22</height>
+               <width>16777215</width>
+               <height>16777215</height>
               </size>
              </property>
              <property name="toolTip">
@@ -123,6 +147,9 @@
              </property>
              <property name="themeID" stdset="0">
               <string notr="true">refreshIconSmall</string>
+             </property>
+             <property name="toolButton" stdset="0">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -184,14 +211,14 @@
            <property name="text">
             <string notr="true"/>
            </property>
-           <property name="openExternalLinks">
-            <bool>false</bool>
-           </property>
            <property name="wordWrap">
             <bool>true</bool>
            </property>
            <property name="margin">
             <number>12</number>
+           </property>
+           <property name="openExternalLinks">
+            <bool>false</bool>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
### Description
The tool buttons would be rendered incorrectly in the Yami based
themes.

Before:
![Screenshot from 2022-08-21 13-38-54](https://user-images.githubusercontent.com/19962531/185806379-b2e5a199-8c0a-415a-abb3-f2244a3bf250.png)

After:
![Screenshot from 2022-08-21 13-45-47](https://user-images.githubusercontent.com/19962531/185806385-b030e647-2e65-4899-b3ef-e7d3fb3a30a5.png)

### Motivation and Context
Fix theme bugs

### How Has This Been Tested?
Checked to see if buttons looked better.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
