### PR TITLE
libobs: Allow overriding video resolution per view

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -187,7 +187,9 @@ static inline bool has_scaling(const struct obs_encoder *encoder)
 
 static inline bool gpu_encode_available(const struct obs_encoder *encoder)
 {
-	struct obs_core_video_mix *video = obs->video.main_mix;
+	struct obs_core_video_mix *video = get_mix_for_video(encoder->media);
+	if (!video)
+		return false;
 	return (encoder->info.caps & OBS_ENCODER_CAP_PASS_TEXTURE) != 0 &&
 	       (video->using_p010_tex || video->using_nv12_tex);
 }

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -284,6 +284,7 @@ struct obs_core_video_mix {
 	volatile bool gpu_encode_stop;
 
 	video_t *video;
+	struct obs_video_info ovi;
 
 	bool gpu_conversion;
 	const char *conversion_techs[NUM_CHANNELS];
@@ -292,7 +293,6 @@ struct obs_core_video_mix {
 	float conversion_height_i;
 
 	float color_matrix[16];
-	enum obs_scale_type scale_type;
 };
 
 extern struct obs_core_video_mix *
@@ -324,9 +324,6 @@ struct obs_core_video {
 	uint32_t lagged_frames;
 	bool thread_initialized;
 
-	uint32_t base_width;
-	uint32_t base_height;
-
 	gs_texture_t *transparent_texture;
 
 	gs_effect_t *deinterlace_discard_effect;
@@ -338,7 +335,6 @@ struct obs_core_video {
 	gs_effect_t *deinterlace_yadif_effect;
 	gs_effect_t *deinterlace_yadif_2x_effect;
 
-	struct obs_video_info ovi;
 	float sdr_white_level;
 	float hdr_nominal_peak_level;
 
@@ -497,6 +493,8 @@ extern gs_effect_t *obs_load_effect(gs_effect_t **effect, const char *file);
 extern bool audio_callback(void *param, uint64_t start_ts_in,
 			   uint64_t end_ts_in, uint64_t *out_ts,
 			   uint32_t mixers, struct audio_output_data *mixes);
+
+extern struct obs_core_video_mix *get_mix_for_video(video_t *video);
 
 extern void
 start_raw_video(video_t *video, const struct video_scale_info *conversion,

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1265,13 +1265,21 @@ static void scene_save(void *data, obs_data_t *settings)
 static uint32_t scene_getwidth(void *data)
 {
 	obs_scene_t *scene = data;
-	return scene->custom_size ? scene->cx : obs->video.base_width;
+	if (scene->custom_size)
+		return scene->cx;
+	if (obs->video.main_mix)
+		return obs->video.main_mix->ovi.base_width;
+	return 0;
 }
 
 static uint32_t scene_getheight(void *data)
 {
 	obs_scene_t *scene = data;
-	return scene->custom_size ? scene->cy : obs->video.base_height;
+	if (scene->custom_size)
+		return scene->cy;
+	if (obs->video.main_mix)
+		return obs->video.main_mix->ovi.base_height;
+	return 0;
 }
 
 static void apply_scene_item_audio_actions(struct obs_scene_item *item,

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -125,8 +125,8 @@ static inline void unmap_last_surface(struct obs_core_video_mix *video)
 static const char *render_main_texture_name = "render_main_texture";
 static inline void render_main_texture(struct obs_core_video_mix *video)
 {
-	uint32_t base_width = obs->video.base_width;
-	uint32_t base_height = obs->video.base_height;
+	uint32_t base_width = video->ovi.base_width;
+	uint32_t base_height = video->ovi.base_height;
 
 	profile_start(render_main_texture_name);
 	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_MAIN_TEXTURE,
@@ -170,12 +170,12 @@ get_scale_effect_internal(struct obs_core_video_mix *mix)
 	/* if the dimension is under half the size of the original image,
 	 * bicubic/lanczos can't sample enough pixels to create an accurate
 	 * image, so use the bilinear low resolution effect instead */
-	if (info->width < (video->base_width / 2) &&
-	    info->height < (video->base_height / 2)) {
+	if (info->width < (mix->ovi.base_width / 2) &&
+	    info->height < (mix->ovi.base_height / 2)) {
 		return video->bilinear_lowres_effect;
 	}
 
-	switch (mix->scale_type) {
+	switch (mix->ovi.scale_type) {
 	case OBS_SCALE_BILINEAR:
 		return video->default_effect;
 	case OBS_SCALE_LANCZOS:
@@ -189,11 +189,11 @@ get_scale_effect_internal(struct obs_core_video_mix *mix)
 	return video->bicubic_effect;
 }
 
-static inline bool resolution_close(struct obs_core_video *video,
+static inline bool resolution_close(struct obs_core_video_mix *mix,
 				    uint32_t width, uint32_t height)
 {
-	long width_cmp = (long)video->base_width - (long)width;
-	long height_cmp = (long)video->base_height - (long)height;
+	long width_cmp = (long)mix->ovi.base_width - (long)width;
+	long height_cmp = (long)mix->ovi.base_height - (long)height;
 
 	return labs(width_cmp) <= 16 && labs(height_cmp) <= 16;
 }
@@ -203,7 +203,7 @@ static inline gs_effect_t *get_scale_effect(struct obs_core_video_mix *mix,
 {
 	struct obs_core_video *video = &obs->video;
 
-	if (resolution_close(video, width, height)) {
+	if (resolution_close(mix, width, height)) {
 		return video->default_effect;
 	} else {
 		/* if the scale method couldn't be loaded, use either bicubic
@@ -233,8 +233,8 @@ render_output_texture(struct obs_core_video_mix *mix)
 	if (video_output_get_format(mix->video) == VIDEO_FORMAT_BGRA) {
 		tech = gs_effect_get_technique(effect, "DrawAlphaDivide");
 	} else {
-		if ((width == video->base_width) &&
-		    (height == video->base_height))
+		if ((width == mix->ovi.base_width) &&
+		    (height == mix->ovi.base_height))
 			return texture;
 
 		tech = gs_effect_get_technique(effect, "Draw");
@@ -254,15 +254,15 @@ render_output_texture(struct obs_core_video_mix *mix)
 
 	if (bres) {
 		struct vec2 base;
-		vec2_set(&base, (float)video->base_width,
-			 (float)video->base_height);
+		vec2_set(&base, (float)mix->ovi.base_width,
+			 (float)mix->ovi.base_height);
 		gs_effect_set_vec2(bres, &base);
 	}
 
 	if (bres_i) {
 		struct vec2 base_i;
-		vec2_set(&base_i, 1.0f / (float)video->base_width,
-			 1.0f / (float)video->base_height);
+		vec2_set(&base_i, 1.0f / (float)mix->ovi.base_width,
+			 1.0f / (float)mix->ovi.base_height);
 		gs_effect_set_vec2(bres_i, &base_i);
 	}
 

--- a/libobs/obs-view.c
+++ b/libobs/obs-view.c
@@ -162,10 +162,17 @@ static inline void set_main_mix()
 
 video_t *obs_view_add(obs_view_t *view)
 {
-	if (!view)
+	if (!obs->video.main_mix)
+		return NULL;
+	return obs_view_add2(view, &obs->video.main_mix->ovi);
+}
+
+video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi)
+{
+	if (!view || !ovi)
 		return NULL;
 
-	struct obs_core_video_mix *mix = obs_create_video_mix(&obs->video.ovi);
+	struct obs_core_video_mix *mix = obs_create_video_mix(ovi);
 	if (!mix) {
 		return NULL;
 	}

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -909,8 +909,11 @@ EXPORT obs_source_t *obs_view_get_source(obs_view_t *view, uint32_t channel);
 /** Renders the sources of this view context */
 EXPORT void obs_view_render(obs_view_t *view);
 
-/** Adds a view to the main render loop */
+/** Adds a view to the main render loop, with current obs_get_video_info state */
 EXPORT video_t *obs_view_add(obs_view_t *view);
+
+/** Adds a view to the main render loop, with custom video settings */
+EXPORT video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi);
 
 /** Removes a view from the main render loop */
 EXPORT void obs_view_remove(obs_view_t *view);


### PR DESCRIPTION
### Description

- Add new variant of obs_view_add to customize view specific canvas/encoder output resolution

### Motivation and Context

I recently got familiar with https://github.com/obsproject/obs-studio/pull/6577 (cc @chippydip ) that was exactly what my plugin needed at the time, for potentially doing multiple outputs with separate encoder instances at the time.

Later on, the requirements changed and I'd prefer to encode an output with a custom resolution. I'm also using a scene with a custom resolution set as view source.

The multiple video mixes PR already did most of the work for making this happen, but this PR is just a small addition to ensure `obs_video_info` is a part of `obs_core_video_mix` context and reduce the direct use of `obs->video.main_mix`.

### How Has This Been Tested?

- Tested on a Mac and PC (x264/nvenc variants, with and without scaling)
- Tested with one or multiple streaming outputs running in parallel, potentially with multiple different resolutions in use

### Types of changes
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
