### PR TITLE
aja: Fix KonaHDMI UHD/4K YUV capture

### DIFF
--- a/plugins/aja/aja-presets.cpp
+++ b/plugins/aja/aja-presets.cpp
@@ -187,6 +187,27 @@ void RoutingConfigurator::build_preset_table()
 		  {DEVICE_ID_IO4KPLUS},
 		  false,
 		  false}},
+		{"HDMI_UHD_4K_YCbCr_Capture",
+		 {"HDMI_UHD_4K_YCbCr_Capture",
+		  ConnectionKind::HDMI,
+		  NTV2_MODE_CAPTURE,
+		  RasterDefinition::UHD_4K,
+		  HDMIWireFormat::UHD_4K_YCBCR,
+		  VPIDStandard_Unknown,
+		  1,
+		  2,
+		  kEnable4KTSI,
+		  "hdmi[{ch1}][0]->tsi[{ch1}][0];"
+		  "hdmi[{ch1}][1]->tsi[{ch1}][1];"
+		  "hdmi[{ch1}][2]->tsi[{ch2}][0];"
+		  "hdmi[{ch1}][3]->tsi[{ch2}][1];"
+		  "tsi[{ch1}][0]->fb[{ch1}][0];"
+		  "tsi[{ch1}][1]->fb[{ch1}][1];"
+		  "tsi[{ch2}][0]->fb[{ch2}][0];"
+		  "tsi[{ch2}][1]->fb[{ch2}][1];",
+		  {},
+		  false,
+		  false}},
 		/*
 		 * HDMI YCbCr Display
 		 */

--- a/plugins/aja/aja-props.cpp
+++ b/plugins/aja/aja-props.cpp
@@ -155,7 +155,7 @@ NTV2Channel SourceProps::Framestore() const
 	    NTV2_IS_4K_VIDEO_FORMAT(videoFormat)) {
 		return NTV2_CHANNEL3;
 	}
-	return NTV2InputSourceToChannel(InitialInputSource());
+	return Channel();
 }
 
 NTV2AudioSystem SourceProps::AudioSystem() const

--- a/plugins/aja/aja-source.cpp
+++ b/plugins/aja/aja-source.cpp
@@ -269,6 +269,7 @@ void AJASource::CaptureThread(AJAThread *thread, void *data)
 				    sourceProps.pixelFormat);
 	auto inputSource = sourceProps.InitialInputSource();
 	auto channel = sourceProps.Channel();
+	auto framestore = sourceProps.Framestore();
 	auto audioSystem = sourceProps.AudioSystem();
 	// Current "on-air" frame on the card. The capture thread "Ping-pongs" between
 	// two frames, starting at an index corresponding to the framestore channel.
@@ -278,12 +279,12 @@ void AJASource::CaptureThread(AJAThread *thread, void *data)
 	// Channel 3 (index 2) = frames 4/5
 	// Channel 4 (index 3) = frames 6/7
 	// etc...
-	ULWord currentCardFrame = (uint32_t)channel * 2;
+	ULWord currentCardFrame = GetIndexForNTV2Channel(framestore) * 2;
 	card->WaitForInputFieldID(NTV2_FIELD0, channel);
 
 	currentCardFrame ^= 1;
 
-	card->SetInputFrame(channel, currentCardFrame);
+	card->SetInputFrame(framestore, currentCardFrame);
 
 	AudioOffsets offsets;
 	ResetAudioBufferOffsets(card, audioSystem, offsets);
@@ -388,7 +389,7 @@ void AJASource::CaptureThread(AJAThread *thread, void *data)
 
 		obs_source_output_video2(ajaSource->mSource, &obsFrame);
 
-		card->SetInputFrame(channel, currentCardFrame);
+		card->SetInputFrame(framestore, currentCardFrame);
 	}
 
 	blog(LOG_INFO, "AJASource::Capturethread: Thread loop stopped");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
- Adds missing signal routing preset for Kona HDMI UHD/4K YUV
- Fix calculation of card's framebuffer index in the capture thread, based upon the preset's framestore widget index, rather than the input channel index.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Capturing UHD/4K YUV on the KonaHDMI, both on input 1 and 2, was not working in OBS.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Verified that capturing UHD/4K YUV signals works on Kona HDMI, on both input 1 and 2.
NOTE: Only inputs 1 and 2 on Kona HDMI are capable of UHD/4K capture. Inputs 3 and 4 can only capture HD, and only when inputs 1 and 2 are also being used to capture HD signals.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
