### PR TITLE
UI: Fix improper usages of `on_foo_bar` slot name pattern

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1053,7 +1053,7 @@ QMenu *OBSBasic::CreatePerSceneTransitionMenu()
 	return menu;
 }
 
-void OBSBasic::on_actionShowTransitionProperties_triggered()
+void OBSBasic::ShowTransitionProperties()
 {
 	OBSSceneItem item = GetCurrentSceneItem();
 	OBSSource source = obs_sceneitem_get_transition(item, true);
@@ -1062,7 +1062,7 @@ void OBSBasic::on_actionShowTransitionProperties_triggered()
 		CreatePropertiesWindow(source);
 }
 
-void OBSBasic::on_actionHideTransitionProperties_triggered()
+void OBSBasic::HideTransitionProperties()
 {
 	OBSSceneItem item = GetCurrentSceneItem();
 	OBSSource source = obs_sceneitem_get_transition(item, false);
@@ -1247,10 +1247,9 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 	menu->addAction(durationAction);
 	if (curId && obs_is_source_configurable(curId)) {
 		menu->addSeparator();
-		menu->addAction(
-			QTStr("Properties"), this,
-			visible ? SLOT(on_actionShowTransitionProperties_triggered())
-				: SLOT(on_actionHideTransitionProperties_triggered()));
+		menu->addAction(QTStr("Properties"), this,
+				visible ? SLOT(ShowTransitionProperties())
+					: SLOT(HideTransitionProperties()));
 	}
 
 	auto copyTransition = [this](QAction *, bool visible) {

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -263,8 +263,6 @@ OBSBasic::OBSBasic(QWidget *parent)
 	setAcceptDrops(true);
 
 	setContextMenuPolicy(Qt::CustomContextMenu);
-	connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this,
-		SLOT(on_customContextMenuRequested(const QPoint &)));
 
 	api = InitializeAPIInterface(this);
 
@@ -10134,7 +10132,7 @@ void OBSBasic::ResetStatsHotkey()
 	foreach(OBSBasicStats * s, list) s->Reset();
 }
 
-void OBSBasic::on_customContextMenuRequested(const QPoint &pos)
+void OBSBasic::on_OBSBasic_customContextMenuRequested(const QPoint &pos)
 {
 	QWidget *widget = childAt(pos);
 	const char *className = nullptr;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1107,8 +1107,8 @@ private slots:
 	void on_transitionDuration_valueChanged(int value);
 	void on_tbar_position_valueChanged(int value);
 
-	void on_actionShowTransitionProperties_triggered();
-	void on_actionHideTransitionProperties_triggered();
+	void ShowTransitionProperties();
+	void HideTransitionProperties();
 
 	void on_modeSwitch_clicked();
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1027,7 +1027,7 @@ private slots:
 	void on_actionVerticalCenter_triggered();
 	void on_actionHorizontalCenter_triggered();
 
-	void on_customContextMenuRequested(const QPoint &pos);
+	void on_OBSBasic_customContextMenuRequested(const QPoint &pos);
 
 	void on_scenes_currentItemChanged(QListWidgetItem *current,
 					  QListWidgetItem *prev);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The `on_foo_bar` slot name in Qt is used by the `QMetaObject::connectSlotsByName` to automatically connect signals to slots (the call is in the generated `ui_OBSBasicWhatever.h` file). As explained in the [documentation](https://doc.qt.io/qt-6/qmetaobject.html#connectSlotsByName), using it precisely requires the name to be `on_[sender name]_[signal name]`. Anything else will not get connected, and shouldn't get connected manually, as it makes it *look* as if it's automatically connected even if it isn't.

To explain in detail, the first commit renames the slot to avoid potential confusion. When there is no automatic connection (and there isn't, as the action gets created dynamically and not by UIC), it shouldn't seem like there is.
In the second commit, there is an object that always exists (with the name `OBSBasic`), so this fixes the automatic connection by bringing the slot name into the `on_sender_signal` pattern.

There are more usages of `SLOT(on_` in the OBS code. However, with the exception of one in `window-basic-main-transitions` which I'm addressing in another Pull Request, these are automatically connected as well (as there are multiple ways to trigger the slot).


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed one of these usages in code. Decided to fix it and look for others.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13

Created a configurable show transition (Stinger), selected "Properties" and saw the window opening.
Right clicked on dock title bar to see that the menu still comes up (while it doesn't if I just remove the connect call).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
