### PR TITLE
UI: Fix source tree hovering being inconsistent

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -1082,8 +1082,6 @@ SourceTree::SourceTree(QWidget *parent_) : QListView(parent_)
 		"*[bgColor=\"7\"]{background-color:rgba(68,68,68,33%);}"
 		"*[bgColor=\"8\"]{background-color:rgba(255,255,255,33%);}"));
 
-	setMouseTracking(true);
-
 	UpdateNoSourcesMessage();
 	connect(App(), &OBSApp::StyleChanged, this,
 		&SourceTree::UpdateNoSourcesMessage);
@@ -1489,31 +1487,6 @@ void SourceTree::dropEvent(QDropEvent *event)
 	event->setDropAction(Qt::CopyAction);
 
 	QListView::dropEvent(event);
-}
-
-void SourceTree::mouseMoveEvent(QMouseEvent *event)
-{
-	QPoint pos = event->pos();
-	SourceTreeItem *item = qobject_cast<SourceTreeItem *>(childAt(pos));
-
-	OBSBasicPreview *preview = OBSBasicPreview::Get();
-
-	QListView::mouseMoveEvent(event);
-
-	std::lock_guard<std::mutex> lock(preview->selectMutex);
-	preview->hoveredPreviewItems.clear();
-	if (item)
-		preview->hoveredPreviewItems.push_back(item->sceneitem);
-}
-
-void SourceTree::leaveEvent(QEvent *event)
-{
-	OBSBasicPreview *preview = OBSBasicPreview::Get();
-
-	QListView::leaveEvent(event);
-
-	std::lock_guard<std::mutex> lock(preview->selectMutex);
-	preview->hoveredPreviewItems.clear();
 }
 
 void SourceTree::selectionChanged(const QItemSelection &selected,

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -211,8 +211,6 @@ public slots:
 protected:
 	virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
 	virtual void dropEvent(QDropEvent *event) override;
-	virtual void mouseMoveEvent(QMouseEvent *event) override;
-	virtual void leaveEvent(QEvent *event) override;
 	virtual void paintEvent(QPaintEvent *event) override;
 
 	virtual void


### PR DESCRIPTION
### Description
When hovering over the source tree items, sometimes the preview
would show the item hovered, sometimes not. This is caused by
the SourceTree mouseMoveEvent/leaveEvent calling the same functions
as the SourceTreeItem enterEvent/leaveEvent, therefore competing
with each other, causing some jankiness.

### Motivation and Context
@WizardCM reported the bug on Discord.

### How Has This Been Tested?
Hovered over items to make sure everything worked as expected.

Want @WizardCM to confirm it fixes the problem he was seeing.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
