### PR TITLE
CI: Fix services checkers using wrong port for RTMPS

### DIFF
--- a/CI/check-services.py
+++ b/CI/check-services.py
@@ -87,7 +87,13 @@ def check_rtmp_server(uri) -> bool:
     """Try connecting and sending a RTMP handshake (with SSL if necessary)"""
     parsed = urlparse(uri)
     hostname, port = parsed.netloc.partition(':')[::2]
-    port = int(port) if port else 1935
+
+    if port:
+        port = int(port)
+    elif parsed.scheme == 'rtmps':
+        port = 443
+    else:
+        port = 1935
 
     try:
         recv = b''


### PR DESCRIPTION
### Description

Fixes the checker trying to connect on 1935 for RTMPS.

### Motivation and Context

librtmp defaults to 443 for RTMP with SSL, we should too:
https://github.com/obsproject/obs-studio/blob/38fc2f3b1d40e5023962f6c796555b19e31d189c/plugins/obs-outputs/librtmp/rtmp.c#L728-L729

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
