### PR TITLE
libobs/media-io: Check codec tag compatibility for out stream

### DIFF
--- a/libobs/media-io/media-remux.c
+++ b/libobs/media-io/media-remux.c
@@ -149,14 +149,17 @@ static inline bool init_output(media_remux_job_t job, const char *out_filename)
 		av_dict_copy(&out_stream->metadata, in_stream->metadata, 0);
 
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
-		if (in_stream->codecpar->codec_tag != 0) {
-			out_stream->codecpar->codec_tag =
-				in_stream->codecpar->codec_tag;
-		} else if (in_stream->codecpar->codec_id == AV_CODEC_ID_HEVC) {
+		if (in_stream->codecpar->codec_id == AV_CODEC_ID_HEVC &&
+		    job->ofmt_ctx->oformat->codec_tag &&
+		    av_codec_get_id(job->ofmt_ctx->oformat->codec_tag,
+				    MKTAG('h', 'v', 'c', '1')) ==
+			    out_stream->codecpar->codec_id) {
 			// Tag HEVC files with industry standard HVC1 tag for wider device compatibility
+			// when HVC1 tag is supported by out stream codec
 			out_stream->codecpar->codec_tag =
 				MKTAG('h', 'v', 'c', '1');
 		} else {
+			// Otherwise tag 0 to let FFmpeg automatically select the appropriate tag
 			out_stream->codecpar->codec_tag = 0;
 		}
 #else


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Check codec tag compatibility for out stream.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fixes #8029 

When the codec tag is not supported by out stream codec, the error happen.

introduced by https://github.com/obsproject/obs-studio/commit/bbb3dc00590a572cf49f97db3397221f0828f9ad

So add judgement to check compatibility.

https://github.com/FFmpeg/FFmpeg/blob/51efa68ec0b4f42b5b124b8987fb68f60a929c4f/libavformat/segment.c#L174-L180

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Follow steps mentioned in issue to test, run well. (`ts, flv, m3u8 ...`)

~Not check hevc behavior.~

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

Bug fix (non-breaking change which fixes an issue)
Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
