### PR TITLE
Add pause-resume feature to ffmpeg plugin to auto pause when switching away

### DIFF
--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -104,3 +104,5 @@ NVENC.CheckDrivers="Please check your video drivers are up to date."
 AV1.8bitUnsupportedHdr="OBS does not support 8-bit output of Rec. 2100."
 
 ReconnectDelayTime="Reconnect Delay"
+
+MediaSource.FFmpeg.PauseResume="Pause on deactivate, resume on activate"

--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -58,6 +58,7 @@ struct ffmpeg_source {
 	bool is_clear_on_media_end;
 	bool restart_on_activate;
 	bool close_when_inactive;
+	bool pause_and_resume;
 	bool seekable;
 
 	pthread_t reconnect_thread;
@@ -115,6 +116,7 @@ static void ffmpeg_source_defaults(obs_data_t *settings)
 	obs_data_set_default_int(settings, "reconnect_delay_sec", 10);
 	obs_data_set_default_int(settings, "buffering_mb", 2);
 	obs_data_set_default_int(settings, "speed_percent", 100);
+	obs_data_set_default_bool(settings, "pause_and_resume", false);
 }
 
 static const char *media_filter =
@@ -199,6 +201,9 @@ static obs_properties_t *ffmpeg_source_getproperties(void *data)
 
 	obs_property_set_long_description(
 		prop, obs_module_text("CloseFileWhenInactive.ToolTip"));
+
+	prop = obs_properties_add_bool(props, "pause_and_resume",
+				       obs_module_text("MediaSource.FFmpeg.PauseResume"));
 
 	prop = obs_properties_add_int_slider(props, "speed_percent",
 					     obs_module_text("SpeedPercentage"),
@@ -465,6 +470,7 @@ static void ffmpeg_source_update(void *data, obs_data_t *settings)
 	s->is_local_file = is_local_file;
 	s->seekable = obs_data_get_bool(settings, "seekable");
 	s->ffmpeg_options = ffmpeg_options ? bstrdup(ffmpeg_options) : NULL;
+	s->pause_and_resume = obs_data_get_bool(settings, "pause_and_resume");
 
 	if (s->speed_percent < 1 || s->speed_percent > 200)
 		s->speed_percent = 100;
@@ -666,6 +672,11 @@ static void ffmpeg_source_activate(void *data)
 {
 	struct ffmpeg_source *s = data;
 
+	if (s->pause_and_resume && s->state == OBS_MEDIA_STATE_PAUSED) {
+		// resume on re-activate
+		obs_source_media_play_pause(s->source, false);
+		return;
+	}
 	if (s->restart_on_activate)
 		obs_source_media_restart(s->source);
 }
@@ -673,6 +684,12 @@ static void ffmpeg_source_activate(void *data)
 static void ffmpeg_source_deactivate(void *data)
 {
 	struct ffmpeg_source *s = data;
+
+	if (s->pause_and_resume && s->state == OBS_MEDIA_STATE_PLAYING) {
+		// pause on deactivate, leave it loaded
+		obs_source_media_play_pause(s->source, true);
+		return;
+	}
 
 	if (s->restart_on_activate) {
 		if (s->media_valid) {


### PR DESCRIPTION
Added option for ffmpeg (video) sources to say they want to be paused on deactivate and resumed on activate, instead of default to stop and restart.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This patch adds a checkbox option to video sources (after "close file when inactive"), labeled "pause and resume"; when enabled the video source will be PAUSED when the source is deactivated, and then RESUMED when it is later reactivated.  This is in contrast to the other options which allow EITHER that video sources are stopped/unloaded and restarted, or are left playing in the background.

### Motivation and Context
This is based on this request:
https://obsproject.com/forum/threads/request-for-video-media-source-pause-and-unpause-when-showing-hiding.154270/#post-565354
The two motivations are: 1) to allow video sources to be paused when switched away from and then resumed and 2) to reduce cpu use when not showing a scene with a video that you will return to.

### How Has This Been Tested?
Tested on windows OBS version 28; it's a super simple modification which makes no assumptions about the video sources.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.

NOTE: This is my first contribution to OBS -- please feel free to modify it as you see fit.