### PR TITLE
CI: Ignore libdshowcapture deps when formatting

### DIFF
--- a/CI/check-format.sh
+++ b/CI/check-format.sh
@@ -48,7 +48,8 @@ find . -type d \( \
     -path ./plugins/enc-amf -o \
     -path ./plugins/mac-syphon/syphon-framework -o \
     -path ./plugins/obs-outputs/ftl-sdk -o \
-    -path ./plugins/obs-websocket/deps \
+    -path ./plugins/obs-websocket/deps -o \
+    -path ./plugins/win-dshow/libdshowcapture/external \
 \) -prune -false -type f -o \
     -name '*.h' -or \
     -name '*.hpp' -or \


### PR DESCRIPTION
### Description

Ignores the `external/` folder in libdshowcapture when running `check-format.sh`

### Motivation and Context

Have you ever gotten annoyed that running the formatting script results in a submodule change on your Mac?
Have you ever had to manually go in and `git restore` that folder just to get a clean `git status` output?

Well I have so that's why I added this (btw no clue why this doesn't cause issues on CI)

### How Has This Been Tested?

Ran locally, no longer formats that folder.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:


- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
