### PR TITLE
UI: Fix Grid Mode operations

### DIFF
--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -143,6 +143,11 @@ void SceneTree::dropEvent(QDropEvent *event)
 
 	QListWidget::dropEvent(event);
 
+	// We must call resizeEvent to correctly place all grid items.
+	// We also do this in rowsInserted.
+	QResizeEvent resEvent(size(), size());
+	SceneTree::resizeEvent(&resEvent);
+
 	QTimer::singleShot(100, [this]() { emit scenesReordered(); });
 }
 

--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -70,7 +70,8 @@ void SceneTree::resizeEvent(QResizeEvent *event)
 {
 	if (gridMode) {
 		int scrollWid = verticalScrollBar()->sizeHint().width();
-		int h = visualItemRect(item(count() - 1)).bottom();
+		const QRect lastItem = visualItemRect(item(count() - 1));
+		const int h = lastItem.y() + lastItem.height();
 
 		if (h < height()) {
 			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -113,7 +114,8 @@ void SceneTree::dropEvent(QDropEvent *event)
 
 	if (gridMode) {
 		int scrollWid = verticalScrollBar()->sizeHint().width();
-		int h = visualItemRect(item(count() - 1)).bottom();
+		const QRect lastItem = visualItemRect(item(count() - 1));
+		const int h = lastItem.y() + lastItem.height();
 
 		if (h < height()) {
 			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -154,7 +156,8 @@ void SceneTree::dropEvent(QDropEvent *event)
 void SceneTree::RepositionGrid(QDragMoveEvent *event)
 {
 	int scrollWid = verticalScrollBar()->sizeHint().width();
-	int h = visualItemRect(item(count() - 1)).bottom();
+	const QRect lastItem = visualItemRect(item(count() - 1));
+	const int h = lastItem.y() + lastItem.height();
 
 	if (h < height()) {
 		setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -114,8 +114,10 @@ void SceneTree::dropEvent(QDropEvent *event)
 
 	if (gridMode) {
 		int scrollWid = verticalScrollBar()->sizeHint().width();
+		const QRect firstItem = visualItemRect(item(0));
 		const QRect lastItem = visualItemRect(item(count() - 1));
 		const int h = lastItem.y() + lastItem.height();
+		const int firstItemY = abs(firstItem.y());
 
 		if (h < height()) {
 			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -133,7 +135,7 @@ void SceneTree::dropEvent(QDropEvent *event)
 #endif
 
 		int x = (float)point.x() / wid * ceil(wid / maxWidth);
-		int y = point.y() / itemHeight;
+		int y = (point.y() + firstItemY) / itemHeight;
 
 		int r = x + y * ceil(wid / maxWidth);
 
@@ -156,8 +158,10 @@ void SceneTree::dropEvent(QDropEvent *event)
 void SceneTree::RepositionGrid(QDragMoveEvent *event)
 {
 	int scrollWid = verticalScrollBar()->sizeHint().width();
+	const QRect firstItem = visualItemRect(item(0));
 	const QRect lastItem = visualItemRect(item(count() - 1));
 	const int h = lastItem.y() + lastItem.height();
+	const int firstItemY = abs(firstItem.y());
 
 	if (h < height()) {
 		setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -176,7 +180,7 @@ void SceneTree::RepositionGrid(QDragMoveEvent *event)
 #endif
 
 		int x = (float)point.x() / wid * ceil(wid / maxWidth);
-		int y = point.y() / itemHeight;
+		int y = (point.y() + firstItemY) / itemHeight;
 
 		int r = x + y * ceil(wid / maxWidth);
 		int orig = selectedIndexes()[0].row();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR is a collection of three commits to fix three distinct issues with the Scene Grid Mode:
1. Dropped items do not appear on the grid location where they were dropped
2. Scrollbar disappears when resizing or dragging while scrolled to the bottom and reappears when resizing or dragging after scrolling back up
3. While scrolled down, grid items repositioning while dragging do not reflect the grabbed object correctly

Fixes #5005.


#### Dropped items not appearing where dropped
##### Before
https://user-images.githubusercontent.com/624931/187057609-cd0e071d-505d-4adf-9a94-6d82fbcccb3b.mp4
##### After
https://user-images.githubusercontent.com/624931/187057688-73ff8af5-672b-4163-b38e-ef0df938e93b.mp4

#### Scrollbar disappears and reappears
##### Before
https://user-images.githubusercontent.com/624931/187057751-f0a7acbe-525a-4a01-915a-0171e1e7ea4e.mp4
##### After
https://user-images.githubusercontent.com/624931/187057766-6d9679b3-d90f-4c35-b162-b5af8810eb34.mp4

#### Grid repositioning incorrect while scrolled
##### Before
https://user-images.githubusercontent.com/624931/187057822-4db5d333-1bc3-4da6-b28d-fcd6311c9a8a.mp4
##### After
https://user-images.githubusercontent.com/624931/187057838-44bbbf9c-2164-4c60-aae0-c515da1ab965.mp4

I had originally written a lot of comments while tracking this down. However, as multiple areas of the code required the same changes, I did not find a suitable place to put them. They were also long, so I will instead include them here in a collapsible section.
<details>
<summary>Notes about Qt coordinates</summary>
height() is height of the SceneTree widget excluding any
window frame.

QRect QListWidget::visualItemRect(const QListWidgetItem *item)
Returns the rectangle on THE VIEWPORT occupied by the item at
item.
The viewport's origin changes as you scroll.

int QRect::bottom()
Returns the y-coordinate of the rectangle's bottom edge.
Note that for historical reasons this function returns
top() + height() - 1;
use y() + height() to retrieve the true y-coordinate.

visualItemRect returns the rectangle relative to current
scroll position of the currently visible view of the
QListWidget.
The further "out of view" the last QListWidgetItem is, the
larger the value of h.
The closer the last QListWidgetItem is to the top of the view
of the QListWidget, the smaller the value of h.

h is intended to be the y coordinate of the bottom of the
last item in the QListWidget. This is used to check if the
bottom of the last widget is below the height of the
enclosing frame/widget. However, if scrolled to the bottom,
this incorrectly asserts that the bottom of the last widget
is above the height of the enclosing frame/widget, so
scrollbars are disabled. This can be resolved by using
y() + height() instead of bottom().

If h = visualItemRect(item(count())).bottom(), when scrolled
all the way to the bottom, then h = height() - 1, so
h < height() is always true.
Thus, y() + height(), which should be 1 pixel larger than
bottom(), should resolve this.


The x() and y() values of point are relative to viewport's
scrolled origin, not the widget's true origin.
Since we do not allow horizontal scrolling, the value of x()
is okay.
However, the value of y() needs to be adjusted by an offset
of the top()/y() value for the first widget in the SceneTree.
When not scrolled, this offset will be 0.
When scrolled down, this offset will be a negative value.
</details>


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want less bugs in Grid Mode.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I've tested this locally on Windows 11. Would appreciate tests on macOS and Linux.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
