### PR TITLE
libobs: Extend NVIDIA anti-flicker to desktops

### DIFF
--- a/libobs/obs-display.c
+++ b/libobs/obs-display.c
@@ -19,13 +19,6 @@
 #include "obs.h"
 #include "obs-internal.h"
 
-#if defined(_WIN32)
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN 1
-#endif
-#include <Windows.h>
-#endif
-
 bool obs_display_init(struct obs_display *display,
 		      const struct gs_init_data *graphics_data)
 {
@@ -33,11 +26,8 @@ bool obs_display_init(struct obs_display *display,
 	pthread_mutex_init_value(&display->draw_info_mutex);
 
 #if defined(_WIN32)
-	/* Conservative test for NVIDIA flickering on Intel display */
-	SYSTEM_POWER_STATUS status;
-	display->use_clear_workaround =
-		!GetSystemPowerStatus(&status) ||
-		(status.BatteryFlag != 128 && gs_get_adapter_count() != 1);
+	/* Conservative test for NVIDIA flickering in multi-GPU setups */
+	display->use_clear_workaround = gs_get_adapter_count() > 1;
 #elif defined(__APPLE__)
 	/* Apple Silicon GL driver doesn't seem to track SRGB clears correctly */
 	display->use_clear_workaround = true;


### PR DESCRIPTION
### Description
Apparently this isn't just a laptop issue.

### Motivation and Context
Flicker is bad for sensitive people.

### How Has This Been Tested?
No regression in the single NVIDIA GPU case...

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.