### PR TITLE
linux-capture: Ensure name pixmap is checked

### DIFF
--- a/plugins/linux-capture/xcomposite-input.c
+++ b/plugins/linux-capture/xcomposite-input.c
@@ -423,7 +423,8 @@ void xcomp_create_pixmap(xcb_connection_t *conn, struct xcompcap *s,
 
 	s->pixmap = xcb_generate_id(conn);
 	xcb_void_cookie_t name_cookie =
-		xcb_composite_name_window_pixmap(conn, s->win, s->pixmap);
+		xcb_composite_name_window_pixmap_checked(conn, s->win,
+							 s->pixmap);
 	err = NULL;
 	if ((err = xcb_request_check(conn, name_cookie)) != NULL) {
 		blog(log_level, "xcb_composite_name_window_pixmap failed");


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The void cookie will never return an error unless we use the explicitly checked version of this function.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Avoids getting annoying x11 errors later in the EGL calls.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with some unnamable pixmaps and it works as intended.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
