### PR TITLE
CI: Fix Steam launching x86 version under Rosetta

### DIFF
--- a/CI/steam/scripts_macos/launch.sh
+++ b/CI/steam/scripts_macos/launch.sh
@@ -2,6 +2,17 @@
  
 arch_name="$(uname -m)"
 
+# When the script is launched from Steam, it'll be run through Rosetta.
+# Manually override arch to arm64 in that case.
+if [ "$(sysctl -in sysctl.proc_translated)" = "1" ]; then
+    arch_name="arm64"
+fi
+
+# Allow users to force Rosetta
+if [[ "$@" =~ \-\-intel ]]; then
+    arch_name="x86_64"
+fi
+
 # legacy app installation
 if [ -d OBS.app ]; then
     exec open OBS.app -W --args "$@"


### PR DESCRIPTION
### Description

Apparently Steam running the OBS launch script makes it run inside Rosetta as well, so it ended up launching the x86 version even on arm64 systems.

Explicitly detect Rosetta translation and set arm64 in those cases. Still allow users to override this by specifying `--intel` as a launch parameter.

This wasn't caught until #7617 due to the script working fine when just run from a terminal (and our macOS user numbers on Steam being rather small).

### Motivation and Context

Want to run native version where possible.

### How Has This Been Tested?

Modified script locally before launching through Steam to verify.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
