### PR TITLE
obs-filters: Log NVIDIA Effects version only if lib is found

### DIFF
--- a/plugins/obs-filters/noise-suppress-filter.c
+++ b/plugins/obs-filters/noise-suppress-filter.c
@@ -630,11 +630,14 @@ bool load_nvafx(void)
 	uint8_t minor = (version >> 16) & 0x00ff;
 	uint8_t build = (version >> 8) & 0x0000ff;
 	uint8_t revision = (version >> 0) & 0x000000ff;
-	blog(LOG_INFO, "[noise suppress]: NVIDIA AUDIO FX version: %i.%i.%i.%i",
-	     major, minor, build, revision);
-	if (version < (MIN_AFX_SDK_VERSION)) {
+	if (version) {
 		blog(LOG_INFO,
-		     "[noise suppress]: NVIDIA AUDIO Effects SDK is outdated; please update both audio & video SDK.");
+		     "[noise suppress]: NVIDIA AUDIO FX version: %i.%i.%i.%i",
+		     major, minor, build, revision);
+		if (version < (MIN_AFX_SDK_VERSION)) {
+			blog(LOG_INFO,
+			     "[noise suppress]: NVIDIA AUDIO Effects SDK is outdated. Please update both audio & video SDK.");
+		}
 	}
 	if (!load_lib()) {
 		blog(LOG_INFO,

--- a/plugins/obs-filters/nvidia-greenscreen-filter.c
+++ b/plugins/obs-filters/nvidia-greenscreen-filter.c
@@ -892,12 +892,14 @@ bool load_nvvfx(void)
 	uint8_t minor = (version >> 16) & 0x00ff;
 	uint8_t build = (version >> 8) & 0x0000ff;
 	uint8_t revision = (version >> 0) & 0x000000ff;
-	blog(LOG_INFO,
-	     "[NVIDIA VIDEO FX]: NVIDIA VIDEO FX version: %i.%i.%i.%i", major,
-	     minor, build, revision);
-	if (version < (MIN_VFX_SDK_VERSION)) {
+	if (version) {
 		blog(LOG_INFO,
-		     "[NVIDIA VIDEO FX]: NVIDIA VIDEO Effects SDK is outdated; please update both audio & video SDK.");
+		     "[NVIDIA VIDEO FX]: NVIDIA VIDEO FX version: %i.%i.%i.%i",
+		     major, minor, build, revision);
+		if (version < (MIN_VFX_SDK_VERSION)) {
+			blog(LOG_INFO,
+			     "[NVIDIA VIDEO FX]: NVIDIA VIDEO Effects SDK is outdated. Please update both audio & video SDK.");
+		}
 	}
 	if (!load_nv_vfx_libs()) {
 		blog(LOG_INFO,


### PR DESCRIPTION
### Description
This puts the version logging behind a condition of having found a lib.

### Motivation and Context
A user reported in beta channel that his log reported an nvidia fx version 0.0.0.0.
This should not be logged because this means the nvidia sdk is not installed.

### How Has This Been Tested?
If no version of the sdk is returned, there's no log anymore.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
