### PR TITLE
UI: Guard GetMonitorName behind Qt < 6.4

### DIFF
--- a/UI/platform-windows.cpp
+++ b/UI/platform-windows.cpp
@@ -356,6 +356,7 @@ static BOOL CALLBACK GetMonitorCallback(HMONITOR monitor, HDC, LPRECT,
 	return true;
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
 #define GENERIC_MONITOR_NAME QStringLiteral("Generic PnP Monitor")
 
 QString GetMonitorName(const QString &id)
@@ -417,6 +418,7 @@ QString GetMonitorName(const QString &id)
 
 	return QString::fromWCharArray(target.monitorFriendlyDeviceName);
 }
+#endif
 
 /* Based on https://www.winehq.org/pipermail/wine-devel/2008-September/069387.html */
 typedef const char *(CDECL *WINEGETVERSION)(void);

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -74,7 +74,9 @@ public:
 	RunOnceMutex &operator=(RunOnceMutex &&rom);
 };
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
 QString GetMonitorName(const QString &id);
+#endif
 bool IsRunningOnWine();
 #endif
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
d27cda1 made `GetMonitorName` unused on newer Qt versions, so it only needs to be defined for older ones.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Potential code cleanup in the (far) future.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Checked via `git grep` that the only other instance of `GetMonitorName` is in `win-capture`, where the function is defined again (since it can't access UI code anyways).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
