### PR TITLE
mac-virtualcam: Fix frame sharing and colourspace issues

### DIFF
--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALMachClient.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALMachClient.mm
@@ -10,6 +10,7 @@
 #import "Logging.h"
 
 @interface OBSDALMachClient () <NSPortDelegate> {
+	uint32_t _seed;
 	NSPort *_receivePort;
 }
 @end
@@ -121,9 +122,11 @@
 				return;
 			}
 
+			IOSurfaceLock(surface, 0, &_seed);
 			CVPixelBufferRef frame;
 			CVPixelBufferCreateWithIOSurface(kCFAllocatorDefault,
 							 surface, NULL, &frame);
+			IOSurfaceUnlock(surface, 0, &_seed);
 			CFRelease(surface);
 
 			uint64_t timestamp;

--- a/plugins/mac-virtualcam/src/obs-plugin/OBSDALMachServer.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/OBSDALMachServer.mm
@@ -15,6 +15,7 @@
 @property NSPort *port;
 @property NSMutableSet *clientPorts;
 @property NSRunLoop *runLoop;
+@property uint32_t seed;
 @end
 
 @implementation OBSDALMachServer
@@ -155,6 +156,7 @@
 			return;
 		}
 
+		IOSurfaceLock(surface, 0, &_seed);
 		mach_port_t framePort = IOSurfaceCreateMachPort(surface);
 
 		if (!framePort) {
@@ -174,6 +176,7 @@
 					 ]];
 
 		mach_port_deallocate(mach_task_self(), framePort);
+		IOSurfaceUnlock(surface, 0, &_seed);
 	}
 }
 


### PR DESCRIPTION
### Description
Fixes an issue with empty IOSurface references on Intel-based Macs and also broken output when OBS is set to deliver full colour range output.

### Motivation and Context
The plugin was missing necessary IOSurface locks to ensure that modifications to the underlying memory reference made by the OS do not occur when client code accesses the image data.

On machines without unified memory this can lead to IOSurfaces pointing to GPU memory even though the data has been moved to CPU memory by the OS (to avoid unnecessarily large copy operations) and a PixelBuffer created from the IOSurface won't contain data.

In addition to the issue above, FFmpeg's `swscale` seems to have issues with converting images with full colour ranges to limited colour ranges, resulting in mangled frame data inside OBS.

As macOS natively supports partial range as well as as full ranges for pixel buffers, use these directly, avoiding costly colour space conversions for even more use cases than before - as this skips swscale entirely, the issue doesn't occur anymore.

Fixes https://github.com/obsproject/obs-studio/issues/7333
Possibly fixes https://github.com/obsproject/obs-studio/issues/7171

### How Has This Been Tested?
Tested with macOS 12.6 on Intel-based and Apple-Silicon-based Macs.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
