### PR TITLE
added support for custom css in browser docks as in browser sources

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -546,13 +546,14 @@ private:
 	QList<QSharedPointer<QDockWidget>> extraBrowserDocks;
 	QList<QSharedPointer<QAction>> extraBrowserDockActions;
 	QStringList extraBrowserDockTargets;
+	QStringList extraBrowserDockCustomCss;
 
 	void ClearExtraBrowserDocks();
 	void LoadExtraBrowserDocks();
 	void SaveExtraBrowserDocks();
 	void ManageExtraBrowserDocks();
 	void AddExtraBrowserDock(const QString &title, const QString &url,
-				 const QString &uuid, bool firstCreate);
+				 const QString &uuid, const QString &customCss, bool firstCreate);
 #endif
 
 	QIcon imageIcon;

--- a/UI/window-extra-browsers.hpp
+++ b/UI/window-extra-browsers.hpp
@@ -50,6 +50,7 @@ public:
 		int prevIdx;
 		QString title;
 		QString url;
+		QString customCss;
 	};
 
 	void TabSelection(bool forward);
@@ -66,9 +67,13 @@ public:
 
 	QString newTitle;
 	QString newURL;
+	QString newCustomCss;
 
 public slots:
 	void Init();
+public:
+	static void SetCustomBrowserScriptFromUrlAndCustomCss(QCefWidget* browser,
+				 QString url, QString customCss);
 };
 
 class ExtraBrowsersDelegate : public QStyledItemDelegate {


### PR DESCRIPTION
added support for custom css in browser docks as in browser sources

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Browser sources allow the user to specify custom css overrides; this is super useful and has been missing for the browser DOCK (UI dock) elements.  This pull request addes a custom css column to the front end browser dock system.
The browser dock code in OBS is not the most elegant thing, but my changes parallel the original code and do not introduce anything unusual.
The only imperfect aspect of the code is that changing the custom css for an already visible browser dock cannot have any effect until the dock is closed and recreated; refreshing the page does not solve this.  If someone can figure out a clean way to force the browser to reapply the script startup code it would be welcome.

### Motivation and Context
OBS forum post here: https://obsproject.com/forum/threads/custom-css-for-browser-docks-like-browser-sources.155735
As an example of how and why one might use this, is to create a youtube studio dock showing the users youtube studio page/account.  But such pages are filled with extraneous information that makes them poorly suited to show in a small dock.  With this mod it is easy to customize the css to show a compact version of these pages which have stats on the current stream, etc.  I will post some sample custom css for these usecases.

### How Has This Been Tested?
Tested in OBS 28, tested by setting complicated custom css for youtube pages in docks.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X ] My code is not on the master branch.
- [X ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
