### PR TITLE
obs-frontend-api: Add theme functions

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -642,6 +642,11 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		return Str(string);
 	}
 
+	bool obs_frontend_is_theme_dark(void) override
+	{
+		return App()->IsThemeDark();
+	}
+
 	void on_load(obs_data_t *settings) override
 	{
 		for (size_t i = saveCallbacks.size(); i > 0; i--) {

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -571,3 +571,8 @@ const char *obs_frontend_get_locale_string(const char *string)
 	return !!callbacks_valid() ? c->obs_frontend_get_locale_string(string)
 				   : nullptr;
 }
+
+bool obs_frontend_is_theme_dark(void)
+{
+	return !!callbacks_valid() ? c->obs_frontend_is_theme_dark() : false;
+}

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -60,6 +60,7 @@ enum obs_frontend_event {
 	OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN,
 	OBS_FRONTEND_EVENT_PROFILE_RENAMED,
 	OBS_FRONTEND_EVENT_SCENE_COLLECTION_RENAMED,
+	OBS_FRONTEND_EVENT_THEME_CHANGED,
 };
 
 /* ------------------------------------------------------------------------- */
@@ -227,6 +228,8 @@ EXPORT void obs_frontend_open_source_interaction(obs_source_t *source);
 
 EXPORT char *obs_frontend_get_current_record_output_path(void);
 EXPORT const char *obs_frontend_get_locale_string(const char *string);
+
+EXPORT bool obs_frontend_is_theme_dark(void);
 
 /* ------------------------------------------------------------------------- */
 

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -145,6 +145,8 @@ struct obs_frontend_callbacks {
 	virtual char *obs_frontend_get_current_record_output_path(void) = 0;
 	virtual const char *
 	obs_frontend_get_locale_string(const char *string) = 0;
+
+	virtual bool obs_frontend_is_theme_dark(void) = 0;
 };
 
 EXPORT void

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -10310,4 +10310,7 @@ void OBSBasic::ResetProxyStyleSliders()
 		ActivateAudioSource(source);
 
 	UpdateContextBar(true);
+
+	if (api)
+		api->on_event(OBS_FRONTEND_EVENT_THEME_CHANGED);
 }

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -178,6 +178,10 @@ Structures/Enumerations
 
      Triggered when the virtual camera is stopped.
 
+   - **OBS_FRONTEND_EVENT_THEME_CHANGED**
+
+     Triggered when the theme is changed.
+
 
 .. struct:: obs_frontend_source_list
 
@@ -785,3 +789,9 @@ Functions
 .. function:: const char *obs_frontend_get_locale_string(const char *string)
 
    :return: Gets the frontend translation of a given string.
+
+---------------------------------------
+
+.. function:: bool obs_frontend_is_theme_dark(void)
+
+   :return: Checks if the current theme is dark or light.


### PR DESCRIPTION
### Description
This adds a frontend function to check if a theme is dark and also adds an event for when the theme is changed.

### Motivation and Context
If a plugin uses their own icons, for example, they can determine whether to use light or dark ones.

### How Has This Been Tested?
Tested with one of my plugins.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
