### PR TITLE
libobs-d3d11,win-capture: Add Force SDR for DXGI duplicator

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -779,6 +779,9 @@ struct gs_vertex_shader : gs_shader {
 struct gs_duplicator : gs_obj {
 	ComPtr<IDXGIOutputDuplication> duplicator;
 	gs_texture_2d *texture;
+	bool hdr = false;
+	enum gs_color_space color_space = GS_CS_SRGB;
+	float sdr_white_nits = 80.f;
 	int idx;
 	long refs;
 	bool updated;
@@ -982,9 +985,13 @@ struct mat4float {
 struct gs_monitor_color_info {
 	bool hdr;
 	UINT bits_per_color;
+	ULONG sdr_white_nits;
 
-	gs_monitor_color_info(bool hdr, int bits_per_color)
-		: hdr(hdr), bits_per_color(bits_per_color)
+	gs_monitor_color_info(bool hdr, int bits_per_color,
+			      ULONG sdr_white_nits)
+		: hdr(hdr),
+		  bits_per_color(bits_per_color),
+		  sdr_white_nits(sdr_white_nits)
 	{
 	}
 };
@@ -1061,9 +1068,9 @@ struct gs_device {
 
 	void LoadVertexBufferData();
 
-	inline void CopyTex(ID3D11Texture2D *dst, uint32_t dst_x,
-			    uint32_t dst_y, gs_texture_t *src, uint32_t src_x,
-			    uint32_t src_y, uint32_t src_w, uint32_t src_h);
+	void CopyTex(ID3D11Texture2D *dst, uint32_t dst_x, uint32_t dst_y,
+		     gs_texture_t *src, uint32_t src_x, uint32_t src_y,
+		     uint32_t src_w, uint32_t src_h);
 
 	void UpdateViewProjMatrix();
 
@@ -1072,6 +1079,8 @@ struct gs_device {
 	void RebuildDevice();
 
 	bool HasBadNV12Output();
+
+	gs_monitor_color_info GetMonitorColorInfo(HMONITOR hMonitor);
 
 	gs_device(uint32_t adapterIdx);
 	~gs_device();

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -218,6 +218,8 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT_OPTIONAL(gs_duplicator_destroy);
 	GRAPHICS_IMPORT_OPTIONAL(gs_duplicator_update_frame);
 	GRAPHICS_IMPORT_OPTIONAL(gs_duplicator_get_texture);
+	GRAPHICS_IMPORT_OPTIONAL(gs_duplicator_get_color_space);
+	GRAPHICS_IMPORT_OPTIONAL(gs_duplicator_get_sdr_white_level);
 	GRAPHICS_IMPORT_OPTIONAL(gs_get_adapter_count);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_create_gdi);
 	GRAPHICS_IMPORT_OPTIONAL(gs_texture_get_dc);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -307,6 +307,9 @@ struct gs_exports {
 
 	bool (*gs_duplicator_update_frame)(gs_duplicator_t *duplicator);
 	gs_texture_t *(*gs_duplicator_get_texture)(gs_duplicator_t *duplicator);
+	enum gs_color_space (*gs_duplicator_get_color_space)(
+		gs_duplicator_t *duplicator);
+	float (*gs_duplicator_get_sdr_white_level)(gs_duplicator_t *duplicator);
 
 	uint32_t (*gs_get_adapter_count)(void);
 

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -3050,6 +3050,28 @@ gs_texture_t *gs_duplicator_get_texture(gs_duplicator_t *duplicator)
 	return thread_graphics->exports.gs_duplicator_get_texture(duplicator);
 }
 
+enum gs_color_space gs_duplicator_get_color_space(gs_duplicator_t *duplicator)
+{
+	if (!gs_valid_p("gs_duplicator_get_color_space", duplicator))
+		return GS_CS_SRGB;
+	if (!thread_graphics->exports.gs_duplicator_get_color_space)
+		return GS_CS_SRGB;
+
+	return thread_graphics->exports.gs_duplicator_get_color_space(
+		duplicator);
+}
+
+float gs_duplicator_get_sdr_white_level(gs_duplicator_t *duplicator)
+{
+	if (!gs_valid_p("gs_duplicator_get_sdr_white_level", duplicator))
+		return 80.f;
+	if (!thread_graphics->exports.gs_duplicator_get_sdr_white_level)
+		return 80.f;
+
+	return thread_graphics->exports.gs_duplicator_get_sdr_white_level(
+		duplicator);
+}
+
 /** creates a windows GDI-lockable texture */
 gs_texture_t *gs_texture_create_gdi(uint32_t width, uint32_t height)
 {

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -919,6 +919,9 @@ EXPORT void gs_duplicator_destroy(gs_duplicator_t *duplicator);
 
 EXPORT bool gs_duplicator_update_frame(gs_duplicator_t *duplicator);
 EXPORT gs_texture_t *gs_duplicator_get_texture(gs_duplicator_t *duplicator);
+EXPORT enum gs_color_space
+gs_duplicator_get_color_space(gs_duplicator_t *duplicator);
+EXPORT float gs_duplicator_get_sdr_white_level(gs_duplicator_t *duplicator);
 
 EXPORT uint32_t gs_get_adapter_count(void);
 

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -265,10 +265,11 @@ static void log_settings(struct duplicator_capture *capture,
 	     "\tmethod: %s\n"
 	     "\tid: %s\n"
 	     "\talt_id: %s\n"
-	     "\tsetting_id: %s",
+	     "\tsetting_id: %s\n"
+	     "\tforce SDR: %s",
 	     monitor, width, height, capture->capture_cursor ? "true" : "false",
 	     get_method_name(capture->method), capture->id, capture->alt_id,
-	     capture->monitor_id);
+	     capture->monitor_id, capture->force_sdr ? "true" : "false");
 }
 
 static enum display_capture_method

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -734,18 +734,32 @@ static void duplicator_capture_render(void *data, gs_effect_t *unused)
 		const char *tech_name = "Draw";
 		float multiplier = 1.f;
 		const enum gs_color_space current_space = gs_get_color_space();
-		if (gs_texture_get_color_format(texture) == GS_RGBA16F) {
-			switch (current_space) {
-			case GS_CS_SRGB:
-			case GS_CS_SRGB_16F:
-				tech_name = "DrawMultiplyTonemap";
-				multiplier =
-					80.f / obs_get_video_sdr_white_level();
-				break;
-			case GS_CS_709_EXTENDED:
+		if (gs_duplicator_get_color_space(capture->duplicator) ==
+		    GS_CS_709_SCRGB) {
+			if (capture->force_sdr) {
 				tech_name = "DrawMultiply";
-				multiplier =
-					80.f / obs_get_video_sdr_white_level();
+				const float target_nits =
+					(current_space == GS_CS_709_SCRGB)
+						? obs_get_video_sdr_white_level()
+						: 80.f;
+				multiplier = target_nits /
+					     gs_duplicator_get_sdr_white_level(
+						     capture->duplicator);
+			} else {
+				switch (current_space) {
+				case GS_CS_SRGB:
+				case GS_CS_SRGB_16F:
+					tech_name = "DrawMultiplyTonemap";
+					multiplier =
+						80.f /
+						obs_get_video_sdr_white_level();
+					break;
+				case GS_CS_709_EXTENDED:
+					tech_name = "DrawMultiply";
+					multiplier =
+						80.f /
+						obs_get_video_sdr_white_level();
+				}
 			}
 		} else if (current_space == GS_CS_709_SCRGB) {
 			tech_name = "DrawMultiply";
@@ -844,9 +858,6 @@ static void update_settings_visibility(obs_properties_t *props,
 	obs_property_t *p = obs_properties_get(props, "cursor");
 	obs_property_set_visible(p, dxgi_options || wgc_cursor_toggle);
 
-	p = obs_properties_get(props, "force_sdr");
-	obs_property_set_visible(p, wgc_options);
-
 	pthread_mutex_unlock(&capture->update_mutex);
 }
 
@@ -909,17 +920,9 @@ duplicator_capture_get_color_space(void *data, size_t count,
 				capture->exports.winrt_capture_get_color_space(
 					capture->capture_winrt);
 		}
-	} else {
-		if (capture->duplicator) {
-			gs_texture_t *const texture =
-				gs_duplicator_get_texture(capture->duplicator);
-			if (texture) {
-				capture_space = (gs_texture_get_color_format(
-							 texture) == GS_RGBA16F)
-							? GS_CS_709_EXTENDED
-							: GS_CS_SRGB;
-			}
-		}
+	} else if (capture->duplicator && !capture->force_sdr) {
+		capture_space =
+			gs_duplicator_get_color_space(capture->duplicator);
 	}
 
 	enum gs_color_space space = capture_space;

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -180,9 +180,12 @@ static void log_settings(struct window_capture *wc, obs_data_t *s)
 		     "[window-capture: '%s'] update settings:\n"
 		     "\texecutable: %s\n"
 		     "\tmethod selected: %s\n"
-		     "\tmethod chosen: %s\n",
+		     "\tmethod chosen: %s\n"
+		     "\tforce SDR: %s",
 		     obs_source_get_name(wc->source), wc->executable,
-		     get_method_name(method), get_method_name(wc->method));
+		     get_method_name(method), get_method_name(wc->method),
+		     (wc->force_sdr && (wc->method == METHOD_WGC)) ? "true"
+								   : "false");
 		blog(LOG_DEBUG, "\tclass:      %s", wc->class);
 	}
 }


### PR DESCRIPTION
### Description
Same function as the checkbox in window capture for forcing SDR capture when HDR is enabled on a display in Windows settings.

Also plumb support for wide SDR although DXGI chooses narrow anyway?

Stacks on top of #7974.

FIxes #7970.

### Motivation and Context
Users don't want to disable HDR in their Windows settings to capture SDR, and that's reasonable.

### How Has This Been Tested?
Checked display capture of SDR and HDR monitor with and without checkbox enabled.

Checked log output for display capture DXGI/WGC, force on/off, and window capture BitBlt/WGC, force on/off.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.