### PR TITLE
Added feature to image source slideshow to rescan for changes in directory on activation

### DIFF
--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -59,6 +59,12 @@
 
 /* clang-format on */
 
+
+// ATTN: jr
+// to rescan for changes in files
+static void jrRescanFiles(struct slideshow *ssdata);
+
+
 /* ------------------------------------------------------------------------- */
 
 extern uint64_t image_source_get_memory_usage(void *data);
@@ -952,6 +958,12 @@ static void ss_activate(void *data)
 {
 	struct slideshow *ss = data;
 
+
+	// ATTN: jr
+	// reload and rescan files on activate
+	jrRescanFiles(ss);
+
+
 	if (ss->behavior == BEHAVIOR_STOP_RESTART) {
 		ss->restart_on_activate = true;
 		ss->use_cut = true;
@@ -1083,3 +1095,22 @@ struct obs_source_info slideshow_info = {
 	.media_get_state = ss_get_state,
 	.video_get_color_space = ss_video_get_color_space,
 };
+
+
+
+
+
+
+
+
+
+
+
+// ATTN: jr
+static void jrRescanFiles(struct slideshow *ssdata)
+{
+	// just force an update
+	obs_source_t *source = ssdata->source;
+	obs_data_t *settings = obs_source_get_settings(source);
+	ss_update(ssdata, settings);
+}


### PR DESCRIPTION
Super simple change to image source slideshow functionality to rescan the directory for changes in available files when activating the source.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Super simple change to image source slideshow functionality to rescan the directory for changes in available files when activating the source.

### Motivation and Context
  This has been requested on the OBS forum a few times.

### How Has This Been Tested?
Tested on windows OBS version 27 and 28.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
