### PR TITLE
rtmp-services: Add IRLToolkit

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services",
-    "version": 212,
+    "version": 213,
     "files": [
         {
             "name": "services.json",
-            "version": 212
+            "version": 213
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2562,6 +2562,41 @@
                 "max video bitrate": 1800,
                 "max audio bitrate": 192
             }
+        },
+        {
+            "name": "IRLToolkit",
+            "stream_key_link": "https://irl.run/settings/ingest/",
+            "servers": [
+                {
+                    "name": "Global (Recommended)",
+                    "url": "rtmp://stream.global.irl.run/ingest"
+                },
+                {
+                    "name": "Los Angeles, US",
+                    "url": "rtmp://stream.lax.irl.run/ingest"
+                },
+                {
+                    "name": "New York, US",
+                    "url": "rtmp://stream.ewr.irl.run/ingest"
+                },
+                {
+                    "name": "Rotterdam, NL",
+                    "url": "rtmp://stream.rtm.irl.run/ingest"
+                },
+                {
+                    "name": "Singapore",
+                    "url": "rtmp://stream.sin.irl.run/ingest"
+                },
+                {
+                    "name": "Tokyo, JP",
+                    "url": "rtmp://stream.tyo.irl.run/ingest"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "bframes": 2,
+                "max video bitrate": 20000
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
Adds IRLToolkit RTMP ingests to services list

### Motivation and Context
IRLToolkit has grown to a size where I feel that it would be beneficial to include it on the services list.

### How Has This Been Tested?
Via standard service testing procedure

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
