### PR TITLE
obs-scripting: Add obs_sceneitem_group_enum_items function call

### DIFF
--- a/deps/obs-scripting/obs-scripting-lua.c
+++ b/deps/obs-scripting/obs-scripting-lua.c
@@ -644,6 +644,17 @@ static int scene_enum_items(lua_State *script)
 	return 1;
 }
 
+static int sceneitem_group_enum_items(lua_State *script)
+{
+	obs_sceneitem_t *sceneitem;
+	if (!ls_get_libobs_obj(obs_sceneitem_t, 1, &sceneitem))
+		return 0;
+
+	lua_newtable(script);
+	obs_sceneitem_group_enum_items(sceneitem, enum_items_proc, script);
+	return 1;
+}
+
 /* -------------------------------------------- */
 
 static void defer_hotkey_unregister(void *p_cb)
@@ -1014,6 +1025,7 @@ static void add_hook_functions(lua_State *script)
 	add_func("obs_enum_sources", enum_sources);
 	add_func("obs_source_enum_filters", source_enum_filters);
 	add_func("obs_scene_enum_items", scene_enum_items);
+	add_func("obs_sceneitem_group_enum_items", sceneitem_group_enum_items);
 	add_func("source_list_release", source_list_release);
 	add_func("sceneitem_list_release", sceneitem_list_release);
 	add_func("calldata_source", calldata_source);

--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -1108,6 +1108,23 @@ static PyObject *scene_enum_items(PyObject *self, PyObject *args)
 	return list;
 }
 
+static PyObject *sceneitem_group_enum_items(PyObject *self, PyObject *args)
+{
+	PyObject *py_sceneitem;
+	obs_sceneitem_t *sceneitem;
+
+	UNUSED_PARAMETER(self);
+
+	if (!parse_args(args, "O", &py_sceneitem))
+		return python_none();
+	if (!py_to_libobs(obs_sceneitem_t, py_sceneitem, &sceneitem))
+		return python_none();
+
+	PyObject *list = PyList_New(0);
+	obs_sceneitem_group_enum_items(sceneitem, enum_items_proc, list);
+	return list;
+}
+
 /* -------------------------------------------- */
 
 static PyObject *source_list_release(PyObject *self, PyObject *args)
@@ -1235,6 +1252,8 @@ static void add_hook_functions(PyObject *module)
 		DEF_FUNC("sceneitem_list_release", sceneitem_list_release),
 		DEF_FUNC("obs_enum_sources", enum_sources),
 		DEF_FUNC("obs_scene_enum_items", scene_enum_items),
+		DEF_FUNC("obs_sceneitem_group_enum_items",
+			 sceneitem_group_enum_items),
 		DEF_FUNC("obs_remove_tick_callback",
 			 obs_python_remove_tick_callback),
 		DEF_FUNC("obs_add_tick_callback", obs_python_add_tick_callback),

--- a/docs/sphinx/scripting.rst
+++ b/docs/sphinx/scripting.rst
@@ -197,6 +197,14 @@ modules/namespaces).
    :return:      List of scene items.  Release with
                  :py:func:`sceneitem_list_release()`.
 
+.. py:function:: obs_sceneitem_group_enum_items(group)
+
+   Enumerates scene items within a group.
+
+   :param group: obs_sceneitem_t object to enumerate items from.
+   :return:      List of scene items.  Release with
+                 :py:func:`sceneitem_list_release()`.
+
 .. py:function:: obs_add_main_render_callback(callback)
 
    **Lua only:** Adds a primary output render callback.  This callback


### PR DESCRIPTION
### Description
Adds function call to enumerate over items contained in a source group.

### Motivation and Context
Implements functionality requested in https://github.com/obsproject/obs-studio/issues/2788.

### How Has This Been Tested?
Tested with Python 3.10 and Lua.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
