### PR TITLE
obs-ffmpeg: Allow srt stream to disconnect after timeout

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-srt.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-srt.h
@@ -155,9 +155,10 @@ static int libsrt_network_wait_fd(URLContext *h, int eid, int write)
 		/* Socket reported in wsock AND rsock signifies an error. */
 		int reason = srt_getrejectreason(*ready);
 
-		if (reason == SRT_REJ_BADSECRET || reason == SRT_REJ_UNSECURE) {
+		if (reason == SRT_REJ_BADSECRET || reason == SRT_REJ_UNSECURE ||
+		    reason == SRT_REJ_TIMEOUT) {
 			blog(LOG_ERROR,
-			     "[obs-ffmpeg mpegts muxer / libsrt]: Connection rejected, wrong password");
+			     "[obs-ffmpeg mpegts muxer / libsrt]: Connection rejected, wrong password or invalid URL");
 			return OBS_OUTPUT_INVALID_STREAM;
 		} else {
 			blog(LOG_ERROR,


### PR DESCRIPTION
### Description
Fixes #7848
Currently OBS_OUTPUT_INVALID_STREAM is emitted when a wrong password is used. This commit expands the signal emission to case of timeouts.

### Motivation and Context
Bugfix is good.

### How Has This Been Tested?
Tested that a wrong srt URL leads to emission of OBS_OUTPUT_INVALID_STREAM and that the stream is stopped with the 
corresponding error message.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
