### PR TITLE
UI: Don't trigger a settings update when property list is empty

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -624,7 +624,7 @@ QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 	children.emplace_back(info);
 
 	/* trigger a settings update if the index was not found */
-	if (idx == -1)
+	if (count && idx == -1)
 		info->ControlChanged();
 
 	return combo;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Don't trigger a settings update when property list is empty
To avoid recursive call

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fixes #7299 

When property list is empty, the `idx` assigned to `combo->findData(value)` is always `-1`.

https://github.com/obsproject/obs-studio/blob/db766273b60a07a9a9b308b98f020e41a0658e56/UI/properties-view.cpp#L626-L628

This cause recursive call in `RefreshProperties`

`RefreshProperties` -> `AddProperty` -> `AddList` -> `ControlChanged` -> `RefreshProperties` ...

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

on win10, obs28

add `return;` procedure above `add_window` in this function
https://github.com/obsproject/obs-studio/blob/db766273b60a07a9a9b308b98f020e41a0658e56/libobs/util/windows/window-helpers.c#L422-L434

before fix:
sometimes the buttonBox cannot work well

after fix:
work fine

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
