### PR TITLE
cmake/CI: Add Sparkle EdDSA key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,8 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET_ARM64: '11.0'
       SPARKLE_VERSION: '1.26.0'
       SPARKLE_HASH: '8312cbf7528297a49f1b97692c33cb8d33254c396dc51be394e9484e4b6833a0'
+      SPARKLE_APPCAST_URL: 'https://obsproject.com/osx_update/stable/updates_${{ matrix.arch }}.xml'
+      SPARKLE_PUBLIC_KEY: 'HQ5/Ba9VHOuEWaM0jtVjZzgHKFJX9YTl+HNVpgNF0iM='
       BLOCKED_FORMULAS: 'speexdsp curl php composer'
       CODESIGN_IDENT: '-'
       HAVE_CODESIGN_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY != '' && secrets.MACOS_SIGNING_CERT != '' }}

--- a/CI/macos/02_build_obs.sh
+++ b/CI/macos/02_build_obs.sh
@@ -69,6 +69,10 @@ _configure_obs() {
         UNITTEST_OPTIONS="-DENABLE_UNIT_TESTS=ON"
     fi
 
+    if [ "${SPARKLE_APPCAST_URL}" -a "${SPARKLE_PUBLIC_KEY}" ]; then
+        SPARKLE_OPTIONS="-DSPARKLE_APPCAST_URL=\"${SPARKLE_APPCAST_URL}\" -DSPARKLE_PUBLIC_KEY=\"${SPARKLE_PUBLIC_KEY}\""
+    fi
+
     cmake -S . -B ${BUILD_DIR} -G ${GENERATOR} \
         -DCEF_ROOT_DIR="${DEPS_BUILD_DIR}/cef_binary_${MACOS_CEF_BUILD_VERSION:-${CI_MACOS_CEF_VERSION}}_macos_${ARCH:-x86_64}" \
         -DENABLE_BROWSER=ON \
@@ -86,6 +90,7 @@ _configure_obs() {
         ${TWITCH_OPTIONS} \
         ${RESTREAM_OPTIONS} \
         ${UNITTEST_OPTIONS} \
+        ${SPARKLE_OPTIONS} \
         ${CI:+-DBUILD_FOR_DISTRIBUTION=${BUILD_FOR_DISTRIBUTION} -DOBS_BUILD_NUMBER=${GITHUB_RUN_ID}} \
         ${QUIET:+-Wno-deprecated -Wno-dev --log-level=ERROR}
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,10 +52,6 @@ if(OS_WINDOWS)
     "Build a multiarch installer (needs to run independently after both archs have compiled) (Windows)"
     OFF)
 
-elseif(OS_MACOS)
-  option(ENABLE_SPARKLE_UPDATER "Enable Sparkle framework for updates (macOS)"
-         OFF)
-
 elseif(OS_POSIX)
   option(LINUX_PORTABLE "Build portable version (Linux)" OFF)
   option(USE_XDG "Utilize XDG Base Directory Specification (Linux)" ON)

--- a/cmake/Modules/ObsDefaults_macOS.cmake
+++ b/cmake/Modules/ObsDefaults_macOS.cmake
@@ -138,7 +138,6 @@ macro(setup_obs_project)
   endif()
 
   if(BUILD_FOR_DISTRIBUTION OR DEFINED ENV{CI})
-    set_option(ENABLE_SPARKLE_UPDATER ON)
     set_option(ENABLE_RTMPS ON)
   endif()
 

--- a/cmake/Modules/ObsHelpers_macOS.cmake
+++ b/cmake/Modules/ObsHelpers_macOS.cmake
@@ -354,13 +354,21 @@ function(setup_obs_bundle target)
     set(_CODESIGN_ENTITLEMENTS \"${CMAKE_SOURCE_DIR}/cmake/bundle/macOS\")"
     COMPONENT obs_resources)
 
-  if(ENABLE_SPARKLE_UPDATER)
+  if(SPARKLE_APPCAST_URL AND SPARKLE_PUBLIC_KEY)
     add_custom_command(
       TARGET ${target}
       POST_BUILD
       COMMAND
         /bin/sh -c
-        "plutil -replace SUFeedURL -string https://obsproject.com/osx_update/stable/updates_${CMAKE_OSX_ARCHITECTURES}.xml \"$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Info.plist\""
+        "plutil -replace SUFeedURL -string ${SPARKLE_APPCAST_URL} \"$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Info.plist\""
+      VERBATIM)
+
+    add_custom_command(
+      TARGET ${target}
+      POST_BUILD
+      COMMAND
+        /bin/sh -c
+        "plutil -replace SUPublicEDKey -string \"${SPARKLE_PUBLIC_KEY}\" \"$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Info.plist\""
       VERBATIM)
 
     add_custom_command(


### PR DESCRIPTION
### Description

Backports some changes from #7723 to add EdDSA keys to future OBS versions sooner rather than later.

### Motivation and Context

For a cleaner transition to Sparkle 2 and purely EdDSA signed updates it would be helpful to start including our EdDSA key now.

Also makes #7830 usable to generate the appcast going forward without waiting on #7723 (even if we might want to cross-sign 29.0 itself with DSA still).

### How Has This Been Tested?

Builds fine.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
