### PR TITLE
decklink: Move preview output rescaling to GPU

### DIFF
--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -697,9 +697,10 @@ Functions used by outputs
 ---------------------
 
 .. function:: void obs_output_set_video_conversion(obs_output_t *output, const struct video_scale_info *conversion)
+              const struct video_scale_info *obs_output_get_video_conversion(obs_output_t *output)
 
-   Optionally sets the video conversion information.  Only used by raw
-   outputs.
+   Optionally sets/gets the video conversion information.  Only used by
+   raw outputs.
 
    Relevant data types used with this function:
 

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -1098,8 +1098,8 @@ static inline bool has_scaling(const struct obs_output *output)
 		video_height != output->scaled_height);
 }
 
-static inline struct video_scale_info *
-get_video_conversion(struct obs_output *output)
+const struct video_scale_info *
+obs_output_get_video_conversion(struct obs_output *output)
 {
 	if (output->video_conversion_set) {
 		if (!output->video_conversion.width)
@@ -1966,7 +1966,7 @@ static void hook_data_capture(struct obs_output *output, bool encoded,
 	} else {
 		if (has_video)
 			start_raw_video(output->video,
-					get_video_conversion(output),
+					obs_output_get_video_conversion(output),
 					default_raw_video_callback, output);
 		if (has_audio)
 			start_raw_audio(output);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2194,6 +2194,10 @@ obs_output_get_supported_audio_codecs(const obs_output_t *output);
 
 EXPORT void *obs_output_get_type_data(obs_output_t *output);
 
+/** Gets the video conversion info.  Used only for raw output */
+EXPORT const struct video_scale_info *
+obs_output_get_video_conversion(obs_output_t *output);
+
 /** Optionally sets the video conversion info.  Used only for raw output */
 EXPORT void
 obs_output_set_video_conversion(obs_output_t *output,


### PR DESCRIPTION
### Description
These commits move rescaling for DeckLink preview output from FFmpeg swscale on the CPU to the GPU where it is much cheaper.

Also convert from premultiplied alphs to straight alpha to match DeckLink's internal keyer behavior. (External keyer is untested.)

### Motivation and Context
Decrease performance hit of using DeckLink. Trying to get DeckLink in good code shape before adding HDR support.

### How Has This Been Tested?
- 4K -> 1080p preview output is no longer a slideshow.
- 1080p -> 1080p has not regressed.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.