### PR TITLE
UI: Don't reselect SceneTree items if tree is clearing

### DIFF
--- a/UI/item-widget-helpers.cpp
+++ b/UI/item-widget-helpers.cpp
@@ -37,10 +37,14 @@ void DeleteListItem(QListWidget *widget, QListWidgetItem *item)
 
 void ClearListItems(QListWidget *widget)
 {
+	// Workaround for the SceneTree workaround for QTBUG-105870
+	widget->setProperty("clearing", true);
+
 	widget->setCurrentItem(nullptr, QItemSelectionModel::Clear);
 
 	for (int i = 0; i < widget->count(); i++)
 		delete widget->itemWidget(widget->item(i));
 
 	widget->clear();
+	widget->setProperty("clearing", false);
 }

--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -252,6 +252,7 @@ void SceneTree::rowsInserted(const QModelIndex &parent, int start, int end)
 void SceneTree::selectionChanged(const QItemSelection &selected,
 				 const QItemSelection &deselected)
 {
-	if (selected.count() == 0 && deselected.count() > 0)
+	if (selected.count() == 0 && deselected.count() > 0 &&
+	    !property("clearing").toBool())
 		setCurrentRow(deselected.indexes().front().row());
 }


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
In the scene tree, we currently prevent deselecting items by automatically reselecting a new one to workaround a regression in Qt 6.2 that would let users unselect items even in SingleSelection QItemViews. When clearing however, we explicitly want to unselect the currently selected item, so we should avoid reselecting it in the SceneTree.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #7280

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13
The unintended side effect of the original commit (the selected transition getting greyed out when switching scene collections) no longer happens, the transitions combobox is still enabled.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
