### PR TITLE
CI: Fix Xcode selection in new runner image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,9 +155,8 @@ jobs:
 
           echo "::set-output name=commitHash::$(git rev-parse --short=9 HEAD)"
 
-      - name: 'Switch to Xcode Beta'
-        shell: zsh {0}
-        run: sudo xcode-select -switch /Applications/Xcode_*_beta.app(On[1])
+      - name: 'Switch to Xcode 14.1'
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
 
       - name: 'Install dependencies'
         env:


### PR DESCRIPTION
### Description

Set Xcode version to 14.1 beta.

### Motivation and Context

GitHub thought it'd be funny to update their runner images and instead of being consistent and naming the Xcode 14.1 beta something like `Xcode_14.1_beta.app` it's just `Xcode_14.1.app`, and to top it off they then removed the 14.0 beta, yay!

### How Has This Been Tested?

CI completed successfully.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
