### PR TITLE
mac-virtualcam: Fix memory access issues for shared IOSurfaces

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/OBSDALMachServer.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/OBSDALMachServer.mm
@@ -148,6 +148,9 @@
 			       length:sizeof(fpsDenominator)];
 
 		IOSurfaceRef surface = CVPixelBufferGetIOSurface(frame);
+#ifndef __aarch64__
+		IOSurfaceLock(surface, 0, NULL);
+#endif
 
 		if (!surface) {
 			blog(LOG_ERROR,
@@ -174,6 +177,10 @@
 					 ]];
 
 		mach_port_deallocate(mach_task_self(), framePort);
+
+#ifndef __aarch64__
+		IOSurfaceUnlock(surface, 0, NULL);
+#endif
 	}
 }
 


### PR DESCRIPTION
### Description
Fixes https://github.com/obsproject/obs-studio/issues/8039.

### Motivation and Context
The DAL plugin-based virtualcamera shares data between OBS and the plugin using an IOSurface. IOSurface locks are necessary to ensure race conditions between data generation (OBS side) and consumption (virtual camera side) and also that an IOSurface is not offloaded to GPU memory when it is indeed needed in CPU memory.

Also moves the invalidation of the NSMachPort for the frames to after the IOSurface data has been converted into a pixelbuffer and added to the frame queue of the virtual camera, as an early invalidation will cut off access to the pixel data shared with the DAL plugin.

### How Has This Been Tested?
Tested on Intel-based iMac (late 2015) and Mac Studio (2022).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
