### PR TITLE
UI: Fix scene tree item spacing

### DIFF
--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -91,7 +91,7 @@ void SceneTree::resizeEvent(QResizeEvent *event)
 		}
 	} else {
 		setGridSize(QSize());
-		setSpacing(0);
+		setSpacing(1);
 		for (int i = 0; i < count(); i++) {
 			item(i)->setData(Qt::SizeHintRole, QVariant());
 		}


### PR DESCRIPTION
### Description
The setSpacing was always set to 0 in the resize event.

Before:
![Screenshot from 2022-08-27 23-26-36](https://user-images.githubusercontent.com/19962531/187057602-b55648c3-6e5e-4cd0-bbe0-26bba3a37473.png)

After:
![Screenshot from 2022-08-29 17-09-34](https://user-images.githubusercontent.com/19962531/187307732-aeec2d0b-d224-49fb-80a7-ef72c7a735c3.png)

### Motivation and Context
Consistent UI

### How Has This Been Tested?
Looked at scene tree to make sure spacing was correct.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
