### PR TITLE
Reading nulls frm txtfiles

### DIFF
--- a/libobs/util/utf8.c
+++ b/libobs/util/utf8.c
@@ -146,8 +146,13 @@ size_t utf8_to_wchar(const char *in, size_t insize, wchar_t *out,
 	wlim = out == NULL ? NULL : out + outsize;
 
 	for (; p < lim; p += n) {
-		if (!*p)
+		if (!*p && !insize) {
 			break;
+		} else if (!*p) {
+			//skip intermediate null chars
+			n = 1;
+			continue;
+		}
 
 		if (utf8_forbidden(*p) != 0 && (flags & UTF8_IGNORE_ERROR) == 0)
 			return 0;

--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -421,7 +421,7 @@ static void remove_cr(wchar_t *source)
 void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 {
 	FILE *tmp_file = NULL;
-	uint32_t filesize = 0;
+	uint32_t filesize = 0, textsize;
 	char *tmp_read = NULL;
 	uint16_t header = 0;
 	size_t bytes_read;
@@ -464,9 +464,10 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 		bfree(srcdata->text);
 		srcdata->text = NULL;
 	}
-	srcdata->text = bzalloc((strlen(tmp_read) + 1) * sizeof(wchar_t));
-	os_utf8_to_wcs(tmp_read, strlen(tmp_read), srcdata->text,
-		       (strlen(tmp_read) + 1));
+
+	textsize = (uint32_t)os_utf8_to_wcs(tmp_read, filesize, NULL, 0) - 1;
+	srcdata->text = bzalloc((textsize + 1) * sizeof(wchar_t));
+	os_utf8_to_wcs(tmp_read, filesize, srcdata->text, (textsize + 1));
 
 	remove_cr(srcdata->text);
 	bfree(tmp_read);


### PR DESCRIPTION
### Description
#7595 
Reading text containing NULL chars by skipping over them.

### Motivation and Context
Improve user experience and also a good learning opportunity.

### How Has This Been Tested?
Tested on POP OS 22.04
Text File causing issue taken from https://github.com/obsproject/obs-studio/files/9793734/test.txt

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
