### PR TITLE
docs: Clarify enum functions return value

### DIFF
--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -299,11 +299,25 @@ Libobs Objects
 
    Enumerates outputs.
 
+   Callback function returns true to continue enumeration, or false to end
+   enumeration.
+
+   Use :c:func:`obs_output_get_ref()` or
+   :c:func:`obs_output_get_weak_output()` if you want to retain a
+   reference after obs_enum_outputs finishes.
+
 ---------------------
 
 .. function:: void obs_enum_encoders(bool (*enum_proc)(void*, obs_encoder_t*), void *param)
 
    Enumerates encoders.
+
+   Callback function returns true to continue enumeration, or false to end
+   enumeration.
+
+   Use :c:func:`obs_encoder_get_ref()` or
+   :c:func:`obs_encoder_get_weak_encoder()` if you want to retain a
+   reference after obs_enum_encoders finishes.
 
 ---------------------
 
@@ -504,6 +518,9 @@ Video, Audio, and Graphics
 .. function:: void obs_enum_audio_monitoring_devices(obs_enum_audio_device_cb cb, void *data)
 
    Enumerates audio devices which can be used for audio monitoring.
+
+   Callback function returns true to continue enumeration, or false to end
+   enumeration.
 
    Relevant data types used with this function:
 

--- a/docs/sphinx/reference-scenes.rst
+++ b/docs/sphinx/reference-scenes.rst
@@ -266,6 +266,12 @@ General Scene Functions
 
    Enumerates scene items within a scene.
 
+   Callback function returns true to continue enumeration, or false to end
+   enumeration.
+
+   Use :c:func:`obs_sceneitem_addref()` if you want to retain a
+   reference after obs_scene_enum_items finishes.
+
    For scripting, use :py:func:`obs_scene_enum_items`.
 
 ---------------------
@@ -744,6 +750,13 @@ Scene Item Group Functions
 .. function:: void obs_sceneitem_group_enum_items(obs_sceneitem_t *group, bool (*callback)(obs_scene_t*, obs_sceneitem_t*, void*), void *param)
 
    Enumerates scene items within a group.
+
+   Callback function returns true to continue enumeration, or false to end
+   enumeration.
+
+   Use :c:func:`obs_sceneitem_addref()` if you want to retain a
+   reference after obs_sceneitem_group_enum_items finishes.
+
 
 ---------------------
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds info on what the enum callbacks should return.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I was using obs_scene_enum_items but I had no idea whether I should return true or false, and the few occurrences of it in the repo only returned true, so I had to check the source code of the function for clarification.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Checked the source code of the functions to see if returning false will end enumeration.
As for the docs, I built it and viewed locally.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
