### PR TITLE
deps: Fix broken prefix for obspython binary module on Linux

### DIFF
--- a/deps/obs-scripting/obspython/CMakeLists.txt
+++ b/deps/obs-scripting/obspython/CMakeLists.txt
@@ -101,8 +101,6 @@ elseif(OS_POSIX)
 
   target_compile_options(obspython PRIVATE -Wno-unused-parameter)
 
-  set_target_properties(obspython PROPERTIES PREFIX "")
-
 endif()
 
 set_target_properties(


### PR DESCRIPTION
### Description
Ensures that the binary module for `obspython` uses the correct prefixed name.

### Motivation and Context
The correct names for the `obspython` module require the Python loader module to be called `obspython.py` and the binary module to be called `_obspython.so` to ensure that the binary module is loaded by the Python wrapper.

Fixes https://github.com/obsproject/obs-studio/issues/7331.

### How Has This Been Tested?
* Tested on Ubuntu 22

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
