### PR TITLE
libobs: Add support for reading I420 HLG

### DIFF
--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -485,6 +485,19 @@ float4 PSPlanar420_PQ_Reverse(VertTexPos frag_in) : TARGET
 	return float4(rgb, 1.);
 }
 
+float4 PSPlanar420_HLG_Reverse(VertTexPos frag_in) : TARGET
+{
+	float y = image.Load(int3(frag_in.pos.xy, 0)).x;
+	int3 xy0_chroma = int3(frag_in.uv, 0);
+	float cb = image1.Load(xy0_chroma).x;
+	float cr = image2.Load(xy0_chroma).x;
+	float3 yuv = float3(y, cb, cr);
+	float3 hlg = YUV_to_RGB(yuv);
+	float3 hdr2020 = hlg_to_linear(hlg, hlg_exponent) * maximum_over_sdr_white_nits;
+	float3 rgb = rec2020_to_rec709(hdr2020);
+	return float4(rgb, 1.);
+}
+
 float4 PSPlanar420A_Reverse(VertTexPos frag_in) : TARGET
 {
 	int3 xy0_luma = int3(frag_in.pos.xy, 0);
@@ -963,6 +976,15 @@ technique I420_PQ_Reverse
 	{
 		vertex_shader = VSTexPosHalfHalf_Reverse(id);
 		pixel_shader  = PSPlanar420_PQ_Reverse(frag_in);
+	}
+}
+
+technique I420_HLG_Reverse
+{
+	pass
+	{
+		vertex_shader = VSTexPosHalfHalf_Reverse(id);
+		pixel_shader  = PSPlanar420_HLG_Reverse(frag_in);
 	}
 }
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2084,8 +2084,14 @@ static const char *select_conversion_technique(enum video_format format,
 		return "YVYU_Reverse";
 
 	case VIDEO_FORMAT_I420:
-		return (trc == VIDEO_TRC_PQ) ? "I420_PQ_Reverse"
-					     : "I420_Reverse";
+		switch (trc) {
+		case VIDEO_TRC_PQ:
+			return "I420_PQ_Reverse";
+		case VIDEO_TRC_HLG:
+			return "I420_HLG_Reverse";
+		default:
+			return "I420_Reverse";
+		}
 
 	case VIDEO_FORMAT_NV12:
 		return "NV12_Reverse";


### PR DESCRIPTION
### Description
Sony cameras can create 8-bit HLG videos for some reason.

Fixes #7251

### Motivation and Context
Make Sony camera users happy.

### How Has This Been Tested?
Verified I420 HLG renders now. Verified I420 SDR & PQ videos still play correctly.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.