### PR TITLE
CI: add source_build job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -369,6 +369,54 @@ jobs:
           name: 'obs-studio-windows-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}'
           path: '${{ env.FILE_NAME }}'
 
+  source_build:
+    name: '02 - Source'
+    runs-on: [ubuntu-22.04]
+    if: always()
+    needs: [clang_check]
+    defaults:
+      run:
+        shell: bash
+        working-directory: 'obs-studio'
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+          path: 'obs-studio'
+          fetch-depth: 0
+
+      - name: 'Setup environment'
+        id: setup
+        run: |
+          echo "commitHash=$(git rev-parse --short=9 HEAD)" >> $GITHUB_OUTPUT
+
+      - name: 'Create source artifact'
+        id: tarball
+        if: ${{ success() && github.event_name != 'pull_request' }}
+        run: |
+          prefix=obs-studio-${{ steps.setup.outputs.commitHash }}
+          commit_date=$(git show -s --format=%cI ${{ steps.setup.outputs.commitHash }})
+          outfile=${prefix}.tar.gz
+          ARTIFACT_NAME=${outfile}
+          outfile=${{ github.workspace }}/${outfile}
+          echo "outfile: $outfile"
+          echo "artifact: $ARTIFACT_NAME"
+          # create a tarball with *all* the sources
+          # - prefix paths with 'obs-studio/' (since we are creating the tarball from within the source dir)
+          # - exclude all repository files
+          # - make the tarball reproducible
+          tar -cvzf ${outfile}  --transform='s|^\.|obs-studio|'  --exclude-vcs --exclude-vcs-ignores --exclude '.git*'  --sort=name  --owner=0 --group=0 --numeric-owner --pax-option="exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime" --mtime="${commit_date}"  .
+          # announce artifact for upload
+          echo "fileName=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
+
+      - name: 'Upload source artifact'
+        if: ${{ success() && (github.event_name != 'pull_request') }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'obs-studio-source-${{ steps.setup.outputs.commitHash }}'
+          path: '${{ github.workspace }}/${{ steps.tarball.outputs.fileName }}'
+
   linux_package:
     name: '02 - Flatpak'
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
### Description

This adds a new job to the BUILD workflow, that generates a tarball with all the submodules (as GitHub's "Source Download" will happily exclude all the submodules, resulting in an incomplete tarball that fails to build).
    
The generated tarball excludes all repository configuration files (everything starting with .git*),
in order to not interfere with downstream consumers of the tarball, who might have their own ideas how to configure a repository.

@PatTheMav suggested in https://github.com/obsproject/obs-studio/issues/7407#issuecomment-1258023718 that i should extend the `build_linux` job, which I did **not** do for the following reasons:
- the build-artifacts are platform-independent (there's nothing "linux"-specific to them, except that i picked `tar.gz` as the output format)
- there's little point in creating the same tarball on multiple Ubuntu versions
- the tarballs might be of interest, even if the Linux builds fail (for whatever reasons)

### Motivation and Context
This is motivated by creating the Debian-official packages of obs-studio ("Debian-official" being the packages that are shipped by Debian itself (and thus by derivatives like Ubuntu), as opposed to .deb-packages shipped by obs-studio itself).

On Debian, we use release tarballs for creating our packages, and as such it is important that these packages contain all the necessary bits and bolts.

Closes: https://github.com/obsproject/obs-studio/issues/7407

### How Has This Been Tested?

This has been tested by running the workflow in my fork of OBS-studio.
https://github.com/umlaeute/obs-studio/actions/runs/3135647019

For whatever reasons, all the other build-jobs fail with some Cmake specific error. Since I did not touch these jobs, I think the problem is somewhere else (e.g. hidden in the project settings).

### Types of changes
?

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format). (*does not apply*)
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation. (*does not apply*)
