### PR TITLE
obs-scripting: Re-enable Python annotations; Enable Python autodoc

### DIFF
--- a/deps/obs-scripting/obspython/obspython.i
+++ b/deps/obs-scripting/obspython/obspython.i
@@ -42,6 +42,7 @@
 %}
 
 %feature("python:annotations", "c");
+%feature("autodoc", "2");
 
 #define DEPRECATED_START
 #define DEPRECATED_END

--- a/deps/obs-scripting/obspython/obspython.i
+++ b/deps/obs-scripting/obspython/obspython.i
@@ -41,6 +41,8 @@
 
 %}
 
+%feature("python:annotations", "c");
+
 #define DEPRECATED_START
 #define DEPRECATED_END
 #define OBS_DEPRECATED


### PR DESCRIPTION
### Description

Re-enables Python annotations which were automatically disabled by the upgrade to SWIG 4. swig/swig@2072ae19c
This was previously available in OBS 27.2.

Additionally enables autodoc to provide the same information to apps such as VS Code.

### Python Annotations

**Before:**

```py
def obs_property_set_long_description(p, long_description):
    return _obspython.obs_property_set_long_description(p, long_description)
```

**After:**

```py
def obs_property_set_long_description(p: "obs_property_t *", long_description: "char const *") -> "void":
    return _obspython.obs_property_set_long_description(p, long_description)

```


### Python autodoc

**Before (same with/without annotations):**

![image](https://user-images.githubusercontent.com/941350/192738708-bbd84a51-9423-42e1-bd3c-518f3aac064f.png)

```py
def obs_property_set_long_description(p: "obs_property_t *", long_description: "char const *") -> "void":
    return _obspython.obs_property_set_long_description(p, long_description)

```

**After:**

![image](https://user-images.githubusercontent.com/941350/192739294-20eb1df7-b594-4d00-acb5-6f27af0b2c0f.png)

```py
def obs_property_set_long_description(p: "obs_property_t *", long_description: "char const *") -> "void":
    r"""
    obs_property_set_long_description(p, long_description)

    Parameters
    ----------
    p: obs_property_t *
    long_description: char const *

    """
    return _obspython.obs_property_set_long_description(p, long_description)
```


### Motivation and Context

Providing more context to Python developers about what parameters they need to provide makes writing scripts faster.

### How Has This Been Tested?

Compile OBS. Check `obspython.py` and VS Code autocomplete.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
