### PR TITLE
libobs: Add new signals and private support for output, encoder and service

### DIFF
--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -180,12 +180,12 @@ void AutoConfigTestPage::TestBandwidthThread()
 	const char *serverType = wiz->customServer ? "rtmp_custom"
 						   : "rtmp_common";
 
-	OBSEncoderAutoRelease vencoder = obs_video_encoder_create(
-		"obs_x264", "test_x264", nullptr, nullptr);
-	OBSEncoderAutoRelease aencoder = obs_audio_encoder_create(
-		"ffmpeg_aac", "test_aac", nullptr, 0, nullptr);
-	OBSServiceAutoRelease service = obs_service_create(
-		serverType, "test_service", nullptr, nullptr);
+	OBSEncoderAutoRelease vencoder = obs_video_encoder_create_private(
+		"obs_x264", "test_x264", nullptr);
+	OBSEncoderAutoRelease aencoder = obs_audio_encoder_create_private(
+		"ffmpeg_aac", "test_aac", nullptr, 0);
+	OBSServiceAutoRelease service =
+		obs_service_create_private(serverType, "test_service", nullptr);
 
 	/* -----------------------------------*/
 	/* configure settings                 */
@@ -273,15 +273,15 @@ void AutoConfigTestPage::TestBandwidthThread()
 		output_type = "rtmp_output";
 
 	OBSOutputAutoRelease output =
-		obs_output_create(output_type, "test_stream", nullptr, nullptr);
+		obs_output_create_private(output_type, "test_stream", nullptr);
 	obs_output_update(output, output_settings);
 
 	const char *audio_codec = obs_output_get_supported_audio_codecs(output);
 
 	if (strcmp(audio_codec, "aac") != 0) {
 		const char *id = FindAudioEncoderFromCodec(audio_codec);
-		aencoder = obs_audio_encoder_create(id, "test_audio", nullptr,
-						    0, nullptr);
+		aencoder = obs_audio_encoder_create_private(id, "test_audio",
+							    nullptr, 0);
 	}
 
 	/* -----------------------------------*/
@@ -520,12 +520,12 @@ bool AutoConfigTestPage::TestSoftwareEncoding()
 	/* -----------------------------------*/
 	/* create obs objects                 */
 
-	OBSEncoderAutoRelease vencoder = obs_video_encoder_create(
-		"obs_x264", "test_x264", nullptr, nullptr);
-	OBSEncoderAutoRelease aencoder = obs_audio_encoder_create(
-		"ffmpeg_aac", "test_aac", nullptr, 0, nullptr);
+	OBSEncoderAutoRelease vencoder = obs_video_encoder_create_private(
+		"obs_x264", "test_x264", nullptr);
+	OBSEncoderAutoRelease aencoder = obs_audio_encoder_create_private(
+		"ffmpeg_aac", "test_aac", nullptr, 0);
 	OBSOutputAutoRelease output =
-		obs_output_create("null_output", "null", nullptr, nullptr);
+		obs_output_create_private("null_output", "null", nullptr);
 
 	/* -----------------------------------*/
 	/* configure settings                 */
@@ -1011,8 +1011,8 @@ void AutoConfigTestPage::FinalizeResults()
 		const char *serverType = wiz->customServer ? "rtmp_custom"
 							   : "rtmp_common";
 
-		OBSServiceAutoRelease service = obs_service_create(
-			serverType, "temp_service", nullptr, nullptr);
+		OBSServiceAutoRelease service = obs_service_create_private(
+			serverType, "temp_service", nullptr);
 
 		OBSDataAutoRelease service_settings = obs_data_create();
 		OBSDataAutoRelease vencoder_settings = obs_data_create();

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -345,8 +345,8 @@ bool AutoConfigStreamPage::validatePage()
 				    QT_TO_UTF8(ui->service->currentText()));
 	}
 
-	OBSServiceAutoRelease service = obs_service_create(
-		serverType, "temp_service", service_settings, nullptr);
+	OBSServiceAutoRelease service = obs_service_create_private(
+		serverType, "temp_service", service_settings);
 
 	int bitrate;
 	if (!ui->doBandwidthTest->isChecked()) {

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -593,8 +593,8 @@ OBSService OBSBasicSettings::SpawnTempService()
 	}
 	obs_data_set_string(settings, "key", QT_TO_UTF8(ui->key->text()));
 
-	OBSServiceAutoRelease newService = obs_service_create(
-		service_id, "temp_service", settings, nullptr);
+	OBSServiceAutoRelease newService = obs_service_create_private(
+		service_id, "temp_service", settings);
 	return newService.Get();
 }
 

--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -706,6 +706,30 @@ Core OBS Signals
 
    Called when a hotkey's bindings has changed.
 
+**output_create** (ptr output)
+
+   Called when an output has been created.
+
+**output_destroy** (ptr output)
+
+   Called when an output has been destroyed.
+
+**encoder_create** (ptr encoder)
+
+   Called when an encoder has been created.
+
+**encoder_destroy** (ptr encoder)
+
+   Called when an encoder has been destroyed.
+
+**service_create** (ptr service)
+
+   Called when a service has been created.
+
+**service_destroy** (ptr service)
+
+   Called when a service has been destroyed.
+
 ---------------------
 
 

--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -714,6 +714,10 @@ Core OBS Signals
 
    Called when an output has been destroyed.
 
+**output_update** (ptr output)
+
+   Called when output settings have been updated.
+
 **encoder_create** (ptr encoder)
 
    Called when an encoder has been created.

--- a/docs/sphinx/reference-encoders.rst
+++ b/docs/sphinx/reference-encoders.rst
@@ -299,6 +299,24 @@ General Encoder Functions
 
 ---------------------
 
+.. function:: obs_encoder_t *obs_video_encoder_create_private(const char *id, const char *name, obs_data_t *settings)
+
+   Creates a 'private' video encoder which is not enumerated by
+   :c:func:`obs_enum_encoders()`.
+
+   The "encoder" context is used for encoding video/audio data.  Use
+   obs_encoder_release to release it.
+
+   :param   id:             The encoder type string identifier
+   :param   name:           The desired name of the encoder.  If this is
+                            not unique, it will be made to be unique
+   :param   settings:       The settings for the encoder, or *NULL* if
+                            none
+   :return:                 A reference to the newly created encoder, or
+                            *NULL* if failed
+
+---------------------
+
 .. function:: obs_encoder_t *obs_audio_encoder_create(const char *id, const char *name, obs_data_t *settings, size_t mixer_idx, obs_data_t *hotkey_data)
 
    Creates an audio encoder with the specified settings.
@@ -315,6 +333,26 @@ General Encoder Functions
                             will capture audio from
    :param   hotkey_data:    Saved hotkey data for the encoder, or *NULL*
                             if none
+   :return:                 A reference to the newly created encoder, or
+                            *NULL* if failed
+
+---------------------
+
+.. function:: obs_encoder_t *obs_audio_encoder_create_private(const char *id, const char *name, obs_data_t *settings, size_t mixer_idx)
+
+   Creates a 'private' audio encoder which is not enumerated by
+   :c:func:`obs_enum_encoders()`.
+
+   The "encoder" context is used for encoding video/audio data.  Use
+   :c:func:`obs_encoder_release()` to release it.
+
+   :param   id:             The encoder type string identifier
+   :param   name:           The desired name of the encoder.  If this is
+                            not unique, it will be made to be unique
+   :param   settings:       The settings for the encoder, or *NULL* if
+                            none
+   :param   mixer_idx:      The audio mixer index this audio encoder
+                            will capture audio from
    :return:                 A reference to the newly created encoder, or
                             *NULL* if failed
 

--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -285,6 +285,10 @@ Output Signals
 
    Called when the output deactivates (stops capturing data).
 
+**update** (ptr output)
+
+   Called when the output settings have been updated.
+
 **reconnect** (ptr output)
 
    Called when the output is reconnecting.

--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -333,6 +333,25 @@ General Output Functions
 
 ---------------------
 
+.. function:: obs_output_t *obs_output_create_private(const char *id, const char *name, obs_data_t *settings)
+
+   Creates a 'private' output which is not enumerated by
+   :c:func:`obs_enum_outputs()`.
+
+   The "output" context is used for anything related to outputting the
+   final video/audio mix (E.g. streaming or recording).  Use
+   obs_output_release to release it.
+
+   :param   id:             The output type string identifier
+   :param   name:           The desired name of the output.  If this is
+                            not unique, it will be made to be unique
+   :param   settings:       The settings for the output, or *NULL* if
+                            none
+   :return:                 A reference to the newly created output, or
+                            *NULL* if failed
+
+---------------------
+
 .. function:: void obs_output_addref(obs_output_t *output)
 
    Adds a reference to an output.

--- a/docs/sphinx/reference-services.rst
+++ b/docs/sphinx/reference-services.rst
@@ -188,6 +188,24 @@ General Service Functions
 
 ---------------------
 
+.. function:: obs_service_t *obs_service_create_private(const char *id, const char *name, obs_data_t *settings)
+
+   Creates a 'private' service which is not enumerated by
+   :c:func:`obs_enum_services()`.
+
+   The "service" context is used for encoding video/audio data.  Use
+   obs_service_release to release it.
+
+   :param   id:             The service type string identifier
+   :param   name:           The desired name of the service.  If this is
+                            not unique, it will be made to be unique
+   :param   settings:       The settings for the service, or *NULL* if
+                            none
+   :return:                 A reference to the newly created service, or
+                            *NULL* if failed
+
+---------------------
+
 .. function:: void obs_service_addref(obs_service_t *service)
 
    Adds a reference to a service.

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -115,6 +115,9 @@ create_encoder(const char *id, enum obs_encoder_type type, const char *name,
 				&obs->data.first_encoder);
 
 	blog(LOG_DEBUG, "encoder '%s' (%s) created", name, id);
+	if (!private) {
+		obs_encoder_dosignal(encoder, "encoder_create", NULL);
+	}
 	return encoder;
 }
 
@@ -277,6 +280,8 @@ static void obs_encoder_actually_destroy(obs_encoder_t *encoder)
 
 		blog(LOG_DEBUG, "encoder '%s' destroyed",
 		     encoder->context.name);
+
+		obs_encoder_dosignal(encoder, "encoder_destroy", NULL);
 
 		free_audio_buffers(encoder);
 

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -44,7 +44,8 @@ const char *obs_encoder_get_display_name(const char *id)
 }
 
 static bool init_encoder(struct obs_encoder *encoder, const char *name,
-			 obs_data_t *settings, obs_data_t *hotkey_data)
+			 obs_data_t *settings, obs_data_t *hotkey_data,
+			 bool private)
 {
 	pthread_mutex_init_value(&encoder->init_mutex);
 	pthread_mutex_init_value(&encoder->callbacks_mutex);
@@ -52,7 +53,7 @@ static bool init_encoder(struct obs_encoder *encoder, const char *name,
 	pthread_mutex_init_value(&encoder->pause.mutex);
 
 	if (!obs_context_data_init(&encoder->context, OBS_OBJ_TYPE_ENCODER,
-				   settings, name, NULL, hotkey_data, false))
+				   settings, name, NULL, hotkey_data, private))
 		return false;
 	if (pthread_mutex_init_recursive(&encoder->init_mutex) != 0)
 		return false;
@@ -76,7 +77,8 @@ static bool init_encoder(struct obs_encoder *encoder, const char *name,
 
 static struct obs_encoder *
 create_encoder(const char *id, enum obs_encoder_type type, const char *name,
-	       obs_data_t *settings, size_t mixer_idx, obs_data_t *hotkey_data)
+	       obs_data_t *settings, size_t mixer_idx, obs_data_t *hotkey_data,
+	       bool private)
 {
 	struct obs_encoder *encoder;
 	struct obs_encoder_info *ei = find_encoder(id);
@@ -100,7 +102,7 @@ create_encoder(const char *id, enum obs_encoder_type type, const char *name,
 		encoder->orig_info = *ei;
 	}
 
-	success = init_encoder(encoder, name, settings, hotkey_data);
+	success = init_encoder(encoder, name, settings, hotkey_data, private);
 	if (!success) {
 		blog(LOG_ERROR, "creating encoder '%s' (%s) failed", name, id);
 		obs_encoder_destroy(encoder);
@@ -123,7 +125,17 @@ obs_encoder_t *obs_video_encoder_create(const char *id, const char *name,
 	if (!name || !id)
 		return NULL;
 	return create_encoder(id, OBS_ENCODER_VIDEO, name, settings, 0,
-			      hotkey_data);
+			      hotkey_data, false);
+}
+
+obs_encoder_t *obs_video_encoder_create_private(const char *id,
+						const char *name,
+						obs_data_t *settings)
+{
+	if (!name || !id)
+		return NULL;
+	return create_encoder(id, OBS_ENCODER_VIDEO, name, settings, 0, NULL,
+			      true);
 }
 
 obs_encoder_t *obs_audio_encoder_create(const char *id, const char *name,
@@ -133,7 +145,18 @@ obs_encoder_t *obs_audio_encoder_create(const char *id, const char *name,
 	if (!name || !id)
 		return NULL;
 	return create_encoder(id, OBS_ENCODER_AUDIO, name, settings, mixer_idx,
-			      hotkey_data);
+			      hotkey_data, false);
+}
+
+obs_encoder_t *obs_audio_encoder_create_private(const char *id,
+						const char *name,
+						obs_data_t *settings,
+						size_t mixer_idx)
+{
+	if (!name || !id)
+		return NULL;
+	return create_encoder(id, OBS_ENCODER_AUDIO, name, settings, mixer_idx,
+			      NULL, true);
 }
 
 static void receive_video(void *param, struct video_data *frame);

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1137,14 +1137,24 @@ struct obs_output {
 	float audio_data[MAX_AUDIO_CHANNELS][AUDIO_OUTPUT_FRAMES];
 };
 
-static inline void do_output_signal(struct obs_output *output,
-				    const char *signal)
+static inline void obs_output_dosignal(struct obs_output *output,
+				       const char *signal_obs,
+				       const char *signal_output)
 {
-	struct calldata params = {0};
-	calldata_set_ptr(&params, "output", output);
-	signal_handler_signal(output->context.signals, signal, &params);
-	calldata_free(&params);
+	struct calldata data;
+	uint8_t stack[128];
+
+	calldata_init_fixed(&data, stack, sizeof(stack));
+	calldata_set_ptr(&data, "output", output);
+	if (signal_obs && !output->context.private)
+		signal_handler_signal(obs->signals, signal_obs, &data);
+	if (signal_output)
+		signal_handler_signal(output->context.signals, signal_output,
+				      &data);
 }
+
+#define do_output_signal(output, signal) \
+	obs_output_dosignal(output, NULL, signal)
 
 extern void process_delay(void *data, struct encoder_packet *packet);
 extern void obs_output_cleanup_delay(obs_output_t *output);
@@ -1245,6 +1255,22 @@ struct obs_encoder {
 	bool reconfigure_requested;
 };
 
+static inline void obs_encoder_dosignal(struct obs_encoder *encoder,
+					const char *signal_obs,
+					const char *signal_encoder)
+{
+	struct calldata data;
+	uint8_t stack[128];
+
+	calldata_init_fixed(&data, stack, sizeof(stack));
+	calldata_set_ptr(&data, "encoder", encoder);
+	if (signal_obs && !encoder->context.private)
+		signal_handler_signal(obs->signals, signal_obs, &data);
+	if (signal_encoder)
+		signal_handler_signal(encoder->context.signals, signal_encoder,
+				      &data);
+}
+
 extern struct obs_encoder_info *find_encoder(const char *id);
 
 extern bool obs_encoder_initialize(obs_encoder_t *encoder);
@@ -1292,6 +1318,22 @@ struct obs_service {
 	bool destroy;
 	struct obs_output *output;
 };
+
+static inline void obs_service_dosignal(struct obs_service *service,
+					const char *signal_obs,
+					const char *signal_service)
+{
+	struct calldata data;
+	uint8_t stack[128];
+
+	calldata_init_fixed(&data, stack, sizeof(stack));
+	calldata_set_ptr(&data, "service", service);
+	if (signal_obs && !service->context.private)
+		signal_handler_signal(obs->signals, signal_obs, &data);
+	if (signal_service)
+		signal_handler_signal(service->context.signals, signal_service,
+				      &data);
+}
 
 extern const struct obs_service_info *find_service(const char *id);
 

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -90,19 +90,11 @@ static const char *output_signals[] = {
 	NULL,
 };
 
-static bool init_output_handlers(struct obs_output *output, const char *name,
-				 obs_data_t *settings, obs_data_t *hotkey_data)
-{
-	if (!obs_context_data_init(&output->context, OBS_OBJ_TYPE_OUTPUT,
-				   settings, name, NULL, hotkey_data, false))
-		return false;
-
-	signal_handler_add_array(output->context.signals, output_signals);
-	return true;
-}
-
-obs_output_t *obs_output_create(const char *id, const char *name,
-				obs_data_t *settings, obs_data_t *hotkey_data)
+static obs_output_t *obs_output_create_internal(const char *id,
+						const char *name,
+						obs_data_t *settings,
+						obs_data_t *hotkey_data,
+						bool private)
 {
 	const struct obs_output_info *info = find_output(id);
 	struct obs_output *output;
@@ -124,9 +116,11 @@ obs_output_t *obs_output_create(const char *id, const char *name,
 		goto fail;
 	if (os_event_init(&output->stopping_event, OS_EVENT_TYPE_MANUAL) != 0)
 		goto fail;
-	if (!init_output_handlers(output, name, settings, hotkey_data))
+	if (!obs_context_data_init(&output->context, OBS_OBJ_TYPE_OUTPUT,
+				   settings, name, NULL, hotkey_data, private))
 		goto fail;
 
+	signal_handler_add_array(output->context.signals, output_signals);
 	os_event_signal(output->stopping_event);
 
 	if (!info) {
@@ -170,6 +164,19 @@ obs_output_t *obs_output_create(const char *id, const char *name,
 fail:
 	obs_output_destroy(output);
 	return NULL;
+}
+
+obs_output_t *obs_output_create(const char *id, const char *name,
+				obs_data_t *settings, obs_data_t *hotkey_data)
+{
+	return obs_output_create_internal(id, name, settings, hotkey_data,
+					  false);
+}
+
+obs_output_t *obs_output_create_private(const char *id, const char *name,
+					obs_data_t *settings)
+{
+	return obs_output_create_internal(id, name, settings, NULL, true);
 }
 
 static inline void free_packets(struct obs_output *output)

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -159,6 +159,9 @@ static obs_output_t *obs_output_create_internal(const char *id,
 		blog(LOG_ERROR, "Failed to create output '%s'!", name);
 
 	blog(LOG_DEBUG, "output '%s' (%s) created", name, id);
+	if (!private) {
+		obs_output_dosignal(output, "output_create", NULL);
+	}
 	return output;
 
 fail:
@@ -209,6 +212,8 @@ void obs_output_destroy(obs_output_t *output)
 		os_event_wait(output->stopping_event);
 		if (data_capture_ending(output))
 			pthread_join(output->end_data_capture_thread, NULL);
+
+		obs_output_dosignal(output, "output_destroy", NULL);
 
 		if (output->service)
 			output->service->output = NULL;

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -85,6 +85,7 @@ static const char *output_signals[] = {
 	"void stopping(ptr output)",
 	"void activate(ptr output)",
 	"void deactivate(ptr output)",
+	"void update(ptr output)",
 	"void reconnect(ptr output)",
 	"void reconnect_success(ptr output)",
 	NULL,
@@ -535,6 +536,8 @@ void obs_output_update(obs_output_t *output, obs_data_t *settings)
 	if (output->info.update)
 		output->info.update(output->context.data,
 				    output->context.settings);
+
+	obs_output_dosignal(output, "output_update", "update");
 }
 
 obs_data_t *obs_output_get_settings(const obs_output_t *output)

--- a/libobs/obs-service.c
+++ b/libobs/obs-service.c
@@ -70,6 +70,9 @@ static obs_service_t *obs_service_create_internal(const char *id,
 				&obs->data.first_service);
 
 	blog(LOG_DEBUG, "service '%s' (%s) created", name, id);
+	if (!private) {
+		obs_service_dosignal(service, "service_create", NULL);
+	}
 	return service;
 }
 
@@ -88,6 +91,8 @@ obs_service_t *obs_service_create_private(const char *id, const char *name,
 
 static void actually_destroy_service(struct obs_service *service)
 {
+	obs_service_dosignal(service, "service_destroy", NULL);
+
 	if (service->context.data)
 		service->info.destroy(service->context.data);
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1958,6 +1958,29 @@ static inline void obs_enum(void *pstart, pthread_mutex_t *mutex, void *proc,
 	pthread_mutex_unlock(mutex);
 }
 
+static inline void obs_enum_public(void *pstart, pthread_mutex_t *mutex,
+				   void *proc, void *param)
+{
+	struct obs_context_data **start = pstart, *context;
+	bool (*enum_proc)(void *, void *) = proc;
+
+	assert(start);
+	assert(mutex);
+	assert(enum_proc);
+
+	pthread_mutex_lock(mutex);
+
+	context = *start;
+	while (context) {
+		if (!context->private && !enum_proc(param, context))
+			break;
+
+		context = context->next;
+	}
+
+	pthread_mutex_unlock(mutex);
+}
+
 static inline void obs_enum_uuid(void *pstart, pthread_mutex_t *mutex,
 				 void *proc, void *param)
 {
@@ -1987,20 +2010,20 @@ void obs_enum_all_sources(bool (*enum_proc)(void *, obs_source_t *),
 
 void obs_enum_outputs(bool (*enum_proc)(void *, obs_output_t *), void *param)
 {
-	obs_enum(&obs->data.first_output, &obs->data.outputs_mutex, enum_proc,
-		 param);
+	obs_enum_public(&obs->data.first_output, &obs->data.outputs_mutex,
+			enum_proc, param);
 }
 
 void obs_enum_encoders(bool (*enum_proc)(void *, obs_encoder_t *), void *param)
 {
-	obs_enum(&obs->data.first_encoder, &obs->data.encoders_mutex, enum_proc,
-		 param);
+	obs_enum_public(&obs->data.first_encoder, &obs->data.encoders_mutex,
+			enum_proc, param);
 }
 
 void obs_enum_services(bool (*enum_proc)(void *, obs_service_t *), void *param)
 {
-	obs_enum(&obs->data.first_service, &obs->data.services_mutex, enum_proc,
-		 param);
+	obs_enum_public(&obs->data.first_service, &obs->data.services_mutex,
+			enum_proc, param);
 }
 
 static inline void *get_context_by_name(void *vfirst, const char *name,

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1110,6 +1110,7 @@ static const char *obs_signals[] = {
 
 	"void output_create(ptr output)",
 	"void output_destroy(ptr output)",
+	"void output_update(ptr output)",
 	"void encoder_create(ptr encoder)",
 	"void encoder_destroy(ptr encoder)",
 	"void service_create(ptr service)",

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1108,6 +1108,13 @@ static const char *obs_signals[] = {
 	"void hotkey_unregister(ptr hotkey)",
 	"void hotkey_bindings_changed(ptr hotkey)",
 
+	"void output_create(ptr output)",
+	"void output_destroy(ptr output)",
+	"void encoder_create(ptr encoder)",
+	"void encoder_destroy(ptr encoder)",
+	"void service_create(ptr service)",
+	"void service_destroy(ptr service)",
+
 	NULL,
 };
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2001,6 +2001,9 @@ EXPORT obs_output_t *obs_output_create(const char *id, const char *name,
 				       obs_data_t *settings,
 				       obs_data_t *hotkey_data);
 
+EXPORT obs_output_t *obs_output_create_private(const char *id, const char *name,
+					       obs_data_t *settings);
+
 /**
  * Adds/releases a reference to an output.  When the last reference is
  * released, the output is destroyed.
@@ -2278,6 +2281,10 @@ EXPORT obs_encoder_t *obs_video_encoder_create(const char *id, const char *name,
 					       obs_data_t *settings,
 					       obs_data_t *hotkey_data);
 
+EXPORT obs_encoder_t *obs_video_encoder_create_private(const char *id,
+						       const char *name,
+						       obs_data_t *settings);
+
 /**
  * Creates an audio encoder context
  *
@@ -2291,6 +2298,11 @@ EXPORT obs_encoder_t *obs_audio_encoder_create(const char *id, const char *name,
 					       obs_data_t *settings,
 					       size_t mixer_idx,
 					       obs_data_t *hotkey_data);
+
+EXPORT obs_encoder_t *obs_audio_encoder_create_private(const char *id,
+						       const char *name,
+						       obs_data_t *settings,
+						       size_t mixer_idx);
 
 /**
  * Adds/releases a reference to an encoder.  When the last reference is


### PR DESCRIPTION
### Description

- Add obs_source_create_private equivalent for output, encoder and service and update UI to use it for test instances
- Add obs_source_dosignal equivalent for output, encoder and service
- Add source_create/source_destroy signal equivalent for output, encoder and service
- Add source_update/update signals when obs_output_update called

### Motivation and Context

This is a follow-up modification for https://github.com/obsproject/obs-studio/pull/7797

I realized that while I can use a tick callback to continuously probe when a service/output instance has changed or been created at all, it's not really efficient when we could have a global signals similar to what sources have.

`obs_output_t` has `starting` and `start` signals, but they're both triggered too late to do any last minute encoder/output configuration inspection or modifications, so I added a new signal `update` to handle this. This also allows me to change the main recording/streaming output instances to use a custom view, if needed, to further improve the flexibility of OBS.

### How Has This Been Tested?

- Tested with a custom plugin on a Mac and a PC

### Types of changes

- New feature (non-breaking change which adds functionality)
- Documentation (a change to documentation pages)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
