### PR TITLE
mac-capture: Replace false with 0

### DIFF
--- a/plugins/mac-capture/mac-screen-capture.m
+++ b/plugins/mac-capture/mac-screen-capture.m
@@ -666,7 +666,7 @@ static void screen_capture_video_render(void *data, gs_effect_t *effect
 		gs_effect_set_texture(param, sc->tex);
 
 	while (gs_effect_loop(sc->effect, "Draw"))
-		gs_draw_sprite(sc->tex, false, 0, 0);
+		gs_draw_sprite(sc->tex, 0, 0, 0);
 
 	gs_enable_framebuffer_srgb(previous);
 }


### PR DESCRIPTION
### Description
Param is uint32_t, not bool.

### Motivation and Context
Want code to be correct, and not misleading.

### How Has This Been Tested?
Verified screen capture still works on Mac.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.