### PR TITLE
UI: Fix Chinese default font

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -82,7 +82,7 @@ QWidget {
     selection-background-color: rgb(22,31,65);
     selection-color: palette(text);
     font-size: 10pt;
-    font-family: 'Open Sans', '.AppleSystemUIFont', Helvetica, Arial, 'MS Shell Dlg', sans-serif;
+    font-family: 'Open Sans', '.AppleSystemUIFont', Helvetica, Arial, 'MS Shell Dlg', sans-serif, 'Microsoft YaHei UI';
 }
 
 QWidget:disabled {

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -82,7 +82,7 @@ QWidget {
     selection-background-color: rgb(40,76,184);
     selection-color: palette(text);
     font-size: 10pt;
-    font-family: 'Open Sans', '.AppleSystemUIFont', Helvetica, Arial, 'MS Shell Dlg', sans-serif;
+    font-family: 'Open Sans', '.AppleSystemUIFont', Helvetica, Arial, 'MS Shell Dlg', sans-serif, 'Microsoft YaHei UI';
 }
 
 QWidget:disabled {

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -82,7 +82,7 @@ QWidget {
     selection-background-color: rgb(140,181,255);
     selection-color: palette(text);
     font-size: 10pt;
-    font-family: 'Open Sans', '.AppleSystemUIFont', Helvetica, Arial, 'MS Shell Dlg', sans-serif;
+    font-family: 'Open Sans', '.AppleSystemUIFont', Helvetica, Arial, 'MS Shell Dlg', sans-serif, 'Microsoft YaHei UI';
 }
 
 QWidget:disabled {

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -84,7 +84,7 @@ QWidget {
     selection-background-color: rgb(0,188,212);
     selection-color: palette(text);
     font-size: 10pt;
-    font-family: 'Open Sans', '.AppleSystemUIFont', Helvetica, Arial, 'MS Shell Dlg', sans-serif;
+    font-family: 'Open Sans', '.AppleSystemUIFont', Helvetica, Arial, 'MS Shell Dlg', sans-serif, 'Microsoft YaHei UI';
 }
 
 QWidget:disabled {

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -82,7 +82,7 @@ QWidget {
     selection-background-color: rgb(40,76,184);
     selection-color: palette(text);
     font-size: 10pt;
-    font-family: 'Open Sans', '.AppleSystemUIFont', Helvetica, Arial, 'MS Shell Dlg', sans-serif;
+    font-family: 'Open Sans', '.AppleSystemUIFont', Helvetica, Arial, 'MS Shell Dlg', sans-serif, 'Microsoft YaHei UI';
 }
 
 QWidget:disabled {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add Microsoft YaHei (Microsoft YaHei UI) to font-family
![Before](https://user-images.githubusercontent.com/45261195/189939835-44dfff6f-1d63-41b2-8e89-9b116267796f.png)
![After](https://user-images.githubusercontent.com/45261195/189939846-17676c06-3c14-4577-825d-06569d2cd66c.png)


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Default Chinese font on Windows Vista+ should not be the old SimSun, it should be Microsoft YaHei.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Replace the qss and verified it was fixed.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
