### PR TITLE
UI: Remove number from multiview labels

### DIFF
--- a/UI/multiview.cpp
+++ b/UI/multiview.cpp
@@ -174,9 +174,8 @@ void Multiview::Update(MultiviewLayout multiviewLayout, bool drawLabel,
 		multiviewScenes.emplace_back(OBSGetWeakRef(src));
 		obs_source_inc_showing(src);
 
-		std::string name = std::to_string(numSrcs) + " - " +
-				   obs_source_get_name(src);
-		multiviewLabels.emplace_back(CreateLabel(name.c_str(), h / 3));
+		multiviewLabels.emplace_back(
+			CreateLabel(obs_source_get_name(src), h / 3));
 	}
 
 	obs_frontend_source_list_free(&scenes);


### PR DESCRIPTION
### Description
Removes the number and dash that prefix the scene name in the multiview

### Motivation and Context
The primary use of a multiview is in larger scale, professional productions. In these environments, it is very common for a director to need to be calling the shots as they are labeled in the multiview.

Scenes themselves have arbitrary names and as such - in the absence of the ability to customize multiview labels - it makes the most sense to display labels with scene names exactly as they exist. A scenario where a label displays "3 - CAM 1" or "2 - 4 BOX" is undesirable. If numbers before name are desired by someone, they can name the scene as such with the added bonus of their scene list having parity with the multiview display.

### How Has This Been Tested?
Viewed multiview with my eyes, used a build of 28 with this change cherrypicked in for a 5 day broadcast comprising 20+ staff viewing it with their eyes.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
