### PR TITLE
UI: Fix dock titlebar icons not loading

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -300,8 +300,8 @@ QDockWidget {
     font-size: 10.5pt;
     font-weight: bold;
 
-    titlebar-close-icon: url('./Dark/Close.svg');
-    titlebar-normal-icon: url('./Dark/Popout.svg');
+    titlebar-close-icon: url('./Dark/close.svg');
+    titlebar-normal-icon: url('./Dark/popout.svg');
 }
 
 QDockWidget::title {

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -300,8 +300,8 @@ QDockWidget {
     font-size: 10.5pt;
     font-weight: bold;
 
-    titlebar-close-icon: url('./Dark/Close.svg');
-    titlebar-normal-icon: url('./Dark/Popout.svg');
+    titlebar-close-icon: url('./Dark/close.svg');
+    titlebar-normal-icon: url('./Dark/popout.svg');
 }
 
 QDockWidget::title {

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -300,8 +300,8 @@ QDockWidget {
     font-size: 10.5pt;
     font-weight: bold;
 
-    titlebar-close-icon: url('./Light/Close.svg');
-    titlebar-normal-icon: url('./Light/Popout.svg');
+    titlebar-close-icon: url('./Light/close.svg');
+    titlebar-normal-icon: url('./Light/popout.svg');
 }
 
 QDockWidget::title {

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -302,8 +302,8 @@ QDockWidget {
     font-size: 10.5pt;
     font-weight: bold;
 
-    titlebar-close-icon: url('./Dark/Close.svg');
-    titlebar-normal-icon: url('./Dark/Popout.svg');
+    titlebar-close-icon: url('./Dark/close.svg');
+    titlebar-normal-icon: url('./Dark/popout.svg');
 }
 
 QDockWidget::title {

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -304,8 +304,8 @@ QDockWidget {
     font-size: 10.5pt;
     font-weight: bold;
 
-    titlebar-close-icon: url('./Dark/Close.svg');
-    titlebar-normal-icon: url('./Dark/Popout.svg');
+    titlebar-close-icon: url('./Dark/close.svg');
+    titlebar-normal-icon: url('./Dark/popout.svg');
 }
 
 QDockWidget::title {


### PR DESCRIPTION
### Description
The icons had the wrong name in the qss files. The docks were missing the icons on at least Linux. I have no idea why the dock icons still worked on Windows though.

### Motivation and Context
Fixes the dock icons missing.

### How Has This Been Tested?
Opened OBS to make sure the icons appeared correctly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
