### PR TITLE
CI: Fix building in PowerShell 7.3.x

### DIFF
--- a/CI/windows/02_build_obs.ps1
+++ b/CI/windows/02_build_obs.ps1
@@ -63,31 +63,61 @@ function Configure-OBS {
     $BuildDirectoryActual = "${BuildDirectory}$(if (${BuildArch} -eq "x64") { "64" } else { "32" })"
     $GeneratorPlatform = "$(if (${BuildArch} -eq "x64") { "x64" } else { "Win32" })"
 
-    $CmakeCommand = @(
-        "-G", ${CmakeGenerator}
-        "-DCMAKE_GENERATOR_PLATFORM=`"${GeneratorPlatform}`"",
-        "-DCMAKE_SYSTEM_VERSION=`"${CmakeSystemVersion}`"",
-        "-DCMAKE_PREFIX_PATH:PATH=`"${CmakePrefixPath}`"",
-        "-DCEF_ROOT_DIR:PATH=`"${CefDirectory}`"",
-        "-DENABLE_BROWSER=ON",
-        "-DVLC_PATH:PATH=`"${CheckoutDir}/../obs-build-dependencies/vlc-${WindowsVlcVersion}`"",
-        "-DENABLE_VLC=ON",
-        "-DCMAKE_INSTALL_PREFIX=`"${BuildDirectoryActual}/install`"",
-        "-DVIRTUALCAM_GUID=`"${Env:VIRTUALCAM-GUID}`"",
-        "-DTWITCH_CLIENTID=`"${Env:TWITCH_CLIENTID}`"",
-        "-DTWITCH_HASH=`"${Env:TWITCH_HASH}`"",
-        "-DRESTREAM_CLIENTID=`"${Env:RESTREAM_CLIENTID}`"",
-        "-DRESTREAM_HASH=`"${Env:RESTREAM_HASH}`"",
-        "-DYOUTUBE_CLIENTID=`"${Env:YOUTUBE_CLIENTID}`"",
-        "-DYOUTUBE_CLIENTID_HASH=`"${Env:YOUTUBE_CLIENTID_HASH}`"",
-        "-DYOUTUBE_SECRET=`"${Env:YOUTUBE_SECRET}`"",
-        "-DYOUTUBE_SECRET_HASH=`"${Env:YOUTUBE_SECRET_HASH}`"",
-        "-DCOPIED_DEPENDENCIES=OFF",
-        "-DCOPY_DEPENDENCIES=ON",
-        "-DBUILD_FOR_DISTRIBUTION=`"$(if (Test-Path Env:BUILD_FOR_DISTRIBUTION) { "ON" } else { "OFF" })`"",
-        "$(if (Test-Path Env:CI) { "-DOBS_BUILD_NUMBER=${Env:GITHUB_RUN_ID}" })",
-        "$(if (Test-Path Variable:$Quiet) { "-Wno-deprecated -Wno-dev --log-level=ERROR" })"
-    )
+    if ( $PSVersionTable.PSVersion -ge '7.3.0' ) {
+        $CmakeCommand = @(
+            "-G", ${CmakeGenerator}
+            "-DCMAKE_GENERATOR_PLATFORM=${GeneratorPlatform}",
+            "-DCMAKE_SYSTEM_VERSION=${CmakeSystemVersion}",
+            "-DCMAKE_PREFIX_PATH:PATH=${CmakePrefixPath}",
+            "-DCEF_ROOT_DIR:PATH=${CefDirectory}",
+            "-DENABLE_BROWSER=ON",
+            "-DVLC_PATH:PATH=${CheckoutDir}/../obs-build-dependencies/vlc-${WindowsVlcVersion}",
+            "-DENABLE_VLC=ON",
+            "-DENABLE_SCRIPTING=OFF",
+            "-DCMAKE_INSTALL_PREFIX=${BuildDirectoryActual}/install",
+            "-DVIRTUALCAM_GUID=${Env:VIRTUALCAM-GUID}",
+            "-DTWITCH_CLIENTID=${Env:TWITCH_CLIENTID}",
+            "-DTWITCH_HASH=${Env:TWITCH_HASH}",
+            "-DRESTREAM_CLIENTID=${Env:RESTREAM_CLIENTID}",
+            "-DRESTREAM_HASH=${Env:RESTREAM_HASH}",
+            "-DYOUTUBE_CLIENTID=${Env:YOUTUBE_CLIENTID}",
+            "-DYOUTUBE_CLIENTID_HASH=${Env:YOUTUBE_CLIENTID_HASH}",
+            "-DYOUTUBE_SECRET=${Env:YOUTUBE_SECRET}",
+            "-DYOUTUBE_SECRET_HASH=${Env:YOUTUBE_SECRET_HASH}",
+            "-DCOPIED_DEPENDENCIES=OFF",
+            "-DCOPY_DEPENDENCIES=ON",
+            "-DBUILD_FOR_DISTRIBUTION=$(if (Test-Path Env:BUILD_FOR_DISTRIBUTION) { "ON" } else { "OFF" })",
+            "$(if (Test-Path Env:CI) { "-DOBS_BUILD_NUMBER=${Env:GITHUB_RUN_ID}" })",
+            "$(if (Test-Path Variable:$Quiet) { "-Wno-deprecated -Wno-dev --log-level=ERROR" })"
+        )
+    } else {
+        $CmakeCommand = @(
+            "-G", ${CmakeGenerator}
+            "-DCMAKE_GENERATOR_PLATFORM=`"${GeneratorPlatform}`"",
+            "-DCMAKE_SYSTEM_VERSION=`"${CmakeSystemVersion}`"",
+            "-DCMAKE_PREFIX_PATH:PATH=`"${CmakePrefixPath}`"",
+            "-DCEF_ROOT_DIR:PATH=`"${CefDirectory}`"",
+            "-DENABLE_BROWSER=ON",
+            "-DVLC_PATH:PATH=`"${CheckoutDir}/../obs-build-dependencies/vlc-${WindowsVlcVersion}`"",
+            "-DENABLE_VLC=ON",
+            "-DENABLE_SCRIPTING=OFF",
+            "-DCMAKE_INSTALL_PREFIX=`"${BuildDirectoryActual}/install`"",
+            "-DVIRTUALCAM_GUID=`"${Env:VIRTUALCAM-GUID}`"",
+            "-DTWITCH_CLIENTID=`"${Env:TWITCH_CLIENTID}`"",
+            "-DTWITCH_HASH=`"${Env:TWITCH_HASH}`"",
+            "-DRESTREAM_CLIENTID=`"${Env:RESTREAM_CLIENTID}`"",
+            "-DRESTREAM_HASH=`"${Env:RESTREAM_HASH}`"",
+            "-DYOUTUBE_CLIENTID=`"${Env:YOUTUBE_CLIENTID}`"",
+            "-DYOUTUBE_CLIENTID_HASH=`"${Env:YOUTUBE_CLIENTID_HASH}`"",
+            "-DYOUTUBE_SECRET=`"${Env:YOUTUBE_SECRET}`"",
+            "-DYOUTUBE_SECRET_HASH=`"${Env:YOUTUBE_SECRET_HASH}`"",
+            "-DCOPIED_DEPENDENCIES=OFF",
+            "-DCOPY_DEPENDENCIES=ON",
+            "-DBUILD_FOR_DISTRIBUTION=`"$(if (Test-Path Env:BUILD_FOR_DISTRIBUTION) { "ON" } else { "OFF" })`"",
+            "$(if (Test-Path Env:CI) { "-DOBS_BUILD_NUMBER=${Env:GITHUB_RUN_ID}" })",
+            "$(if (Test-Path Variable:$Quiet) { "-Wno-deprecated -Wno-dev --log-level=ERROR" })"
+        )
+    }
 
     Invoke-External cmake -S . -B  "${BuildDirectoryActual}" @CmakeCommand
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The backtick double-quote pattern does not work in PowerShell 7.3.x. There are still some other possible PowerShell 7.3.x issues in the packaging steps, but let's fix this first to get regular builds working in PowerShell 7.3.x again.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Updates are coming to the Windows CI images. Don't want CI to immediately fail all builds.

Some devs are getting PowerShell 7.3. Want them to be able to build locally.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11 with PowerShell 7.3.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
