### PR TITLE
Re-enable Virtual Camera Source Selection with Scene Transform

### DIFF
--- a/UI/forms/OBSBasicVCamConfig.ui
+++ b/UI/forms/OBSBasicVCamConfig.ui
@@ -33,6 +33,11 @@
        <string>Basic.Scene</string>
       </property>
      </item>
+     <item>
+      <property name="text">
+       <string>Basic.Main.Source</string>
+      </property>
+     </item>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
### Description
This re-enables the individual source selection option in the virtual camera config window. In order to address the previously identified sizing issue, it now creates a private scene to add the source to and applies a transform the fit the source to the canvas size. Essentially it transparently automates the steps under [Show a single source in the virtual camera](https://obsproject.com/kb/virtual-camera-guide) help article.

### Motivation and Context
This feature was pulled right before OBS 28's release due to the sizing issue. This PR fixes that issue and re-enables the individual source selection option.

### How Has This Been Tested?
Testes primary with a webcam source by re-importing the vcam into OBS and then selecting different custom resolutions for the webcam. In all cases the webcam was resized and centered within the vcam's output. Also tested quickly with several other source types and checked for memory leaks with and without the vcam running at shutdown.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
