### PR TITLE
frontend: Disable hotkeys when typing or in modal dialog

### DIFF
--- a/frontend/OBSApp.hpp
+++ b/frontend/OBSApp.hpp
@@ -70,6 +70,7 @@ private:
 
 	bool enableHotkeysInFocus = true;
 	bool enableHotkeysOutOfFocus = true;
+	bool hotkeysDisabled = false;
 
 	std::deque<obs_frontend_translate_ui_cb> translatorHooks;
 
@@ -188,6 +189,9 @@ public:
 #ifndef _WIN32
 	static void SigIntSignalHandler(int);
 #endif
+
+private slots:
+	void WidgetFocusChanged(QWidget *old, QWidget *now);
 
 public slots:
 	void Exec(VoidFunc func);

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -873,8 +873,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 
 	UpdateAutomaticReplayBufferCheckboxes();
 
-	App()->DisableHotkeys();
-
 	channelIndex = ui->channelSetup->currentIndex();
 	sampleRateIndex = ui->sampleRate->currentIndex();
 	llBufferingEnabled = ui->lowLatencyBuffering->isChecked();
@@ -907,8 +905,6 @@ OBSBasicSettings::~OBSBasicSettings()
 {
 	delete ui->filenameFormatting->completer();
 	main->EnableOutputs(true);
-
-	App()->UpdateHotkeyFocusSetting();
 
 	EnableThreadedMessageBoxes(false);
 }


### PR DESCRIPTION
### Description
This disables hotkeys when an user is typing in a editable widget or a modal dialog is open.

### Motivation and Context
Simpler version of https://github.com/obsproject/obs-studio/pull/3072 (was reverted) and it automatically works with all widgets.

Fixes https://github.com/obsproject/obs-studio/issues/7824

### How Has This Been Tested?
Focused a editable widget and made sure the hotkeys didn't trigger. Also unfocused the same widget and made sure the hotkeys worked again. Also made sure hotkeys didn't trigger when opening a modal dialog.

Tested on Ubuntu 22.04 and Windows 10.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
