### PR TITLE
obs-frontend-api: Add screenshot event

### DIFF
--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -61,6 +61,7 @@ enum obs_frontend_event {
 	OBS_FRONTEND_EVENT_PROFILE_RENAMED,
 	OBS_FRONTEND_EVENT_SCENE_COLLECTION_RENAMED,
 	OBS_FRONTEND_EVENT_THEME_CHANGED,
+	OBS_FRONTEND_EVENT_SCREENSHOT_TAKEN,
 };
 
 /* ------------------------------------------------------------------------- */

--- a/UI/window-basic-main-screenshot.cpp
+++ b/UI/window-basic-main-screenshot.cpp
@@ -53,6 +53,10 @@ ScreenshotObj::~ScreenshotObj()
 			main->ShowStatusBarMessage(
 				QTStr("Basic.StatusBar.ScreenshotSavedTo")
 					.arg(QT_UTF8(path.c_str())));
+
+			if (main->api)
+				main->api->on_event(
+					OBS_FRONTEND_EVENT_SCREENSHOT_TAKEN);
 		}
 	}
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -189,6 +189,7 @@ class OBSBasic : public OBSMainWindow {
 	friend class OBSPermissions;
 	friend struct BasicOutputHandler;
 	friend struct OBSStudioAPI;
+	friend class ScreenshotObj;
 
 	enum class MoveDir { Up, Down, Left, Right };
 

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -182,6 +182,9 @@ Structures/Enumerations
 
      Triggered when the theme is changed.
 
+   - **OBS_FRONTEND_EVENT_SCREENSHOT_TAKEN**
+
+     Triggered when a screenshot is taken.
 
 .. struct:: obs_frontend_source_list
 


### PR DESCRIPTION
### Description
This adds a frontend event for when a screenshot is taken.

### Motivation and Context
https://ideas.obsproject.com/posts/1928/add-event-for-screenshot-saved

### How Has This Been Tested?
Tested with script.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
