### PR TITLE
UI: Fix crash with adding source

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -1757,5 +1757,8 @@ QSize SourceTreeDelegate::sizeHint(const QStyleOptionViewItem &,
 	SourceTree *tree = qobject_cast<SourceTree *>(parent());
 	QWidget *item = tree->indexWidget(index);
 
+	if (!item)
+		return (QSize(0, 0));
+
 	return (QSize(item->width(), item->height()));
 }


### PR DESCRIPTION
### Description
Bug introduced with https://github.com/obsproject/obs-studio/commit/adba393ca85fba19ed1bf6cd825ab8188beb2d16

OBS would crash when adding a new source because the source tree item's
widget would be NULL in the sizeHint function when the list item is first
created.

### Motivation and Context
Fixes crash I found

### How Has This Been Tested?
Added new source and made sure it didn't crash.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
