### PR TITLE
UI: Add separator in source toolbar

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -979,6 +979,7 @@
           </property>
           <addaction name="actionAddSource"/>
           <addaction name="actionRemoveSource"/>
+          <addaction name="separator"/>
           <addaction name="actionSourceProperties"/>
           <addaction name="separator"/>
           <addaction name="actionSourceUp"/>


### PR DESCRIPTION
### Description
It makes the source properties button more distinguishable.

![Screenshot from 2022-11-12 07-58-43](https://user-images.githubusercontent.com/19962531/201477522-f893b0ab-6695-47d6-b4ce-0fa49c0450f6.png)

### Motivation and Context
Suggestion from @Warchamp7

### How Has This Been Tested?
Looked at source toolbar to make sure it looked correct.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
