### PR TITLE
CI: Upload beta builds as Steam Playtest

### DIFF
--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -27,6 +27,7 @@ env:
   STEAM_NIGHTLY_BRANCH: nightly
   STEAM_STABLE_BRANCH: staging
   STEAM_BETA_BRANCH: beta_staging
+  STEAM_PLAYTEST_BRANCH: staging
   SEVENZIP_HASH: 5290409e7bbe2f133d0bd7e7482548678157ea2be276b0f9cb440600f4be9a2d
 
 jobs:
@@ -145,8 +146,14 @@ jobs:
       run: |
         if [[ '${{ steps.build-info.outputs.type }}' == 'release' || '${{ steps.cache.outputs.cache-hit }}' != 'true' ]]; then
             echo "result=true" >> $GITHUB_OUTPUT
+            if [[ '${{ steps.build-info.outputs.branch }}' == '${{ env.STEAM_BETA_BRANCH }}' ]]; then
+                echo "result_playtest=true" >> $GITHUB_OUTPUT
+            else
+                echo "result_playtest=false" >> $GITHUB_OUTPUT
+            fi
         else
             echo "result=false" >> $GITHUB_OUTPUT
+            echo "result_playtest=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Download and prepare builds
@@ -254,6 +261,26 @@ jobs:
         echo "::endgroup::"
         echo "::group::Upload to Steam"
         steamcmd +login '${{ secrets.STEAM_USER }}' '${{ secrets.STEAM_PASSWORD }}' '${{ steps.steam-totp.outputs.code }}' +run_app_build "$(pwd)/build.vdf" +quit
+        echo "::endgroup::"
+
+    - name: Generate Steam auth code (Playtest)
+      if: steps.should-run.outputs.result_playtest == 'true'
+      id: steam-totp-playtest
+      uses: CyberAndrii/steam-totp@0fc9e59dc5bbf4368d23d5a33956f104248da31a
+      with:
+        shared_secret: ${{ secrets.STEAM_SHARED_SECRET }}
+
+    - name: Upload to Steam (Playtest)
+      if: steps.should-run.outputs.result_playtest == 'true'
+      run: |
+        cd steam
+        echo "::group::Prepare Steam build script"
+        sed 's/@@DESC@@/${{ steps.build-info.outputs.branch }}-${{ steps.build-info.outputs.desc }}/;s/@@BRANCH@@/${{ env.STEAM_PLAYTEST_BRANCH }}/' ../source/CI/steam/obs_playtest_build.vdf > build_playtest.vdf
+        echo "Generated file:"
+        cat build_playtest.vdf
+        echo "::endgroup::"
+        echo "::group::Upload to Steam"
+        steamcmd +login '${{ secrets.STEAM_USER }}' '${{ secrets.STEAM_PASSWORD }}' '${{ steps.steam-totp-playtest.outputs.code }}' +run_app_build "$(pwd)/build_playtest.vdf" +quit
         echo "::endgroup::"
 
     - name: Upload Steam build logs

--- a/CI/steam/obs_playtest_build.vdf
+++ b/CI/steam/obs_playtest_build.vdf
@@ -1,0 +1,35 @@
+"AppBuild"
+{
+	"AppID" "1905640"
+	"Desc" "github_@@DESC@@"
+
+	"ContentRoot" "./"
+	"BuildOutput" "build/"
+	
+	"SetLive" "@@BRANCH@@"
+
+	"Depots"
+	{
+		"1905642" // Windows
+		{
+			"ContentRoot" "./steam-windows"
+			"FileMapping"
+			{
+				"LocalPath" "*"
+				"DepotPath" "."
+				"recursive" "1"
+			}
+		}
+		
+		"1905641" // Mac
+	 	{
+			"ContentRoot" "./steam-macos"
+			"FileMapping"
+			{
+				"LocalPath" "*"
+				"DepotPath" "."
+				"recursive" "1"
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description

Uploads pre-release builds to Steam Playtest as well as beta branch.

### Motivation and Context

Want to potentially use playtests in the future to allow side-by-side installation and better/easier discoverability of betas on Steam: https://partner.steamgames.com/doc/features/playtest

### How Has This Been Tested?

Tested on my fork.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
