### PR TITLE
obs-ffmpeg: Disable VBAQ for HEVC CQP rate control

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1580,7 +1580,8 @@ static bool amf_hevc_init(void *data, obs_data_t *settings)
 	int rc = get_hevc_rate_control(rc_str);
 
 	set_hevc_property(enc, RATE_CONTROL_METHOD, rc);
-	set_hevc_property(enc, ENABLE_VBAQ, true);
+	if (rc != AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CONSTANT_QP)
+		set_hevc_property(enc, ENABLE_VBAQ, true);
 
 	amf_hevc_update_data(enc, rc, bitrate * 1000, qp);
 


### PR DESCRIPTION
### Description
Check rate control, if cqp (0), dont use vbaq.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/7827

Want CQP to work properly for HEVC AMF.

### How Has This Been Tested?
On win 11 22H2. Checked all rate controls using breakpoints, making sure only CQP disables VBAQ.

Recorded videos and made sure output was ok (fixed).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
