### PR TITLE
Revert "UI: Remove "Resize output (source size)" menu"

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1285,6 +1285,11 @@ AddUrl.Title="Add Source via URL"
 AddUrl.Text="You have dragged a URL into OBS. This will automatically add the link as a source. Continue?"
 AddUrl.Text.Url="URL: %1"
 
+# Dynamic output size
+ResizeOutputSizeOfSource="Resize output (source size)"
+ResizeOutputSizeOfSource.Text="The base and output resolutions will be resized to the size of the current source."
+ResizeOutputSizeOfSource.Continue="Do you want to continue?"
+
 PreviewTransition="Preview Transition"
 
 # Import Dialog

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1174,6 +1174,8 @@ private slots:
 
 	void StackedMixerAreaContextMenuRequested();
 
+	void ResizeOutputSizeOfSource();
+
 public slots:
 	void on_actionResetTransform_triggered();
 


### PR DESCRIPTION
### Description

This reverts commit 829e906ac2b15d822173009cde5c90b5ec6c04c1.

### Motivation and Context

Honestly this change annoyed me because it's a useful feature that got removed without replacement. And clearly I'm not the only one judging by some forum posts/comments about it (like https://obsproject.com/forum/threads/resize-output-missing-in-28-0-0.159123/ and on the PR/commit itself).

**Edit:**
To elaborate; one of the annoying design decisions in OBS is that canvas size is tied to profile, and not scene collection. Meaning that switching between profiles or scene collections can require you to change your canvas/output sizes. Sometimes this gets extra annoying because the scaled dropdown will default to something weird rather than what you select for the canvas. Being able to just right-click a fullscreen source and automatically switch was convenient and quick.

The probably even bigger advantage applies when switching between games that run in different resolutions for local recording with 1:1 scaling, just CTRL+R the source and then resize output to it.

### How Has This Been Tested?

Hasn't yet.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
