### PR TITLE
obs-ffmpeg: Make AMF encoder work on Linux

### DIFF
--- a/plugins/obs-ffmpeg/CMakeLists.txt
+++ b/plugins/obs-ffmpeg/CMakeLists.txt
@@ -108,10 +108,12 @@ if(OS_WINDOWS)
             jim-nvenc-ver.h
             obs-ffmpeg.rc)
 elseif(OS_LINUX OR OS_FREEBSD)
+  add_subdirectory(obs-amf-test)
+
   find_package(Libva REQUIRED)
   find_package(Libpci REQUIRED)
 
-  target_sources(obs-ffmpeg PRIVATE obs-ffmpeg-vaapi.c vaapi-utils.c vaapi-utils.h)
+  target_sources(obs-ffmpeg PRIVATE obs-ffmpeg-vaapi.c vaapi-utils.c vaapi-utils.h texture-amf.cpp)
   target_link_libraries(obs-ffmpeg PRIVATE Libva::va Libva::drm Libpci::pci)
 endif()
 

--- a/plugins/obs-ffmpeg/cmake/legacy.cmake
+++ b/plugins/obs-ffmpeg/cmake/legacy.cmake
@@ -106,9 +106,10 @@ if(OS_WINDOWS)
             obs-ffmpeg.rc)
 
 elseif(OS_POSIX AND NOT OS_MACOS)
+  add_subdirectory(obs-amf-test)
   find_package(Libva REQUIRED)
   find_package(Libpci REQUIRED)
-  target_sources(obs-ffmpeg PRIVATE obs-ffmpeg-vaapi.c vaapi-utils.c vaapi-utils.h)
+  target_sources(obs-ffmpeg PRIVATE obs-ffmpeg-vaapi.c vaapi-utils.c vaapi-utils.h texture-amf.cpp)
   target_link_libraries(obs-ffmpeg PRIVATE Libva::va Libva::drm LIBPCI::LIBPCI)
 endif()
 

--- a/plugins/obs-ffmpeg/obs-amf-test/CMakeLists.txt
+++ b/plugins/obs-ffmpeg/obs-amf-test/CMakeLists.txt
@@ -6,8 +6,14 @@ find_package(AMF 1.4.29 REQUIRED)
 
 target_include_directories(obs-amf-test PRIVATE ${CMAKE_SOURCE_DIR}/libobs)
 
-target_sources(obs-amf-test PRIVATE obs-amf-test.cpp)
-target_link_libraries(obs-amf-test d3d11 dxgi dxguid AMF::AMF)
+if(OS_WINDOWS)
+  target_sources(obs-amf-test PRIVATE obs-amf-test.cpp)
+  target_link_libraries(obs-amf-test d3d11 dxgi dxguid AMF::AMF)
+elseif(OS_POSIX AND NOT OS_MACOS)
+  find_package(Vulkan REQUIRED)
+  target_sources(obs-amf-test PRIVATE obs-amf-test-linux.cpp)
+  target_link_libraries(obs-amf-test dl Vulkan::Vulkan AMF::AMF)
+endif()
 
 set_target_properties(obs-amf-test PROPERTIES FOLDER "plugins/obs-ffmpeg")
 

--- a/plugins/obs-ffmpeg/obs-amf-test/obs-amf-test-linux.cpp
+++ b/plugins/obs-ffmpeg/obs-amf-test/obs-amf-test-linux.cpp
@@ -1,0 +1,140 @@
+#include <AMF/core/Factory.h>
+#include <AMF/core/Trace.h>
+#include <AMF/components/VideoEncoderVCE.h>
+#include <AMF/components/VideoEncoderHEVC.h>
+#include <AMF/components/VideoEncoderAV1.h>
+
+#include <dlfcn.h>
+#include <vulkan/vulkan.hpp>
+
+#include <string>
+#include <map>
+
+using namespace amf;
+
+struct adapter_caps {
+	bool is_amd = false;
+	bool supports_avc = false;
+	bool supports_hevc = false;
+	bool supports_av1 = false;
+};
+
+static AMFFactory *amf_factory = nullptr;
+static std::map<uint32_t, adapter_caps> adapter_info;
+
+static bool has_encoder(AMFContextPtr &amf_context, const wchar_t *encoder_name)
+{
+	AMFComponentPtr encoder;
+	AMF_RESULT res = amf_factory->CreateComponent(amf_context, encoder_name,
+						      &encoder);
+	return res == AMF_OK;
+}
+
+static bool get_adapter_caps(uint32_t adapter_idx)
+{
+	if (adapter_idx)
+		return false;
+
+	adapter_caps &caps = adapter_info[adapter_idx];
+
+	AMF_RESULT res;
+	AMFContextPtr amf_context;
+	res = amf_factory->CreateContext(&amf_context);
+	if (res != AMF_OK)
+		return true;
+
+	AMFContext1 *context1 = NULL;
+	res = amf_context->QueryInterface(AMFContext1::IID(),
+					  (void **)&context1);
+	if (res != AMF_OK)
+		return false;
+	res = context1->InitVulkan(nullptr);
+	context1->Release();
+	if (res != AMF_OK)
+		return false;
+
+	caps.is_amd = true;
+	caps.supports_avc = has_encoder(amf_context, AMFVideoEncoderVCE_AVC);
+	caps.supports_hevc = has_encoder(amf_context, AMFVideoEncoder_HEVC);
+	caps.supports_av1 = has_encoder(amf_context, AMFVideoEncoder_AV1);
+
+	return true;
+}
+
+int main(void)
+try {
+	AMF_RESULT res;
+	VkResult vkres;
+
+	VkApplicationInfo app_info = {};
+	app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+	app_info.pApplicationName = "obs-amf-test";
+	app_info.apiVersion = VK_API_VERSION_1_2;
+
+	VkInstanceCreateInfo info = {};
+	info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+	info.pApplicationInfo = &app_info;
+
+	VkInstance instance;
+	vkres = vkCreateInstance(&info, nullptr, &instance);
+	if (vkres != VK_SUCCESS)
+		throw "Failed to initialize Vulkan";
+
+	uint32_t device_count;
+	vkres = vkEnumeratePhysicalDevices(instance, &device_count, nullptr);
+	if (vkres != VK_SUCCESS || !device_count)
+		throw "Failed to enumerate Vulkan devices";
+
+	VkPhysicalDevice *devices = new VkPhysicalDevice[device_count];
+	vkres = vkEnumeratePhysicalDevices(instance, &device_count, devices);
+	if (vkres != VK_SUCCESS)
+		throw "Failed to enumerate Vulkan devices";
+
+	VkPhysicalDeviceDriverProperties driver_props = {};
+	driver_props.sType =
+		VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES;
+	VkPhysicalDeviceProperties2 device_props = {};
+	device_props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+	device_props.pNext = &driver_props;
+	vkGetPhysicalDeviceProperties2(devices[0], &device_props);
+
+	if (strcmp(driver_props.driverName, "AMD proprietary driver"))
+		throw "Not running AMD proprietary driver";
+
+	vkDestroyInstance(instance, nullptr);
+
+	/* --------------------------------------------------------- */
+	/* try initializing amf, I guess                             */
+
+	void *amf_module = dlopen(AMF_DLL_NAMEA, RTLD_LAZY);
+	if (!amf_module)
+		throw "Failed to load AMF lib";
+
+	auto init = (AMFInit_Fn)dlsym(amf_module, AMF_INIT_FUNCTION_NAME);
+	if (!init)
+		throw "Failed to get init func";
+
+	res = init(AMF_FULL_VERSION, &amf_factory);
+	if (res != AMF_OK)
+		throw "AMFInit failed";
+
+	uint32_t idx = 0;
+	while (get_adapter_caps(idx++))
+		;
+
+	for (auto &[idx, caps] : adapter_info) {
+		printf("[%u]\n", idx);
+		printf("is_amd=%s\n", caps.is_amd ? "true" : "false");
+		printf("supports_avc=%s\n",
+		       caps.supports_avc ? "true" : "false");
+		printf("supports_hevc=%s\n",
+		       caps.supports_hevc ? "true" : "false");
+		printf("supports_av1=%s\n",
+		       caps.supports_av1 ? "true" : "false");
+	}
+
+	return 0;
+} catch (const char *text) {
+	printf("[error]\nstring=%s\n", text);
+	return 0;
+}

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -360,6 +360,9 @@ static bool hevc_vaapi_supported(void)
 #ifdef _WIN32
 extern void jim_nvenc_load(bool h264, bool hevc, bool av1);
 extern void jim_nvenc_unload(void);
+#endif
+
+#if defined(_WIN32) || defined(__linux__)
 extern void amf_load(void);
 extern void amf_unload(void);
 #endif
@@ -434,7 +437,7 @@ bool obs_module_load(void)
 #endif
 	}
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__linux__)
 	amf_load();
 #endif
 
@@ -475,8 +478,11 @@ void obs_module_unload(void)
 	obs_ffmpeg_unload_logging();
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__linux__)
 	amf_unload();
+#endif
+
+#ifdef _WIN32
 	jim_nvenc_unload();
 #endif
 }

--- a/plugins/obs-ffmpeg/texture-amf-opts.hpp
+++ b/plugins/obs-ffmpeg/texture-amf-opts.hpp
@@ -321,7 +321,7 @@ static void amf_apply_opt(amf_base *enc, obs_option *opt)
 			val = atoi(opt->value);
 		}
 
-		os_utf8_to_wcs(opt->name, 0, wname, _countof(wname));
+		os_utf8_to_wcs(opt->name, 0, wname, amf_countof(wname));
 		if (is_bool) {
 			bool bool_val = (bool)val;
 			set_amf_property(enc, wname, bool_val);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Add Linux support for AMF encoder.
Only the fallback encoders are available (no texture support).

Requires AMD proprietary Vulkan driver, using different driver
will be detected on startup and the encoders disabled.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

AMF is also available on Linux and thus users on Linux should be able to use it in OBS too.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested with RX 6700 XT using latest driver version 22.20 on Arch Linux.

    VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/amd_pro_icd64.json obs

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
