### PR TITLE
UI: Use valueChanged() signal for T-Bar everywhere

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -793,9 +793,7 @@ void OBSBasic::CreateProgramOptions()
 
 	tBar->setProperty("themeID", "tBarSlider");
 
-	connect(tBar, SIGNAL(sliderMoved(int)), this, SLOT(TBarChanged(int)));
-	connect(tBar, SIGNAL(valueChanged(int)), this,
-		SLOT(on_tbar_position_valueChanged(int)));
+	connect(tBar, &QSlider::valueChanged, this, &OBSBasic::TBarChanged);
 	connect(tBar, SIGNAL(sliderReleased()), this, SLOT(TBarReleased()));
 
 	layout->addStretch(0);
@@ -918,8 +916,6 @@ void OBSBasic::TBarChanged(int value)
 {
 	OBSSourceAutoRelease transition = obs_get_output_source(0);
 
-	tBar->setValue(value);
-
 	if (!tBarActive) {
 		OBSSource sceneSource = GetCurrentSceneSource();
 		OBSSource tBarTr = GetOverrideTransition(sceneSource);
@@ -945,6 +941,9 @@ void OBSBasic::TBarChanged(int value)
 
 	obs_transition_set_manual_time(transition,
 				       (float)value / T_BAR_PRECISION_F);
+
+	if (api)
+		api->on_event(OBS_FRONTEND_EVENT_TBAR_VALUE_CHANGED);
 }
 
 int OBSBasic::GetTbarPosition()
@@ -952,14 +951,6 @@ int OBSBasic::GetTbarPosition()
 	return tBar->value();
 }
 
-void OBSBasic::on_tbar_position_valueChanged(int value)
-{
-	if (api) {
-		api->on_event(OBS_FRONTEND_EVENT_TBAR_VALUE_CHANGED);
-	}
-
-	UNUSED_PARAMETER(value);
-}
 void OBSBasic::on_modeSwitch_clicked()
 {
 	SetPreviewProgramMode(!IsPreviewProgramMode());

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1117,7 +1117,6 @@ private slots:
 	void on_transitionRemove_clicked();
 	void on_transitionProps_clicked();
 	void on_transitionDuration_valueChanged(int value);
-	void on_tbar_position_valueChanged(int value);
 
 	void ShowTransitionProperties();
 	void HideTransitionProperties();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The `sliderMoved` signal doesn't trigger when clicking on the slider, only the `valueChanged` signal. According to QTBUG-72995 this is intentional, since the documentation states that `sliderDown` also needs to be true for the sliderMoved signal to be triggered. As for why `sliderDown` isn't true when clicking, or why that would even be necessary for a signal that should trigger when the slider is moved (and it very clearly moves) remains a mystery.

Also gets rid of the wrong usage of the `on_foo_bar` slot declaration, which should only be used for signals where the sender is part of a UI file and it gets connected automatically. While it of course is possible to connect it manually, this is against convention and can cause confusion. In this case it was particularly wrong since even if tBar was part of a UI file (which it isn't), the method should have been called `on_tBar_valueChanged` instead of `on_tbar_position_valueChanged`.

Note: The diff on this might look a bit confusing. I kept the old `TBarChanged` method but connected it to the `valueChanged` signal, and then moved the code that used to be connected to the valueChanged into that same `TBarChanged` method.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed that when clicking on the tBar instead of dragging, the slider position would change but the transition wouldn't start / continue. On Windows, this is most notable when middle-clicking (since left-click only jumps a small ), a PR to change this will come in the future.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Clicking on the tBar now triggers the transition, which is at least less incorrect than moving the slider but not doing anything.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
