### PR TITLE
obs-qsv11: Put mastering primaries in GBR order

### DIFF
--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -624,12 +624,12 @@ static void update_params(struct obs_qsv *obsqsv, obs_data_t *settings)
 			pq ? (int)obs_get_video_hdr_nominal_peak_level()
 			   : (hlg ? 1000 : 0);
 
-		obsqsv->params.DisplayPrimariesX[0] = 34000;
-		obsqsv->params.DisplayPrimariesX[1] = 13250;
-		obsqsv->params.DisplayPrimariesX[2] = 7500;
-		obsqsv->params.DisplayPrimariesY[0] = 16000;
-		obsqsv->params.DisplayPrimariesY[1] = 34500;
-		obsqsv->params.DisplayPrimariesY[2] = 3000;
+		obsqsv->params.DisplayPrimariesX[0] = 13250;
+		obsqsv->params.DisplayPrimariesX[1] = 7500;
+		obsqsv->params.DisplayPrimariesX[2] = 34000;
+		obsqsv->params.DisplayPrimariesY[0] = 34500;
+		obsqsv->params.DisplayPrimariesY[1] = 3000;
+		obsqsv->params.DisplayPrimariesY[2] = 16000;
 		obsqsv->params.WhitePointX = 15635;
 		obsqsv->params.WhitePointY = 16450;
 		obsqsv->params.MaxDisplayMasteringLuminance =


### PR DESCRIPTION
### Description
HDR mastering primaries are supposed to be GBR order, not RGB. FFmpeg does the same with their QSV implementation.

### Motivation and Context
Want metadata to be correct.

### How Has This Been Tested?
Verified MediaInfo still parses HEVC as Display P3.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.