### PR TITLE
UI: Ignore left-click on non-multiview projectors

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -274,12 +274,14 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 
 		popup.addAction(QTStr("Close"), this, SLOT(EscapeTriggered()));
 		popup.exec(QCursor::pos());
-	}
+	} else if (event->button() == Qt::LeftButton) {
+		// Only MultiView projectors handle left click
+		if (this->type != ProjectorType::Multiview)
+			return;
 
-	if (!mouseSwitching)
-		return;
+		if (!mouseSwitching)
+			return;
 
-	if (event->button() == Qt::LeftButton) {
 		QPoint pos = event->pos();
 		OBSSource src =
 			multiview->GetSourceByPosition(pos.x(), pos.y());


### PR DESCRIPTION
### Description
Fixes a crash that could occur after having a multiview opened and clicking a non-multiview projector.

https://obsproject.com/forum/threads/double-clicking-on-obs-projector-scene-causes-crash.159557/

### Motivation and Context
Crashes are bad.

### How Has This Been Tested?
Reproduced crash and verified it was fixed.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
