### PR TITLE
UI: Fix missing files warning icon

### DIFF
--- a/UI/forms/OBSMissingFiles.ui
+++ b/UI/forms/OBSMissingFiles.ui
@@ -21,7 +21,7 @@
        <property name="minimumSize">
         <size>
          <width>0</width>
-         <height>20</height>
+         <height>0</height>
         </size>
        </property>
       </widget>


### PR DESCRIPTION
### Description
The missing files icon would be cut off if the dialog was made
smaller.

Before:
![Screenshot from 2022-08-29 22-58-56](https://user-images.githubusercontent.com/19962531/187346954-35dec53b-e032-4a3f-8b81-2d1aef37df2e.png)

After:
![Screenshot from 2022-08-29 23-04-11](https://user-images.githubusercontent.com/19962531/187346967-47bfa726-6bf6-4432-96a5-df26d85bd1be.png)

### Motivation and Context
Fix UI bugs

### How Has This Been Tested?
Made missing files dialog smaller and made sure the icon didn't get cut off.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
