### PR TITLE
CI: Add Debian debug symbols to build and CI artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -273,6 +273,7 @@ jobs:
           CI/linux/03_package_obs.sh
           ARTIFACT_NAME=$(basename $(/usr/bin/find build  -maxdepth 1 -type f -name "obs-studio-*.deb" | sort -rn | head -1))
           echo "FILE_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
+          echo "DEBUG_FILE_NAME=${ARTIFACT_NAME//.deb/-dbgsym.ddeb}" >> $GITHUB_ENV
 
       - name: 'Upload build Artifact'
         if: ${{ success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1') }}
@@ -280,6 +281,13 @@ jobs:
         with:
           name: 'obs-studio-${{ matrix.ubuntu }}-${{ steps.setup.outputs.commitHash }}'
           path: '${{ github.workspace }}/obs-studio/build/${{ env.FILE_NAME }}'
+
+      - name: 'Upload debug symbol Artifact'
+        if: ${{ success() && (github.event_name != 'pull_request' || env.SEEKING_TESTERS == '1') }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'obs-studio-${{ matrix.ubuntu }}-${{ steps.setup.outputs.commitHash }}-dbgsym'
+          path: '${{ github.workspace }}/obs-studio/build/${{ env.DEBUG_FILE_NAME }}'
 
   windows_build:
     name: '02 - Windows'

--- a/CI/linux/03_package_obs.sh
+++ b/CI/linux/03_package_obs.sh
@@ -21,9 +21,14 @@ package_obs() {
     cmake --build ${BUILD_DIR} -t package
 
     DEB_NAME=$(find ${BUILD_DIR} -maxdepth 1 -type f -name "obs*.deb" | sort -rn | head -1)
+    DEBUG_NAME="${DEB_NAME//.deb/-dbgsym.ddeb}"
 
     if [ "${DEB_NAME}" ]; then
-        mv ${DEB_NAME} ${BUILD_DIR}/${FILE_NAME}
+        mv "${DEB_NAME}" "${BUILD_DIR}/${FILE_NAME}"
+
+        if [ "${DEBUG_NAME}" ]; then
+            mv "${DEBUG_NAME}" "${BUILD_DIR}/${FILE_NAME//.deb/-dbgsym.ddeb}"
+        fi
     else
         error "ERROR No suitable OBS debian package generated"
     fi

--- a/cmake/Modules/ObsDefaults_Linux.cmake
+++ b/cmake/Modules/ObsDefaults_Linux.cmake
@@ -49,7 +49,7 @@ macro(setup_obs_project)
 				└ libobs
 				└ obs-plugins
 				└ obs-studio
-	]]
+	#]]
 
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(_ARCH_SUFFIX 64)
@@ -114,14 +114,13 @@ macro(setup_obs_project)
   set(CPACK_RESOURCE_FILE_LICENSE
       "${CMAKE_SOURCE_DIR}/UI/data/license/gplv2.txt")
   set(CPACK_PACKAGE_VERSION "${OBS_VERSION_CANONICAL}-${OBS_BUILD_NUMBER}")
-  set(CPACK_STRIP_FILES "bin/obs" "bin/obs-ffmpeg-mux")
-  set(CPACK_SOURCE_STRIP_FILES "")
   set(CPACK_PACKAGE_EXECUTABLES "obs")
 
   if(OS_LINUX AND NOT LINUX_PORTABLE)
     set(CPACK_GENERATOR "DEB")
     set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
     set(CPACK_SET_DESTDIR ON)
+    set(CPACK_DEBIAN_DEBUGINFO_PACKAGE ON)
   elseif(OS_FREEBSD)
     option(ENABLE_CPACK_GENERATOR
            "Enable FreeBSD CPack generator (experimental)" OFF)


### PR DESCRIPTION
### Description
Ensures that binaries inside Debian packages are not only stripped, but also associated debug symbols are contained in a separate debug symbol package.

### Motivation and Context
Enable debugging on builds installed via Debian packages.

### How Has This Been Tested?
* Debug symbol generation tested on Ubuntu 22-arm64
* CI runs checked via PR

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
