### PR TITLE
frontend-tools: Fix crash on non X11 windowing systems

### DIFF
--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher-nix.cpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher-nix.cpp
@@ -46,8 +46,14 @@ static bool ewmhIsSupported()
 	unsigned long num = 0, bytes = 0;
 	unsigned char *data = NULL;
 	Window ewmh_window = 0;
+	Window root_window = 0;
 
-	int status = XGetWindowProperty(display, DefaultRootWindow(display),
+	root_window = DefaultRootWindow(display);
+	if (!root_window) {
+		return false;
+	}
+
+	int status = XGetWindowProperty(display, root_window,
 					netSupportingWmCheck, 0L, 1L, false,
 					XA_WINDOW, &actualType, &format, &num,
 					&bytes, &data);
@@ -97,6 +103,9 @@ static std::vector<Window> getTopLevelWindows()
 
 	for (int i = 0; i < ScreenCount(disp()); ++i) {
 		Window rootWin = RootWindow(disp(), i);
+		if (!rootWin) {
+			continue;
+		}
 
 		int status = XGetWindowProperty(disp(), rootWin, netClList, 0L,
 						~0L, false, AnyPropertyType,
@@ -119,6 +128,9 @@ static std::vector<Window> getTopLevelWindows()
 static std::string GetWindowTitle(size_t i)
 {
 	Window w = getTopLevelWindows().at(i);
+	if (!w) {
+		return "";
+	}
 	std::string windowTitle;
 	char *name;
 
@@ -164,11 +176,17 @@ void GetCurrentWindowTitle(string &title)
 	char *name;
 
 	Window rootWin = RootWindow(disp(), 0);
+	if (!rootWin) {
+		return;
+	}
 
 	XGetWindowProperty(disp(), rootWin, active, 0L, ~0L, false,
 			   AnyPropertyType, &actualType, &format, &num, &bytes,
 			   (uint8_t **)&data);
 
+	if (!data[0]) {
+		return;
+	}
 	int status = XFetchName(disp(), data[0], &name);
 
 	if (status >= Success && name != nullptr) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
On non X11 windowing systems OBS will crash when the automatic scene switcher is enabled and the current foreground window is changed due to invalid Window parameters being passed to various X11 functions:

```
X Error of failed request:  BadWindow (invalid Window parameter)
  Major opcode of failed request:  20 (X_GetProperty)
  Resource id in failed request:  0x0
  Serial number of failed request:  29
  Current serial number in output stream:  29
```


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Add error handling to avoid passing invalid windows to various X11 functions and thus crashes of OBS.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OBS no longer crashes on Ubuntu 22 with the Wayland windowing system when the automatic scene switcher is enabled and the foreground window is changed.

The automatic scene switcher still works as expected on Ubuntu 22 with the X11 windowing system.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
