### PR TITLE
UI: Add space for right arrow in menu

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -201,6 +201,10 @@ SceneTree::item {
     padding: 6px;
 }
 
+QMenu::item {
+    padding-right: 20px;
+}
+
 QListWidget::item,
 SourceTreeItem,
 QMenu::item,

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -201,6 +201,10 @@ SceneTree::item {
     padding: 6px;
 }
 
+QMenu::item {
+    padding-right: 20px;
+}
+
 QListWidget::item,
 SourceTreeItem,
 QMenu::item,

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -201,6 +201,10 @@ SceneTree::item {
     padding: 6px;
 }
 
+QMenu::item {
+    padding-right: 20px;
+}
+
 QListWidget::item,
 SourceTreeItem,
 QMenu::item,

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -203,6 +203,10 @@ SceneTree::item {
     padding: 6px;
 }
 
+QMenu::item {
+    padding-right: 20px;
+}
+
 QListWidget::item,
 SourceTreeItem,
 QMenu::item,

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -201,6 +201,10 @@ SceneTree::item {
     padding: 6px;
 }
 
+QMenu::item {
+    padding-right: 20px;
+}
+
 QListWidget::item,
 SourceTreeItem,
 QMenu::item,


### PR DESCRIPTION
### Description
Add space for right arrow in menu

### Motivation and Context
When making custom menu I noticed that the right arrow was on top of the text.
It looks to me that it is caused by setting the padding for QMenu::item to 6px in the theme.
Now I override only the right padding for QMenu::item to 12px
Before:
![image](https://user-images.githubusercontent.com/5457024/213119081-a53c2edb-8c69-45ff-8837-5bc675ba3e7f.png)
After:
![image](https://user-images.githubusercontent.com/5457024/213118798-4cc293a6-5021-42c0-8853-430f1dde97d2.png)

The dark and system theme don't set the padding and don't have the issue.

### How Has This Been Tested?
On windows 64 by having only 1 menu item that has a right arrow.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
