### PR TITLE
Revert adapter reordering on Intel iGPU+dGPU systems

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -367,10 +367,6 @@ void gs_device::InitFactory()
 #define VENDOR_ID_INTEL 0x8086
 #define IGPU_MEM (512 * 1024 * 1024)
 
-extern "C" {
-EXPORT void obs_internal_set_adapter_idx_this_is_dumb(uint32_t adapter_idx);
-}
-
 void gs_device::ReorderAdapters(uint32_t &adapterIdx)
 {
 	std::vector<uint32_t> adapterOrder;
@@ -404,8 +400,6 @@ void gs_device::ReorderAdapters(uint32_t &adapterIdx)
 		adapterOrder.erase(adapterOrder.begin() + iGPUIndex);
 		adapterOrder.insert(adapterOrder.begin(), iGPUIndex);
 		adapterIdx = adapterOrder[adapterIdx];
-
-		obs_internal_set_adapter_idx_this_is_dumb(adapterIdx);
 	}
 }
 

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -1049,7 +1049,6 @@ struct gs_device {
 
 	void InitCompiler();
 	void InitFactory();
-	void ReorderAdapters(uint32_t &adapterIdx);
 	void InitAdapter(uint32_t adapterIdx);
 	void InitDevice(uint32_t adapterIdx);
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -341,8 +341,6 @@ struct obs_core_video {
 	pthread_mutex_t task_mutex;
 	struct circlebuf tasks;
 
-	uint32_t adapter_index;
-
 	pthread_mutex_t mixes_mutex;
 	DARRAY(struct obs_core_video_mix *) mixes;
 	struct obs_core_video_mix *main_mix;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -462,8 +462,6 @@ static int obs_init_graphics(struct obs_video_info *ovi)
 	bool success = true;
 	int errorcode;
 
-	video->adapter_index = ovi->adapter;
-
 	errorcode =
 		gs_create(&video->graphics, ovi->graphics_module, ovi->adapter);
 	if (errorcode != GS_SUCCESS) {
@@ -476,8 +474,6 @@ static int obs_init_graphics(struct obs_video_info *ovi)
 			return OBS_VIDEO_FAIL;
 		}
 	}
-
-	ovi->adapter = video->adapter_index;
 
 	gs_enter_context(video->graphics);
 
@@ -3103,13 +3099,4 @@ bool obs_weak_object_references_object(obs_weak_object_t *weak,
 				       obs_object_t *object)
 {
 	return weak && object && weak->object == object;
-}
-
-/* this function is a hack for the annoying intel igpu + dgpu situation. I
- * guess. I don't care anymore. */
-EXPORT void obs_internal_set_adapter_idx_this_is_dumb(uint32_t adapter_idx)
-{
-	if (!obs)
-		return;
-	obs->video.adapter_index = adapter_idx;
 }

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -477,6 +477,8 @@ static int obs_init_graphics(struct obs_video_info *ovi)
 		}
 	}
 
+	ovi->adapter = video->adapter_index;
+
 	gs_enter_context(video->graphics);
 
 	char *filename = obs_find_data_file("default.effect");
@@ -1410,8 +1412,6 @@ int obs_reset_video(struct obs_video_info *ovi)
 			return errorcode;
 		}
 	}
-
-	ovi->adapter = obs->video.adapter_index;
 
 	const char *scale_type_name = "";
 	switch (ovi->scale_type) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR reverts commits related to Intel iGPU+dGPU adapter reordering that occurs in systems with both an Intel iGPU and Intel dGPU. See PR #3686 where this was originally introduced.

Reverts the following commits:
* https://github.com/obsproject/obs-studio/commit/02d20e9f36c21069f59269ea94bf393231217e34
* https://github.com/obsproject/obs-studio/commit/e62759a3fa3d20366f80ddaa70fa58ca4f61a358
* https://github.com/obsproject/obs-studio/commit/c83eaaa51c260c3844baaf1cb76de63e0f096cea

Fixes #7917.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

PR #3686 originally introduced this change "to improve performance" (per commit c83eaaa51c260c3844baaf1cb76de63e0f096cea). With the release of the Intel Arc GPUs, users were confused as to why they could not run OBS on their Arc GPU if their system also had an Intel iGPU. After further discussion internally and with Intel, we've decided that it's less confusing to just allow users to choose to run OBS on their Arc dGPU if they want to. If they run into GPU headroom issues, that will become apparent in the video output and in log files, and we can make recommendations from there during troubleshooting sessions.

Initially, I also wanted to revert these commits:
* https://github.com/obsproject/obs-studio/commit/1e106c8bb8fd4421c472e3d3697578a351cca3c9
* https://github.com/obsproject/obs-studio/commit/477199ef2c0e901b647a74f260569745010fa68a

However, the new `InitFactory` introduced in https://github.com/obsproject/obs-studio/commit/1e106c8bb8fd4421c472e3d3697578a351cca3c9 was used in https://github.com/obsproject/obs-studio/commit/abddfead2f08ae36a29cb1ae2d0314051817773f (#6146), and I did not want to adjust the code there. Commit https://github.com/obsproject/obs-studio/commit/477199ef2c0e901b647a74f260569745010fa68a does not revert cleanly, and it only seems to apply to DG1 GPUs, so it has a limited scope, and I decided not address it here. We could look into addressing either of those later.

I don't see a reason that we would need to keep https://github.com/obsproject/obs-studio/commit/02d20e9f36c21069f59269ea94bf393231217e34 or https://github.com/obsproject/obs-studio/commit/e62759a3fa3d20366f80ddaa70fa58ca4f61a358 , but we can keep them if needed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on my Intel iGPU+dGPU system (Iris Xe + Arc A770M). The QSV encoder worked fine no matter which GPU I set OBS to use via Windows Graphics Settings, and the encoder preferred the GPU OBS is running on if the codec is available. The OBS log showed the selected GPU as adapter index 0 and that OBS was running on it. When running on the iGPU, the AV1 encoder uses its non-texture sharing fallback, though with additional resource usage.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
