### PR TITLE
UI: Don't load global plugins in portable mode; Minor portable mode fixes

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -3220,12 +3220,14 @@ int main(int argc, char *argv[])
 	obs_set_cmdline_args(argc, argv);
 
 	for (int i = 1; i < argc; i++) {
-		if (arg_is(argv[i], "--portable", "-p")) {
-			portable_mode = true;
-
-		} else if (arg_is(argv[i], "--multi", "-m")) {
+		if (arg_is(argv[i], "--multi", "-m")) {
 			multi = true;
 
+#if ALLOW_PORTABLE_MODE
+		} else if (arg_is(argv[i], "--portable", "-p")) {
+			portable_mode = true;
+
+#endif
 		} else if (arg_is(argv[i], "--verbose", nullptr)) {
 			log_verbose = true;
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -173,6 +173,9 @@ static void AddExtraModulePaths()
 				    data_path_with_module_suffix.c_str());
 	}
 
+	if (portable_mode)
+		return;
+
 	char base_module_dir[512];
 #if defined(_WIN32)
 	int ret = GetProgramDataPath(base_module_dir, sizeof(base_module_dir),


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Consists of three small commits that all are related / kinda depend on each other. I'm all for atomic commits but don't think separate PR's are needed here. Feel free to disagree with me and let me know.

1. Nearly everything that involves portable mode is ifdef'ed, just not actually setting the variable. This would mean that if the `--portable` argument was passed on unsupported systems, the log would show portable mode as enabled even though it's effectively no-op. This can lead to confusion and shouldn't be the case.
2.  Portable mode is meant to be separated from the rest of the system, and as such it doesn't make sense to load globally installed plugins there. On Windows, there currently are only two major plugins that I'm aware of (StreamDeck and StreamFX) that install themselves there. Plugins installing themselves there is good, but it currently also means that even portable instances load them which can make testing and debugging in a clean environment annoying.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Read about the annoyance of global plugins loading in portable mode multiple times over the last few days.
Noticed the other things while working on that.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
1 has been tested on my Mac (macOS 13.1).

2 was tested by Flaeri, who confirmed that the streamdeck plugin no longer loads.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
