### PR TITLE
libobs-d3d11: Support advanced SDR window preview

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -979,6 +979,16 @@ struct mat4float {
 	float mat[16];
 };
 
+struct gs_monitor_color_info {
+	bool hdr;
+	UINT bits_per_color;
+
+	gs_monitor_color_info(bool hdr, int bits_per_color)
+		: hdr(hdr), bits_per_color(bits_per_color)
+	{
+	}
+};
+
 struct gs_device {
 	ComPtr<IDXGIFactory1> factory;
 	ComPtr<IDXGIAdapter1> adapter;
@@ -1035,7 +1045,7 @@ struct gs_device {
 	vector<gs_device_loss> loss_callbacks;
 	gs_obj *first_obj = nullptr;
 
-	vector<std::pair<HMONITOR, bool>> monitor_to_hdr;
+	vector<std::pair<HMONITOR, gs_monitor_color_info>> monitor_to_hdr;
 
 	void InitCompiler();
 	void InitFactory();


### PR DESCRIPTION
### Description
Displays more than 8 bpc if monitor is configured to be higher.

### Motivation and Context
Want to support high-precision SDR.

### How Has This Been Tested?
- [x] sRGB8 on SDR8
- [x] sRGB10 on SDR8 (similar banding when truncated via sRGB8 mix)
- [x] HDR on SDR8
- [x] sRGB8 on SDR10
- [x] sRGB10 on SDR10 (more banding when truncated via sRGB8 mix)
- [x] HDR on SDR10
- [x] sRGB8 on HDR
- [x] sRGB10 on HDR (more banding when truncated via sRGB8 mix)
- [x] HDR on HDR

Also verified by another user that Windows 10 21H1 does not regress.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.