### PR TITLE
libobs: Fix audio-only output did not receive raw_audio

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -1778,6 +1778,11 @@ static void default_raw_video_callback(void *param, struct video_data *frame)
 static bool prepare_audio(struct obs_output *output,
 			  const struct audio_data *old, struct audio_data *new)
 {
+	if ((output->info.flags & OBS_OUTPUT_VIDEO) == 0) {
+		*new = *old;
+		return true;
+	}
+
 	if (!output->video_start_ts) {
 		pthread_mutex_lock(&output->pause.mutex);
 		output->video_start_ts = output->pause.last_video_ts;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix audio-only output did not receive `raw_audio` callback at all.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I want to make a plugin that outputs mixed audio track(s).

When defining `obs_output_info` as below, the callback `raw_audio` was never called.
```c
struct obs_output_info vban_output_info = {
        .id = ID_PREFIX "output",
        .flags = OBS_OUTPUT_AUDIO,
        .get_name = vban_out_get_name,
        .create = vban_out_create,
        .destroy = vban_out_destroy,
        .start = vban_out_start,
        .stop = vban_out_stop,
        .raw_audio = vban_out_raw_audio,
        .update = vban_out_update,
        .get_defaults = vban_out_get_defaults,
        .get_properties = vban_out_get_properties,
};
```

As a workaround, audio arrives if adding `OBS_OUTPUT_VIDEO` to `flags` and defining `raw_video`. However, I don't think this workaround is not ideal as it causes raw-video to be sent from the GPU.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

- Build norihiro/obs-vban/pull/1 with modification of `vban_output_info` as above code.
- Start the output.
- Check `raw_audio` is called.

OS: Fedora 35.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
