### PR TITLE
linux-capture: Fixup window name/class checking

### DIFF
--- a/plugins/linux-capture/xcomposite-input.c
+++ b/plugins/linux-capture/xcomposite-input.c
@@ -310,11 +310,10 @@ xcb_window_t xcomp_find_window(xcb_connection_t *conn, Display *disp,
 	char *wcls = bzalloc(strEnd - thirdStr + 1);
 	memcpy(wname, secondStr, secondMark - secondStr);
 	memcpy(wcls, thirdStr, strEnd - thirdStr);
-	xcb_window_t wid = (xcb_window_t)strtol(str, NULL, 10);
+	ret = (xcb_window_t)strtol(str, NULL, 10);
 
 	// first try to find a match by the window-id
-	if (da_find(tlw, &wid, 0) != DARRAY_INVALID) {
-		ret = wid;
+	if (da_find(tlw, &ret, 0) != DARRAY_INVALID) {
 		goto cleanup2;
 	}
 
@@ -325,8 +324,8 @@ xcb_window_t xcomp_find_window(xcb_connection_t *conn, Display *disp,
 
 		struct dstr cwname = xcomp_window_name(conn, disp, cwin);
 		struct dstr cwcls = xcomp_window_class(conn, cwin);
-		bool found = (strcmp(wname, cwname.array) == 0 &&
-			      strcmp(wcls, cwcls.array));
+		bool found = strcmp(wname, cwname.array) == 0 &&
+			     strcmp(wcls, cwcls.array) == 0;
 
 		dstr_free(&cwname);
 		dstr_free(&cwcls);
@@ -345,7 +344,7 @@ cleanup2:
 	bfree(wcls);
 cleanup1:
 	da_free(tlw);
-	return wid;
+	return ret;
 }
 
 void xcomp_cleanup_pixmap(Display *disp, struct xcompcap *s)


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
There were a couple mistakes here that caused the fallback checks other than window ID to fail to ever return valid results. This restores this functionality that was broken since the c++/c transition.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

fixes #7404


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested that capturing obs works, closing obs, openign and closing some windows and then starting obs again regains capture. Sometimes X11 will reuse window IDs so opening and closing some windows in the interim helps avoid this.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
