### PR TITLE
libobs: Deprecate obs_get/set_master_volume

### DIFF
--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -479,13 +479,19 @@ Video, Audio, and Graphics
 
 .. function:: void obs_set_master_volume(float volume)
 
-   Sets the master user volume.
+   No-op, only exists to keep ABI compatibility.
+
+   .. deprecated:: 29.0
 
 ---------------------
 
 .. function:: float obs_get_master_volume(void)
 
-   :return: The master user volume
+   No-op, only exists to keep ABI compatibility.
+
+   :return: Always returns 1
+
+   .. deprecated:: 29.0
 
 ---------------------
 
@@ -645,10 +651,6 @@ Core OBS Signals
 **channel_change** (int channel, in out ptr source, ptr prev_source)
 
    Called when :c:func:`obs_set_output_source()` has been called.
-
-**master_volume** (in out float volume)
-
-   Called when the master volume has changed.
 
 **hotkey_layout_change** ()
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -365,8 +365,6 @@ struct obs_core_audio {
 	int max_buffering_ticks;
 	bool fixed_buffer;
 
-	float user_volume;
-
 	pthread_mutex_t monitoring_mutex;
 	DARRAY(struct audio_monitor *) monitors;
 	char *monitoring_device_name;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -831,8 +831,6 @@ static bool obs_init_audio(struct audio_output_info *ai)
 	struct obs_task_info audio_init = {.task = set_audio_thread};
 	circlebuf_push_back(&audio->tasks, &audio_init, sizeof(audio_init));
 
-	audio->user_volume = 1.0f;
-
 	audio->monitoring_device_name = bstrdup("Default");
 	audio->monitoring_device_id = bstrdup("default");
 
@@ -988,7 +986,6 @@ static const char *obs_signals[] = {
 	"void source_transition_stop(ptr source)",
 
 	"void channel_change(int channel, in out ptr source, ptr prev_source)",
-	"void master_volume(in out float volume)",
 
 	"void hotkey_layout_change()",
 	"void hotkey_register(ptr hotkey)",
@@ -2091,19 +2088,12 @@ gs_texture_t *obs_get_main_texture(void)
 
 void obs_set_master_volume(float volume)
 {
-	struct calldata data = {0};
-
-	calldata_set_float(&data, "volume", volume);
-	signal_handler_signal(obs->signals, "master_volume", &data);
-	volume = (float)calldata_float(&data, "volume");
-	calldata_free(&data);
-
-	obs->audio.user_volume = volume;
+	UNUSED_PARAMETER(volume);
 }
 
 float obs_get_master_volume(void)
 {
-	return obs->audio.user_volume;
+	return 1.f;
 }
 
 static obs_source_t *obs_load_source_type(obs_data_t *source_data,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -754,10 +754,10 @@ EXPORT void obs_render_main_texture_src_color_only(void);
 EXPORT gs_texture_t *obs_get_main_texture(void);
 
 /** Sets the master user volume */
-EXPORT void obs_set_master_volume(float volume);
+OBS_DEPRECATED EXPORT void obs_set_master_volume(float volume);
 
 /** Gets the master user volume */
-EXPORT float obs_get_master_volume(void);
+OBS_DEPRECATED EXPORT float obs_get_master_volume(void);
 
 /** Saves a source to settings data */
 EXPORT obs_data_t *obs_save_source(obs_source_t *source);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Marks the `obs_set_master_volume` and `obs_get_master_volume` as deprecated
as they aren't used by OBS and don't actually do anything.
Removes the associated event (that never gets called, because the function doesn't get called).
Removes the associated variable. The struct is in `obs-internal.h` so this shouldn't break the ABI.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Reported in #3786. We shouldn't have dead functions.
Closes #3786.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13 RC 1

Code still compiles.
Check that nothing in OBS uses these functions. Checked with git grep that the `master_volume` isn't used anywhere (tbf, it would have been odd if it was used).
Checked that the functions aren't used in #4741 (that PR is per channel)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
