### PR TITLE
libobs: Fixes for the new FFmpeg channel API

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -353,6 +353,12 @@ static void mp_media_next_audio(mp_media_t *m)
 	struct mp_decode *d = &m->a;
 	struct obs_source_audio audio = {0};
 	AVFrame *f = d->frame;
+	int channels;
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(59, 19, 100)
+	channels = f->channels;
+#else
+	channels = f->ch_layout.nb_channels;
+#endif
 
 	if (!mp_media_can_play_frame(m, d))
 		return;
@@ -365,7 +371,7 @@ static void mp_media_next_audio(mp_media_t *m)
 		audio.data[i] = f->data[i];
 
 	audio.samples_per_sec = f->sample_rate * m->speed / 100;
-	audio.speakers = convert_speaker_layout(f->channels);
+	audio.speakers = convert_speaker_layout(channels);
 	audio.format = convert_sample_format(f->format);
 	audio.frames = f->nb_samples;
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -257,12 +257,19 @@ static bool create_audio_stream(struct ffmpeg_output *stream,
 	context->time_base = (AVRational){1, aoi.samples_per_sec};
 	context->channels = get_audio_channels(aoi.speakers);
 	context->sample_rate = aoi.samples_per_sec;
+
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)
 	context->channel_layout =
 		av_get_default_channel_layout(context->channels);
 
 	//avutil default channel layout for 5 channels is 5.0 ; fix for 4.1
 	if (aoi.speakers == SPEAKERS_4POINT1)
 		context->channel_layout = av_get_channel_layout("4.1");
+#else
+	av_channel_layout_default(&context->ch_layout, context->channels);
+	if (aoi.speakers == SPEAKERS_4POINT1)
+		context->ch_layout = (AVChannelLayout)AV_CHANNEL_LAYOUT_4POINT1;
+#endif
 
 	context->sample_fmt = AV_SAMPLE_FMT_S16;
 	context->frame_size = data->config.frame_size;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -235,6 +235,7 @@ static bool create_audio_stream(struct ffmpeg_output *stream,
 	void *extradata = NULL;
 	struct obs_audio_info aoi;
 	const char *name = data->config.audio_encoder;
+	int channels;
 
 	const AVCodecDescriptor *codec = avcodec_descriptor_get_by_name(name);
 	if (!codec) {
@@ -255,7 +256,10 @@ static bool create_audio_stream(struct ffmpeg_output *stream,
 	context->codec_id = codec->id;
 	context->bit_rate = (int64_t)data->config.audio_bitrate * 1000;
 	context->time_base = (AVRational){1, aoi.samples_per_sec};
+	channels = get_audio_channels(aoi.speakers);
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(57, 24, 100)
 	context->channels = get_audio_channels(aoi.speakers);
+#endif
 	context->sample_rate = aoi.samples_per_sec;
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)
@@ -266,7 +270,7 @@ static bool create_audio_stream(struct ffmpeg_output *stream,
 	if (aoi.speakers == SPEAKERS_4POINT1)
 		context->channel_layout = av_get_channel_layout("4.1");
 #else
-	av_channel_layout_default(&context->ch_layout, context->channels);
+	av_channel_layout_default(&context->ch_layout, channels);
 	if (aoi.speakers == SPEAKERS_4POINT1)
 		context->ch_layout = (AVChannelLayout)AV_CHANNEL_LAYOUT_4POINT1;
 #endif


### PR DESCRIPTION
### Description
Also changes obs-ffmpeg.
This allows compilation with FFmpeg master.
More precisely for:
-  swresample >= 4.5.100, 
- avutil >= 57.24.100,
- avcodec >= 59.24.100.

One commit adapts the changes done in 5b6cc73 to the obs-ffmpeg-mpegts output.
The second updates obs audio resampler by swapping a deprecated function to its new version 
which uses the new channel layout API.
The third deals with the deprecation of AVFrame and AVCodecContext channels member by switching to new API.

### Motivation and Context
Enable later updates of FFmpeg library on which obs-studio relies for a variety of stuff.

### How Has This Been Tested?
test platform: win 10 pro 21H2 x64 & win 11 22h2, visual studio 2022 

- checked that audio is resampled correctly with both new & old api (both new and old FFmpeg dlls),
- checked that mono audio is upmixed correctly with both new and old api.
- checked that mpegts output works with new FFmpeg dlls.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
