### PR TITLE
libobs: Fix SRGB to SCRGB async video rendering

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2492,6 +2492,7 @@ static inline void obs_source_render_async_video(obs_source_t *source)
 					nonlinear_alpha
 						? "DrawNonlinearAlphaMultiply"
 						: "DrawMultiply";
+				linear_srgb = true;
 				multiplier =
 					obs_get_video_sdr_white_level() / 80.0f;
 			}


### PR DESCRIPTION
### Description
SDR source projectors are no longer blown out on HDR displays.

Fixes #7790

### Motivation and Context
Want correct colors.

### How Has This Been Tested?
Windowed and fullscreen SDR projectors for async video sources (media source, video capture) were too bright before, and normal after.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.