### PR TITLE
cmake: Fix FindGio.cmake to find libgio

### DIFF
--- a/cmake/Modules/FindGio.cmake
+++ b/cmake/Modules/FindGio.cmake
@@ -21,7 +21,7 @@ find_path(
 
 find_library(
   GIO_LIB
-  NAMES ${_GIO_LIBRARIES} gio-2.0 libgio-2.0 gio-unix-2.0
+  NAMES gio-2.0 libgio-2.0 gio-unix-2.0
   HINTS ${_GIO_LIBRARY_DIRS}
   PATHS /usr/lib /usr/local/lib /opt/local/lib /sw/lib)
 


### PR DESCRIPTION
Find actual `libgio-2.0.so` instead of `libgobject-2.0.so`.

### Description
Without this change CMake detects `libgobject-2.0.so` instead of the actual `libgio-2.0.so`
```
-- Checking for modules 'gio-2.0;gio-unix-2.0'
--   Found gio-2.0, version 2.74.0
--   Found gio-unix-2.0, version 2.74.0
-- Found Gio: /usr/x86_64-pc-linux-gnu/lib/libgobject-2.0.so
```

and later on fails the build ([obs-studio-28.0.3.log](https://github.com/obsproject/obs-studio/files/9715172/obs-studio-28.0.3.log)) with:

```
[ 48%] Linking C executable obs-x264-test
cd /var/tmp/paludis/build/media-video-obs-studio-28.0.3/work/build/plugins/obs-x264 && /usr/x86_64-pc-linux-gnu/bin/cmake -E cmake_link_script CMakeFiles/obs-x264-test.dir/link.txt --verbose=1
/usr/bin/x86_64-pc-linux-gnu-cc -march=native -O2 -pipe -Wl,-O1 -Wl,--as-needed "CMakeFiles/obs-x264-test.dir/obs-x264-test.c.o" "CMakeFiles/obs-x264-test.dir/__/__/deps/opts-parser/opts-parser.c.o" -o obs-x264-test  -Wl,-rpath,/var/tmp/paludis/build/media-video-obs-studio-28.0.3/work/build/libobs ../../libobs/libobs.so.28 
make[2]: Leaving directory '/var/tmp/paludis/build/media-video-obs-studio-28.0.3/work/build'
make[1]: Leaving directory '/var/tmp/paludis/build/media-video-obs-studio-28.0.3/work/build'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../../libobs/libobs.so.28: undefined reference to `g_bus_get_sync'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../../libobs/libobs.so.28: undefined reference to `g_dbus_connection_get_unique_name'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../../libobs/libobs.so.28: undefined reference to `g_dbus_connection_call'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../../libobs/libobs.so.28: undefined reference to `g_dbus_connection_call_finish'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../../libobs/libobs.so.28: undefined reference to `g_cancellable_new'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../../libobs/libobs.so.28: undefined reference to `g_dbus_connection_signal_subscribe'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../../libobs/libobs.so.28: undefined reference to `g_io_error_quark'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../../libobs/libobs.so.28: undefined reference to `g_cancellable_cancel'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../../libobs/libobs.so.28: undefined reference to `g_dbus_connection_call_sync'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: ../../libobs/libobs.so.28: undefined reference to `g_dbus_connection_signal_unsubscribe'
collect2: error: ld returned 1 exit status
make[2]: *** [plugins/obs-x264/CMakeFiles/obs-x264-test.dir/build.make:117: plugins/obs-x264/obs-x264-test] Error 1
make[1]: *** [CMakeFiles/Makefile2:1205: plugins/obs-x264/CMakeFiles/obs-x264-test.dir/all] Error 2
make: *** [Makefile:159: all] Error 2
```

With the change CMake instead detects the actual `libgio-2.0.so`

```
-- Checking for modules 'gio-2.0;gio-unix-2.0'
--   Found gio-2.0, version 2.74.0
--   Found gio-unix-2.0, version 2.74.0
-- Found Gio: /usr/x86_64-pc-linux-gnu/lib/libgio-2.0.so
```

and build succeeds.

```
# lddtree /usr/x86_64-pc-linux-gnu/lib/libobs.so.28
libobs.so.28 => /usr/x86_64-pc-linux-gnu/lib/libobs.so.28 (interpreter => none)
[...]
    libgio-2.0.so.0 => /usr/x86_64-pc-linux-gnu/lib/libgio-2.0.so.0
        libglib-2.0.so.0 => /usr/host/lib/libglib-2.0.so.0
            libpcre2-8.so.0 => /usr/host/lib/libpcre2-8.so.0
        libgobject-2.0.so.0 => /usr/host/lib/libgobject-2.0.so.0
            libffi.so.8 => /usr/host/lib/libffi.so.8
        libgmodule-2.0.so.0 => /usr/host/lib/libgmodule-2.0.so.0
        libmount.so.1 => /usr/host/lib/libmount.so.1
            libcryptsetup.so.12 => /usr/x86_64-pc-linux-gnu/lib/libcryptsetup.so.12
            libuuid.so.1 => /usr/x86_64-pc-linux-gnu/lib/libuuid.so.1
            libdevmapper.so.1.02 => /usr/x86_64-pc-linux-gnu/lib/libdevmapper.so.1.02
                libudev.so.1 => /usr/host/lib/libudev.so.1
            libargon2.so.1 => /usr/x86_64-pc-linux-gnu/lib/libargon2.so.1
            libjson-c.so.5 => /usr/x86_64-pc-linux-gnu/lib/libjson-c.so.5
            libblkid.so.1 => /usr/x86_64-pc-linux-gnu/lib/libblkid.so.1
[...]
```

### Motivation and Context
* Discussion at https://gitlab.exherbo.org/exherbo/media/-/merge_requests/1004#note_34384
* Fix build failure, explanation above.

### How Has This Been Tested?
Locally, Exherbo Linux, x86_64 as well as on our CI which failed before with the same error:
https://gitlab.exherbo.org/tgurr/media/-/jobs/50164 and built fine with the fix https://gitlab.exherbo.org/tgurr/media/-/jobs/50207.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
