### PR TITLE
obs-ffmpeg: Disable VBAQ for H264 CQP rate control

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1286,7 +1286,8 @@ static bool amf_avc_init(void *data, obs_data_t *settings)
 	int rc = get_avc_rate_control(rc_str);
 
 	set_avc_property(enc, RATE_CONTROL_METHOD, rc);
-	set_avc_property(enc, ENABLE_VBAQ, true);
+	if (rc != AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CONSTANT_QP)
+		set_avc_property(enc, ENABLE_VBAQ, true);
 
 	amf_avc_update_data(enc, rc, bitrate * 1000, qp);
 


### PR DESCRIPTION
### Description
Checks if rate control is CQP, if not, enable VBAQ.

### Motivation and Context
File size is substantially (potentially 50% increase) larger with VBAQ for close to zero gain at same QP. Some metrics even score the substantially smaller file higher.

AMD says VBAQ was not designed to work with CQP. See https://github.com/GPUOpen-LibrariesAndSDKs/AMF/issues/362

Both files generated using CQP 10, with the only variable changing being VBAQ.

VMAF:
![image](https://user-images.githubusercontent.com/50419942/203372754-25352dd9-72a8-4dfd-9213-bde55f822a77.png)

| - | VBAQ Off | VBAQ On|
| ------------- | ------------- | ------------- |
| Bitrate: | 16 322 | 27 029  |
| VMAF | 98.612322  | 98.447583 |
| SSIM | 0.999355  | 0.999594 |
| PSNR | 60.837514| 61.978996 |



### How Has This Been Tested?
On Win 11 22H2, using breakpoints to ensure it only affecting CQP.

Recorded files, using all rate controls and verified output looks as expected.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
