### PR TITLE
UI: Don't save/overwrite browser docks if CEF hasn't loaded

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4768,7 +4768,9 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 			  saveState().toBase64().constData());
 
 #ifdef BROWSER_AVAILABLE
-	SaveExtraBrowserDocks();
+	if (cef)
+		SaveExtraBrowserDocks();
+
 	ClearExtraBrowserDocks();
 #endif
 


### PR DESCRIPTION
### Description

OBS only populates the extraBrowserDocks list if `cef` is valid. By saving docks regardless of whether `cef` is valid, this can result in the user's custom docks being cleared unexpectedly.

This ensures the list is only saved if it was loaded in the first place. Consistent with

https://github.com/obsproject/obs-studio/blob/db766273b60a07a9a9b308b98f020e41a0658e56/UI/window-basic-main.cpp#L1954-L1968

### Motivation and Context

Losing configuration is bad. Especially if it's unnecessary.

User reported that after updating, the browser component didn't load, and after running the Integrity Check, the browser component returned but custom browser docks did not. After digging, found the discrepancy in loading vs saving.

### How Has This Been Tested?

Closed and reopened OBS, verified docks were still saved.

### Types of changes

- Bug fix (non-breaking change which fixes an issue) 


### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
