### PR TITLE
UI: Refactor Virtual Camera source selector dialog

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -259,6 +259,7 @@ target_sources(
           window-basic-transform.cpp
           window-basic-transform.hpp
           window-basic-preview.hpp
+          window-basic-vcam.hpp
           window-basic-vcam-config.cpp
           window-basic-vcam-config.hpp
           window-dock.cpp

--- a/UI/window-basic-main-outputs.hpp
+++ b/UI/window-basic-main-outputs.hpp
@@ -16,6 +16,11 @@ struct BasicOutputHandler {
 	bool virtualCamActive = false;
 	OBSBasic *main;
 
+	obs_view_t *virtualCamView = nullptr;
+	video_t *virtualCamVideo = nullptr;
+	obs_scene_t *vCamSourceScene = nullptr;
+	obs_sceneitem_t *vCamSourceSceneItem = nullptr;
+
 	std::string outputType;
 	std::string lastError;
 
@@ -56,6 +61,9 @@ struct BasicOutputHandler {
 
 	virtual void Update() = 0;
 	virtual void SetupOutputs() = 0;
+
+	virtual void UpdateVirtualCamOutputSource();
+	virtual void DestroyVirtualCamView();
 
 	inline bool Active() const
 	{

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -763,8 +763,27 @@ void OBSBasic::Save(const char *file)
 	obs_data_set_double(saveData, "scaling_off_y",
 			    ui->preview->GetScrollY());
 
-	if (vcamEnabled)
-		OBSBasicVCamConfig::SaveData(saveData, true);
+	if (vcamEnabled) {
+		OBSDataAutoRelease obj = obs_data_create();
+
+		obs_data_set_int(obj, "type", (int)vcamConfig.type);
+		switch (vcamConfig.type) {
+		case VCamOutputType::InternalOutput:
+			obs_data_set_int(obj, "internal",
+					 (int)vcamConfig.internal);
+			break;
+		case VCamOutputType::SceneOutput:
+			obs_data_set_string(obj, "scene",
+					    vcamConfig.scene.c_str());
+			break;
+		case VCamOutputType::SourceOutput:
+			obs_data_set_string(obj, "source",
+					    vcamConfig.source.c_str());
+			break;
+		}
+
+		obs_data_set_obj(saveData, "virtual-camera", obj);
+	}
 
 	if (api) {
 		OBSDataAutoRelease moduleObj = obs_data_create();
@@ -1178,8 +1197,16 @@ retryScene:
 	ui->preview->SetFixedScaling(fixedScaling);
 	emit ui->preview->DisplayResized();
 
-	if (vcamEnabled)
-		OBSBasicVCamConfig::SaveData(data, false);
+	if (vcamEnabled) {
+		OBSDataAutoRelease obj =
+			obs_data_get_obj(data, "virtual-camera");
+
+		vcamConfig.type = (VCamOutputType)obs_data_get_int(obj, "type");
+		vcamConfig.internal =
+			(VCamInternalType)obs_data_get_int(obj, "internal");
+		vcamConfig.scene = obs_data_get_string(obj, "scene");
+		vcamConfig.source = obs_data_get_string(obj, "source");
+	}
 
 	/* ---------------------- */
 
@@ -1224,6 +1251,9 @@ retryScene:
 		ShowMissingFilesDialog(files);
 
 	disableSaving--;
+
+	if (vcamEnabled && vcamConfig.internal == VCamInternalType::Preview)
+		outputHandler->UpdateVirtualCamOutputSource();
 
 	if (api) {
 		api->on_event(OBS_FRONTEND_EVENT_SCENE_CHANGED);
@@ -1696,8 +1726,6 @@ void OBSBasic::ReplayBufferClicked()
 
 void OBSBasic::AddVCamButton()
 {
-	OBSBasicVCamConfig::Init();
-
 	vcamButton = new ControlsSplitButton(
 		QTStr("Basic.Main.StartVirtualCam"), "vcamButton",
 		&OBSBasic::VCamButtonClicked);
@@ -2738,8 +2766,6 @@ OBSBasic::~OBSBasic()
 	delete cef;
 	cef = nullptr;
 #endif
-
-	OBSBasicVCamConfig::DestroyView();
 }
 
 void OBSBasic::SaveProjectNow()
@@ -5083,6 +5109,9 @@ void OBSBasic::on_scenes_currentItemChanged(QListWidgetItem *current,
 	}
 
 	SetCurrentScene(source);
+
+	if (vcamEnabled && vcamConfig.internal == VCamInternalType::Preview)
+		outputHandler->UpdateVirtualCamOutputSource();
 
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
@@ -7841,8 +7870,19 @@ void OBSBasic::VCamButtonClicked()
 
 void OBSBasic::VCamConfigButtonClicked()
 {
-	OBSBasicVCamConfig config(this);
-	config.exec();
+	OBSBasicVCamConfig dialog(vcamConfig, this);
+
+	connect(&dialog, &OBSBasicVCamConfig::Accepted, this,
+		&OBSBasic::UpdateVirtualCamConfig);
+
+	dialog.exec();
+}
+
+void OBSBasic::UpdateVirtualCamConfig(const VCamConfig &config)
+{
+	vcamConfig = config;
+
+	outputHandler->UpdateVirtualCamOutputSource();
 }
 
 void OBSBasic::on_settingsButton_clicked()

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3072,6 +3072,13 @@ void OBSBasic::RenameSources(OBSSource source, QString newName,
 			projectors[i]->RenameProjector(prevName, newName);
 	}
 
+	if (vcamConfig.type == VCamOutputType::SourceOutput &&
+	    prevName == QString::fromStdString(vcamConfig.source))
+		vcamConfig.source = newName.toStdString();
+	if (vcamConfig.type == VCamOutputType::SceneOutput &&
+	    prevName == QString::fromStdString(vcamConfig.scene))
+		vcamConfig.scene = newName.toStdString();
+
 	SaveProject();
 
 	obs_scene_t *scene = obs_scene_from_source(source);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4830,6 +4830,9 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 
 	closing = true;
 
+	if (outputHandler->VirtualCamActive())
+		outputHandler->StopVirtualCam();
+
 	if (introCheckThread)
 		introCheckThread->wait();
 	if (whatsNewInitThread)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include "window-main.hpp"
 #include "window-basic-interaction.hpp"
+#include "window-basic-vcam.hpp"
 #include "window-basic-properties.hpp"
 #include "window-basic-transform.hpp"
 #include "window-basic-adv-audio.hpp"
@@ -51,6 +52,7 @@ class QMessageBox;
 class QListWidgetItem;
 class VolControl;
 class OBSBasicStats;
+class OBSBasicVCamConfig;
 
 #include "ui_OBSBasic.h"
 #include "ui_ColorSelect.h"
@@ -309,6 +311,7 @@ private:
 
 	QPointer<ControlsSplitButton> vcamButton;
 	bool vcamEnabled = false;
+	VCamConfig vcamConfig;
 
 	QScopedPointer<QSystemTrayIcon> trayIcon;
 	QPointer<QAction> sysTrayStream;
@@ -818,6 +821,8 @@ private slots:
 
 	void LockVolumeControl(bool lock);
 	void ResetProxyStyleSliders();
+
+	void UpdateVirtualCamConfig(const VCamConfig &config);
 
 private:
 	/* OBS Callbacks */

--- a/UI/window-basic-vcam-config.hpp
+++ b/UI/window-basic-vcam-config.hpp
@@ -4,27 +4,28 @@
 #include <QDialog>
 #include <memory>
 
+#include "window-basic-vcam.hpp"
+
 #include "ui_OBSBasicVCamConfig.h"
+
+struct VCamConfig;
 
 class OBSBasicVCamConfig : public QDialog {
 	Q_OBJECT
 
+	VCamConfig config;
+
 public:
-	static void Init();
-
-	static video_t *StartVideo();
-	static void StopVideo();
-	static void DestroyView();
-
-	static void UpdateOutputSource();
-	static void SaveData(obs_data_t *data, bool saving);
-
-	explicit OBSBasicVCamConfig(QWidget *parent = 0);
+	explicit OBSBasicVCamConfig(const VCamConfig &config,
+				    QWidget *parent = 0);
 
 private slots:
 	void OutputTypeChanged(int type);
-	void Save();
+	void UpdateConfig();
 
 private:
 	std::unique_ptr<Ui::OBSBasicVCamConfig> ui;
+
+signals:
+	void Accepted(const VCamConfig &config);
 };

--- a/UI/window-basic-vcam.hpp
+++ b/UI/window-basic-vcam.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+enum VCamOutputType {
+	InternalOutput,
+	SceneOutput,
+	SourceOutput,
+};
+
+enum VCamInternalType {
+	Default,
+	Preview,
+};
+
+struct VCamConfig {
+	VCamOutputType type = VCamOutputType::InternalOutput;
+	VCamInternalType internal = VCamInternalType::Default;
+	std::string scene;
+	std::string source;
+};


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Prepare the dialog to be extended with new feature like #5383 by moving some code elsewhere.

Most of the "dialog" code does not belong there and was moved.
- Struct & enum moved to their own header.
- The config code moved to the main window code.
- The video mix code is moved to output handler.

Also a fix the issue where if a scene/source is renamed, it is not in the vcam config.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Avoid putting those change directly in #5383 and allow a separate review.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I tested:
- If the config was saved
- Starting the VCam with a source/scene/internal
- Changing the config while the VCam is active.
- Re-starting the VCam

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
