### PR TITLE
obs-filters: disable NVIDIA FX audio model loading if SDK is not installed

### DIFF
--- a/plugins/obs-filters/noise-suppress-filter.c
+++ b/plugins/obs-filters/noise-suppress-filter.c
@@ -466,7 +466,7 @@ static void noise_suppress_update(void *data, obs_data_t *s)
 		strcmp(method, S_METHOD_NVAFX_DEREVERB) == 0 ||
 		strcmp(method, S_METHOD_NVAFX_DEREVERB_DENOISER) == 0;
 #ifdef LIBNVAFX_ENABLED
-	if (nvafx_requested)
+	if (nvafx_requested && ng->nvafx_enabled)
 		set_model(ng, method);
 	float intensity = (float)obs_data_get_double(s, S_NVAFX_INTENSITY);
 	if (ng->use_nvafx && ng->nvafx_initialized) {


### PR DESCRIPTION
### Description
This fixes a bug reported by R1ch internally.
If someone uses NVIDIA noise suppression filter and later uninstalls the SDK, 
there can be a crash because the filter tries to load the models.

### Motivation and Context
Crashes are bad. Fixes a crash.

### How Has This Been Tested?
Tested that there's no crash when the SDK is not found (removed the env var for the sdk path).
Tested that the filter works when the SDK is re-enabled or reinstalled.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
