### PR TITLE
win-wasapi: Don't reconnect when inactive

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -182,7 +182,7 @@ class WASAPISource {
 	std::atomic<bool> isDefaultDevice = false;
 
 	bool previouslyFailed = false;
-	WinHandle reconnectThread;
+	WinHandle reconnectThread = NULL;
 
 	class CallbackStartCapture : public ARtwqAsyncCallback {
 	public:
@@ -238,6 +238,7 @@ class WASAPISource {
 	WinHandle stopSignal;
 	WinHandle receiveSignal;
 	WinHandle restartSignal;
+	WinHandle reconnectExitSignal;
 	WinHandle exitSignal;
 	WinHandle initSignal;
 	DWORD reconnectDuration = 0;
@@ -297,6 +298,9 @@ public:
 
 	void Update(obs_data_t *settings);
 	void OnWindowChanged(obs_data_t *settings);
+
+	void Activate();
+	void Deactivate();
 
 	void SetDefaultDevice(EDataFlow flow, ERole role, LPCWSTR id);
 
@@ -390,6 +394,10 @@ WASAPISource::WASAPISource(obs_data_t *settings, obs_source_t *source_,
 	if (!restartSignal.Valid())
 		throw "Could not create restart signal";
 
+	reconnectExitSignal = CreateEvent(nullptr, true, false, nullptr);
+	if (!reconnectExitSignal.Valid())
+		throw "Could not create reconnect exit signal";
+
 	exitSignal = CreateEvent(nullptr, true, false, nullptr);
 	if (!exitSignal.Valid())
 		throw "Could not create exit signal";
@@ -401,11 +409,6 @@ WASAPISource::WASAPISource(obs_data_t *settings, obs_source_t *source_,
 	reconnectSignal = CreateEvent(nullptr, false, false, nullptr);
 	if (!reconnectSignal.Valid())
 		throw "Could not create reconnect signal";
-
-	reconnectThread = CreateThread(
-		nullptr, 0, WASAPISource::ReconnectThread, this, 0, nullptr);
-	if (!reconnectThread.Valid())
-		throw "Failed to create reconnect thread";
 
 	notify = new WASAPINotify(this);
 	if (!notify)
@@ -525,6 +528,9 @@ void WASAPISource::Start()
 
 void WASAPISource::Stop()
 {
+	if (!reconnectThread.Valid())
+		WaitForSingleObject(reconnectSignal, INFINITE);
+
 	SetEvent(stopSignal);
 
 	blog(LOG_INFO, "WASAPI: Device '%s' Terminated", device_name.c_str());
@@ -532,11 +538,15 @@ void WASAPISource::Stop()
 	if (rtwq_supported)
 		SetEvent(receiveSignal);
 
-	WaitForSingleObject(idleSignal, INFINITE);
+	if (reconnectThread.Valid())
+		WaitForSingleObject(idleSignal, INFINITE);
 
 	SetEvent(exitSignal);
 
-	WaitForSingleObject(reconnectThread, INFINITE);
+	if (reconnectThread.Valid()) {
+		SetEvent(reconnectExitSignal);
+		WaitForSingleObject(reconnectThread, INFINITE);
+	}
 
 	if (rtwq_supported)
 		rtwq_unlock_work_queue(sampleReady.GetQueueId());
@@ -655,6 +665,25 @@ void WASAPISource::OnWindowChanged(obs_data_t *settings)
 
 	if (restart)
 		SetEvent(restartSignal);
+}
+
+void WASAPISource::Activate()
+{
+	if (!reconnectThread.Valid()) {
+		ResetEvent(reconnectExitSignal);
+		reconnectThread = CreateThread(nullptr, 0,
+					       WASAPISource::ReconnectThread,
+					       this, 0, nullptr);
+	}
+}
+
+void WASAPISource::Deactivate()
+{
+	if (reconnectThread.Valid()) {
+		SetEvent(reconnectExitSignal);
+		WaitForSingleObject(reconnectThread, INFINITE);
+		reconnectThread = NULL;
+	}
 }
 
 ComPtr<IMMDevice> WASAPISource::InitDevice(IMMDeviceEnumerator *enumerator,
@@ -1005,8 +1034,13 @@ DWORD WINAPI WASAPISource::ReconnectThread(LPVOID param)
 	WASAPISource *source = (WASAPISource *)param;
 
 	const HANDLE sigs[] = {
-		source->exitSignal,
+		source->reconnectExitSignal,
 		source->reconnectSignal,
+	};
+
+	const HANDLE reconnect_sigs[] = {
+		source->reconnectExitSignal,
+		source->stopSignal,
 	};
 
 	bool exit = false;
@@ -1020,8 +1054,10 @@ DWORD WINAPI WASAPISource::ReconnectThread(LPVOID param)
 		default:
 			assert(ret == (WAIT_OBJECT_0 + 1));
 			if (source->reconnectDuration > 0) {
-				WaitForSingleObject(source->stopSignal,
-						    source->reconnectDuration);
+				WaitForMultipleObjects(
+					_countof(reconnect_sigs),
+					reconnect_sigs, false,
+					source->reconnectDuration);
 			}
 			source->Start();
 		}
@@ -1426,6 +1462,16 @@ static void UpdateWASAPISource(void *obj, obs_data_t *settings)
 	static_cast<WASAPISource *>(obj)->Update(settings);
 }
 
+static void ActivateWASAPISource(void *obj)
+{
+	static_cast<WASAPISource *>(obj)->Activate();
+}
+
+static void DeactivateWASAPISource(void *obj)
+{
+	static_cast<WASAPISource *>(obj)->Deactivate();
+}
+
 static bool UpdateWASAPIMethod(obs_properties_t *props, obs_property_t *,
 			       obs_data_t *settings)
 {
@@ -1542,6 +1588,8 @@ void RegisterWASAPIInput()
 	info.create = CreateWASAPIInput;
 	info.destroy = DestroyWASAPISource;
 	info.update = UpdateWASAPISource;
+	info.activate = ActivateWASAPISource;
+	info.deactivate = DeactivateWASAPISource;
 	info.get_defaults = GetWASAPIDefaultsInput;
 	info.get_properties = GetWASAPIPropertiesInput;
 	info.icon_type = OBS_ICON_TYPE_AUDIO_INPUT;
@@ -1559,6 +1607,8 @@ void RegisterWASAPIDeviceOutput()
 	info.create = CreateWASAPIDeviceOutput;
 	info.destroy = DestroyWASAPISource;
 	info.update = UpdateWASAPISource;
+	info.activate = ActivateWASAPISource;
+	info.deactivate = DeactivateWASAPISource;
 	info.get_defaults = GetWASAPIDefaultsDeviceOutput;
 	info.get_properties = GetWASAPIPropertiesDeviceOutput;
 	info.icon_type = OBS_ICON_TYPE_AUDIO_OUTPUT;
@@ -1576,6 +1626,8 @@ void RegisterWASAPIProcessOutput()
 	info.create = CreateWASAPIProcessOutput;
 	info.destroy = DestroyWASAPISource;
 	info.update = UpdateWASAPISource;
+	info.activate = ActivateWASAPISource;
+	info.deactivate = DeactivateWASAPISource;
 	info.get_defaults = GetWASAPIDefaultsProcessOutput;
 	info.get_properties = GetWASAPIPropertiesProcessOutput;
 	info.icon_type = OBS_ICON_TYPE_PROCESS_AUDIO_OUTPUT;


### PR DESCRIPTION
### Description
Unnecessary reconnect attempts may cause noticeable hitches.

### Motivation and Context
Don't want hitches to occur, particularly when a scene collection may contain a ton of inactive application audio captures.

### How Has This Been Tested?
- [x] Verify audio input capture reconnects are active when launching OBS directly to scene.
- [x] Verify audio input capture reconnects are inactive when launching OBS directly to different scene.
- [x] Verify audio input capture reconnects are active after activating scene.
- [x] Verify audio input capture reconnects are inactive after deactivating scene.
- [x] Verify clean OBS exit when audio input capture is active.
- [x] Verify clean OBS exit when audio input capture is inactive.
- [x] Verify audio output capture reconnects are active when launching OBS directly to scene.
- [x] Verify audio output capture reconnects are inactive when launching OBS directly to different scene.
- [x] Verify audio output capture reconnects are active after activating scene.
- [x] Verify audio output capture reconnects are inactive after deactivating scene.
- [x] Verify clean OBS exit when audio output capture is active.
- [x] Verify clean OBS exit when audio output capture is inactive.
- [x] Verify application audio capture reconnects are active when launching OBS directly to scene.
- [x] Verify application audio capture reconnects are inactive when launching OBS directly to different scene.
- [x] Verify application audio capture reconnects are active after activating scene.
- [x] Verify application audio capture reconnects are inactive after deactivating scene.
- [x] Verify clean OBS exit when application audio capture is active.
- [x] Verify clean OBS exit when application audio capture is inactive.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.