### PR TITLE
linux-pulseaudio: Use DONT_MOVE for non-default devices

### DIFF
--- a/plugins/linux-pulseaudio/pulse-input.c
+++ b/plugins/linux-pulseaudio/pulse-input.c
@@ -34,6 +34,7 @@ struct pulse_data {
 
 	/* user settings */
 	char *device;
+	bool is_default;
 	bool input;
 
 	/* server info */
@@ -236,9 +237,9 @@ static void pulse_server_info(pa_context *c, const pa_server_info *i,
 	blog(LOG_INFO, "Server name: '%s %s'", i->server_name,
 	     i->server_version);
 
-	if (data->device && strcmp("default", data->device) == 0) {
+	if (data->is_default) {
+		bfree(data->device);
 		if (data->input) {
-			bfree(data->device);
 			data->device = bstrdup(i->default_source_name);
 
 			blog(LOG_DEBUG, "Default input device: '%s'",
@@ -249,7 +250,6 @@ static void pulse_server_info(pa_context *c, const pa_server_info *i,
 			strcat(monitor, i->default_sink_name);
 			strcat(monitor, ".monitor");
 
-			bfree(data->device);
 			data->device = bstrdup(monitor);
 
 			blog(LOG_DEBUG, "Default output device: '%s'",
@@ -379,6 +379,8 @@ static int_fast32_t pulse_start_recording(struct pulse_data *data)
 	attr.tlength = (uint32_t)-1;
 
 	pa_stream_flags_t flags = PA_STREAM_ADJUST_LATENCY;
+	if (!data->is_default)
+		flags |= PA_STREAM_DONT_MOVE;
 
 	pulse_lock();
 	int_fast32_t ret = pa_stream_connect_record(data->stream, data->device,
@@ -390,7 +392,12 @@ static int_fast32_t pulse_start_recording(struct pulse_data *data)
 		return -1;
 	}
 
-	blog(LOG_INFO, "Started recording from '%s'", data->device);
+	if (data->is_default)
+		blog(LOG_INFO, "Started recording from '%s' (default)",
+		     data->device);
+	else
+		blog(LOG_INFO, "Started recording from '%s'", data->device);
+
 	return 0;
 }
 
@@ -547,6 +554,7 @@ static void pulse_update(void *vptr, obs_data_t *settings)
 		if (data->device)
 			bfree(data->device);
 		data->device = bstrdup(new_device);
+		data->is_default = strcmp("default", data->device) == 0;
 		restart = true;
 	}
 


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Ask the PA server to kindly not migrate our streams to the default device unless the user chose the default device for input/output captures.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #3211

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with some default and non-default sources. Changing the default device in `pavucontrol` no longer causes non-default sources to be migrated to the new default device. Default sources continue to migrate as the default device changes.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
