### PR TITLE
libobs: Override fps ovi for aux views

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -589,6 +589,18 @@ static int obs_init_video_mix(struct obs_video_info *ovi,
 
 	make_video_info(&vi, ovi);
 	video->ovi = *ovi;
+
+	/* main view graphics thread drives all frame output,
+	 * so share FPS settings for aux views */
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+	size_t num = obs->video.mixes.num;
+	if (num && obs->video.main_mix) {
+		struct obs_video_info main_ovi = obs->video.main_mix->ovi;
+		video->ovi.fps_num = main_ovi.fps_num;
+		video->ovi.fps_den = main_ovi.fps_den;
+	}
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
 	video->gpu_conversion = ovi->gpu_conversion;
 	video->gpu_was_active = false;
 	video->raw_was_active = false;


### PR DESCRIPTION
### Description
- libobs: Override fps ovi for aux views

### Motivation and Context

Previous iteration at https://github.com/obsproject/obs-studio/pull/7797 had discussion that since the one graphics thread drives all outputs, aux views should inherit the FPS settings from the main view

### How Has This Been Tested?
- Tested on a custom plugin that aux view do get settings from the main mix when available
- Tested what happens when video output settings are changed in the UI and obs_reset_video() is triggered

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
