### PR TITLE
CI: Revise repository conditions to validate JSON schema of services

### DIFF
--- a/.github/workflows/services-json.yml
+++ b/.github/workflows/services-json.yml
@@ -17,6 +17,7 @@ jobs:
   schema:
     name: Schema
     runs-on: [ubuntu-20.04]
+    if: ${{ github.repository_owner == 'obsproject' || github.event_name != 'schedule' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -46,7 +47,7 @@ jobs:
     name: Service Check
     runs-on: ubuntu-20.04
     needs: schema
-    if: ${{ github.repository_owner == 'obsproject' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ github.repository_owner == 'obsproject' && github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This commit blocks schema validation every day in repositories other than `obsproject`. Also enables `service_check` if the owner triggers it manually.

A truth table shows when the jobs will be run.

| `repository_owner` | `event_name`     | `schema` | `service_check` |
| --- | --- | --- | --- |
| `obsproject` | `push`, `pull_request` | Yes       | No        |
| `obsproject` | `schedule`             | Yes       | Yes       |
| `obsproject` | `workflow_dispatch`    | Yes       | Yes       |
| *other*      | `push`, `pull_request` | Yes       | No        |
| *other*      | `schedule`             | Yes &rarr; No | No        |
| *other*      | `workflow_dispatch`    | Yes       | No &rarr; Yes |

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The schema validation (the job `schema`) is running every day on my repository, which is not necessary.

Summarizing on the truth table, I noticed `workflow_dispatch` only triggers `schema` job but not `service_check`. I revised the condition so that `servcie_check` will be run if an owner triggers the workflow manually even on other repositories.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

The first modification (`schema`) was not checked.
The later modification (`service_check`) was checked on my repository as below.
https://github.com/norihiro/obs-studio/actions/runs/3843130910

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
