### PR TITLE
libobs: Refactor obs-output in preparation of multiple video encoders

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -255,7 +255,9 @@ static void obs_encoder_actually_destroy(obs_encoder_t *encoder)
 		pthread_mutex_lock(&encoder->outputs_mutex);
 		for (size_t i = 0; i < encoder->outputs.num; i++) {
 			struct obs_output *output = encoder->outputs.array[i];
-			obs_output_remove_encoder(output, encoder);
+			// This happens while the output is still "active", so
+			// remove without checking active
+			obs_output_remove_encoder_internal(output, encoder);
 		}
 		da_free(encoder->outputs);
 		pthread_mutex_unlock(&encoder->outputs_mutex);

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1024,7 +1024,7 @@ struct obs_output {
 	volatile bool data_active;
 	volatile bool end_data_capture_thread_active;
 	int64_t video_offset;
-	int64_t audio_offsets[MAX_AUDIO_MIXES];
+	int64_t audio_offsets[MAX_OUTPUT_AUDIO_ENCODERS];
 	int64_t highest_audio_ts;
 	int64_t highest_video_ts;
 	pthread_t end_data_capture_thread;
@@ -1054,7 +1054,7 @@ struct obs_output {
 	video_t *video;
 	audio_t *audio;
 	obs_encoder_t *video_encoder;
-	obs_encoder_t *audio_encoders[MAX_AUDIO_MIXES];
+	obs_encoder_t *audio_encoders[MAX_OUTPUT_AUDIO_ENCODERS];
 	obs_service_t *service;
 	size_t mixer_mask;
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1265,3 +1265,6 @@ extern bool obs_service_initialize(struct obs_service *service,
 				   struct obs_output *output);
 
 void obs_service_destroy(obs_service_t *service);
+
+void obs_output_remove_encoder_internal(struct obs_output *output,
+					struct obs_encoder *encoder);

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -792,10 +792,10 @@ size_t obs_output_get_mixers(const obs_output_t *output)
 		       : 0;
 }
 
-void obs_output_remove_encoder(struct obs_output *output,
-			       struct obs_encoder *encoder)
+void obs_output_remove_encoder_internal(struct obs_output *output,
+					struct obs_encoder *encoder)
 {
-	if (!obs_output_valid(output, "obs_output_remove_encoder"))
+	if (!obs_output_valid(output, "obs_output_remove_encoder_internal"))
 		return;
 
 	if (output->video_encoder == encoder) {
@@ -806,6 +806,18 @@ void obs_output_remove_encoder(struct obs_output *output,
 				output->audio_encoders[i] = NULL;
 		}
 	}
+}
+
+void obs_output_remove_encoder(struct obs_output *output,
+			       struct obs_encoder *encoder)
+{
+	if (!obs_output_valid(output, "obs_output_remove_encoder"))
+		return;
+	if (active(output)) {
+		return;
+	}
+
+	obs_output_remove_encoder_internal(output, encoder);
 }
 
 void obs_output_set_video_encoder(obs_output_t *output, obs_encoder_t *encoder)

--- a/libobs/obs-output.h
+++ b/libobs/obs-output.h
@@ -29,6 +29,8 @@ extern "C" {
 #define OBS_OUTPUT_MULTI_TRACK (1 << 4)
 #define OBS_OUTPUT_CAN_PAUSE (1 << 5)
 
+#define MAX_OUTPUT_AUDIO_ENCODERS 6
+
 struct encoder_packet;
 
 struct obs_output_info {


### PR DESCRIPTION
### Description
Refactors the obs-output to better separate the usage of MAX_AUDIO_MIXES (raw audio) and the audio encoders.

### Motivation and Context
This is in preparation for adding multiple video encoders per output as well as generally clarifying usage and allowing potentially more encoders than audio mix tracks (6).

Also fixes some bugs around removing encoders from outputs while active

### How Has This Been Tested?
* Tested multi track consecutive and sparse tracks (ffmpeg muxer)
* Tested multi track consecutive and sparse tracks (ffmpeg adv recording)
### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
