### PR TITLE
UI: Fix Qt AutoUic warning

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -7664,7 +7664,6 @@
   <tabstop>colorSpace</tabstop>
   <tabstop>colorRange</tabstop>
   <tabstop>sdrWhiteLevel</tabstop>
-  <tabstop>horizontalLayout_sdrPaperWhite</tabstop>
   <tabstop>hdrNominalPeakLevel</tabstop>
   <tabstop>disableOSXVSync</tabstop>
   <tabstop>resetOSXVSync</tabstop>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Currently, Qt's User Interface Compiler (UIC) emits a warning about the tabstop assignment for horizontalLayout_sdrPaperWhite, which is a QLayout rather than a QWidget. Remove the tabstop assignment to fix the warning.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want less warnings while building. Get rid of this warning:
```
Automatic MOC and UIC for target obs
AutoUic: C:\dev\obsproject\obs-studio\UI\forms\OBSBasicSettings.ui: Warning: Tab-stop assignment: 'horizontalLayout_sdrPaperWhite' is not a valid widget.
```

cc @norihiro since this was added in #7486.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
On Windows 11, I built OBS before and after this change. Verified that the warning is gone and that OBS builds and runs.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
