### PR TITLE
UI: Fix slide counter with no slides

### DIFF
--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -510,6 +510,11 @@ void MediaControls::UpdateSlideCounter()
 	int total = calldata_int(&cd, "total_files");
 	calldata_free(&cd);
 
-	ui->timerLabel->setText(QString::number(slide + 1));
-	ui->durationLabel->setText(QString::number(total));
+	if (total > 0) {
+		ui->timerLabel->setText(QString::number(slide + 1));
+		ui->durationLabel->setText(QString::number(total));
+	} else {
+		ui->timerLabel->setText("-");
+		ui->durationLabel->setText("-");
+	}
 }


### PR DESCRIPTION
### Description
When a slideshow is created with no slides, the slide counter shows value of "1 / 0". Now it shows "- / -".

Before:
![Screenshot from 2022-11-24 00-00-24](https://user-images.githubusercontent.com/19962531/203709466-2cfb1185-8e72-45d4-8196-aa21a88110a2.png)

After:
![Screenshot from 2022-11-24 00-19-38](https://user-images.githubusercontent.com/19962531/203709525-45a74aea-3a2d-4004-bcf6-00e08acc983d.png)

### Motivation and Context
Fixes bug I noticed.

### How Has This Been Tested?
Created slideshow with no slides and made sure the slide counter looked correct.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
