### PR TITLE
linux-v4l2: Add additional Extension Unit controls

### DIFF
--- a/plugins/linux-v4l2/CMakeLists.txt
+++ b/plugins/linux-v4l2/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library(OBS::v4l2 ALIAS linux-v4l2)
 
 target_sources(
   linux-v4l2
-  PRIVATE linux-v4l2.c v4l2-controls.c v4l2-decoder.c v4l2-helpers.c v4l2-input.c v4l2-output.c
+  PRIVATE linux-v4l2.c v4l2-controls.c v4l2-decoder.c v4l2-helpers.c v4l2-input.c v4l2-output.c v4l2-uvc-xu-controls.c
 )
 
 target_link_libraries(

--- a/plugins/linux-v4l2/v4l2-helpers.c
+++ b/plugins/linux-v4l2/v4l2-helpers.c
@@ -310,3 +310,15 @@ int_fast32_t v4l2_set_dv_timing(int_fast32_t dev, int *timing)
 
 	return 0;
 }
+
+char *brealpath(const char *link_path)
+{
+	char *tmp_real_path = realpath(link_path, NULL);
+	if (NULL != tmp_real_path) {
+		char *real_path = bstrdup(tmp_real_path);
+		free(tmp_real_path);
+		return real_path;
+	} else {
+		return bstrdup(link_path);
+	}
+}

--- a/plugins/linux-v4l2/v4l2-helpers.h
+++ b/plugins/linux-v4l2/v4l2-helpers.h
@@ -322,6 +322,15 @@ int_fast32_t v4l2_enum_dv_timing(int_fast32_t dev, struct v4l2_dv_timings *dvt, 
  */
 int_fast32_t v4l2_set_dv_timing(int_fast32_t dev, int *timing);
 
+/**
+ * Resolves link_path into real_path or returns link_path if not a link.
+ *
+ * @param link_path path to link
+ *
+ * @return characters allocated using bstrdup. Has to freed with bfree
+ */
+char *brealpath(const char *link_path);
+
 #ifdef __cplusplus
 }
 #endif

--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -68,7 +68,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 struct v4l2_data {
 	/* settings */
-	char *device_id;
+	char *device_id; // /dev/v4l/by-id/usb-046d_Logitech_BRIO_0D26FE7B-video-index0
+	char *real_path; // /dev/video0
 	int input;
 	int pixfmt;
 	int standard;
@@ -93,6 +94,16 @@ struct v4l2_data {
 
 	bool auto_reset;
 	int timeout_frames;
+};
+
+enum v4l2_device_entry_type { DEVICE_BY_ID = 1, DEVICE_BY_PATH, DEVICE_OTHER };
+
+struct v4l2_device_entry {
+	enum v4l2_device_entry_type type;
+	struct dstr label;
+	struct dstr device_id;
+	struct dstr real_path;
+	struct v4l2_device_entry *next;
 };
 
 /* forward declarations */
@@ -328,88 +339,207 @@ static void v4l2_props_set_enabled(obs_properties_t *props, obs_property_t *igno
 }
 
 /*
+ * Get capabilities of device
+ */
+static bool get_device_capabilities(char *dev_name, struct v4l2_capability *video_cap)
+{
+	int fd;
+	uint32_t caps;
+	if ((fd = v4l2_open(dev_name, O_RDWR | O_NONBLOCK)) == -1) {
+		const char *errstr = strerror(errno);
+		blog(LOG_WARNING, "Unable to open %s: %s", dev_name, errstr);
+		return false;
+	}
+
+	if (v4l2_ioctl(fd, VIDIOC_QUERYCAP, video_cap) == -1) {
+		blog(LOG_WARNING, "Failed to query capabilities for %s", dev_name);
+		v4l2_close(fd);
+		return false;
+	}
+	v4l2_close(fd);
+
+#ifndef V4L2_CAP_DEVICE_CAPS
+	caps = video_cap->capabilities;
+#else
+	/* ... since Linux 3.3 */
+	caps = (video_cap->capabilities & V4L2_CAP_DEVICE_CAPS) ? video_cap->device_caps : video_cap->capabilities;
+#endif
+
+	if (!(caps & V4L2_CAP_VIDEO_CAPTURE)) {
+		blog(LOG_WARNING, "%s seems to not support video capture", dev_name);
+		return false;
+	}
+
+	return true;
+}
+
+/*
+ * Build list of video devices available at path
+ */
+static struct v4l2_device_entry *v4l2_device_add_devices_from(struct v4l2_device_entry *first_device,
+							      const char *basedir, enum v4l2_device_entry_type type)
+{
+	struct dirent *dp;
+	struct dstr full_path;
+	const char *scanned_dir;
+	struct dirent **namelist = NULL;
+	int no;
+
+#ifdef __FreeBSD__
+	scanned_dir = basedir;
+#else
+	if (0 == strcmp("/dev/", basedir)) {
+		scanned_dir = "/sys/class/video4linux";
+	} else {
+		scanned_dir = basedir;
+	}
+#endif
+
+	dstr_init(&full_path);
+
+	if ((no = scandir(scanned_dir, &namelist, 0, alphasort)) > 0) {
+		for (int i = 0; i < no; i++) {
+			dp = namelist[i];
+
+			dstr_copy(&full_path, basedir);
+			dstr_cat(&full_path, dp->d_name);
+
+			char *real_path = brealpath(full_path.array);
+#ifdef __FreeBSD__
+			if (strstr(dp->d_name, "video") == NULL)
+				goto next_entry;
+#endif
+
+			if (dp->d_type == DT_DIR)
+				goto next_entry;
+
+			struct v4l2_capability video_cap;
+			if (!get_device_capabilities(full_path.array, &video_cap)) {
+				goto next_entry;
+			}
+
+			if (type == DEVICE_OTHER) {
+				bool device_already_added = false;
+
+				struct v4l2_device_entry *current_device = first_device;
+				while (current_device->next != NULL) {
+					if (strncmp(real_path, current_device->real_path.array, PATH_MAX) == 0) {
+						device_already_added = true;
+						break;
+					}
+					current_device = current_device->next;
+				}
+
+				if (device_already_added) {
+					goto next_entry;
+				}
+			}
+
+			char label[PATH_MAX];
+			if (0 == strcmp("/dev/v4l/by-path/", basedir)) {
+				snprintf(label, PATH_MAX, "Bus: %s (%s)", video_cap.bus_info, dp->d_name);
+			} else {
+				snprintf(label, PATH_MAX, "%s (%s)", video_cap.card, dp->d_name);
+			}
+
+			struct v4l2_device_entry *last_device;
+			if (first_device == NULL) {
+				first_device = bzalloc(sizeof(struct v4l2_device_entry));
+				last_device = first_device;
+			} else {
+				last_device = first_device;
+				while (last_device->next != NULL) {
+					last_device = last_device->next;
+				}
+				last_device->next = bzalloc(sizeof(struct v4l2_device_entry));
+				last_device = last_device->next;
+			}
+
+			last_device->next = NULL;
+			last_device->type = type;
+			dstr_init_copy(&last_device->label, label);
+			dstr_init_copy(&last_device->device_id, full_path.array);
+			dstr_init_copy(&last_device->real_path, real_path);
+
+			blog(LOG_INFO, "Found device '%s' at %s", video_cap.card, full_path.array);
+		next_entry:
+			free(dp);
+			bfree(real_path);
+		}
+	}
+
+	if (NULL != namelist) {
+		free(namelist);
+	}
+	dstr_free(&full_path);
+
+	return first_device;
+}
+
+/*
+ * Build UI for video devices list
+ */
+static void v4l2_build_device_list_ui(obs_property_t *prop, struct v4l2_device_entry *current_device)
+{
+	enum v4l2_device_entry_type last_type = -1;
+	bool list_empty = true;
+
+	while (current_device != NULL) {
+		if (last_type != current_device->type && !list_empty) {
+			if (current_device->type == DEVICE_BY_PATH) {
+				obs_property_list_item_disable(
+					prop,
+					obs_property_list_add_string(prop, "Select device by connection:", "by_path"),
+					true);
+			} else if (current_device->type == DEVICE_OTHER) {
+				obs_property_list_item_disable(
+					prop, obs_property_list_add_string(prop, "Other devices:", "other"), true);
+			}
+		}
+		obs_property_list_add_string(prop, current_device->label.array, current_device->device_id.array);
+
+		dstr_free(&current_device->label);
+		dstr_free(&current_device->device_id);
+		dstr_free(&current_device->real_path);
+		struct v4l2_device_entry *next_device = current_device->next;
+		last_type = current_device->type;
+		bfree(current_device);
+		current_device = next_device;
+		list_empty = false;
+	}
+}
+
+/*
  * List available devices
  */
 static void v4l2_device_list(obs_property_t *prop, obs_data_t *settings)
 {
-	DIR *dirp;
-	struct dirent *dp;
-	struct dstr device;
 	bool cur_device_found;
 	size_t cur_device_index;
 	const char *cur_device_name;
 
+	obs_property_list_clear(prop);
+
+	struct v4l2_device_entry *first_device = NULL;
 #ifdef __FreeBSD__
-	dirp = opendir("/dev");
+	first_device = v4l2_device_add_devices_from(first_device, "/dev/", DEVICE_OTHER);
 #else
-	dirp = opendir("/sys/class/video4linux");
+	first_device = v4l2_device_add_devices_from(first_device, "/dev/v4l/by-id/", DEVICE_BY_ID);
+	first_device = v4l2_device_add_devices_from(first_device, "/dev/v4l/by-path/", DEVICE_BY_PATH);
+	first_device = v4l2_device_add_devices_from(first_device, "/dev/", DEVICE_OTHER);
 #endif
-	if (!dirp)
-		return;
+	v4l2_build_device_list_ui(prop, first_device);
 
 	cur_device_found = false;
 	cur_device_name = obs_data_get_string(settings, "device_id");
 
-	obs_property_list_clear(prop);
-
-	dstr_init_copy(&device, "/dev/");
-
-	while ((dp = readdir(dirp)) != NULL) {
-		int fd;
-		uint32_t caps;
-		struct v4l2_capability video_cap;
-
-#ifdef __FreeBSD__
-		if (strstr(dp->d_name, "video") == NULL)
-			continue;
-#endif
-
-		if (dp->d_type == DT_DIR)
-			continue;
-
-		dstr_resize(&device, 5);
-		dstr_cat(&device, dp->d_name);
-
-		if ((fd = v4l2_open(device.array, O_RDWR | O_NONBLOCK)) == -1) {
-			blog(LOG_INFO, "Unable to open %s", device.array);
-			continue;
-		}
-
-		if (v4l2_ioctl(fd, VIDIOC_QUERYCAP, &video_cap) == -1) {
-			blog(LOG_INFO, "Failed to query capabilities for %s", device.array);
-			v4l2_close(fd);
-			continue;
-		}
-
-#ifndef V4L2_CAP_DEVICE_CAPS
-		caps = video_cap.capabilities;
-#else
-		/* ... since Linux 3.3 */
-		caps = (video_cap.capabilities & V4L2_CAP_DEVICE_CAPS) ? video_cap.device_caps : video_cap.capabilities;
-#endif
-
-		if (!(caps & V4L2_CAP_VIDEO_CAPTURE)) {
-			blog(LOG_INFO, "%s seems to not support video capture", device.array);
-			v4l2_close(fd);
-			continue;
-		}
-
-		/* make sure device names are unique */
-		char unique_device_name[68];
-		int ret = snprintf(unique_device_name, sizeof(unique_device_name), "%s (%s)", video_cap.card,
-				   video_cap.bus_info);
-		if (ret >= (int)sizeof(unique_device_name))
-			blog(LOG_DEBUG, "linux-v4l2: A format truncation may have occurred."
-					" This can be ignored since it is quite improbable.");
-
-		obs_property_list_add_string(prop, unique_device_name, device.array);
-		blog(LOG_INFO, "Found device '%s' at %s", video_cap.card, device.array);
-
-		/* check if this is the currently used device */
-		if (cur_device_name && !strcmp(cur_device_name, device.array))
+	size_t listidx = 0;
+	const char *item_name;
+	while (NULL != (item_name = obs_property_list_item_string(prop, listidx++))) {
+		if (0 == strcmp(item_name, cur_device_name)) {
 			cur_device_found = true;
-
-		v4l2_close(fd);
+			break;
+		}
 	}
 
 	/* add currently selected device if not present, but disable it ... */
@@ -417,9 +547,6 @@ static void v4l2_device_list(obs_property_t *prop, obs_data_t *settings)
 		cur_device_index = obs_property_list_add_string(prop, cur_device_name, cur_device_name);
 		obs_property_list_item_disable(prop, cur_device_index, true);
 	}
-
-	closedir(dirp);
-	dstr_free(&device);
 }
 
 /*
@@ -727,6 +854,60 @@ static bool resolution_selected(obs_properties_t *props, obs_property_t *p, obs_
 
 #if HAVE_UDEV
 /**
+ * Converts /dev/video0 to /dev/v4l/by-id/usb-046d_Logitech_BRIO_0D26FE7B-video-index0
+ *
+ * If not found returns NULL
+ * Use bfree to deallocate
+ */
+static char *find_device_id_by_real_path(const char *device_added_real_path, enum v4l2_device_entry_type type)
+{
+	DIR *dirp;
+	struct dirent *dp;
+	const char *scanned_dir = "/dev/";
+	struct dstr full_path;
+	char *ret_val = NULL;
+
+#ifndef __FreeBSD__
+	switch (type) {
+	case DEVICE_BY_ID:
+		scanned_dir = "/dev/v4l/by-id/";
+		break;
+	case DEVICE_BY_PATH:
+		scanned_dir = "/dev/v4l/by-path/";
+		break;
+	default:
+		break;
+	}
+#endif
+
+	dirp = opendir(scanned_dir);
+	if (!dirp)
+		return ret_val;
+
+	dstr_init(&full_path);
+
+	while ((dp = readdir(dirp)) != NULL) {
+		dstr_copy(&full_path, scanned_dir);
+		dstr_cat(&full_path, dp->d_name);
+
+		char *real_path = brealpath(full_path.array);
+
+		if (0 == strcmp(real_path, device_added_real_path)) {
+			ret_val = bstrdup(full_path.array);
+			bfree(real_path);
+			break;
+		}
+
+		bfree(real_path);
+	}
+
+	dstr_free(&full_path);
+	closedir(dirp);
+
+	return ret_val;
+}
+
+/**
  * Device added callback
  *
  * If everything went fine we can start capturing again when the device is
@@ -738,15 +919,32 @@ static void device_added(void *vptr, calldata_t *calldata)
 
 	obs_source_update_properties(data->source);
 
-	const char *dev;
-	calldata_get_string(calldata, "device", &dev);
+	const char *device_added_real_path;
+	calldata_get_string(calldata, "device", &device_added_real_path);
 
-	if (strcmp(data->device_id, dev))
-		return;
+	enum v4l2_device_entry_type type = DEVICE_OTHER;
+	if (strstr(data->device_id, "/by-id/")) {
+		type = DEVICE_BY_ID;
+	}
+	if (strstr(data->device_id, "/by-path/")) {
+		type = DEVICE_BY_PATH;
+	}
 
-	blog(LOG_INFO, "Device %s reconnected", dev);
+	char *device_added_device_id = find_device_id_by_real_path(device_added_real_path, type);
+
+	if (NULL == device_added_device_id) {
+		goto fail;
+	}
+
+	if (strcmp(device_added_device_id, data->device_id))
+		goto fail;
+
+	blog(LOG_INFO, "Device %s reconnected, is opened as %s", device_added_device_id, data->device_id);
 
 	v4l2_init(data);
+fail:
+	if (NULL != device_added_device_id)
+		bfree(device_added_device_id);
 }
 /**
  * Device removed callback
@@ -762,10 +960,10 @@ static void device_removed(void *vptr, calldata_t *calldata)
 	const char *dev;
 	calldata_get_string(calldata, "device", &dev);
 
-	if (strcmp(data->device_id, dev))
+	if (strcmp(data->real_path, dev))
 		return;
 
-	blog(LOG_INFO, "Device %s disconnected", dev);
+	blog(LOG_INFO, "Device %s disconnected, was opened as %s", dev, data->device_id);
 
 	v4l2_terminate(data);
 }
@@ -860,6 +1058,9 @@ static void v4l2_destroy(void *vptr)
 
 	if (data->device_id)
 		bfree(data->device_id);
+
+	if (data->real_path)
+		bfree(data->real_path);
 
 #if HAVE_UDEV
 	signal_handler_t *sh = v4l2_get_udev_signalhandler();
@@ -1047,6 +1248,9 @@ static void v4l2_update(void *vptr, obs_data_t *settings)
 	if (data->device_id)
 		bfree(data->device_id);
 
+	if (data->real_path)
+		bfree(data->real_path);
+
 	data->device_id = bstrdup(obs_data_get_string(settings, "device_id"));
 	data->input = obs_data_get_int(settings, "input");
 	data->pixfmt = obs_data_get_int(settings, "pixelformat");
@@ -1057,6 +1261,8 @@ static void v4l2_update(void *vptr, obs_data_t *settings)
 	data->color_range = obs_data_get_int(settings, "color_range");
 	data->auto_reset = obs_data_get_bool(settings, "auto_reset");
 	data->timeout_frames = obs_data_get_int(settings, "timeout_frames");
+
+	data->real_path = brealpath(data->device_id);
 
 	v4l2_update_source_flags(data, settings);
 

--- a/plugins/linux-v4l2/v4l2-uvc-xu-brio.h
+++ b/plugins/linux-v4l2/v4l2-uvc-xu-brio.h
@@ -1,0 +1,59 @@
+/*
+Copyright (C) 2022 by Grzegorz Godlewski
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "v4l2-uvc-xu-controls.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LOGITECH_BRIO_VENDOR_PRODUCT "046d:085e"
+#define LOGITECH_BRIO_GUID \
+	"\x15\x02\xe4\x49\x34\xf4\xfe\x47\xb1\x58\x0e\x88\x50\x23\xe5\x1b"
+
+#define LOGITECH_BRIO_FOV_SEL 0x05
+
+struct uvc_xu_control_query BRIO_QUERIES_FOV_65[] = {
+	{.selector = LOGITECH_BRIO_FOV_SEL, .query = UVC_SET_CUR, .size = 1, .data = (unsigned char *)"\x02"}};
+
+struct uvc_xu_control_query BRIO_QUERIES_FOV_78[] = {
+	{.selector = LOGITECH_BRIO_FOV_SEL, .query = UVC_SET_CUR, .size = 1, .data = (unsigned char *)"\x01"}};
+
+struct uvc_xu_control_query BRIO_QUERIES_FOV_90[] = {
+	{.selector = LOGITECH_BRIO_FOV_SEL, .query = UVC_SET_CUR, .size = 1, .data = (unsigned char *)"\x00"}};
+
+struct menu_item_pos BRIO_MENU_POSITIONS[] = {
+	{.label = "65",
+	 .queries_cnt = sizeof(BRIO_QUERIES_FOV_65) / sizeof(struct uvc_xu_control_query),
+	 .queries = BRIO_QUERIES_FOV_65},
+	{.label = "78",
+	 .queries_cnt = sizeof(BRIO_QUERIES_FOV_78) / sizeof(struct uvc_xu_control_query),
+	 .queries = BRIO_QUERIES_FOV_78},
+	{.label = "90",
+	 .queries_cnt = sizeof(BRIO_QUERIES_FOV_90) / sizeof(struct uvc_xu_control_query),
+	 .queries = BRIO_QUERIES_FOV_90}};
+
+struct menu_item BRIO_MENU[] = {{.id = "brio_fov",
+				 .label = "FOV",
+				 .positions_cnt = sizeof(BRIO_MENU_POSITIONS) / sizeof(struct menu_item_pos),
+				 .positions = BRIO_MENU_POSITIONS}};
+
+#ifdef __cplusplus
+}
+#endif

--- a/plugins/linux-v4l2/v4l2-uvc-xu-controls.c
+++ b/plugins/linux-v4l2/v4l2-uvc-xu-controls.c
@@ -1,0 +1,196 @@
+/*
+Copyright (C) 2022 by Grzegorz Godlewski
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <linux/uvcvideo.h>
+#include <linux/usb/video.h>
+#include <errno.h>
+#include <string.h>
+
+#include "v4l2-uvc-xu-controls.h"
+#include "v4l2-uvc-xu-brio.h"
+#include "v4l2-uvc-xu-kiyo.h"
+
+/**
+ * Checks if device matches matches specific product.
+ *
+ * @param device_path path to device within /dev directory
+ * @param vendor_product_to_compare vendor and product string in "XXXX:YYYY" format
+ *
+ * @return true if device matches vendor and product string
+ */
+bool v4l2_compare_vendor_product(const char *device_path, const char *vendor_product_to_compare)
+{
+	char vendor_path[PATH_MAX];
+	char product_path[PATH_MAX];
+	char vendor_product[10];
+	const char *device_name;
+	FILE *fp;
+	int len;
+
+	if (device_path != strstr(device_path, "/dev/")) {
+		return false;
+	}
+	device_name = device_path + 5;
+
+	snprintf(vendor_path, PATH_MAX, "/sys/class/video4linux/%s/../../../idVendor", device_name);
+	snprintf(product_path, PATH_MAX, "/sys/class/video4linux/%s/../../../idProduct", device_name);
+
+	if (access(vendor_path, F_OK) == 0 && access(product_path, F_OK) == 0) {
+		fp = fopen(vendor_path, "r");
+		len = fscanf(fp, "%4s", vendor_product);
+		fclose(fp);
+
+		fp = fopen(product_path, "r");
+		len = fscanf(fp, "%4s", vendor_product + 5);
+		fclose(fp);
+
+		vendor_product[4] = ':';
+		vendor_product[9] = 0;
+		return vendor_product == strstr(vendor_product, vendor_product_to_compare);
+	}
+
+	return false;
+}
+
+/**
+ * Find unit id for device GUID
+ *
+ * @param device_path path to device within /dev directory
+ * @param guid GUID in binary format
+ *
+ * Descriptors file contains the descriptors in a binary format
+ * the byte before the extension guid is the extension unit id
+ *
+ * @return true if device matches vendor and product string
+ */
+int v4l2_find_unit_id_in_sysfs(const char *device_path, char *guid)
+{
+	char descriptors_path[PATH_MAX];
+
+	const char *device_name;
+	FILE *fp;
+
+	if (device_path != strstr(device_path, "/dev/")) {
+		return -1;
+	}
+	device_name = device_path + 5;
+
+	snprintf(descriptors_path, PATH_MAX, "/sys/class/video4linux/%s/../../../descriptors", device_name);
+
+	char buf[0x10000];
+	if (access(descriptors_path, F_OK) == 0 && access(descriptors_path, F_OK) == 0) {
+		fp = fopen(descriptors_path, "r");
+		int res = fread(buf, 1, sizeof(buf), fp);
+		fclose(fp);
+
+		if (res <= 0) {
+			return -1;
+		}
+
+		char *pos;
+		for (pos = buf; pos < buf + sizeof(buf) - 16; pos++) {
+			if (0 == memcmp(pos, guid, 16)) {
+				pos--;
+				return *pos;
+			}
+		}
+	}
+
+	return -1;
+}
+
+static bool v4l2_xu_control_changed(void *data, obs_properties_t *props, obs_property_t *prop, obs_data_t *settings)
+{
+	(void)prop;
+	(void)props;
+
+	int dev = v4l2_open(obs_data_get_string(settings, "device_id"), O_RDWR | O_NONBLOCK);
+
+	if (dev == -1)
+		return false;
+
+	struct menu_item *menu = data;
+	char pos = obs_data_get_int(settings, menu->id);
+	struct menu_item_pos *position = &menu->positions[pos];
+
+	bool ret = false;
+
+	for (int query_no = 0; query_no < position->queries_cnt; query_no++) {
+		struct uvc_xu_control_query *xu_query = &position->queries[query_no];
+		if (ioctl(dev, UVCIOC_CTRL_QUERY, xu_query) < 0) {
+			const char *errstr = strerror(errno);
+			blog(LOG_ERROR, "Error changing XU setting: %s", errstr);
+		}
+	}
+
+	v4l2_close(dev);
+	return ret;
+}
+
+int_fast32_t v4l2_xu_update_controls(char unit_id, struct menu_item *menu, size_t menu_cnt, obs_properties_t *props)
+{
+	obs_property_t *prop;
+
+	for (size_t menu_pos = 0; menu_pos < menu_cnt; menu_pos++) {
+		struct menu_item *menu_item = &menu[menu_pos];
+		prop = obs_properties_add_list(props, menu_item->id, menu_item->label, OBS_COMBO_TYPE_LIST,
+					       OBS_COMBO_FORMAT_INT);
+
+		for (int item_pos = 0; item_pos < menu_item->positions_cnt; item_pos++) {
+			struct menu_item_pos *menu_item_pos = &menu_item->positions[item_pos];
+			obs_property_list_add_int(prop, menu_item_pos->label, item_pos);
+			for (int query_pos = 0; query_pos < menu_item_pos->queries_cnt; query_pos++) {
+				struct uvc_xu_control_query *query = &menu_item_pos->queries[query_pos];
+				query->unit = unit_id;
+			}
+		}
+
+		obs_property_set_modified_callback2(prop, v4l2_xu_control_changed, menu_item);
+	}
+
+	return 0;
+}
+
+int_fast32_t v4l2_update_uvc_xu_controls(const char *device_path, obs_properties_t *props)
+{
+	int unit_id;
+	if (!props)
+		return -1;
+
+	if (v4l2_compare_vendor_product(device_path, LOGITECH_BRIO_VENDOR_PRODUCT)) {
+		unit_id = v4l2_find_unit_id_in_sysfs(device_path, LOGITECH_BRIO_GUID);
+		if (-1 == unit_id) {
+			blog(LOG_WARNING, "Error getting unit_id for device: %s", device_path);
+			return -1;
+		}
+		return v4l2_xu_update_controls(unit_id, BRIO_MENU, sizeof(BRIO_MENU) / sizeof(struct menu_item), props);
+	}
+
+	if (v4l2_compare_vendor_product(device_path, KIYO_PRO_VENDOR_PRODUCT)) {
+		unit_id = v4l2_find_unit_id_in_sysfs(device_path, KIYO_PRO_GUID);
+		if (-1 == unit_id) {
+			blog(LOG_WARNING, "Error getting unit_id for device: %s", device_path);
+			return -1;
+		}
+		return v4l2_xu_update_controls(unit_id, KIYO_PRO_MENU, sizeof(KIYO_PRO_MENU) / sizeof(struct menu_item),
+					       props);
+	}
+
+	return 0;
+}

--- a/plugins/linux-v4l2/v4l2-uvc-xu-controls.h
+++ b/plugins/linux-v4l2/v4l2-uvc-xu-controls.h
@@ -1,0 +1,56 @@
+/*
+Copyright (C) 2022 by Grzegorz Godlewski
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <linux/videodev2.h>
+#include <libv4l2.h>
+
+#include <obs-module.h>
+#include <media-io/video-io.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct menu_item_pos {
+	const char *label;
+	int queries_cnt;
+	struct uvc_xu_control_query *queries;
+};
+
+struct menu_item {
+	const char *id;
+	const char *label;
+	int positions_cnt;
+	struct menu_item_pos *positions;
+};
+
+/**
+ * Update devices properties to include Extension Unit controls.
+ *
+ * @param device_path path device within /dev
+ * @param props properties for the device
+ * @param settings the settings for the source
+ *
+ * @return negative on failure
+ */
+int_fast32_t v4l2_update_uvc_xu_controls(const char *device_path, obs_properties_t *props);
+
+#ifdef __cplusplus
+}
+#endif

--- a/plugins/linux-v4l2/v4l2-uvc-xu-kiyo.h
+++ b/plugins/linux-v4l2/v4l2-uvc-xu-kiyo.h
@@ -1,0 +1,138 @@
+/*
+Copyright (C) 2022 by Grzegorz Godlewski
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "v4l2-uvc-xu-controls.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define KIYO_PRO_VENDOR_PRODUCT "1532:0e05"
+#define KIYO_PRO_GUID \
+	"\xd0\x9e\xe4\x23\x78\x11\x31\x4f\xae\x52\xd2\xfb\x8a\x8d\x3b\x48"
+
+#define EU1_SET_ISP 0x01
+
+struct uvc_xu_control_query KIYO_QUERIES_FOV_NARROW[] = {{.selector = EU1_SET_ISP,
+							  .query = UVC_SET_CUR,
+							  .size = 8,
+							  .data = (unsigned char *)"\xff\x01\x00\x03\x01\x00\x00\x00"},
+							 {.selector = EU1_SET_ISP,
+							  .query = UVC_SET_CUR,
+							  .size = 8,
+							  .data = (unsigned char *)"\xff\x01\x01\x03\x01\x00\x00\x00"}};
+
+struct uvc_xu_control_query KIYO_QUERIES_FOV_MEDIUM[] = {{.selector = EU1_SET_ISP,
+							  .query = UVC_SET_CUR,
+							  .size = 8,
+							  .data = (unsigned char *)"\xff\x01\x00\x03\x02\x00\x00\x00"},
+							 {.selector = EU1_SET_ISP,
+							  .query = UVC_SET_CUR,
+							  .size = 8,
+							  .data = (unsigned char *)"\xff\x01\x01\x03\x02\x00\x00\x00"}};
+
+struct uvc_xu_control_query KIYO_QUERIES_FOV_WIDE[] = {{.selector = EU1_SET_ISP,
+							.query = UVC_SET_CUR,
+							.size = 8,
+							.data = (unsigned char *)"\xff\x01\x00\x03\x00\x00\x00\x00"}};
+
+struct menu_item_pos KIYO_PRO_MENU_FOV[] = {
+	{.label = "Narrow",
+	 .queries_cnt = sizeof(KIYO_QUERIES_FOV_NARROW) / sizeof(struct uvc_xu_control_query),
+	 .queries = KIYO_QUERIES_FOV_NARROW},
+	{.label = "Medium",
+	 .queries_cnt = sizeof(KIYO_QUERIES_FOV_MEDIUM) / sizeof(struct uvc_xu_control_query),
+	 .queries = KIYO_QUERIES_FOV_MEDIUM},
+	{.label = "Wide",
+	 .queries_cnt = sizeof(KIYO_QUERIES_FOV_WIDE) / sizeof(struct uvc_xu_control_query),
+	 .queries = KIYO_QUERIES_FOV_WIDE}};
+
+struct uvc_xu_control_query KIYO_QUERIES_AF_RESPONSIVE[] = {
+	{.selector = EU1_SET_ISP,
+	 .query = UVC_SET_CUR,
+	 .size = 8,
+	 .data = (unsigned char *)"\xff\x06\x00\x00\x00\x00\x00\x00"}};
+
+struct uvc_xu_control_query KIYO_QUERIES_AF_PASSIVE[] = {{.selector = EU1_SET_ISP,
+							  .query = UVC_SET_CUR,
+							  .size = 8,
+							  .data = (unsigned char *)"\xff\x06\x01\x00\x00\x00\x00\x00"}};
+
+struct menu_item_pos KIYO_PRO_MENU_AF[] = {
+	{.label = "Responsive",
+	 .queries_cnt = sizeof(KIYO_QUERIES_AF_RESPONSIVE) / sizeof(struct uvc_xu_control_query),
+	 .queries = KIYO_QUERIES_AF_RESPONSIVE},
+	{.label = "Passive",
+	 .queries_cnt = sizeof(KIYO_QUERIES_AF_PASSIVE) / sizeof(struct uvc_xu_control_query),
+	 .queries = KIYO_QUERIES_AF_PASSIVE}};
+
+struct uvc_xu_control_query KIYO_QUERIES_HDR_OFF[] = {{.selector = EU1_SET_ISP,
+						       .query = UVC_SET_CUR,
+						       .size = 8,
+						       .data = (unsigned char *)"\xff\x02\x00\x00\x00\x00\x00\x00"}};
+
+struct uvc_xu_control_query KIYO_QUERIES_HDR_ON[] = {{.selector = EU1_SET_ISP,
+						      .query = UVC_SET_CUR,
+						      .size = 8,
+						      .data = (unsigned char *)"\xff\x02\x01\x00\x00\x00\x00\x00"}};
+
+struct uvc_xu_control_query KIYO_QUERIES_HDR_DARK[] = {{.selector = EU1_SET_ISP,
+							.query = UVC_SET_CUR,
+							.size = 8,
+							.data = (unsigned char *)"\xff\x07\x00\x00\x00\x00\x00\x00"}};
+
+struct uvc_xu_control_query KIYO_QUERIES_HDR_BRIGHT[] = {
+	{.selector = EU1_SET_ISP, .query = UVC_SET_CUR, .size = 8, .data = (__u8 *)"\xff\x07\x01\x00\x00\x00\x00\x00"}};
+
+struct menu_item_pos KIYO_PRO_MENU_HDR[] = {
+	{.label = "On",
+	 .queries_cnt = sizeof(KIYO_QUERIES_HDR_ON) / sizeof(struct uvc_xu_control_query),
+	 .queries = KIYO_QUERIES_HDR_ON},
+	{.label = "Off",
+	 .queries_cnt = sizeof(KIYO_QUERIES_HDR_OFF) / sizeof(struct uvc_xu_control_query),
+	 .queries = KIYO_QUERIES_HDR_OFF}};
+
+struct menu_item_pos KIYO_PRO_MENU_HDR_MODE[] = {
+	{.label = "Bright",
+	 .queries_cnt = sizeof(KIYO_QUERIES_HDR_BRIGHT) / sizeof(struct uvc_xu_control_query),
+	 .queries = KIYO_QUERIES_HDR_BRIGHT},
+	{.label = "Dark",
+	 .queries_cnt = sizeof(KIYO_QUERIES_HDR_DARK) / sizeof(struct uvc_xu_control_query),
+	 .queries = KIYO_QUERIES_HDR_DARK}};
+
+struct menu_item KIYO_PRO_MENU[] = {{.id = "kiyo_af",
+				     .label = "AF Mode",
+				     .positions_cnt = sizeof(KIYO_PRO_MENU_AF) / sizeof(struct menu_item_pos),
+				     .positions = KIYO_PRO_MENU_AF},
+				    {.id = "kiyo_hdr",
+				     .label = "HDR",
+				     .positions_cnt = sizeof(KIYO_PRO_MENU_HDR) / sizeof(struct menu_item_pos),
+				     .positions = KIYO_PRO_MENU_HDR},
+				    {.id = "kiyo_hdr_mode",
+				     .label = "HDR Mode",
+				     .positions_cnt = sizeof(KIYO_PRO_MENU_HDR_MODE) / sizeof(struct menu_item_pos),
+				     .positions = KIYO_PRO_MENU_HDR_MODE},
+				    {.id = "kiyo_fov",
+				     .label = "FOV",
+				     .positions_cnt = sizeof(KIYO_PRO_MENU_FOV) / sizeof(struct menu_item_pos),
+				     .positions = KIYO_PRO_MENU_FOV}};
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
### Description

It allows controlling Logitech BRIO and Kiyo Pro FOV and other settings

https://www.kernel.org/doc/html/v4.10/media/v4l-drivers/uvcvideo.html#extension-unit-xu-support

### Motivation and Context

Normal V4L2 controls do not allow to change FOV and HDR settings for Logitech Brio and Kiyo Pro.

### How Has This Been Tested?

Tested with Logitech BRIO. FOV change works.

Looking for tester who owns Kiyo Pro. 
The constants were copied from https://github.com/soyersoyer/cameractrls so in theory it should work.

Looking for someone with FreeBSD to test. Maybe it should be turned off for this OS?

### Types of changes

New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
