### PR TITLE
CI: Add cherry picker

### DIFF
--- a/.github/workflows/cherry-picker.yml
+++ b/.github/workflows/cherry-picker.yml
@@ -1,0 +1,36 @@
+name: Cherry Picker
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  cherry_picker:
+    name: Cherry Picker
+    runs-on: ubuntu-22.04
+    if: ${{ github.event.pull_request.merged == true }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install & Configure Python
+        run: |
+          sudo apt install python3.10
+          python3.10 -m pip install requests
+
+      - name: Setup git config
+        run: |
+          git config user.name "Service Checker"
+          git config user.email "commits@obsproject.com"
+
+      - name: Run picker
+        id: picker
+        run: python3.10 -u CI/cherry-picker.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}

--- a/CI/cherry-picker.py
+++ b/CI/cherry-picker.py
@@ -1,0 +1,165 @@
+import os
+import sys
+
+from subprocess import check_output, STDOUT, CalledProcessError
+
+import requests
+
+
+CHERRY_PICK_TAG_PREFIX = 'cherry-pick-to-'
+PR_MESSAGE = '''Cherry Picker results:
+{}
+
+Errors:
+{}
+
+Created by workflow run https://github.com/{}/actions/runs/{}
+'''
+
+
+def get_pr_targets(s, repo, pr_num):
+    """
+    Fetch labels from PR, get cherry-pick tags and return target branches
+
+    :return: list of target branch names
+    """
+
+    # fetch run first, get workflow id from there to get workflow runs
+    r = s.get(f'https://api.github.com/repos/{repo}/pulls/{pr_num}')
+    r.raise_for_status()
+    j = r.json()
+
+    targets = []
+    for label in j['labels']:
+        name = label['name']
+        if not name.startswith(CHERRY_PICK_TAG_PREFIX):
+            continue
+        targets.append(name.replace(CHERRY_PICK_TAG_PREFIX, ''))
+
+    return targets
+
+
+def get_pr_commits(s, repo, pr_num):
+    """
+    Fetch commits for
+
+    :return: list of target branch names
+    """
+
+    # fetch run first, get workflow id from there to get workflow runs
+    r = s.get(f'https://api.github.com/repos/{repo}/pulls/{pr_num}/commits')
+    r.raise_for_status()
+    j = r.json()
+
+    return [c['sha'] for c in j]
+
+
+def post_pr_comment(s, repo, pr_num, info=None, warnings=None):
+    run_id = os.environ['WORKFLOW_RUN_ID']
+
+    if not info:
+        info = ['N/A']
+    if not warnings:
+        warnings = ['N/A']
+
+    formatted_info = '\n'.join(f'- {e}' for e in info)
+    formatted_warnings = '\n'.join(f'- {e}' for e in warnings)
+    comment = PR_MESSAGE.format(formatted_info, formatted_warnings, repo, run_id)
+
+    r = s.post(f'https://api.github.com/repos/{repo}/issues/{pr_num}/comments',
+               json=dict(body=comment))
+    r.raise_for_status()
+
+
+def cherry_pick_to(target, commits):
+    try:
+        print(f'Checking out branch "{target}"...')
+        _ = check_output(['git', 'checkout', '-f', target], stderr=STDOUT)
+    except CalledProcessError as e:
+        err = e.output.decode('utf-8')
+        print('⚠ Checking out failed:', err)
+        return err
+
+    try:
+        print(f'Picking commits to "{target}"...')
+        _ = check_output(['git', 'cherry-pick', *commits], stderr=STDOUT)
+        return ''
+    except CalledProcessError as e:
+        err = e.output.decode('utf-8')
+        print('⚠ Cherry-picking failed:', err)
+
+        # Also try to abort cherry-pick, just in case
+        try:
+            check_output(['git', 'cherry-pick', '--abort'], stderr=STDOUT)
+        except CalledProcessError as _e:
+            print(f'⚠ Aborting cherry-pick failed: {_e!r}')
+
+        return err
+
+
+def push_branches(branches):
+    try:
+        _ = check_output(['git', 'push', 'origin', *branches], stderr=STDOUT)
+    except CalledProcessError as e:
+        err = e.output.decode('utf-8')
+        print('⚠ Pushing branches failed:', err)
+        return err
+
+
+def main():
+    # comment contents
+    warnings = []
+    info = []
+
+    session = requests.session()
+    session.headers['Accept'] = 'application/vnd.github+json'
+    session.headers['Authorization'] = f'Bearer {os.environ["GITHUB_TOKEN"]}'
+    repo = os.environ['REPOSITORY']
+    pr_number = os.environ['PR_NUMBER']
+
+    try:
+        targets = get_pr_targets(session, repo, pr_number)
+    except Exception as e:
+        print(f'⚠ Fetching PR tags failed: {e!r}')
+        return 1
+
+    if not targets:
+        print(f'No cherry pick requested for PR {pr_number}')
+        return 0
+
+    # get the PR's commits to pick
+    try:
+        commits = get_pr_commits(session, repo, pr_number)
+        if not commits:
+            raise ValueError('No commits in PR?!')
+    except Exception as e:
+        print(f'⚠ Fetching PR tags failed: {e!r}')
+        return 1
+
+    successes = []
+    for target in targets:
+        if err := cherry_pick_to(target, commits):
+            warnings.append(f'Failed to merge into `{target}`: `{err}`')
+        else:
+            info.append(f'Successfully merged into `{target}`')
+            successes.append(target)
+
+    if push_err := push_branches(successes):
+        warnings.append(f'Failed to push: {push_err}')
+    else:
+        info.append(f'Successfully pushed all branches.')
+
+    try:
+        post_pr_comment(session, repo, pr_number, info, warnings)
+    except Exception as e:
+        print(f'⚠ Posting PR comment failed: {e!r}')
+
+    # if no branches were successfully picked or pushing failed, also set an error status
+    if not successes or push_err:
+        return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
### Description

Adds automated cherry picks to branches specified in `cherry-pick-to-<branch>` tags.

### Motivation and Context

Want to make branching and picking easier.

### How Has This Been Tested?

PR on my repo: https://github.com/derrod/obs-studio/pull/21

Edit: Might require another test with a PR from an actual fork, it could be that the cherry-pick in that case since the commit hashes might not be available in the `pull_request_target` context.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
