### PR TITLE
obs-vst: Toggle properties button visibility upon VST selection

### DIFF
--- a/plugins/obs-vst/obs-vst.cpp
+++ b/plugins/obs-vst/obs-vst.cpp
@@ -289,6 +289,35 @@ static void fill_out_plugins(obs_property_t *list)
 	}
 }
 
+static bool vst_changed(void *data, obs_properties_t *props,
+			obs_property_t *list, obs_data_t *settings)
+{
+	UNUSED_PARAMETER(settings);
+	UNUSED_PARAMETER(list);
+
+	bool open_settings_vis = true;
+	bool close_settings_vis = false;
+	if (data) {
+		VSTPlugin *vstPlugin = (VSTPlugin *)data;
+		if (!vstPlugin->vstLoaded()) {
+			close_settings_vis = false;
+			open_settings_vis = false;
+		} else {
+			if (vstPlugin->isEditorOpen()) {
+				close_settings_vis = true;
+				open_settings_vis = false;
+			}
+		}
+	}
+
+	obs_property_set_visible(obs_properties_get(props, OPEN_VST_SETTINGS),
+				 open_settings_vis);
+	obs_property_set_visible(obs_properties_get(props, CLOSE_VST_SETTINGS),
+				 close_settings_vis);
+
+	return true;
+}
+
 static obs_properties_t *vst_properties(void *data)
 {
 	obs_properties_t *props = obs_properties_create();
@@ -326,6 +355,8 @@ static obs_properties_t *vst_properties(void *data)
 
 	obs_properties_add_bool(props, OPEN_WHEN_ACTIVE_VST_SETTINGS,
 				OPEN_WHEN_ACTIVE_VST_TEXT);
+
+	obs_property_set_modified_callback2(list, vst_changed, data);
 
 	return props;
 }


### PR DESCRIPTION
### Description
Fix visibility of VST window display button on first selection of VST.

### Motivation and Context
A prior patch made the button to show/hide a VST check the current status of a loaded VST. This lead to situation where upon first selection a VST might be loaded but the button's visibility is not changed.

This change will reevaluate the status of a loaded VST upon selection in the drop-down menu and trigger button visibility accordingly.

### How Has This Been Tested?
Tested with multiple VSTs on macOS 12.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
