### PR TITLE
Non-Yami Theme Source Context Bar Height Fixes

### DIFF
--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -232,9 +232,12 @@ QScrollBar::left-arrow:horizontal, QScrollBar::right-arrow:horizontal, QScrollBa
 }
 
 /* Source Context */
+#contextContainer QPushButton {
+    padding: 3px 10px;
+}
+
 #contextContainer QPushButton[themeID2=contextBarButton] {
-    padding: 3px;
-    margin: 0px;
+    padding: 3px 6px;
 }
 
 #contextContainer QPushButton#sourcePropertiesButton {

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -298,8 +298,12 @@ QSlider::handle:horizontal[themeID="tBarSlider"] {
 }
 
 /* Source Context */
+#contextContainer QPushButton {
+    padding: 3px 10px;
+}
+
 #contextContainer QPushButton[themeID2=contextBarButton] {
-    padding: 0px;
+    padding: 3px 6px;
 }
 
 #contextContainer QPushButton#sourcePropertiesButton {


### PR DESCRIPTION
### Description
Fix source context bar changing height on non-Yami based themes depending on the type of source selected. Not sure why this regressed, but with 28 coming up we need a fix regardless. Approved off-thread by @Warchamp7.

~~Also normalizes the theme files to use spaces instead of tabs.~~

Video of issue:
https://user-images.githubusercontent.com/876345/186013516-9a8e639e-f523-445c-86f6-9aec54214c73.mp4

### Motivation and Context
The changing height of the bar made the user think they'd accidentally changed something when clicking as the preview window shrunk in response.

### How Has This Been Tested?
Tested Dark and System, verified no more jumping height. **Should ideally be tested on macOS and Linux if we have the time**.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
