### PR TITLE
CI: Update GitHub Actions for set-output deprecation

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -32,14 +32,14 @@ jobs:
 
           case ${GITHUB_REF##*/} in
             +([0-9]).+([0-9]).+([0-9]) )
-              echo '::set-output name=valid_tag::${{ toJSON(true) }}'
-              echo '::set-output name=matrix::["beta", "stable"]'
+              echo 'valid_tag=${{ toJSON(true) }}' >> $GITHUB_OUTPUT
+              echo 'matrix=["beta", "stable"]' >> $GITHUB_OUTPUT
               ;;
             +([0-9]).+([0-9]).+([0-9])-@(beta|rc)*([0-9]) )
-              echo '::set-output name=valid_tag::${{ toJSON(true) }}'
-              echo '::set-output name=matrix::["beta"]'
+              echo 'valid_tag=${{ toJSON(true) }}' >> $GITHUB_OUTPUT
+              echo 'matrix=["beta"]' >> $GITHUB_OUTPUT
               ;;
-            * ) echo '::set-output name=valid_tag::${{ toJSON(false) }}' ;;
+            * ) echo 'valid_tag=${{ toJSON(false) }}' >> $GITHUB_OUTPUT ;;
           esac
 
   publish:
@@ -65,7 +65,7 @@ jobs:
         id: setup
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE
-          echo "::set-output name=commitHash::$(git rev-parse --short=9 HEAD)"
+          echo "commitHash=$(git rev-parse --short=9 HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build Flatpak Manifest
         uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,7 @@ jobs:
             brew uninstall ${REMOVE_FORMULAS}
           fi
 
-          echo "::set-output name=commitHash::$(git rev-parse --short=9 HEAD)"
+          echo "commitHash=$(git rev-parse --short=9 HEAD)" >> $GITHUB_OUTPUT
 
       - name: 'Switch to Xcode 14.1'
         run: sudo xcode-select -switch /Applications/Xcode_14.1.app
@@ -253,7 +253,7 @@ jobs:
       - name: 'Setup build environment'
         id: setup
         run: |
-          echo "::set-output name=commitHash::$(git rev-parse --short=9 HEAD)"
+          echo "commitHash=$(git rev-parse --short=9 HEAD)" >> $GITHUB_OUTPUT
 
       - name: 'Install dependencies'
         env:
@@ -336,7 +336,7 @@ jobs:
         id: setup
         run: |
           $CommitHash = git rev-parse --short=9 HEAD
-          Write-Output "::set-output name=commitHash::${CommitHash}"
+          "commitHash=${CommitHash}" >> $env:GITHUB_OUTPUT
 
       - name: 'Install dependencies'
         env:
@@ -421,7 +421,7 @@ jobs:
         id: setup
         run: |
           $CommitHash = git rev-parse --short=9 HEAD
-          Write-Output "::set-output name=commitHash::${CommitHash}"
+          "commitHash=${CommitHash}" >> $env:GITHUB_OUTPUT
 
       - name: 'Add msbuild to PATH'
         uses: microsoft/setup-msbuild@v1.1
@@ -449,7 +449,7 @@ jobs:
           CI/windows/03_package_obs.ps1 -CombinedArchs -Package
 
           $ArtifactName = (Get-ChildItem -filter "obs-studio-*-windows-x86+x64.zip" -File).Name
-          Write-Output "::set-output name=filename::${ArtifactName}"
+          "filename=${ArtifactName}" >> $env:GITHUB_OUTPUT
 
       - name: 'Upload build artifact'
         uses: actions/upload-artifact@v3
@@ -479,7 +479,7 @@ jobs:
       - name: 'Setup build environment'
         id: setup
         run: |
-          echo "::set-output name=commitHash::$(git rev-parse --short=9 HEAD)"
+          echo "commitHash=$(git rev-parse --short=9 HEAD)" >> $GITHUB_OUTPUT
 
       - name: 'Download artifact'
         if: env.HAVE_CODESIGN_IDENTITY == 'true'

--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -119,12 +119,12 @@ jobs:
         fi
 
         # set env variables for subsequent steps
-        echo "::set-output name=type::${TYPE}"
-        echo "::set-output name=branch::${BRANCH}"
-        echo "::set-output name=desc::${DESC}"
-        echo "::set-output name=win_url::${WIN_ASSET_URL}"
-        echo "::set-output name=mac_intel_url::${MAC_ASSET_URL}"
-        echo "::set-output name=mac_arm_url::${MAC_ARM_ASSET_URL}"
+        echo "type=${TYPE}" >> $GITHUB_OUTPUT
+        echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+        echo "desc=${DESC}" >> $GITHUB_OUTPUT
+        echo "win_url=${WIN_ASSET_URL}" >> $GITHUB_OUTPUT
+        echo "mac_intel_url=${MAC_ASSET_URL}" >> $GITHUB_OUTPUT
+        echo "mac_arm_url=${MAC_ARM_ASSET_URL}" >> $GITHUB_OUTPUT
 
     - name: Restore build cache
       id: cache
@@ -144,9 +144,9 @@ jobs:
       id: should-run
       run: |
         if [[ '${{ steps.build-info.outputs.type }}' == 'release' || '${{ steps.cache.outputs.cache-hit }}' != 'true' ]]; then
-            echo "::set-output name=result::true"
+            echo "result=true" >> $GITHUB_OUTPUT
         else
-            echo "::set-output name=result::false"
+            echo "result=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Download and prepare builds


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
GitHub Actions has deprecated set-output. Replace usages of set-output in stdout with the new syntax to save the output to the new environment variable.

See:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't want deprecation warnings hiding real issues.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
It hasn't. This was written by following documentation. A CI run will be the test.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
