### PR TITLE
obs-ffmpeg: Remove forced x264 and aac on RTMP

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -640,9 +640,7 @@ bool ffmpeg_data_init(struct ffmpeg_data *data, struct ffmpeg_cfg *config)
 	}
 #else
 	if (is_rtmp) {
-		data->config.audio_encoder = "aac";
 		data->config.audio_encoder_id = AV_CODEC_ID_AAC;
-		data->config.video_encoder = "libx264";
 		data->config.video_encoder_id = AV_CODEC_ID_H264;
 	}
 #endif


### PR DESCRIPTION
### Description
Remove code forcing x264 and ffmpeg aac encoder. People in custom ffmpeg output should be able to use other video and audio encoders when streaming with RTMP, given its h264 or aac.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/8043

Nice to be able to use fdk_aac, or harware encoders like nvenc, amf, qsv etc. in custom ffmpeg output.

### How Has This Been Tested?
I built OBS, and streamed to twitch using RTMP and custom ffmpeg output, and selected the h264_nvenc encoder. Using several monitoring tools I confirmed that the encoding was happening on nvenc, and confirmed usable output on the twitch player.

Windows 10 22H2.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
