### PR TITLE
UI: Remove Qt taskbar overlay

### DIFF
--- a/UI/platform-windows.cpp
+++ b/UI/platform-windows.cpp
@@ -37,11 +37,6 @@
 #include <util/windows/HRError.hpp>
 #include <util/windows/ComPtr.hpp>
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-#include <QWinTaskbarButton>
-#include <QMainWindow>
-#endif
-
 using namespace std;
 
 static inline bool check_path(const char *data, const char *path,
@@ -443,35 +438,6 @@ bool IsRunningOnWine()
 	return false;
 }
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-QWinTaskbarButton *taskBtn;
-
-void TaskbarOverlayInit()
-{
-	QMainWindow *main = App()->GetMainWindow();
-	taskBtn = new QWinTaskbarButton(main);
-	taskBtn->setWindow(main->windowHandle());
-}
-
-void TaskbarOverlaySetStatus(TaskbarOverlayStatus status)
-{
-	if (status == TaskbarOverlayStatusInactive) {
-		taskBtn->clearOverlayIcon();
-		return;
-	}
-
-	QIcon icon;
-	if (status == TaskbarOverlayStatusActive) {
-		icon = QIcon::fromTheme("obs-active",
-					QIcon(":/res/images/active.png"));
-	} else {
-		icon = QIcon::fromTheme("obs-paused",
-					QIcon(":/res/images/paused.png"));
-	}
-	taskBtn->setOverlayIcon(icon);
-}
-#else
-
 HWND hwnd;
 void TaskbarOverlayInit()
 {
@@ -527,4 +493,3 @@ void TaskbarOverlaySetStatus(TaskbarOverlayStatus status)
 	}
 	taskbarIcon->Release();
 }
-#endif


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes the Qt implementation of the taskbar overlay on Windows.
This was removed with Qt 6, which is why we now have a native integration for that. There's no reason for this native integration to not be used with Qt 5 (except that we're not using Qt 5 anymore anyways).


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
+0 -35

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Millions of users used this "new" codepath with OBS 28 which I consider to be enough of a test.
That being said, this PR itself hasn't been tested, but I consider it to be very low risk (and even in the tiny chance that it does somehow break, it would only break Qt 5 which we're not using anymore on Windows anyways).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
