### PR TITLE
libobs/media-io: Avoid scaler for range diff

### DIFF
--- a/libobs/media-io/video-io.c
+++ b/libobs/media-io/video-io.c
@@ -297,7 +297,11 @@ static size_t video_get_input_idx(const video_t *video,
 
 static bool match_range(enum video_range_type a, enum video_range_type b)
 {
-	return (a == VIDEO_RANGE_FULL) == (b == VIDEO_RANGE_FULL);
+	//return (a == VIDEO_RANGE_FULL) == (b == VIDEO_RANGE_FULL);
+	/* TODO: Restore test when full NV12 to limited NV12 works */
+	UNUSED_PARAMETER(a);
+	UNUSED_PARAMETER(b);
+	return true;
 }
 
 static enum video_colorspace collapse_space(enum video_colorspace cs)


### PR DESCRIPTION
### Description
Green tint appears when using converting full NV12 to limited NV12 with
swscale, so just avoid creating scaler by color range for now.

Fixes #7442

### Motivation and Context
Green tint is worse than slightly off luminance.

### How Has This Been Tested?
Green tint no longer appears when outputting full range. Limited range still works.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.