### PR TITLE
graphics-hook: Print DXGI swap chain desc

### DIFF
--- a/plugins/win-capture/graphics-hook/d3d10-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d10-capture.cpp
@@ -172,6 +172,8 @@ static inline bool d3d10_init_format(IDXGISwapChain *swap, HWND &window)
 		return false;
 	}
 
+	print_swap_desc(&desc);
+
 	data.format = strip_dxgi_format_srgb(desc.BufferDesc.Format);
 	data.multisampled = desc.SampleDesc.Count > 1;
 	window = desc.OutputWindow;

--- a/plugins/win-capture/graphics-hook/d3d11-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d11-capture.cpp
@@ -174,6 +174,8 @@ static inline bool d3d11_init_format(IDXGISwapChain *swap, HWND &window)
 		return false;
 	}
 
+	print_swap_desc(&desc);
+
 	data.format = strip_dxgi_format_srgb(desc.BufferDesc.Format);
 	data.multisampled = desc.SampleDesc.Count > 1;
 	window = desc.OutputWindow;

--- a/plugins/win-capture/graphics-hook/d3d12-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d12-capture.cpp
@@ -236,6 +236,8 @@ static inline bool d3d12_init_format(IDXGISwapChain *swap, HWND &window,
 		return false;
 	}
 
+	print_swap_desc(&desc);
+
 	data.format = strip_dxgi_format_srgb(desc.BufferDesc.Format);
 	data.multisampled = desc.SampleDesc.Count > 1;
 	window = desc.OutputWindow;
@@ -248,9 +250,6 @@ static inline bool d3d12_init_format(IDXGISwapChain *swap, HWND &window,
 		hlog("We're DXGI1.4 boys!");
 		swap3->Release();
 	}
-
-	hlog("Buffer count: %d, swap effect: %d", (int)desc.BufferCount,
-	     (int)desc.SwapEffect);
 
 	bb.count = desc.SwapEffect == DXGI_SWAP_EFFECT_DISCARD
 			   ? 1

--- a/plugins/win-capture/graphics-hook/dxgi-capture.cpp
+++ b/plugins/win-capture/graphics-hook/dxgi-capture.cpp
@@ -290,8 +290,6 @@ hook_present1(IDXGISwapChain1 *swap, UINT sync_interval, UINT flags,
 		IUnknown *backbuffer = get_dxgi_backbuffer(swap);
 
 		if (backbuffer) {
-			DXGI_SWAP_CHAIN_DESC1 desc;
-			swap->GetDesc1(&desc);
 			data.capture(swap, backbuffer);
 			backbuffer->Release();
 		}

--- a/plugins/win-capture/graphics-hook/dxgi-helpers.hpp
+++ b/plugins/win-capture/graphics-hook/dxgi-helpers.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "graphics-hook.h"
+
 static inline DXGI_FORMAT strip_dxgi_format_srgb(DXGI_FORMAT format)
 {
 	switch ((unsigned long)format) {
@@ -25,4 +27,30 @@ static inline DXGI_FORMAT apply_dxgi_format_typeless(DXGI_FORMAT format,
 	}
 
 	return format;
+}
+
+static void print_swap_desc(const DXGI_SWAP_CHAIN_DESC *desc)
+{
+	hlog("DXGI_SWAP_CHAIN_DESC:\n"
+	     "    BufferDesc.Width: %u\n"
+	     "    BufferDesc.Height: %u\n"
+	     "    BufferDesc.RefreshRate.Numerator: %u\n"
+	     "    BufferDesc.RefreshRate.Denominator: %u\n"
+	     "    BufferDesc.Format: %u\n"
+	     "    BufferDesc.ScanlineOrdering: %u\n"
+	     "    BufferDesc.Scaling: %u\n"
+	     "    SampleDesc.Count: %u\n"
+	     "    SampleDesc.Quality: %u\n"
+	     "    BufferUsage: %u\n"
+	     "    BufferCount: %u\n"
+	     "    Windowed: %u\n"
+	     "    SwapEffect: %u\n"
+	     "    Flags: %u",
+	     desc->BufferDesc.Width, desc->BufferDesc.Height,
+	     desc->BufferDesc.RefreshRate.Numerator,
+	     desc->BufferDesc.RefreshRate.Denominator, desc->BufferDesc.Format,
+	     desc->BufferDesc.ScanlineOrdering, desc->BufferDesc.Scaling,
+	     desc->SampleDesc.Count, desc->SampleDesc.Quality,
+	     desc->BufferUsage, desc->BufferCount, desc->Windowed,
+	     desc->SwapEffect, desc->Flags);
 }


### PR DESCRIPTION
### Description
Log the DXGI_SWAP_CHAIN_DESC of the game for debugging.

Also add commit to remove some unused code.

### Motivation and Context
More info can only make debugging easier.

### How Has This Been Tested?
Verified logging appears for D3D10, D3D11, and D3D12 applications.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.