### PR TITLE
updater: Pass AppData path to elevated process

### DIFF
--- a/UI/win-update/updater/updater.cpp
+++ b/UI/win-update/updater/updater.cpp
@@ -1352,6 +1352,7 @@ static bool Update(wchar_t *cmdLine)
 
 	bool bIsPortable = false;
 	wstring branch = L"stable";
+	wstring appdata;
 
 	if (cmdLine[0]) {
 		int argc;
@@ -1366,6 +1367,9 @@ static bool Update(wchar_t *cmdLine)
 				} else if (wcsncmp(argv[i], L"--branch=", 9) ==
 					   0) {
 					branch = argv[i] + 9;
+				} else if (wcsncmp(argv[i], L"--appdata=",
+						   10) == 0) {
+					appdata = argv[i] + 10;
 				} else if (wcscmp(argv[i], L"--portable") ==
 					   0) {
 					bIsPortable = true;
@@ -1385,18 +1389,16 @@ static bool Update(wchar_t *cmdLine)
 		GetCurrentDirectory(_countof(lpAppDataPath), lpAppDataPath);
 		StringCbCat(lpAppDataPath, sizeof(lpAppDataPath), L"\\config");
 	} else {
-		DWORD ret;
-		ret = GetEnvironmentVariable(L"OBS_USER_APPDATA_PATH",
-					     lpAppDataPath,
-					     _countof(lpAppDataPath));
-
-		if (ret >= _countof(lpAppDataPath)) {
-			Status(L"Update failed: Could not determine AppData "
-			       L"location");
-			return false;
-		}
-
-		if (!ret) {
+		if (!appdata.empty()) {
+			HRESULT hr = StringCbCopy(lpAppDataPath,
+						  sizeof(lpAppDataPath),
+						  appdata.c_str());
+			if (hr != S_OK) {
+				Status(L"Update failed: Could not determine AppData "
+				       L"location");
+				return false;
+			}
+		} else {
 			CoTaskMemPtr<wchar_t> pOut;
 			HRESULT hr = SHGetKnownFolderPath(
 				FOLDERID_RoamingAppData, KF_FLAG_DEFAULT,
@@ -1916,13 +1918,26 @@ static int RestartAsAdmin(LPCWSTR lpCmdLine, LPCWSTR cwd)
 		return 0;
 	}
 
+	/* If the admin is a different user, add the path to the user's
+	 * AppData to the command line so we can load the correct manifest. */
+	wstring elevatedCmdLine(lpCmdLine);
+	CoTaskMemPtr<wchar_t> pOut;
+	HRESULT hr = SHGetKnownFolderPath(FOLDERID_RoamingAppData,
+					  KF_FLAG_DEFAULT, nullptr, &pOut);
+	if (hr == S_OK) {
+		elevatedCmdLine += L" \"--appdata=";
+		elevatedCmdLine += pOut;
+		elevatedCmdLine += L"\"";
+	}
+
 	SHELLEXECUTEINFO shExInfo = {0};
 	shExInfo.cbSize = sizeof(shExInfo);
 	shExInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
 	shExInfo.hwnd = 0;
-	shExInfo.lpVerb = L"runas";        /* Operation to perform */
-	shExInfo.lpFile = myPath;          /* Application to start */
-	shExInfo.lpParameters = lpCmdLine; /* Additional parameters */
+	shExInfo.lpVerb = L"runas"; /* Operation to perform */
+	shExInfo.lpFile = myPath;   /* Application to start */
+	shExInfo.lpParameters =
+		elevatedCmdLine.c_str(); /* Additional parameters */
 	shExInfo.lpDirectory = cwd;
 	shExInfo.nShow = SW_NORMAL;
 	shExInfo.hInstApp = 0;
@@ -1930,14 +1945,6 @@ static int RestartAsAdmin(LPCWSTR lpCmdLine, LPCWSTR cwd)
 	/* annoyingly the actual elevated updater will disappear behind other
 	 * windows :( */
 	AllowSetForegroundWindow(ASFW_ANY);
-
-	/* if the admin is a different user, save the path to the user's
-	 * appdata so we can load the correct manifest */
-	CoTaskMemPtr<wchar_t> pOut;
-	HRESULT hr = SHGetKnownFolderPath(FOLDERID_RoamingAppData,
-					  KF_FLAG_DEFAULT, nullptr, &pOut);
-	if (hr == S_OK)
-		SetEnvironmentVariable(L"OBS_USER_APPDATA_PATH", pOut);
 
 	if (ShellExecuteEx(&shExInfo)) {
 		DWORD exitCode;


### PR DESCRIPTION
### Description

Pass AppData location to elevated process via command line parameter.

(This is classed as a bug fix as the previous method doesn't work [anymore] and this replaces it.)

### Motivation and Context

When a separate administrator account is used for elevation the appdata path would be set to the wrong user's directory.

Previously this was attempted via an environment variable, but those are not retained for the elevated process.

### How Has This Been Tested?

Verified correct path is passed and read by the elevated process.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
