### PR TITLE
libobs: Bind to only one wayland seat

### DIFF
--- a/libobs/obs-nix-wayland.c
+++ b/libobs/obs-nix-wayland.c
@@ -219,6 +219,11 @@ static void platform_registry_handler(void *data, struct wl_registry *registry,
 	obs_hotkeys_platform_t *plat = (obs_hotkeys_platform_t *)data;
 
 	if (strcmp(interface, wl_seat_interface.name) == 0) {
+		if (plat->seat != NULL) {
+			blog(LOG_WARNING,
+			     "[wayland] multiple seats detected, only using the first one");
+			return;
+		}
 		if (version < 4) {
 			blog(LOG_WARNING,
 			     "[wayland] hotkeys disabled, compositor is too old");


### PR DESCRIPTION
### Description
Bind to only one wl_seat.

### Motivation and Context
Compositors like Sway are mulit-seat aware. This means the registry will send multiple global events for each wl_seat.
This cause an issue where obs will leak every seat other than the last one sent, and will try to get the keyboard for a seat that doesn't support it, causing a protocol error.

Relevant Wayland log:
```
[2453323.467] wl_seat@30.name("seat0")
[2453323.508] wl_seat@30.capabilities(3)
[2453323.516]  -> wl_seat@31.get_keyboard(new id wl_keyboard@34)
[2453323.526] wl_seat@31.name("seat1")
[2453323.533] wl_seat@31.capabilities(0)
[2453323.539]  -> wl_keyboard@34.release()
[2453323.719] wl_display@1.error(wl_seat@31, 0, "wl_seat.get_keyboard called when no keyboard capability has existed")
wl_seat@31: error 0: wl_seat.get_keyboard called when no keyboard capability has existed
The Wayland connection experienced a fatal error: Protocol error
```

### How Has This Been Tested?
- ArchLinux: 5.19.12.arch1-1
- Sway: 1.7 (configured with 2 seats)

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
