### PR TITLE
obs-ffmpeg: Add AVContentLightMetadata to MPEG-TS

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -163,6 +163,15 @@ static bool create_video_stream(struct ffmpeg_output *stream,
 			pq ? (int)obs_get_video_hdr_nominal_peak_level()
 			   : (hlg ? 1000 : 0);
 
+		size_t content_size;
+		AVContentLightMetadata *const content =
+			av_content_light_metadata_alloc(&content_size);
+		content->MaxCLL = hdr_nominal_peak_level;
+		content->MaxFALL = hdr_nominal_peak_level;
+		av_stream_add_side_data(data->video,
+					AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
+					(uint8_t *)content, content_size);
+
 		AVMasteringDisplayMetadata *const mastering =
 			av_mastering_display_metadata_alloc();
 		mastering->display_primaries[0][0] = av_make_q(17, 25);


### PR DESCRIPTION
### Description
Add overlooked metadata.

### Motivation and Context
Want to provide reliable metadata for decoding.

### How Has This Been Tested?
Debugger inspection using SRT looks good. Didn't verify metadata appears on the other side, but we can work that out some other day.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.