### PR TITLE
UI: Fix crash when removing filter after changing a value.

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -275,9 +275,25 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 	if (view) {
 		updatePropertiesSignal.Disconnect();
 		ui->propertiesFrame->setVisible(false);
-		view->hide();
-		view->deleteLater();
-		view = nullptr;
+		/* Deleting a filter will trigger a visibility change, which will also
+		 * trigger a focus change if the focus has not been on the list itself
+		 * (e.g. after interacting with the property view).
+		 *
+		 * When an async filter list is available in the view, it will be the first
+		 * candidate to receive focus. If this list is empty, we hide the property
+		 * view by default and set the view to a `nullptr`.
+		 *
+		 * When the call for the visibility change returns, we need to check for
+		 * this possibility, as another event might have hidden (and deleted) the
+		 * view already.
+		 *
+		 * macOS might be especially affected as it doesn't switch keyboard focus
+		 * to buttons like Windows does. */
+		if (view) {
+			view->hide();
+			view->deleteLater();
+			view = nullptr;
+		}
 	}
 
 	if (!filter)


### PR DESCRIPTION
### Description
Deleting a filter will trigger a visibility change, which will also trigger a focus change if the focus has not been on the list itself (e.g. after interacting with the property view).

When an async filter list is available in the view, it will be the first candidate to receive focus. If this list is empty, we hide the property view by default and set the view to a `nullptr`.

When the call for the visibility change returns, we need to check for this possibility, as another event might have hidden (and deleted) the view already.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/7325

### How Has This Been Tested?
Tested with Colour Correction filter on macOS 12.6.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
