### PR TITLE
[WIP] obs-ffmpeg: Add av1 vaapi implementation

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -42,6 +42,7 @@ extern struct obs_encoder_info aom_av1_encoder_info;
 
 #ifdef LIBAVUTIL_VAAPI_AVAILABLE
 extern struct obs_encoder_info vaapi_encoder_info;
+extern struct obs_encoder_info vaapi_av1_encoder_info;
 #endif
 
 #ifndef __APPLE__
@@ -297,6 +298,12 @@ static bool vaapi_supported(void)
 	const AVCodec *vaenc = avcodec_find_encoder_by_name("h264_vaapi");
 	return !!vaenc;
 }
+
+static bool vaapi_av1_supported(void)
+{
+	const AVCodec *vaenc = avcodec_find_encoder_by_name("av1_vaapi");
+	return !!vaenc;
+}
 #endif
 
 #ifdef _WIN32
@@ -373,6 +380,11 @@ bool obs_module_load(void)
 	if (vaapi_supported()) {
 		blog(LOG_INFO, "FFMPEG VAAPI supported");
 		obs_register_encoder(&vaapi_encoder_info);
+	}
+
+	if (vaapi_av1_supported()) {
+		blog(LOG_INFO, "FFMPEG VAAPI AV1 supported");
+		obs_register_encoder(&vaapi_av1_encoder_info);
 	}
 #endif
 #endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Work in progress. Add a vaapi encoder for AV1, tested on non-upstreamed patchsets for ffmpeg from intel so this wont actually work if you using official ffmpeg sources until those patches land. Once those patches do land this may or may not need some changes.

This is also kind of a mess thrown together, we might be able to use the new ffmpeg-video-encoders tooling that was added for software AV1 but I havnt looked too hard at the code.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I wanted to test this intel gpu encoder, it works and the encoder is fast ~250fps but since only CQP is supported its not really suitable for streaming. Maybe this will motivate vendors to try again to land their patches. Also its nice to have for anyone wanting to play around with it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Encoding and playback on an a750 worked fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
