### PR TITLE
decklink: Always output BGRA

### DIFF
--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -81,16 +81,10 @@ static bool decklink_output_start(void *data)
 	decklink->SetSize(mode->GetWidth(), mode->GetHeight());
 
 	struct video_scale_info to = {};
-
-	if (decklink->keyerMode != 0) {
-		to.format = VIDEO_FORMAT_BGRA;
-		to.range = VIDEO_RANGE_FULL;
-	} else {
-		to.format = VIDEO_FORMAT_UYVY;
-		to.range = VIDEO_RANGE_PARTIAL;
-	}
+	to.format = VIDEO_FORMAT_BGRA;
 	to.width = mode->GetWidth();
 	to.height = mode->GetHeight();
+	to.range = VIDEO_RANGE_FULL;
 	to.colorspace = VIDEO_CS_709;
 
 	obs_output_set_video_conversion(decklink->GetOutput(), &to);


### PR DESCRIPTION
### Description
Remove conversion to UYVY.

### Motivation and Context
Quality preservation, and code simplification.

### How Has This Been Tested?
Verified Output and Preview Output both still work, both without and without rescaling output via swscale.

Internal keyer and disabled keyer still work.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.