### PR TITLE
UI: Fix hotkey settings screen not accepting all input on macOS

### DIFF
--- a/UI/hotkey-edit.cpp
+++ b/UI/hotkey-edit.cpp
@@ -59,6 +59,15 @@ void OBSHotkeyEdit::keyPressEvent(QKeyEvent *event)
 	HandleNewKey(new_key);
 }
 
+QVariant OBSHotkeyEdit::inputMethodQuery(Qt::InputMethodQuery query) const
+{
+	if (query == Qt::ImEnabled) {
+		return false;
+	} else {
+		return QLineEdit::inputMethodQuery(query);
+	}
+}
+
 #ifdef __APPLE__
 void OBSHotkeyEdit::keyReleaseEvent(QKeyEvent *event)
 {

--- a/UI/hotkey-edit.hpp
+++ b/UI/hotkey-edit.hpp
@@ -98,6 +98,7 @@ public:
 
 	void UpdateDuplicationState();
 	bool hasDuplicate = false;
+	QVariant inputMethodQuery(Qt::InputMethodQuery) const override;
 
 protected:
 	OBSSignal layoutChanged;


### PR DESCRIPTION
### Description
Re-enables full availability of hotkeys on macOS in OBS 28.

### Motivation and Context
By default Qt will hand off key events to platform-native input methods on macOS because the OS or additional software can intercept key input and transform it (e.g. the international variations popping up when holding down the key for certain letters).

This functionality can lead to certain key combinations being ignored because they don't call the delegate methods implemented by Qt to handle the input after it's been interpreted by the Input Method.

Disabling Input Methods for hotkey input fields fixes this issue, as the native input methods are bypassed entirely and the key events are handled by the widget and its keyboard events directly.

Fixes https://github.com/obsproject/obs-studio/issues/7259.

### How Has This Been Tested?
* Tested on macOS 12.5
* Tested on Windows 11
* Tested on Ubuntu 22

For testing several different combinations of keys and modifiers were used to bind hotkeys in the settings window.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
