### PR TITLE
obs-scripting: Fix compile when python is not found

### DIFF
--- a/deps/obs-scripting/obs-scripting.c
+++ b/deps/obs-scripting/obs-scripting.c
@@ -458,4 +458,9 @@ bool obs_scripting_python_runtime_linked(void)
 {
 	return (bool)true;
 }
+
+void obs_scripting_python_version(char *version, size_t version_length)
+{
+	version[0] = 0;
+}
 #endif


### PR DESCRIPTION
### Description
Fix compile when python is not found

### Motivation and Context
I want to be able to compile without python

### How Has This Been Tested?
On windows 64 bits compiling without python

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
