### PR TITLE
UI: Add workaround for scenes being unselected

### DIFF
--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -236,3 +236,11 @@ void SceneTree::rowsInserted(const QModelIndex &parent, int start, int end)
 
 	QListWidget::rowsInserted(parent, start, end);
 }
+
+// Workaround for QTBUG-105870. Remove once that is solved upstream.
+void SceneTree::selectionChanged(const QItemSelection &selected,
+				 const QItemSelection &deselected)
+{
+	if (selected.count() == 0)
+		setCurrentRow(deselected.indexes().front().row());
+}

--- a/UI/scene-tree.hpp
+++ b/UI/scene-tree.hpp
@@ -38,6 +38,9 @@ protected:
 	virtual void dragLeaveEvent(QDragLeaveEvent *event) override;
 	virtual void rowsInserted(const QModelIndex &parent, int start,
 				  int end) override;
+	virtual void
+	selectionChanged(const QItemSelection &selected,
+			 const QItemSelection &deselected) override;
 
 signals:
 	void scenesReordered();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a workaround for [QTBUG-105870](https://bugreports.qt.io/browse/QTBUG-105870).
This makes the user unable to deselect the current scene in the scene tree.

Does not fix same happening on the settings page but that isn't very important, it can
wait until the issue is fixed (or else wise clarified) on the QT side.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
It's possible to very easily lose any indicator of which scene you're on, which can be an issue.

Fixes #7196

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13
Clicked on the empty area, scene no longer gets unselected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
