### PR TITLE
libobs,UI: Add bool list and radio button list to properties

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -511,6 +511,9 @@ static void AddComboItem(QComboBox *combo, obs_property_t *prop,
 
 	} else if (format == OBS_COMBO_FORMAT_STRING) {
 		var = QByteArray(obs_property_list_item_string(prop, idx));
+	} else if (format == OBS_COMBO_FORMAT_BOOL) {
+		bool val = obs_property_list_item_bool(prop, idx);
+		var = QVariant::fromValue<bool>(val);
 	}
 
 	combo->addItem(QT_UTF8(name), var);
@@ -533,7 +536,8 @@ static void AddComboItem(QComboBox *combo, obs_property_t *prop,
 
 template<long long get_int(obs_data_t *, const char *),
 	 double get_double(obs_data_t *, const char *),
-	 const char *get_string(obs_data_t *, const char *)>
+	 const char *get_string(obs_data_t *, const char *),
+	 bool get_bool(obs_data_t *, const char *)>
 static QVariant from_obs_data(obs_data_t *data, const char *name,
 			      obs_combo_format format)
 {
@@ -544,6 +548,8 @@ static QVariant from_obs_data(obs_data_t *data, const char *name,
 		return QVariant::fromValue(get_double(data, name));
 	case OBS_COMBO_FORMAT_STRING:
 		return QByteArray(get_string(data, name));
+	case OBS_COMBO_FORMAT_BOOL:
+		return QVariant::fromValue(get_bool(data, name));
 	default:
 		return QVariant();
 	}
@@ -553,16 +559,17 @@ static QVariant from_obs_data(obs_data_t *data, const char *name,
 			      obs_combo_format format)
 {
 	return from_obs_data<obs_data_get_int, obs_data_get_double,
-			     obs_data_get_string>(data, name, format);
+			     obs_data_get_string, obs_data_get_bool>(data, name,
+								     format);
 }
 
 static QVariant from_obs_data_autoselect(obs_data_t *data, const char *name,
 					 obs_combo_format format)
 {
-	return from_obs_data<obs_data_get_autoselect_int,
-			     obs_data_get_autoselect_double,
-			     obs_data_get_autoselect_string>(data, name,
-							     format);
+	return from_obs_data<
+		obs_data_get_autoselect_int, obs_data_get_autoselect_double,
+		obs_data_get_autoselect_string, obs_data_get_autoselect_bool>(
+		data, name, format);
 }
 
 QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
@@ -1790,6 +1797,10 @@ void WidgetInfo::ListChanged(const char *setting)
 	case OBS_COMBO_FORMAT_STRING:
 		obs_data_set_string(view->settings, setting,
 				    data.toByteArray().constData());
+		break;
+	case OBS_COMBO_FORMAT_BOOL:
+		obs_data_set_bool(view->settings, setting,
+				  data.value<double>());
 		break;
 	}
 }

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -11,6 +11,8 @@
 #include <QComboBox>
 #include <QListWidget>
 #include <QPushButton>
+#include <QRadioButton>
+#include <QButtonGroup>
 #include <QStandardItem>
 #include <QFileDialog>
 #include <QColorDialog>
@@ -495,26 +497,30 @@ void OBSPropertiesView::AddFloat(obs_property_t *prop, QFormLayout *layout,
 	layout->addRow(*label, subLayout);
 }
 
-static void AddComboItem(QComboBox *combo, obs_property_t *prop,
-			 obs_combo_format format, size_t idx)
+static QVariant propertyListToQVariant(obs_property_t *prop, size_t idx)
 {
-	const char *name = obs_property_list_item_name(prop, idx);
-	QVariant var;
+	obs_combo_format format = obs_property_list_format(prop);
 
+	QVariant var;
 	if (format == OBS_COMBO_FORMAT_INT) {
 		long long val = obs_property_list_item_int(prop, idx);
 		var = QVariant::fromValue<long long>(val);
-
 	} else if (format == OBS_COMBO_FORMAT_FLOAT) {
 		double val = obs_property_list_item_float(prop, idx);
 		var = QVariant::fromValue<double>(val);
-
 	} else if (format == OBS_COMBO_FORMAT_STRING) {
 		var = QByteArray(obs_property_list_item_string(prop, idx));
 	} else if (format == OBS_COMBO_FORMAT_BOOL) {
 		bool val = obs_property_list_item_bool(prop, idx);
 		var = QVariant::fromValue<bool>(val);
 	}
+	return var;
+}
+
+static void AddComboItem(QComboBox *combo, obs_property_t *prop, size_t idx)
+{
+	const char *name = obs_property_list_item_name(prop, idx);
+	QVariant var = propertyListToQVariant(prop, idx);
 
 	combo->addItem(QT_UTF8(name), var);
 
@@ -532,6 +538,19 @@ static void AddComboItem(QComboBox *combo, obs_property_t *prop,
 
 	QStandardItem *item = model->item(index);
 	item->setFlags(Qt::NoItemFlags);
+}
+
+static void AddRadioItem(QButtonGroup *buttonGroup, QFormLayout *layout,
+			 obs_property_t *prop, QVariant value, size_t idx)
+{
+	const char *name = obs_property_list_item_name(prop, idx);
+
+	QVariant var = propertyListToQVariant(prop, idx);
+	QRadioButton *button = new QRadioButton(name);
+	button->setChecked(value == var);
+	button->setProperty("value", var);
+	buttonGroup->addButton(button);
+	layout->addRow(button);
 }
 
 template<long long get_int(obs_data_t *, const char *),
@@ -579,18 +598,39 @@ QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 	obs_combo_type type = obs_property_list_type(prop);
 	obs_combo_format format = obs_property_list_format(prop);
 	size_t count = obs_property_list_item_count(prop);
+
+	QVariant value = from_obs_data(settings, name, format);
+
+	if (type == OBS_COMBO_TYPE_RADIO) {
+		QButtonGroup *buttonGroup = new QButtonGroup();
+		QFormLayout *subLayout = new QFormLayout();
+		subLayout->setContentsMargins(0, 0, 0, 0);
+
+		for (size_t idx = 0; idx < count; idx++)
+			AddRadioItem(buttonGroup, subLayout, prop, value, idx);
+
+		buttonGroup->setExclusive(true);
+		WidgetInfo *info =
+			new WidgetInfo(this, prop, buttonGroup->buttons()[0]);
+		children.emplace_back(info);
+		connect(buttonGroup, SIGNAL(buttonClicked(QAbstractButton *)),
+			info, SLOT(ControlChanged()));
+
+		QWidget *widget = new QWidget();
+		widget->setLayout(subLayout);
+		return widget;
+	}
+
 	int idx = -1;
 
 	for (size_t i = 0; i < count; i++)
-		AddComboItem(combo, prop, format, i);
+		AddComboItem(combo, prop, i);
 
 	if (type == OBS_COMBO_TYPE_EDITABLE)
 		combo->setEditable(true);
 
 	combo->setMaxVisibleItems(40);
 	combo->setToolTip(QT_UTF8(obs_property_long_description(prop)));
-
-	QVariant value = from_obs_data(settings, name, format);
 
 	if (format == OBS_COMBO_FORMAT_STRING &&
 	    type == OBS_COMBO_TYPE_EDITABLE) {
@@ -1768,14 +1808,19 @@ bool WidgetInfo::PathChanged(const char *setting)
 
 void WidgetInfo::ListChanged(const char *setting)
 {
-	QComboBox *combo = static_cast<QComboBox *>(widget);
 	obs_combo_format format = obs_property_list_format(property);
 	obs_combo_type type = obs_property_list_type(property);
 	QVariant data;
 
-	if (type == OBS_COMBO_TYPE_EDITABLE) {
-		data = combo->currentText().toUtf8();
+	if (type == OBS_COMBO_TYPE_RADIO) {
+		QButtonGroup *group =
+			static_cast<QAbstractButton *>(widget)->group();
+		QAbstractButton *button = group->checkedButton();
+		data = button->property("value");
+	} else if (type == OBS_COMBO_TYPE_EDITABLE) {
+		data = static_cast<QComboBox *>(widget)->currentText().toUtf8();
 	} else {
+		QComboBox *combo = static_cast<QComboBox *>(widget);
 		int index = combo->currentIndex();
 		if (index != -1)
 			data = combo->itemData(index);

--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -194,7 +194,8 @@ Property Object Functions
 
                           - **OBS_COMBO_TYPE_EDITABLE** - Can be edited.
                             Only used with string lists.
-                          - **OBS_COMBO_TYPE_LIST** - Not editable.
+                          - **OBS_COMBO_TYPE_LIST** - Not editable. Displayed as combo box.
+                          - **OBS_COMBO_TYPE_RADIO** - Not editable. Displayed as radio buttons.
 
    :param    format:      Can be one of the following values:
 

--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -202,6 +202,7 @@ Property Object Functions
                           - **OBS_COMBO_FORMAT_FLOAT** - Floating point
                             list
                           - **OBS_COMBO_FORMAT_STRING** - String list
+                          - **OBS_COMBO_FORMAT_BOOL** - Boolean list
 
    :return:               The property
 

--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -44,6 +44,7 @@ struct list_item {
 		char *str;
 		long long ll;
 		double d;
+		bool b;
 	};
 };
 
@@ -1174,6 +1175,8 @@ static size_t add_item(struct list_data *data, const char *name,
 		item.ll = *(const long long *)val;
 	else if (data->format == OBS_COMBO_FORMAT_FLOAT)
 		item.d = *(const double *)val;
+	else if (data->format == OBS_COMBO_FORMAT_BOOL)
+		item.b = *(const bool *)val;
 	else
 		item.str = bstrdup(val);
 
@@ -1190,6 +1193,8 @@ static void insert_item(struct list_data *data, size_t idx, const char *name,
 		item.ll = *(const long long *)val;
 	else if (data->format == OBS_COMBO_FORMAT_FLOAT)
 		item.d = *(const double *)val;
+	else if (data->format == OBS_COMBO_FORMAT_BOOL)
+		item.b = *(const bool *)val;
 	else
 		item.str = bstrdup(val);
 
@@ -1223,6 +1228,14 @@ size_t obs_property_list_add_float(obs_property_t *p, const char *name,
 	return 0;
 }
 
+size_t obs_property_list_add_bool(obs_property_t *p, const char *name, bool val)
+{
+	struct list_data *data = get_list_data(p);
+	if (data && data->format == OBS_COMBO_FORMAT_BOOL)
+		return add_item(data, name, &val);
+	return 0;
+}
+
 void obs_property_list_insert_string(obs_property_t *p, size_t idx,
 				     const char *name, const char *val)
 {
@@ -1244,6 +1257,14 @@ void obs_property_list_insert_float(obs_property_t *p, size_t idx,
 {
 	struct list_data *data = get_list_data(p);
 	if (data && data->format == OBS_COMBO_FORMAT_FLOAT)
+		insert_item(data, idx, name, &val);
+}
+
+void obs_property_list_insert_bool(obs_property_t *p, size_t idx,
+				   const char *name, bool val)
+{
+	struct list_data *data = get_list_data(p);
+	if (data && data->format == OBS_COMBO_FORMAT_BOOL)
 		insert_item(data, idx, name, &val);
 }
 
@@ -1302,6 +1323,13 @@ double obs_property_list_item_float(obs_property_t *p, size_t idx)
 {
 	struct list_data *data = get_list_fmt_data(p, OBS_COMBO_FORMAT_FLOAT);
 	return (data && idx < data->items.num) ? data->items.array[idx].d : 0.0;
+}
+
+bool obs_property_list_item_bool(obs_property_t *p, size_t idx)
+{
+	struct list_data *data = get_list_fmt_data(p, OBS_COMBO_FORMAT_BOOL);
+	return (data && idx < data->items.num) ? data->items.array[idx].d
+					       : false;
 }
 
 enum obs_editable_list_type obs_property_editable_list_type(obs_property_t *p)

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -71,6 +71,7 @@ enum obs_combo_type {
 	OBS_COMBO_TYPE_INVALID,
 	OBS_COMBO_TYPE_EDITABLE,
 	OBS_COMBO_TYPE_LIST,
+	OBS_COMBO_TYPE_RADIO,
 };
 
 enum obs_editable_list_type {

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -64,6 +64,7 @@ enum obs_combo_format {
 	OBS_COMBO_FORMAT_INT,
 	OBS_COMBO_FORMAT_FLOAT,
 	OBS_COMBO_FORMAT_STRING,
+	OBS_COMBO_FORMAT_BOOL,
 };
 
 enum obs_combo_type {
@@ -364,6 +365,8 @@ EXPORT size_t obs_property_list_add_int(obs_property_t *p, const char *name,
 					long long val);
 EXPORT size_t obs_property_list_add_float(obs_property_t *p, const char *name,
 					  double val);
+EXPORT size_t obs_property_list_add_bool(obs_property_t *p, const char *name,
+					 bool val);
 
 EXPORT void obs_property_list_insert_string(obs_property_t *p, size_t idx,
 					    const char *name, const char *val);
@@ -371,6 +374,8 @@ EXPORT void obs_property_list_insert_int(obs_property_t *p, size_t idx,
 					 const char *name, long long val);
 EXPORT void obs_property_list_insert_float(obs_property_t *p, size_t idx,
 					   const char *name, double val);
+EXPORT void obs_property_list_insert_bool(obs_property_t *p, size_t idx,
+					  const char *name, bool val);
 
 EXPORT void obs_property_list_item_disable(obs_property_t *p, size_t idx,
 					   bool disabled);
@@ -383,6 +388,7 @@ EXPORT const char *obs_property_list_item_name(obs_property_t *p, size_t idx);
 EXPORT const char *obs_property_list_item_string(obs_property_t *p, size_t idx);
 EXPORT long long obs_property_list_item_int(obs_property_t *p, size_t idx);
 EXPORT double obs_property_list_item_float(obs_property_t *p, size_t idx);
+EXPORT bool obs_property_list_item_bool(obs_property_t *p, size_t idx);
 
 EXPORT enum obs_editable_list_type
 obs_property_editable_list_type(obs_property_t *p);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds `OBS_COMBO_FORMAT_BOOL` to combo formats, making it possible to have bool values in a properties list (dropdown).

Adds `OBS_COMBO_TYPE_RADIO`, which displays a properties list as radio buttons instead of as a combobox. For the API user, input and output behaves the same as `OBS_COMBO_TYPE_LIST`.
Hypothetical case of how this would look (this isn't the actual use case, which will follow in a second separated PR to make reviewing easier.):
<p float="left">
<img width="400" alt="Bildschirm­foto 2022-11-22 um 17 52 45" src="https://user-images.githubusercontent.com/59806498/203374272-8950ddbc-86a1-40ec-bcd7-e7cf0e39d17a.png">
<img width="400" alt="Bildschirm­foto 2022-11-22 um 17 53 11" src="https://user-images.githubusercontent.com/59806498/203374286-3fa965d8-a81e-4bb9-8242-92488e105f25.png">
</p>

Technically, these changes are unrelated, but one modifies each other, making it simpler to have them combined (cause the radio type also needs bool support if that would be merged first, so I'd have to fix conflicts from my own PR).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Having radio buttons in properties would be beneficial for some use cases, and a year ago at least was something on Warchamp's wishlist.
I then made this branch about half a year ago, then forgot it.

This is preparation for a second PR which I will open shortly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with the properties of the ft2-text source, as well as the browser source (see screenshot above). Also tested with a properties view in encoder settings.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
