### PR TITLE
image-source: Update media states when source is de-/activated

### DIFF
--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -955,8 +955,10 @@ static void ss_activate(void *data)
 	if (ss->behavior == BEHAVIOR_STOP_RESTART) {
 		ss->restart_on_activate = true;
 		ss->use_cut = true;
+		set_media_state(ss, OBS_MEDIA_STATE_PLAYING);
 	} else if (ss->behavior == BEHAVIOR_PAUSE_UNPAUSE) {
 		ss->pause_on_deactivate = false;
+		set_media_state(ss, OBS_MEDIA_STATE_PLAYING);
 	}
 }
 
@@ -964,8 +966,10 @@ static void ss_deactivate(void *data)
 {
 	struct slideshow *ss = data;
 
-	if (ss->behavior == BEHAVIOR_PAUSE_UNPAUSE)
+	if (ss->behavior == BEHAVIOR_PAUSE_UNPAUSE) {
 		ss->pause_on_deactivate = true;
+		set_media_state(ss, OBS_MEDIA_STATE_PAUSED);
+	}
 }
 
 static void missing_file_callback(void *src, const char *new_path, void *data)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

Update the media states of the image slide show when the source is de-/activated.

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Add calls to `set_media_state` in `ss_activate` and `ss_deactivate`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Currently the image slide show media state is not being updated properly in some circumstances:
For example it would continuously remain in `OBS_MEDIA_STATE_ENDED`, even if the slide show was restarted again due to the `behavior` being set to `BEHAVIOR_STOP_RESTART`, if the slide show reached its end at least once.
Similarly, the `OBS_MEDIA_STATE_PAUSED` state was never set in combination with `behavior` being set to `BEHAVIOR_PAUSE_UNPAUSE`.

This was discovered by @Zhaph in https://github.com/WarmUpTill/SceneSwitcher/issues/527 as checking the media state of the image slide show source did not function properly when using the advanced scene switcher plugin.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Was tested by checking the media states of an image slide show source in the advanced scene switcher plugin:
 * The image slide show source is reporting `OBS_MEDIA_STATE_PAUSED` when the source is deactivated with `behavior` being set to `BEHAVIOR_STOP_RESTART`.
 * The image slide show source is reporting `OBS_MEDIA_STATE_PLAYING`, when being restarted by being activated again, after reaching the `OBS_MEDIA_STATE_ENDED` state at least once.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
