### PR TITLE
linux-pipewire: Check format availablity against DRM only for dmabufs

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -359,16 +359,14 @@ static void init_format_info(obs_pipewire_data *obs_pw)
 	for (size_t i = 0; i < N_SUPPORTED_FORMATS; i++) {
 		struct format_info *info;
 
-		if (!drm_format_available(supported_formats[i].drm_format,
-					  drm_formats, n_drm_formats))
-			continue;
-
 		info = da_push_back_new(obs_pw->format_info);
 		da_init(info->modifiers);
 		info->spa_format = supported_formats[i].spa_format;
 		info->drm_format = supported_formats[i].drm_format;
 
-		if (!capabilities_queried)
+		if (!capabilities_queried ||
+		    !drm_format_available(supported_formats[i].drm_format,
+					  drm_formats, n_drm_formats))
 			continue;
 
 		size_t n_modifiers;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixes pipewire-screencast when using a software renderer

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Whe using a software renderer there will be no formats available for using with dmabufs. We should only consider those formats wrt. to modifiers and as such move this check after adding general support for that format.

Fixes #7985 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Run obs with `LIBGL_ALWAYS_SOFTWARE=true`

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
