### PR TITLE
CI: fix build on non-x86 Linux platforms

### DIFF
--- a/CI/linux/01_install_dependencies.sh
+++ b/CI/linux/01_install_dependencies.sh
@@ -98,7 +98,6 @@ install_dependencies() {
          libpulse-dev libsndio-dev libspeexdsp-dev libudev-dev libv4l-dev libva-dev libvlc-dev libdrm-dev"
     )
 
-    sudo dpkg --add-architecture amd64
     sudo apt-get -qq update
 
     for DEPENDENCY in "${BUILD_DEPS[@]}"; do


### PR DESCRIPTION
### Description
The CI build script is useful to build OBS Studio even outside the CI environment. However, the current script hard codes adding the 'amd64' architecture to dpkg, the Debian/Ubuntu package management database. This breaks the system when run on non-x86 machines. e.g., a linux-aarch64 VM running on an Apple silicon macbook. Fixing the system requires telling dpkg to remove 'amd64' again with 'sudo dpkg --remove-architecture amd64'

As the CI build always runs on an amd64 machine, adding amd64 is not necessary and can be safely removed.

### How Has This Been Tested?
Tested locally on an Ubuntu linux-aarch64 virtual machine. Also tested by pushing out to GitHub and passing all Linux build actions.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
