### PR TITLE
UI: Fix position of Sources dock actions on horizontal resize

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -1751,7 +1751,7 @@ SourceTreeDelegate::SourceTreeDelegate(QObject *parent)
 {
 }
 
-QSize SourceTreeDelegate::sizeHint(const QStyleOptionViewItem &,
+QSize SourceTreeDelegate::sizeHint(const QStyleOptionViewItem &option,
 				   const QModelIndex &index) const
 {
 	SourceTree *tree = qobject_cast<SourceTree *>(parent());
@@ -1760,5 +1760,5 @@ QSize SourceTreeDelegate::sizeHint(const QStyleOptionViewItem &,
 	if (!item)
 		return (QSize(0, 0));
 
-	return (QSize(item->width(), item->height()));
+	return (QSize(option.widget->minimumWidth(), item->height()));
 }


### PR DESCRIPTION
### Description

Attempting to resize the Sources dock to be smaller than when initially loaded would result in the contents of the list to never shrink.
Switching to another scene & back would temporary fix the sizing.

Fixes an issue introduced in adba393ca85fba19ed1bf6cd825ab8188beb2d16

Original bug video:

https://user-images.githubusercontent.com/941350/187218158-369e1485-616b-49ba-8a6f-93daa158d7d1.mp4

### Motivation and Context

Users should be able to resize docks without running into bugs.

Bug reported by _m in Discord beta-testing.

### How Has This Been Tested?

Resize the Sources dock.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
