### PR TITLE
UI: Fix styling of buttons in scene switcher dialog

### DIFF
--- a/UI/frontend-plugins/frontend-tools/forms/auto-scene-switcher.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/auto-scene-switcher.ui
@@ -66,8 +66,8 @@
       <widget class="QPushButton" name="add">
        <property name="maximumSize">
         <size>
-         <width>22</width>
-         <height>22</height>
+         <width>16777215</width>
+         <height>16777215</height>
         </size>
        </property>
        <property name="flat">
@@ -76,14 +76,17 @@
        <property name="themeID" stdset="0">
         <string notr="true">addIconSmall</string>
        </property>
+       <property name="toolButton" stdset="0">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>
       <widget class="QPushButton" name="remove">
        <property name="maximumSize">
         <size>
-         <width>22</width>
-         <height>22</height>
+         <width>16777215</width>
+         <height>16777215</height>
         </size>
        </property>
        <property name="flat">
@@ -91,6 +94,9 @@
        </property>
        <property name="themeID" stdset="0">
         <string notr="true">removeIconSmall</string>
+       </property>
+       <property name="toolButton" stdset="0">
+        <bool>true</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
### Description
Set the tool buttons in the advanced scene switcher dialog to use
tool button styling and remove fixed sizing.

Before:
![Screenshot from 2022-08-29 19-27-31](https://user-images.githubusercontent.com/19962531/187321851-a507a08d-6671-4ae0-af29-632983fc541e.png)

After:
![Screenshot from 2022-08-29 19-19-37](https://user-images.githubusercontent.com/19962531/187321557-dabbb9e8-711f-4356-abcc-e70bfee1d5d0.png)

### Motivation and Context
Make UI look better

### How Has This Been Tested?
Opened dialog to see if buttons looked good.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
