### PR TITLE
libobs,UI: Swap red/blue render/output channels

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4346,7 +4346,7 @@ static inline enum video_format GetVideoFormatFromName(const char *name)
 		return VIDEO_FORMAT_UYVY;
 #endif
 	else
-		return VIDEO_FORMAT_RGBA;
+		return VIDEO_FORMAT_BGRA;
 }
 
 static inline enum video_colorspace GetVideoColorSpaceFromName(const char *name)

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -230,7 +230,7 @@ render_output_texture(struct obs_core_video_mix *mix)
 	gs_effect_t *effect = get_scale_effect(mix, width, height);
 	gs_technique_t *tech;
 
-	if (video_output_get_format(mix->video) == VIDEO_FORMAT_RGBA) {
+	if (video_output_get_format(mix->video) == VIDEO_FORMAT_BGRA) {
 		tech = gs_effect_get_technique(effect, "DrawAlphaDivide");
 	} else {
 		if ((width == video->base_width) &&

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -337,6 +337,16 @@ static bool obs_init_textures(struct obs_core_video_mix *video)
 
 	bool success = true;
 
+	enum gs_color_format format = GS_BGRA;
+	switch (info->format) {
+	case VIDEO_FORMAT_I010:
+	case VIDEO_FORMAT_P010:
+	case VIDEO_FORMAT_I210:
+	case VIDEO_FORMAT_I412:
+	case VIDEO_FORMAT_YA2L:
+		format = GS_RGBA16F;
+	}
+
 	for (size_t i = 0; i < NUM_TEXTURES; i++) {
 #ifdef _WIN32
 		if (video->using_nv12_tex) {
@@ -365,22 +375,12 @@ static bool obs_init_textures(struct obs_core_video_mix *video)
 			}
 		} else {
 			video->copy_surfaces[i][0] = gs_stagesurface_create(
-				info->width, info->height, GS_RGBA);
+				info->width, info->height, format);
 			if (!video->copy_surfaces[i][0]) {
 				success = false;
 				break;
 			}
 		}
-	}
-
-	enum gs_color_format format = GS_RGBA;
-	switch (info->format) {
-	case VIDEO_FORMAT_I010:
-	case VIDEO_FORMAT_P010:
-	case VIDEO_FORMAT_I210:
-	case VIDEO_FORMAT_I412:
-	case VIDEO_FORMAT_YA2L:
-		format = GS_RGBA16F;
 	}
 
 	enum gs_color_space space = GS_CS_SRGB;


### PR DESCRIPTION
### Description
Don't need to unswizzle channels for DeckLink output in the future.

### Motivation and Context
Want to set up more efficient DeckLink output.

### How Has This Been Tested?
Verified no regression to DeckLink NV12/RGB output, and x264/Intel NV12/RGB recordings.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.