### PR TITLE
linux-v4l2: Improve error handling in interacting with V4L2 loopback module

### DIFF
--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -125,15 +125,15 @@ static bool try_connect(void *data, const char *device)
 
 	vcam->device = open(device, O_RDWR);
 
-	if (vcam->device < 0)
+	if (vcam->device == -1)
 		return false;
 
-	if (ioctl(vcam->device, VIDIOC_QUERYCAP, &capability) < 0)
+	if (ioctl(vcam->device, VIDIOC_QUERYCAP, &capability) == -1)
 		goto fail_close_device;
 
 	format.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
 
-	if (ioctl(vcam->device, VIDIOC_G_FMT, &format) < 0)
+	if (ioctl(vcam->device, VIDIOC_G_FMT, &format) == -1)
 		goto fail_close_device;
 
 	struct obs_video_info ovi;
@@ -146,7 +146,7 @@ static bool try_connect(void *data, const char *device)
 	parm.parm.output.timeperframe.numerator = ovi.fps_den;
 	parm.parm.output.timeperframe.denominator = ovi.fps_num;
 
-	if (ioctl(vcam->device, VIDIOC_S_PARM, &parm) < 0)
+	if (ioctl(vcam->device, VIDIOC_S_PARM, &parm) == -1)
 		goto fail_close_device;
 
 	format.fmt.pix.width = width;
@@ -154,7 +154,7 @@ static bool try_connect(void *data, const char *device)
 	format.fmt.pix.pixelformat = V4L2_PIX_FMT_YUYV;
 	format.fmt.pix.sizeimage = vcam->frame_size;
 
-	if (ioctl(vcam->device, VIDIOC_S_FMT, &format) < 0)
+	if (ioctl(vcam->device, VIDIOC_S_FMT, &format) == -1)
 		goto fail_close_device;
 
 	struct video_scale_info vsi = {0};

--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -225,7 +225,7 @@ static bool try_connect(void *data, const char *device)
 	memset(&parm, 0, sizeof(parm));
 	parm.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
 
-	if (ioctl(vcam->device, VIDIOC_STREAMON, &parm) < 0) {
+	if (ioctl(vcam->device, VIDIOC_STREAMON, &parm) == -1) {
 		blog(LOG_ERROR, "Failed to start streaming on '%s' (%s)",
 		     device, strerror(errno));
 		goto fail_close_device;
@@ -319,7 +319,7 @@ static void virtualcam_stop(void *data, uint64_t ts)
 	struct v4l2_streamparm parm = {0};
 	parm.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
 
-	if (ioctl(vcam->device, VIDIOC_STREAMOFF, &parm) < 0) {
+	if (ioctl(vcam->device, VIDIOC_STREAMOFF, &parm) == -1) {
 		blog(LOG_WARNING,
 		     "Failed to stop streaming on video device %d (%s)",
 		     vcam->device, strerror(errno));


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Improve error detection and general (debug, warning, error) diagnostics for interacting with the V4L2 loopback kernel module via the OBS V4L2 output component.

### Motivation and Context

Fix API error checking; enable diagnosis of runtime challenges in log output.

### How Has This Been Tested?

Manual testing of a portable OBS build on Fedora Linux 36.

With (only) this PR applied, diagnostic information now clearly indicates that some functional challenges exist in combination with the version of the V4L2 loopback module shipped with Fedora Linux 36 (which is, at the time of this writing, the latest released version of this module).

This (improved diagnostic, bad functional) situation will remain for the upcoming Fedora Linux 37, and any other Linux distribution using clean release, unpatched versions of the V4L2 loopback Linux kernel module.

Note that these improvements go beyond a specific Linux distribution or a specific version of the V4L2 loopback kernel module; they simply make sure that API contracts are followed and that appropriate logging is emitted in case problems are detected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
