### PR TITLE
rtmp-services: Update Glimesh to add RTMP ingests

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services",
-    "version": 208,
+    "version": 209,
     "files": [
         {
             "name": "services.json",
-            "version": 208
+            "version": 209
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1896,6 +1896,10 @@
                     "url": "ingest.cyyz.live.glimesh.tv"
                 },
                 {
+                    "name": "South America - Sao Paulo, Brazil",
+                    "url": "ingest.sbgr.live.glimesh.tv"
+                },
+                {
                     "name": "Europe - Amsterdam, Netherlands",
                     "url": "ingest.eham.live.glimesh.tv"
                 },
@@ -1914,11 +1918,72 @@
                 {
                     "name": "Asia - Singapore",
                     "url": "ingest.wsss.live.glimesh.tv"
+                },
+                {
+                    "name": "Australia - Sydney, Australia",
+                    "url": "ingest.yssy.live.glimesh.tv"
                 }
             ],
             "recommended": {
                 "keyint": 2,
                 "output": "ftl_output",
+                "max audio bitrate": 160,
+                "max video bitrate": 6000,
+                "bframes": 0,
+                "x264opts": "scenecut=0"
+            }
+        },
+        {
+            "name": "Glimesh - RTMP",
+            "stream_key_link": "https://glimesh.tv/users/settings/stream",
+            "servers": [
+                {
+                    "name": "North America - Chicago, United States",
+                    "url": "rtmp://ingest.kord.live.glimesh.tv"
+                },
+                {
+                    "name": "North America - New York, United States",
+                    "url": "rtmp://ingest.kjfk.live.glimesh.tv"
+                },
+                {
+                    "name": "North America - San Francisco, United States",
+                    "url": "rtmp://ingest.ksfo.live.glimesh.tv"
+                },
+                {
+                    "name": "North America - Toronto, Canada",
+                    "url": "rtmp://ingest.cyyz.live.glimesh.tv"
+                },
+                {
+                    "name": "South America - Sao Paulo, Brazil",
+                    "url": "rtmp://ingest.sbgr.live.glimesh.tv"
+                },
+                {
+                    "name": "Europe - Amsterdam, Netherlands",
+                    "url": "rtmp://ingest.eham.live.glimesh.tv"
+                },
+                {
+                    "name": "Europe - Frankfurt, Germany",
+                    "url": "rtmp://ingest.eddf.live.glimesh.tv"
+                },
+                {
+                    "name": "Europe - London, United Kingdom",
+                    "url": "rtmp://ingest.egll.live.glimesh.tv"
+                },
+                {
+                    "name": "Asia - Bangalore, India",
+                    "url": "rtmp://ingest.vobl.live.glimesh.tv"
+                },
+                {
+                    "name": "Asia - Singapore",
+                    "url": "rtmp://ingest.wsss.live.glimesh.tv"
+                },
+                {
+                    "name": "Australia - Sydney, Australia",
+                    "url": "rtmp://ingest.yssy.live.glimesh.tv"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
                 "max audio bitrate": 160,
                 "max video bitrate": 6000,
                 "bframes": 0,


### PR DESCRIPTION
### Description
Adds two new FTL ingest locations for our existing FTL service.
Adds some Glimesh RTMP ingests in parallel of our existing infrastructure.

### How Has This Been Tested?
Confirmed the JSON files are both valid, and tested them locally in my OBS client to ensure they show up in the UI and work correctly.

### Types of changes
- Service Change / Addition

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
