### PR TITLE
UI: Fix source name edit textbox not accepting input on enter

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -1555,8 +1555,12 @@ bool SourceTree::Edit(int row)
 	QModelIndex index = stm->createIndex(row, 0);
 	QWidget *widget = indexWidget(index);
 	SourceTreeItem *itemWidget = reinterpret_cast<SourceTreeItem *>(widget);
-	if (itemWidget->IsEditing())
+	if (itemWidget->IsEditing()) {
+#ifdef __APPLE__
+		itemWidget->ExitEditMode(true);
+#endif
 		return false;
+	}
 
 	itemWidget->EnterEditMode();
 	edit(index);


### PR DESCRIPTION
### Description
The Enter key is connected to the `Edit` function and is handled by Qt with the highest priority in its key event handler. Alas the boolean return value is not propagated to the shortcut handling system, so the key event will always be consumed and as such the user will be stuck in editing state.

To fix this, `Edit` needs to behave like a toggle, saving the current state of the input at a repeat press of Enter while in editing state.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/7240

### How Has This Been Tested?
Tested on macOS, also tested that functionality is not impacted on Windows 11 and Ubuntu 22.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
