### PR TITLE
UI: Fix alignment of volume sliders

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -974,10 +974,6 @@ QHeaderView::section {
 
 /* Mute CheckBox */
 
-MuteCheckBox {
-    margin: 4px 0px 0px;
-}
-
 MuteCheckBox::indicator:checked {
     image: url(./Dark/mute.svg);
 }

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -962,10 +962,6 @@ QHeaderView::section {
 
 /* Mute CheckBox */
 
-MuteCheckBox {
-    margin: 4px 0px 0px;
-}
-
 MuteCheckBox::indicator:checked {
     image: url(./Dark/mute.svg);
 }

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -962,10 +962,6 @@ QHeaderView::section {
 
 /* Mute CheckBox */
 
-MuteCheckBox {
-    margin: 4px 0px 0px;
-}
-
 MuteCheckBox::indicator:checked {
     image: url(./Light/mute.svg);
 }

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -966,10 +966,6 @@ QHeaderView::section {
 
 /* Mute CheckBox */
 
-MuteCheckBox {
-    margin: 4px 0px 0px;
-}
-
 MuteCheckBox::indicator:checked {
     image: url(./Dark/mute.svg);
 }

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -966,10 +966,6 @@ QHeaderView::section {
 
 /* Mute CheckBox */
 
-MuteCheckBox {
-    margin: 4px 0px 0px;
-}
-
 MuteCheckBox::indicator:checked {
     image: url(./Dark/mute.svg);
 }

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -248,7 +248,6 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 
 		setMaximumWidth(110);
 	} else {
-		QHBoxLayout *volLayout = new QHBoxLayout;
 		QHBoxLayout *textLayout = new QHBoxLayout;
 		QHBoxLayout *botLayout = new QHBoxLayout;
 
@@ -261,16 +260,17 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 		textLayout->setAlignment(nameLabel, Qt::AlignLeft);
 		textLayout->setAlignment(volLabel, Qt::AlignRight);
 
-		volLayout->addWidget(slider);
-		volLayout->addWidget(mute);
-		volLayout->setSpacing(5);
-
 		botLayout->setContentsMargins(0, 0, 0, 0);
-		botLayout->setSpacing(0);
-		botLayout->addLayout(volLayout);
+		botLayout->setSpacing(5);
+		botLayout->addWidget(slider);
+		botLayout->addWidget(mute);
+		botLayout->setAlignment(slider, Qt::AlignVCenter);
+		botLayout->setAlignment(mute, Qt::AlignVCenter);
 
-		if (showConfig)
+		if (showConfig) {
 			botLayout->addWidget(config);
+			botLayout->setAlignment(config, Qt::AlignVCenter);
+		}
 
 		mainLayout->addItem(textLayout);
 		mainLayout->addWidget(volMeter);


### PR DESCRIPTION
### Description
With the Yami themes, the volume sliders wouldn't
be aligned in the center of the layout.

Before:
![Screenshot from 2022-09-01 08-07-00](https://user-images.githubusercontent.com/19962531/187926084-fd3f21a4-2eac-4a22-aa36-07d9f791d80a.png)

After:
![Screenshot from 2022-09-01 08-16-45](https://user-images.githubusercontent.com/19962531/187926316-9d1dff66-feeb-4236-8854-dc19c7402cae.png)

### Motivation and Context
Fix UI bugs

### How Has This Been Tested?
Looked at sliders to see if they looked good.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
