### PR TITLE
rtmp-services: Add Vindral service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services",
-    "version": 210,
+    "version": 211,
     "files": [
         {
             "name": "services.json",
-            "version": 210
+            "version": 211
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2525,6 +2525,27 @@
                 "keyint": 2,
                 "max video bitrate": 16000
             }
+        },
+        {
+            "name": "Vindral",
+            "more_info_link": "https://docs.vindral.com/docs/vindral-cdn/",
+            "servers": [
+                {
+                    "name": "eu-north",
+                    "url": "rtmps://rtmp.eu-north.cdn.vindral.com/publish"
+                },
+                {
+                    "name": "eu-west",
+                    "url": "rtmps://rtmp.eu-west.cdn.vindral.com/publish"
+                }
+            ],
+            "recommended": {
+                "keyint": 1,
+                "profile": "high",
+                "bframes": 0,
+                "max video bitrate": 20000,
+                "max audio bitrate": 192
+            }
         }
     ]
 }


### PR DESCRIPTION
Adding Vindral rtmp endpoints to streaming services dropdown, wrapped with the following changes:

- Adding active Vindral rtmp endpoints to **services.json** file.
- Incrementing rtmp-services version in **package.json** file.

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Updating the rtmp-services ingestion list to introduce Vindral as a service

### Motivation and Context
Vindral Live CDN delivers next-generation live streaming at sub-second latency, synchronized playout, and 4K video quality at a global scale.

[https://www.vindral.com/](https://www.vindral.com/)
[https://docs.vindral.com/docs/vindral-cdn/](https://docs.vindral.com/docs/vindral-cdn/)

### How Has This Been Tested?
Took the updated JSON and had it validated at jsonlint.com.
Build testing not required.

### Types of changes
New feature (non-breaking change which adds functionality)
Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

