### PR TITLE
libobs: Fix stopping transitions that are not active

### DIFF
--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -439,7 +439,7 @@ void obs_transition_set(obs_source_t *transition, obs_source_t *source)
 	obs_source_t *s[2];
 	bool active[2];
 
-	if (!transition_valid(transition, "obs_transition_clear"))
+	if (!transition_valid(transition, "obs_transition_set"))
 		return;
 
 	source = obs_source_get_ref(source);
@@ -892,6 +892,9 @@ bool obs_transition_video_render_direct(obs_source_t *transition,
 	if (t >= 1.0f && transition->transitioning_video) {
 		transition->transitioning_video = false;
 		video_stopped = true;
+
+		if (!obs_source_active(transition))
+			transition->transitioning_audio = false;
 
 		if (!transition->transitioning_audio) {
 			obs_transition_stop(transition);


### PR DESCRIPTION
### Description
Fix stopping transitions that are not active

### Motivation and Context
For transitions in the properties dialog (cloned private source) no audio render is done, so the transition never stopped, it kept waiting for the audio to finish. With these changes it will set the audio as done when video is done.

### How Has This Been Tested?
On windows 64 bit by checking if transition_stop function is called after the preview button is clicked in the properties dialog of a transition.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
