### PR TITLE
obs-filters: Reapply audio processing above threshold for expander

### DIFF
--- a/plugins/obs-filters/expander-filter.c
+++ b/plugins/obs-filters/expander-filter.c
@@ -384,8 +384,8 @@ static inline void process_sample(size_t idx, float *samples, float *env_buf,
 			   : 0.0f;
 	gain = db_to_mul(fminf(min_val, gain_db[idx]));
 
-	// above threshold, don't process expander nor upward compressor
-	if (threshold - env_db <= 0)
+	// above threshold, don't process upward compressor
+	if (is_upwcomp && threshold - env_db <= 0)
 		gain = 1.0f;
 
 	samples[idx] *= gain * output_gain;


### PR DESCRIPTION
### Description
Some code was applied to both expander and upward compressor. We limit it now to the compressor to keep the same behaviour as previous versions.
The said code was setting the gain to 0 dB above threshold.
Fixes issue #8030 .
### Motivation and Context
Try not to break existing behaviour.
Some users report clicks : https://github.com/obsproject/obs-studio/issues/8030

### How Has This Been Tested?
Works as v28.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
