### PR TITLE
plugins: Fix property getter methods crashing when NULL sources are passed

### DIFF
--- a/plugins/coreaudio-encoder/encoder.cpp
+++ b/plugins/coreaudio-encoder/encoder.cpp
@@ -1361,23 +1361,27 @@ static bool samplerate_updated(obs_properties_t *props, obs_property_t *prop,
 
 static obs_properties_t *aac_properties(void *data)
 {
-	ca_encoder *ca = static_cast<ca_encoder *>(data);
 
 	obs_properties_t *props = obs_properties_create();
 
-	obs_property_t *p = obs_properties_add_list(
+	obs_property_t *sample_rates = obs_properties_add_list(
 		props, "samplerate", obs_module_text("OutputSamplerate"),
 		OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
-	add_samplerates(p, ca);
-	obs_property_set_modified_callback(p, samplerate_updated);
 
-	p = obs_properties_add_list(props, "bitrate",
-				    obs_module_text("Bitrate"),
-				    OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
-	add_bitrates(p, ca);
+	obs_property_set_modified_callback(sample_rates, samplerate_updated);
+
+	obs_property_t *bit_rates = obs_properties_add_list(
+		props, "bitrate", obs_module_text("Bitrate"),
+		OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
 
 	obs_properties_add_bool(props, "allow he-aac",
 				obs_module_text("AllowHEAAC"));
+
+	if (data) {
+		ca_encoder *ca = static_cast<ca_encoder *>(data);
+		add_samplerates(sample_rates, ca);
+		add_bitrates(bit_rates, ca);
+	}
 
 	return props;
 }

--- a/plugins/mac-avcapture/av-capture.mm
+++ b/plugins/mac-avcapture/av-capture.mm
@@ -2198,11 +2198,7 @@ static void add_manual_properties(obs_properties_t *props)
 
 static obs_properties_t *av_capture_properties(void *data)
 {
-	struct av_capture *capture = static_cast<av_capture *>(data);
-
 	obs_properties_t *props = obs_properties_create();
-
-	add_properties_param(props, capture);
 
 	obs_property_t *dev_list = obs_properties_add_list(
 		props, "device", TEXT_DEVICE, OBS_COMBO_TYPE_LIST,
@@ -2253,25 +2249,33 @@ static obs_properties_t *av_capture_properties(void *data)
 	obs_properties_add_bool(props, "buffering",
 				obs_module_text("Buffering"));
 
-	OBSDataAutoRelease current_settings =
-		obs_source_get_settings(capture->source);
-	if (!obs_data_get_bool(current_settings, "enable_audio")) {
-		auto cb = [](obs_properties_t *, obs_property_t *prop,
-			     void *data) {
-			struct av_capture *capture =
-				static_cast<av_capture *>(data);
-			OBSDataAutoRelease settings = obs_data_create();
-			obs_data_set_bool(settings, "enable_audio", true);
-			obs_source_update(capture->source, settings);
+	if (data) {
+		struct av_capture *capture = static_cast<av_capture *>(data);
 
-			// Enable all audio tracks
-			obs_source_set_audio_mixers(capture->source, 0x3F);
-			obs_property_set_visible(prop, false);
-			return true;
-		};
-		obs_properties_add_button2(props, "enable_audio_button",
-					   obs_module_text("EnableAudio"), cb,
-					   capture);
+		add_properties_param(props, capture);
+
+		OBSDataAutoRelease current_settings =
+			obs_source_get_settings(capture->source);
+		if (!obs_data_get_bool(current_settings, "enable_audio")) {
+			auto cb = [](obs_properties_t *, obs_property_t *prop,
+				     void *data) {
+				struct av_capture *capture =
+					static_cast<av_capture *>(data);
+				OBSDataAutoRelease settings = obs_data_create();
+				obs_data_set_bool(settings, "enable_audio",
+						  true);
+				obs_source_update(capture->source, settings);
+
+				// Enable all audio tracks
+				obs_source_set_audio_mixers(capture->source,
+							    0x3F);
+				obs_property_set_visible(prop, false);
+				return true;
+			};
+			obs_properties_add_button2(
+				props, "enable_audio_button",
+				obs_module_text("EnableAudio"), cb, capture);
+		}
 	}
 
 	return props;

--- a/plugins/mac-capture/mac-screen-capture.m
+++ b/plugins/mac-capture/mac-screen-capture.m
@@ -983,41 +983,43 @@ static obs_properties_t *screen_capture_properties(void *data)
 		props, "show_hidden_windows",
 		obs_module_text("WindowUtils.ShowHidden"));
 
-	obs_property_set_modified_callback2(hidden, content_settings_changed,
-					    sc);
-
 	obs_properties_add_bool(props, "show_cursor",
 				obs_module_text("DisplayCapture.ShowCursor"));
 
-	switch (sc->capture_type) {
-	case 0: {
-		obs_property_set_visible(display_list, true);
-		obs_property_set_visible(window_list, false);
-		obs_property_set_visible(app_list, false);
-		obs_property_set_visible(empty, false);
-		obs_property_set_visible(hidden, false);
-		break;
-	}
-	case 1: {
-		obs_property_set_visible(display_list, false);
-		obs_property_set_visible(window_list, true);
-		obs_property_set_visible(app_list, false);
-		obs_property_set_visible(empty, true);
-		obs_property_set_visible(hidden, true);
-		break;
-	}
-	case 2: {
-		obs_property_set_visible(display_list, true);
-		obs_property_set_visible(app_list, true);
-		obs_property_set_visible(window_list, false);
-		obs_property_set_visible(empty, false);
-		obs_property_set_visible(hidden, true);
-		break;
-	}
-	}
+	if (sc) {
+		obs_property_set_modified_callback2(
+			hidden, content_settings_changed, sc);
 
-	obs_property_set_modified_callback2(empty, content_settings_changed,
-					    sc);
+		switch (sc->capture_type) {
+		case 0: {
+			obs_property_set_visible(display_list, true);
+			obs_property_set_visible(window_list, false);
+			obs_property_set_visible(app_list, false);
+			obs_property_set_visible(empty, false);
+			obs_property_set_visible(hidden, false);
+			break;
+		}
+		case 1: {
+			obs_property_set_visible(display_list, false);
+			obs_property_set_visible(window_list, true);
+			obs_property_set_visible(app_list, false);
+			obs_property_set_visible(empty, true);
+			obs_property_set_visible(hidden, true);
+			break;
+		}
+		case 2: {
+			obs_property_set_visible(display_list, true);
+			obs_property_set_visible(app_list, true);
+			obs_property_set_visible(window_list, false);
+			obs_property_set_visible(empty, false);
+			obs_property_set_visible(hidden, true);
+			break;
+		}
+		}
+
+		obs_property_set_modified_callback2(
+			empty, content_settings_changed, sc);
+	}
 
 	if (@available(macOS 13.0, *))
 		;

--- a/plugins/obs-transitions/transition-luma-wipe.c
+++ b/plugins/obs-transitions/transition-luma-wipe.c
@@ -128,7 +128,6 @@ static void luma_wipe_destroy(void *data)
 static obs_properties_t *luma_wipe_properties(void *data)
 {
 	obs_properties_t *props = obs_properties_create();
-	struct luma_wipe_info *lwipe = data;
 
 	obs_property_t *p;
 
@@ -136,12 +135,17 @@ static obs_properties_t *luma_wipe_properties(void *data)
 				    OBS_COMBO_TYPE_LIST,
 				    OBS_COMBO_FORMAT_STRING);
 
-	obs_data_item_t *item = obs_data_first(lwipe->wipes_list);
+	if (data) {
+		struct luma_wipe_info *lwipe = data;
 
-	for (; item != NULL; obs_data_item_next(&item)) {
-		const char *name = obs_data_item_get_name(item);
-		const char *path = obs_data_item_get_string(item);
-		obs_property_list_add_string(p, obs_module_text(name), path);
+		obs_data_item_t *item = obs_data_first(lwipe->wipes_list);
+
+		for (; item != NULL; obs_data_item_next(&item)) {
+			const char *name = obs_data_item_get_name(item);
+			const char *path = obs_data_item_get_string(item);
+			obs_property_list_add_string(p, obs_module_text(name),
+						     path);
+		}
 	}
 
 	obs_properties_add_float(props, S_LUMA_SOFT, T_LUMA_SOFT, 0.0, 1.0,


### PR DESCRIPTION
### Description
Fixes property getter methods to work even with NULL sources passed into the method.

### Motivation and Context
According to [OBS' documentation](https://obsproject.com/docs/reference-sources.html#c.obs_get_source_properties), the API call can also be used to fetch a _source type's_ properties, which means that no active source reference will be passed.

Some plugins haven't implemented their property getters with that in mind, which this PR fixes.

Fixes https://github.com/obsproject/obs-studio/issues/7020.

### How Has This Been Tested?
Requires additional testing.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
