### PR TITLE
UI: Fix placeholder element not being deleted

### DIFF
--- a/UI/window-basic-about.cpp
+++ b/UI/window-basic-about.cpp
@@ -34,7 +34,9 @@ OBSAbout::OBSAbout(QWidget *parent) : QDialog(parent), ui(new Ui::OBSAbout)
 
 	ui->contribute->setText(QTStr("About.Contribute"));
 
-	if (!steam) {
+	if (steam) {
+		delete ui->donate;
+	} else {
 		ui->donate->setText(
 			"&nbsp;&nbsp;<a href='https://obsproject.com/contribute'>" +
 			QTStr("About.Donate") + "</a>");


### PR DESCRIPTION
### Description

The `ui->donate` element wasn't being deleted, resulting in a placeholder element with the untranslated string "Donate" to be left over.

### Motivation and Context

This shouldn't be there.

### How Has This Been Tested?

Compiled and ran with and without `--steam` flag.

### Types of changes

- Bug fix (non-breaking change which fixes an issue) -->

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
