### PR TITLE
Fix resource leak v4l2 output

### DIFF
--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -75,8 +75,7 @@ static bool loopback_module_loaded()
 		}
 	}
 
-	if (fp)
-		fclose(fp);
+	fclose(fp);
 
 	return loaded;
 }


### PR DESCRIPTION
### Description

Fix resource leak occurring on error path in Linux v4l2-output.

### Motivation and Context

Resource leaks generally are to be avoided.

### How Has This Been Tested?

Manual code review.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
