### PR TITLE
Suppress LNK4098

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -318,7 +318,8 @@ if(OS_WINDOWS)
     target_compile_options(libobs PRIVATE "$<$<COMPILE_LANGUAGE:C>:/EHc->"
                                           "$<$<COMPILE_LANGUAGE:CXX>:/EHc->")
 
-    target_link_options(libobs PRIVATE "LINKER:/SAFESEH:NO")
+    target_link_options(libobs PRIVATE "LINKER:/IGNORE:4098"
+                        "LINKER:/SAFESEH:NO")
   endif()
 
 elseif(OS_MACOS)

--- a/plugins/rtmp-services/CMakeLists.txt
+++ b/plugins/rtmp-services/CMakeLists.txt
@@ -43,6 +43,10 @@ if(OS_WINDOWS)
                  rtmp-services.rc)
 
   target_sources(rtmp-services PRIVATE rtmp-services.rc)
+
+  if(MSVC)
+    target_link_options(rtmp-services PRIVATE "LINKER:/IGNORE:4098")
+  endif()
 endif()
 
 set_target_properties(rtmp-services PROPERTIES FOLDER "plugins" PREFIX "")


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Suppress LNK4098 in libobs and rtmp-services to allow building against pre-built Jansson from obs-deps in Debug configuration.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want to be able to build in Debug for now.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built in Debug locally.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
