### PR TITLE
libobs: Make wcs<->utf8 conversion consistent

### DIFF
--- a/libobs/util/utf8.c
+++ b/libobs/util/utf8.c
@@ -146,7 +146,7 @@ size_t utf8_to_wchar(const char *in, size_t insize, wchar_t *out,
 	wlim = out == NULL ? NULL : out + outsize;
 
 	for (; p < lim; p += n) {
-		if (!*p)
+		if (!*p && insize == 0)
 			break;
 
 		if (utf8_forbidden(*p) != 0 && (flags & UTF8_IGNORE_ERROR) == 0)
@@ -276,7 +276,7 @@ size_t wchar_to_utf8(const wchar_t *in, size_t insize, char *out,
 	total = 0;
 
 	for (; w < wlim; w++) {
-		if (!*w)
+		if (!*w && insize == 0)
 			break;
 
 		if (wchar_forbidden(*w) != 0) {


### PR DESCRIPTION
### Description

On Windows NULL characters would be included in the output if insize is non-zero, but on *nix it would abort on the first NULL.
This just changes the condition to only `break` if insize is 0.

(This is arguably also more consistent with the function description in the comments.)

### Motivation and Context

First step towards fixing #7595, will need changes to gdi/freetype source to handle `NULL`s in output, for instance by replacing it with a placeholder character such as �

### How Has This Been Tested?

Hasn't as of yet.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
