### PR TITLE
win-capture: Remove unused wildcard code

### DIFF
--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -86,7 +86,6 @@ struct window_capture {
 	bool compatibility;
 	bool client_area;
 	bool force_sdr;
-	bool use_wildcards; /* TODO */
 
 	struct dc_capture capture;
 
@@ -209,7 +208,6 @@ static void update_settings(struct window_capture *wc, obs_data_t *s)
 	wc->priority = (enum window_priority)priority;
 	wc->cursor = obs_data_get_bool(s, "cursor");
 	wc->force_sdr = obs_data_get_bool(s, "force_sdr");
-	wc->use_wildcards = obs_data_get_bool(s, "use_wildcards");
 	wc->compatibility = obs_data_get_bool(s, "compatibility");
 	wc->client_area = obs_data_get_bool(s, "client_area");
 


### PR DESCRIPTION
### Description
Remove temporary code that never ended up being used.

### Motivation and Context
Don't want dead code.

### How Has This Been Tested?
Window capture still works.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.