### PR TITLE
[Feature Request] | 'Facebook VOD Track' ?

### DIFF
--- a/libobs/obs-config.h
+++ b/libobs/obs-config.h
@@ -41,7 +41,7 @@
  *
  * Reset to zero each major or minor version
  */
-#define LIBOBS_API_PATCH_VER 1
+#define LIBOBS_API_PATCH_VER 2
 
 #define MAKE_SEMANTIC_VERSION(major, minor, patch) \
 	((major << 24) | (minor << 16) | patch)

--- a/plugins/obs-filters/nvafx-load.h
+++ b/plugins/obs-filters/nvafx-load.h
@@ -18,6 +18,12 @@ static HMODULE nv_cuda = NULL;
 #define NVAFX_EFFECT_AEC "aec"
 #define NVAFX_EFFECT_SUPERRES "superres"
 
+/** Model paths */
+#define NVAFX_EFFECT_DENOISER_MODEL "\\models\\denoiser_48k.trtpkg"
+#define NVAFX_EFFECT_DEREVERB_MODEL "\\models\\dereverb_48k.trtpkg"
+#define NVAFX_EFFECT_DEREVERB_DENOISER_MODEL \
+	"\\models\\dereverb_denoiser_48k.trtpkg"
+
 #define NVAFX_CHAINED_EFFECT_DENOISER_16k_SUPERRES_16k_TO_48k \
 	"denoiser16k_superres16kto48k"
 #define NVAFX_CHAINED_EFFECT_DEREVERB_16k_SUPERRES_16k_TO_48k \


### PR DESCRIPTION
### Description

More and more creators are jumping ship from Twitch and it would be great to get a Facebook VOD Track like how Twitch has this feature. Getting the ability to select a setting like 'Twitch VOD Track' which records a different audio for the VOD so stream doesn't get any copyrighted notices.

### Motivation and Context

This will allow Facebook creators to livestream content without having streams being taken down due to copyright notices. If you stream copyrighted music on YouTube by mistake from a video game the stream has a chance to be taken down then to have to press 'Livestream' again in order to livestream again. It's a bit redundant.

### Types of changes
- New feature (non-breaking change which adds functionality)
