### PR TITLE
Added toolbar menu to export and import dock sets with recent dockset…

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -793,6 +793,13 @@ Basic.MainMenu.Docks.ResetDocks="&Reset Docks"
 Basic.MainMenu.Docks.LockDocks="&Lock Docks"
 Basic.MainMenu.Docks.CustomBrowserDocks="&Custom Browser Docks..."
 
+#ATTN: importing and exporting docksets
+Basic.DocksMenu.menuDocksets="&Dock sets"
+Basic.DocksMenu.menuDocksets.importDockset="&Import dockset..."
+Basic.DocksMenu.menuDocksets.exportDockset="&Export dockset..."
+Basic.DocksMenu.menuDocksets.browseDocksets="&Browse dockset files"
+Basic.DocksMenu.menuDocksets.refreshDocksets="&Refresh this dockset file list"
+
 # basic mode profile/scene collection menus
 Basic.MainMenu.SceneCollection="&Scene Collection"
 Basic.MainMenu.Profile="&Profile"

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -698,12 +698,26 @@
     <addaction name="autoConfigure"/>
     <addaction name="separator"/>
    </widget>
+
+   <widget class="QMenu" name="menuDocksets">
+    <property name="title">
+     <string>Basic.DocksMenu.menuDocksets</string>
+    </property>
+     <addaction name="actionImportDockset"/>
+     <addaction name="actionExportDockset"/>
+     <addaction name="actionBrowseDocksets"/>
+     <addaction name="actionRefreshDocksets"/>
+     <addaction name="separator"/>
+   </widget>
+
    <widget class="QMenu" name="menuDocks">
     <property name="title">
      <string>Basic.MainMenu.Docks</string>
     </property>
     <addaction name="lockDocks"/>
     <addaction name="resetDocks"/>
+    <addaction name="separator"/>
+    <addaction name="menuDocksets"/>
     <addaction name="separator"/>
     <addaction name="toggleScenes"/>
     <addaction name="toggleSources"/>
@@ -2171,6 +2185,29 @@
     <string>Basic.MainMenu.Docks.LockDocks</string>
    </property>
   </action>
+
+  <action name="actionImportDockset">
+   <property name="text">
+    <string>Basic.DocksMenu.menuDocksets.importDockset</string>
+   </property>
+  </action>
+  <action name="actionExportDockset">
+   <property name="text">
+    <string>Basic.DocksMenu.menuDocksets.exportDockset</string>
+   </property>
+  </action>
+  <action name="actionBrowseDocksets">
+   <property name="text">
+    <string>Basic.DocksMenu.menuDocksets.browseDocksets</string>
+   </property>
+  </action>
+  <action name="actionRefreshDocksets">
+   <property name="text">
+    <string>Basic.DocksMenu.menuDocksets.refreshDocksets</string>
+   </property>
+  </action>
+
+
   <action name="toggleScenes">
    <property name="checkable">
     <bool>true</bool>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -10420,8 +10420,6 @@ bool OBSBasic::ImportDockstateFromFile(QString filepath)
 		return false;
 	}
 	bool success = ImportDockstateFromCharp(dockStateCharp);
-	blog(LOG_WARNING, "Imported dockset from file %s [%d bytes in length].",
-	     filepath.toLocal8Bit(), strlen(dockStateCharp));
 	bfree(dockStateCharp);
 	if (success) {
 		RefreshDocksetRecentMenu();
@@ -10492,7 +10490,6 @@ void OBSBasic::EnumDocksetFiles(
 	}
 	strcat(path, "/*");
 	strcat(path, DefDocksetFileExtension);
-	blog(LOG_WARNING, "Searching for docksets in %s.", path);
 
 	os_glob_t *glob;
 	if (os_glob(path, 0, &glob) != 0) {
@@ -10512,9 +10509,6 @@ void OBSBasic::EnumDocksetFiles(
 		if (dotpos != string::npos) {
 			name.resize(dotpos);
 		}
-
-		blog(LOG_WARNING, "Searching for docksets entry is %s --> %s.",
-		     filePath, name.c_str());
 
 		// callback
 		if (!cb(name.c_str(), filePath))

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -10316,3 +10316,204 @@ void OBSBasic::ResetProxyStyleSliders()
 
 	UpdateContextBar(true);
 }
+
+
+//---------------------------------------------------------------------------
+// ATTN: 9/25/22 dock saving and loading
+#define DefDocksetFileExtension ".dockset"
+
+void OBSBasic::on_actionExportDockset_triggered() {
+	ExportDockstateToFileUserChooses();
+}
+void OBSBasic::on_actionImportDockset_triggered() {
+	ImportDockstateFromFileUserChooses();
+}
+void OBSBasic::on_actionBrowseDocksets_triggered() {
+	char path[512];
+	int ret = GetConfigPathDockset(path, 512);
+	if (ret <= 0) {
+		return;
+	}
+	QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+}
+void OBSBasic::on_actionRefreshDocksets_triggered() {
+	RefreshDocksetRecentMenu();
+}
+
+int OBSBasic::GetConfigPathDockset(char* path, int maxlen) {
+	int success = GetConfigPath(path, maxlen, "obs-studio/basic/docksets");
+	if (success < 0) {
+		if (os_mkdirs(path) == MKDIR_ERROR) {
+			blog(LOG_WARNING, "Failed to get or make dockset config path (%s).", path);
+			success = -1;
+		}
+	}
+	return success;
+}
+
+
+bool OBSBasic::ExportDockstateToFileUserChooses() {
+	char path[512];
+	int ret = GetConfigPathDockset(path, 512);
+	if (ret <= 0) {
+		return false;
+	}
+	QString currentFile = QT_UTF8("mydocks");
+	QString filePath =
+		SaveFile(this, QTStr("Basic.MainMenu.DockSet.Export"),
+			QString(path) + "/" + currentFile, "Dockset Files (*" + QString(DefDocksetFileExtension) + ")");
+
+	if (!filePath.isEmpty() && !filePath.isNull()) {
+		if (QFile::exists(filePath))
+			QFile::remove(filePath);
+		return ExportDockstateToFile(filePath);
+	}
+	return false;
+}
+
+
+bool OBSBasic::ImportDockstateFromFileUserChooses() {
+	char path[512];
+	int ret = GetConfigPathDockset(path, 512);
+	if (ret <= 0) {
+		return false;
+	}
+	QString currentFile = QT_UTF8("mydocks");
+	QString filePath =
+		OpenFile(this, QTStr("Basic.MainMenu.DockSet.Import"),
+			QString(path) + "/" + currentFile, "Dockset Files (*" + QString(DefDocksetFileExtension) + ")");
+
+	if (!filePath.isEmpty() && !filePath.isNull()) {
+		if (!QFile::exists(filePath))
+			return false;
+		return ImportDockstateFromFile(filePath);
+	}
+	return false;
+}
+
+
+bool OBSBasic::ExportDockstateToFile(QString filepath) {
+	const char* dockStateCharp = saveState().toBase64().constData();
+	if (!dockStateCharp) {
+		return false;
+	}
+	bool success =  os_quick_write_utf8_file(filepath.toUtf8(), dockStateCharp, strlen(dockStateCharp), false);
+	if (success) {
+		RefreshDocksetRecentMenu();
+	}
+	return true;
+}
+
+
+bool OBSBasic::ImportDockstateFromFile(QString filepath) {
+	char* dockStateCharp = os_quick_read_utf8_file(filepath.toUtf8());
+	if (!dockStateCharp) {
+		return false;
+	}
+	bool success = ImportDockstateFromCharp(dockStateCharp);
+	blog(LOG_WARNING,"Imported dockset from file %s [%d bytes in length].", filepath.toLocal8Bit(), strlen(dockStateCharp));
+	bfree(dockStateCharp);
+	if (success) {
+		RefreshDocksetRecentMenu();
+	}
+	return success;
+}
+
+
+bool OBSBasic::ImportDockstateFromCharp(const char* dockStateStr) {
+	if (dockStateStr == NULL) {
+		return false;
+	}
+	QByteArray dockState = QByteArray::fromBase64(QByteArray(dockStateStr));
+	return restoreState(dockState);
+}
+
+
+
+
+
+// recent dockset menu code based on https://het.as.utexas.edu/HET/Software/html/mainwindows-recentfiles-mainwindow-cpp.html and https://www.walletfox.com/course/qtopenrecentfiles.php
+//
+void OBSBasic::OnClickRecentDockset() {
+	QAction *action = qobject_cast<QAction *>(sender());
+	if (action) {
+		QVariant v = action->property("file_name");
+		ImportDockstateFromFile(v.toString());
+	}
+ }
+
+
+
+
+ void OBSBasic::RefreshDocksetRecentMenu() {
+	 QList<QAction *> menuActions = ui->menuDocksets->actions();
+
+	// clear existing actions
+	int count = 0;
+	for (int i = 0; i < menuActions.count(); i++) {
+		QVariant v = menuActions[i]->property("file_name");
+		if (v.typeName() != nullptr)
+			delete menuActions[i];
+	}
+
+	// add all docksets found in directory
+	char path[512];
+	int ret = GetConfigPathDockset(path, 512);
+	if (ret < 0) {
+		return;
+	}
+	const char* cur_name = "";
+
+	// iterate through directory looking for matches
+	auto addRecentDocksetFile = [&](const char *name, const char *path) {
+		QAction *action = new QAction(QT_UTF8(name), this);
+		action->setProperty("file_name", QT_UTF8(path));
+		connect(action, &QAction::triggered, this,
+			&OBSBasic::OnClickRecentDockset);
+		ui->menuDocksets->addAction(action);
+		count++;
+		return true;
+	};
+	EnumDocksetFiles(addRecentDocksetFile);
+}
+
+
+void OBSBasic::EnumDocksetFiles(std::function<bool(const char *, const char *)> &&cb) {
+	// based on code in EnumSceneCollections()
+	char path[512];
+	int ret = GetConfigPathDockset(path, 512);
+	if (ret < 0) {
+		return;
+	}
+	strcat(path, "/*");
+	strcat(path, DefDocksetFileExtension);
+	blog(LOG_WARNING, "Searching for docksets in %s.", path);
+
+	os_glob_t *glob;
+	if (os_glob(path, 0, &glob) != 0) {
+		blog(LOG_WARNING, "Failed to glob dockset file path");
+		return;
+	}
+
+	for (size_t i = 0; i < glob->gl_pathc; i++) {
+		const char *filePath = glob->gl_pathv[i].path;
+
+		if (glob->gl_pathv[i].directory)
+			continue;
+
+		std::string name = strrchr(filePath, '/') + 1;
+		// remove the extension
+		size_t dotpos = name.find_last_of('.');
+		if (dotpos != string::npos) {
+			name.resize(dotpos);
+		}
+
+		blog(LOG_WARNING, "Searching for docksets entry is %s --> %s.", filePath, name.c_str());
+
+		// callback
+		if (!cb(name.c_str(), filePath))
+			break;
+	}
+	os_globfree(glob);
+}
+//---------------------------------------------------------------------------

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1891,6 +1891,7 @@ void OBSBasic::OBSInit()
 
 	RefreshSceneCollections();
 	RefreshProfiles();
+	RefreshDocksetRecentMenu();
 	disableSaving--;
 
 	auto addDisplay = [this](OBSQTDisplay *window) {

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -10318,18 +10318,18 @@ void OBSBasic::ResetProxyStyleSliders()
 	UpdateContextBar(true);
 }
 
-
-//---------------------------------------------------------------------------
-// ATTN: 9/25/22 dock saving and loading
 #define DefDocksetFileExtension ".dockset"
 
-void OBSBasic::on_actionExportDockset_triggered() {
+void OBSBasic::on_actionExportDockset_triggered()
+{
 	ExportDockstateToFileUserChooses();
 }
-void OBSBasic::on_actionImportDockset_triggered() {
+void OBSBasic::on_actionImportDockset_triggered()
+{
 	ImportDockstateFromFileUserChooses();
 }
-void OBSBasic::on_actionBrowseDocksets_triggered() {
+void OBSBasic::on_actionBrowseDocksets_triggered()
+{
 	char path[512];
 	int ret = GetConfigPathDockset(path, 512);
 	if (ret <= 0) {
@@ -10337,32 +10337,37 @@ void OBSBasic::on_actionBrowseDocksets_triggered() {
 	}
 	QDesktopServices::openUrl(QUrl::fromLocalFile(path));
 }
-void OBSBasic::on_actionRefreshDocksets_triggered() {
+void OBSBasic::on_actionRefreshDocksets_triggered()
+{
 	RefreshDocksetRecentMenu();
 }
 
-int OBSBasic::GetConfigPathDockset(char* path, int maxlen) {
+int OBSBasic::GetConfigPathDockset(char *path, int maxlen)
+{
 	int success = GetConfigPath(path, maxlen, "obs-studio/basic/docksets");
 	if (success < 0) {
 		if (os_mkdirs(path) == MKDIR_ERROR) {
-			blog(LOG_WARNING, "Failed to get or make dockset config path (%s).", path);
+			blog(LOG_WARNING,
+			     "Failed to get or make dockset config path (%s).",
+			     path);
 			success = -1;
 		}
 	}
 	return success;
 }
 
-
-bool OBSBasic::ExportDockstateToFileUserChooses() {
+bool OBSBasic::ExportDockstateToFileUserChooses()
+{
 	char path[512];
 	int ret = GetConfigPathDockset(path, 512);
 	if (ret <= 0) {
 		return false;
 	}
 	QString currentFile = QT_UTF8("mydocks");
-	QString filePath =
-		SaveFile(this, QTStr("Basic.MainMenu.DockSet.Export"),
-			QString(path) + "/" + currentFile, "Dockset Files (*" + QString(DefDocksetFileExtension) + ")");
+	QString filePath = SaveFile(
+		this, QTStr("Basic.MainMenu.DockSet.Export"),
+		QString(path) + "/" + currentFile,
+		"Dockset Files (*" + QString(DefDocksetFileExtension) + ")");
 
 	if (!filePath.isEmpty() && !filePath.isNull()) {
 		if (QFile::exists(filePath))
@@ -10372,17 +10377,18 @@ bool OBSBasic::ExportDockstateToFileUserChooses() {
 	return false;
 }
 
-
-bool OBSBasic::ImportDockstateFromFileUserChooses() {
+bool OBSBasic::ImportDockstateFromFileUserChooses()
+{
 	char path[512];
 	int ret = GetConfigPathDockset(path, 512);
 	if (ret <= 0) {
 		return false;
 	}
 	QString currentFile = QT_UTF8("mydocks");
-	QString filePath =
-		OpenFile(this, QTStr("Basic.MainMenu.DockSet.Import"),
-			QString(path) + "/" + currentFile, "Dockset Files (*" + QString(DefDocksetFileExtension) + ")");
+	QString filePath = OpenFile(
+		this, QTStr("Basic.MainMenu.DockSet.Import"),
+		QString(path) + "/" + currentFile,
+		"Dockset Files (*" + QString(DefDocksetFileExtension) + ")");
 
 	if (!filePath.isEmpty() && !filePath.isNull()) {
 		if (!QFile::exists(filePath))
@@ -10392,27 +10398,30 @@ bool OBSBasic::ImportDockstateFromFileUserChooses() {
 	return false;
 }
 
-
-bool OBSBasic::ExportDockstateToFile(QString filepath) {
-	const char* dockStateCharp = saveState().toBase64().constData();
+bool OBSBasic::ExportDockstateToFile(QString filepath)
+{
+	const char *dockStateCharp = saveState().toBase64().constData();
 	if (!dockStateCharp) {
 		return false;
 	}
-	bool success =  os_quick_write_utf8_file(filepath.toUtf8(), dockStateCharp, strlen(dockStateCharp), false);
+	bool success = os_quick_write_utf8_file(filepath.toUtf8(),
+						dockStateCharp,
+						strlen(dockStateCharp), false);
 	if (success) {
 		RefreshDocksetRecentMenu();
 	}
 	return true;
 }
 
-
-bool OBSBasic::ImportDockstateFromFile(QString filepath) {
-	char* dockStateCharp = os_quick_read_utf8_file(filepath.toUtf8());
+bool OBSBasic::ImportDockstateFromFile(QString filepath)
+{
+	char *dockStateCharp = os_quick_read_utf8_file(filepath.toUtf8());
 	if (!dockStateCharp) {
 		return false;
 	}
 	bool success = ImportDockstateFromCharp(dockStateCharp);
-	blog(LOG_WARNING,"Imported dockset from file %s [%d bytes in length].", filepath.toLocal8Bit(), strlen(dockStateCharp));
+	blog(LOG_WARNING, "Imported dockset from file %s [%d bytes in length].",
+	     filepath.toLocal8Bit(), strlen(dockStateCharp));
 	bfree(dockStateCharp);
 	if (success) {
 		RefreshDocksetRecentMenu();
@@ -10420,8 +10429,8 @@ bool OBSBasic::ImportDockstateFromFile(QString filepath) {
 	return success;
 }
 
-
-bool OBSBasic::ImportDockstateFromCharp(const char* dockStateStr) {
+bool OBSBasic::ImportDockstateFromCharp(const char *dockStateStr)
+{
 	if (dockStateStr == NULL) {
 		return false;
 	}
@@ -10429,25 +10438,19 @@ bool OBSBasic::ImportDockstateFromCharp(const char* dockStateStr) {
 	return restoreState(dockState);
 }
 
-
-
-
-
 // recent dockset menu code based on https://het.as.utexas.edu/HET/Software/html/mainwindows-recentfiles-mainwindow-cpp.html and https://www.walletfox.com/course/qtopenrecentfiles.php
-//
-void OBSBasic::OnClickRecentDockset() {
+void OBSBasic::OnClickRecentDockset()
+{
 	QAction *action = qobject_cast<QAction *>(sender());
 	if (action) {
 		QVariant v = action->property("file_name");
 		ImportDockstateFromFile(v.toString());
 	}
- }
+}
 
-
-
-
- void OBSBasic::RefreshDocksetRecentMenu() {
-	 QList<QAction *> menuActions = ui->menuDocksets->actions();
+void OBSBasic::RefreshDocksetRecentMenu()
+{
+	QList<QAction *> menuActions = ui->menuDocksets->actions();
 
 	// clear existing actions
 	int count = 0;
@@ -10463,7 +10466,7 @@ void OBSBasic::OnClickRecentDockset() {
 	if (ret < 0) {
 		return;
 	}
-	const char* cur_name = "";
+	const char *cur_name = "";
 
 	// iterate through directory looking for matches
 	auto addRecentDocksetFile = [&](const char *name, const char *path) {
@@ -10478,8 +10481,9 @@ void OBSBasic::OnClickRecentDockset() {
 	EnumDocksetFiles(addRecentDocksetFile);
 }
 
-
-void OBSBasic::EnumDocksetFiles(std::function<bool(const char *, const char *)> &&cb) {
+void OBSBasic::EnumDocksetFiles(
+	std::function<bool(const char *, const char *)> &&cb)
+{
 	// based on code in EnumSceneCollections()
 	char path[512];
 	int ret = GetConfigPathDockset(path, 512);
@@ -10509,7 +10513,8 @@ void OBSBasic::EnumDocksetFiles(std::function<bool(const char *, const char *)> 
 			name.resize(dotpos);
 		}
 
-		blog(LOG_WARNING, "Searching for docksets entry is %s --> %s.", filePath, name.c_str());
+		blog(LOG_WARNING, "Searching for docksets entry is %s --> %s.",
+		     filePath, name.c_str());
 
 		// callback
 		if (!cb(name.c_str(), filePath))
@@ -10517,4 +10522,3 @@ void OBSBasic::EnumDocksetFiles(std::function<bool(const char *, const char *)> 
 	}
 	os_globfree(glob);
 }
-//---------------------------------------------------------------------------

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1209,24 +1209,25 @@ public:
 
 	static void InitBrowserPanelSafeBlock();
 
-
-// ATTN: jr 9/25/22
 private slots:
 	void on_actionExportDockset_triggered();
 	void on_actionImportDockset_triggered();
 	void on_actionBrowseDocksets_triggered();
 	void on_actionRefreshDocksets_triggered();
 	void OnClickRecentDockset();
+
 public:
-	int GetConfigPathDockset(char* path, int maxlen);
+	int GetConfigPathDockset(char *path, int maxlen);
 	bool ExportDockstateToFileUserChooses();
 	bool ImportDockstateFromFileUserChooses();
 	bool ExportDockstateToFile(QString filepath);
 	bool ImportDockstateFromFile(QString filepath);
-	bool ImportDockstateFromCharp(const char* dockStateStr);
+	bool ImportDockstateFromCharp(const char *dockStateStr);
+
 public:
 	void RefreshDocksetRecentMenu();
-	void EnumDocksetFiles(std::function<bool(const char*, const char*)>&& cb);
+	void
+	EnumDocksetFiles(std::function<bool(const char *, const char *)> &&cb);
 };
 
 class SceneRenameDelegate : public QStyledItemDelegate {

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1208,6 +1208,25 @@ public:
 				   const char *file) const override;
 
 	static void InitBrowserPanelSafeBlock();
+
+
+// ATTN: jr 9/25/22
+private slots:
+	void on_actionExportDockset_triggered();
+	void on_actionImportDockset_triggered();
+	void on_actionBrowseDocksets_triggered();
+	void on_actionRefreshDocksets_triggered();
+	void OnClickRecentDockset();
+public:
+	int GetConfigPathDockset(char* path, int maxlen);
+	bool ExportDockstateToFileUserChooses();
+	bool ImportDockstateFromFileUserChooses();
+	bool ExportDockstateToFile(QString filepath);
+	bool ImportDockstateFromFile(QString filepath);
+	bool ImportDockstateFromCharp(const char* dockStateStr);
+public:
+	void RefreshDocksetRecentMenu();
+	void EnumDocksetFiles(std::function<bool(const char*, const char*)>&& cb);
 };
 
 class SceneRenameDelegate : public QStyledItemDelegate {


### PR DESCRIPTION
Added toolbar submenu for exporting and importing docksets (configuration files containing layout of docks), as well as a recent dockset list.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Added new submenu under Docks to allow user to export and import docksets (saved configurations of docks), along with a recent dockset list.  This makes it easy to save configurations of docks (where they are, which ones are visible, etc.).  Very lightweight, uses the built-in dock saving and loading code in OBS.


### Motivation and Context
Lots of requests for this over the years.

### How Has This Been Tested?
Tested on windows OBS version 27 and 28.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
