### PR TITLE
CI: Enable running code format check locally

### DIFF
--- a/CI/linux/run-code-format-check.dockerfile
+++ b/CI/linux/run-code-format-check.dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:22.04
+
+RUN apt update
+
+# Baseline infrastructure
+RUN apt install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    git
+
+# Tooling required to run the checks
+RUN apt install -y \
+    clang-format-13 \
+    pip
+
+RUN pip install cmakelang

--- a/CI/linux/run-code-format-check.sh
+++ b/CI/linux/run-code-format-check.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+#
+# This script enables running code format checks in a control
+# fashion independent of the CI environment, but with the
+# results of the CI environment.
+#
+# Execution takes place inside a docker container to be
+# able to target the very specific software versions that
+# are used for checking, without infecting the (local)
+# development system.
+#
+# Example: clang-format-13 is not necessarily conveniently
+#    available on the local system
+#
+#
+set -e
+
+DOCKER=docker
+# DOCKER=podman
+
+OBS_GIT_WORKING_COPY=$(git rev-parse --show-toplevel)
+CI_LINUX="${OBS_GIT_WORKING_COPY}/CI/linux"
+IMAGE_NAME_AND_TAG=obs-studio-build-format-check:latest
+
+${DOCKER} build "${CI_LINUX}" \
+    --file "${CI_LINUX}/run-code-format-check.dockerfile" \
+    --tag "${IMAGE_NAME_AND_TAG}"
+
+#
+# Note that the format check actually modifies source files
+# in place, so we cannot mount the OBS git repository
+# in read-only mode.
+#
+${DOCKER} run -it --rm \
+    -v "${OBS_GIT_WORKING_COPY}":/obs-git-working-copy \
+    "${IMAGE_NAME_AND_TAG}" \
+    /bin/bash -c 'pushd /obs-git-working-copy && ./CI/format-check.sh'
+
+${DOCKER} run -it --rm \
+    -v "${OBS_GIT_WORKING_COPY}":/obs-git-working-copy \
+    "${IMAGE_NAME_AND_TAG}" \
+    /bin/bash -c 'pushd /obs-git-working-copy && ./CI/check-changes.sh'
+
+${DOCKER} run -it --rm \
+    -v "${OBS_GIT_WORKING_COPY}":/obs-git-working-copy \
+    "${IMAGE_NAME_AND_TAG}" \
+    /bin/bash -c 'pushd /obs-git-working-copy && ./CI/check-cmake.sh'


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Supply a script and a Dockerfile enabling containerized local running of the exact rules applied by OBS (remote) CI check format.

### Motivation and Context

Part of OBS CI is a dedicated check that all code conforms to defined policy through _exactly_ clang-format 13.

On some Linux distributions - like Fedora Linux 36 - the _exact_ version of the clang-format dependency is not conveniently available, while other versions of clang-format - e.g. clang-format 14 - apply materially different, incompatible rules in their formatting.

Improve the developer experience around this policy such that these checks can be run locally, through a docker container, before CI kicks in. This will spare developers the effort to rewrite commits after they have been pushed; it also shortens the feedback cycle on PRs.

This contribution might also apply to other host operating systems; any benefits will depend on the respective local developer setup.

### How Has This Been Tested?

My last two pull requests were created supported by the content of this PR.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
