### PR TITLE
libobs: Remove unnecessary branch

### DIFF
--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -233,8 +233,7 @@ render_output_texture(struct obs_core_video_mix *mix)
 	if (video_output_get_format(mix->video) == VIDEO_FORMAT_RGBA) {
 		tech = gs_effect_get_technique(effect, "DrawAlphaDivide");
 	} else {
-		if ((effect == video->default_effect) &&
-		    (width == video->base_width) &&
+		if ((width == video->base_width) &&
 		    (height == video->base_height))
 			return texture;
 


### PR DESCRIPTION
### Description
Fast path for output texture shouldn't care what the effect is.

### Motivation and Context
Simplify code.

### How Has This Been Tested?
Fast and slow paths are still taken as expected.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.