### PR TITLE
libobs: Fix format wide characters on windows

### DIFF
--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -21,8 +21,8 @@ try {
 		IsApiContractPresent(L"Windows.Foundation.UniversalApiContract",
 				     8);
 } catch (const winrt::hresult_error &err) {
-	blog(LOG_ERROR, "winrt_capture_supported (0x%08X): %ls",
-	     err.code().value, err.message().c_str());
+	blog(LOG_ERROR, "winrt_capture_supported (0x%08X): %s",
+	     err.code().value, winrt::to_string(err.message()).c_str());
 	return false;
 } catch (...) {
 	blog(LOG_ERROR, "winrt_capture_supported (0x%08X)",
@@ -37,8 +37,8 @@ try {
 			L"Windows.Graphics.Capture.GraphicsCaptureSession",
 			L"IsCursorCaptureEnabled");
 } catch (const winrt::hresult_error &err) {
-	blog(LOG_ERROR, "winrt_capture_cursor_toggle_supported (0x%08X): %ls",
-	     err.code().value, err.message().c_str());
+	blog(LOG_ERROR, "winrt_capture_cursor_toggle_supported (0x%08X): %s",
+	     err.code().value, winrt::to_string(err.message()).c_str());
 	return false;
 } catch (...) {
 	blog(LOG_ERROR, "winrt_capture_cursor_toggle_supported (0x%08X)",
@@ -274,8 +274,8 @@ static void winrt_capture_device_loss_release(void *data)
 		capture->frame_pool.Close();
 	} catch (winrt::hresult_error &err) {
 		blog(LOG_ERROR,
-		     "Direct3D11CaptureFramePool::Close (0x%08X): %ls",
-		     err.code().value, err.message().c_str());
+		     "Direct3D11CaptureFramePool::Close (0x%08X): %s",
+		     err.code().value, winrt::to_string(err.message()).c_str());
 	} catch (...) {
 		blog(LOG_ERROR, "Direct3D11CaptureFramePool::Close (0x%08X)",
 		     winrt::to_hresult().value);
@@ -284,8 +284,8 @@ static void winrt_capture_device_loss_release(void *data)
 	try {
 		capture->session.Close();
 	} catch (winrt::hresult_error &err) {
-		blog(LOG_ERROR, "GraphicsCaptureSession::Close (0x%08X): %ls",
-		     err.code().value, err.message().c_str());
+		blog(LOG_ERROR, "GraphicsCaptureSession::Close (0x%08X): %s",
+		     err.code().value, winrt::to_string(err.message()).c_str());
 	} catch (...) {
 		blog(LOG_ERROR, "GraphicsCaptureSession::Close (0x%08X)",
 		     winrt::to_hresult().value);
@@ -305,8 +305,8 @@ try {
 			L"Windows.Graphics.Capture.GraphicsCaptureSession",
 			L"IsBorderRequired");
 } catch (const winrt::hresult_error &err) {
-	blog(LOG_ERROR, "winrt_capture_border_toggle_supported (0x%08X): %ls",
-	     err.code().value, err.message().c_str());
+	blog(LOG_ERROR, "winrt_capture_border_toggle_supported (0x%08X): %s",
+	     err.code().value, winrt::to_string(err.message()).c_str());
 	return false;
 } catch (...) {
 	blog(LOG_ERROR, "winrt_capture_border_toggle_supported (0x%08X)",
@@ -330,8 +330,9 @@ winrt_capture_create_item(IGraphicsCaptureItemInterop *const interop_factory,
 			if (FAILED(hr))
 				blog(LOG_ERROR, "CreateForWindow (0x%08X)", hr);
 		} catch (winrt::hresult_error &err) {
-			blog(LOG_ERROR, "CreateForWindow (0x%08X): %ls",
-			     err.code().value, err.message().c_str());
+			blog(LOG_ERROR, "CreateForWindow (0x%08X): %s",
+			     err.code().value,
+			     winrt::to_string(err.message()).c_str());
 		} catch (...) {
 			blog(LOG_ERROR, "CreateForWindow (0x%08X)",
 			     winrt::to_hresult().value);
@@ -350,8 +351,9 @@ winrt_capture_create_item(IGraphicsCaptureItemInterop *const interop_factory,
 				blog(LOG_ERROR, "CreateForMonitor (0x%08X)",
 				     hr);
 		} catch (winrt::hresult_error &err) {
-			blog(LOG_ERROR, "CreateForMonitor (0x%08X): %ls",
-			     err.code().value, err.message().c_str());
+			blog(LOG_ERROR, "CreateForMonitor (0x%08X): %s",
+			     err.code().value,
+			     winrt::to_string(err.message()).c_str());
 		} catch (...) {
 			blog(LOG_ERROR, "CreateForMonitor (0x%08X)",
 			     winrt::to_hresult().value);
@@ -425,8 +427,8 @@ static void winrt_capture_device_loss_rebuild(void *device_void, void *data)
 		session.StartCapture();
 		capture->active = TRUE;
 	} catch (winrt::hresult_error &err) {
-		blog(LOG_ERROR, "StartCapture (0x%08X): %ls", err.code().value,
-		     err.message().c_str());
+		blog(LOG_ERROR, "StartCapture (0x%08X): %s", err.code().value,
+		     winrt::to_string(err.message()).c_str());
 	} catch (...) {
 		blog(LOG_ERROR, "StartCapture (0x%08X)",
 		     winrt::to_hresult().value);
@@ -528,8 +530,8 @@ try {
 	return capture;
 
 } catch (const winrt::hresult_error &err) {
-	blog(LOG_ERROR, "winrt_capture_init (0x%08X): %ls", err.code().value,
-	     err.message().c_str());
+	blog(LOG_ERROR, "winrt_capture_init (0x%08X): %s", err.code().value,
+	     winrt::to_string(err.message()).c_str());
 	return nullptr;
 } catch (...) {
 	blog(LOG_ERROR, "winrt_capture_init (0x%08X)",
@@ -580,8 +582,9 @@ extern "C" EXPORT void winrt_capture_free(struct winrt_capture *capture)
 				capture->frame_pool.Close();
 		} catch (winrt::hresult_error &err) {
 			blog(LOG_ERROR,
-			     "Direct3D11CaptureFramePool::Close (0x%08X): %ls",
-			     err.code().value, err.message().c_str());
+			     "Direct3D11CaptureFramePool::Close (0x%08X): %s",
+			     err.code().value,
+			     winrt::to_string(err.message()).c_str());
 		} catch (...) {
 			blog(LOG_ERROR,
 			     "Direct3D11CaptureFramePool::Close (0x%08X)",
@@ -593,8 +596,9 @@ extern "C" EXPORT void winrt_capture_free(struct winrt_capture *capture)
 				capture->session.Close();
 		} catch (winrt::hresult_error &err) {
 			blog(LOG_ERROR,
-			     "GraphicsCaptureSession::Close (0x%08X): %ls",
-			     err.code().value, err.message().c_str());
+			     "GraphicsCaptureSession::Close (0x%08X): %s",
+			     err.code().value,
+			     winrt::to_string(err.message()).c_str());
 		} catch (...) {
 			blog(LOG_ERROR,
 			     "GraphicsCaptureSession::Close (0x%08X)",
@@ -627,8 +631,8 @@ extern "C" EXPORT BOOL winrt_capture_show_cursor(struct winrt_capture *capture,
 		success = TRUE;
 	} catch (winrt::hresult_error &err) {
 		blog(LOG_ERROR,
-		     "GraphicsCaptureSession::IsCursorCaptureEnabled (0x%08X): %ls",
-		     err.code().value, err.message().c_str());
+		     "GraphicsCaptureSession::IsCursorCaptureEnabled (0x%08X): %s",
+		     err.code().value, winrt::to_string(err.message()).c_str());
 	} catch (...) {
 		blog(LOG_ERROR,
 		     "GraphicsCaptureSession::IsCursorCaptureEnabled (0x%08X)",

--- a/libobs-winrt/winrt-dispatch.cpp
+++ b/libobs-winrt/winrt-dispatch.cpp
@@ -42,8 +42,9 @@ extern "C" EXPORT struct winrt_disaptcher *winrt_dispatcher_init()
 			dispatcher->controller = std::move(controller);
 		}
 	} catch (const winrt::hresult_error &err) {
-		blog(LOG_ERROR, "winrt_dispatcher_init (0x%08X): %ls",
-		     (int32_t)err.code(), err.message().c_str());
+		blog(LOG_ERROR, "winrt_dispatcher_init (0x%08X): %s",
+		     (int32_t)err.code(),
+		     winrt::to_string(err.message()).c_str());
 	} catch (...) {
 		blog(LOG_ERROR, "winrt_dispatcher_init (0x%08X)",
 		     (int32_t)winrt::to_hresult());
@@ -57,8 +58,8 @@ winrt_dispatcher_free(struct winrt_disaptcher *dispatcher)
 try {
 	delete dispatcher;
 } catch (const winrt::hresult_error &err) {
-	blog(LOG_ERROR, "winrt_dispatcher_free (0x%08X): %ls",
-	     (int32_t)err.code(), err.message().c_str());
+	blog(LOG_ERROR, "winrt_dispatcher_free (0x%08X): %s",
+	     (int32_t)err.code(), winrt::to_string(err.message()).c_str());
 } catch (...) {
 	blog(LOG_ERROR, "winrt_dispatcher_free (0x%08X)",
 	     (int32_t)winrt::to_hresult());

--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -316,8 +316,19 @@ static void log_security_products_by_type(IWSCProductList *prod_list, int type)
 			continue;
 		}
 
-		blog(LOG_INFO, "\t%S: %s (%s)", name,
-		     get_str_for_state(prod_state), get_str_for_type(type));
+		size_t name_length = SysStringLen(name);
+		size_t utf8_name_length =
+			os_wcs_to_utf8(name, name_length, NULL, 0);
+
+		if (utf8_name_length) {
+			char *utf8_name = bmalloc(utf8_name_length);
+			os_wcs_to_utf8(name, name_length, utf8_name,
+				       utf8_name_length);
+			blog(LOG_INFO, "\t%s: %s (%s)", utf8_name,
+			     get_str_for_state(prod_state),
+			     get_str_for_type(type));
+			bfree(utf8_name);
+		}
 
 		SysFreeString(name);
 		prod->lpVtbl->Release(prod);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix printf wide characters on windows(zh)
vsnprintf cannot format wide chinese characters(1 char has 2 bytes usually)

can also be used setlocale(LC_ALL, ...) to support wide char*
but it's not clear if there are other effects
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The log is found in the windows environment(zh) as follows:
12:37:44.371: Sec. Software Status:
12:37:44.372: 
12:37:44.372: 
12:37:44.373: Current Date/Time: 2022-11-10, 12:37:44
Then I read the code and found that vsnprintf goes to format wide characters and utf8 strings at the same time
But if it contains wide chinese characters, vsnprintf will return -1 
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Checked that the log analyser continues to correctly read the Windows version
### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix (non-breaking change which fixes an issue)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
