### PR TITLE
Fix mixed WCS and UTF-8 format strings

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -1287,9 +1287,14 @@ static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 
 		const RECT &rect = desc.DesktopCoordinates;
 		const ULONG nits = GetSdrWhiteNits(desc.Monitor);
+
+		char *friendly_name;
+		os_wcs_to_utf8_ptr(target.monitorFriendlyDeviceName, 0,
+				   &friendly_name);
+
 		blog(LOG_INFO,
 		     "\t  output %u:\n"
-		     "\t    name=%ls\n"
+		     "\t    name=%s\n"
 		     "\t    pos={%d, %d}\n"
 		     "\t    size={%d, %d}\n"
 		     "\t    attached=%s\n"
@@ -1301,11 +1306,12 @@ static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 		     "\t    dpi=%u (%u%%)\n"
 		     "\t    id=%s\n"
 		     "\t    alt_id=%s",
-		     i, target.monitorFriendlyDeviceName, rect.left, rect.top,
+		     i, friendly_name, rect.left, rect.top,
 		     rect.right - rect.left, rect.bottom - rect.top,
 		     desc.AttachedToDesktop ? "true" : "false", refresh,
 		     bits_per_color, space, nits, min_luminance, max_luminance,
 		     max_full_frame_luminance, dpiX, scaling, id, alt_id);
+		bfree(friendly_name);
 	}
 }
 

--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -21,8 +21,8 @@ try {
 		IsApiContractPresent(L"Windows.Foundation.UniversalApiContract",
 				     8);
 } catch (const winrt::hresult_error &err) {
-	blog(LOG_ERROR, "winrt_capture_supported (0x%08X): %ls",
-	     err.code().value, err.message().c_str());
+	blog(LOG_ERROR, "winrt_capture_supported (0x%08X): %s",
+	     err.code().value, winrt::to_string(err.message()).c_str());
 	return false;
 } catch (...) {
 	blog(LOG_ERROR, "winrt_capture_supported (0x%08X)",
@@ -37,8 +37,8 @@ try {
 			L"Windows.Graphics.Capture.GraphicsCaptureSession",
 			L"IsCursorCaptureEnabled");
 } catch (const winrt::hresult_error &err) {
-	blog(LOG_ERROR, "winrt_capture_cursor_toggle_supported (0x%08X): %ls",
-	     err.code().value, err.message().c_str());
+	blog(LOG_ERROR, "winrt_capture_cursor_toggle_supported (0x%08X): %s",
+	     err.code().value, winrt::to_string(err.message()).c_str());
 	return false;
 } catch (...) {
 	blog(LOG_ERROR, "winrt_capture_cursor_toggle_supported (0x%08X)",
@@ -274,8 +274,8 @@ static void winrt_capture_device_loss_release(void *data)
 		capture->frame_pool.Close();
 	} catch (winrt::hresult_error &err) {
 		blog(LOG_ERROR,
-		     "Direct3D11CaptureFramePool::Close (0x%08X): %ls",
-		     err.code().value, err.message().c_str());
+		     "Direct3D11CaptureFramePool::Close (0x%08X): %s",
+		     err.code().value, winrt::to_string(err.message()).c_str());
 	} catch (...) {
 		blog(LOG_ERROR, "Direct3D11CaptureFramePool::Close (0x%08X)",
 		     winrt::to_hresult().value);
@@ -284,8 +284,8 @@ static void winrt_capture_device_loss_release(void *data)
 	try {
 		capture->session.Close();
 	} catch (winrt::hresult_error &err) {
-		blog(LOG_ERROR, "GraphicsCaptureSession::Close (0x%08X): %ls",
-		     err.code().value, err.message().c_str());
+		blog(LOG_ERROR, "GraphicsCaptureSession::Close (0x%08X): %s",
+		     err.code().value, winrt::to_string(err.message()).c_str());
 	} catch (...) {
 		blog(LOG_ERROR, "GraphicsCaptureSession::Close (0x%08X)",
 		     winrt::to_hresult().value);
@@ -305,8 +305,8 @@ try {
 			L"Windows.Graphics.Capture.GraphicsCaptureSession",
 			L"IsBorderRequired");
 } catch (const winrt::hresult_error &err) {
-	blog(LOG_ERROR, "winrt_capture_border_toggle_supported (0x%08X): %ls",
-	     err.code().value, err.message().c_str());
+	blog(LOG_ERROR, "winrt_capture_border_toggle_supported (0x%08X): %s",
+	     err.code().value, winrt::to_string(err.message()).c_str());
 	return false;
 } catch (...) {
 	blog(LOG_ERROR, "winrt_capture_border_toggle_supported (0x%08X)",
@@ -330,8 +330,9 @@ winrt_capture_create_item(IGraphicsCaptureItemInterop *const interop_factory,
 			if (FAILED(hr))
 				blog(LOG_ERROR, "CreateForWindow (0x%08X)", hr);
 		} catch (winrt::hresult_error &err) {
-			blog(LOG_ERROR, "CreateForWindow (0x%08X): %ls",
-			     err.code().value, err.message().c_str());
+			blog(LOG_ERROR, "CreateForWindow (0x%08X): %s",
+			     err.code().value,
+			     winrt::to_string(err.message()).c_str());
 		} catch (...) {
 			blog(LOG_ERROR, "CreateForWindow (0x%08X)",
 			     winrt::to_hresult().value);
@@ -350,8 +351,9 @@ winrt_capture_create_item(IGraphicsCaptureItemInterop *const interop_factory,
 				blog(LOG_ERROR, "CreateForMonitor (0x%08X)",
 				     hr);
 		} catch (winrt::hresult_error &err) {
-			blog(LOG_ERROR, "CreateForMonitor (0x%08X): %ls",
-			     err.code().value, err.message().c_str());
+			blog(LOG_ERROR, "CreateForMonitor (0x%08X): %s",
+			     err.code().value,
+			     winrt::to_string(err.message()).c_str());
 		} catch (...) {
 			blog(LOG_ERROR, "CreateForMonitor (0x%08X)",
 			     winrt::to_hresult().value);
@@ -425,8 +427,8 @@ static void winrt_capture_device_loss_rebuild(void *device_void, void *data)
 		session.StartCapture();
 		capture->active = TRUE;
 	} catch (winrt::hresult_error &err) {
-		blog(LOG_ERROR, "StartCapture (0x%08X): %ls", err.code().value,
-		     err.message().c_str());
+		blog(LOG_ERROR, "StartCapture (0x%08X): %s", err.code().value,
+		     winrt::to_string(err.message()).c_str());
 	} catch (...) {
 		blog(LOG_ERROR, "StartCapture (0x%08X)",
 		     winrt::to_hresult().value);
@@ -528,8 +530,8 @@ try {
 	return capture;
 
 } catch (const winrt::hresult_error &err) {
-	blog(LOG_ERROR, "winrt_capture_init (0x%08X): %ls", err.code().value,
-	     err.message().c_str());
+	blog(LOG_ERROR, "winrt_capture_init (0x%08X): %s", err.code().value,
+	     winrt::to_string(err.message()).c_str());
 	return nullptr;
 } catch (...) {
 	blog(LOG_ERROR, "winrt_capture_init (0x%08X)",
@@ -581,8 +583,9 @@ extern "C" EXPORT void winrt_capture_free(struct winrt_capture *capture)
 				capture->frame_pool.Close();
 		} catch (winrt::hresult_error &err) {
 			blog(LOG_ERROR,
-			     "Direct3D11CaptureFramePool::Close (0x%08X): %ls",
-			     err.code().value, err.message().c_str());
+			     "Direct3D11CaptureFramePool::Close (0x%08X): %s",
+			     err.code().value,
+			     winrt::to_string(err.message()).c_str());
 		} catch (...) {
 			blog(LOG_ERROR,
 			     "Direct3D11CaptureFramePool::Close (0x%08X)",
@@ -594,8 +597,9 @@ extern "C" EXPORT void winrt_capture_free(struct winrt_capture *capture)
 				capture->session.Close();
 		} catch (winrt::hresult_error &err) {
 			blog(LOG_ERROR,
-			     "GraphicsCaptureSession::Close (0x%08X): %ls",
-			     err.code().value, err.message().c_str());
+			     "GraphicsCaptureSession::Close (0x%08X): %s",
+			     err.code().value,
+			     winrt::to_string(err.message()).c_str());
 		} catch (...) {
 			blog(LOG_ERROR,
 			     "GraphicsCaptureSession::Close (0x%08X)",
@@ -628,8 +632,8 @@ extern "C" EXPORT BOOL winrt_capture_show_cursor(struct winrt_capture *capture,
 		success = TRUE;
 	} catch (winrt::hresult_error &err) {
 		blog(LOG_ERROR,
-		     "GraphicsCaptureSession::IsCursorCaptureEnabled (0x%08X): %ls",
-		     err.code().value, err.message().c_str());
+		     "GraphicsCaptureSession::IsCursorCaptureEnabled (0x%08X): %s",
+		     err.code().value, winrt::to_string(err.message()).c_str());
 	} catch (...) {
 		blog(LOG_ERROR,
 		     "GraphicsCaptureSession::IsCursorCaptureEnabled (0x%08X)",

--- a/libobs-winrt/winrt-dispatch.cpp
+++ b/libobs-winrt/winrt-dispatch.cpp
@@ -42,8 +42,9 @@ extern "C" EXPORT struct winrt_disaptcher *winrt_dispatcher_init()
 			dispatcher->controller = std::move(controller);
 		}
 	} catch (const winrt::hresult_error &err) {
-		blog(LOG_ERROR, "winrt_dispatcher_init (0x%08X): %ls",
-		     (int32_t)err.code(), err.message().c_str());
+		blog(LOG_ERROR, "winrt_dispatcher_init (0x%08X): %s",
+		     (int32_t)err.code(),
+		     winrt::to_string(err.message()).c_str());
 	} catch (...) {
 		blog(LOG_ERROR, "winrt_dispatcher_init (0x%08X)",
 		     (int32_t)winrt::to_hresult());
@@ -57,8 +58,8 @@ winrt_dispatcher_free(struct winrt_disaptcher *dispatcher)
 try {
 	delete dispatcher;
 } catch (const winrt::hresult_error &err) {
-	blog(LOG_ERROR, "winrt_dispatcher_free (0x%08X): %ls",
-	     (int32_t)err.code(), err.message().c_str());
+	blog(LOG_ERROR, "winrt_dispatcher_free (0x%08X): %s",
+	     (int32_t)err.code(), winrt::to_string(err.message()).c_str());
 } catch (...) {
 	blog(LOG_ERROR, "winrt_dispatcher_free (0x%08X)",
 	     (int32_t)winrt::to_hresult());

--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -316,8 +316,13 @@ static void log_security_products_by_type(IWSCProductList *prod_list, int type)
 			continue;
 		}
 
-		blog(LOG_INFO, "\t%S: %s (%s)", name,
+		char *product_name;
+		os_wcs_to_utf8_ptr(name, 0, &product_name);
+
+		blog(LOG_INFO, "\t%s: %s (%s)", product_name,
 		     get_str_for_state(prod_state), get_str_for_type(type));
+
+		bfree(product_name);
 
 		SysFreeString(name);
 		prod->lpVtbl->Release(prod);

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -100,7 +100,7 @@ struct duplicator_monitor_info {
 	char device_id[128];
 	char id[128];
 	char alt_id[128];
-	char name[64];
+	char name[128];
 	RECT rect;
 	HMONITOR handle;
 };
@@ -182,7 +182,12 @@ static void GetMonitorName(HMONITOR handle, char *name, size_t count)
 	mi.cbSize = sizeof(mi);
 	if (GetMonitorInfoW(handle, (LPMONITORINFO)&mi) &&
 	    GetMonitorTarget(mi.szDevice, &target)) {
-		snprintf(name, count, "%ls", target.monitorFriendlyDeviceName);
+		char *friendly_name;
+		os_wcs_to_utf8_ptr(target.monitorFriendlyDeviceName, 0,
+				   &friendly_name);
+
+		strcpy_s(name, count, friendly_name);
+		bfree(friendly_name);
 	} else {
 		strcpy_s(name, count, "[OBS: Unknown]");
 	}


### PR DESCRIPTION
### Description
PRs #7749 and #7766 highlighted a bug in how we process wide character format strings. For whatever reason, these are locale-dependent and without us changing the process locale, the strings would either be truncated or empty when the `*sprintf` family of functions hit the wide character bytes. Unfortunately these PRs were closed without resolution, so I am trying to finish the changes required.

Fixes #7816

### Motivation and Context
Missing information in log files is bad, and possibly empty monitor names is worse.

### How Has This Been Tested?
Breakpoint tested most changes, winrt errors were not easy to trigger but the code looks correct.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
