### PR TITLE
win-dshow: Ignore FFmpeg colorspace if overridden

### DIFF
--- a/plugins/win-dshow/ffmpeg-decode.c
+++ b/plugins/win-dshow/ffmpeg-decode.c
@@ -312,7 +312,7 @@ convert_color_space(enum AVColorSpace s, enum AVColorTransferCharacteristic trc,
 }
 
 bool ffmpeg_decode_video(struct ffmpeg_decode *decode, uint8_t *data,
-			 size_t size, long long *ts,
+			 size_t size, long long *ts, enum video_colorspace cs,
 			 enum video_range_type range,
 			 struct obs_source_frame2 *frame, bool *got_output)
 {
@@ -396,9 +396,11 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode, uint8_t *data,
 				: VIDEO_RANGE_PARTIAL;
 	}
 
-	const enum video_colorspace cs = convert_color_space(
-		decode->frame->colorspace, decode->frame->color_trc,
-		decode->frame->color_primaries);
+	if (cs == VIDEO_CS_DEFAULT) {
+		cs = convert_color_space(decode->frame->colorspace,
+					 decode->frame->color_trc,
+					 decode->frame->color_primaries);
+	}
 
 	const bool success = video_format_get_parameters_for_format(
 		cs, range, format, frame->color_matrix, frame->color_range_min,

--- a/plugins/win-dshow/ffmpeg-decode.h
+++ b/plugins/win-dshow/ffmpeg-decode.h
@@ -59,6 +59,7 @@ extern bool ffmpeg_decode_audio(struct ffmpeg_decode *decode, uint8_t *data,
 
 extern bool ffmpeg_decode_video(struct ffmpeg_decode *decode, uint8_t *data,
 				size_t size, long long *ts,
+				enum video_colorspace cs,
 				enum video_range_type range,
 				struct obs_source_frame2 *frame,
 				bool *got_output);

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -198,6 +198,7 @@ struct DShowInput {
 	VideoConfig videoConfig;
 	AudioConfig audioConfig;
 
+	enum video_colorspace cs;
 	obs_source_frame2 frame;
 	obs_source_audio audio;
 	long lastRotation = 0;
@@ -505,7 +506,7 @@ void DShowInput::OnEncodedVideoData(enum AVCodecID id, unsigned char *data,
 	}
 
 	bool got_output;
-	bool success = ffmpeg_decode_video(video_decoder, data, size, &ts,
+	bool success = ffmpeg_decode_video(video_decoder, data, size, &ts, cs,
 					   frame.range, &frame, &got_output);
 	if (!success) {
 		blog(LOG_WARNING, "Error decoding video");
@@ -1155,7 +1156,7 @@ inline bool DShowInput::Activate(obs_data_t *settings)
 	if (device.Start() != Result::Success)
 		return false;
 
-	const enum video_colorspace cs = GetColorSpace(settings);
+	cs = GetColorSpace(settings);
 	const enum video_range_type range = GetColorRange(settings);
 
 	enum video_trc trc = VIDEO_TRC_DEFAULT;


### PR DESCRIPTION
### Description
Verified MJPEG devices are no longer locked to Rec. 601.

### Motivation and Context
Want to be able to have more accurate colors.

### How Has This Been Tested?
Verified matrix override works now on Logitech BRIO in MJPEG mode.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.