### PR TITLE
obs-frontend-api: Add function to get the virtual camera view

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -3,6 +3,7 @@
 #include "qt-wrappers.hpp"
 #include "window-basic-main.hpp"
 #include "window-basic-main-outputs.hpp"
+#include "window-basic-vcam-config.hpp"
 
 #include <functional>
 
@@ -593,6 +594,11 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	{
 		OBSOutput output = main->outputHandler->virtualCam.Get();
 		return obs_output_get_ref(output);
+	}
+
+	obs_view_t *obs_frontend_get_virtualcam_view(void) override
+	{
+		return OBSBasicVCamConfig::GetView();
 	}
 
 	void obs_frontend_start_virtualcam(void) override

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -517,6 +517,12 @@ obs_output_t *obs_frontend_get_virtualcam_output(void)
 				   : nullptr;
 }
 
+obs_view_t *obs_frontend_get_virtualcam_view(void)
+{
+	return !!callbacks_valid() ? c->obs_frontend_get_virtualcam_view()
+				   : nullptr;
+}
+
 void obs_frontend_start_virtualcam(void)
 {
 	if (callbacks_valid())

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -217,6 +217,7 @@ EXPORT void obs_frontend_take_screenshot(void);
 EXPORT void obs_frontend_take_source_screenshot(obs_source_t *source);
 
 EXPORT obs_output_t *obs_frontend_get_virtualcam_output(void);
+EXPORT obs_view_t *obs_frontend_get_virtualcam_view(void);
 EXPORT void obs_frontend_start_virtualcam(void);
 EXPORT void obs_frontend_stop_virtualcam(void);
 EXPORT bool obs_frontend_virtualcam_active(void);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -130,6 +130,7 @@ struct obs_frontend_callbacks {
 	obs_frontend_take_source_screenshot(obs_source_t *source) = 0;
 
 	virtual obs_output_t *obs_frontend_get_virtualcam_output(void) = 0;
+	virtual obs_view_t *obs_frontend_get_virtualcam_view(void) = 0;
 	virtual void obs_frontend_start_virtualcam(void) = 0;
 	virtual void obs_frontend_stop_virtualcam(void) = 0;
 	virtual bool obs_frontend_virtualcam_active(void) = 0;

--- a/UI/window-basic-vcam-config.cpp
+++ b/UI/window-basic-vcam-config.cpp
@@ -210,6 +210,11 @@ video_t *OBSBasicVCamConfig::StartVideo()
 	return video;
 }
 
+obs_view_t *OBSBasicVCamConfig::GetView()
+{
+	return view;
+}
+
 void OBSBasicVCamConfig::StopVideo()
 {
 	obs_view_remove(view);

--- a/UI/window-basic-vcam-config.hpp
+++ b/UI/window-basic-vcam-config.hpp
@@ -15,6 +15,7 @@ public:
 	static video_t *StartVideo();
 	static void StopVideo();
 	static void DestroyView();
+	static obs_view_t *GetView();
 
 	static void UpdateOutputSource();
 	static void SaveData(obs_data_t *data, bool saving);

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -740,6 +740,12 @@ Functions
 
 ---------------------------------------
 
+.. function:: obs_view_t *obs_frontend_get_virtualcam_view(void)
+
+   :return: The view that is used for the virtual camera.
+
+---------------------------------------
+
 .. function:: void obs_frontend_start_virtualcam(void)
 
    Starts the virtual camera.


### PR DESCRIPTION
### Description
Add function to get the virtual camera view

### Motivation and Context
Since in OBS 28 a view is used for the virtual camera instead of the main output, other channels that are set on the output in the [downstream keyer](https://obsproject.com/forum/resources/downstream-keyer.1254/) plugin are not visible anymore in the output of the virtual camera. This change will allow plugins like the downstream keyer plugin to set the other channels of the view for the virtual camera.

### How Has This Been Tested?
On windows 64 bit with changes to the downstream keyer plugin.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
