### PR TITLE
UI: Hide "Update Channel" label on macOS

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -288,7 +288,7 @@
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                    </property>
                    <item row="0" column="0">
-                    <widget class="QLabel" name="label_10">
+                    <widget class="QLabel" name="updateChannelLabel">
                      <property name="text">
                       <string>Basic.Settings.General.UpdateChannel</string>
                      </property>

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -588,6 +588,8 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 #elif defined(__APPLE__)
 	delete ui->updateChannelBox;
 	ui->updateChannelBox = nullptr;
+	delete ui->updateChannelLabel;
+	ui->updateChannelLabel = nullptr;
 #else
 	// Hide update section if disabled
 	if (App()->IsUpdaterDisabled())


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes the "Update Channel" label on macOS.
<img width="600" alt="Bildschirm­foto 2022-11-26 um 01 04 17" src="https://user-images.githubusercontent.com/59806498/204064385-c166eed1-6f0f-4829-9e11-5c0d83d0fc29.png">

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Update channels aren't implemented on macOS yet (until #7723, which doesn't look like it'll get merged for this update), and this looks weird:
<img width="600" alt="Bildschirm­foto 2022-11-26 um 01 05 12" src="https://user-images.githubusercontent.com/59806498/204064386-e285ff6d-2fbe-470a-b299-b77c8f93c879.png">


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Confirmed that the label is gone, see screenshot above.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
