### PR TITLE
CI,obs-vst: Update Flatpak KDE Runtime to version 6.4

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -50,7 +50,7 @@ jobs:
     env:
       FLATPAK_BUILD_PATH: flatpak_app/files/share
     container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-6.3
+      image: bilelmoussaoui/flatpak-github-actions:kde-6.4
       options: --privileged
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -378,7 +378,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-6.3
+      image: bilelmoussaoui/flatpak-github-actions:kde-6.4
       options: --privileged
     steps:
       - name: 'Check for Github Labels'

--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.obsproject.Studio",
   "runtime": "org.kde.Platform",
-  "runtime-version": "6.3",
+  "runtime-version": "6.4",
   "sdk": "org.kde.Sdk",
   "command": "obs",
   "finish-args": [
@@ -19,7 +19,7 @@
     "--talk-name=org.a11y.Bus",
     "--own-name=org.kde.StatusNotifierItem-2-2",
     "--system-talk-name=org.freedesktop.Avahi",
-    "--env=VST_PATH=/app/extensions/Plugins/lxvst"
+    "--env=VST_PATH=/app/extensions/Plugins/vst"
   ],
   "add-extensions": {
     "com.obsproject.Studio.Plugin": {
@@ -32,9 +32,9 @@
     },
     "org.freedesktop.LinuxAudio.Plugins": {
       "directory": "extensions/Plugins",
-      "version": "21.08",
+      "version": "22.08",
       "add-ld-path": "lib",
-      "merge-dirs": "lxvst",
+      "merge-dirs": "vst",
       "subdirectories": true,
       "no-autodownload": true
     }
@@ -329,38 +329,6 @@
           "type": "archive",
           "url": "https://github.com/jackaudio/jack2/releases/download/v1.9.14/v1.9.14.tar.gz",
           "sha256": "a20a32366780c0061fd58fbb5f09e514ea9b7ce6e53b080a44b11a558a83217c"
-        }
-      ]
-    },
-    {
-      "name": "pipewire",
-      "buildsystem": "meson",
-      "config-opts": [
-        "-Daudiotestsrc=disabled",
-        "-Droc=disabled",
-        "-Dvideotestsrc=disabled",
-        "-Dvolume=disabled",
-        "-Dvulkan=disabled",
-        "-Ddocs=disabled",
-        "-Dman=disabled",
-        "-Dbluez5-codec-ldac=disabled",
-        "-Dbluez5-codec-aptx=disabled",
-        "-Dlibcamera=disabled",
-        "-Dudevrulesdir=/app/lib/udev/rules.d/",
-        "-Dsession-managers=[]",
-        "-Dtests=disabled",
-        "-Dexamples=disabled",
-        "-Dpw-cat=disabled"
-      ],
-      "cleanup": [
-        "/bin"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://github.com/pipewire/pipewire.git",
-          "tag": "0.3.40",
-          "commit": "7afd80052b7c49754a13c9ab49c368f95b60e0a7"
         }
       ]
     },

--- a/plugins/obs-vst/obs-vst.cpp
+++ b/plugins/obs-vst/obs-vst.cpp
@@ -111,6 +111,19 @@ static void vst_update(void *data, obs_data_t *settings)
 
 	const char *path = obs_data_get_string(settings, "plugin_path");
 
+#ifdef __linux__
+	// Migrate freedesktop.org Flatpak runtime 21.08 VST paths to 22.08.
+	if (QFile::exists("/.flatpak-info") &&
+	    QString(path).startsWith("/app/extensions/Plugins/lxvst")) {
+		QString newPath(path);
+		newPath.replace("/app/extensions/Plugins/lxvst",
+				"/app/extensions/Plugins/vst");
+		obs_data_set_string(settings, "plugin_path",
+				    newPath.toStdString().c_str());
+		path = obs_data_get_string(settings, "plugin_path");
+	}
+#endif
+
 	if (!*path) {
 		vstPlugin->unloadEffect();
 		return;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Closes #7132

The 6.4 runtime rely on Freedesktop 22.08 which provide a more recent version of Mesa and PipeWire.

The switch to 22.08 also requires to migrate paths of VST 2 plugins.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

We need to bump the runtime version to provide a more recent version of Mesa and other stuff (Qt 6.4, remove custom PipeWire module).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

- I installed `org.freedesktop.LinuxAudio.Plugins.DISTRHO-Ports//21.08` and `org.freedesktop.LinuxAudio.Plugins.DISTRHO-Ports//22.08`.
- Add a VST filter (from 21.08) with OBS Flatpak from Flathub (so 28.1.2 with 6.3)
- Run OBS Flatpak with this change, the filter stilsl work because the VST path has successfully been updated (and now use the 22.08 one)

Note: for unknown reason I had to build the flatpak with "beta" or "stable" has branch to test it, "master" seems to not allow to see VST filters (6.3 or 6.4).

To build and run the flatpak with `beta` branch
```
flatpak-builder _flatpak_build CI/flatpak/com.obsproject.Studio.json --force-clean --verbose --default-branch=beta
flatpak-builder --run _flatpak_build CI/flatpak/com.obsproject.Studio.json obs
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
