### PR TITLE
obs-filter: Fix upward compressor

### DIFF
--- a/plugins/obs-filters/expander-filter.c
+++ b/plugins/obs-filters/expander-filter.c
@@ -178,7 +178,7 @@ static void upward_compressor_defaults(obs_data_t *s)
 	obs_data_set_default_int(s, S_ATTACK_TIME, 10);
 	obs_data_set_default_int(s, S_RELEASE_TIME, 50);
 	obs_data_set_default_double(s, S_OUTPUT_GAIN, 0.0);
-	obs_data_set_default_string(s, S_DETECTOR, "peak");
+	obs_data_set_default_string(s, S_DETECTOR, "RMS");
 }
 
 static void expander_update(void *data, obs_data_t *s)
@@ -382,8 +382,12 @@ static inline void process_sample(size_t idx, float *samples, float *env_buf,
 	float min_val =
 		is_upwcomp ? fminf(diff, threshold - mul_to_db(samples[idx]))
 			   : 0.0f;
-
 	gain = db_to_mul(fminf(min_val, gain_db[idx]));
+
+	// above threshold, don't process expander nor upward compressor
+	if (threshold - env_db <= 0)
+		gain = 1.0f;
+
 	samples[idx] *= gain * output_gain;
 }
 


### PR DESCRIPTION
### Description
This fixes a bug where the upward compressor would hard limit above the threshold.
Also this changes detection to RMS instead of peak for the upward compressor.
This sounds better than peak (tested on regular mike and a test tone).

### Motivation and Context
Fixes a bug. Bugs are bad.

### How Has This Been Tested?
Tested on a sine test tone and on a regular mike.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Performance enhancement (non-breaking change which improves efficiency) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
