### PR TITLE
UI: Fix possible crash due to UI property access from graphics thread

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -2453,7 +2453,12 @@ void OBSBasicPreview::DrawSpacingHelpers()
 
 	OBSBasic *main = OBSBasic::Get();
 
-	if (main->ui->sources->selectionModel()->selectedIndexes().count() > 1)
+	vec2 s;
+	SceneFindBoxData data(s, s);
+
+	obs_scene_enum_items(main->GetCurrentScene(), FindSelected, &data);
+
+	if (data.sceneItems.size() > 1)
 		return;
 
 	OBSSceneItem item = main->GetCurrentSceneItem();


### PR DESCRIPTION
### Description
Selection state can change by main thread while UI thread (which calls DrawSpacingHelpers) tries to evaluate the amount of selected items. Get amount of selected items by enumerating over the scene data instead (which stays within the graphics thread).

### Motivation and Context
Fix possible crashes introduced by quick UI changes and resulting race conditions.

### How Has This Been Tested?
Tested on macOS 12.6 and step-debugging through the function to check if any calls leave the graphics thread boundary.

Spacing helpers are not displayed when multiple items are selected and moved in the preview.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
