### PR TITLE
libobs: Add "source_update" signal

### DIFF
--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -582,6 +582,10 @@ Core OBS Signals
    Called when a source has been removed (:c:func:`obs_source_remove()`
    has been called on the source).
 
+**source_update** (ptr source)
+
+   Called when a source's settings have been updated.
+
 **source_save** (ptr source)
 
    Called when a source is being saved.

--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -531,6 +531,10 @@ Source Signals
    Called when the :c:func:`obs_source_remove()` function is called on
    the source.
 
+**update** (ptr source)
+
+   Called when the source's settings have been updated.
+
 **save** (ptr source)
 
    Called when the source is being saved.

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -77,6 +77,7 @@ struct obs_source_info *get_source_info2(const char *unversioned_id,
 static const char *source_signals[] = {
 	"void destroy(ptr source)",
 	"void remove(ptr source)",
+	"void update(ptr source)",
 	"void save(ptr source)",
 	"void load(ptr source)",
 	"void activate(ptr source)",
@@ -968,6 +969,7 @@ static void obs_source_deferred_update(obs_source_t *source)
 				    source->context.settings);
 		os_atomic_compare_swap_long(&source->defer_update_count, count,
 					    0);
+		obs_source_dosignal(source, "source_update", "update");
 	}
 }
 
@@ -985,6 +987,7 @@ void obs_source_update(obs_source_t *source, obs_data_t *settings)
 	} else if (source->context.data && source->info.update) {
 		source->info.update(source->context.data,
 				    source->context.settings);
+		obs_source_dosignal(source, "source_update", "update");
 	}
 }
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -970,6 +970,7 @@ static const char *obs_signals[] = {
 	"void source_create(ptr source)",
 	"void source_destroy(ptr source)",
 	"void source_remove(ptr source)",
+	"void source_update(ptr source)",
 	"void source_save(ptr source)",
 	"void source_load(ptr source)",
 	"void source_activate(ptr source)",


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a source signal that gets triggered when a source's settings are updated.

~~There is `update_properties`, but it acts in a very different way.
Confirmation that it's not *supposed* to do what the new signal does would be great.~~

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Writing a feature / plugin (probably plugin for the time being) that requires constantly watching a source's settings.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13
Connected to the signal via `signal_handler_connect(obs_source_get_signal_handler(source), "update", source_update_signal, data)` and saw the signal being triggered each time the source was updated.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
