### PR TITLE
libobs-winrt,win-capture: Allow forcing SDR

### DIFF
--- a/libobs-winrt/winrt-capture.h
+++ b/libobs-winrt/winrt-capture.h
@@ -12,7 +12,8 @@ extern "C" {
 EXPORT BOOL winrt_capture_supported();
 EXPORT BOOL winrt_capture_cursor_toggle_supported();
 EXPORT struct winrt_capture *winrt_capture_init_window(BOOL cursor, HWND window,
-						       BOOL client_area);
+						       BOOL client_area,
+						       BOOL force_sdr);
 EXPORT struct winrt_capture *winrt_capture_init_monitor(BOOL cursor,
 							HMONITOR monitor);
 EXPORT void winrt_capture_free(struct winrt_capture *capture);

--- a/plugins/win-capture/data/locale/en-US.ini
+++ b/plugins/win-capture/data/locale/en-US.ini
@@ -12,6 +12,7 @@ WindowCapture.Priority.Exe="Match title, otherwise find window of same executabl
 CaptureCursor="Capture Cursor"
 Compatibility="Multi-adapter Compatibility"
 ClientArea="Client Area"
+ForceSdr="Force SDR"
 SLIFix="SLI/Crossfire Capture Mode (Slow)"
 AllowTransparency="Allow Transparency"
 Monitor="Display"


### PR DESCRIPTION
### Description
We don't know if there's a way to get window color space, so we've been
using the monitor color space of the window. This toggle forces OBS to
ignore the monitor color space, and assume the window is SDR.

### Motivation and Context
Good to treat SDR windows as SDR windows both for look, and filter compatibility.

### How Has This Been Tested?
- [x] SDR window, SDR monitor, Force SDR off -> SDR
- [x] SDR window, SDR monitor, Force SDR on -> SDR
- [x] SDR window, HDR monitor, Force SDR off -> SDR direct mapped to HDR, tonemapped back to SDR
- [x] SDR window, HDR monitor, Force SDR on -> SDR
- [x] HDR window, HDR monitor, Force SDR off -> HDR
- [x] HDR window, HDR monitor, Force SDR on -> HDR aliased as SDR

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.