### PR TITLE
UI: Use main video on the virtual camera if program

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -740,9 +740,9 @@ Basic.Main.VirtualCamConfig="Configure Virtual Camera"
 Basic.VCam.VirtualCamera="Virtual Camera"
 Basic.VCam.OutputType="Output Type"
 Basic.VCam.OutputSelection="Output Selection"
-Basic.VCam.Internal="Internal"
-Basic.VCam.InternalDefault="Program Output (Default)"
-Basic.VCam.InternalPreview="Preview Output"
+Basic.VCam.OutputType.Program="Program (Default)"
+Basic.VCam.OutputSelection.NoSelection="No selection for this output type"
+Basic.VCam.RestartWarning="The virtual camera will be restarted to apply this change"
 
 # basic mode file menu
 Basic.MainMenu.File="&File"

--- a/UI/forms/OBSBasicVCamConfig.ui
+++ b/UI/forms/OBSBasicVCamConfig.ui
@@ -22,23 +22,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QComboBox" name="outputType">
-     <item>
-      <property name="text">
-       <string>Basic.VCam.Internal</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Basic.Scene</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Basic.Main.Source</string>
-      </property>
-     </item>
-    </widget>
+    <widget class="QComboBox" name="outputType"/>
    </item>
    <item>
     <widget class="QLabel" name="outputSelectionLabel">
@@ -49,6 +33,16 @@
    </item>
    <item>
     <widget class="QComboBox" name="outputSelection"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="warningLabel">
+     <property name="text">
+      <string>Basic.VCam.RestartWarning</string>
+     </property>
+     <property name="visible">
+	<bool>false</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <spacer name="verticalSpacer">

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -283,10 +283,6 @@ void OBSBasic::OverrideTransition(OBSSource transition)
 		obs_transition_swap_begin(transition, oldTransition);
 		obs_set_output_source(0, transition);
 		obs_transition_swap_end(transition, oldTransition);
-
-		// Transition overrides don't raise an event so we need to call update directly
-		if (vcamEnabled)
-			outputHandler->UpdateVirtualCamOutputSource();
 	}
 }
 
@@ -425,10 +421,6 @@ void OBSBasic::SetTransition(OBSSource transition)
 	bool configurable = obs_source_configurable(transition);
 	ui->transitionRemove->setEnabled(configurable);
 	ui->transitionProps->setEnabled(configurable);
-
-	if (vcamEnabled && vcamConfig.type == VCamOutputType::InternalOutput &&
-	    vcamConfig.internal == VCamInternalType::Default)
-		outputHandler->UpdateVirtualCamOutputSource();
 
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_TRANSITION_CHANGED);
@@ -697,8 +689,8 @@ void OBSBasic::SetCurrentScene(OBSSource scene, bool force)
 				ui->scenes->blockSignals(false);
 
 				if (vcamEnabled &&
-				    vcamConfig.internal ==
-					    VCamInternalType::Preview)
+				    vcamConfig.type ==
+					    VCamOutputType::PreviewOutput)
 					outputHandler
 						->UpdateVirtualCamOutputSource();
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -656,6 +656,8 @@ private:
 
 	void UpdatePreviewOverflowSettings();
 
+	bool restartingVCam = false;
+
 public slots:
 	void DeferSaveBegin();
 	void DeferSaveEnd();
@@ -830,6 +832,8 @@ private slots:
 	void ResetProxyStyleSliders();
 
 	void UpdateVirtualCamConfig(const VCamConfig &config);
+	void RestartVirtualCam(const VCamConfig &config);
+	void RestartingVirtualCam();
 
 private:
 	/* OBS Callbacks */

--- a/UI/window-basic-vcam-config.hpp
+++ b/UI/window-basic-vcam-config.hpp
@@ -15,12 +15,16 @@ class OBSBasicVCamConfig : public QDialog {
 
 	VCamConfig config;
 
+	bool vcamActive;
+	VCamOutputType activeType;
+	bool requireRestart;
+
 public:
-	explicit OBSBasicVCamConfig(const VCamConfig &config,
+	explicit OBSBasicVCamConfig(const VCamConfig &config, bool VCamActive,
 				    QWidget *parent = 0);
 
 private slots:
-	void OutputTypeChanged(int type);
+	void OutputTypeChanged();
 	void UpdateConfig();
 
 private:
@@ -28,4 +32,5 @@ private:
 
 signals:
 	void Accepted(const VCamConfig &config);
+	void AcceptedAndRestart(const VCamConfig &config);
 };

--- a/UI/window-basic-vcam.hpp
+++ b/UI/window-basic-vcam.hpp
@@ -3,19 +3,21 @@
 #include <string>
 
 enum VCamOutputType {
-	InternalOutput,
+	Invalid,
 	SceneOutput,
 	SourceOutput,
+	ProgramView,
+	PreviewOutput,
 };
 
+// Kept for config upgrade
 enum VCamInternalType {
 	Default,
 	Preview,
 };
 
 struct VCamConfig {
-	VCamOutputType type = VCamOutputType::InternalOutput;
-	VCamInternalType internal = VCamInternalType::Default;
+	VCamOutputType type = VCamOutputType::ProgramView;
 	std::string scene;
 	std::string source;
 };


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes #7780

Depends on #7169 so review the last commit.

This change allows the virtual camera to really output what is in the program view, some plugin interract with this view but their changes does not appear on the virtual camera.

<!-- But now if the virtual camera is started with program the config dialog is disabled because we use the main view.
And so if another type (preview, source, scene) is set, the dialog prevents you to set program if the virtual camera is active.

![2022-11-15_10-07](https://user-images.githubusercontent.com/17492366/201877784-1f83b86c-2da3-47ff-8bdb-c3afbff0c525.png) -->

This change requires to restart the virtual camera when changing the view is needed, so changing from/to the Program type will require a restart.

New type list:
![2023-03-07_15-47](https://user-images.githubusercontent.com/17492366/223457194-396de297-33bb-4354-94a3-e25ab81cbf3a.png)

Output selection when Program or Preview is selected:
![Screenshot from 2023-03-07 15-44-53](https://user-images.githubusercontent.com/17492366/223456915-c2c6fa1e-c540-4dd3-9493-a83ea1a21e21.png)

Warning when changing from/to Program type:
![Screenshot from 2023-03-07 15-45-27](https://user-images.githubusercontent.com/17492366/223456970-2a0bf8f9-c257-4e56-856b-c2a32fa1f162.png)
![Screenshot from 2023-03-07 15-45-18](https://user-images.githubusercontent.com/17492366/223456939-5e558757-58d3-47ff-92e4-426ffd488657.png)


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The virtual camera shall show the program view and this is not case.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

1. Install downstream keyer plugin
2. Add and enable a downstream keyer
3. Start virtual camera with program as type
4. Check output of virtual camera is the same as the main output of obs

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
