### PR TITLE
win-wasapi: Fix Stop hang

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -528,9 +528,6 @@ void WASAPISource::Start()
 
 void WASAPISource::Stop()
 {
-	if (!reconnectThread.Valid())
-		WaitForSingleObject(reconnectSignal, INFINITE);
-
 	SetEvent(stopSignal);
 
 	blog(LOG_INFO, "WASAPI: Device '%s' Terminated", device_name.c_str());
@@ -538,8 +535,12 @@ void WASAPISource::Stop()
 	if (rtwq_supported)
 		SetEvent(receiveSignal);
 
-	if (reconnectThread.Valid())
+	if (reconnectThread.Valid()) {
 		WaitForSingleObject(idleSignal, INFINITE);
+	} else {
+		const HANDLE sigs[] = {reconnectSignal, idleSignal};
+		WaitForMultipleObjects(_countof(sigs), sigs, false, INFINITE);
+	}
 
 	SetEvent(exitSignal);
 


### PR DESCRIPTION
### Description
Fix hang when audio capture is active in the background and stopped by either closing OBS, or switching scene collections.

### Motivation and Context
Don't want OBS to hang.

### How Has This Been Tested?
Verified both cases were broken before, and fixed after.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.