### PR TITLE
obs-ffmpeg: Improve chroma location decision

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -99,6 +99,7 @@ struct main_params {
 	int color_trc;
 	int colorspace;
 	int color_range;
+	int chroma_sample_location;
 	int max_luminance;
 	char *acodec;
 	char *muxer_settings;
@@ -369,6 +370,9 @@ static bool init_params(int *argc, char ***argv, struct main_params *params,
 		if (!get_opt_int(argc, argv, &params->color_range,
 				 "video color range"))
 			return false;
+		if (!get_opt_int(argc, argv, &params->chroma_sample_location,
+				 "video chroma sample location"))
+			return false;
 		if (!get_opt_int(argc, argv, &params->max_luminance,
 				 "video max luminance"))
 			return false;
@@ -459,10 +463,7 @@ static void create_video_stream(struct ffmpeg_mux *ffm)
 	context->color_trc = ffm->params.color_trc;
 	context->colorspace = ffm->params.colorspace;
 	context->color_range = ffm->params.color_range;
-	context->chroma_sample_location =
-		(ffm->params.colorspace == AVCOL_SPC_BT2020_NCL)
-			? AVCHROMA_LOC_TOPLEFT
-			: AVCHROMA_LOC_LEFT;
+	context->chroma_sample_location = ffm->params.chroma_sample_location;
 	context->extradata = extradata;
 	context->extradata_size = ffm->video_header.size;
 	context->time_base =

--- a/plugins/obs-ffmpeg/obs-ffmpeg-formats.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-formats.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <libavcodec/avcodec.h>
+#include <libavutil/pixdesc.h>
 
 static inline int64_t rescale_ts(int64_t val, AVCodecContext *context,
 				 AVRational new_base)
@@ -47,11 +48,9 @@ obs_to_ffmpeg_video_format(enum video_format format)
 		return AV_PIX_FMT_YUVA422P;
 	case VIDEO_FORMAT_YUVA:
 		return AV_PIX_FMT_YUVA444P;
-	case VIDEO_FORMAT_YA2L:
 #if LIBAVUTIL_BUILD >= AV_VERSION_INT(56, 31, 100)
+	case VIDEO_FORMAT_YA2L:
 		return AV_PIX_FMT_YUVA444P12LE;
-#else
-		return AV_PIX_FMT_NONE;
 #endif
 	case VIDEO_FORMAT_I010:
 		return AV_PIX_FMT_YUV420P10LE;
@@ -59,11 +58,41 @@ obs_to_ffmpeg_video_format(enum video_format format)
 		return AV_PIX_FMT_P010LE;
 	case VIDEO_FORMAT_NONE:
 	case VIDEO_FORMAT_AYUV:
-		/* not supported by FFmpeg */
+	default:
 		return AV_PIX_FMT_NONE;
 	}
+}
 
-	return AV_PIX_FMT_NONE;
+static enum AVChromaLocation
+determine_chroma_location(enum AVPixelFormat pix_fmt,
+			  enum AVColorSpace colorspace)
+{
+	const AVPixFmtDescriptor *const desc = av_pix_fmt_desc_get(pix_fmt);
+	if (desc) {
+		const unsigned log_chroma_w = desc->log2_chroma_w;
+		const unsigned log_chroma_h = desc->log2_chroma_h;
+		switch (log_chroma_h) {
+		case 0:
+			switch (log_chroma_w) {
+			case 0:
+				/* 4:4:4 */
+				return AVCHROMA_LOC_CENTER;
+			case 1:
+				/* 4:2:2 */
+				return AVCHROMA_LOC_LEFT;
+			}
+			break;
+		case 1:
+			if (log_chroma_w == 1) {
+				/* 4:2:0 */
+				return (colorspace == AVCOL_SPC_BT2020_NCL)
+					       ? AVCHROMA_LOC_TOPLEFT
+					       : AVCHROMA_LOC_LEFT;
+			}
+		}
+	}
+
+	return AVCHROMA_LOC_UNSPECIFIED;
 }
 
 static inline enum audio_format

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -206,10 +206,8 @@ static bool create_video_stream(struct ffmpeg_output *stream,
 	context->color_primaries = data->config.color_primaries;
 	context->color_trc = data->config.color_trc;
 	context->colorspace = data->config.colorspace;
-	context->chroma_sample_location =
-		(data->config.colorspace == AVCOL_SPC_BT2020_NCL)
-			? AVCHROMA_LOC_TOPLEFT
-			: AVCHROMA_LOC_LEFT;
+	context->chroma_sample_location = determine_chroma_location(
+		data->config.format, data->config.colorspace);
 	context->thread_count = 0;
 
 	data->video->time_base = context->time_base;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -16,6 +16,7 @@
 ******************************************************************************/
 #include "ffmpeg-mux/ffmpeg-mux.h"
 #include "obs-ffmpeg-mux.h"
+#include "obs-ffmpeg-formats.h"
 
 #ifdef _WIN32
 #include "util/windows/win-version.h"
@@ -192,12 +193,15 @@ static void add_video_encoder_params(struct ffmpeg_muxer *stream,
 			? (int)obs_get_video_hdr_nominal_peak_level()
 			: ((trc == AVCOL_TRC_ARIB_STD_B67) ? 1000 : 0);
 
-	dstr_catf(cmd, "%s %d %d %d %d %d %d %d %d %d %d %d ",
+	dstr_catf(cmd, "%s %d %d %d %d %d %d %d %d %d %d %d %d ",
 		  obs_encoder_get_codec(vencoder), bitrate,
 		  obs_output_get_width(stream->output),
 		  obs_output_get_height(stream->output), (int)pri, (int)trc,
-		  (int)spc, (int)range, max_luminance, (int)info->fps_num,
-		  (int)info->fps_den, (int)codec_tag);
+		  (int)spc, (int)range,
+		  (int)determine_chroma_location(
+			  obs_to_ffmpeg_video_format(info->format), spc),
+		  max_luminance, (int)info->fps_num, (int)info->fps_den,
+		  (int)codec_tag);
 }
 
 static void add_audio_encoder_params(struct dstr *cmd, obs_encoder_t *aencoder)

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -152,10 +152,8 @@ static bool open_video_codec(struct ffmpeg_data *data)
 	data->vframe->color_primaries = data->config.color_primaries;
 	data->vframe->color_trc = data->config.color_trc;
 	data->vframe->colorspace = data->config.colorspace;
-	data->vframe->chroma_location =
-		(data->config.colorspace == AVCOL_SPC_BT2020_NCL)
-			? AVCHROMA_LOC_TOPLEFT
-			: AVCHROMA_LOC_LEFT;
+	data->vframe->chroma_location = determine_chroma_location(
+		context->pix_fmt, data->config.colorspace);
 
 	ret = av_frame_get_buffer(data->vframe, base_get_alignment());
 	if (ret < 0) {
@@ -262,10 +260,8 @@ static bool create_video_stream(struct ffmpeg_data *data)
 	context->color_primaries = data->config.color_primaries;
 	context->color_trc = data->config.color_trc;
 	context->colorspace = data->config.colorspace;
-	context->chroma_sample_location =
-		(data->config.colorspace == AVCOL_SPC_BT2020_NCL)
-			? AVCHROMA_LOC_TOPLEFT
-			: AVCHROMA_LOC_LEFT;
+	context->chroma_sample_location = determine_chroma_location(
+		closest_format, data->config.colorspace);
 	context->thread_count = 0;
 
 	data->video->time_base = context->time_base;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -145,6 +145,8 @@ static bool vaapi_init_codec(struct vaapi_encoder *enc, const char *path)
 	enc->vframe->height = enc->context->height;
 	enc->vframe->colorspace = enc->context->colorspace;
 	enc->vframe->color_range = enc->context->color_range;
+	enc->vframe->chroma_location = determine_chroma_location(
+		enc->context->pix_fmt, enc->context->colorspace);
 
 	ret = av_frame_get_buffer(enc->vframe, base_get_alignment());
 	if (ret < 0) {
@@ -700,7 +702,7 @@ static obs_properties_t *vaapi_properties(void *unused)
 				char card[128];
 				int ret = snprintf(card, sizeof(card),
 						   "Card%d: %s", i - 28, path);
-				if (ret >= sizeof(card))
+				if (ret >= (int)sizeof(card))
 					blog(LOG_DEBUG,
 					     "obs-ffmpeg-vaapi: A format truncation may have occurred."
 					     " This can be ignored since it is quite improbable.");


### PR DESCRIPTION
### Description
The chroma location doesn't just depend on pixel format, but we're just trying to pick something reasonable for now.

This was part of #7818, but I split these changes out in case we don't want to take the ProRes changes yet.

### Motivation and Context
Want accurate metadata, so players are more likely to decode correctly.

### How Has This Been Tested?
Verified chroma location is still good in debugger for NV12 Rec. 709 and Rec. 2100 PQ. Tested P216 and P416 in #7818.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.