### PR TITLE
UI: Fix tabstop on settings dialog

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -7490,6 +7490,7 @@
   <tabstop>hideProjectorCursor</tabstop>
   <tabstop>projectorAlwaysOnTop</tabstop>
   <tabstop>saveProjectors</tabstop>
+  <tabstop>closeProjectors</tabstop>
   <tabstop>systemTrayEnabled</tabstop>
   <tabstop>systemTrayWhenStarted</tabstop>
   <tabstop>systemTrayAlways</tabstop>
@@ -7497,6 +7498,7 @@
   <tabstop>overflowAlwaysVisible</tabstop>
   <tabstop>overflowSelectionHide</tabstop>
   <tabstop>previewSafeAreas</tabstop>
+  <tabstop>previewSpacingHelpers</tabstop>
   <tabstop>automaticSearch</tabstop>
   <tabstop>doubleClickSwitch</tabstop>
   <tabstop>studioPortraitLayout</tabstop>
@@ -7506,6 +7508,7 @@
   <tabstop>multiviewDrawAreas</tabstop>
   <tabstop>multiviewLayout</tabstop>
   <tabstop>service</tabstop>
+  <tabstop>moreInfoButton</tabstop>
   <tabstop>connectAccount</tabstop>
   <tabstop>useStreamKey</tabstop>
   <tabstop>server</tabstop>
@@ -7551,6 +7554,7 @@
   <tabstop>advOutRecType</tabstop>
   <tabstop>advOutRecPath</tabstop>
   <tabstop>advOutRecPathBrowse</tabstop>
+  <tabstop>advOutNoSpace</tabstop>
   <tabstop>advOutRecFormat</tabstop>
   <tabstop>advOutRecTrack1</tabstop>
   <tabstop>advOutRecTrack2</tabstop>
@@ -7558,7 +7562,10 @@
   <tabstop>advOutRecTrack4</tabstop>
   <tabstop>advOutRecTrack5</tabstop>
   <tabstop>advOutRecTrack6</tabstop>
+  <tabstop>advOutRecEncoder</tabstop>
+  <tabstop>advOutRecUseRescale</tabstop>
   <tabstop>advOutRecRescale</tabstop>
+  <tabstop>advOutMuxCustom</tabstop>
   <tabstop>advOutSplitFile</tabstop>
   <tabstop>advOutSplitFileType</tabstop>
   <tabstop>advOutSplitFileTime</tabstop>
@@ -7591,6 +7598,7 @@
   <tabstop>monitoringDevice</tabstop>
   <tabstop>disableAudioDucking</tabstop>
   <tabstop>lowLatencyBuffering</tabstop>
+  <tabstop>baseResolution</tabstop>
   <tabstop>outputResolution</tabstop>
   <tabstop>downscaleFilter</tabstop>
   <tabstop>fpsType</tabstop>
@@ -7606,6 +7614,9 @@
   <tabstop>colorFormat</tabstop>
   <tabstop>colorSpace</tabstop>
   <tabstop>colorRange</tabstop>
+  <tabstop>sdrWhiteLevel</tabstop>
+  <tabstop>horizontalLayout_sdrPaperWhite</tabstop>
+  <tabstop>hdrNominalPeakLevel</tabstop>
   <tabstop>disableOSXVSync</tabstop>
   <tabstop>resetOSXVSync</tabstop>
   <tabstop>filenameFormatting</tabstop>
@@ -7626,17 +7637,12 @@
   <tabstop>browserHWAccel</tabstop>
   <tabstop>hotkeyFocusType</tabstop>
   <tabstop>hideOBSFromCapture</tabstop>
-  <tabstop>closeProjectors</tabstop>
-  <tabstop>moreInfoButton</tabstop>
   <tabstop>ignoreRecommended</tabstop>
   <tabstop>useStreamKeyAdv</tabstop>
-  <tabstop>baseResolution</tabstop>
   <tabstop>hotkeyFilterSearch</tabstop>
   <tabstop>hotkeyFilterInput</tabstop>
   <tabstop>hotkeyFilterReset</tabstop>
   <tabstop>hotkeyScrollArea</tabstop>
-  <tabstop>sdrWhiteLevel</tabstop>
-  <tabstop>hdrNominalPeakLevel</tabstop>
  </tabstops>
  <resources>
   <include location="obs.qrc"/>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Define tabstop based on the location of widgets.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Some tabstops are not defined or just defined at the end.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Checked the tabstop numbers on Qt Creator by eyes.

These two widgets are still not correctly defined the tabstops because these are created from C++ code.
- Hotkeys on Audio tab.
- `Twitch VOD Track` on Streaming section for Advanced Output.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
