### PR TITLE
UI: Add filters button to scenes toolbar

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -113,6 +113,7 @@ MoveSourceDown="Move Source(s) Down"
 SourceProperties="Open Source Properties"
 SourceFilters="Open Source Filters"
 MixerToolbarMenu="Audio Mixer Menu"
+SceneFilters="Open Scene Filters"
 
 # warning for plugin load failures
 PluginsFailedToLoad.Title="Plugin Load Error"

--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -524,6 +524,10 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/media-pause.svg);
 }
 
+* [themeID="filtersIcon"] {
+    qproperty-icon: url(./Dark/filter.svg);
+}
+
 QToolBarExtension {
     background: palette(button);
     min-width: 12px;

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -328,6 +328,10 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/cogs.svg);
 }
 
+* [themeID="filtersIcon"] {
+    qproperty-icon: url(./Dark/filter.svg);
+}
+
 /* Tab Widget */
 
 QTabWidget::pane { /* The tab widget frame */

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -522,6 +522,10 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/media-pause.svg);
 }
 
+* [themeID="filtersIcon"] {
+    qproperty-icon: url(./Dark/filter.svg);
+}
+
 QToolBarExtension {
     background: palette(button);
     min-width: 12px;

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -522,6 +522,10 @@ QToolButton:pressed {
     qproperty-icon: url(./Light/media-pause.svg);
 }
 
+* [themeID="filtersIcon"] {
+    qproperty-icon: url(./Light/filter.svg);
+}
+
 QToolBarExtension {
     background: palette(button);
     min-width: 12px;

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -530,6 +530,10 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/media-pause.svg);
 }
 
+* [themeID="filtersIcon"] {
+    qproperty-icon: url(./Dark/filter.svg);
+}
+
 QToolBarExtension {
     background: palette(button);
     min-width: 12px;

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -58,6 +58,10 @@ OBSThemeMeta {
     qproperty-icon: url(:/res/images/cogs.svg);
 }
 
+* [themeID="filtersIcon"] {
+    qproperty-icon: url(:/res/images/filter.svg);
+}
+
 MuteCheckBox {
     outline: none;
 }

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -526,6 +526,10 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/media-pause.svg);
 }
 
+* [themeID="filtersIcon"] {
+    qproperty-icon: url(./Dark/filter.svg);
+}
+
 QToolBarExtension {
     background: palette(button);
     min-width: 12px;

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -842,6 +842,8 @@
           <addaction name="actionAddScene"/>
           <addaction name="actionRemoveScene"/>
           <addaction name="separator"/>
+          <addaction name="actionSceneFilters"/>
+          <addaction name="separator"/>
           <addaction name="actionSceneUp"/>
           <addaction name="actionSceneDown"/>
          </widget>
@@ -2346,6 +2348,21 @@
    </property>
    <property name="themeID" stdset="0">
     <string>menuIconSmall</string>
+   </property>
+  </action>
+  <action name="actionSceneFilters">
+   <property name="icon">
+    <iconset resource="obs.qrc">
+     <normaloff>:/res/images/filter.svg</normaloff>:/res/images/filter.svg</iconset>
+   </property>
+   <property name="text">
+    <string>SceneFilters</string>
+   </property>
+   <property name="toolTip">
+    <string>SceneFilters</string>
+   </property>
+   <property name="themeID" stdset="0">
+    <string>filtersIcon</string>
    </property>
   </action>
  </widget>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -10197,6 +10197,14 @@ void OBSBasic::on_sourceFiltersButton_clicked()
 	OpenFilters();
 }
 
+void OBSBasic::on_actionSceneFilters_triggered()
+{
+	OBSSource sceneSource = GetCurrentSceneSource();
+
+	if (sceneSource)
+		OpenFilters(sceneSource);
+}
+
 void OBSBasic::on_sourceInteractButton_clicked()
 {
 	on_actionInteract_triggered();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1031,6 +1031,7 @@ private slots:
 	void on_actionCenterToScreen_triggered();
 	void on_actionVerticalCenter_triggered();
 	void on_actionHorizontalCenter_triggered();
+	void on_actionSceneFilters_triggered();
 
 	void on_OBSBasic_customContextMenuRequested(const QPoint &pos);
 


### PR DESCRIPTION
### Description
Makes it easier to access scene filters.

![Screenshot from 2022-11-12 07-50-30](https://user-images.githubusercontent.com/19962531/201477247-dc33c75b-35c0-47e5-a423-7d808726406e.png)

### Motivation and Context
Make UI better

### How Has This Been Tested?
Clicked on button to open scene filters.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
