### PR TITLE
UI: Move "Always On Top" into View menu

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -742,7 +742,6 @@ Basic.MainMenu.File.Settings="&Settings"
 Basic.MainMenu.File.ShowSettingsFolder="Show Settings Folder"
 Basic.MainMenu.File.ShowProfileFolder="Show Profile Folder"
 Basic.MainMenu.File.ShowMissingFiles="Check for Missing Files"
-Basic.MainMenu.AlwaysOnTop="&Always On Top"
 Basic.MainMenu.File.Exit="E&xit"
 
 # basic mode edit menu
@@ -786,6 +785,8 @@ Basic.MainMenu.View.SourceIcons="Source &Icons"
 Basic.MainMenu.View.StatusBar="&Status Bar"
 Basic.MainMenu.View.Fullscreen.Interface="Fullscreen Interface"
 Basic.MainMenu.View.ResetUI="&Reset UI"
+Basic.MainMenu.View.AlwaysOnTop="&Always On Top"
+
 
 #basic mode docks menu
 Basic.MainMenu.Docks="&Docks"

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -690,6 +690,14 @@
     <addaction name="toggleStatusBar"/>
     <addaction name="separator"/>
     <addaction name="stats"/>
+    <addaction name="separator"/>
+    <addaction name="multiviewProjectorMenu"/>
+    <addaction name="multiviewProjectorWindowed"/>
+   </widget>
+   <widget class="QMenu" name="multiviewProjectorMenu">
+    <property name="title">
+     <string>MultiviewProjector</string>
+    </property>
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
@@ -2153,6 +2161,11 @@
   <action name="stats">
    <property name="text">
     <string>Basic.Stats</string>
+   </property>
+  </action>
+  <action name="multiviewProjectorWindowed">
+   <property name="text">
+    <string>MultiviewWindowed</string>
    </property>
   </action>
   <action name="resetDocks">

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -501,8 +501,6 @@
     <addaction name="actionShowSettingsFolder"/>
     <addaction name="actionShowProfileFolder"/>
     <addaction name="separator"/>
-    <addaction name="actionAlwaysOnTop"/>
-    <addaction name="separator"/>
     <addaction name="actionE_xit"/>
    </widget>
    <widget class="QMenu" name="menuBasic_MainMenu_Help">
@@ -693,6 +691,8 @@
     <addaction name="separator"/>
     <addaction name="multiviewProjectorMenu"/>
     <addaction name="multiviewProjectorWindowed"/>
+    <addaction name="separator"/>
+    <addaction name="actionAlwaysOnTop"/>
    </widget>
    <widget class="QMenu" name="multiviewProjectorMenu">
     <property name="title">
@@ -2086,7 +2086,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Basic.MainMenu.AlwaysOnTop</string>
+    <string>Basic.MainMenu.View.AlwaysOnTop</string>
    </property>
   </action>
   <action name="toggleListboxToolbars">

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2036,14 +2036,10 @@ void OBSBasic::OBSInit()
 
 	ui->viewMenu->addSeparator();
 
-	multiviewProjectorMenu = new QMenu(QTStr("MultiviewProjector"));
-	ui->viewMenu->addMenu(multiviewProjectorMenu);
-	AddProjectorMenuMonitors(multiviewProjectorMenu, this,
+	AddProjectorMenuMonitors(ui->multiviewProjectorMenu, this,
 				 SLOT(OpenMultiviewProjector()));
 	connect(ui->viewMenu->menuAction(), &QAction::hovered, this,
 		&OBSBasic::UpdateMultiviewProjectorMenu);
-	ui->viewMenu->addAction(QTStr("MultiviewWindowed"), this,
-				SLOT(OpenMultiviewWindow()));
 
 	ui->sources->UpdateIcons();
 
@@ -2279,8 +2275,8 @@ void OBSBasic::ShowWhatsNew(const QString &url)
 
 void OBSBasic::UpdateMultiviewProjectorMenu()
 {
-	multiviewProjectorMenu->clear();
-	AddProjectorMenuMonitors(multiviewProjectorMenu, this,
+	ui->multiviewProjectorMenu->clear();
+	AddProjectorMenuMonitors(ui->multiviewProjectorMenu, this,
 				 SLOT(OpenMultiviewProjector()));
 }
 
@@ -2604,7 +2600,6 @@ OBSBasic::~OBSBasic()
 		updateCheckThread->wait();
 
 	delete screenshotData;
-	delete multiviewProjectorMenu;
 	delete previewProjector;
 	delete studioProgramProjector;
 	delete previewProjectorSource;
@@ -8800,11 +8795,6 @@ void OBSBasic::OpenSourceWindow()
 		      ProjectorType::Source);
 }
 
-void OBSBasic::OpenMultiviewWindow()
-{
-	OpenProjector(nullptr, -1, ProjectorType::Multiview);
-}
-
 void OBSBasic::OpenSceneWindow()
 {
 	OBSScene scene = GetCurrentScene();
@@ -9019,6 +9009,11 @@ void OBSBasic::on_resetUI_triggered()
 	ui->toggleContextBar->setChecked(true);
 	ui->toggleSourceIcons->setChecked(true);
 	ui->toggleStatusBar->setChecked(true);
+}
+
+void OBSBasic::on_multiviewProjectorWindowed_triggered()
+{
+	OpenProjector(nullptr, -1, ProjectorType::Multiview);
 }
 
 void OBSBasic::on_toggleListboxToolbars_toggled(bool visible)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -315,7 +315,6 @@ private:
 	QPointer<QMenu> trayMenu;
 	QPointer<QMenu> previewProjector;
 	QPointer<QMenu> studioProgramProjector;
-	QPointer<QMenu> multiviewProjectorMenu;
 	QPointer<QMenu> previewProjectorSource;
 	QPointer<QMenu> previewProjectorMain;
 	QPointer<QMenu> sceneProjectorMenu;
@@ -1123,6 +1122,7 @@ private slots:
 	void on_resetUI_triggered();
 	void on_resetDocks_triggered(bool force = false);
 	void on_lockDocks_toggled(bool lock);
+	void on_multiviewProjectorWindowed_triggered();
 
 	void PauseToggled();
 
@@ -1169,7 +1169,6 @@ private slots:
 	void OpenStudioProgramWindow();
 	void OpenPreviewWindow();
 	void OpenSourceWindow();
-	void OpenMultiviewWindow();
 	void OpenSceneWindow();
 
 	void StackedMixerAreaContextMenuRequested();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Moves the "Always On Top" option from the "File" menu into the "View" menu.

<img width="294" alt="image" src="https://user-images.githubusercontent.com/59806498/193855857-245185a8-1125-46ef-95ed-90044cdfea79.png">

This also requires putting the "Multiview (Fullscreen)" and "Multiview (Windowed)" actions into UI files instead of generating them in code, so that we can put the "Always On Top" action below it (without having to add it from code as well). That's something that should have been done at some point anyways though.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The View menu is the correct place for options like these. The View menu was added after the Always On Top option, but the option was never moved to it.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13

See screenshot above.
Tested that the multiview actions (both windowed and fullscreen) still work.
Tested that toggling Always On Top still works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
