### PR TITLE
cmake: Fix CMake package files not being installed on FreeBSD

### DIFF
--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -238,7 +238,7 @@ endfunction()
 function(export_target target)
   set(CMAKE_EXPORT_PACKAGE_REGISTRY OFF)
 
-  if(OS_LINUX)
+  if(OS_LINUX OR OS_FREEBSD)
     set(_EXCLUDE "")
   else()
     set(_EXCLUDE "EXCLUDE_FROM_ALL")


### PR DESCRIPTION
### Description
By default libraries and their CMake package files should be installed on Linux and FreeBSD and omitted on Windows. This explicitly adds FreeBSD.

### Motivation and Context
Ensure that libraries, CMake packages, pkg-config, as well as header files are installed by default on FreeBSD as well as on Linux.

Fixes https://github.com/obsproject/obs-studio/issues/7289.

### How Has This Been Tested?
Tested on FreeBSD 13.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
