### PR TITLE
obs-ffmpeg: Fix seek offset being calculated incorrectly

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -780,7 +780,12 @@ static void *ffmpeg_mux_io_thread(void *data)
 			if (want_seek) {
 				os_fseeki64(ffm->io.output_file,
 					    next_seek_position, SEEK_SET);
-				current_seek_position = next_seek_position;
+
+				// Update the next virtual position, making sure to take
+				// into account the size of the chunk we're about to write.
+				current_seek_position =
+					next_seek_position + chunk_used;
+
 				want_seek = false;
 			}
 


### PR DESCRIPTION
### Description
A problem was identified in the buffering thread added to `obs-ffmpeg-mux` in #5717. If FFmpeg seeked, wrote data and then seeked back to immediately overwrite it, the second seek would be skipped as our virtual offset was not being updated with the data offset caused by the first write. This caused MP4 corruption when seeking back in the file to write the moov atom.

Fixes https://github.com/obsproject/obs-studio/issues/7269

Fixes https://github.com/obsproject/obs-studio/issues/7144

### Motivation and Context
Corrupting files by seeking incorrectly is bad 🙁

### How Has This Been Tested?
Reproduced the issue, confirmed fix worked.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
