### PR TITLE
UI: Lock volume meter sliders to LTR to fix RTL slider direction

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -204,6 +204,7 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 
 		volMeter = new VolumeMeter(nullptr, obs_volmeter, true);
 		slider = new VolumeSlider(obs_fader, Qt::Vertical);
+		slider->setLayoutDirection(Qt::LeftToRight);
 
 		nameLayout->setAlignment(Qt::AlignCenter);
 		meterLayout->setAlignment(Qt::AlignCenter);
@@ -253,6 +254,7 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 
 		volMeter = new VolumeMeter(nullptr, obs_volmeter, false);
 		slider = new VolumeSlider(obs_fader, Qt::Horizontal);
+		slider->setLayoutDirection(Qt::LeftToRight);
 
 		textLayout->setContentsMargins(0, 0, 0, 0);
 		textLayout->addWidget(nameLabel);


### PR DESCRIPTION

### Description

Fixes #5447 where sliders would work in reverse.

Before:

https://user-images.githubusercontent.com/941350/207585709-357d860a-dffc-49a0-85a6-74aee99c0eed.mp4

### Motivation and Context

Bugs are bad. Some are relatively easy to fix.

### How Has This Been Tested?

On Windows with Qt set to launch in RTL mode.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
