### PR TITLE
libobs-opengl: Drop gl pointers on device_leave_context

### DIFF
--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -265,6 +265,8 @@ void device_leave_context(gs_device_t *device)
 {
 	glFlush();
 	[NSOpenGLContext clearCurrentContext];
+	device->cur_vertex_buffer = NULL;
+	device->cur_index_buffer = NULL;
 	device->cur_render_target = NULL;
 	device->cur_zstencil_buffer = NULL;
 	device->cur_swap = NULL;

--- a/libobs-opengl/gl-nix.c
+++ b/libobs-opengl/gl-nix.c
@@ -86,6 +86,12 @@ extern void device_enter_context(gs_device_t *device)
 
 extern void device_leave_context(gs_device_t *device)
 {
+	device->cur_render_target = NULL;
+	device->cur_zstencil_buffer = NULL;
+	device->cur_vertex_buffer = NULL;
+	device->cur_index_buffer = NULL;
+	device->cur_swap = NULL;
+	device->cur_fbo = NULL;
 	gl_vtable->device_leave_context(device);
 }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Mac was already dropping a most of these when leaving contexts, this patch brings the same drops to linux and also drops vertex/index buffers that were noticed as leaking across contexts and resulting in invalid bindings by later draws. Especially with the new spacing labels.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes opengl error spam when moving sources on linux.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with all the default sources and some transitions, and i could not find anything rendering differently. I expect that no one tried to do something as dangerous as depend on gl state across calls to obs_enter_graphics(). Especially since mac was already dropping various state, so any such plugins would probably be broken on mac already.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
