### PR TITLE
UI: Add option to "Hide Transitions widgets" in Studio Mode

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -866,6 +866,7 @@ Basic.Settings.General.OverflowSelectionHidden="Show overflow even when source i
 Basic.Settings.General.Importers="Importers"
 Basic.Settings.General.AutomaticCollectionSearch="Search known locations for scene collections when importing"
 Basic.Settings.General.SwitchOnDoubleClick="Transition to scene when double-clicked"
+Basic.Settings.General.HideTransitionWidget="Hide Transition widgets"
 Basic.Settings.General.StudioPortraitLayout="Enable portrait/vertical layout"
 Basic.Settings.General.TogglePreviewProgramLabels="Show preview/program labels"
 Basic.Settings.General.Multiview="Multiview"

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -440,6 +440,22 @@
             </property>
            </widget>
           </item>
+	  <item>
+	   <widget class="QLabel" name="hiddenTransitionsLabel">
+	    <property name="sizePolicy">
+	     <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+	      <horstretch>0</horstretch>
+	      <verstretch>0</verstretch>
+	     </sizepolicy>
+	    </property>
+	    <property name="text">
+	     <string>Note that "Hide Transitions widget" is enabled in Settings</string>
+	    </property>
+	    <property name="alignment">
+	     <set>Qt::AlignLeading|Qt::AlignRight</set>
+	    </property>
+	   </widget>
+	  </item>
          </layout>
         </widget>
        </item>

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -723,6 +723,13 @@
                      </property>
                     </widget>
                    </item>
+                   <item row="1" column="1">
+                    <widget class="QCheckBox" name="hideTransitionWidget">
+                     <property name="text">
+                      <string>Basic.Settings.General.HideTransitionWidget</string>
+                     </property>
+                    </widget>
+                   </item>
                    <item row="0" column="0">
                     <spacer name="horizontalSpacer_6">
                      <property name="orientation">
@@ -736,14 +743,14 @@
                      </property>
                     </spacer>
                    </item>
-                   <item row="1" column="1">
+                   <item row="2" column="1">
                     <widget class="QCheckBox" name="studioPortraitLayout">
                      <property name="text">
                       <string>Basic.Settings.General.StudioPortraitLayout</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="2" column="1">
+                   <item row="3" column="1">
                     <widget class="QCheckBox" name="prevProgLabelToggle">
                      <property name="text">
                       <string>Basic.Settings.General.TogglePreviewProgramLabels</string>
@@ -7501,6 +7508,7 @@
   <tabstop>previewSpacingHelpers</tabstop>
   <tabstop>automaticSearch</tabstop>
   <tabstop>doubleClickSwitch</tabstop>
+  <tabstop>hideTransitionWidget</tabstop>
   <tabstop>studioPortraitLayout</tabstop>
   <tabstop>prevProgLabelToggle</tabstop>
   <tabstop>multiviewMouseSwitch</tabstop>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4373,6 +4373,11 @@ void OBSBasic::ResetUI()
 		ui->previewLayout->setDirection(QBoxLayout::LeftToRight);
 
 	UpdatePreviewProgramIndicators();
+
+	bool hideTransitionWidget = config_get_bool(
+		App()->GlobalConfig(), "BasicWindow", "HideTransitionWidget");
+	if (programOptions)
+		programOptions->setVisible(!hideTransitionWidget);
 }
 
 int OBSBasic::ResetVideo()

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -311,6 +311,11 @@ OBSBasic::OBSBasic(QWidget *parent)
 
 	ui->scenes->setItemDelegate(new SceneRenameDelegate(ui->scenes));
 
+	bool hideTransitionWidget = config_get_bool(
+		App()->GlobalConfig(), "BasicWindow", "HideTransitionWidget");
+	ui->hiddenTransitionsLabel->setVisible(previewProgramMode &&
+					       hideTransitionWidget);
+
 	auto displayResize = [this]() {
 		struct obs_video_info ovi;
 
@@ -4378,6 +4383,8 @@ void OBSBasic::ResetUI()
 		App()->GlobalConfig(), "BasicWindow", "HideTransitionWidget");
 	if (programOptions)
 		programOptions->setVisible(!hideTransitionWidget);
+	ui->hiddenTransitionsLabel->setVisible(previewProgramMode &&
+					       hideTransitionWidget);
 }
 
 int OBSBasic::ResetVideo()

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -409,6 +409,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->automaticSearch,      CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->previewSpacingHelpers,CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->doubleClickSwitch,    CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->hideTransitionWidget, CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->studioPortraitLayout, CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->prevProgLabelToggle,  CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->multiviewMouseSwitch, CHECK_CHANGED,  GENERAL_CHANGED);
@@ -1348,6 +1349,10 @@ void OBSBasicSettings::LoadGeneralSettings()
 	bool doubleClickSwitch = config_get_bool(
 		GetGlobalConfig(), "BasicWindow", "TransitionOnDoubleClick");
 	ui->doubleClickSwitch->setChecked(doubleClickSwitch);
+
+	bool hideTransitionWidget = config_get_bool(
+		GetGlobalConfig(), "BasicWindow", "HideTransitionWidget");
+	ui->hideTransitionWidget->setChecked(hideTransitionWidget);
 
 	bool studioPortraitLayout = config_get_bool(
 		GetGlobalConfig(), "BasicWindow", "StudioPortraitLayout");
@@ -3132,6 +3137,14 @@ void OBSBasicSettings::SaveGeneralSettings()
 		config_set_bool(GetGlobalConfig(), "BasicWindow",
 				"TransitionOnDoubleClick",
 				ui->doubleClickSwitch->isChecked());
+
+	if (WidgetChanged(ui->hideTransitionWidget)) {
+		config_set_bool(GetGlobalConfig(), "BasicWindow",
+				"HideTransitionWidget",
+				ui->hideTransitionWidget->isChecked());
+		main->ResetUI();
+	}
+
 	if (WidgetChanged(ui->automaticSearch))
 		config_set_bool(GetGlobalConfig(), "General",
 				"AutomaticCollectionSearch",


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

New Settings option: General -> Studio Mode -> Hide Transition widgets

When checked, the Transition button and associated widgets are hidden, allowing the side-by-side Preview and Program video windows to display as large as possible.

Note: When the Transition widgets are hidden, transitions can still be invoked by the "Transition to scene when double-clicked" method, websocket, or scripting methods.

![obs-HideTransitionWidgets](https://user-images.githubusercontent.com/1181534/195230130-14d8b97d-702e-47e1-9d41-327b396374f3.png)

### Motivation and Context

https://ideas.obsproject.com/posts/1129/studio-mode-ability-to-hide-transition-panel

Closes obsproject/obs-studio#7592


### How Has This Been Tested?

Functional testing of the option switch behavior on Ubuntu 22.04.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
