### PR TITLE
obs-ffmpeg: Add quality preset for VA-API

### DIFF
--- a/plugins/obs-ffmpeg/vaapi-utils.c
+++ b/plugins/obs-ffmpeg/vaapi-utils.c
@@ -185,6 +185,25 @@ bool vaapi_device_rc_supported(VAProfile profile, VADisplay dpy, uint32_t rc,
 	return false;
 }
 
+bool vaapi_quality_preset_supported(VAProfile profile, VADisplay dpy)
+{
+	const char *vendor_string = vaQueryVendorString(dpy);
+	if (strncmp("Mesa Gallium", vendor_string, 12) != 0)
+		return false;
+
+	VAStatus va_status;
+	VAConfigAttrib attrib[1];
+	attrib->type = VAConfigAttribEncQualityRange;
+
+	va_status = vaGetConfigAttributes(dpy, profile, VAEntrypointEncSlice,
+					  attrib, 1);
+
+	if (va_status != VA_STATUS_SUCCESS)
+		return false;
+
+	return attrib->value != VA_ATTRIB_NOT_SUPPORTED;
+}
+
 #define CHECK_PROFILE(ret, profile, va_dpy, device_path)                      \
 	if (vaapi_display_ep_combo_supported(profile, VAEntrypointEncSlice,   \
 					     va_dpy, device_path)) {          \

--- a/plugins/obs-ffmpeg/vaapi-utils.h
+++ b/plugins/obs-ffmpeg/vaapi-utils.h
@@ -15,6 +15,8 @@ void vaapi_close_device(int *fd, VADisplay dpy);
 bool vaapi_device_rc_supported(VAProfile profile, VADisplay dpy, uint32_t rc,
 			       const char *device_path);
 
+bool vaapi_quality_preset_supported(VAProfile profile, VADisplay dpy);
+
 bool vaapi_display_h264_supported(VADisplay dpy, const char *device_path);
 
 bool vaapi_device_h264_supported(const char *device_path);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Added support for VA-API quality preset in Mesa >= 22.3.
https://gitlab.freedesktop.org/mesa/mesa/-/commit/a727ec83ba01776e9c6f61c912c4caac280e968e

### Motivation and Context
Better encoding quality on AMD cards on Linux.

### How Has This Been Tested?
On ArchLinux (mesa 22.3.1, ffmpeg 5.1.2).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

### Screenshot:
![2022-12-21_16:44:02](https://user-images.githubusercontent.com/522831/208945116-36f835e6-e8a2-416f-9849-0ca876c3db58.png)
