### PR TITLE
libobs: Add media key support for linux

### DIFF
--- a/libobs/obs-nix-wayland.c
+++ b/libobs/obs-nix-wayland.c
@@ -1061,6 +1061,21 @@ static obs_key_t obs_nix_wayland_key_from_virtual_key(int sym)
 		return OBS_KEY_NUM8;
 	case XKB_KEY_KP_9:
 		return OBS_KEY_NUM9;
+
+	case XKB_KEY_XF86AudioPlay:
+		return OBS_KEY_VK_MEDIA_PLAY_PAUSE;
+	case XKB_KEY_XF86AudioStop:
+		return OBS_KEY_VK_MEDIA_STOP;
+	case XKB_KEY_XF86AudioPrev:
+		return OBS_KEY_VK_MEDIA_PREV_TRACK;
+	case XKB_KEY_XF86AudioNext:
+		return OBS_KEY_VK_MEDIA_NEXT_TRACK;
+	case XKB_KEY_XF86AudioMute:
+		return OBS_KEY_VK_VOLUME_MUTE;
+	case XKB_KEY_XF86AudioRaiseVolume:
+		return OBS_KEY_VK_VOLUME_DOWN;
+	case XKB_KEY_XF86AudioLowerVolume:
+		return OBS_KEY_VK_VOLUME_UP;
 	}
 	return OBS_KEY_NONE;
 }
@@ -1607,6 +1622,21 @@ static int obs_nix_wayland_key_to_virtual_key(obs_key_t key)
 		return XKB_KEY_KP_8;
 	case OBS_KEY_NUM9:
 		return XKB_KEY_KP_9;
+
+	case OBS_KEY_VK_MEDIA_PLAY_PAUSE:
+		return XKB_KEY_XF86AudioPlay;
+	case OBS_KEY_VK_MEDIA_STOP:
+		return XKB_KEY_XF86AudioStop;
+	case OBS_KEY_VK_MEDIA_PREV_TRACK:
+		return XKB_KEY_XF86AudioPrev;
+	case OBS_KEY_VK_MEDIA_NEXT_TRACK:
+		return XKB_KEY_XF86AudioNext;
+	case OBS_KEY_VK_VOLUME_MUTE:
+		return XKB_KEY_XF86AudioMute;
+	case OBS_KEY_VK_VOLUME_DOWN:
+		return XKB_KEY_XF86AudioRaiseVolume;
+	case OBS_KEY_VK_VOLUME_UP:
+		return XKB_KEY_XF86AudioLowerVolume;
 	default:
 		break;
 	}

--- a/libobs/obs-nix-x11.c
+++ b/libobs/obs-nix-x11.c
@@ -673,6 +673,21 @@ static int get_keysym(obs_key_t key)
 	case OBS_KEY_MOUSE5:
 		return MOUSE_5;
 
+	case OBS_KEY_VK_MEDIA_PLAY_PAUSE:
+		return XF86XK_AudioPlay;
+	case OBS_KEY_VK_MEDIA_STOP:
+		return XF86XK_AudioStop;
+	case OBS_KEY_VK_MEDIA_PREV_TRACK:
+		return XF86XK_AudioPrev;
+	case OBS_KEY_VK_MEDIA_NEXT_TRACK:
+		return XF86XK_AudioNext;
+	case OBS_KEY_VK_VOLUME_MUTE:
+		return XF86XK_AudioMute;
+	case OBS_KEY_VK_VOLUME_DOWN:
+		return XF86XK_AudioRaiseVolume;
+	case OBS_KEY_VK_VOLUME_UP:
+		return XF86XK_AudioLowerVolume;
+
 	/* TODO: Implement keys for non-US keyboards */
 	default:;
 	}


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Links up the xkb keysyms with the obs vk codes.

Fixes #7649

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Someone asked for it

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with my keyboard which only has these 7 buttons as a function extension on wayland ~~Ill test X11 another day but it should be right.~~ and X11.

 I couldnt find a PLAY_PAUSE keysym in xkb but my PLAY_PAUSE key maps to this AudioPlay so I think its right.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
