### PR TITLE
libobs/graphics: unbreak DMABUF on FreeBSD

### DIFF
--- a/docs/sphinx/reference-libobs-graphics-graphics.rst
+++ b/docs/sphinx/reference-libobs-graphics-graphics.rst
@@ -1009,7 +1009,7 @@ Texture Functions
 
 .. function:: gs_texture_t *gs_texture_create_from_dmabuf(unsigned int width, unsigned int height, uint32_t drm_format, enum gs_color_format color_format, uint32_t n_planes, const int *fds, const uint32_t *strides, const uint32_t *offsets, const uint64_t *modifiers)
 
-   **Linux only:** Creates a texture from DMA-BUF metadata.
+   **only Linux, FreeBSD, DragonFly:** Creates a texture from DMA-BUF metadata.
 
    Exchanging DMA-BUFs is a verbose process because of its multiplanar nature.
    For example, YUV can have each plane as a color channel, or a monitor buffer
@@ -1049,7 +1049,7 @@ Texture Functions
 
 .. function:: bool *gs_query_dmabuf_capabilities(enum gs_dmabuf_flags *dmabuf_flags, uint32_t **drm_formats, size_t *n_formats)
 
-   **Linux only:** Queries the capabilities for DMA-BUFs.
+   **only Linux, FreeBSD, DragonFly:** Queries the capabilities for DMA-BUFs.
 
    Graphics cards can optimize frame buffers by storing them in custom layouts,
    depending on their hardware features. These layouts can make these frame
@@ -1068,7 +1068,7 @@ Texture Functions
 
 .. function:: bool *gs_query_dmabuf_modifiers_for_format(uint32_t drm_format, uint64_t **modifiers, size_t *n_modifiers)
 
-   **Linux only:** Queries the supported DMA-BUF modifiers for a given format.
+   **only Linux, FreeBSD, DragonFly:** Queries the supported DMA-BUF modifiers for a given format.
 
    This function queries all supported explicit modifiers for a format,
    stores them as an array and returns the number of supported modifiers.

--- a/libobs/graphics/device-exports.h
+++ b/libobs/graphics/device-exports.h
@@ -178,7 +178,7 @@ EXPORT void device_debug_marker_begin(gs_device_t *device,
 				      const float color[4]);
 EXPORT void device_debug_marker_end(gs_device_t *device);
 
-#if __linux__
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
 
 EXPORT gs_texture_t *device_texture_create_from_dmabuf(
 	gs_device_t *device, unsigned int width, unsigned int height,

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -234,7 +234,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT_OPTIONAL(device_stagesurface_create_p010);
 	GRAPHICS_IMPORT_OPTIONAL(device_register_loss_callbacks);
 	GRAPHICS_IMPORT_OPTIONAL(device_unregister_loss_callbacks);
-#elif __linux__
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
 	GRAPHICS_IMPORT(device_texture_create_from_dmabuf);
 	GRAPHICS_IMPORT(device_query_dmabuf_capabilities);
 	GRAPHICS_IMPORT(device_query_dmabuf_modifiers_for_format);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -348,7 +348,7 @@ struct gs_exports {
 		gs_device_t *device, const struct gs_device_loss *callbacks);
 	void (*device_unregister_loss_callbacks)(gs_device_t *device,
 						 void *data);
-#elif __linux__
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
 	struct gs_texture *(*device_texture_create_from_dmabuf)(
 		gs_device_t *device, unsigned int width, unsigned int height,
 		uint32_t drm_format, enum gs_color_format color_format,

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -1387,7 +1387,7 @@ gs_texture_t *gs_texture_create(uint32_t width, uint32_t height,
 						       levels, data, flags);
 }
 
-#if __linux__
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
 
 gs_texture_t *gs_texture_create_from_dmabuf(
 	unsigned int width, unsigned int height, uint32_t drm_format,

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -967,7 +967,7 @@ EXPORT gs_stagesurf_t *gs_stagesurface_create_p010(uint32_t width,
 EXPORT void gs_register_loss_callbacks(const struct gs_device_loss *callbacks);
 EXPORT void gs_unregister_loss_callbacks(void *data);
 
-#elif defined(__linux__) || defined(__FreeBSD__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
 
 EXPORT gs_texture_t *gs_texture_create_from_dmabuf(
 	unsigned int width, unsigned int height, uint32_t drm_format,


### PR DESCRIPTION
### Description
Trying to build [wlrobs](https://hg.sr.ht/~scoopta/wlrobs) >= 1.1 I get the following error:
```
ld: error: undefined symbol: gs_texture_create_from_dmabuf
>>> referenced by dmabuf_source.c
>>>               libwlrobs.so.p/src_dmabuf_source.c.o:(ready)
cc: error: linker command failed with exit code 1 (use -v to see invocation)
```
despite https://github.com/obsproject/obs-studio/blob/88ea0bbb56b0a020b60c908a706cbe2403a13fd8/libobs/graphics/graphics.h#L970-L976

### Motivation and Context
wlroots (Wayland) support on FreeBSD and DragonFly. wlrobs-1.0 already works fine but wlrobs-1.1 needs this change.

wlroots + wlrobs are also supported on DragonFly, so expose DMABUF API there as well.

### How Has This Been Tested?
```
$ pkg install sway wlrobs glx-utils
$ sway
$ glxgears &
$ obs
<Sources>
<Add Source>
<Wayland output(dmabuf)>
<OK>

<Sources>
<Add Source>
<Window Capture (Xcomposite)>
<Window: glxgears>
<OK>

<Start recording>
<Stop recording>
```

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
