### PR TITLE
libobs: Add Windows X64 Emulation on ARM64 and move Rosetta Detection

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2315,10 +2315,6 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 				audio_permission, accessibility_permission);
 			check->exec();
 		}
-
-		bool rosettaTranslated = os_get_emulation_status();
-		blog(LOG_INFO, "Rosetta translation used: %s",
-		     rosettaTranslated ? "true" : "false");
 #endif
 
 #ifdef _WIN32

--- a/docs/sphinx/reference-libobs-util-platform.rst
+++ b/docs/sphinx/reference-libobs-util-platform.rst
@@ -483,7 +483,8 @@ Other Functions
 
 .. function:: bool os_get_emulation_status(void)
 
-   Returns true if the current process is a x64 binary and is being emulated or translated
-   by the host operating system. On macOS, it returns true when a x64 binary is 
-   being translated by Rosetta and running on Apple Silicon Macs. This function is not yet
-   implemented on Windows and Linux and will always return false on those platforms.
+   Returns true if the current process is an x64 binary and is being emulated or translated
+   by the host operating system. On macOS, it returns true when an x64 binary is 
+   being translated by Rosetta and running on Apple Silicon Macs. On Windows, it 
+   returns true when an x64 binary is being emulated on Windows ARM64 PCs. On all other 
+   platforms, it will always returns false.

--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -123,6 +123,12 @@ static void log_processor_cores(void)
 	     os_get_physical_cores(), os_get_logical_cores());
 }
 
+static void log_emulation_status(void)
+{
+	blog(LOG_INFO, "Rosetta translation used: %s",
+	     os_get_emulation_status() ? "true" : "false");
+}
+
 static void log_available_memory(void)
 {
 	size_t size;
@@ -162,6 +168,7 @@ void log_system_info(void)
 	log_processor_cores();
 	log_available_memory();
 	log_os();
+	log_emulation_status();
 	log_kernel_version();
 }
 

--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -108,6 +108,13 @@ static void log_processor_cores(void)
 	     os_get_physical_cores(), os_get_logical_cores());
 }
 
+static void log_emulation_status(void)
+{
+	if (os_get_emulation_status()) {
+		blog(LOG_WARNING, "Windows ARM64: Running with x64 emulation");
+	}
+}
+
 static void log_available_memory(void)
 {
 	MEMORYSTATUSEX ms;
@@ -138,10 +145,13 @@ static void log_windows_version(void)
 	bool b64 = is_64_bit_windows();
 	const char *windows_bitness = b64 ? "64" : "32";
 
+	bool arm64 = is_arm64_windows();
+	const char *arm64_windows = arm64 ? "ARM " : "";
+
 	blog(LOG_INFO,
-	     "Windows Version: %d.%d Build %d (release: %s; revision: %d; %s-bit)",
+	     "Windows Version: %d.%d Build %d (release: %s; revision: %d; %s%s-bit)",
 	     ver.major, ver.minor, ver.build, release_id, ver.revis,
-	     windows_bitness);
+	     arm64_windows, windows_bitness);
 }
 
 static void log_admin_status(void)
@@ -407,6 +417,7 @@ void log_system_info(void)
 	log_processor_cores();
 	log_available_memory();
 	log_windows_version();
+	log_emulation_status();
 	log_admin_status();
 	log_aero();
 	log_gaming_features();

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -1088,9 +1088,26 @@ bool is_64_bit_windows(void)
 #endif
 }
 
+bool is_arm64_windows(void)
+{
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
+	return true;
+#else
+	USHORT processMachine;
+	USHORT nativeMachine;
+	bool result = IsWow64Process2(GetCurrentProcess(), &processMachine,
+				      &nativeMachine);
+	return (result && (nativeMachine == IMAGE_FILE_MACHINE_ARM64));
+#endif
+}
+
 bool os_get_emulation_status(void)
 {
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
 	return false;
+#else
+	return is_arm64_windows();
+#endif
 }
 
 void get_reg_dword(HKEY hkey, LPCWSTR sub_key, LPCWSTR value_name,

--- a/libobs/util/windows/win-version.h
+++ b/libobs/util/windows/win-version.h
@@ -48,6 +48,7 @@ static inline int win_version_compare(const struct win_version_info *dst,
 }
 
 EXPORT bool is_64_bit_windows(void);
+EXPORT bool is_arm64_windows(void);
 EXPORT bool get_dll_ver(const wchar_t *lib, struct win_version_info *info);
 EXPORT void get_win_ver(struct win_version_info *info);
 EXPORT uint32_t get_win_ver_int(void);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a check that detects if OBS is running on Windows ARM64 emulation and logs the result.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
https://github.com/obsproject/obs-studio/pull/5644
I messed up #5738, this is the new PR. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Running X64 OBS Studio gives the following log:

#### Windows:

<details>

```
23:10:09.304: CPU Name: Microsoft SQ1 @ 3.0 GHz
23:10:09.305: CPU Speed: 1670MHz
23:10:09.305: Physical Cores: 8, Logical Cores: 8
23:10:09.305: Physical Memory: 7718MB Total, 3202MB Free
23:10:09.305: Windows Version: 10.0 Build 22538 (release: 2009; revision: 1010; ARM 64-bit)
23:10:09.305: Windows ARM64: Running with X64 Emulation
23:10:09.306: Running as administrator: false
23:10:09.307: Aero is Enabled (Aero is always on for windows 8 and above)
23:10:09.307: Windows 10 Gaming Features:
23:10:09.307: 	Game Bar: On
23:10:09.307: 	Game DVR: On
23:10:09.307: 	Game DVR Background Recording: Off
23:10:09.317: Current Date/Time: 2022-01-25, 23:10:09
23:10:09.317: Browser Hardware Acceleration: false
23:10:09.317: Qt Version: 5.15.2 (runtime), 5.15.2 (compiled)
23:10:09.317: Portable mode: false
23:10:10.338: OBS 27.2.0-beta4-23-g026987a2b (64-bit, windows)
```

</details>


#### macOS:

<details>

```
17:58:05.833: CPU Name: Apple M1 Pro
17:58:05.833: CPU Speed: 2400MHz
17:58:05.833: Physical Cores: 10, Logical Cores: 10
17:58:05.833: Physical Memory: 16384MB Total
17:58:05.833: OS Name: macOS
17:58:05.833: OS Version: Version 12.1 (Build 21C52)
17:58:05.833: Rosetta translation used: true
17:58:05.833: Kernel Version: 21.2.0
17:58:05.842: hotkeys-cocoa: Getting keyboard keys failed
17:58:05.842: hotkeys-cocoa: Using layout 'com.apple.keylayout.Dvorak'
17:58:05.843: Current Date/Time: 2022-01-26, 17:58:05
17:58:05.843: Browser Hardware Acceleration: true
17:58:05.843: Qt Version: 5.15.2 (runtime), 5.15.2 (compiled)
17:58:05.843: Portable mode: false
17:58:05.965: OBS 27.2.0-beta4-23-g026987a2b (mac)
```

</details>

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality) 
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
