### PR TITLE
UI: Disable properties button in source toolbar

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3089,10 +3089,26 @@ void OBSBasic::UpdateContextBarDeferred(bool force)
 				  Qt::QueuedConnection, Q_ARG(bool, force));
 }
 
-void OBSBasic::SourceToolBarActionsSetEnabled(bool enable)
+void OBSBasic::SourceToolBarActionsSetEnabled()
 {
+	bool enable = false;
+	bool disableProps = false;
+
+	OBSSceneItem item = GetCurrentSceneItem();
+
+	if (item) {
+		OBSSource source = obs_sceneitem_get_source(item);
+		disableProps = !obs_source_configurable(source);
+
+		enable = true;
+	}
+
+	if (disableProps)
+		ui->actionSourceProperties->setEnabled(false);
+	else
+		ui->actionSourceProperties->setEnabled(enable);
+
 	ui->actionRemoveSource->setEnabled(enable);
-	ui->actionSourceProperties->setEnabled(enable);
 	ui->actionSourceUp->setEnabled(enable);
 	ui->actionSourceDown->setEnabled(enable);
 
@@ -3101,13 +3117,12 @@ void OBSBasic::SourceToolBarActionsSetEnabled(bool enable)
 
 void OBSBasic::UpdateContextBar(bool force)
 {
-	OBSSceneItem item = GetCurrentSceneItem();
-	bool enable = item != nullptr;
-
-	SourceToolBarActionsSetEnabled(enable);
+	SourceToolBarActionsSetEnabled();
 
 	if (!ui->contextContainer->isVisible() && !force)
 		return;
+
+	OBSSceneItem item = GetCurrentSceneItem();
 
 	if (item) {
 		obs_source_t *source = obs_sceneitem_get_source(item);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -638,7 +638,7 @@ private:
 	bool drawSpacingHelpers = true;
 
 	float GetDevicePixelRatio();
-	void SourceToolBarActionsSetEnabled(bool enable);
+	void SourceToolBarActionsSetEnabled();
 
 	std::string lastScreenshot;
 	std::string lastReplay;


### PR DESCRIPTION
### Description
If a scene or group is selected, disable the properties button in the source toolbar. This also does a refactor of the function to enable/disable the toolbar buttons.

![Screenshot from 2022-12-11 22-49-45](https://user-images.githubusercontent.com/19962531/206963704-e2a359bd-27bf-43ba-8e3b-4d520e2e1f61.png)

### Motivation and Context
Makes the source toolbar consistent with the source context bar.

### How Has This Been Tested?
Selected/unselected a nested scene in the sources list to make sure the toolbar updated correctly.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
