### PR TITLE
UI: Disable toolbar buttons when no source is selected

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -819,7 +819,7 @@ QPushButton:pressed {
     background-color: rgb(22,31,65);
 }
 
-QPushButton:disabled {
+QPushButton:disabled, QToolButton:disabled {
     background-color: rgb(22,31,65);
 }
 

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -530,7 +530,7 @@ QPushButton:pressed {
     background-color: palette(base);
 }
 
-QPushButton:disabled {
+QPushButton:disabled, QToolButton:disabled {
     background-color: rgb(46,45,46);
 }
 

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -808,7 +808,7 @@ QPushButton:pressed {
     background-color: rgb(28,28,28);
 }
 
-QPushButton:disabled {
+QPushButton:disabled, QToolButton:disabled {
     background-color: rgb(28,28,28);
 }
 

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -808,7 +808,7 @@ QPushButton:pressed {
     background-color: rgb(193,193,193);
 }
 
-QPushButton:disabled {
+QPushButton:disabled, QToolButton:disabled {
     background-color: rgb(193,193,193);
 }
 

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -812,7 +812,7 @@ QPushButton:pressed {
     background-color: rgb(240,98,146);
 }
 
-QPushButton:disabled {
+QPushButton:disabled, QToolButton:disabled {
     background-color: rgb(0,139,163);
 }
 

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -812,7 +812,7 @@ QPushButton:pressed {
     background-color: rgb(25,27,38);
 }
 
-QPushButton:disabled {
+QPushButton:disabled, QToolButton:disabled {
     background-color: rgb(25,27,38);
 }
 

--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -30,6 +30,7 @@
 #include <QStandardItemModel>
 #include <QLabel>
 #include <QPushButton>
+#include <QToolBar>
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 #include <obs-nix-platform.h>
@@ -405,4 +406,13 @@ void TruncateLabel(QLabel *label, QString newText, int length)
 	newText += "...";
 
 	SetLabelText(label, newText);
+}
+
+void RefreshToolBarStyling(QToolBar *toolBar)
+{
+	for (QAction *action : toolBar->actions()) {
+		QWidget *widget = toolBar->widgetForAction(action);
+		widget->style()->unpolish(widget);
+		widget->style()->polish(widget);
+	}
 }

--- a/UI/qt-wrappers.hpp
+++ b/UI/qt-wrappers.hpp
@@ -39,6 +39,7 @@ class QLayout;
 class QString;
 struct gs_window;
 class QLabel;
+class QToolBar;
 
 class OBSMessageBox {
 public:
@@ -122,3 +123,5 @@ QStringList OpenFiles(QWidget *parent, QString title, QString path,
 
 void TruncateLabel(QLabel *label, QString newText,
 		   int length = MAX_LABEL_LENGTH);
+
+void RefreshToolBarStyling(QToolBar *toolBar);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3091,12 +3091,25 @@ void OBSBasic::UpdateContextBarDeferred(bool force)
 				  Qt::QueuedConnection, Q_ARG(bool, force));
 }
 
+void OBSBasic::SourceToolBarActionsSetEnabled(bool enable)
+{
+	ui->actionRemoveSource->setEnabled(enable);
+	ui->actionSourceProperties->setEnabled(enable);
+	ui->actionSourceUp->setEnabled(enable);
+	ui->actionSourceDown->setEnabled(enable);
+
+	RefreshToolBarStyling(ui->sourcesToolbar);
+}
+
 void OBSBasic::UpdateContextBar(bool force)
 {
+	OBSSceneItem item = GetCurrentSceneItem();
+	bool enable = item != nullptr;
+
+	SourceToolBarActionsSetEnabled(enable);
+
 	if (!ui->contextContainer->isVisible() && !force)
 		return;
-
-	OBSSceneItem item = GetCurrentSceneItem();
 
 	if (item) {
 		obs_source_t *source = obs_sceneitem_get_source(item);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -634,6 +634,7 @@ private:
 	bool drawSpacingHelpers = true;
 
 	float GetDevicePixelRatio();
+	void SourceToolBarActionsSetEnabled(bool enable);
 
 public slots:
 	void DeferSaveBegin();


### PR DESCRIPTION
### Description
When no source is selected, disable the toolbar buttons so the user knows the buttons can't be clicked. They would just do nothing before.

![Screenshot from 2022-09-14 21-14-32](https://user-images.githubusercontent.com/19962531/190298295-d7460f2f-fdce-4b30-9cce-cab8b7a7b547.png)

### Motivation and Context
Make UI better

### How Has This Been Tested?
Deselected and selected sources to make sure the buttons updated correctly.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
