### PR TITLE
frontend, libobs: Add ability to set custom source icons

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -479,7 +479,15 @@ Source Definition Structure (obs_source_info)
    - **OBS_ICON_TYPE_TEXT**            - Text
    - **OBS_ICON_TYPE_MEDIA**           - Media
    - **OBS_ICON_TYPE_BROWSER**         - Browser
-   - **OBS_ICON_TYPE_CUSTOM**          - Custom (not implemented yet)
+   - **OBS_ICON_TYPE_CUSTOM**          - Custom
+
+.. member:: const char *(*obs_source_info.get_dark_icon)(void *type_data)
+
+   Gets the icon file path used for dark themes. Make sure icon_type is set to OBS_ICON_TYPE_CUSTOM.
+
+.. member:: const char *(*obs_source_info.get_light_icon)(void *type_data)
+
+   Gets the icon file path used for light themes. Make sure icon_type is set to OBS_ICON_TYPE_CUSTOM.
 
 .. member:: void (*obs_source_info.media_play_pause)(void *data, bool pause)
 
@@ -1434,6 +1442,18 @@ General Source Functions
 .. function:: enum obs_icon_type obs_source_get_icon_type(const char *id)
 
    Calls the :c:member:`obs_source_info.icon_type` to get the icon type.
+
+---------------------
+
+.. function:: const char *obs_source_get_dark_icon(const char *id)
+
+   Calls the :c:member:`obs_source_info.get_dark_icon` to get the dark icon.
+
+---------------------
+
+.. function:: const char *obs_source_get_light_icon(const char *id)
+
+   Calls the :c:member:`obs_source_info.get_light_icon` to get the light icon.
 
 ---------------------
 

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -560,6 +560,7 @@ public:
 	QIcon GetSourceIcon(const char *id) const;
 	QIcon GetGroupIcon() const;
 	QIcon GetSceneIcon() const;
+	QIcon GetCustomIcon(const char *id) const;
 
 	/* -------------------------------------
 	 * MARK: - OBSBasic_MainControls

--- a/frontend/widgets/OBSBasic_Icons.cpp
+++ b/frontend/widgets/OBSBasic_Icons.cpp
@@ -49,8 +49,7 @@ QIcon OBSBasic::GetSourceIcon(const char *id) const
 	case OBS_ICON_TYPE_BROWSER:
 		return GetBrowserIcon();
 	case OBS_ICON_TYPE_CUSTOM:
-		//TODO: Add ability for sources to define custom icons
-		return GetDefaultIcon();
+		return GetCustomIcon(id);
 	case OBS_ICON_TYPE_PROCESS_AUDIO_OUTPUT:
 		return GetAudioProcessOutputIcon();
 	default:
@@ -216,4 +215,13 @@ QIcon OBSBasic::GetDefaultIcon() const
 QIcon OBSBasic::GetAudioProcessOutputIcon() const
 {
 	return audioProcessOutputIcon;
+}
+
+QIcon OBSBasic::GetCustomIcon(const char *id) const
+{
+	const char *path = App()->IsThemeDark() ? obs_source_get_dark_icon(id) : obs_source_get_light_icon(id);
+	QIcon icon = (path && *path) ? QIcon(path) : GetDefaultIcon();
+	bfree((void *)path);
+
+	return icon;
 }

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -5708,6 +5708,24 @@ enum obs_icon_type obs_source_get_icon_type(const char *id)
 	return (info) ? info->icon_type : OBS_ICON_TYPE_UNKNOWN;
 }
 
+const char *obs_source_get_dark_icon(const char *id)
+{
+	if (obs_source_get_icon_type(id) != OBS_ICON_TYPE_CUSTOM)
+		return NULL;
+
+	const struct obs_source_info *info = get_source_info(id);
+	return (info && info->get_dark_icon) ? info->get_dark_icon(info->type_data) : NULL;
+}
+
+const char *obs_source_get_light_icon(const char *id)
+{
+	if (obs_source_get_icon_type(id) != OBS_ICON_TYPE_CUSTOM)
+		return NULL;
+
+	const struct obs_source_info *info = get_source_info(id);
+	return (info && info->get_light_icon) ? info->get_light_icon(info->type_data) : NULL;
+}
+
 void obs_source_media_play_pause(obs_source_t *source, bool pause)
 {
 	if (!data_valid(source, "obs_source_media_play_pause"))

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -551,6 +551,10 @@ struct obs_source_info {
 	 * @param  source  Source that the filter is being added to
 	 */
 	void (*filter_add)(void *data, obs_source_t *source);
+
+	/** Gets custom icons for dark and light themes */
+	const char *(*get_dark_icon)(void *type_data);
+	const char *(*get_light_icon)(void *type_data);
 };
 
 EXPORT void obs_register_source_s(const struct obs_source_info *info, size_t size);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2588,6 +2588,10 @@ EXPORT void obs_source_frame_copy(struct obs_source_frame *dst, const struct obs
 /* Get source icon type */
 EXPORT enum obs_icon_type obs_source_get_icon_type(const char *id);
 
+/* Get dark and light versions of custom icons */
+EXPORT const char *obs_source_get_dark_icon(const char *id);
+EXPORT const char *obs_source_get_light_icon(const char *id);
+
 /* ------------------------------------------------------------------------- */
 /* Canvases */
 


### PR DESCRIPTION
### Description
This allows setting dark and light icons for a source.

### Motivation and Context
This was a TO DO with the original source icons feature https://github.com/obsproject/obs-studio/commit/f81cd29e0bf49692b172991d85535788dd83ac31

### How Has This Been Tested?
Set a custom dark and light icon for a source and switched themes to make sure everything worked.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
