### PR TITLE
UI: Change adv audio background color

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -1519,3 +1519,8 @@ QDialogButtonBox {
 OBSBasicStats {
     background: palette(dark);
 }
+
+/* Advanced audio dialog */
+OBSBasicAdvAudio #scrollAreaWidgetContents {
+    background: palette(dark);
+}

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -1507,3 +1507,8 @@ QDialogButtonBox {
 OBSBasicStats {
     background: palette(dark);
 }
+
+/* Advanced audio dialog */
+OBSBasicAdvAudio #scrollAreaWidgetContents {
+    background: palette(dark);
+}

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -1513,3 +1513,8 @@ QDialogButtonBox {
 OBSBasicStats {
     background: palette(dark);
 }
+
+/* Advanced audio dialog */
+OBSBasicAdvAudio #scrollAreaWidgetContents {
+    background: palette(dark);
+}

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -1511,3 +1511,8 @@ QDialogButtonBox {
 OBSBasicStats {
     background: palette(dark);
 }
+
+/* Advanced audio dialog */
+OBSBasicAdvAudio #scrollAreaWidgetContents {
+    background: palette(dark);
+}

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -1511,3 +1511,8 @@ QDialogButtonBox {
 OBSBasicStats {
     background: palette(dark);
 }
+
+/* Advanced audio dialog */
+OBSBasicAdvAudio #scrollAreaWidgetContents {
+    background: palette(dark);
+}


### PR DESCRIPTION
### Description
The color of the disabled sliders would be the same as the background in the advanced audio dialog.

Before:
![Screenshot from 2022-10-23 22-33-46](https://user-images.githubusercontent.com/19962531/197443565-a8c41e26-8d91-465b-a076-7af36e8a8903.png)

After:
![Screenshot from 2022-10-23 22-27-55](https://user-images.githubusercontent.com/19962531/197443413-4c1797f4-1af8-44c4-a0e4-2829f81217f6.png)

### Motivation and Context
Fix Yami bugs.

### How Has This Been Tested?
Opened advanced audio dialog to make sure the background color was correct.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
