### PR TITLE
libobs: add qt5 check for linux

### DIFF
--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -27,6 +27,7 @@
 #include <glob.h>
 #include <time.h>
 #include <signal.h>
+#include <stdlib.h>
 
 #include "obsconfig.h"
 
@@ -99,8 +100,16 @@ void os_dlclose(void *module)
 void get_plugin_info(const char *path, bool *is_obs_plugin, bool *can_load)
 {
 	*is_obs_plugin = true;
-	*can_load = true;
+#if OBS_QT_VERSION == 6 && !defined(__APPLE__)
+	if (strstr(path, "'"))
+		return;
+	char cmd[2048];
+	snprintf(cmd, 2048, "ldd '%s' | grep -q 'libQt5'", path);
+	*can_load = !!system(cmd);
+#else
 	UNUSED_PARAMETER(path);
+	*can_load = true;
+#endif
 }
 
 bool os_is_obs_plugin(const char *path)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This adds a very poorman's check for qt5 linkages into obs. It works for
checking some of the common broken plugins on my machine but it may be
produce false positives if someone has the text `libQt5` in their
binary. It also slows down startup (by ~500ms) by introducing a bunch of shell/grep
invocations, but it prevents crashes on v28.

### Motivation and Context
Lots of linux users use plugins, as many as windows or more. But we didn't introduce this check so linux users just get a segfault and the experience sucks.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Loaded some of the commonly seen plugins that fail and observed they were not loaded. In the case where shell or grep is not available on the destination machine `system` should return an error and all errors are treated as `can_load=true`. Only when shell,grep, and the match succeed does `system` return `0` which we treat as `can_load=false`. So it should be fairly safe.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
