### PR TITLE
cmake: Fix Sparkle framework permissions

### DIFF
--- a/cmake/Modules/ObsHelpers_macOS.cmake
+++ b/cmake/Modules/ObsHelpers_macOS.cmake
@@ -384,6 +384,7 @@ function(setup_obs_bundle target)
     install(
       DIRECTORY ${SPARKLE}
       DESTINATION $<TARGET_FILE_BASE_NAME:${target}>.app/Contents/Frameworks
+      USE_SOURCE_PERMISSIONS
       COMPONENT obs_frameworks)
   endif()
 


### PR DESCRIPTION
### Description

Ensure file permissions (e.g. executable bit) are copied when bundling OBS.

### Motivation and Context

The Sparkle updater is broken due to missing executable bits in `Autoupdate.app` in 28.0 and 28.0.1, as reported for example in #7277

### How Has This Been Tested?

Ran update from CI build, ensured Autoupdate.app now runs (even though it refuses to install due CI build being a newer version).

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
