### PR TITLE
obs-ffmpeg: Log codec when creating NVENC encoders

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -578,6 +578,7 @@ static bool init_encoder_h264(struct nvenc_data *enc, obs_data_t *settings,
 	}
 
 	info("settings:\n"
+	     "\tcodec:        H264\n"
 	     "\trate_control: %s\n"
 	     "\tbitrate:      %d\n"
 	     "\tcqp:          %d\n"
@@ -866,6 +867,7 @@ static bool init_encoder_hevc(struct nvenc_data *enc, obs_data_t *settings,
 	}
 
 	info("settings:\n"
+	     "\tcodec:        HEVC\n"
 	     "\trate_control: %s\n"
 	     "\tbitrate:      %d\n"
 	     "\tcqp:          %d\n"

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -170,6 +170,7 @@ static bool nvenc_update(struct nvenc_encoder *enc, obs_data_t *settings,
 				    ffmpeg_opts);
 
 	info("settings:\n"
+	     "\tencoder:      %s\n"
 	     "\trate_control: %s\n"
 	     "\tbitrate:      %d\n"
 	     "\tcqp:          %d\n"
@@ -182,8 +183,8 @@ static bool nvenc_update(struct nvenc_encoder *enc, obs_data_t *settings,
 	     "\tb-frames:     %d\n"
 	     "\tpsycho-aq:    %d\n"
 	     "\tGPU:          %d\n",
-	     rc, bitrate, cqp, enc->ffve.context->gop_size, preset, profile,
-	     enc->ffve.context->width, enc->ffve.height,
+	     enc->ffve.enc_name, rc, bitrate, cqp, enc->ffve.context->gop_size,
+	     preset, profile, enc->ffve.context->width, enc->ffve.height,
 	     twopass ? "true" : "false", enc->ffve.context->max_b_frames,
 	     psycho_aq, gpu);
 


### PR DESCRIPTION
### Description
With HEVC and H264 settings being near-identical, it was impossible to figure out which codec was being used by context alone. This applies to both ffmpeg output and jim-nvenc.

Fixes #6976.

### Motivation and Context
Avoid confusion for user support.

### How Has This Been Tested?
Ran OBS, checked logs.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
