### PR TITLE
mac-virtualcam: Fix crashes in apps loading virtual camera and performance fixes

### DIFF
--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALMachClient.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALMachClient.mm
@@ -114,6 +114,7 @@
 
 			IOSurfaceRef surface = IOSurfaceLookupFromMachPort(
 				[framePort machPort]);
+			[framePort invalidate];
 			mach_port_deallocate(mach_task_self(),
 					     [framePort machPort]);
 

--- a/plugins/mac-virtualcam/src/obs-plugin/OBSDALMachServer.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/OBSDALMachServer.mm
@@ -15,7 +15,6 @@
 @property NSPort *port;
 @property NSMutableSet *clientPorts;
 @property NSRunLoop *runLoop;
-@property uint32_t seed;
 @end
 
 @implementation OBSDALMachServer
@@ -156,7 +155,6 @@
 			return;
 		}
 
-		IOSurfaceLock(surface, 0, &_seed);
 		mach_port_t framePort = IOSurfaceCreateMachPort(surface);
 
 		if (!framePort) {
@@ -176,7 +174,6 @@
 					 ]];
 
 		mach_port_deallocate(mach_task_self(), framePort);
-		IOSurfaceUnlock(surface, 0, &_seed);
 	}
 }
 

--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -84,11 +84,9 @@ static bool check_dal_plugin()
 					copyPluginCmd];
 
 			NSDictionary *errorDict;
-			NSAppleEventDescriptor *returnDescriptor = NULL;
 			NSAppleScript *scriptObject =
 				[[NSAppleScript alloc] initWithSource:copyCmd];
-			returnDescriptor =
-				[scriptObject executeAndReturnError:&errorDict];
+			[scriptObject executeAndReturnError:&errorDict];
 			if (errorDict != nil) {
 				const char *errorMessage = [[errorDict
 					objectForKey:@"NSAppleScriptErrorMessage"]


### PR DESCRIPTION
### Description
Fixes crashes that could happen in applications that load the virtual camera multiple times consecutively or in parallel and improves performance on M1-based Macs.

### Motivation and Context
Without invalidating the mach port used for sharing the IOSurface between OBS and the application displaying the virtual camera output, IOKit seems to run into the issue of receiving "shared" mach ports, possibly because of port exhaustion. IOKit requires a "new" port however and crashes upon that error otherwise.

Fixes https://github.com/obsproject/obs-studio/issues/7287

Additionally, because Apple Silicon-based Macs have a unified memory architecture, an IOSurface will always be available in memory accessible to the CPU and GPU (and an off-load of the IOSurface will not take place).

eGPUs are not supported on Apple Silicon-based Macs either, so an IOSurface lock to ensure data is copied back to CPU memory is not necessary.

### How Has This Been Tested?
Tested on macOS 12.6 with OBS itself and using Cameo to load and initialise the virtual camera plugin multiple times.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
