### PR TITLE
win-dshow: Fix virtualcam output a default video format

### DIFF
--- a/plugins/win-dshow/virtualcam-module/virtualcam-filter.cpp
+++ b/plugins/win-dshow/virtualcam-module/virtualcam-filter.cpp
@@ -14,17 +14,10 @@ extern volatile long locks;
 
 /* ========================================================================= */
 
-VCamFilter::VCamFilter()
-	: OutputFilter(VideoFormat::NV12, DEFAULT_CX, DEFAULT_CY,
-		       DEFAULT_INTERVAL)
+VCamFilter::VCamFilter() : OutputFilter()
 {
 	thread_start = CreateEvent(nullptr, true, false, nullptr);
 	thread_stop = CreateEvent(nullptr, true, false, nullptr);
-
-	AddVideoFormat(VideoFormat::I420, DEFAULT_CX, DEFAULT_CY,
-		       DEFAULT_INTERVAL);
-	AddVideoFormat(VideoFormat::YUY2, DEFAULT_CX, DEFAULT_CY,
-		       DEFAULT_INTERVAL);
 
 	format = VideoFormat::NV12;
 

--- a/plugins/win-dshow/virtualcam-module/virtualcam-filter.hpp
+++ b/plugins/win-dshow/virtualcam-module/virtualcam-filter.hpp
@@ -10,10 +10,6 @@
 #include "../../../libobs/util/windows/WinHandle.hpp"
 #include "../../../libobs/util/threading-windows.h"
 
-#define DEFAULT_CX 1920
-#define DEFAULT_CY 1080
-#define DEFAULT_INTERVAL 333333ULL
-
 typedef struct {
 	int cx;
 	int cy;
@@ -30,11 +26,11 @@ class VCamFilter : public DShow::OutputFilter {
 	bool in_obs = false;
 	enum queue_state prev_state = SHARED_QUEUE_STATE_INVALID;
 	placeholder_t placeholder;
-	uint32_t obs_cx = DEFAULT_CX;
-	uint32_t obs_cy = DEFAULT_CY;
-	uint64_t obs_interval = DEFAULT_INTERVAL;
-	uint32_t filter_cx = DEFAULT_CX;
-	uint32_t filter_cy = DEFAULT_CY;
+	uint32_t obs_cx = 0;
+	uint32_t obs_cy = 0;
+	uint64_t obs_interval = 0;
+	uint32_t filter_cx = 0;
+	uint32_t filter_cy = 0;
 	DShow::VideoFormat format;
 	WinHandle thread_start;
 	WinHandle thread_stop;


### PR DESCRIPTION
### Description
Fix virtualcam output a default video format
Depends on: https://github.com/obsproject/libdshowcapture/pull/50

### Motivation and Context
The virtual camera indicates it supports a resolution that is not the resolution of the output.
This makes apps like vdo.ninja use the wrong resolution, which results in stretched images.

### How Has This Been Tested?
On windows 64bit with a virtual camera and vdo.ninja

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
