### PR TITLE
UI: Fix properties tool button styling

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -636,8 +636,7 @@ static void NewButton(QLayout *layout, WidgetInfo *info, const char *themeIcon,
 	QPushButton *button = new QPushButton();
 	button->setProperty("themeID", themeIcon);
 	button->setFlat(true);
-	button->setMaximumSize(22, 22);
-	button->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
+	button->setProperty("toolButton", true);
 
 	QObject::connect(button, &QPushButton::clicked, info, method);
 


### PR DESCRIPTION
### Description
Set toolButton to true with the tool buttons in the properties widget.

Before:
![Screenshot from 2022-08-29 20-51-19](https://user-images.githubusercontent.com/19962531/187331688-dc656820-8958-452a-9750-5690c45f026e.png)

After:
![Screenshot from 2022-08-29 20-54-21](https://user-images.githubusercontent.com/19962531/187331104-c2523ace-8e1d-4fc7-9050-1b48d8b3b16f.png)

### Motivation and Context
Make UI look better.

### How Has This Been Tested?
Add source with a list property and checked to see if the tool buttons were styled correctly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
