### PR TITLE
UI: Add Apple Hardware Encoder to AutoConfig

### DIFF
--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -894,6 +894,8 @@ void AutoConfigTestPage::TestStreamEncoderThread()
 			wiz->streamingEncoder = AutoConfig::Encoder::NVENC;
 		else if (wiz->qsvAvailable)
 			wiz->streamingEncoder = AutoConfig::Encoder::QSV;
+		else if (wiz->appleAvailable)
+			wiz->streamingEncoder = AutoConfig::Encoder::Apple;
 		else
 			wiz->streamingEncoder = AutoConfig::Encoder::AMD;
 	} else {
@@ -927,6 +929,8 @@ void AutoConfigTestPage::TestRecordingEncoderThread()
 			wiz->recordingEncoder = AutoConfig::Encoder::NVENC;
 		else if (wiz->qsvAvailable)
 			wiz->recordingEncoder = AutoConfig::Encoder::QSV;
+		else if (wiz->appleAvailable)
+			wiz->recordingEncoder = AutoConfig::Encoder::Apple;
 		else
 			wiz->recordingEncoder = AutoConfig::Encoder::AMD;
 	} else {
@@ -948,6 +952,7 @@ void AutoConfigTestPage::TestRecordingEncoderThread()
 #define ENCODER_NVENC ENCODER_TEXT("Hardware.NVENC.H264")
 #define ENCODER_QSV ENCODER_TEXT("Hardware.QSV.H264")
 #define ENCODER_AMD ENCODER_TEXT("Hardware.AMD.H264")
+#define ENCODER_APPLE ENCODER_TEXT("Hardware.Apple.H264")
 
 #define QUALITY_SAME "Basic.Settings.Output.Simple.RecordingQuality.Stream"
 #define QUALITY_HIGH "Basic.Settings.Output.Simple.RecordingQuality.Small"
@@ -990,6 +995,8 @@ void AutoConfigTestPage::FinalizeResults()
 			return QTStr(ENCODER_QSV);
 		case AutoConfig::Encoder::AMD:
 			return QTStr(ENCODER_AMD);
+		case AutoConfig::Encoder::Apple:
+			return QTStr(ENCODER_APPLE);
 		case AutoConfig::Encoder::Stream:
 			return QTStr(QUALITY_SAME);
 		}

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -969,7 +969,7 @@ AutoConfig::AutoConfig(QWidget *parent) : QWizard(parent)
 		/* Newer generations of NVENC have a high enough quality to
 		 * bitrate ratio that if NVENC is available, it makes sense to
 		 * just always prefer hardware encoding by default */
-		bool preferHardware = nvencAvailable ||
+		bool preferHardware = nvencAvailable || appleAvailable ||
 				      os_get_physical_cores() <= 4;
 		streamPage->ui->preferHardware->setChecked(preferHardware);
 	}
@@ -1000,6 +1000,18 @@ void AutoConfig::TestHardwareEncoding()
 			hardwareEncodingAvailable = qsvAvailable = true;
 		else if (strcmp(id, "h264_texture_amf") == 0)
 			hardwareEncodingAvailable = vceAvailable = true;
+#ifdef __APPLE__
+		else if (strcmp(id,
+				"com.apple.videotoolbox.videoencoder.ave.avc") ==
+				 0
+#ifndef __aarch64__
+			 && os_get_emulation_status() == true
+#endif
+		)
+			if (__builtin_available(macOS 13.0, *))
+				hardwareEncodingAvailable = appleAvailable =
+					true;
+#endif
 	}
 }
 
@@ -1047,6 +1059,8 @@ inline const char *AutoConfig::GetEncoderId(Encoder enc)
 		return SIMPLE_ENCODER_QSV;
 	case Encoder::AMD:
 		return SIMPLE_ENCODER_AMD;
+	case Encoder::Apple:
+		return SIMPLE_ENCODER_APPLE_H264;
 	default:
 		return SIMPLE_ENCODER_X264;
 	}

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -47,6 +47,7 @@ class AutoConfig : public QWizard {
 		NVENC,
 		QSV,
 		AMD,
+		Apple,
 		Stream,
 	};
 
@@ -89,6 +90,7 @@ class AutoConfig : public QWizard {
 	bool nvencAvailable = false;
 	bool qsvAvailable = false;
 	bool vceAvailable = false;
+	bool appleAvailable = false;
 
 	int startingBitrate = 2500;
 	bool customServer = false;


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds the M1/Pro/Max/Ultra/M2 Hardware encoder to AutoConfig on macOS 13 or newer.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We added this to simple mode with OBS 28, but not to AutoConfig.
This meant that when running AutoConfig, people would still only get recommended x264 even if the hardware encoder was available.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Ran AutoConfig, both for recording and streaming.
Optimizing for streaming, with "Prefer hardware encoder" checked the encoder got selected and applied correctly.
Optimizing for recording, the hardware encoder got selected and applied correctly.
When the encoder was set to unavailable, x264 got set.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
