### PR TITLE
UI: Hide Donation CTA when launched from Steam

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -80,6 +80,7 @@ static string lastLogFile;
 static string lastCrashLogFile;
 
 bool portable_mode = false;
+bool steam = false;
 static bool multi = false;
 static bool log_verbose = false;
 static bool unfiltered_log = false;
@@ -3045,6 +3046,9 @@ int main(int argc, char *argv[])
 		} else if (arg_is(argv[i], "--disable-missing-files-check",
 				  nullptr)) {
 			opt_disable_missing_files_check = true;
+
+		} else if (arg_is(argv[i], "--steam", nullptr)) {
+			steam = true;
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 		} else if (arg_is(argv[i], "--disable-high-dpi-scaling",

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -240,6 +240,7 @@ static inline int GetProfilePath(char *path, size_t size, const char *file)
 }
 
 extern bool portable_mode;
+extern bool steam;
 
 extern bool opt_start_streaming;
 extern bool opt_start_recording;

--- a/UI/window-basic-about.cpp
+++ b/UI/window-basic-about.cpp
@@ -33,11 +33,14 @@ OBSAbout::OBSAbout(QWidget *parent) : QDialog(parent), ui(new Ui::OBSAbout)
 	ui->version->setText(ver + bitness);
 
 	ui->contribute->setText(QTStr("About.Contribute"));
-	ui->donate->setText(
-		"&nbsp;&nbsp;<a href='https://obsproject.com/contribute'>" +
-		QTStr("About.Donate") + "</a>");
-	ui->donate->setTextInteractionFlags(Qt::TextBrowserInteraction);
-	ui->donate->setOpenExternalLinks(true);
+
+	if (!steam) {
+		ui->donate->setText(
+			"&nbsp;&nbsp;<a href='https://obsproject.com/contribute'>" +
+			QTStr("About.Donate") + "</a>");
+		ui->donate->setTextInteractionFlags(Qt::TextBrowserInteraction);
+		ui->donate->setOpenExternalLinks(true);
+	}
 
 	ui->getInvolved->setText(
 		"&nbsp;&nbsp;<a href='https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst'>" +


### PR DESCRIPTION
### Description

Adds new internal `steam` flag and hides donate link when running under Steam.

### Motivation and Context

Playtest app failed Valve review due to donation link in-app, to make use of it and make #7560 useful just hide the link when launched from Steam.

### How Has This Been Tested?

Hasn't yet, I'm too tired and my PC is too slow to compile before my face will hit the keyboard

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
