### PR TITLE
obs-frontend-api: Add audio mixer functions

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -747,6 +747,27 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 			undo_data, redo_data, repeatable);
 	}
 
+	void obs_frontend_audio_mixer_add_source(obs_source_t *source) override
+	{
+		uint32_t flags = obs_source_get_output_flags(source);
+
+		if (flags & OBS_SOURCE_AUDIO)
+			QMetaObject::invokeMethod(main, "AddExtraAudioSource",
+						  Q_ARG(OBSSource,
+							OBSSource(source)));
+	}
+
+	void
+	obs_frontend_audio_mixer_remove_source(obs_source_t *source) override
+	{
+		uint32_t flags = obs_source_get_output_flags(source);
+
+		if (flags & OBS_SOURCE_AUDIO)
+			QMetaObject::invokeMethod(
+				main, "RemoveExtraAudioSource",
+				Q_ARG(OBSSource, OBSSource(source)));
+	}
+
 	void on_load(obs_data_t *settings) override
 	{
 		for (size_t i = saveCallbacks.size(); i > 0; i--) {

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -631,3 +631,15 @@ void obs_frontend_add_undo_redo_action(const char *name,
 		c->obs_frontend_add_undo_redo_action(
 			name, undo, redo, undo_data, redo_data, repeatable);
 }
+
+void obs_frontend_audio_mixer_add_source(obs_source_t *source)
+{
+	if (callbacks_valid())
+		c->obs_frontend_audio_mixer_add_source(source);
+}
+
+void obs_frontend_audio_mixer_remove_source(obs_source_t *source)
+{
+	if (callbacks_valid())
+		c->obs_frontend_audio_mixer_remove_source(source);
+}

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -252,6 +252,9 @@ EXPORT void obs_frontend_add_undo_redo_action(
 	const char *name, const undo_redo_cb undo, const undo_redo_cb redo,
 	const char *undo_data, const char *redo_data, bool repeatable);
 
+EXPORT void obs_frontend_audio_mixer_add_source(obs_source_t *source);
+EXPORT void obs_frontend_audio_mixer_remove_source(obs_source_t *source);
+
 /* ------------------------------------------------------------------------- */
 
 #ifdef __cplusplus

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -167,6 +167,11 @@ struct obs_frontend_callbacks {
 						       const char *undo_data,
 						       const char *redo_data,
 						       bool repeatable) = 0;
+
+	virtual void
+	obs_frontend_audio_mixer_add_source(obs_source_t *source) = 0;
+	virtual void
+	obs_frontend_audio_mixer_remove_source(obs_source_t *source) = 0;
 };
 
 EXPORT void

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3636,6 +3636,11 @@ void OBSBasic::UnhideAllAudioControls()
 	};
 
 	obs_enum_sources(PreEnum, &UnhideAudioMixer);
+
+	PruneExtraAudioSources();
+
+	for (const auto &source : extraAudioSources)
+		UnhideAudioMixer(source);
 }
 
 void OBSBasic::ToggleHideMixer()
@@ -3897,6 +3902,42 @@ void OBSBasic::ToggleVolControlLayout()
 
 	for (const auto &source : sources)
 		ActivateAudioSource(source);
+}
+
+void OBSBasic::PruneExtraAudioSources()
+{
+	for (size_t i = 0; i < extraAudioSources.size(); i++) {
+		if (!extraAudioSources[i])
+			extraAudioSources.erase(extraAudioSources.begin() + i);
+	}
+}
+
+void OBSBasic::AddExtraAudioSource(OBSSource source)
+{
+	if (!source)
+		return;
+
+	PruneExtraAudioSources();
+
+	extraAudioSources.emplace_back(source);
+	ActivateAudioSource(source);
+}
+
+void OBSBasic::RemoveExtraAudioSource(OBSSource source)
+{
+	if (!source)
+		return;
+
+	PruneExtraAudioSources();
+
+	for (size_t i = 0; i < extraAudioSources.size(); i++) {
+		if (extraAudioSources[i] == source) {
+			extraAudioSources.erase(extraAudioSources.begin() + i);
+			break;
+		}
+	}
+
+	DeactivateAudioSource(source);
 }
 
 void OBSBasic::ActivateAudioSource(OBSSource source)
@@ -4956,6 +4997,7 @@ void OBSBasic::ClearSceneData()
 	CloseDialogs();
 
 	ClearVolumeControls();
+	extraAudioSources.clear();
 	ClearListItems(ui->scenes);
 	ui->sources->Clear();
 	ClearQuickTransitions();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -225,6 +225,7 @@ private:
 	std::shared_ptr<Auth> auth;
 
 	std::vector<VolControl *> volumes;
+	std::vector<OBSSource> extraAudioSources;
 
 	std::vector<OBSSignal> signalHandlers;
 
@@ -747,6 +748,8 @@ private slots:
 
 	void ActivateAudioSource(OBSSource source);
 	void DeactivateAudioSource(OBSSource source);
+	void AddExtraAudioSource(OBSSource source);
+	void RemoveExtraAudioSource(OBSSource source);
 
 	void DuplicateSelectedScene();
 	void RemoveSelectedScene();
@@ -881,6 +884,8 @@ private:
 	OBSSource prevFTBSource = nullptr;
 
 	float dpi = 1.0;
+
+	void PruneExtraAudioSources();
 
 public:
 	OBSSource GetProgramSource();

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -913,3 +913,19 @@ Functions
                       This uses the undo action from the first and the redo action from the last action.
 
    .. versionadded:: 29.1
+
+---------------------------------------
+
+.. function:: void obs_frontend_audio_mixer_add_source(obs_source_t *source)
+
+   Adds a source to the audio mixer.
+
+   :param source: The source to add to the mixer
+
+---------------------------------------
+
+.. function:: void obs_frontend_audio_mixer_remove_source(obs_source_t *source)
+
+   Removes a source from the audio mixer.
+
+   :param source: The source to remove from the mixer


### PR DESCRIPTION
### Description
Adds functions to the frontend api to add and remove sources from the audio mixer

### Motivation and Context
In one of my plugins, the source is private, so these functions allow me to add it to the audio mixer.

### How Has This Been Tested?
Tested with my plugin.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
