### PR TITLE
obs-filter: Update model for NVIDIA Audio FX

### DIFF
--- a/plugins/obs-filters/nvafx-load.h
+++ b/plugins/obs-filters/nvafx-load.h
@@ -18,6 +18,12 @@ static HMODULE nv_cuda = NULL;
 #define NVAFX_EFFECT_AEC "aec"
 #define NVAFX_EFFECT_SUPERRES "superres"
 
+/** Model paths */
+#define NVAFX_EFFECT_DENOISER_MODEL "\\models\\denoiser_48k.trtpkg"
+#define NVAFX_EFFECT_DEREVERB_MODEL "\\models\\dereverb_48k.trtpkg"
+#define NVAFX_EFFECT_DEREVERB_DENOISER_MODEL \
+	"\\models\\dereverb_denoiser_48k.trtpkg"
+
 #define NVAFX_CHAINED_EFFECT_DENOISER_16k_SUPERRES_16k_TO_48k \
 	"denoiser16k_superres16kto48k"
 #define NVAFX_CHAINED_EFFECT_DEREVERB_16k_SUPERRES_16k_TO_48k \


### PR DESCRIPTION
### Description
This updates the model when swapping effects with NVIDIA Audio Effects. 
This fixes a bug where the model was not updated. :(

### Motivation and Context
Bug fix.

### How Has This Been Tested?
Tested that the model is swapped correctly when changing the FX.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
