### PR TITLE
CI: Use official Flatpak actions

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -50,7 +50,7 @@ jobs:
     env:
       FLATPAK_BUILD_PATH: flatpak_app/files/share
     container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-6.3
+      image: flatpak/flatpak-github-actions:kde-6.3
       options: --privileged
     strategy:
       matrix:
@@ -68,7 +68,7 @@ jobs:
           echo "::set-output name=commitHash::$(git rev-parse --short=9 HEAD)"
 
       - name: Build Flatpak Manifest
-        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@master
+        uses: flatpak/flatpak-github-actions/flatpak-builder@master
         with:
           bundle: obs-studio-${{ steps.setup.outputs.commitHash }}.flatpak
           manifest-path: CI/flatpak/com.obsproject.Studio.json
@@ -94,7 +94,7 @@ jobs:
           ostree commit --repo=repo --canonical-permissions --branch=screenshots/x86_64 flatpak_app/screenshots
 
       - name: Publish to Flathub Beta
-        uses: bilelmoussaoui/flatpak-github-actions/flat-manager@v4
+        uses: flatpak/flatpak-github-actions/flat-manager@master
         if: matrix.branch == 'beta'
         with:
           flat-manager-url: https://hub.flathub.org/
@@ -102,7 +102,7 @@ jobs:
           token: ${{ secrets.FLATHUB_BETA_TOKEN }}
 
       - name: Publish to Flathub
-        uses: bilelmoussaoui/flatpak-github-actions/flat-manager@v4
+        uses: flatpak/flatpak-github-actions/flat-manager@master
         if: matrix.branch == 'stable'
         with:
           flat-manager-url: https://hub.flathub.org/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -370,7 +370,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-6.3
+      image: flatpak/flatpak-github-actions:kde-6.3
       options: --privileged
     steps:
       - name: 'Check for Github Labels'
@@ -399,7 +399,7 @@ jobs:
           echo "OBS_GIT_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
       - name: Build Flatpak Manifest
-        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+        uses: flatpak/flatpak-github-actions/flatpak-builder@master
         if: ${{ success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1') }}
         with:
           bundle: obs-studio-flatpak-${{ env.OBS_GIT_HASH }}.flatpak


### PR DESCRIPTION
### Description

The actions from Bilal were moved [to the Flatpak organization in GitHub](https://github.com/flatpak/flatpak-github-actions/), so let's just use that.

### Motivation and Context

Routine cleanup.

### How Has This Been Tested?

 - Let CI pass

### Types of changes

 - Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
