### PR TITLE
Retain P3 for Mac screen capture

### DIFF
--- a/libobs/data/color.effect
+++ b/libobs/data/color.effect
@@ -26,6 +26,14 @@ float3 rec709_to_rec2020(float3 v)
 	return float3(r, g, b);
 }
 
+float3 d65p3_to_rec709(float3 v)
+{
+	float r = dot(v, float3(1.2249401762805598, -0.22494017628055996, 0.));
+	float g = dot(v, float3(-0.042056954709688163, 1.0420569547096881, 0.));
+	float b = dot(v, float3(-0.019637554590334432, -0.078636045550631889, 1.0982736001409663));
+	return float3(r, g, b);
+}
+
 float3 rec2020_to_rec709(float3 v)
 {
 	float r = dot(v, float3(1.6604910021084345, -0.58764113878854951, -0.072849863319884883));

--- a/libobs/data/default_rect.effect
+++ b/libobs/data/default_rect.effect
@@ -27,6 +27,14 @@ float4 PSDrawBare(VertInOut vert_in) : TARGET
 	return image.Sample(def_sampler, vert_in.uv);
 }
 
+float4 PSDrawD65P3(VertInOut vert_in) : TARGET
+{
+	float4 rgba = image.Sample(def_sampler, vert_in.uv);
+	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
+	rgba.rgb = d65p3_to_rec709(rgba.rgb);
+	return rgba;
+}
+
 float4 PSDrawOpaque(VertInOut vert_in) : TARGET
 {
 	return float4(image.Sample(def_sampler, vert_in.uv).rgb, 1.0);
@@ -45,6 +53,15 @@ technique Draw
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawBare(vert_in);
+	}
+}
+
+technique DrawD65P3
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawD65P3(vert_in);
 	}
 }
 

--- a/plugins/mac-capture/mac-screen-capture.m
+++ b/plugins/mac-capture/mac-screen-capture.m
@@ -462,8 +462,8 @@ static bool init_screen_stream(struct screen_capture *sc)
 	os_sem_post(sc->shareable_content_available);
 	[sc->stream_properties setQueueDepth:8];
 	[sc->stream_properties setShowsCursor:!sc->hide_cursor];
-	[sc->stream_properties setColorSpaceName:kCGColorSpaceSRGB];
-	[sc->stream_properties setPixelFormat:'BGRA'];
+	[sc->stream_properties setColorSpaceName:kCGColorSpaceDisplayP3];
+	[sc->stream_properties setPixelFormat:'l10r'];
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
 	if (@available(macOS 13.0, *)) {
 		[sc->stream_properties setCapturesAudio:TRUE];
@@ -649,18 +649,13 @@ static void screen_capture_video_render(void *data, gs_effect_t *effect
 	if (!sc->tex)
 		return;
 
-	const bool linear_srgb = gs_get_linear_srgb();
-
 	const bool previous = gs_framebuffer_srgb_enabled();
-	gs_enable_framebuffer_srgb(linear_srgb);
+	gs_enable_framebuffer_srgb(true);
 
 	gs_eparam_t *param = gs_effect_get_param_by_name(sc->effect, "image");
-	if (linear_srgb)
-		gs_effect_set_texture_srgb(param, sc->tex);
-	else
-		gs_effect_set_texture(param, sc->tex);
+	gs_effect_set_texture(param, sc->tex);
 
-	while (gs_effect_loop(sc->effect, "Draw"))
+	while (gs_effect_loop(sc->effect, "DrawD65P3"))
 		gs_draw_sprite(sc->tex, 0, 0, 0);
 
 	gs_enable_framebuffer_srgb(previous);
@@ -1034,6 +1029,29 @@ static obs_properties_t *screen_capture_properties(void *data)
 	return props;
 }
 
+enum gs_color_space screen_capture_video_get_color_space(
+	void *data, size_t count, const enum gs_color_space *preferred_spaces)
+{
+	UNUSED_PARAMETER(data);
+
+	for (size_t i = 0; i < count; ++i) {
+		if (preferred_spaces[i] == GS_CS_SRGB_16F)
+			return GS_CS_SRGB_16F;
+	}
+
+	for (size_t i = 0; i < count; ++i) {
+		if (preferred_spaces[i] == GS_CS_709_EXTENDED)
+			return GS_CS_709_EXTENDED;
+	}
+
+	for (size_t i = 0; i < count; ++i) {
+		if (preferred_spaces[i] == GS_CS_SRGB)
+			return GS_CS_SRGB;
+	}
+
+	return GS_CS_SRGB_16F;
+}
+
 struct obs_source_info screen_capture_info = {
 	.id = "screen_capture",
 	.type = OBS_SOURCE_TYPE_INPUT,
@@ -1055,6 +1073,7 @@ struct obs_source_info screen_capture_info = {
 	.get_properties = screen_capture_properties,
 	.update = screen_capture_update,
 	.icon_type = OBS_ICON_TYPE_DESKTOP_CAPTURE,
+	.video_get_color_space = screen_capture_video_get_color_space,
 };
 
 @implementation ScreenCaptureDelegate


### PR DESCRIPTION
### Description
Added support for retaining P3 colors when capturing Mac screens. Gets clipped for SDR recordings, but kept for HDR recordings.

### Motivation and Context
Want to keep wide colors when possible.

### How Has This Been Tested?
Verified SDR looks the same, and AOM AV1 HDR recording retains P3 colors.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.