### PR TITLE
Avoid having two docks with the same object name

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -398,6 +398,35 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		return (void *)main->AddDockWidget(d);
 	}
 
+	bool obs_frontend_add_dock_by_id(const char *id, const char *title,
+					 void *widget) override
+	{
+		if (main->IsDockObjectNameUsed(QT_UTF8(id))) {
+			blog(LOG_WARNING,
+			     "Dock id '%s' already used!  "
+			     "Duplicate library?",
+			     id);
+			return false;
+		}
+
+		OBSDock *dock = new OBSDock(main);
+		dock->setWidget((QWidget *)widget);
+		dock->setWindowTitle(QT_UTF8(title));
+		dock->setObjectName(QT_UTF8(id));
+
+		main->AddDockWidget(dock, Qt::RightDockWidgetArea);
+
+		dock->setFloating(true);
+		dock->setVisible(false);
+
+		return true;
+	}
+
+	void obs_frontend_remove_dock(const char *id) override
+	{
+		main->RemoveDockWidget(QT_UTF8(id));
+	}
+
 	void obs_frontend_add_event_callback(obs_frontend_event_cb callback,
 					     void *private_data) override
 	{

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -427,6 +427,24 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		main->RemoveDockWidget(QT_UTF8(id));
 	}
 
+	bool obs_frontend_add_custom_qdock(const char *id, void *dock) override
+	{
+		if (main->IsDockObjectNameUsed(QT_UTF8(id))) {
+			blog(LOG_WARNING,
+			     "Dock id '%s' already used!  "
+			     "Duplicate library?",
+			     id);
+			return false;
+		}
+
+		QDockWidget *d = reinterpret_cast<QDockWidget *>(dock);
+		d->setObjectName(QT_UTF8(id));
+
+		main->AddCustomDockWidget(d);
+
+		return true;
+	}
+
 	void obs_frontend_add_event_callback(obs_frontend_event_cb callback,
 					     void *private_data) override
 	{

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -379,7 +379,23 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 
 	void *obs_frontend_add_dock(void *dock) override
 	{
-		return (void *)main->AddDockWidget((QDockWidget *)dock);
+		QDockWidget *d = reinterpret_cast<QDockWidget *>(dock);
+
+		QString name = d->objectName();
+		if (name.isEmpty() || main->IsDockObjectNameUsed(name)) {
+			blog(LOG_WARNING,
+			     "The object name of the added dock is empty or already used,"
+			     " a temporary one will be set to avoid conflicts");
+
+			char *uuid = os_generate_uuid();
+			name = QT_UTF8(uuid);
+			bfree(uuid);
+			name.append("_oldExtraDock");
+
+			d->setObjectName(name);
+		}
+
+		return (void *)main->AddDockWidget(d);
 	}
 
 	void obs_frontend_add_event_callback(obs_frontend_event_cb callback,

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -330,6 +330,20 @@ void *obs_frontend_add_dock(void *dock)
 	return !!callbacks_valid() ? c->obs_frontend_add_dock(dock) : nullptr;
 }
 
+bool obs_frontend_add_dock_by_id(const char *id, const char *title,
+				 void *widget)
+{
+	return !!callbacks_valid()
+		       ? c->obs_frontend_add_dock_by_id(id, title, widget)
+		       : false;
+}
+
+void obs_frontend_remove_dock(const char *id)
+{
+	if (callbacks_valid())
+		c->obs_frontend_remove_dock(id);
+}
+
 void obs_frontend_add_event_callback(obs_frontend_event_cb callback,
 				     void *private_data)
 {

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -344,6 +344,12 @@ void obs_frontend_remove_dock(const char *id)
 		c->obs_frontend_remove_dock(id);
 }
 
+bool obs_frontend_add_custom_qdock(const char *id, void *dock)
+{
+	return !!callbacks_valid() ? c->obs_frontend_add_custom_qdock(id, dock)
+				   : false;
+}
+
 void obs_frontend_add_event_callback(obs_frontend_event_cb callback,
 				     void *private_data)
 {

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -138,7 +138,14 @@ EXPORT void obs_frontend_add_tools_menu_item(const char *name,
 					     void *private_data);
 
 /* takes QDockWidget and returns QAction */
+OBS_DEPRECATED
 EXPORT void *obs_frontend_add_dock(void *dock);
+
+/* takes QWidget for widget */
+EXPORT bool obs_frontend_add_dock_by_id(const char *id, const char *title,
+					void *widget);
+
+EXPORT void obs_frontend_remove_dock(const char *id);
 
 typedef void (*obs_frontend_event_cb)(enum obs_frontend_event event,
 				      void *private_data);

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -147,6 +147,9 @@ EXPORT bool obs_frontend_add_dock_by_id(const char *id, const char *title,
 
 EXPORT void obs_frontend_remove_dock(const char *id);
 
+/* takes QDockWidget for dock */
+EXPORT bool obs_frontend_add_custom_qdock(const char *id, void *dock);
+
 typedef void (*obs_frontend_event_cb)(enum obs_frontend_event event,
 				      void *private_data);
 

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -70,6 +70,8 @@ struct obs_frontend_callbacks {
 						 const char *title,
 						 void *widget) = 0;
 	virtual void obs_frontend_remove_dock(const char *id) = 0;
+	virtual bool obs_frontend_add_custom_qdock(const char *id,
+						   void *dock) = 0;
 
 	virtual void
 	obs_frontend_add_event_callback(obs_frontend_event_cb callback,

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -66,6 +66,11 @@ struct obs_frontend_callbacks {
 
 	virtual void *obs_frontend_add_dock(void *dock) = 0;
 
+	virtual bool obs_frontend_add_dock_by_id(const char *id,
+						 const char *title,
+						 void *widget) = 0;
+	virtual void obs_frontend_remove_dock(const char *id) = 0;
+
 	virtual void
 	obs_frontend_add_event_callback(obs_frontend_event_cb callback,
 					void *private_data) = 0;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -9302,10 +9302,12 @@ void OBSBasic::on_resetDocks_triggered(bool force)
 
 #ifdef BROWSER_AVAILABLE
 	if ((oldExtraDocks.size() || extraDocks.size() ||
-	     extraBrowserDocks.size()) &&
+	     extraCustomDocks.size() || extraBrowserDocks.size()) &&
 	    !force) {
 #else
-	if ((oldExtraDocks.size() || extraDocks.size()) && !force) {
+	if ((oldExtraDocks.size() || extraDocks.size() ||
+	     extraCustomDocks.size()) &&
+	    !force) {
 #endif
 		QMessageBox::StandardButton button = QMessageBox::question(
 			this, QTStr("ResetUIWarning.Title"),
@@ -9338,6 +9340,7 @@ void OBSBasic::on_resetDocks_triggered(bool force)
 	}
 
 	RESET_DOCKLIST(extraDocks)
+	RESET_DOCKLIST(extraCustomDocks)
 #ifdef BROWSER_AVAILABLE
 	RESET_DOCKLIST(extraBrowserDocks)
 #endif
@@ -9396,6 +9399,9 @@ void OBSBasic::on_lockDocks_toggled(bool lock)
 
 	for (int i = extraDocks.size() - 1; i >= 0; i--)
 		extraDocks[i]->setFeatures(features);
+
+	for (int i = extraCustomDocks.size() - 1; i >= 0; i--)
+		extraCustomDocks[i]->setFeatures(features);
 
 #ifdef BROWSER_AVAILABLE
 	for (int i = extraBrowserDocks.size() - 1; i >= 0; i--)
@@ -10296,13 +10302,17 @@ void OBSBasic::AddDockWidget(QDockWidget *dock, Qt::DockWidgetArea area,
 
 void OBSBasic::RemoveDockWidget(const QString &name)
 {
-	if (!extraDockNames.contains(name))
-		return;
-
-	int idx = extraDockNames.indexOf(name);
-	extraDockNames.removeAt(idx);
-	extraDocks[idx].clear();
-	extraDocks.removeAt(idx);
+	if (extraDockNames.contains(name)) {
+		int idx = extraDockNames.indexOf(name);
+		extraDockNames.removeAt(idx);
+		extraDocks[idx].clear();
+		extraDocks.removeAt(idx);
+	} else if (extraCustomDockNames.contains(name)) {
+		int idx = extraCustomDockNames.indexOf(name);
+		extraCustomDockNames.removeAt(idx);
+		removeDockWidget(extraCustomDocks[idx]);
+		extraCustomDocks.removeAt(idx);
+	}
 }
 
 bool OBSBasic::IsDockObjectNameUsed(const QString &name)
@@ -10316,8 +10326,46 @@ bool OBSBasic::IsDockObjectNameUsed(const QString &name)
 	     << "statsDock";
 	list << oldExtraDockNames;
 	list << extraDockNames;
+	list << extraCustomDockNames;
 
 	return list.contains(name);
+}
+
+void OBSBasic::AddCustomDockWidget(QDockWidget *dock)
+{
+	// Prevent the object name from being changed
+	connect(dock, &QObject::objectNameChanged, this,
+		&OBSBasic::RepairCustomExtraDockName);
+
+	bool lock = ui->lockDocks->isChecked();
+	QDockWidget::DockWidgetFeatures features =
+		lock ? QDockWidget::NoDockWidgetFeatures
+		     : (QDockWidget::DockWidgetClosable |
+			QDockWidget::DockWidgetMovable |
+			QDockWidget::DockWidgetFloatable);
+
+	dock->setFeatures(features);
+	addDockWidget(Qt::RightDockWidgetArea, dock);
+
+	extraCustomDockNames.push_back(dock->objectName());
+	extraCustomDocks.push_back(dock);
+}
+
+void OBSBasic::RepairCustomExtraDockName()
+{
+	QDockWidget *dock = reinterpret_cast<QDockWidget *>(sender());
+	int idx = extraCustomDocks.indexOf(dock);
+	QSignalBlocker block(dock);
+
+	if (idx == -1) {
+		blog(LOG_WARNING, "A custom dock got its object name changed");
+		return;
+	}
+
+	blog(LOG_WARNING, "The custom dock '%s' got its object name restored",
+	     QT_TO_UTF8(extraCustomDockNames[idx]));
+
+	dock->setObjectName(extraCustomDockNames[idx]);
 }
 
 OBSBasic *OBSBasic::Get()

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -9296,6 +9296,7 @@ void OBSBasic::on_resetDocks_triggered(bool force)
 	for (int i = oldExtraDocks.size() - 1; i >= 0; i--) {
 		if (!oldExtraDocks[i]) {
 			oldExtraDocks.removeAt(i);
+			oldExtraDockNames.removeAt(i);
 		}
 	}
 
@@ -9404,6 +9405,7 @@ void OBSBasic::on_lockDocks_toggled(bool lock)
 	for (int i = oldExtraDocks.size() - 1; i >= 0; i--) {
 		if (!oldExtraDocks[i]) {
 			oldExtraDocks.removeAt(i);
+			oldExtraDockNames.removeAt(i);
 		} else {
 			oldExtraDocks[i]->setFeatures(features);
 		}
@@ -10196,6 +10198,10 @@ void OBSBasic::ResizeOutputSizeOfSource()
 
 QAction *OBSBasic::AddDockWidget(QDockWidget *dock)
 {
+	// Prevent the object name from being changed
+	connect(dock, &QObject::objectNameChanged, this,
+		&OBSBasic::RepairOldExtraDockName);
+
 #ifdef BROWSER_AVAILABLE
 	QAction *action = new QAction(dock->windowTitle(), ui->menuDocks);
 
@@ -10210,6 +10216,7 @@ QAction *OBSBasic::AddDockWidget(QDockWidget *dock)
 	action->setCheckable(true);
 	assignDockToggle(dock, action);
 	oldExtraDocks.push_back(dock);
+	oldExtraDockNames.push_back(dock->objectName());
 
 	bool lock = ui->lockDocks->isChecked();
 	QDockWidget::DockWidgetFeatures features =
@@ -10224,10 +10231,28 @@ QAction *OBSBasic::AddDockWidget(QDockWidget *dock)
 	for (int i = oldExtraDocks.size() - 1; i >= 0; i--) {
 		if (!oldExtraDocks[i]) {
 			oldExtraDocks.removeAt(i);
+			oldExtraDockNames.removeAt(i);
 		}
 	}
 
 	return action;
+}
+
+void OBSBasic::RepairOldExtraDockName()
+{
+	QDockWidget *dock = reinterpret_cast<QDockWidget *>(sender());
+	int idx = oldExtraDocks.indexOf(dock);
+	QSignalBlocker block(dock);
+
+	if (idx == -1) {
+		blog(LOG_WARNING, "A dock got its object name changed");
+		return;
+	}
+
+	blog(LOG_WARNING, "The dock '%s' got its object name restored",
+	     QT_TO_UTF8(oldExtraDockNames[idx]));
+
+	dock->setObjectName(oldExtraDockNames[idx]);
 }
 
 void OBSBasic::AddDockWidget(QDockWidget *dock, Qt::DockWidgetArea area,
@@ -10278,6 +10303,21 @@ void OBSBasic::RemoveDockWidget(const QString &name)
 	extraDockNames.removeAt(idx);
 	extraDocks[idx].clear();
 	extraDocks.removeAt(idx);
+}
+
+bool OBSBasic::IsDockObjectNameUsed(const QString &name)
+{
+	QStringList list;
+	list << "scenesDock"
+	     << "sourcesDock"
+	     << "mixerDock"
+	     << "transitionsDock"
+	     << "controlsDock"
+	     << "statsDock";
+	list << oldExtraDockNames;
+	list << extraDockNames;
+
+	return list.contains(name);
 }
 
 OBSBasic *OBSBasic::Get()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -557,6 +557,9 @@ private:
 	QStringList extraDockNames;
 	QList<QSharedPointer<QDockWidget>> extraDocks;
 
+	QStringList extraCustomDockNames;
+	QList<QPointer<QDockWidget>> extraCustomDocks;
+
 #ifdef BROWSER_AVAILABLE
 	QPointer<QAction> extraBrowserMenuDocksSeparator;
 
@@ -972,6 +975,7 @@ public:
 			   bool extraBrowser = false);
 	void RemoveDockWidget(const QString &name);
 	bool IsDockObjectNameUsed(const QString &name);
+	void AddCustomDockWidget(QDockWidget *dock);
 
 	static OBSBasic *Get();
 
@@ -1204,6 +1208,7 @@ private slots:
 	void ResizeOutputSizeOfSource();
 
 	void RepairOldExtraDockName();
+	void RepairCustomExtraDockName();
 
 public slots:
 	void on_actionResetTransform_triggered();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -229,6 +229,7 @@ private:
 	std::vector<OBSSignal> signalHandlers;
 
 	QList<QPointer<QDockWidget>> oldExtraDocks;
+	QStringList oldExtraDockNames;
 
 	bool loaded = false;
 	long disableSaving = 1;
@@ -970,6 +971,7 @@ public:
 	void AddDockWidget(QDockWidget *dock, Qt::DockWidgetArea area,
 			   bool extraBrowser = false);
 	void RemoveDockWidget(const QString &name);
+	bool IsDockObjectNameUsed(const QString &name);
 
 	static OBSBasic *Get();
 
@@ -1200,6 +1202,8 @@ private slots:
 	void StackedMixerAreaContextMenuRequested();
 
 	void ResizeOutputSizeOfSource();
+
+	void RepairOldExtraDockName();
 
 public slots:
 	void on_actionResetTransform_triggered();

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -448,7 +448,8 @@ Functions
    :return: A pointer to the added QAction
 
 .. deprecated:: 29.1
-   Prefer :c:func:`obs_frontend_add_dock_by_id()` instead.
+   Prefer :c:func:`obs_frontend_add_dock_by_id()` or
+   :c:func:`obs_frontend_add_custom_qdock()` instead.
 
 ---------------------------------------
 
@@ -473,6 +474,20 @@ Functions
    Removes the dock with this id from the UI.
 
    :param id: Unique identifier of the dock to remove.
+
+---------------------------------------
+
+.. function:: bool obs_frontend_add_custom_qdock(const char *id, void *dock)
+
+   Adds a custom dock to the UI with no toggle.
+
+   Note: Use :c:func:`obs_frontend_remove_dock` to remove the dock
+         reference and id from the UI.
+
+   :param id: Unique identifier of the dock
+   :param dock: QDockWidget to add
+   :return: *true* if the dock was added, *false* if the id was already
+            used
 
 ---------------------------------------
 

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -447,6 +447,33 @@ Functions
    :param dock: QDockWidget to add/create
    :return: A pointer to the added QAction
 
+.. deprecated:: 29.1
+   Prefer :c:func:`obs_frontend_add_dock_by_id()` instead.
+
+---------------------------------------
+
+.. function:: bool obs_frontend_add_dock_by_id(const char *id, const char *title, void *widget)
+
+   Adds a dock with the widget to the UI with a toggle in the Docks
+   menu.
+
+   Note: Use :c:func:`obs_frontend_remove_dock` to remove the dock
+         and the id from the UI.
+
+   :param id: Unique identifier of the dock
+   :param title: Window title of the dock
+   :param widget: QWidget to insert in the dock
+   :return: *true* if the dock was added, *false* if the id was already
+            used
+
+---------------------------------------
+
+.. function:: void obs_frontend_remove_dock(const char *id)
+
+   Removes the dock with this id from the UI.
+
+   :param id: Unique identifier of the dock to remove.
+
 ---------------------------------------
 
 .. function:: void obs_frontend_add_event_callback(obs_frontend_event_cb callback, void *private_data)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

**Depends on:**
- https://github.com/obsproject/obs-studio/pull/7636

**Dependency of:**
- https://github.com/obsproject/obs-studio/pull/7638

https://doc.qt.io/qt-6/qmainwindow.html#saveState
> You should make sure that this property is unique for each QToolBar and QDockWidget you add to the QMainWindow.

We should avoid letting plugins add docks with the same object name. So to implement that:
- `obs_frontend_add_dock()` is deprecated in favor of `obs_frontend_add_dock_by_id()` and `obs_frontend_add_custom_qdock()` which ask for an unique id (object name). The dock is not added if the id is already used and return false in this case. 
- Also the new method does not return a QAction since internally we use the one included in QDockWidget.
- `obs_frontend_add_dock()` implements a temporary workaround to avoid this.
- `obs_frontend_add_custom_qdock()` replace the usage of `obs_frontend_add_dock()` where the returned QAction is deleted (e.g. Sources Dock plugin). The dock is not added if the id is already used and return false in this case. 
- If the object name of docks added with `obs_frontend_add_dock()` and  `obs_frontend_add_custom_qdock()` happen to be changed, the object name is changed back to its original.
- Docks added with new methods can be removed from the UI with `obs_frontend_remove_dock()`

**Note: If `obs_frontend_add_custom_qdock()` usecase is something we want to avoid, review the code about removing it and deprecate the usecase through `obs_frontend_add_dock()` deprecation.**

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fix a potential issue and preparation for PRs that depends on this one.

Also make the API more neutral toward the used dock system for non-custom methods.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Modified Downstream Keyer plugin to use `obs_frontend_add_dock_by_id()` or `obs_frontend_add_custom_qdock()`

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
