### PR TITLE
libobs: Fix reading Windows release name

### DIFF
--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -1187,7 +1187,9 @@ static inline void get_reg_ver(struct win_version_info *ver)
 		ver->build = wcstol(str, NULL, 10);
 	}
 
-	if (get_reg_sz(key, L"ReleaseId", str, sizeof(str))) {
+	const wchar_t *release_key = ver->build > 19041 ? L"DisplayVersion"
+							: L"ReleaseId";
+	if (get_reg_sz(key, release_key, str, sizeof(str))) {
 		os_wcs_to_utf8(str, 0, win_release_id, MAX_SZ_LEN);
 	}
 


### PR DESCRIPTION
### Description

Fixes Windows release name to get correctly read for 20H2 ("2009") or later.

Fixes #7726

### Motivation and Context

Per https://twitter.com/bytenerd/status/1395071115072966656 the old key is no longer updated as to not break compatibility with software that (incorrectly) parsed it as an integer. OBS doesn't do this and the string exists purely as a convenience to have a human-readable major version identifier in the log.

### How Has This Been Tested?

- Checked strings is now correct on Windows 20H2 and later
- Checked that the log analyser continues to correctly read the Windows version

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
