### PR TITLE
UI: Swap mq and hq NVENC Preset mappings

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2821,12 +2821,12 @@ static void convert_28_1_encoder_setting(const char *encoder, const char *file)
 			const char *preset =
 				obs_data_get_string(data, "preset");
 
-			if (astrcmpi(preset, "hq") == 0) {
+			if (astrcmpi(preset, "mq") == 0) {
 				obs_data_set_string(data, "preset2", "p6");
 				obs_data_set_string(data, "tune", "hq");
 				obs_data_set_string(data, "multipass", "qres");
 
-			} else if (astrcmpi(preset, "mq") == 0) {
+			} else if (astrcmpi(preset, "hq") == 0) {
 				obs_data_set_string(data, "preset2", "p4");
 				obs_data_set_string(data, "tune", "hq");
 				obs_data_set_string(data, "multipass", "qres");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The old preset "mq" was "Max Quality", which used the old HQ preset with two-pass enabled. The old preset "hq" was "Quality", which used the old HQ preset without two-pass. Of the two, "mq" would have been considered "slower" or "higher quality" than "hq", so let's swap these entries.

Note: There is perhaps some argument to be made that "mq" and "hq" should simply both map to P4/P5 with different multipass settings, but let's get the simple fix out of the way before getting stuck on other items.

Reference:
https://docs.nvidia.com/video-technologies/video-codec-sdk/nvenc-preset-migration-guide/index.html

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want more accurate migrations.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Checked locally that recording encoder settings are migrated as follows on application start:
* hq -> p4
* mq -> p6

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
