### PR TITLE
libobs: Enable fast clear on Windows always

### DIFF
--- a/libobs/obs-display.c
+++ b/libobs/obs-display.c
@@ -19,21 +19,18 @@
 #include "obs.h"
 #include "obs-internal.h"
 
+#if defined(__APPLE__)
+/* Apple Silicon GL driver doesn't seem to track SRGB clears correctly */
+#define OBS_USE_CLEAR_WORKAROUND 1
+#else
+#define OBS_USE_CLEAR_WORKAROUND 0
+#endif
+
 bool obs_display_init(struct obs_display *display,
 		      const struct gs_init_data *graphics_data)
 {
 	pthread_mutex_init_value(&display->draw_callbacks_mutex);
 	pthread_mutex_init_value(&display->draw_info_mutex);
-
-#if defined(_WIN32)
-	/* Conservative test for NVIDIA flickering in multi-GPU setups */
-	display->use_clear_workaround = gs_get_adapter_count() > 1;
-#elif defined(__APPLE__)
-	/* Apple Silicon GL driver doesn't seem to track SRGB clears correctly */
-	display->use_clear_workaround = true;
-#else
-	display->use_clear_workaround = false;
-#endif
 
 	if (graphics_data) {
 		display->swap = gs_swapchain_create(graphics_data);
@@ -203,11 +200,12 @@ static inline bool render_display_begin(struct obs_display *display,
 					    display->background_color);
 		clear_color.w = 1.0f;
 
-		const bool use_clear_workaround = display->use_clear_workaround;
-
-		uint32_t clear_flags = GS_CLEAR_DEPTH | GS_CLEAR_STENCIL;
-		if (!use_clear_workaround)
-			clear_flags |= GS_CLEAR_COLOR;
+#if OBS_USE_CLEAR_WORKAROUND
+		const uint32_t clear_flags = GS_CLEAR_DEPTH | GS_CLEAR_STENCIL;
+#else
+		const uint32_t clear_flags = GS_CLEAR_COLOR | GS_CLEAR_DEPTH |
+					     GS_CLEAR_STENCIL;
+#endif
 		gs_clear(clear_flags, &clear_color, 1.0f, 0);
 
 		gs_enable_depth_test(false);
@@ -217,15 +215,14 @@ static inline bool render_display_begin(struct obs_display *display,
 		gs_ortho(0.0f, (float)cx, 0.0f, (float)cy, -100.0f, 100.0f);
 		gs_set_viewport(0, 0, cx, cy);
 
-		if (use_clear_workaround) {
-			gs_effect_t *const solid_effect =
-				obs->video.solid_effect;
-			gs_effect_set_vec4(gs_effect_get_param_by_name(
-						   solid_effect, "color"),
-					   &clear_color);
-			while (gs_effect_loop(solid_effect, "Solid"))
-				gs_draw_sprite(NULL, 0, cx, cy);
-		}
+#if OBS_USE_CLEAR_WORKAROUND
+		gs_effect_t *const solid_effect = obs->video.solid_effect;
+		gs_effect_set_vec4(gs_effect_get_param_by_name(solid_effect,
+							       "color"),
+				   &clear_color);
+		while (gs_effect_loop(solid_effect, "Solid"))
+			gs_draw_sprite(NULL, 0, cx, cy);
+#endif
 	}
 
 	return success;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -213,7 +213,6 @@ struct obs_display {
 	pthread_mutex_t draw_callbacks_mutex;
 	pthread_mutex_t draw_info_mutex;
 	DARRAY(struct draw_callback) draw_callbacks;
-	bool use_clear_workaround;
 
 	struct obs_display *next;
 	struct obs_display **prev_next;


### PR DESCRIPTION
### Description
NVIDIA driver 527.37 fixes flickering when multiple GPUs are installed.

### Motivation and Context
Gotta go fast.

### How Has This Been Tested?
Clear color is still visible on Windows and Mac.

Flicker verified gone in 528.49.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.