### PR TITLE
obs-filters: Use correct signal to reset greenscreen filter

### DIFF
--- a/plugins/obs-filters/nvidia-greenscreen-filter.c
+++ b/plugins/obs-filters/nvidia-greenscreen-filter.c
@@ -724,7 +724,7 @@ static void nv_greenscreen_filter_render(void *data, gs_effect_t *effect)
 
 	if (parent && !filter->handler) {
 		filter->handler = obs_source_get_signal_handler(parent);
-		signal_handler_connect(filter->handler, "update_properties",
+		signal_handler_connect(filter->handler, "update",
 				       nv_greenscreen_filter_reset, filter);
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Use the `source_update` signal instead of `update_properties` to find out when the parent's settings have changed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed when writing #7845 and looking for potential wrong uses of `update_properties`.
Currently it likely only works on `Video Capture Device` and `Decklink Input` sources, because those sources happen to call `obs_source_update_properties` which triggers the `update_properties` signal. This means that the original issue of #6870 should still appear on other sources, which this PR is looking to change.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested by pkv 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
