### PR TITLE
NVENC error handling improvements

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc-helpers.c
+++ b/plugins/obs-ffmpeg/jim-nvenc-helpers.c
@@ -58,6 +58,7 @@ bool nv_failed2(obs_encoder_t *encoder, void *session, NVENCSTATUS err,
 			encoder, obs_module_text("NVENC.TooManySessions"));
 		break;
 
+	case NV_ENC_ERR_NO_ENCODE_DEVICE:
 	case NV_ENC_ERR_UNSUPPORTED_DEVICE:
 		obs_encoder_set_last_error(
 			encoder, obs_module_text("NVENC.UnsupportedDevice"));

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -93,6 +93,7 @@ static const int blacklisted_adapters[] = {
 	0x1d13, // GP108M [GeForce MX250]
 	0x1d52, // GP108BM [GeForce MX250]
 	0x1c94, // GP107 [GeForce MX350]
+	0x1c96, // GP107 [GeForce MX350]
 	0x1f97, // TU117 [GeForce MX450]
 	0x137b, // GM108GLM [Quadro M520 Mobile]
 	0x1d33, // GP108GLM [Quadro P500 Mobile]


### PR DESCRIPTION
### Description
This copies the result of `nvEncGetLastErrorString` to the last encoder error instead of only writing it to the log file. This makes it user-visible, which should help users diagnose and solve the problem.

Also strips off leading colons from NVENC error strings as these can look odd given our format string. An example of such an error:

`::NV_ENC_TWO_PASS_FULL_RESOLUTION is only supported multipass encoding on this architecture.`

Additionally handles `NV_ENC_ERR_NO_ENCODE_DEVICE` with the unsupported device message and blacklists a GeForce MX350 variant.

### Motivation and Context
While the full error message in the log file is useful, it's not really visible to users. Showing it in the encoder failure message box should help users solve the problem.

### How Has This Been Tested?
Not tested very well as I couldn't easily trigger error conditions on my GPU, code seems OK though?

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
