### PR TITLE
vlc-video: Fix videos larger than 1080p being squished

### DIFF
--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -401,8 +401,8 @@ static void calculate_display_size(struct vlc_source *c, unsigned *width,
 			if (track->i_type != libvlc_track_video)
 				continue;
 
-			int display_width = track->video->i_width;
-			int display_height = track->video->i_height;
+			unsigned display_width = track->video->i_width;
+			unsigned display_height = track->video->i_height;
 
 			if (display_width == 0 || display_height == 0)
 				continue;
@@ -410,9 +410,9 @@ static void calculate_display_size(struct vlc_source *c, unsigned *width,
 			/* Adjust for Sample Aspect Ratio (SAR) */
 			if (track->video->i_sar_num > 0 &&
 			    track->video->i_sar_den > 0) {
-				display_width = display_width *
-						track->video->i_sar_num /
-						track->video->i_sar_den;
+				display_width = (unsigned)util_mul_div64(
+					display_width, track->video->i_sar_num,
+					track->video->i_sar_den);
 			}
 
 			switch (track->video->i_orientation) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Current behavior leads to overflow in computing source width with Sample Aspect Ratio. Changing to `uint64_t` fixed this problem.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Resolve #7666.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Playing testing videos described in #7666.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Changed precision of computing `display_width` with SAR.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
