### PR TITLE
docs: Clarify source update_properties signal

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -616,7 +616,11 @@ Source Signals
 
 **update_properties** (ptr source)
 
-   Called when the properties of the source have been updated.
+   Called to signal to any properties view (or other users of the source's
+   obs_properties_t) that the presentable properties of the source have changed
+   and should be re-queried via obs_source_properties.
+   Does not mean that the source's *settings* (as configured by the user) have
+   changed. For that, use the `update` signal instead.
 
 **update_flags** (ptr source, int flags)
 
@@ -1506,7 +1510,9 @@ Functions used by sources
 
 .. function:: void obs_source_update_properties(obs_source_t *source)
 
-   Signal an update to any currently used properties.
+   Signals to any currently opened properties views (or other users of the
+   source's obs_properties_t) that the source's presentable properties have
+   changed and that the view should be updated.
 
 ---------------------
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Clarifies the documentation on the `update_properties` signal of a source.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Over time, there's been a lot of confusion about this signal.
Quite a few of people (including myself) mistook it for a signal that's called when a source's settings are updated, which is wrong.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Had CI generate the docs:
<img width="789" alt="image" src="https://user-images.githubusercontent.com/59806498/203629569-a855ecb4-acdb-46f0-9ded-af343ff389ae.png">

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
