### PR TITLE
libobs: Add sub property group

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -130,7 +130,7 @@ void OBSPropertiesView::RefreshProperties()
 	bool hasNoProperties = !property;
 
 	while (property) {
-		AddProperty(property, layout);
+		AddProperty(property, layout, settings);
 		obs_property_next(&property);
 	}
 
@@ -246,11 +246,11 @@ void OBSPropertiesView::resizeEvent(QResizeEvent *event)
 }
 
 QWidget *OBSPropertiesView::NewWidget(obs_property_t *prop, QWidget *widget,
-				      const char *signal)
+				      const char *signal, obs_data_t *settings)
 {
 	const char *long_desc = obs_property_long_description(prop);
 
-	WidgetInfo *info = new WidgetInfo(this, prop, widget);
+	WidgetInfo *info = new WidgetInfo(this, prop, widget, settings);
 	connect(widget, signal, info, SLOT(ControlChanged()));
 	children.emplace_back(info);
 
@@ -258,7 +258,8 @@ QWidget *OBSPropertiesView::NewWidget(obs_property_t *prop, QWidget *widget,
 	return widget;
 }
 
-QWidget *OBSPropertiesView::AddCheckbox(obs_property_t *prop)
+QWidget *OBSPropertiesView::AddCheckbox(obs_property_t *prop,
+					obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	const char *desc = obs_property_description(prop);
@@ -266,11 +267,11 @@ QWidget *OBSPropertiesView::AddCheckbox(obs_property_t *prop)
 
 	QCheckBox *checkbox = new QCheckBox(QT_UTF8(desc));
 	checkbox->setCheckState(val ? Qt::Checked : Qt::Unchecked);
-	return NewWidget(prop, checkbox, SIGNAL(stateChanged(int)));
+	return NewWidget(prop, checkbox, SIGNAL(stateChanged(int)), settings);
 }
 
 QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
-				    QLabel *&label)
+				    QLabel *&label, obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	const char *val = obs_data_get_string(settings, name);
@@ -281,7 +282,7 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
 		OBSPlainTextEdit *edit = new OBSPlainTextEdit(this, monospace);
 		edit->setPlainText(QT_UTF8(val));
 		edit->setTabStopDistance(40);
-		return NewWidget(prop, edit, SIGNAL(textChanged()));
+		return NewWidget(prop, edit, SIGNAL(textChanged()), settings);
 
 	} else if (type == OBS_TEXT_PASSWORD) {
 		QLayout *subLayout = new QHBoxLayout();
@@ -296,7 +297,7 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
 		subLayout->addWidget(edit);
 		subLayout->addWidget(show);
 
-		WidgetInfo *info = new WidgetInfo(this, prop, edit);
+		WidgetInfo *info = new WidgetInfo(this, prop, edit, settings);
 		connect(show, &QAbstractButton::toggled, info,
 			&WidgetInfo::TogglePasswordText);
 		connect(show, &QAbstractButton::toggled, [=](bool hide) {
@@ -350,7 +351,8 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
 		if (label)
 			label->setObjectName(info_label->objectName());
 
-		WidgetInfo *info = new WidgetInfo(this, prop, info_label);
+		WidgetInfo *info =
+			new WidgetInfo(this, prop, info_label, settings);
 		children.emplace_back(info);
 
 		layout->addRow(label, info_label);
@@ -363,11 +365,12 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
 	edit->setText(QT_UTF8(val));
 	edit->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 
-	return NewWidget(prop, edit, SIGNAL(textEdited(const QString &)));
+	return NewWidget(prop, edit, SIGNAL(textEdited(const QString &)),
+			 settings);
 }
 
 void OBSPropertiesView::AddPath(obs_property_t *prop, QFormLayout *layout,
-				QLabel **label)
+				QLabel **label, obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	const char *val = obs_data_get_string(settings, name);
@@ -388,7 +391,7 @@ void OBSPropertiesView::AddPath(obs_property_t *prop, QFormLayout *layout,
 	subLayout->addWidget(edit);
 	subLayout->addWidget(button);
 
-	WidgetInfo *info = new WidgetInfo(this, prop, edit);
+	WidgetInfo *info = new WidgetInfo(this, prop, edit, settings);
 	connect(button, SIGNAL(clicked()), info, SLOT(ControlChanged()));
 	children.emplace_back(info);
 
@@ -397,7 +400,7 @@ void OBSPropertiesView::AddPath(obs_property_t *prop, QFormLayout *layout,
 }
 
 void OBSPropertiesView::AddInt(obs_property_t *prop, QFormLayout *layout,
-			       QLabel **label)
+			       QLabel **label, obs_data_t *settings)
 {
 	obs_number_type type = obs_property_int_type(prop);
 	QLayout *subLayout = new QHBoxLayout();
@@ -420,7 +423,7 @@ void OBSPropertiesView::AddInt(obs_property_t *prop, QFormLayout *layout,
 	spin->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 	spin->setSuffix(QT_UTF8(suffix));
 
-	WidgetInfo *info = new WidgetInfo(this, prop, spin);
+	WidgetInfo *info = new WidgetInfo(this, prop, spin, settings);
 	children.emplace_back(info);
 
 	if (type == OBS_NUMBER_SLIDER) {
@@ -448,7 +451,7 @@ void OBSPropertiesView::AddInt(obs_property_t *prop, QFormLayout *layout,
 }
 
 void OBSPropertiesView::AddFloat(obs_property_t *prop, QFormLayout *layout,
-				 QLabel **label)
+				 QLabel **label, obs_data_t *settings)
 {
 	obs_number_type type = obs_property_float_type(prop);
 	QLayout *subLayout = new QHBoxLayout();
@@ -480,7 +483,7 @@ void OBSPropertiesView::AddFloat(obs_property_t *prop, QFormLayout *layout,
 	spin->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 	spin->setSuffix(QT_UTF8(suffix));
 
-	WidgetInfo *info = new WidgetInfo(this, prop, spin);
+	WidgetInfo *info = new WidgetInfo(this, prop, spin, settings);
 	children.emplace_back(info);
 
 	if (type == OBS_NUMBER_SLIDER) {
@@ -574,7 +577,8 @@ static QVariant from_obs_data_autoselect(obs_data_t *data, const char *name,
 							     format);
 }
 
-QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
+QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning,
+				    obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	QComboBox *combo = new QComboBox();
@@ -603,7 +607,8 @@ QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 
 	if (type == OBS_COMBO_TYPE_EDITABLE)
 		return NewWidget(prop, combo,
-				 SIGNAL(editTextChanged(const QString &)));
+				 SIGNAL(editTextChanged(const QString &)),
+				 settings);
 
 	if (idx != -1)
 		combo->setCurrentIndex(idx);
@@ -627,7 +632,7 @@ QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 	warning = idx != -1 &&
 		  model->flags(model->index(idx, 0)) == Qt::NoItemFlags;
 
-	WidgetInfo *info = new WidgetInfo(this, prop, combo);
+	WidgetInfo *info = new WidgetInfo(this, prop, combo, settings);
 	connect(combo, SIGNAL(currentIndexChanged(int)), info,
 		SLOT(ControlChanged()));
 	children.emplace_back(info);
@@ -653,7 +658,8 @@ static void NewButton(QLayout *layout, WidgetInfo *info, const char *themeIcon,
 }
 
 void OBSPropertiesView::AddEditableList(obs_property_t *prop,
-					QFormLayout *layout, QLabel *&label)
+					QFormLayout *layout, QLabel *&label,
+					obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	OBSDataArrayAutoRelease array = obs_data_get_array(settings, name);
@@ -676,7 +682,7 @@ void OBSPropertiesView::AddEditableList(obs_property_t *prop,
 		list_item->setHidden(obs_data_get_bool(item, "hidden"));
 	}
 
-	WidgetInfo *info = new WidgetInfo(this, prop, list);
+	WidgetInfo *info = new WidgetInfo(this, prop, list, settings);
 
 	list->setDragDropMode(QAbstractItemView::InternalMove);
 	connect(list->model(), SIGNAL(rowsMoved()), info,
@@ -704,19 +710,21 @@ void OBSPropertiesView::AddEditableList(obs_property_t *prop,
 	layout->addRow(label, subLayout);
 }
 
-QWidget *OBSPropertiesView::AddButton(obs_property_t *prop)
+QWidget *OBSPropertiesView::AddButton(obs_property_t *prop,
+				      obs_data_t *settings)
 {
 	const char *desc = obs_property_description(prop);
 
 	QPushButton *button = new QPushButton(QT_UTF8(desc));
 	button->setProperty("themeID", "settingsButtons");
 	button->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
-	return NewWidget(prop, button, SIGNAL(clicked()));
+	return NewWidget(prop, button, SIGNAL(clicked()), settings);
 }
 
 void OBSPropertiesView::AddColorInternal(obs_property_t *prop,
 					 QFormLayout *layout, QLabel *&label,
-					 bool supportAlpha)
+					 bool supportAlpha,
+					 obs_data_t *settings)
 {
 	QPushButton *button = new QPushButton;
 	QLabel *colorLabel = new QLabel;
@@ -759,7 +767,7 @@ void OBSPropertiesView::AddColorInternal(obs_property_t *prop,
 	subLayout->addWidget(colorLabel);
 	subLayout->addWidget(button);
 
-	WidgetInfo *info = new WidgetInfo(this, prop, colorLabel);
+	WidgetInfo *info = new WidgetInfo(this, prop, colorLabel, settings);
 	connect(button, SIGNAL(clicked()), info, SLOT(ControlChanged()));
 	children.emplace_back(info);
 
@@ -768,15 +776,15 @@ void OBSPropertiesView::AddColorInternal(obs_property_t *prop,
 }
 
 void OBSPropertiesView::AddColor(obs_property_t *prop, QFormLayout *layout,
-				 QLabel *&label)
+				 QLabel *&label, obs_data_t *settings)
 {
-	AddColorInternal(prop, layout, label, false);
+	AddColorInternal(prop, layout, label, false, settings);
 }
 
 void OBSPropertiesView::AddColorAlpha(obs_property_t *prop, QFormLayout *layout,
-				      QLabel *&label)
+				      QLabel *&label, obs_data_t *settings)
 {
-	AddColorInternal(prop, layout, label, true);
+	AddColorInternal(prop, layout, label, true, settings);
 }
 
 void MakeQFont(obs_data_t *font_obj, QFont &font, bool limit = false)
@@ -813,7 +821,7 @@ void MakeQFont(obs_data_t *font_obj, QFont &font, bool limit = false)
 }
 
 void OBSPropertiesView::AddFont(obs_property_t *prop, QFormLayout *layout,
-				QLabel *&label)
+				QLabel *&label, obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	OBSDataAutoRelease font_obj = obs_data_get_obj(settings, name);
@@ -847,7 +855,7 @@ void OBSPropertiesView::AddFont(obs_property_t *prop, QFormLayout *layout,
 	subLayout->addWidget(fontLabel);
 	subLayout->addWidget(button);
 
-	WidgetInfo *info = new WidgetInfo(this, prop, fontLabel);
+	WidgetInfo *info = new WidgetInfo(this, prop, fontLabel, settings);
 	connect(button, SIGNAL(clicked()), info, SLOT(ControlChanged()));
 	children.emplace_back(info);
 
@@ -1325,7 +1333,8 @@ static void UpdateFPSLabels(OBSFrameRatePropertyWidget *w)
 }
 
 void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning,
-				     QFormLayout *layout, QLabel *&label)
+				     QFormLayout *layout, QLabel *&label,
+				     obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	bool enabled = obs_property_enabled(prop);
@@ -1349,7 +1358,7 @@ void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning,
 
 	auto widget = CreateFrameRateWidget(prop, warning, option, valid_fps,
 					    fps_ranges);
-	auto info = new WidgetInfo(this, prop, widget);
+	auto info = new WidgetInfo(this, prop, widget, settings);
 
 	widget->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 
@@ -1422,17 +1431,21 @@ void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning,
 	});
 }
 
-void OBSPropertiesView::AddGroup(obs_property_t *prop, QFormLayout *layout)
+void OBSPropertiesView::AddGroup(obs_property_t *prop, QFormLayout *layout,
+				 obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
-	bool val = obs_data_get_bool(settings, name);
 	const char *desc = obs_property_description(prop);
 	enum obs_group_type type = obs_property_group_type(prop);
 
 	// Create GroupBox
 	QGroupBox *groupBox = new QGroupBox(QT_UTF8(desc));
-	groupBox->setCheckable(type == OBS_GROUP_CHECKABLE);
-	groupBox->setChecked(groupBox->isCheckable() ? val : true);
+	if (type == OBS_GROUP_CHECKABLE) {
+		groupBox->setCheckable(true);
+		groupBox->setChecked(obs_data_get_bool(settings, name));
+	} else {
+		groupBox->setCheckable(false);
+	}
 	groupBox->setAccessibleName("group");
 	groupBox->setEnabled(obs_property_enabled(prop));
 
@@ -1440,11 +1453,19 @@ void OBSPropertiesView::AddGroup(obs_property_t *prop, QFormLayout *layout)
 	QFormLayout *subLayout = new QFormLayout();
 	subLayout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
 	groupBox->setLayout(subLayout);
-
+	obs_data_t *subSettings = settings;
+	if (type == OBS_GROUP_SUB) {
+		subSettings = obs_data_get_obj(settings, name);
+		if (!subSettings) {
+			subSettings = obs_data_create();
+			obs_data_set_obj(settings, name, subSettings);
+		}
+		obs_data_release(subSettings);
+	}
 	obs_properties_t *content = obs_property_group_content(prop);
 	obs_property_t *el = obs_properties_first(content);
 	while (el != nullptr) {
-		AddProperty(el, subLayout);
+		AddProperty(el, subLayout, subSettings);
 		obs_property_next(&el);
 	}
 
@@ -1453,7 +1474,7 @@ void OBSPropertiesView::AddGroup(obs_property_t *prop, QFormLayout *layout)
 			  QFormLayout::ItemRole::SpanningRole, groupBox);
 
 	// Register Group Widget
-	WidgetInfo *info = new WidgetInfo(this, prop, groupBox);
+	WidgetInfo *info = new WidgetInfo(this, prop, groupBox, settings);
 	children.emplace_back(info);
 
 	// Signals
@@ -1461,7 +1482,7 @@ void OBSPropertiesView::AddGroup(obs_property_t *prop, QFormLayout *layout)
 }
 
 void OBSPropertiesView::AddProperty(obs_property_t *property,
-				    QFormLayout *layout)
+				    QFormLayout *layout, obs_data_t *settings)
 {
 	const char *name = obs_property_name(property);
 	obs_property_type type = obs_property_get_type(property);
@@ -1477,43 +1498,43 @@ void OBSPropertiesView::AddProperty(obs_property_t *property,
 	case OBS_PROPERTY_INVALID:
 		return;
 	case OBS_PROPERTY_BOOL:
-		widget = AddCheckbox(property);
+		widget = AddCheckbox(property, settings);
 		break;
 	case OBS_PROPERTY_INT:
-		AddInt(property, layout, &label);
+		AddInt(property, layout, &label, settings);
 		break;
 	case OBS_PROPERTY_FLOAT:
-		AddFloat(property, layout, &label);
+		AddFloat(property, layout, &label, settings);
 		break;
 	case OBS_PROPERTY_TEXT:
-		widget = AddText(property, layout, label);
+		widget = AddText(property, layout, label, settings);
 		break;
 	case OBS_PROPERTY_PATH:
-		AddPath(property, layout, &label);
+		AddPath(property, layout, &label, settings);
 		break;
 	case OBS_PROPERTY_LIST:
-		widget = AddList(property, warning);
+		widget = AddList(property, warning, settings);
 		break;
 	case OBS_PROPERTY_COLOR:
-		AddColor(property, layout, label);
+		AddColor(property, layout, label, settings);
 		break;
 	case OBS_PROPERTY_FONT:
-		AddFont(property, layout, label);
+		AddFont(property, layout, label, settings);
 		break;
 	case OBS_PROPERTY_BUTTON:
-		widget = AddButton(property);
+		widget = AddButton(property, settings);
 		break;
 	case OBS_PROPERTY_EDITABLE_LIST:
-		AddEditableList(property, layout, label);
+		AddEditableList(property, layout, label, settings);
 		break;
 	case OBS_PROPERTY_FRAME_RATE:
-		AddFrameRate(property, warning, layout, label);
+		AddFrameRate(property, warning, layout, label, settings);
 		break;
 	case OBS_PROPERTY_GROUP:
-		AddGroup(property, layout);
+		AddGroup(property, layout, settings);
 		break;
 	case OBS_PROPERTY_COLOR_ALPHA:
-		AddColorAlpha(property, layout, label);
+		AddColorAlpha(property, layout, label, settings);
 	}
 
 	if (!widget && !label)
@@ -1644,7 +1665,7 @@ static bool FrameRateChangedRational(OBSFrameRatePropertyWidget *w,
 }
 
 static bool FrameRateChanged(QWidget *widget, const char *name,
-			     OBSData &settings)
+			     obs_data_t *settings)
 {
 	auto w = qobject_cast<OBSFrameRatePropertyWidget *>(widget);
 	if (!w)
@@ -1705,20 +1726,20 @@ static bool FrameRateChanged(QWidget *widget, const char *name,
 void WidgetInfo::BoolChanged(const char *setting)
 {
 	QCheckBox *checkbox = static_cast<QCheckBox *>(widget);
-	obs_data_set_bool(view->settings, setting,
+	obs_data_set_bool(settings, setting,
 			  checkbox->checkState() == Qt::Checked);
 }
 
 void WidgetInfo::IntChanged(const char *setting)
 {
 	QSpinBox *spin = static_cast<QSpinBox *>(widget);
-	obs_data_set_int(view->settings, setting, spin->value());
+	obs_data_set_int(settings, setting, spin->value());
 }
 
 void WidgetInfo::FloatChanged(const char *setting)
 {
 	QDoubleSpinBox *spin = static_cast<QDoubleSpinBox *>(widget);
-	obs_data_set_double(view->settings, setting, spin->value());
+	obs_data_set_double(settings, setting, spin->value());
 }
 
 void WidgetInfo::TextChanged(const char *setting)
@@ -1728,13 +1749,13 @@ void WidgetInfo::TextChanged(const char *setting)
 	if (type == OBS_TEXT_MULTILINE) {
 		OBSPlainTextEdit *edit =
 			static_cast<OBSPlainTextEdit *>(widget);
-		obs_data_set_string(view->settings, setting,
+		obs_data_set_string(settings, setting,
 				    QT_TO_UTF8(edit->toPlainText()));
 		return;
 	}
 
 	QLineEdit *edit = static_cast<QLineEdit *>(widget);
-	obs_data_set_string(view->settings, setting, QT_TO_UTF8(edit->text()));
+	obs_data_set_string(settings, setting, QT_TO_UTF8(edit->text()));
 }
 
 bool WidgetInfo::PathChanged(const char *setting)
@@ -1765,7 +1786,7 @@ bool WidgetInfo::PathChanged(const char *setting)
 
 	QLineEdit *edit = static_cast<QLineEdit *>(widget);
 	edit->setText(path);
-	obs_data_set_string(view->settings, setting, QT_TO_UTF8(path));
+	obs_data_set_string(settings, setting, QT_TO_UTF8(path));
 	return true;
 }
 
@@ -1790,15 +1811,13 @@ void WidgetInfo::ListChanged(const char *setting)
 	case OBS_COMBO_FORMAT_INVALID:
 		return;
 	case OBS_COMBO_FORMAT_INT:
-		obs_data_set_int(view->settings, setting,
-				 data.value<long long>());
+		obs_data_set_int(settings, setting, data.value<long long>());
 		break;
 	case OBS_COMBO_FORMAT_FLOAT:
-		obs_data_set_double(view->settings, setting,
-				    data.value<double>());
+		obs_data_set_double(settings, setting, data.value<double>());
 		break;
 	case OBS_COMBO_FORMAT_STRING:
-		obs_data_set_string(view->settings, setting,
+		obs_data_set_string(settings, setting,
 				    data.toByteArray().constData());
 		break;
 	}
@@ -1807,7 +1826,7 @@ void WidgetInfo::ListChanged(const char *setting)
 bool WidgetInfo::ColorChangedInternal(const char *setting, bool supportAlpha)
 {
 	const char *desc = obs_property_description(property);
-	long long val = obs_data_get_int(view->settings, setting);
+	long long val = obs_data_get_int(settings, setting);
 	QColor color = color_from_int(val);
 	QColor::NameFormat format;
 
@@ -1848,7 +1867,7 @@ bool WidgetInfo::ColorChangedInternal(const char *setting, bool supportAlpha)
 			.arg(palette.color(QPalette::Window).name(format))
 			.arg(palette.color(QPalette::WindowText).name(format)));
 
-	obs_data_set_int(view->settings, setting, color_to_int(color));
+	obs_data_set_int(settings, setting, color_to_int(color));
 
 	return true;
 }
@@ -1865,7 +1884,7 @@ bool WidgetInfo::ColorAlphaChanged(const char *setting)
 
 bool WidgetInfo::FontChanged(const char *setting)
 {
-	OBSDataAutoRelease font_obj = obs_data_get_obj(view->settings, setting);
+	OBSDataAutoRelease font_obj = obs_data_get_obj(settings, setting);
 	bool success;
 	uint32_t flags;
 	QFont font;
@@ -1906,14 +1925,14 @@ bool WidgetInfo::FontChanged(const char *setting)
 	label->setFont(labelFont);
 	label->setText(QString("%1 %2").arg(font.family(), font.styleName()));
 
-	obs_data_set_obj(view->settings, setting, font_obj);
+	obs_data_set_obj(settings, setting, font_obj);
 	return true;
 }
 
 void WidgetInfo::GroupChanged(const char *setting)
 {
 	QGroupBox *groupbox = static_cast<QGroupBox *>(widget);
-	obs_data_set_bool(view->settings, setting,
+	obs_data_set_bool(settings, setting,
 			  groupbox->isCheckable() ? groupbox->isChecked()
 						  : true);
 }
@@ -1939,7 +1958,7 @@ void WidgetInfo::EditableListChanged()
 		obs_data_array_push_back(array, arrayItem);
 	}
 
-	obs_data_set_array(view->settings, setting, array);
+	obs_data_set_array(settings, setting, array);
 
 	ControlChanged();
 }
@@ -1992,7 +2011,7 @@ void WidgetInfo::ControlChanged()
 
 	if (!recently_updated) {
 		old_settings_cache = obs_data_create();
-		obs_data_apply(old_settings_cache, view->settings);
+		obs_data_apply(old_settings_cache, settings);
 		obs_data_release(old_settings_cache);
 	}
 
@@ -2032,7 +2051,7 @@ void WidgetInfo::ControlChanged()
 	case OBS_PROPERTY_EDITABLE_LIST:
 		break;
 	case OBS_PROPERTY_FRAME_RATE:
-		if (!FrameRateChanged(widget, setting, view->settings))
+		if (!FrameRateChanged(widget, setting, settings))
 			return;
 		break;
 	case OBS_PROPERTY_GROUP:
@@ -2055,7 +2074,7 @@ void WidgetInfo::ControlChanged()
 				if (obj && view->callback &&
 				    !view->deferUpdate) {
 					view->callback(obj, old_settings_cache,
-						       view->settings);
+						       settings);
 				}
 
 				ru = false;
@@ -2075,12 +2094,12 @@ void WidgetInfo::ControlChanged()
 		OBSObject strongObj = view->GetObject();
 		void *obj = strongObj ? strongObj.Get() : view->rawObj;
 		if (obj)
-			view->visUpdateCb(obj, view->settings);
+			view->visUpdateCb(obj, settings);
 	}
 
 	view->SignalChanged();
 
-	if (obs_property_modified(property, view->settings)) {
+	if (obs_property_modified(property, settings)) {
 		view->lastFocused = setting;
 		QMetaObject::invokeMethod(view, "RefreshProperties",
 					  Qt::QueuedConnection);

--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -31,6 +31,7 @@ private:
 	QPointer<QTimer> update_timer;
 	bool recently_updated = false;
 	OBSData old_settings_cache;
+	obs_data_t *settings;
 
 	void BoolChanged(const char *setting);
 	void IntChanged(const char *setting);
@@ -50,8 +51,11 @@ private:
 
 public:
 	inline WidgetInfo(OBSPropertiesView *view_, obs_property_t *prop,
-			  QWidget *widget_)
-		: view(view_), property(prop), widget(widget_)
+			  QWidget *widget_, obs_data_t *settings_)
+		: view(view_),
+		  property(prop),
+		  widget(widget_),
+		  settings(settings_)
 	{
 	}
 
@@ -108,32 +112,40 @@ private:
 	bool deferUpdate;
 
 	QWidget *NewWidget(obs_property_t *prop, QWidget *widget,
-			   const char *signal);
+			   const char *signal, obs_data_t *settings);
 
-	QWidget *AddCheckbox(obs_property_t *prop);
+	QWidget *AddCheckbox(obs_property_t *prop, obs_data_t *settings);
 	QWidget *AddText(obs_property_t *prop, QFormLayout *layout,
-			 QLabel *&label);
-	void AddPath(obs_property_t *prop, QFormLayout *layout, QLabel **label);
-	void AddInt(obs_property_t *prop, QFormLayout *layout, QLabel **label);
-	void AddFloat(obs_property_t *prop, QFormLayout *layout,
-		      QLabel **label);
-	QWidget *AddList(obs_property_t *prop, bool &warning);
+			 QLabel *&label, obs_data_t *settings);
+	void AddPath(obs_property_t *prop, QFormLayout *layout, QLabel **label,
+		     obs_data_t *settings);
+	void AddInt(obs_property_t *prop, QFormLayout *layout, QLabel **label,
+		    obs_data_t *settings);
+	void AddFloat(obs_property_t *prop, QFormLayout *layout, QLabel **label,
+		      obs_data_t *settings);
+	QWidget *AddList(obs_property_t *prop, bool &warning,
+			 obs_data_t *settings);
 	void AddEditableList(obs_property_t *prop, QFormLayout *layout,
-			     QLabel *&label);
-	QWidget *AddButton(obs_property_t *prop);
+			     QLabel *&label, obs_data_t *settings);
+	QWidget *AddButton(obs_property_t *prop, obs_data_t *settings);
 	void AddColorInternal(obs_property_t *prop, QFormLayout *layout,
-			      QLabel *&label, bool supportAlpha);
-	void AddColor(obs_property_t *prop, QFormLayout *layout,
-		      QLabel *&label);
+			      QLabel *&label, bool supportAlpha,
+			      obs_data_t *settings);
+	void AddColor(obs_property_t *prop, QFormLayout *layout, QLabel *&label,
+		      obs_data_t *settings);
 	void AddColorAlpha(obs_property_t *prop, QFormLayout *layout,
-			   QLabel *&label);
-	void AddFont(obs_property_t *prop, QFormLayout *layout, QLabel *&label);
+			   QLabel *&label, obs_data_t *settings);
+	void AddFont(obs_property_t *prop, QFormLayout *layout, QLabel *&label,
+		     obs_data_t *settings);
 	void AddFrameRate(obs_property_t *prop, bool &warning,
-			  QFormLayout *layout, QLabel *&label);
+			  QFormLayout *layout, QLabel *&label,
+			  obs_data_t *settings);
 
-	void AddGroup(obs_property_t *prop, QFormLayout *layout);
+	void AddGroup(obs_property_t *prop, QFormLayout *layout,
+		      obs_data_t *settings);
 
-	void AddProperty(obs_property_t *property, QFormLayout *layout);
+	void AddProperty(obs_property_t *property, QFormLayout *layout,
+			 obs_data_t *settings);
 
 	void resizeEvent(QResizeEvent *event) override;
 

--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -565,6 +565,7 @@ Property Enumeration Functions
             - OBS_COMBO_INVALID
             - OBS_GROUP_NORMAL
             - OBS_GROUP_CHECKABLE
+            - OBS_GROUP_SUB
 
 ---------------------
 

--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -311,7 +311,8 @@ obs_property_t *obs_properties_get(obs_properties_t *props, const char *name)
 
 	/* Recursively check groups as well, if any */
 	HASH_ITER (hh, props->properties, property, tmp) {
-		if (property->type != OBS_PROPERTY_GROUP)
+		if (property->type != OBS_PROPERTY_GROUP ||
+		    obs_property_group_type(property) == OBS_GROUP_SUB)
 			continue;
 
 		obs_properties_t *group = obs_property_group_content(property);
@@ -351,7 +352,8 @@ void obs_properties_remove_by_name(obs_properties_t *props, const char *name)
 		return;
 
 	HASH_ITER (hh, props->properties, cur, tmp) {
-		if (cur->type != OBS_PROPERTY_GROUP)
+		if (cur->type != OBS_PROPERTY_GROUP ||
+		    obs_property_group_type(cur) == OBS_GROUP_SUB)
 			continue;
 
 		obs_properties_remove_by_name(obs_property_group_content(cur),
@@ -367,9 +369,23 @@ void obs_properties_apply_settings_internal(obs_properties_t *props,
 
 	HASH_ITER (hh, props->properties, p, tmp) {
 		if (p->type == OBS_PROPERTY_GROUP) {
-			obs_properties_apply_settings_internal(
-				obs_property_group_content(p), settings,
-				realprops);
+			if (obs_property_group_type(p) == OBS_GROUP_SUB) {
+				obs_data_t *sub_settings =
+					obs_data_get_obj(settings, p->name);
+				if (!sub_settings) {
+					sub_settings = obs_data_create();
+					obs_data_set_obj(settings, p->name,
+							 sub_settings);
+				}
+				obs_properties_apply_settings_internal(
+					obs_property_group_content(p),
+					sub_settings, realprops);
+				obs_data_release(sub_settings);
+			} else {
+				obs_properties_apply_settings_internal(
+					obs_property_group_content(p), settings,
+					realprops);
+			}
 		}
 		if (p->modified)
 			p->modified(realprops, p, settings);
@@ -470,7 +486,8 @@ static inline bool contains_prop(struct obs_properties *props, const char *name)
 		return false;
 
 	HASH_ITER (hh, props->properties, p, tmp) {
-		if (p->type != OBS_PROPERTY_GROUP)
+		if (p->type != OBS_PROPERTY_GROUP ||
+		    obs_property_group_type(p) == OBS_GROUP_SUB)
 			continue;
 		if (contains_prop(obs_property_group_content(p), name))
 			return true;
@@ -774,7 +791,8 @@ obs_property_t *obs_properties_add_group(obs_properties_t *props,
 		return NULL;
 
 	/* Prevent duplicate properties */
-	if (check_property_group_duplicates(props, group))
+	if (type != OBS_GROUP_SUB &&
+	    check_property_group_duplicates(props, group))
 		return NULL;
 
 	obs_property_t *p = new_prop(props, name, desc, OBS_PROPERTY_GROUP);
@@ -1457,7 +1475,7 @@ enum obs_text_type obs_proprety_text_type(obs_property_t *p)
 enum obs_group_type obs_property_group_type(obs_property_t *p)
 {
 	struct group_data *data = get_type_data(p, OBS_PROPERTY_GROUP);
-	return data ? data->type : OBS_COMBO_INVALID;
+	return data ? data->type : OBS_GROUP_INVALID;
 }
 
 obs_properties_t *obs_property_group_content(obs_property_t *p)

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -103,9 +103,10 @@ enum obs_number_type {
 };
 
 enum obs_group_type {
-	OBS_COMBO_INVALID,
+	OBS_GROUP_INVALID,
 	OBS_GROUP_NORMAL,
 	OBS_GROUP_CHECKABLE,
+	OBS_GROUP_SUB,
 };
 
 enum obs_button_type {


### PR DESCRIPTION
### Description
Add sub property group, this will make the properties in the group be in a setting object with the name of the group instead of all properties in the root settings object.

### Motivation and Context
I want to have multiple groups with settings that do not have unique setting names, only unique per group.

### How Has This Been Tested?
On windows 64 bit with a plugin that is not published yet.

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
