### PR TITLE
libobs-opengl: Disable deprecation warnings on macOS

### DIFF
--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -16,6 +16,7 @@
 ******************************************************************************/
 
 #include "gl-subsystem.h"
+#define GL_SILENCE_DEPRECATION
 #include <OpenGL/OpenGL.h>
 
 #import <Cocoa/Cocoa.h>


### PR DESCRIPTION
### Description
We are aware of OpenGL having been deprecated on macOS since Mac OS X 10.14, so silence the deprecation warnings the "official" way.

### Motivation and Context
Remove unnecessary warnings from build output or Xcode project reports.

### How Has This Been Tested?
Tested with macOS 12.6.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
