### PR TITLE
obs-ffmpeg: Fix Ubuntu 20.04 detection

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -242,43 +242,19 @@ static void do_nvenc_check_for_ubuntu_20_04(void)
 	FILE *fp;
 	char *line = NULL;
 	size_t linecap = 0;
-	struct dstr distro;
-	struct dstr version;
 
 	fp = fopen("/etc/os-release", "r");
 	if (!fp) {
 		return;
 	}
 
-	dstr_init_copy(&distro, "Unknown");
-	dstr_init_copy(&version, "Unknown");
-
 	while (getline(&line, &linecap, fp) != -1) {
-		if (!strncmp(line, "NAME", 4)) {
-			char *start = strchr(line, '=');
-			if (!start || *(++start) == '\0')
-				continue;
-			dstr_copy(&distro, start);
-			dstr_resize(&distro, distro.len - 1);
+		if (strncmp(line, "VERSION_CODENAME=focal", 22) == 0) {
+			ubuntu_20_04_nvenc_fallback = true;
 		}
-
-		if (!strncmp(line, "VERSION_ID", 10)) {
-			char *start = strchr(line, '=');
-			if (!start || *(++start) == '\0')
-				continue;
-			dstr_copy(&version, start);
-			dstr_resize(&version, version.len - 1);
-		}
-	}
-
-	if (dstr_cmpi(&distro, "ubuntu") == 0 &&
-	    dstr_cmp(&version, "20.04") == 0) {
-		ubuntu_20_04_nvenc_fallback = true;
 	}
 
 	fclose(fp);
-	dstr_free(&version);
-	dstr_free(&distro);
 	free(line);
 }
 #endif


### PR DESCRIPTION
### Description

The current Ubuntu 20.04 check doesn't work since both name and version id are quoted, but quotes are not stripped, resulting in the `dstrcmp`s here failing:

https://github.com/obsproject/obs-studio/blob/dd26fe4f8a5fc603a405841bfb02069bf59ee5c8/plugins/obs-ffmpeg/obs-ffmpeg.c#L274-L275

`VERSION_CODENAME` on the other hand is not quoted, and also easier since it requires just a single string.

### Motivation and Context

Fixes.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
