### PR TITLE
UI: Fix sizing of virtual camera button

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -754,6 +754,7 @@ QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
     margin: 1px;
 }
 
+QPushButton[themeID="vcamButton"],
 #streamButton,
 #recordButton,
 QPushButton[themeID="replayBufferButton"],

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -752,6 +752,7 @@ QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
     margin: 1px;
 }
 
+QPushButton[themeID="vcamButton"],
 #streamButton,
 #recordButton,
 QPushButton[themeID="replayBufferButton"],

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -752,6 +752,7 @@ QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
     margin: 1px;
 }
 
+QPushButton[themeID="vcamButton"],
 #streamButton,
 #recordButton,
 QPushButton[themeID="replayBufferButton"],

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -756,6 +756,7 @@ QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
     margin: 1px;
 }
 
+QPushButton[themeID="vcamButton"],
 #streamButton,
 #recordButton,
 QPushButton[themeID="replayBufferButton"],

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -756,6 +756,7 @@ QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
     margin: 1px;
 }
 
+QPushButton[themeID="vcamButton"],
 #streamButton,
 #recordButton,
 QPushButton[themeID="replayBufferButton"],


### PR DESCRIPTION
### Description
This makes the virtual camera button the same
size as the stream, record and replay buttons.
This also makes the secondary buttons line up
with each other.

Before:
![Screenshot from 2022-09-01 07-29-37](https://user-images.githubusercontent.com/19962531/187915467-b05781f9-f655-42d7-ab7d-d22b55e6e1c4.png)

After:
![Screenshot from 2022-09-01 07-34-05](https://user-images.githubusercontent.com/19962531/187915460-0ca7c54f-bfc4-4a12-b3f1-dffe4456d036.png)

### Motivation and Context
Fix UI bugs.

### How Has This Been Tested?
Looked at buttons and made sure they looked good.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
