### PR TITLE
w32-pthreads: Add pthread.h as public header

### DIFF
--- a/deps/w32-pthreads/CMakeLists.txt
+++ b/deps/w32-pthreads/CMakeLists.txt
@@ -19,7 +19,8 @@ target_compile_definitions(w32-pthreads PRIVATE __CLEANUP_C PTW32_BUILD)
 target_include_directories(
   w32-pthreads PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
 
-set_target_properties(w32-pthreads PROPERTIES FOLDER "deps")
+set_target_properties(w32-pthreads PROPERTIES FOLDER "deps" PUBLIC_HEADER
+                                                            "pthread.h;sched.h")
 
 setup_binary_target(w32-pthreads)
 export_target(w32-pthreads)


### PR DESCRIPTION
### Description
When exporting w32-pthreads, the public header file `pthread.h` needs to be exported as well to expose the implemented functionality.

(`sched.h` is required by `pthread.h` and added as well.)

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/7155

### How Has This Been Tested?
Tested with a plugin template build on windows including `<util/threading.h>` from `libobs`.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
