### PR TITLE
cmake: Improve Windows SDK detection handling

### DIFF
--- a/cmake/Modules/CompilerConfig.cmake
+++ b/cmake/Modules/CompilerConfig.cmake
@@ -21,33 +21,26 @@ if(OS_WINDOWS AND MSVC)
     set(THREADS_HAVE_PTHREAD_ARG OFF)
   endif()
 
-  # Check for Win SDK version 10.0.20348 or above
-  obs_status(
-    STATUS "Windows API version is ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
-  string(REPLACE "." ";" WINAPI_VER
-                 "${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
-
-  list(GET WINAPI_VER 0 WINAPI_VER_MAJOR)
-  list(GET WINAPI_VER 1 WINAPI_VER_MINOR)
-  list(GET WINAPI_VER 2 WINAPI_VER_BUILD)
-
-  set(WINAPI_COMPATIBLE FALSE)
-  if(WINAPI_VER_MAJOR EQUAL 10)
-    if(WINAPI_VER_MINOR EQUAL 0)
-      if(WINAPI_VER_BUILD GREATER_EQUAL 20348)
-        set(WINAPI_COMPATIBLE TRUE)
-      endif()
-    else()
-      set(WINAPI_COMPATIBLE TRUE)
-    endif()
-  elseif(WINAPI_VER_MAJOR GREATER 10)
-    set(WINAPI_COMPATIBLE TRUE)
+  unset(FOUND_SDK_VERSION)
+  if(DEFINED CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
+    set(FOUND_SDK_VERSION "${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
+  elseif(DEFINED ENV{WindowsSDKLibVersion})
+    string(REGEX REPLACE "\\\\$" "" FOUND_SDK_VERSION
+                         "$ENV{WindowsSDKLibVersion}")
   endif()
 
-  if(NOT WINAPI_COMPATIBLE)
+  if(DEFINED FOUND_SDK_VERSION)
+    obs_status(STATUS "Found Windows SDK version is ${FOUND_SDK_VERSION}")
+  else()
+    obs_status(FATAL_ERROR "Windows SDK not found.")
+  endif()
+
+  set(REQUIRED_SDK_VERSION "10.0.20348")
+
+  if(FOUND_SDK_VERSION VERSION_LESS REQUIRED_SDK_VERSION)
     obs_status(
       FATAL_ERROR
-      "OBS requires Windows 10 SDK version 10.0.20348.0 and above to compile.\n"
+      "OBS requires Windows SDK version ${REQUIRED_SDK_VERSION} and above to compile.\n"
       "Please download the most recent Windows 10 SDK in order to compile.")
   endif()
 


### PR DESCRIPTION
We rely on CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION which isn't defined when using the Ninja generator.

Changes in a list:
* Some of the messages used the terminology "Windows API" instead of "Windows SDK". I've changed those to "Windows SDK".
* There is now a Windows 11 SDK so specifying Windows 10 specifically in the error message I think is a touch misleading. Simply referring to it as "Windows SDK" is more generic but still concise in what we're referring to. I've removed the "10" as a result.
* If CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION wasn't defined, it would give an odd message saying Windows SDK wasn't found even if it's available and being used in the toolchain. Now it uses a fallback that uses an environment variable that's required to be present in this scenario. If that doesn't work, it assumes the SDK isn't present.
* If no SDK is found at all, it now errors out after logging a message as such.
* Since Windows SDK version fits within CMake's idea of a version, I've changed the comparison logic to use CMake's built-in version comparison.

There's another problem here with the FATAL_ERROR message when the found Windows SDK version isn't high enough. It only displays the first line because obs_status appears to only allow two arguments but three are provided. No fix for that is provided here.

The environment variable I use here is WindowsSDKLibVersion which the only documentation for is in winsdk.bat in the VS developer prompt tools. I learned about this trick from the apitrace folks.

### Motivation and Context
Allows building with Ninja while using cl.exe (MSVC) while improving the resulting errors in a problematic environment.

### How Has This Been Tested?
Built with both Ninja and Visual Studio 2022 generators using cl version 19.34.31933

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
