### PR TITLE
UI: Fix context bar being squished

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -215,7 +215,7 @@
       <property name="minimumSize">
        <size>
         <width>0</width>
-        <height>30</height>
+        <height>0</height>
        </size>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout9">


### PR DESCRIPTION
### Description
When making the OBS window smaller, the context bar would be cut
in half.

Before:
![Screenshot from 2022-08-29 22-50-39](https://user-images.githubusercontent.com/19962531/187345276-ce8e51fb-3186-4d0f-9a6b-b1913cad9b44.png)

After:
![Screenshot from 2022-08-29 22-47-03](https://user-images.githubusercontent.com/19962531/187345302-4851ecdc-bfc7-40a1-a7a9-6f16141ee3c6.png)

### Motivation and Context
Fix UI bug.

### How Has This Been Tested?
Made OBS smaller and made sure context bar sizing was correct.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
