### PR TITLE
win-capture: Always reset timeout when searching for target display

### DIFF
--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -526,9 +526,9 @@ static void duplicator_capture_tick(void *data, float seconds)
 									capture->handle);
 						}
 					}
-
-					capture->reset_timeout = 0.0f;
 				}
+
+				capture->reset_timeout = 0.0f;
 			}
 		}
 	} else {
@@ -563,10 +563,10 @@ static void duplicator_capture_tick(void *data, float seconds)
 						capture->duplicator =
 							gs_duplicator_create(
 								dxgi_index);
-
-						capture->reset_timeout = 0.0f;
 					}
 				}
+
+				capture->reset_timeout = 0.0f;
 			}
 		}
 


### PR DESCRIPTION
### Description
If the target display wasn't found, the timer was not reset, causing the code to execute on every single tick, stalling the graphics thread and using excessive CPU.

### Motivation and Context
With 29.0 resetting everyone's monitor capture, this would cause FPS drops / excessive CPU usage until users fixed their sources which isn't a great experience.

### How Has This Been Tested?
Ran in debugger.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
