### PR TITLE
obs-ffmpeg: Prevent media source restart

### DIFF
--- a/deps/media-playback/media-playback/media-playback.c
+++ b/deps/media-playback/media-playback/media-playback.c
@@ -85,6 +85,23 @@ void media_playback_stop(media_playback_t *mp)
 		mp_media_stop(&mp->media);
 }
 
+void media_playback_set_looping(media_playback_t *mp, bool looping)
+{
+	if (mp->is_cached)
+		mp->cache.looping = looping;
+	else
+		mp->media.looping = looping;
+}
+
+void media_playback_set_is_linear_alpha(media_playback_t *mp,
+					bool is_linear_alpha)
+{
+	if (mp->is_cached)
+		mp->cache.m.is_linear_alpha = is_linear_alpha;
+	else
+		mp->media.is_linear_alpha = is_linear_alpha;
+}
+
 void media_playback_preload_frame(media_playback_t *mp)
 {
 	if (!mp)

--- a/deps/media-playback/media-playback/media-playback.h
+++ b/deps/media-playback/media-playback/media-playback.h
@@ -56,6 +56,9 @@ extern void media_playback_play(media_playback_t *mp, bool looping,
 				bool reconnecting);
 extern void media_playback_play_pause(media_playback_t *mp, bool pause);
 extern void media_playback_stop(media_playback_t *mp);
+extern void media_playback_set_looping(media_playback_t *mp, bool looping);
+extern void media_playback_set_is_linear_alpha(media_playback_t *mp,
+					       bool is_linear_alpha);
 extern void media_playback_preload_frame(media_playback_t *mp);
 extern int64_t media_playback_get_current_time(media_playback_t *mp);
 extern void media_playback_seek(media_playback_t *mp, int64_t pos);

--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -483,7 +483,7 @@ void mp_media_next_video(mp_media_t *m, bool preload)
 	frame->height = f->height;
 	frame->max_luminance = d->max_luminance;
 	frame->flip = flip;
-	frame->flags |= m->is_linear_alpha ? OBS_SOURCE_FRAME_LINEAR_ALPHA : 0;
+	frame->flags = m->is_linear_alpha ? OBS_SOURCE_FRAME_LINEAR_ALPHA : 0;
 	switch (f->color_trc) {
 	case AVCOL_TRC_BT709:
 	case AVCOL_TRC_GAMMA22:


### PR DESCRIPTION
Some options do not require a media source restart. Saving source unchanged source settings should also not trigger a restart.

I tried to also make it so speed changes do not require a restart by manipulating the elapsed timestamp  for the source, but it sometimes causes the first few milliseconds after saving settings to be rough or slightly distorted. I am also unsure whether a/v frame buffers should be cleared on a speed change (and how to) so I made it so restarts are required for speed changes. Chiyo also mentioned that successive quick speed changes will cause maximum audio buffering (which I was able to reproduce once).

Nonlocal file playback is unaffected, and will cause the media source to restart because I am not aware of the possible consequences and because there's no restart button for it.

Changing "Apply alpha in linear space" is only visible after a few milliseconds (when mp_media_next_video is called for new frames).

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Idea: https://ideas.obsproject.com/posts/1622/do-not-restart-media-source-when-not-necessary
To be honest, that's mine. I know no one else voted on it, but I know people who wouldn't
want to restart the media source either.

The media source currently restarts every time the source is saved, even if it is unnecessary.
It restarts even when no setting is changed. It should not restart if I just want to toggle _Loop_,
_Restart playback when source becomes active_, _Close file when inactive_, and _Show nothing when playback ends_.
If a video only has transparency in a certain part of the video, you would have to toggle the _linear alpha_
option, then skip to that part again. In addition, workflows could have adding media sources directly
by dragging and dropping, and while it's playing out, I realize that I forgot to turn on _Show Nothing when playback ends_. 

This was my attempt at making speed changes not need media restarts. I tried it many times, and it was mostly fine, other than the fact the first few milliseconds after changing it makes audio a bit distorted. There's also probably some buffered data/frames that I would need to free or flush, but I have no idea about that, so I left it alone and decided that speed changes should require a restart.
![image](https://user-images.githubusercontent.com/65320293/192114660-5cb157e7-1e81-4234-b221-69d4bafa673c.png)

Nonlocal file playback is left with original behavior of restarting all the time because of the lack of a restart button and my lack of knowledge on which properties can be updated without restarting the source.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Windows 10 Build 19043 64-bit on a Lenovo Thinkpad T570
Ran this in portable mode.
Used monitor and output for the media source.

Tests:
- Repeatedly saving settings without changes, ensuring that playback continues.
- Toggling the settings that should not cause a restart and ensuring playback continues.
- Tried to change input file path, speed, color range, hardware decoding, and ffmpeg options, along with combinations I can think of, and ensuring that the media source is restarted.
- Toggling "Local File" restarts the source (if it is actually changed upon saving).
- If local file is off, saving properties, even if unchanged, will restart the source.
- Tested that linear alpha change works using the test file Flaeri kindly provided 
[test.webm](https://user-images.githubusercontent.com/65320293/192115161-677fd8c0-800d-4f39-be3a-dfa30b9b105f.webm)
Note that linear alpha change does not get applied instantly, but it is only a matter of a few milliseconds, which is better than having it restart.
- Verified that toggling Restart Playback when source becomes active works without a restart by switching to a blank scene.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 - Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
