### PR TITLE
rtmp-services: Specify RTMP_SERVICES_FORMAT_VERSION in package.json

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
-    "url": "https://obsproject.com/obs2_update/rtmp-services",
-    "version": 215,
+    "url": "https://obsproject.com/obs2_update/rtmp-services/v4",
+    "version": 216,
     "files": [
         {
             "name": "services.json",
-            "version": 215
+            "version": 216
         }
     ]
 }


### PR DESCRIPTION
### Description
In preparation for v29, I adjusted the server-side to serve separate files for `/v3` and `/v4`. Unfortunately while `package.json` was correctly downloaded from `/v3` by OBS 28.x and lower, the `services.json` was fetched from the root URL and unintentionally "updated" everyone to an older version than v28 ships with, breaking things like YouTube - HLS.

This PR fixes the URL in `package.json` and bumps the version to force a re-download for affected users.  On the server-side, the URL is replaced for the `/v3` path during update.

### Motivation and Context
Broken services are bad.

### How Has This Been Tested?
Checked file contents.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
