### PR TITLE
UI: allow side docks to be tall

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -803,6 +803,7 @@ Basic.MainMenu.View.SceneListMode="Scene List Mode"
 Basic.MainMenu.Docks="&Docks"
 Basic.MainMenu.Docks.ResetDocks="&Reset Docks"
 Basic.MainMenu.Docks.LockDocks="&Lock Docks"
+Basic.MainMenu.Docks.SideDocks="&Full-height docks"
 Basic.MainMenu.Docks.CustomBrowserDocks="&Custom Browser Docks..."
 
 # basic mode profile/scene collection menus

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -720,6 +720,7 @@
      <string>Basic.MainMenu.Docks</string>
     </property>
     <addaction name="lockDocks"/>
+    <addaction name="sideDocks"/>
     <addaction name="resetDocks"/>
     <addaction name="separator"/>
    </widget>
@@ -2188,6 +2189,17 @@
    </property>
    <property name="text">
     <string>Basic.MainMenu.Docks.LockDocks</string>
+   </property>
+  </action>
+  <action name="sideDocks">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Basic.MainMenu.Docks.SideDocks</string>
    </property>
   </action>
   <action name="actionHelpPortal">

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2171,6 +2171,13 @@ void OBSBasic::OBSInit()
 	ui->lockDocks->setChecked(docksLocked);
 	ui->lockDocks->blockSignals(false);
 
+	bool sideDocks = config_get_bool(App()->GlobalConfig(), "BasicWindow",
+					 "SideDocks");
+	on_sideDocks_toggled(sideDocks);
+	ui->sideDocks->blockSignals(true);
+	ui->sideDocks->setChecked(sideDocks);
+	ui->sideDocks->blockSignals(false);
+
 	SystemTray(true);
 
 	TaskbarOverlayInit();
@@ -2896,6 +2903,8 @@ OBSBasic::~OBSBasic()
 			"PreviewProgramMode", IsPreviewProgramMode());
 	config_set_bool(App()->GlobalConfig(), "BasicWindow", "DocksLocked",
 			ui->lockDocks->isChecked());
+	config_set_bool(App()->GlobalConfig(), "BasicWindow", "SideDocks",
+			ui->sideDocks->isChecked());
 	config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
 
 #ifdef BROWSER_AVAILABLE
@@ -9363,6 +9372,21 @@ void OBSBasic::on_lockDocks_toggled(bool lock)
 		} else {
 			oldExtraDocks[i]->setFeatures(features);
 		}
+	}
+}
+
+void OBSBasic::on_sideDocks_toggled(bool side)
+{
+	if (side) {
+		setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
+		setCorner(Qt::TopRightCorner, Qt::RightDockWidgetArea);
+		setCorner(Qt::BottomLeftCorner, Qt::LeftDockWidgetArea);
+		setCorner(Qt::BottomRightCorner, Qt::RightDockWidgetArea);
+	} else {
+		setCorner(Qt::TopLeftCorner, Qt::TopDockWidgetArea);
+		setCorner(Qt::TopRightCorner, Qt::TopDockWidgetArea);
+		setCorner(Qt::BottomLeftCorner, Qt::BottomDockWidgetArea);
+		setCorner(Qt::BottomRightCorner, Qt::BottomDockWidgetArea);
 	}
 }
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1154,6 +1154,7 @@ private slots:
 	void on_resetDocks_triggered(bool force = false);
 	void on_lockDocks_toggled(bool lock);
 	void on_multiviewProjectorWindowed_triggered();
+	void on_sideDocks_toggled(bool side);
 
 	void PauseToggled();
 


### PR DESCRIPTION
### Description

Before: widgets docked on the sides of the preview are of the height of the preview

![image](https://user-images.githubusercontent.com/108798/187915194-d7908ac0-f7e9-410a-8b02-de09d96e92a8.png)

After: the user can toggle the setting in the docks menu so the side widgets are of the height of the whole window

![image](https://user-images.githubusercontent.com/108798/187915229-b811f4ba-281a-45e7-813c-a72fb1013be9.png)

### Motivation and Context

The feature is long requested. It was stated that the feature would require total rewrite of widget system.

https://ideas.obsproject.com/posts/488/allow-top-level-vertical-splits-for-docks
https://obsproject.com/forum/threads/chat-dock-size-customisation.151609/
https://obsproject.com/forum/threads/make-a-widget-full-vertical.150216/

It is actually possible with minimal changes and backward compatibility.

### How Has This Been Tested?

Tested on Windows 10 system.

### Types of changes

This is a new feature that allows user to have docks of the height of the main OBS window.
