### PR TITLE
Fix error when CmakeGenerator contains spaces

### DIFF
--- a/CI/windows/02_build_obs.ps1
+++ b/CI/windows/02_build_obs.ps1
@@ -64,7 +64,7 @@ function Configure-OBS {
     $GeneratorPlatform = "$(if (${BuildArch} -eq "x64") { "x64" } else { "Win32" })"
 
     $CmakeCommand = @(
-        "-G", ${CmakeGenerator}
+        "-G", "`"${CmakeGenerator}`""
         "-DCMAKE_GENERATOR_PLATFORM=`"${GeneratorPlatform}`"",
         "-DCMAKE_SYSTEM_VERSION=`"${CmakeSystemVersion}`"",
         "-DCMAKE_PREFIX_PATH:PATH=`"${CmakePrefixPath}`"",


### PR DESCRIPTION
Fixes the following error:
```powershell
PS C:\Users\Avasam\Documents\Git\obs-studio> .\CI\build-windows.ps1
cmake -S . -B build64 -G Visual Studio 17 2022 -DCMAKE_GENERATOR_PLATFORM="x64"
-DCMAKE_SYSTEM_VERSION="10.0.18363.657"
-DCMAKE_PREFIX_PATH:PATH="C:\Users\Avasam\Documents\Git\obs-build-dependencies\windows-deps-2022-08-02-x64"
-DCEF_ROOT_DIR:PATH="C:\Users\Avasam\Documents\Git\obs-build-dependencies\cef_binary_5060_windows_x64"
-DENABLE_BROWSER=ON -DVLC_PATH:PATH="C:\Users\Avasam\Documents\Git\obs-studio/../obs-build-dependencies/vlc-3.0.0-git"
-DENABLE_VLC=ON -DCMAKE_INSTALL_PREFIX="build64/install" -DVIRTUALCAM_GUID="" -DTWITCH_CLIENTID="" -DTWITCH_HASH=""
-DRESTREAM_CLIENTID="" -DRESTREAM_HASH="" -DYOUTUBE_CLIENTID="" -DYOUTUBE_CLIENTID_HASH="" -DYOUTUBE_SECRET=""
-DYOUTUBE_SECRET_HASH="" -DCOPIED_DEPENDENCIES=OFF -DCOPY_DEPENDENCIES=ON -DBUILD_FOR_DISTRIBUTION="OFF"
-Wno-deprecated -Wno-dev --log-level=ERROR exited with non-zero code 1.
At C:\Users\Avasam\Documents\Git\obs-studio\CI\include\build_support_windows.ps1:137 char:9
+         throw "${Command} ${CommandArgs} exited with non-zero code ${ ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (cmake -S . -B b...on-zero code 1.:String) [], RuntimeException
    + FullyQualifiedErrorId : cmake -S . -B build64 -G Visual Studio 17 2022 -DCMAKE_GENERATOR_PLATFORM="x64" -DCMAKE_
   SYSTEM_VERSION="10.0.18363.657" -DCMAKE_PREFIX_PATH:PATH="C:\Users\Avasam\Documents\Git\obs-build-dependencies\win
  dows-deps-2022-08-02-x64" -DCEF_ROOT_DIR:PATH="C:\Users\Avasam\Documents\Git\obs-build-dependencies\cef_binary_506
 0_windows_x64" -DENABLE_BROWSER=ON -DVLC_PATH:PATH="C:\Users\Avasam\Documents\Git\obs-studio/../obs-build-dependen
cies/vlc-3.0.0-git" -DENABLE_VLC=ON -DCMAKE_INSTALL_PREFIX="build64/install" -DVIRTUALCAM_GUID="" -DTWITCH_CLIENTI
D="" -DTWITCH_HASH="" -DRESTREAM_CLIENTID="" -DRESTREAM_HASH="" -DYOUTUBE_CLIENTID="" -DYOUTUBE_CLIENTID_HASH="" -
DYOUTUBE_SECRET="" -DYOUTUBE_SECRET_HASH="" -DCOPIED_DEPENDENCIES=OFF -DCOPY_DEPENDENCIES=ON -DBUILD_FOR_DISTRIBUT
ION="OFF"  -Wno-deprecated -Wno-dev --log-level=ERROR exited with non-zero code 1.

PS C:\Users\Avasam\Documents\Git\obs-studio> cmake -S . -B build64 -G "Visual Studio 17 2022" -DCMAKE_GENERATOR_PLATFORM="x64" -DCMAKE_SYSTEM_VERSION="10.0.18363.657" -DCMAKE_PREFIX_PATH:PATH="C:\Users\Avasam\Documents\Git\obs-build-dependencies\windows-deps-2022-08-02-x64" -DCEF_ROOT_DIR:PATH="C:\Users\Avasam\Documents\Git\obs-build-dependencies\cef_binary_5060_windows_x64" -DENABLE_BROWSER=ON -DVLC_PATH:PATH="C:\Users\Avasam\Documents\Git\obs-studio/../obs-build-dependencies/vlc-3.0.0-git" -DENABLE_VLC=ON -DCMAKE_INSTALL_PREFIX="build64/install" -DVIRTUALCAM_GUID="" -DTWITCH_CLIENTID="" -DTWITCH_HASH="" -DRESTREAM_CLIENTID="" -DRESTREAM_HASH="" -DYOUTUBE_CLIENTID="" -DYOUTUBE_CLIENTID_HASH="" -DYOUTUBE_SECRET="" -DYOUTUBE_SECRET_HASH="" -DCOPIED_DEPENDENCIES=OFF -DCOPY_DEPENDENCIES=ON -DBUILD_FOR_DISTRIBUTION="OFF" -Wno-deprecated -Wno-dev --log-level=ERROR
CMake Error: Could not create named generator Visual

Generators
* Visual Studio 17 2022        = Generates Visual Studio 2022 project files.
                                 Use -A option to specify architecture.
  Visual Studio 16 2019        = Generates Visual Studio 2019 project files.
                                 Use -A option to specify architecture.
  Visual Studio 15 2017 [arch] = Generates Visual Studio 2017 project files.
                                 Optional [arch] can be "Win64" or "ARM".
  Visual Studio 14 2015 [arch] = Generates Visual Studio 2015 project files.
                                 Optional [arch] can be "Win64" or "ARM".
  Visual Studio 12 2013 [arch] = Generates Visual Studio 2013 project files.
                                 Optional [arch] can be "Win64" or "ARM".
  Visual Studio 11 2012 [arch] = Generates Visual Studio 2012 project files.
                                 Optional [arch] can be "Win64" or "ARM".
  Visual Studio 10 2010 [arch] = Deprecated.  Generates Visual Studio 2010
                                 project files.  Optional [arch] can be
                                 "Win64" or "IA64".
  Visual Studio 9 2008 [arch]  = Generates Visual Studio 2008 project files.
                                 Optional [arch] can be "Win64" or "IA64".
  Borland Makefiles            = Generates Borland makefiles.
  NMake Makefiles              = Generates NMake makefiles.
  NMake Makefiles JOM          = Generates JOM makefiles.
  MSYS Makefiles               = Generates MSYS makefiles.
  MinGW Makefiles              = Generates a make file for use with
                                 mingw32-make.
  Green Hills MULTI            = Generates Green Hills MULTI files
                                 (experimental, work-in-progress).
  Unix Makefiles               = Generates standard UNIX makefiles.
  Ninja                        = Generates build.ninja files.
  Ninja Multi-Config           = Generates build-<Config>.ninja files.
  Watcom WMake                 = Generates Watcom WMake makefiles.
  CodeBlocks - MinGW Makefiles = Generates CodeBlocks project files.
  CodeBlocks - NMake Makefiles = Generates CodeBlocks project files.
  CodeBlocks - NMake Makefiles JOM
                               = Generates CodeBlocks project files.
  CodeBlocks - Ninja           = Generates CodeBlocks project files.
  CodeBlocks - Unix Makefiles  = Generates CodeBlocks project files.
  CodeLite - MinGW Makefiles   = Generates CodeLite project files.
  CodeLite - NMake Makefiles   = Generates CodeLite project files.
  CodeLite - Ninja             = Generates CodeLite project files.
  CodeLite - Unix Makefiles    = Generates CodeLite project files.
  Eclipse CDT4 - NMake Makefiles
                               = Generates Eclipse CDT 4.0 project files.
  Eclipse CDT4 - MinGW Makefiles
                               = Generates Eclipse CDT 4.0 project files.
  Eclipse CDT4 - Ninja         = Generates Eclipse CDT 4.0 project files.
  Eclipse CDT4 - Unix Makefiles= Generates Eclipse CDT 4.0 project files.
  Kate - MinGW Makefiles       = Generates Kate project files.
  Kate - NMake Makefiles       = Generates Kate project files.
  Kate - Ninja                 = Generates Kate project files.
  Kate - Unix Makefiles        = Generates Kate project files.
  Sublime Text 2 - MinGW Makefiles
                               = Generates Sublime Text 2 project files.
  Sublime Text 2 - NMake Makefiles
                               = Generates Sublime Text 2 project files.
  Sublime Text 2 - Ninja       = Generates Sublime Text 2 project files.
  Sublime Text 2 - Unix Makefiles
                               = Generates Sublime Text 2 project files.

CMake Warning:
  Ignoring extra path from command line:

   "2022"
```

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
