### PR TITLE
text-freetype2: Permit null-chars

### DIFF
--- a/libobs/util/utf8.c
+++ b/libobs/util/utf8.c
@@ -14,6 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 #include <wchar.h>
+#include <string.h>
 
 #include "utf8.h"
 
@@ -142,13 +143,10 @@ size_t utf8_to_wchar(const char *in, size_t insize, wchar_t *out,
 
 	total = 0;
 	p = (unsigned char *)in;
-	lim = (insize != 0) ? (p + insize) : (unsigned char *)-1;
+	lim = p + (insize != 0 ? insize : strlen(in));
 	wlim = out == NULL ? NULL : out + outsize;
 
 	for (; p < lim; p += n) {
-		if (!*p)
-			break;
-
 		if (utf8_forbidden(*p) != 0 && (flags & UTF8_IGNORE_ERROR) == 0)
 			return 0;
 
@@ -270,15 +268,12 @@ size_t wchar_to_utf8(const wchar_t *in, size_t insize, char *out,
 		return 0;
 
 	w = (wchar_t *)in;
-	wlim = (insize != 0) ? (w + insize) : (wchar_t *)-1;
+	wlim = w + (insize != 0 ? insize : wcslen(w));
 	p = (unsigned char *)out;
 	lim = out == NULL ? NULL : p + outsize;
 	total = 0;
 
 	for (; w < wlim; w++) {
-		if (!*w)
-			break;
-
 		if (wchar_forbidden(*w) != 0) {
 			if ((flags & UTF8_IGNORE_ERROR) == 0)
 				return 0;

--- a/plugins/text-freetype2/text-freetype2.h
+++ b/plugins/text-freetype2/text-freetype2.h
@@ -40,6 +40,7 @@ struct ft2_source {
 	bool antialiasing;
 	char *text_file;
 	wchar_t *text;
+	size_t text_len;
 	time_t m_timestamp;
 	bool update_file;
 	uint64_t last_checked;
@@ -99,7 +100,8 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename);
 void read_from_end(struct ft2_source *srcdata, const char *filename);
 
 void cache_standard_glyphs(struct ft2_source *srcdata);
-void cache_glyphs(struct ft2_source *srcdata, wchar_t *cache_glyphs);
+void cache_glyphs(struct ft2_source *srcdata, wchar_t *cache_glyphs,
+		  size_t cache_glyphs_len);
 
 void set_up_vertex_buffer(struct ft2_source *srcdata);
 void fill_vertex_buffer(struct ft2_source *srcdata);


### PR DESCRIPTION
### Description
Permit null-chars in text plugin.

### Motivation and Context
https://github.com/obsproject/obs-studio/issues/7595 for Hacktoberfest (Requesting `hacktoberfest-accepted` label.)

### How Has This Been Tested?
Tested with and without text containing null chars.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
