### PR TITLE
docs: Fix sphinx import error on Python 3.10+

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -35,10 +35,10 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.coverage",
     "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
     "sphinx_rtd_theme",
-    "sphinxcontrib.napoleon",
     "sphinx.ext.autosectionlabel",
-    "sphinx.ext.extlinks"
+    "sphinx.ext.extlinks",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -1,2 +1,2 @@
+sphinx>=1.3
 sphinx_rtd_theme>=0.5.2
-sphinxcontrib-napoleon>=0.7


### PR DESCRIPTION
### Description
Fixes the extension definition of sphinx-napoleon for Python 3.10 per official docs:

> As of Sphinx 1.3, the napoleon extension will come packaged with Sphinx under sphinx.ext.napoleon. The sphinxcontrib.napoleon extension will continue to work with Sphinx <= 1.2.

### Motivation and Context
Restore functionality of sphinx-build on Python 3.10+.

### How Has This Been Tested?
Tested on macOS 12.6 with Python 3.10.7

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
