### PR TITLE
obs-frontend-api: Add functions to get last saved files

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -647,6 +647,21 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		return App()->IsThemeDark();
 	}
 
+	const char *obs_frontend_get_last_recording(void) override
+	{
+		return main->outputHandler->lastRecordingPath.c_str();
+	}
+
+	const char *obs_frontend_get_last_screenshot(void) override
+	{
+		return main->lastScreenshot.c_str();
+	}
+
+	const char *obs_frontend_get_last_replay(void) override
+	{
+		return main->lastReplay.c_str();
+	}
+
 	void on_load(obs_data_t *settings) override
 	{
 		for (size_t i = saveCallbacks.size(); i > 0; i--) {

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -576,3 +576,21 @@ bool obs_frontend_is_theme_dark(void)
 {
 	return !!callbacks_valid() ? c->obs_frontend_is_theme_dark() : false;
 }
+
+const char *obs_frontend_get_last_recording(void)
+{
+	return !!callbacks_valid() ? c->obs_frontend_get_last_recording()
+				   : nullptr;
+}
+
+const char *obs_frontend_get_last_screenshot(void)
+{
+	return !!callbacks_valid() ? c->obs_frontend_get_last_screenshot()
+				   : nullptr;
+}
+
+const char *obs_frontend_get_last_replay(void)
+{
+	return !!callbacks_valid() ? c->obs_frontend_get_last_replay()
+				   : nullptr;
+}

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -232,6 +232,10 @@ EXPORT const char *obs_frontend_get_locale_string(const char *string);
 
 EXPORT bool obs_frontend_is_theme_dark(void);
 
+EXPORT const char *obs_frontend_get_last_recording(void);
+EXPORT const char *obs_frontend_get_last_screenshot(void);
+EXPORT const char *obs_frontend_get_last_replay(void);
+
 /* ------------------------------------------------------------------------- */
 
 #ifdef __cplusplus

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -147,6 +147,10 @@ struct obs_frontend_callbacks {
 	obs_frontend_get_locale_string(const char *string) = 0;
 
 	virtual bool obs_frontend_is_theme_dark(void) = 0;
+
+	virtual const char *obs_frontend_get_last_recording(void) = 0;
+	virtual const char *obs_frontend_get_last_screenshot(void) = 0;
+	virtual const char *obs_frontend_get_last_replay(void) = 0;
 };
 
 EXPORT void

--- a/UI/window-basic-main-screenshot.cpp
+++ b/UI/window-basic-main-screenshot.cpp
@@ -54,6 +54,8 @@ ScreenshotObj::~ScreenshotObj()
 				QTStr("Basic.StatusBar.ScreenshotSavedTo")
 					.arg(QT_UTF8(path.c_str())));
 
+			main->lastScreenshot = path;
+
 			if (main->api)
 				main->api->on_event(
 					OBS_FRONTEND_EVENT_SCREENSHOT_TAKEN);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7476,15 +7476,17 @@ void OBSBasic::ReplayBufferSaved()
 	proc_handler_t *ph =
 		obs_output_get_proc_handler(outputHandler->replayBuffer);
 	proc_handler_call(ph, "get_last_replay", &cd);
-	QString path = QT_UTF8(calldata_string(&cd, "path"));
-	QString msg = QTStr("Basic.StatusBar.ReplayBufferSavedTo").arg(path);
+	std::string path = calldata_string(&cd, "path");
+	QString msg = QTStr("Basic.StatusBar.ReplayBufferSavedTo")
+			      .arg(QT_UTF8(path.c_str()));
 	ShowStatusBarMessage(msg);
+	lastReplay = path;
 	calldata_free(&cd);
 
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED);
 
-	AutoRemux(path);
+	AutoRemux(QT_UTF8(path.c_str()));
 }
 
 void OBSBasic::ReplayBufferStop(int code)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -636,6 +636,9 @@ private:
 
 	float GetDevicePixelRatio();
 
+	std::string lastScreenshot;
+	std::string lastReplay;
+
 public slots:
 	void DeferSaveBegin();
 	void DeferSaveEnd();

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -798,3 +798,21 @@ Functions
 .. function:: bool obs_frontend_is_theme_dark(void)
 
    :return: Checks if the current theme is dark or light.
+
+---------------------------------------
+
+.. function:: const char *obs_frontend_get_last_recording(void)
+
+   :return: The file path of the last recording.
+
+---------------------------------------
+
+.. function:: const char *obs_frontend_get_last_screenshot(void)
+
+   :return: The file path of the last screenshot taken.
+
+---------------------------------------
+
+.. function:: const char *obs_frontend_get_last_replay(void)
+
+   :return: The file path of the last replay buffer saved.


### PR DESCRIPTION
### Description
Adds functions to the frontend api to get the last recording, screenshot and replay buffer saved.

### Motivation and Context
Makes it easier for developers to find these files.

### How Has This Been Tested?
Tested with script.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
