### PR TITLE
cmake: Fix rundir installation accepting DESTDIR environment variable

### DIFF
--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -57,9 +57,9 @@ function(setup_binary_target target)
     TARGET ${target}
     POST_BUILD
     COMMAND
-      "${CMAKE_COMMAND}" --install .. --config $<CONFIG> --prefix
-      ${OBS_OUTPUT_DIR}/$<CONFIG> --component obs_${target} >
-      "$<IF:$<PLATFORM_ID:Windows>,nul,/dev/null>"
+      "${CMAKE_COMMAND}" -E env DESTDIR= "${CMAKE_COMMAND}" --install ..
+      --config $<CONFIG> --prefix ${OBS_OUTPUT_DIR}/$<CONFIG> --component
+      obs_${target} > "$<IF:$<PLATFORM_ID:Windows>,nul,/dev/null>"
     COMMENT "Installing OBS rundir"
     VERBATIM)
 
@@ -91,9 +91,9 @@ function(setup_plugin_target target)
     TARGET ${target}
     POST_BUILD
     COMMAND
-      "${CMAKE_COMMAND}" --install .. --config $<CONFIG> --prefix
-      ${OBS_OUTPUT_DIR}/$<CONFIG> --component obs_${target} >
-      "$<IF:$<PLATFORM_ID:Windows>,nul,/dev/null>"
+      "${CMAKE_COMMAND}" -E env DESTDIR= "${CMAKE_COMMAND}" --install ..
+      --config $<CONFIG> --prefix ${OBS_OUTPUT_DIR}/$<CONFIG> --component
+      obs_${target} > "$<IF:$<PLATFORM_ID:Windows>,nul,/dev/null>"
     COMMENT "Installing ${target} to OBS rundir"
     VERBATIM)
 
@@ -131,9 +131,9 @@ function(setup_script_plugin_target target)
     TARGET ${target}
     POST_BUILD
     COMMAND
-      "${CMAKE_COMMAND}" --install .. --config $<CONFIG> --prefix
-      ${OBS_OUTPUT_DIR}/$<CONFIG> --component obs_${target} >
-      "$<IF:$<PLATFORM_ID:Windows>,nul,/dev/null>"
+      "${CMAKE_COMMAND}" -E env DESTDIR= "${CMAKE_COMMAND}" --install ..
+      --config $<CONFIG> --prefix ${OBS_OUTPUT_DIR}/$<CONFIG> --component
+      obs_${target} > "$<IF:$<PLATFORM_ID:Windows>,nul,/dev/null>"
     COMMENT "Installing ${target} to OBS rundir"
     VERBATIM)
 
@@ -201,9 +201,9 @@ function(setup_obs_app target)
     TARGET ${target}
     POST_BUILD
     COMMAND
-      "${CMAKE_COMMAND}" --install .. --config $<CONFIG> --prefix
-      ${OBS_OUTPUT_DIR}/$<CONFIG> --component obs_rundir >
-      "$<IF:$<PLATFORM_ID:Windows>,nul,/dev/null>"
+      "${CMAKE_COMMAND}" -E env DESTDIR= "${CMAKE_COMMAND}" --install ..
+      --config $<CONFIG> --prefix ${OBS_OUTPUT_DIR}/$<CONFIG> --component
+      obs_rundir > "$<IF:$<PLATFORM_ID:Windows>,nul,/dev/null>"
     COMMENT "Installing OBS rundir"
     VERBATIM)
 endfunction()
@@ -540,9 +540,9 @@ function(_install_obs_datatarget target destination)
     TARGET ${target}
     POST_BUILD
     COMMAND
-      "${CMAKE_COMMAND}" --install .. --config $<CONFIG> --prefix
-      ${OBS_OUTPUT_DIR}/$<CONFIG> --component obs_${target} >
-      "$<IF:$<PLATFORM_ID:Windows>,nul,/dev/null>"
+      "${CMAKE_COMMAND}" -E env DESTDIR= "${CMAKE_COMMAND}" --install ..
+      --config $<CONFIG> --prefix ${OBS_OUTPUT_DIR}/$<CONFIG> --component
+      obs_${target} > "$<IF:$<PLATFORM_ID:Windows>,nul,/dev/null>"
     COMMENT "Installing ${target} to OBS rundir"
     VERBATIM)
 endfunction()


### PR DESCRIPTION
### Description
The environment variable DESTDIR is commonly used to specify an install- time prefix for installation of build artifacts (e.g. for staging an installation in a temporary directory while keeping the overall prefixes intact).

This variable should be ignored by all targets but the install target, which requires us to set it to an empty string/path when we use `install` to set up our rundir.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/7265.

### How Has This Been Tested?
Tested on Windows 11 and Ubuntu 22 (set a `DESTDIR` environment variable and observed only the `install` command installing files into the directory).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
