### PR TITLE
mac-videotoolbox: Default to High profile

### DIFF
--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -1328,7 +1328,10 @@ static void vt_defaults(obs_data_t *settings, void *data)
 	obs_data_set_default_int(settings, "max_bitrate", 2500);
 	obs_data_set_default_double(settings, "max_bitrate_window", 1.5f);
 	obs_data_set_default_int(settings, "keyint_sec", 0);
-	obs_data_set_default_string(settings, "profile", "main");
+	obs_data_set_default_string(
+		settings, "profile",
+		type_data->codec_type == kCMVideoCodecType_H264 ? "high"
+								: "main");
 	obs_data_set_default_int(settings, "codec_type",
 				 kCMVideoCodecType_AppleProRes422);
 	obs_data_set_default_bool(settings, "bframes", true);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the default profile of the VT H.264 encoder to High.
HEVC stays at main.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
[R1ch's stream analyzer](https://r-1.ch/analyzer/) got mad at me for using the main profile.
We really should be using High in Simple Mode, I consider current behavior to be a bug.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested that recordings using the simple Apple H.264 streaming encoder use the High profile now (whereas before it was Main) by throwing the file into MediaInfo.
Tested that x264 recordings using the stream encoder in simple mode use the High profile both before and after.
Checked manually (by looking at the code) that both NVENC and AMF already use High.

Tested that HEVC recordings using the simple Apple HEVC streaming encoder still use the Main profile (which is correct for HEVC).


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
