### PR TITLE
obs-vst: Fix crashes and unusable property button on M1 Macs

### DIFF
--- a/plugins/obs-vst/headers/VSTPlugin.h
+++ b/plugins/obs-vst/headers/VSTPlugin.h
@@ -98,6 +98,7 @@ public:
 	void getSourceNames();
 	obs_audio_data *process(struct obs_audio_data *audio);
 	bool openInterfaceWhenActive = false;
+	bool vstLoaded();
 
 	bool isEditorOpen();
 	void onEditorClosed();

--- a/plugins/obs-vst/linux/VSTPlugin-linux.cpp
+++ b/plugins/obs-vst/linux/VSTPlugin-linux.cpp
@@ -63,3 +63,8 @@ void VSTPlugin::unloadLibrary()
 		soHandle = nullptr;
 	}
 }
+
+bool VSTPlugin::vstLoaded()
+{
+	return (soHandle != nullptr);
+}

--- a/plugins/obs-vst/mac/VSTPlugin-osx.mm
+++ b/plugins/obs-vst/mac/VSTPlugin-osx.mm
@@ -58,16 +58,16 @@ AEffect *VSTPlugin::loadEffect()
 
 	if (mainEntryPoint == NULL) {
 		blog(LOG_WARNING, "Couldn't get a pointer to plug-in's main()");
-		CFBundleUnloadExecutable(bundle);
 		CFRelease(bundle);
+		bundle = NULL;
 		return NULL;
 	}
 
 	newEffect = mainEntryPoint(hostCallback_static);
 	if (newEffect == NULL) {
 		blog(LOG_WARNING, "VST Plug-in's main() returns null.");
-		CFBundleUnloadExecutable(bundle);
 		CFRelease(bundle);
+		bundle = NULL;
 		return NULL;
 	}
 
@@ -83,7 +83,7 @@ AEffect *VSTPlugin::loadEffect()
 void VSTPlugin::unloadLibrary()
 {
 	if (bundle) {
-		CFBundleUnloadExecutable(bundle);
 		CFRelease(bundle);
+		bundle = NULL;
 	}
 }

--- a/plugins/obs-vst/mac/VSTPlugin-osx.mm
+++ b/plugins/obs-vst/mac/VSTPlugin-osx.mm
@@ -87,3 +87,8 @@ void VSTPlugin::unloadLibrary()
 		bundle = NULL;
 	}
 }
+
+bool VSTPlugin::vstLoaded()
+{
+	return (bundle != NULL);
+}

--- a/plugins/obs-vst/obs-vst.cpp
+++ b/plugins/obs-vst/obs-vst.cpp
@@ -40,12 +40,15 @@ static bool open_editor_button_clicked(obs_properties_t *props,
 {
 	VSTPlugin *vstPlugin = (VSTPlugin *)data;
 
-	QMetaObject::invokeMethod(vstPlugin, "openEditor");
+	if (vstPlugin && vstPlugin->vstLoaded()) {
 
-	obs_property_set_visible(obs_properties_get(props, OPEN_VST_SETTINGS),
-				 false);
-	obs_property_set_visible(obs_properties_get(props, CLOSE_VST_SETTINGS),
-				 true);
+		QMetaObject::invokeMethod(vstPlugin, "openEditor");
+
+		obs_property_set_visible(
+			obs_properties_get(props, OPEN_VST_SETTINGS), false);
+		obs_property_set_visible(
+			obs_properties_get(props, CLOSE_VST_SETTINGS), true);
+	}
 
 	UNUSED_PARAMETER(props);
 	UNUSED_PARAMETER(property);
@@ -59,12 +62,15 @@ static bool close_editor_button_clicked(obs_properties_t *props,
 {
 	VSTPlugin *vstPlugin = (VSTPlugin *)data;
 
-	QMetaObject::invokeMethod(vstPlugin, "closeEditor");
+	if (vstPlugin && vstPlugin->vstLoaded() && vstPlugin->isEditorOpen()) {
 
-	obs_property_set_visible(obs_properties_get(props, OPEN_VST_SETTINGS),
-				 true);
-	obs_property_set_visible(obs_properties_get(props, CLOSE_VST_SETTINGS),
-				 false);
+		QMetaObject::invokeMethod(vstPlugin, "closeEditor");
+
+		obs_property_set_visible(
+			obs_properties_get(props, OPEN_VST_SETTINGS), true);
+		obs_property_set_visible(
+			obs_properties_get(props, CLOSE_VST_SETTINGS), false);
+	}
 
 	UNUSED_PARAMETER(property);
 
@@ -302,9 +308,14 @@ static obs_properties_t *vst_properties(void *data)
 	bool close_settings_vis = false;
 	if (data) {
 		VSTPlugin *vstPlugin = (VSTPlugin *)data;
-		if (vstPlugin->isEditorOpen()) {
-			close_settings_vis = true;
+		if (!vstPlugin->vstLoaded()) {
+			close_settings_vis = false;
 			open_settings_vis = false;
+		} else {
+			if (vstPlugin->isEditorOpen()) {
+				close_settings_vis = true;
+				open_settings_vis = false;
+			}
 		}
 	}
 

--- a/plugins/obs-vst/obs-vst.cpp
+++ b/plugins/obs-vst/obs-vst.cpp
@@ -285,7 +285,6 @@ static void fill_out_plugins(obs_property_t *list)
 
 static obs_properties_t *vst_properties(void *data)
 {
-	VSTPlugin *vstPlugin = (VSTPlugin *)data;
 	obs_properties_t *props = obs_properties_create();
 	obs_property_t *list = obs_properties_add_list(props, "plugin_path",
 						       PLUG_IN_NAME,
@@ -299,13 +298,20 @@ static obs_properties_t *vst_properties(void *data)
 	obs_properties_add_button(props, CLOSE_VST_SETTINGS, CLOSE_VST_TEXT,
 				  close_editor_button_clicked);
 
-	if (vstPlugin->isEditorOpen()) {
-		obs_property_set_visible(
-			obs_properties_get(props, OPEN_VST_SETTINGS), false);
-	} else {
-		obs_property_set_visible(
-			obs_properties_get(props, CLOSE_VST_SETTINGS), false);
+	bool open_settings_vis = true;
+	bool close_settings_vis = false;
+	if (data) {
+		VSTPlugin *vstPlugin = (VSTPlugin *)data;
+		if (vstPlugin->isEditorOpen()) {
+			close_settings_vis = true;
+			open_settings_vis = false;
+		}
 	}
+
+	obs_property_set_visible(obs_properties_get(props, OPEN_VST_SETTINGS),
+				 open_settings_vis);
+	obs_property_set_visible(obs_properties_get(props, CLOSE_VST_SETTINGS),
+				 close_settings_vis);
 
 	obs_properties_add_bool(props, OPEN_WHEN_ACTIVE_VST_SETTINGS,
 				OPEN_WHEN_ACTIVE_VST_TEXT);

--- a/plugins/obs-vst/win/VSTPlugin-win.cpp
+++ b/plugins/obs-vst/win/VSTPlugin-win.cpp
@@ -89,3 +89,8 @@ void VSTPlugin::unloadLibrary()
 		dllHandle = nullptr;
 	}
 }
+
+bool VSTPlugin::vstLoaded()
+{
+	return (dllHandle != nullptr);
+}


### PR DESCRIPTION
### Description
Fixes crashes on M1 Macs introduced by the fact that most (if not all) VSTs available do not support the Apple Silicon (arm64) architecture.

### Motivation and Context
VST bundles might be present on user systems, but symbols will not be loaded as most VSTs do not contain arm64 binaries. This can lead to non-null bundle pointers to invalid references, which crash the plugin once it tries to free the references.

This PR ensures that no valid bundle pointers exist if the bundle wasn't loaded.

Also hides the VST UI button in the properties if no valid VST is currently loaded.

### How Has This Been Tested?
Tested on macOS 12.6 with M1 Max.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
