### PR TITLE
decklink,media-io: Use scaler for range and color space

### DIFF
--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
@@ -176,7 +176,7 @@ void preview_output_start()
 		vi.fps_num = context.ovi.fps_num;
 		vi.cache_size = 16;
 		vi.colorspace = mainVOI->colorspace;
-		vi.range = mainVOI->range;
+		vi.range = VIDEO_RANGE_FULL;
 		vi.name = "decklink_preview_output";
 
 		video_output_open(&context.video_queue, &vi);

--- a/libobs/media-io/video-io.c
+++ b/libobs/media-io/video-io.c
@@ -295,12 +295,39 @@ static size_t video_get_input_idx(const video_t *video,
 	return DARRAY_INVALID;
 }
 
+static bool match_range(enum video_range_type a, enum video_range_type b)
+{
+	return (a == VIDEO_RANGE_FULL) == (b == VIDEO_RANGE_FULL);
+}
+
+static enum video_colorspace collapse_space(enum video_colorspace cs)
+{
+	switch (cs) {
+	case VIDEO_CS_DEFAULT:
+	case VIDEO_CS_SRGB:
+		cs = VIDEO_CS_709;
+		break;
+	case VIDEO_CS_2100_HLG:
+		cs = VIDEO_CS_2100_PQ;
+	}
+
+	return cs;
+}
+
+static bool match_space(enum video_colorspace a, enum video_colorspace b)
+{
+	return collapse_space(a) == collapse_space(b);
+}
+
 static inline bool video_input_init(struct video_input *input,
 				    struct video_output *video)
 {
 	if (input->conversion.width != video->info.width ||
 	    input->conversion.height != video->info.height ||
-	    input->conversion.format != video->info.format) {
+	    input->conversion.format != video->info.format ||
+	    !match_range(input->conversion.range, video->info.range) ||
+	    !match_space(input->conversion.colorspace,
+			 video->info.colorspace)) {
 		struct video_scale_info from = {.format = video->info.format,
 						.width = video->info.width,
 						.height = video->info.height,

--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -84,11 +84,14 @@ static bool decklink_output_start(void *data)
 
 	if (decklink->keyerMode != 0) {
 		to.format = VIDEO_FORMAT_BGRA;
+		to.range = VIDEO_RANGE_FULL;
 	} else {
 		to.format = VIDEO_FORMAT_UYVY;
+		to.range = VIDEO_RANGE_PARTIAL;
 	}
 	to.width = mode->GetWidth();
 	to.height = mode->GetHeight();
+	to.colorspace = VIDEO_CS_709;
 
 	obs_output_set_video_conversion(decklink->GetOutput(), &to);
 


### PR DESCRIPTION
### Description
Fix up DeckLink video metadata, and use FFmpeg scaler to adjust for more conditions.

### Motivation and Context
Don't want incorrect, untransformed data.

### How Has This Been Tested?
Don't have a test case that exercises this, but test case that doesn't is still working.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.