### PR TITLE
win-capture: Fix reporting valid width and height if not capturing

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -2194,13 +2194,13 @@ static void game_capture_render(void *data, gs_effect_t *unused)
 static uint32_t game_capture_width(void *data)
 {
 	struct game_capture *gc = data;
-	return gc->active ? gc->cx : 0;
+	return (gc->active && gc->capturing) ? gc->cx : 0;
 }
 
 static uint32_t game_capture_height(void *data)
 {
 	struct game_capture *gc = data;
-	return gc->active ? gc->cy : 0;
+	return (gc->active && gc->capturing) ? gc->cy : 0;
 }
 
 static const char *game_capture_name(void *unused)


### PR DESCRIPTION
### Description
While the inject-helper tries to hook an application, the source is set to `active` until the `inject-helper` reports being unable to hook.

If the graphics thread updates the transformations of every source in that time frame, the game-capture source will report the width and height used from the last valid capture, leading to its selection box flickering in and out of view.

Ensuring that width and height are only reported when the source is not only made active but is also capturing content fixes the flickering issue.

**Note:** This is a naive fix, but possibly the easiest one for the reported issue.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/7569

### How Has This Been Tested?
Tested on Windows 11 with an active game in windowed mode and another application that cannot be hooked by the `inject-helper`.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
