### PR TITLE
libobs-winrt,win-capture: Add Force SDR for WGC display

### DIFF
--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -546,9 +546,10 @@ winrt_capture_init_window(BOOL cursor, HWND window, BOOL client_area,
 }
 
 extern "C" EXPORT struct winrt_capture *
-winrt_capture_init_monitor(BOOL cursor, HMONITOR monitor)
+winrt_capture_init_monitor(BOOL cursor, HMONITOR monitor, BOOL force_sdr)
 {
-	return winrt_capture_init_internal(cursor, NULL, false, false, monitor);
+	return winrt_capture_init_internal(cursor, NULL, false, force_sdr,
+					   monitor);
 }
 
 extern "C" EXPORT void winrt_capture_free(struct winrt_capture *capture)

--- a/libobs-winrt/winrt-capture.h
+++ b/libobs-winrt/winrt-capture.h
@@ -14,8 +14,8 @@ EXPORT BOOL winrt_capture_cursor_toggle_supported();
 EXPORT struct winrt_capture *winrt_capture_init_window(BOOL cursor, HWND window,
 						       BOOL client_area,
 						       BOOL force_sdr);
-EXPORT struct winrt_capture *winrt_capture_init_monitor(BOOL cursor,
-							HMONITOR monitor);
+EXPORT struct winrt_capture *
+winrt_capture_init_monitor(BOOL cursor, HMONITOR monitor, BOOL force_sdr);
 EXPORT void winrt_capture_free(struct winrt_capture *capture);
 
 EXPORT BOOL winrt_capture_active(const struct winrt_capture *capture);

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -27,6 +27,7 @@
 #define TEXT_METHOD_AUTO     obs_module_text("WindowCapture.Method.Auto")
 #define TEXT_METHOD_DXGI     obs_module_text("Method.DXGI")
 #define TEXT_METHOD_WGC      obs_module_text("Method.WindowsGraphicsCapture")
+#define TEXT_FORCE_SDR       obs_module_text("ForceSdr")
 
 /* clang-format on */
 
@@ -35,7 +36,7 @@
 typedef BOOL (*PFN_winrt_capture_supported)();
 typedef BOOL (*PFN_winrt_capture_cursor_toggle_supported)();
 typedef struct winrt_capture *(*PFN_winrt_capture_init_monitor)(
-	BOOL cursor, HMONITOR monitor);
+	BOOL cursor, HMONITOR monitor, BOOL force_sdr);
 typedef void (*PFN_winrt_capture_free)(struct winrt_capture *capture);
 
 typedef BOOL (*PFN_winrt_capture_active)(const struct winrt_capture *capture);
@@ -74,6 +75,7 @@ struct duplicator_capture {
 	bool reset_wgc;
 	HMONITOR handle;
 	bool capture_cursor;
+	bool force_sdr;
 	bool showing;
 	LONG logged_width;
 	LONG logged_height;
@@ -278,6 +280,7 @@ static inline void update_settings(struct duplicator_capture *capture,
 	capture->handle = monitor.handle;
 
 	capture->capture_cursor = obs_data_get_bool(settings, "capture_cursor");
+	capture->force_sdr = obs_data_get_bool(settings, "force_sdr");
 
 	capture->logged_width = monitor.rect.right - monitor.rect.left;
 	capture->logged_height = monitor.rect.bottom - monitor.rect.top;
@@ -351,6 +354,7 @@ static void duplicator_capture_defaults(obs_data_t *settings)
 	obs_data_set_default_string(settings, "monitor_id", "DUMMY");
 	obs_data_set_default_int(settings, "monitor_wgc", 0);
 	obs_data_set_default_bool(settings, "capture_cursor", true);
+	obs_data_set_default_bool(settings, "force_sdr", false);
 }
 
 static void duplicator_capture_update(void *data, obs_data_t *settings)
@@ -515,7 +519,8 @@ static void duplicator_capture_tick(void *data, float seconds)
 					capture->capture_winrt =
 						capture->exports.winrt_capture_init_monitor(
 							capture->capture_cursor,
-							capture->handle);
+							capture->handle,
+							capture->force_sdr);
 					if (!capture->capture_winrt) {
 						update_monitor_handle(capture);
 
@@ -523,7 +528,8 @@ static void duplicator_capture_tick(void *data, float seconds)
 							capture->capture_winrt =
 								capture->exports.winrt_capture_init_monitor(
 									capture->capture_cursor,
-									capture->handle);
+									capture->handle,
+									capture->force_sdr);
 						}
 					}
 
@@ -782,6 +788,9 @@ static void update_settings_visibility(obs_properties_t *props,
 	obs_property_t *p = obs_properties_get(props, "cursor");
 	obs_property_set_visible(p, dxgi_options || wgc_cursor_toggle);
 
+	p = obs_properties_get(props, "force_sdr");
+	obs_property_set_visible(p, wgc_options);
+
 	pthread_mutex_unlock(&capture->update_mutex);
 }
 
@@ -824,6 +833,7 @@ static obs_properties_t *duplicator_capture_properties(void *data)
 		OBS_COMBO_FORMAT_STRING);
 
 	obs_properties_add_bool(props, "capture_cursor", TEXT_CAPTURE_CURSOR);
+	obs_properties_add_bool(props, "force_sdr", TEXT_FORCE_SDR);
 
 	EnumDisplayMonitors(NULL, NULL, enum_monitor_props, (LPARAM)monitors);
 

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -401,7 +401,7 @@ static void update_settings_visibility(obs_properties_t *props,
 	obs_property_set_visible(p, wgc_options);
 
 	p = obs_properties_get(props, "force_sdr");
-	obs_property_set_visible(p, wgc_cursor_toggle);
+	obs_property_set_visible(p, wgc_options);
 
 	pthread_mutex_unlock(&wc->update_mutex);
 }


### PR DESCRIPTION
### Description
Leverage existing window capture support for display capture.

(Also add another commit to fix visibility for window capture setting as a bonus.)

### Motivation and Context
Users don't want to disable HDR in their Windows settings to capture SDR, and that's reasonable.

### How Has This Been Tested?
Checkbox appears when it should, and behaves as it should.

I didn't inspect color values this time since the same code path was tested for window capture, but they looked reasonable at a glance, i.e. not dim.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.