### PR TITLE
UI: Disable replay buffer checkbox when using custom FFmpeg

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -945,6 +945,7 @@ Basic.Settings.Output.ReplayBuffer.EstimateTooLarge="Warning: Estimated memory u
 Basic.Settings.Output.ReplayBuffer.EstimateUnknown="Cannot estimate memory usage. Please set maximum memory limit."
 Basic.Settings.Output.ReplayBuffer.Prefix="Replay Buffer Filename Prefix"
 Basic.Settings.Output.ReplayBuffer.Suffix="Suffix"
+Basic.Settings.Output.ReplayBuffer.UnavailableCustomFFmpeg="Replay Buffer cannot be used when recording type is set to Custom Output (FFmpeg)."
 Basic.Settings.Output.Simple.SavePath="Recording Path"
 Basic.Settings.Output.Simple.RecordingQuality="Recording Quality"
 Basic.Settings.Output.Simple.RecordingQuality.Stream="Same as stream"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -4594,6 +4594,16 @@
                         <number>9</number>
                        </property>
                        <item>
+                        <widget class="QLabel" name="advReplayBufCustomFFmpeg">
+                         <property name="text">
+                          <string>Basic.Settings.Output.ReplayBuffer.UnavailableCustomFFmpeg</string>
+                         </property>
+                         <property name="themeID" stdset="0">
+                          <string>warning</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
                         <widget class="QCheckBox" name="advReplayBuf">
                          <property name="text">
                           <string>Basic.Settings.Output.UseReplayBuffer</string>

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -5083,8 +5083,10 @@ void OBSBasicSettings::UpdateAutomaticReplayBufferCheckboxes()
 		break;
 	case 1:
 		state = ui->advReplayBuf->isChecked();
+		bool customFFmpeg = ui->advOutRecType->currentIndex() == 1;
 		ui->advReplayBuf->setEnabled(
-			!obs_frontend_replay_buffer_active());
+			!obs_frontend_replay_buffer_active() && !customFFmpeg);
+		ui->advReplayBufCustomFFmpeg->setVisible(customFFmpeg);
 		break;
 	}
 	ui->replayWhileStreaming->setEnabled(state);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Disables the "Enable Replay Buffer" checkbox in Advanced output mode if the recording type is set to "Custom Output (FFmpeg)" and adds a label stating why it's disabled.

<img width="600" alt="Bildschirm­foto 2022-11-25 um 10 42 02" src="https://user-images.githubusercontent.com/59806498/203950039-8a724a59-c850-480c-bb21-3fb340bfda40.png">

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Closes #4948


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Switched back and forth between normal and custom FFmpeg Output, checked that the checkbox is disabled and the text is visible, and that the checkbox is enabled and the text invisible otherwise.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
