### PR TITLE
UI: Make list widget styles consistent

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -179,22 +179,29 @@ QMenuBar::item:selected {
 }
 
 /* Item Lists */
+QListWidget {
+    border-radius: 4px;
+}
+
 QListWidget::item {
     color: palette(text);
 }
 
+QListWidget,
 QMenu,
 SceneTree,
 SourceTree {
     padding: 3px;
 }
 
+QListWidget::item,
 SourceTreeItem,
 QMenu::item,
 SceneTree::item {
     padding: 6px;
 }
 
+QListWidget::item,
 SourceTreeItem,
 QMenu::item,
 SceneTree::item,

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -179,22 +179,29 @@ QMenuBar::item:selected {
 }
 
 /* Item Lists */
+QListWidget {
+    border-radius: 4px;
+}
+
 QListWidget::item {
     color: palette(text);
 }
 
+QListWidget,
 QMenu,
 SceneTree,
 SourceTree {
     padding: 3px;
 }
 
+QListWidget::item,
 SourceTreeItem,
 QMenu::item,
 SceneTree::item {
     padding: 6px;
 }
 
+QListWidget::item,
 SourceTreeItem,
 QMenu::item,
 SceneTree::item,

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -179,22 +179,29 @@ QMenuBar::item:selected {
 }
 
 /* Item Lists */
+QListWidget {
+    border-radius: 4px;
+}
+
 QListWidget::item {
     color: palette(text);
 }
 
+QListWidget,
 QMenu,
 SceneTree,
 SourceTree {
     padding: 3px;
 }
 
+QListWidget::item,
 SourceTreeItem,
 QMenu::item,
 SceneTree::item {
     padding: 6px;
 }
 
+QListWidget::item,
 SourceTreeItem,
 QMenu::item,
 SceneTree::item,

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -181,22 +181,29 @@ QMenuBar::item:selected {
 }
 
 /* Item Lists */
+QListWidget {
+    border-radius: 4px;
+}
+
 QListWidget::item {
     color: palette(text);
 }
 
+QListWidget,
 QMenu,
 SceneTree,
 SourceTree {
     padding: 3px;
 }
 
+QListWidget::item,
 SourceTreeItem,
 QMenu::item,
 SceneTree::item {
     padding: 6px;
 }
 
+QListWidget::item,
 SourceTreeItem,
 QMenu::item,
 SceneTree::item,

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -179,22 +179,29 @@ QMenuBar::item:selected {
 }
 
 /* Item Lists */
+QListWidget {
+    border-radius: 4px;
+}
+
 QListWidget::item {
     color: palette(text);
 }
 
+QListWidget,
 QMenu,
 SceneTree,
 SourceTree {
     padding: 3px;
 }
 
+QListWidget::item,
 SourceTreeItem,
 QMenu::item,
 SceneTree::item {
     padding: 6px;
 }
 
+QListWidget::item,
 SourceTreeItem,
 QMenu::item,
 SceneTree::item,

--- a/UI/forms/OBSBasicFilters.ui
+++ b/UI/forms/OBSBasicFilters.ui
@@ -66,6 +66,9 @@
             <property name="contextMenuPolicy">
              <enum>Qt::CustomContextMenu</enum>
             </property>
+            <property name="spacing">
+             <number>1</number>
+            </property>
            </widget>
           </item>
           <item>
@@ -275,6 +278,9 @@
             </property>
             <property name="contextMenuPolicy">
              <enum>Qt::CustomContextMenu</enum>
+            </property>
+            <property name="spacing">
+             <number>1</number>
             </property>
            </widget>
           </item>

--- a/UI/frontend-plugins/frontend-tools/forms/auto-scene-switcher.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/auto-scene-switcher.ui
@@ -52,6 +52,9 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="spacing">
+      <number>1</number>
+     </property>
      <property name="sortingEnabled">
       <bool>true</bool>
      </property>

--- a/UI/frontend-plugins/frontend-tools/forms/scripts.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/scripts.ui
@@ -44,6 +44,9 @@
            <property name="contextMenuPolicy">
             <enum>Qt::CustomContextMenu</enum>
            </property>
+           <property name="spacing">
+            <number>1</number>
+           </property>
            <property name="sortingEnabled">
             <bool>true</bool>
            </property>

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -658,6 +658,7 @@ void OBSPropertiesView::AddEditableList(obs_property_t *prop,
 	list->setSortingEnabled(false);
 	list->setSelectionMode(QAbstractItemView::ExtendedSelection);
 	list->setToolTip(QT_UTF8(obs_property_long_description(prop)));
+	list->setSpacing(1);
 
 	for (size_t i = 0; i < count; i++) {
 		OBSDataAutoRelease item = obs_data_array_item(array, i);


### PR DESCRIPTION
### Description
The script and scene switcher lists were not being styled.

This also sets the spacing to 1 for the filter, script, scene
switcher and properties view lists, the same as other lists.

Before:
![Screenshot from 2022-08-29 19-55-23](https://user-images.githubusercontent.com/19962531/187324485-4408c1b2-6c03-4836-a889-a87e98df716d.png)

![Screenshot from 2022-08-29 19-55-45](https://user-images.githubusercontent.com/19962531/187324502-05072a5e-e16e-4628-a58d-7871723625ef.png)

After:
![Screenshot from 2022-08-29 19-50-56](https://user-images.githubusercontent.com/19962531/187324270-7044dde6-45b3-4e2e-b73a-d90d662cfde3.png)

![Screenshot from 2022-08-29 19-51-49](https://user-images.githubusercontent.com/19962531/187324283-ad5c244b-ae75-41b1-871c-bf40ff2af233.png)

### Motivation and Context
Make UI look better.

### How Has This Been Tested?
Opened the dialogs to make sure the lists looked good.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
