### PR TITLE
Fix Simple Output Mode NVENC Preset migrations

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2812,6 +2812,122 @@ static void convert_14_2_encoder_setting(const char *encoder, const char *file)
 	obs_data_item_release(&cbr_item);
 }
 
+static void convert_nvenc_h264_presets(obs_data_t *data)
+{
+	const char *preset = obs_data_get_string(data, "preset");
+	const char *rc = obs_data_get_string(data, "rate_control");
+
+	// If already using SDK10+ preset, return early.
+	if (astrcmpi_n(preset, "p", 1) == 0) {
+		obs_data_set_string(data, "preset2", preset);
+		return;
+	}
+
+	if (astrcmpi(rc, "lossless") == 0 && astrcmpi(preset, "mq")) {
+		obs_data_set_string(data, "preset2", "p3");
+		obs_data_set_string(data, "tune", "lossless");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(rc, "lossless") == 0 && astrcmpi(preset, "hp")) {
+		obs_data_set_string(data, "preset2", "p2");
+		obs_data_set_string(data, "tune", "lossless");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(preset, "mq") == 0) {
+		obs_data_set_string(data, "preset2", "p5");
+		obs_data_set_string(data, "tune", "hq");
+		obs_data_set_string(data, "multipass", "qres");
+
+	} else if (astrcmpi(preset, "hq") == 0) {
+		obs_data_set_string(data, "preset2", "p5");
+		obs_data_set_string(data, "tune", "hq");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(preset, "default") == 0) {
+		obs_data_set_string(data, "preset2", "p3");
+		obs_data_set_string(data, "tune", "hq");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(preset, "hp") == 0) {
+		obs_data_set_string(data, "preset2", "p1");
+		obs_data_set_string(data, "tune", "hq");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(preset, "ll") == 0) {
+		obs_data_set_string(data, "preset2", "p3");
+		obs_data_set_string(data, "tune", "ll");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(preset, "llhq") == 0) {
+		obs_data_set_string(data, "preset2", "p4");
+		obs_data_set_string(data, "tune", "ll");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(preset, "llhp") == 0) {
+		obs_data_set_string(data, "preset2", "p2");
+		obs_data_set_string(data, "tune", "ll");
+		obs_data_set_string(data, "multipass", "disabled");
+	}
+}
+
+static void convert_nvenc_hevc_presets(obs_data_t *data)
+{
+	const char *preset = obs_data_get_string(data, "preset");
+	const char *rc = obs_data_get_string(data, "rate_control");
+
+	// If already using SDK10+ preset, return early.
+	if (astrcmpi_n(preset, "p", 1) == 0) {
+		obs_data_set_string(data, "preset2", preset);
+		return;
+	}
+
+	if (astrcmpi(rc, "lossless") == 0 && astrcmpi(preset, "mq")) {
+		obs_data_set_string(data, "preset2", "p5");
+		obs_data_set_string(data, "tune", "lossless");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(rc, "lossless") == 0 && astrcmpi(preset, "hp")) {
+		obs_data_set_string(data, "preset2", "p3");
+		obs_data_set_string(data, "tune", "lossless");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(preset, "mq") == 0) {
+		obs_data_set_string(data, "preset2", "p6");
+		obs_data_set_string(data, "tune", "hq");
+		obs_data_set_string(data, "multipass", "qres");
+
+	} else if (astrcmpi(preset, "hq") == 0) {
+		obs_data_set_string(data, "preset2", "p6");
+		obs_data_set_string(data, "tune", "hq");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(preset, "default") == 0) {
+		obs_data_set_string(data, "preset2", "p5");
+		obs_data_set_string(data, "tune", "hq");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(preset, "hp") == 0) {
+		obs_data_set_string(data, "preset2", "p1");
+		obs_data_set_string(data, "tune", "hq");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(preset, "ll") == 0) {
+		obs_data_set_string(data, "preset2", "p3");
+		obs_data_set_string(data, "tune", "ll");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(preset, "llhq") == 0) {
+		obs_data_set_string(data, "preset2", "p4");
+		obs_data_set_string(data, "tune", "ll");
+		obs_data_set_string(data, "multipass", "disabled");
+
+	} else if (astrcmpi(preset, "llhp") == 0) {
+		obs_data_set_string(data, "preset2", "p2");
+		obs_data_set_string(data, "tune", "ll");
+		obs_data_set_string(data, "multipass", "disabled");
+	}
+}
+
 static void convert_28_1_encoder_setting(const char *encoder, const char *file)
 {
 	OBSDataAutoRelease data =
@@ -2823,66 +2939,7 @@ static void convert_28_1_encoder_setting(const char *encoder, const char *file)
 
 		if (obs_data_has_user_value(data, "preset") &&
 		    !obs_data_has_user_value(data, "preset2")) {
-			const char *preset =
-				obs_data_get_string(data, "preset");
-			const char *rc =
-				obs_data_get_string(data, "rate_control");
-
-			if (astrcmpi(rc, "lossless") == 0 &&
-			    astrcmpi(preset, "mq")) {
-				obs_data_set_string(data, "preset2", "p3");
-				obs_data_set_string(data, "tune", "lossless");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(rc, "lossless") == 0 &&
-				   astrcmpi(preset, "hp")) {
-				obs_data_set_string(data, "preset2", "p2");
-				obs_data_set_string(data, "tune", "lossless");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(preset, "mq") == 0) {
-				obs_data_set_string(data, "preset2", "p5");
-				obs_data_set_string(data, "tune", "hq");
-				obs_data_set_string(data, "multipass", "qres");
-
-			} else if (astrcmpi(preset, "hq") == 0) {
-				obs_data_set_string(data, "preset2", "p5");
-				obs_data_set_string(data, "tune", "hq");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(preset, "default") == 0) {
-				obs_data_set_string(data, "preset2", "p3");
-				obs_data_set_string(data, "tune", "hq");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(preset, "hp") == 0) {
-				obs_data_set_string(data, "preset2", "p1");
-				obs_data_set_string(data, "tune", "hq");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(preset, "ll") == 0) {
-				obs_data_set_string(data, "preset2", "p3");
-				obs_data_set_string(data, "tune", "ll");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(preset, "llhq") == 0) {
-				obs_data_set_string(data, "preset2", "p4");
-				obs_data_set_string(data, "tune", "ll");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(preset, "llhp") == 0) {
-				obs_data_set_string(data, "preset2", "p2");
-				obs_data_set_string(data, "tune", "ll");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-			}
+			convert_nvenc_h264_presets(data);
 
 			modified = true;
 		}
@@ -2891,66 +2948,7 @@ static void convert_28_1_encoder_setting(const char *encoder, const char *file)
 
 		if (obs_data_has_user_value(data, "preset") &&
 		    !obs_data_has_user_value(data, "preset2")) {
-			const char *preset =
-				obs_data_get_string(data, "preset");
-			const char *rc =
-				obs_data_get_string(data, "rate_control");
-
-			if (astrcmpi(rc, "lossless") == 0 &&
-			    astrcmpi(preset, "mq")) {
-				obs_data_set_string(data, "preset2", "p5");
-				obs_data_set_string(data, "tune", "lossless");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(rc, "lossless") == 0 &&
-				   astrcmpi(preset, "hp")) {
-				obs_data_set_string(data, "preset2", "p3");
-				obs_data_set_string(data, "tune", "lossless");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(preset, "mq") == 0) {
-				obs_data_set_string(data, "preset2", "p6");
-				obs_data_set_string(data, "tune", "hq");
-				obs_data_set_string(data, "multipass", "qres");
-
-			} else if (astrcmpi(preset, "hq") == 0) {
-				obs_data_set_string(data, "preset2", "p6");
-				obs_data_set_string(data, "tune", "hq");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(preset, "default") == 0) {
-				obs_data_set_string(data, "preset2", "p5");
-				obs_data_set_string(data, "tune", "hq");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(preset, "hp") == 0) {
-				obs_data_set_string(data, "preset2", "p1");
-				obs_data_set_string(data, "tune", "hq");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(preset, "ll") == 0) {
-				obs_data_set_string(data, "preset2", "p3");
-				obs_data_set_string(data, "tune", "ll");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(preset, "llhq") == 0) {
-				obs_data_set_string(data, "preset2", "p4");
-				obs_data_set_string(data, "tune", "ll");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-
-			} else if (astrcmpi(preset, "llhp") == 0) {
-				obs_data_set_string(data, "preset2", "p2");
-				obs_data_set_string(data, "tune", "ll");
-				obs_data_set_string(data, "multipass",
-						    "disabled");
-			}
+			convert_nvenc_hevc_presets(data);
 
 			modified = true;
 		}

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2958,6 +2958,32 @@ static void convert_28_1_encoder_setting(const char *encoder, const char *file)
 		obs_data_save_json_safe(data, file, "tmp", "bak");
 }
 
+bool update_nvenc_presets(ConfigFile &config)
+{
+	if (config_has_user_value(config, "SimpleOutput", "NVENCPreset2") ||
+	    !config_has_user_value(config, "SimpleOutput", "NVENCPreset"))
+		return false;
+
+	const char *streamEncoder =
+		config_get_string(config, "SimpleOutput", "StreamEncoder");
+	const char *nvencPreset =
+		config_get_string(config, "SimpleOutput", "NVENCPreset");
+
+	OBSDataAutoRelease data = obs_data_create();
+	obs_data_set_string(data, "preset", nvencPreset);
+
+	if (astrcmpi(streamEncoder, "nvenc_hevc") == 0) {
+		convert_nvenc_hevc_presets(data);
+	} else {
+		convert_nvenc_h264_presets(data);
+	}
+
+	config_set_string(config, "SimpleOutput", "NVENCPreset2",
+			  obs_data_get_string(data, "preset2"));
+
+	return true;
+}
+
 static void upgrade_settings(void)
 {
 	char path[512];

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -535,15 +535,15 @@ void SimpleOutput::Update()
 #endif
 
 	} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC) == 0) {
-		presetType = "NVENCPreset";
+		presetType = "NVENCPreset2";
 
 #ifdef ENABLE_HEVC
 	} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC_HEVC) == 0) {
-		presetType = "NVENCPreset";
+		presetType = "NVENCPreset2";
 #endif
 
 	} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC_AV1) == 0) {
-		presetType = "NVENCPreset";
+		presetType = "NVENCPreset2";
 
 	} else {
 		presetType = "Preset";
@@ -551,8 +551,9 @@ void SimpleOutput::Update()
 
 	preset = config_get_string(main->Config(), "SimpleOutput", presetType);
 	obs_data_set_string(videoSettings,
-			    (strcmp(presetType, "NVENCPreset") == 0) ? "preset2"
-								     : "preset",
+			    (strcmp(presetType, "NVENCPreset2") == 0)
+				    ? "preset2"
+				    : "preset",
 			    preset);
 
 	obs_data_set_string(videoSettings, "rate_control", "CBR");

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1398,8 +1398,8 @@ bool OBSBasic::InitBasicConfigDefaults()
 				false);
 	config_set_default_string(basicConfig, "SimpleOutput", "Preset",
 				  "veryfast");
-	config_set_default_string(basicConfig, "SimpleOutput", "NVENCPreset",
-				  "hq");
+	config_set_default_string(basicConfig, "SimpleOutput", "NVENCPreset2",
+				  "p6");
 	config_set_default_string(basicConfig, "SimpleOutput", "RecQuality",
 				  "Stream");
 	config_set_default_bool(basicConfig, "SimpleOutput", "RecRB", false);
@@ -1536,6 +1536,7 @@ bool OBSBasic::InitBasicConfigDefaults()
 }
 
 extern bool EncoderAvailable(const char *encoder);
+extern bool update_nvenc_presets(ConfigFile &config);
 
 void OBSBasic::InitBasicConfigDefaults2()
 {
@@ -1549,6 +1550,9 @@ void OBSBasic::InitBasicConfigDefaults2()
 	config_set_default_string(basicConfig, "SimpleOutput", "RecEncoder",
 				  useNV ? SIMPLE_ENCODER_NVENC
 					: SIMPLE_ENCODER_X264);
+
+	if (update_nvenc_presets(basicConfig))
+		config_save_safe(basicConfig, "tmp", nullptr);
 }
 
 bool OBSBasic::InitBasicConfig()

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1759,7 +1759,7 @@ void OBSBasicSettings::LoadSimpleOutputSettings()
 	const char *qsvPreset =
 		config_get_string(main->Config(), "SimpleOutput", "QSVPreset");
 	const char *nvPreset = config_get_string(main->Config(), "SimpleOutput",
-						 "NVENCPreset");
+						 "NVENCPreset2");
 	const char *amdPreset =
 		config_get_string(main->Config(), "SimpleOutput", "AMDPreset");
 	const char *custom = config_get_string(main->Config(), "SimpleOutput",
@@ -3520,14 +3520,14 @@ void OBSBasicSettings::SaveOutputSettings()
 	if (encoder == SIMPLE_ENCODER_QSV)
 		presetType = "QSVPreset";
 	else if (encoder == SIMPLE_ENCODER_NVENC)
-		presetType = "NVENCPreset";
+		presetType = "NVENCPreset2";
 	else if (encoder == SIMPLE_ENCODER_NVENC_AV1)
-		presetType = "NVENCPreset";
+		presetType = "NVENCPreset2";
 #ifdef ENABLE_HEVC
 	else if (encoder == SIMPLE_ENCODER_AMD_HEVC)
 		presetType = "AMDPreset";
 	else if (encoder == SIMPLE_ENCODER_NVENC_HEVC)
-		presetType = "NVENCPreset";
+		presetType = "NVENCPreset2";
 #endif
 	else if (encoder == SIMPLE_ENCODER_AMD)
 		presetType = "AMDPreset";


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Simple Output Mode NVENC Presets were not migrated, so the UI would display the `Encoder Preset` dropdown with nothing selected. The user could still start a recording, but this is confusing. Let's actually migrate Simple Output Mode NVENC Presets when needed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want migrations to work. Don't want bugs.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally in a new portable mode instance with a new profile and with imported 28.0.x profiles. Checked that preset values before and after matched intended migration mappings. Checked that already migrated presets did not trigger another migration or file save.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
