### PR TITLE
Fix svt-av1 and libaom-av1 CQP ratecontrol

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-av1.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-av1.c
@@ -115,6 +115,8 @@ static bool av1_update(struct av1_encoder *enc, obs_data_t *settings)
 #else
 			av_opt_set(enc->ffve.context->priv_data, "rc", "cqp",
 				   0);
+			av_opt_set_int(enc->ffve.context->priv_data, "qp", cqp,
+				       0);
 #endif
 		}
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-av1.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-av1.c
@@ -105,7 +105,7 @@ static bool av1_update(struct av1_encoder *enc, obs_data_t *settings)
 
 	if (astrcmpi(rc, "cqp") == 0) {
 		bitrate = 0;
-		enc->ffve.context->global_quality = cqp;
+		av_opt_set_int(enc->ffve.context->priv_data, "crf", cqp, 0);
 
 		if (enc->svtav1) {
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59, 37, 100)


### PR DESCRIPTION
### Description
This makes the CQP rate control QP value be respected, which it is currently not. `global_quality` does not get respected by the encoders, and this is remedied by specifying via `priv_data`.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/7784

Want CQP rate control to work properly.

### How Has This Been Tested?
Tested on Win 11 22H2.

Confirmed QP value gets respected by encoding and checking the files produced (one file qp 10 one qp 50).

Made sure other rate control methods still work for both encoders.

Also tested ffmpeg deps 59.37.100 from https://github.com/obsproject/obs-deps/pull/141

CQP mode still works for both encoders with this PR.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
