### PR TITLE
linux-pipewire: Close sessions as we are done with them

### DIFF
--- a/plugins/linux-pipewire/screencast-portal.c
+++ b/plugins/linux-pipewire/screencast-portal.c
@@ -627,6 +627,20 @@ static bool reload_session_cb(obs_properties_t *properties,
 	g_clear_pointer(&capture->restore_token, bfree);
 	g_clear_pointer(&capture->obs_pw, obs_pipewire_destroy);
 
+	if (capture->session_handle) {
+		blog(LOG_DEBUG, "[pipewire] Cleaning previous session %s",
+		     capture->session_handle);
+		g_dbus_connection_call(portal_get_dbus_connection(),
+				       "org.freedesktop.portal.Desktop",
+				       capture->session_handle,
+				       "org.freedesktop.portal.Session",
+				       "Close", NULL, NULL,
+				       G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL,
+				       NULL);
+
+		g_clear_pointer(&capture->session_handle, g_free);
+	}
+
 	init_screencast_capture(capture);
 
 	return false;


### PR DESCRIPTION
### Description
This way the stream can be cleaned up. Otherwise, we closed them all when OBS closes which works but is not entirely correct.

### Motivation and Context
On Plasma we show an element for each button and it would infinitely grow as we interact with OBS.

### How Has This Been Tested?
I've been testing this against our system and confirmed that Close is called as we replace the session_handle so the system can properly clean up the UI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
