### PR TITLE
obs-scripting: Fix script state variable being reset by tick callback

### DIFF
--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -1514,10 +1514,11 @@ void obs_python_script_save(obs_script_t *s)
 static void python_tick(void *param, float seconds)
 {
 	struct obs_python_script *data;
-	/* When loading a new Python script, the GIL might be released while importing the module,
-     allowing the tick to run and change and reset the cur_python_script state variable. Use the
-     busy_script variable to save and restore the value if not null.
-     */
+	/* When loading a new Python script, the GIL might be released while
+	 * importing the module, allowing the tick to run and change and reset
+	 * the cur_python_script state variable. Use the busy_script variable
+	 * to save and restore the value if not null.
+	 */
 	struct obs_python_script *busy_script;
 	bool valid;
 	uint64_t ts = obs_get_video_frame_time();


### PR DESCRIPTION
### Description
When loading a new Python script, the GIL might be released while importing the module, allowing the tick to run and change and reset the `cur_python_script` state variable. Use the `busy_script` variable to save and restore the value if not null.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/3209

### How Has This Been Tested?
Tested with scripts provided in the linked issue, confirmed the script name prefix is correctly used.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
