### PR TITLE
obs-ffmpeg: Fix NVENC HEVC regression

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -697,7 +697,7 @@ static bool init_encoder_hevc(struct nvenc_data *enc, obs_data_t *settings,
 
 	NV_ENC_CONFIG *config = &enc->config;
 	NV_ENC_CONFIG_HEVC *hevc_config = &config->encodeCodecConfig.hevcConfig;
-	NV_ENC_CONFIG_H264_VUI_PARAMETERS *vui_params =
+	NV_ENC_CONFIG_HEVC_VUI_PARAMETERS *vui_params =
 		&hevc_config->hevcVUIParameters;
 
 	initialize_params(&enc->params, &NV_ENC_CODEC_HEVC_GUID, &nv_preset,


### PR DESCRIPTION
### Description
Forgot to switch enableEncodeAsync to 0.

### Motivation and Context
Want NVENC HEVC to work.

### How Has This Been Tested?
HEVC works again. H.264 tested to still work.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.