### PR TITLE
UI: Update volume controls decay rate on profile switch

### DIFF
--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -338,6 +338,7 @@ bool OBSBasic::CreateProfile(const std::string &newName, bool create_new,
 
 	config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
 	UpdateTitleBar();
+	UpdateVolumeControlsDecayRate();
 
 	Auth::Load();
 
@@ -614,6 +615,7 @@ void OBSBasic::on_actionRemoveProfile_triggered(bool skipConfirmation)
 	blog(LOG_INFO, "------------------------------------------------");
 
 	UpdateTitleBar();
+	UpdateVolumeControlsDecayRate();
 
 	Auth::Load();
 
@@ -785,6 +787,7 @@ void OBSBasic::ChangeProfile()
 	RefreshProfiles();
 	config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
 	UpdateTitleBar();
+	UpdateVolumeControlsDecayRate();
 
 	Auth::Load();
 


### PR DESCRIPTION
### Description
Ensures the volume controls decay rate is correctly updated on a profile switch, as there is no hook onto that UI event yet.

### Motivation and Context
Without this change the decay rate would only be updated when an audio source is added or when the volume meter itself is changed (e.g. from horizontal to vertical layout).

Fixes https://github.com/obsproject/obs-studio/issues/7409

### How Has This Been Tested?
Tested on macOS 12.6 with 2 profiles and different decay rates (fast vs slow).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
