### PR TITLE
obs-ffmpeg: Add new rate control method mappings for AVC/HEVC

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1189,8 +1189,18 @@ static inline int get_avc_rate_control(const char *rc_str)
 {
 	if (astrcmpi(rc_str, "cqp") == 0)
 		return AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CONSTANT_QP;
+	else if (astrcmpi(rc_str, "cbr") == 0)
+		return AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CBR;
 	else if (astrcmpi(rc_str, "vbr") == 0)
 		return AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR;
+	else if (astrcmpi(rc_str, "vbr_lat") == 0)
+		return AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR;
+	else if (astrcmpi(rc_str, "qvbr") == 0)
+		return AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_QUALITY_VBR;
+	else if (astrcmpi(rc_str, "hqvbr") == 0)
+		return AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR;
+	else if (astrcmpi(rc_str, "hqcbr") == 0)
+		return AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_HIGH_QUALITY_CBR;
 
 	return AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CBR;
 }
@@ -1514,8 +1524,18 @@ static inline int get_hevc_rate_control(const char *rc_str)
 {
 	if (astrcmpi(rc_str, "cqp") == 0)
 		return AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CONSTANT_QP;
+	else if (astrcmpi(rc_str, "vbr_lat") == 0)
+		return AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR;
 	else if (astrcmpi(rc_str, "vbr") == 0)
 		return AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR;
+	else if (astrcmpi(rc_str, "cbr") == 0)
+		return AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CBR;
+	else if (astrcmpi(rc_str, "qvbr") == 0)
+		return AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_QUALITY_VBR;
+	else if (astrcmpi(rc_str, "hqvbr") == 0)
+		return AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR;
+	else if (astrcmpi(rc_str, "hqcbr") == 0)
+		return AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_HIGH_QUALITY_CBR;
 
 	return AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CBR;
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Added mappings for the new AMD AVC/HEVC rate control methods in AMF v1.4.29 to set the correct new values.

### Motivation and Context
My last PR to enable the new RC methods for AVC/HEVC enabled the options in the UI. The OBS logs for the AMF texture encode show the encoder settings based on the UI settings and before actual encoder initialization which may or may not change more settings based on requested user config. With this change, I have confirmed the RC methods are correctly mapped and have appropriate values set at the AMF level inside the AMD driver.

### How Has This Been Tested?
Tested on Windows 10 with the new AMF texture based encoder integration. Confirmed the RC methods are correctly mapped and have appropriate values set at the AMF level inside the AMD driver.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
