### PR TITLE
updater: Bump to version 2.2

### DIFF
--- a/UI/win-update/updater/http.cpp
+++ b/UI/win-update/updater/http.cpp
@@ -125,7 +125,7 @@ bool HTTPPostData(const wchar_t *url, const BYTE *data, int dataLen,
 	/* -------------------------------------- *
 	 * connect to server                      */
 
-	hSession = WinHttpOpen(L"OBS Studio Updater/2.1",
+	hSession = WinHttpOpen(L"OBS Studio Updater/2.2",
 			       WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
 			       WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS,
 			       0);

--- a/UI/win-update/updater/updater.cpp
+++ b/UI/win-update/updater/updater.cpp
@@ -376,7 +376,7 @@ bool DownloadWorkerThread()
 
 	const DWORD enableHTTP2Flag = WINHTTP_PROTOCOL_FLAG_HTTP2;
 
-	HttpHandle hSession = WinHttpOpen(L"OBS Studio Updater/2.1",
+	HttpHandle hSession = WinHttpOpen(L"OBS Studio Updater/2.2",
 					  WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
 					  WINHTTP_NO_PROXY_NAME,
 					  WINHTTP_NO_PROXY_BYPASS, 0);
@@ -1092,7 +1092,7 @@ static bool UpdateVS2019Redists(const Json &root)
 
 	const DWORD tlsProtocols = WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2;
 
-	HttpHandle hSession = WinHttpOpen(L"OBS Studio Updater/2.1",
+	HttpHandle hSession = WinHttpOpen(L"OBS Studio Updater/2.2",
 					  WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
 					  WINHTTP_NO_PROXY_NAME,
 					  WINHTTP_NO_PROXY_BYPASS, 0);


### PR DESCRIPTION
### Description

Bumps updater version to 2.2.

### Motivation and Context

It's been 2.1 since it's introduction, I think it's time to update it :P

### How Has This Been Tested?

Hasn't, but what could a simple 3 byte change break?

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
