### PR TITLE
UI: Add system dark theme

### DIFF
--- a/UI/data/themes/System-Dark.qss
+++ b/UI/data/themes/System-Dark.qss
@@ -11,47 +11,47 @@
 /* We need to set back the icons, or the preview wont stick. */
 
 * [themeID="addIconSmall"] {
-    qproperty-icon: url(:/res/images/plus.svg);
+    qproperty-icon: url(./Dark/plus.svg);
 }
 
 * [themeID="removeIconSmall"] {
-    qproperty-icon: url(:/res/images/minus.svg);
+    qproperty-icon: url(./Dark/minus.svg);
 }
 
 * [themeID="clearIconSmall"] {
-    qproperty-icon: url(:/res/images/entry-clear.svg);
+    qproperty-icon: url(./Dark/entry-clear.svg);
 }
 
 * [themeID="propertiesIconSmall"] {
-    qproperty-icon: url(:/settings/images/settings/general.svg);
+    qproperty-icon: url(./Dark/settings/general.svg);
 }
 
 * [themeID="configIconSmall"] {
-    qproperty-icon: url(:/settings/images/settings/general.svg);
+    qproperty-icon: url(./Dark/settings/general.svg);
 }
 
 * [themeID="upArrowIconSmall"] {
-    qproperty-icon: url(:/res/images/up.svg);
+    qproperty-icon: url(./Dark/up.svg);
 }
 
 * [themeID="refreshIconSmall"] {
-    qproperty-icon: url(:/res/images/refresh.svg);
+    qproperty-icon: url(./Dark/refresh.svg);
 }
 
 * [themeID="downArrowIconSmall"] {
-    qproperty-icon: url(:/res/images/down.svg);
+    qproperty-icon: url(./Dark/down.svg);
 }
 
 * [themeID="pauseIconSmall"] {
-    qproperty-icon: url(:/res/images/media-pause.svg);
+    qproperty-icon: url(./Dark/media-pause.svg);
 }
 
 * [themeID="menuIconSmall"] {
-    qproperty-icon: url(:res/images/dots-vert.svg);
+    qproperty-icon: url(./Dark/dots-vert.svg);
 }
 
 * [themeID="cogsIcon"] {
-    qproperty-icon: url(:/res/images/cogs.svg);
+    qproperty-icon: url(./Dark/cogs.svg);
 }
 
 MuteCheckBox {
@@ -63,7 +63,7 @@ MuteCheckBox::indicator:checked {
 }
 
 MuteCheckBox::indicator:unchecked {
-    image: url(:/settings/images/settings/audio.svg);
+    image: url(./Dark/settings/audio.svg);
 }
 
 SourceTreeSubItemCheckBox {
@@ -77,30 +77,29 @@ SourceTreeSubItemCheckBox::indicator {
 }
 
 SourceTreeSubItemCheckBox::indicator:checked {
-    image: url(:/res/images/expand.svg);
+    image: url(./Dark/expand.svg);
 }
 
 SourceTreeSubItemCheckBox::indicator:unchecked {
-    image: url(:/res/images/collapse.svg);
+    image: url(./Dark/collapse.svg);
 }
 
 OBSHotkeyLabel[hotkeyPairHover=true] {
     color: red;
 }
 
-
 /* Volume Control */
 
 VolumeMeter {
-    qproperty-backgroundNominalColor: rgb(15, 100, 15);
-    qproperty-backgroundWarningColor: rgb(100, 100, 15);
-    qproperty-backgroundErrorColor: rgb(100, 15, 15);
-    qproperty-foregroundNominalColor: rgb(50, 200, 50);
-    qproperty-foregroundWarningColor: rgb(255, 200, 50);
-    qproperty-foregroundErrorColor: rgb(200, 50, 50);
-    qproperty-magnitudeColor: rgb(0, 0, 0);
-    qproperty-majorTickColor: rgb(0, 0, 0);
-    qproperty-minorTickColor: rgb(50, 50, 50);
+    qproperty-backgroundNominalColor: rgb(38,127,38);
+    qproperty-backgroundWarningColor: rgb(127,127,38);
+    qproperty-backgroundErrorColor: rgb(127,38,38);
+    qproperty-foregroundNominalColor: rgb(76,255,76);
+    qproperty-foregroundWarningColor: rgb(255,255,76);
+    qproperty-foregroundErrorColor: rgb(255,76,76);
+    qproperty-magnitudeColor: rgb(0,0,0);
+    qproperty-majorTickColor: palette(window-text);
+    qproperty-minorTickColor: rgb(122,121,122); /* light */
     qproperty-meterThickness: 3;
 
     /* The meter scale numbers normally use your QWidget font, with size    */
@@ -109,7 +108,6 @@ VolumeMeter {
     /* font-size here, and set meterFontScaling to 1.0.                     */
     qproperty-meterFontScaling: 0.7;
 }
-
 
 /* Label warning/error */
 
@@ -182,14 +180,14 @@ OBSQTDisplay {
 /* Settings Icons */
 
 OBSBasicSettings {
-    qproperty-generalIcon: url(:settings/images/settings/general.svg);
-    qproperty-streamIcon: url(:settings/images/settings/stream.svg);
-    qproperty-outputIcon: url(:settings/images/settings/output.svg);
-    qproperty-audioIcon: url(:settings/images/settings/audio.svg);
-    qproperty-videoIcon: url(:settings/images/settings/video.svg);
-    qproperty-hotkeysIcon: url(:settings/images/settings/hotkeys.svg);
-    qproperty-accessibilityIcon: url(:settings/images/settings/accessibility.svg);
-    qproperty-advancedIcon: url(:settings/images/settings/advanced.svg);
+    qproperty-generalIcon: url(./Dark/settings/general.svg);
+    qproperty-streamIcon: url(./Dark/settings/stream.svg);
+    qproperty-outputIcon: url(./Dark/settings/output.svg);
+    qproperty-audioIcon: url(./Dark/settings/audio.svg);
+    qproperty-videoIcon: url(./Dark/settings/video.svg);
+    qproperty-hotkeysIcon: url(./Dark/settings/hotkeys.svg);
+    qproperty-accessibilityIcon: url(./Dark/settings/accessibility.svg);
+    qproperty-advancedIcon: url(./Dark/settings/advanced.svg);
 }
 
 OBSBasicSettings QListView::item {
@@ -205,7 +203,7 @@ LockedCheckBox {
 }
 
 LockedCheckBox::indicator:checked {
-    image: url(:res/images/locked.svg);
+    image: url(./Dark/locked.svg);
 }
 
 LockedCheckBox::indicator:unchecked {
@@ -220,7 +218,7 @@ VisibilityCheckBox {
 }
 
 VisibilityCheckBox::indicator:checked {
-    image: url(:res/images/visible.svg);
+    image: url(./Dark/visible.svg);
 }
 
 VisibilityCheckBox::indicator:unchecked {
@@ -228,32 +226,32 @@ VisibilityCheckBox::indicator:unchecked {
 }
 
 * [themeID="revertIcon"] {
-    qproperty-icon: url(:res/images/revert.svg);
+    qproperty-icon: url(./Dark/revert.svg);
 }
 
 OBSMissingFiles {
-	qproperty-warningIcon: url(:res/images/alert.svg);
+	qproperty-warningIcon: url(./Dark/alert.svg);
 }
 
 /* Source Icons */
 
 OBSBasic {
-    qproperty-imageIcon: url(:res/images/sources/image.svg);
-    qproperty-colorIcon: url(:res/images/sources/brush.svg);
-    qproperty-slideshowIcon: url(:res/images/sources/slideshow.svg);
-    qproperty-audioInputIcon: url(:res/images/sources/microphone.svg);
-    qproperty-audioOutputIcon: url(:settings/images/settings/audio.svg);
-    qproperty-desktopCapIcon: url(:settings/images/settings/video.svg);
-    qproperty-windowCapIcon: url(:res/images/sources/window.svg);
-    qproperty-gameCapIcon: url(:res/images/sources/gamepad.svg);
-    qproperty-cameraIcon: url(:res/images/sources/camera.svg);
-    qproperty-textIcon: url(:res/images/sources/text.svg);
-    qproperty-mediaIcon: url(:res/images/sources/media.svg);
-    qproperty-browserIcon: url(:res/images/sources/globe.svg);
-    qproperty-groupIcon: url(:res/images/sources/group.svg);
-    qproperty-sceneIcon: url(:res/images/sources/scene.svg);
-    qproperty-defaultIcon: url(:res/images/sources/default.svg);
-    qproperty-audioProcessOutputIcon: url(:res/images/sources/windowaudio.svg);
+    qproperty-imageIcon: url(./Dark/sources/image.svg);
+    qproperty-colorIcon: url(./Dark/sources/brush.svg);
+    qproperty-slideshowIcon: url(./Dark/sources/slideshow.svg);
+    qproperty-audioInputIcon: url(./Dark/sources/microphone.svg);
+    qproperty-audioOutputIcon: url(./Dark/settings/audio.svg);
+    qproperty-desktopCapIcon: url(./Dark/settings/video.svg);
+    qproperty-windowCapIcon: url(./Dark/sources/window.svg);
+    qproperty-gameCapIcon: url(./Dark/sources/gamepad.svg);
+    qproperty-cameraIcon: url(./Dark/sources/camera.svg);
+    qproperty-textIcon: url(./Dark/sources/text.svg);
+    qproperty-mediaIcon: url(./Dark/sources/media.svg);
+    qproperty-browserIcon: url(./Dark/sources/globe.svg);
+    qproperty-groupIcon: url(./Dark/sources/group.svg);
+    qproperty-sceneIcon: url(./Dark/sources/scene.svg);
+    qproperty-defaultIcon: url(./Dark/sources/default.svg);
+    qproperty-audioProcessOutputIcon: url(./Dark/sources/windowaudio.svg);
 }
 
 /* Scene Tree */
@@ -266,7 +264,7 @@ SceneTree {
 /* Save icon */
 
 * [themeID="replayIconSmall"] {
-    qproperty-icon: url(:res/images/save.svg);
+    qproperty-icon: url(./Dark/save.svg);
 }
 
 /* Studio Mode T-Bar */
@@ -303,46 +301,46 @@ QSlider::handle:horizontal[themeID="tBarSlider"] {
 }
 
 #contextContainer QPushButton#sourcePropertiesButton {
-    qproperty-icon: url(:/settings/images/settings/general.svg);
+    qproperty-icon: url(./Dark/settings/general.svg);
 }
 
 #contextContainer QPushButton#sourceFiltersButton {
-    qproperty-icon: url(:/res/images/filter.svg);
+    qproperty-icon: url(./Dark/filter.svg);
 }
 
 #contextContainer QPushButton#sourceInteractButton {
-    qproperty-icon: url(:/res/images/interact.svg);
+    qproperty-icon: url(./Dark/interact.svg);
 }
 
 /* Media icons */
 
 * [themeID="playIcon"] {
-    qproperty-icon: url(:res/images/media/media_play.svg);
+    qproperty-icon: url(./Dark/media/media_play.svg);
 }
 
 * [themeID="pauseIcon"] {
-    qproperty-icon: url(:/res/images/media/media_pause.svg);
+    qproperty-icon: url(./Dark/media/media_pause.svg);
 }
 
 * [themeID="restartIcon"] {
-    qproperty-icon: url(:/res/images/media/media_restart.svg);
+    qproperty-icon: url(./Dark/media/media_restart.svg);
 }
 
 * [themeID="stopIcon"] {
-    qproperty-icon: url(:/res/images/media/media_stop.svg);
+    qproperty-icon: url(./Dark/media/media_stop.svg);
 }
 
 * [themeID="nextIcon"] {
-    qproperty-icon: url(:/res/images/media/media_next.svg);
+    qproperty-icon: url(./Dark/media/media_next.svg);
 }
 
 * [themeID="previousIcon"] {
-    qproperty-icon: url(:/res/images/media/media_previous.svg);
+    qproperty-icon: url(./Dark/media/media_previous.svg);
 }
 
 /* YouTube Integration */
 OBSYoutubeActions {
-    qproperty-thumbPlaceholder: url(:res/images/sources/image.svg);
+    qproperty-thumbPlaceholder: url(./Dark/sources/image.svg);
 }
 
 #ytEventList QLabel {
@@ -375,7 +373,7 @@ QCalendarWidget QToolButton {
 }
 
 #qt_calendar_monthbutton::menu-indicator:hover {
-    image: url(:/res/images/down.svg);
+    image: url(./Dark/down.svg);
     color: red;
 }
 

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1224,13 +1224,18 @@ bool OBSApp::SetTheme(std::string name, std::string path)
 
 	QString mpath = QString("file:///") + lpath.c_str();
 	ParseExtraThemeData(path.c_str());
-	setStyleSheet(mpath);
+
 	if (themeMeta) {
 		themeDarkMode = themeMeta->dark;
 	} else {
 		QColor color = palette().text().color();
 		themeDarkMode = !(color.redF() < 0.5);
 	}
+
+	if (themeDarkMode && name == "System")
+		mpath.replace("System.qss", "System-Dark.qss");
+
+	setStyleSheet(mpath);
 
 	emit StyleChanged();
 	return true;

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1206,7 +1206,8 @@ void OBSBasicSettings::LoadThemeList()
 		if (name == DEFAULT_THEME)
 			name += " " + QTStr("Default");
 
-		if (!uniqueSet.contains(value) && name != "Default")
+		if (!uniqueSet.contains(value) && name != "Default" &&
+		    name != "System-Dark")
 			ui->theme->addItem(name, value);
 	}
 


### PR DESCRIPTION
### Description
This adds a system dark theme, so system themes that are dark can use the correct icons. It is just a copy of System.qss, except replacing the icons with the dark versions.

It doesn't show up in the theme list because it is programmatically selected if the System theme is selected and OBS detects it is dark.

**Using a KDE dark theme**
Before:
![Screenshot_20220920_032420](https://user-images.githubusercontent.com/19962531/191209050-dc609170-3bf7-458f-b3db-6d3760d4930d.png)

After:
![Screenshot_20220920_035716](https://user-images.githubusercontent.com/19962531/191215171-565e2728-59fa-4ea8-922c-40235a188493.png)

### Motivation and Context
Make dark system themes work.

### How Has This Been Tested?
Installed a KDE dark theme.

### Types of changes
- Bug fix
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
