### PR TITLE
obs-ffmpeg: Add option to disable settings logging

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -53,6 +53,7 @@ struct ffmpeg_source {
 	bool close_when_inactive;
 	bool seekable;
 	bool is_stinger;
+	bool log_changes;
 
 	pthread_t reconnect_thread;
 	pthread_mutex_t reconnect_mutex;
@@ -127,6 +128,7 @@ static void ffmpeg_source_defaults(obs_data_t *settings)
 	obs_data_set_default_int(settings, "reconnect_delay_sec", 10);
 	obs_data_set_default_int(settings, "buffering_mb", 2);
 	obs_data_set_default_int(settings, "speed_percent", 100);
+	obs_data_set_default_bool(settings, "log_changes", true);
 }
 
 static const char *media_filter =
@@ -245,6 +247,8 @@ static obs_properties_t *ffmpeg_source_getproperties(void *data)
 static void dump_source_info(struct ffmpeg_source *s, const char *input,
 			     const char *input_format)
 {
+	if (!s->log_changes)
+		return;
 	FF_BLOG(LOG_INFO,
 		"settings:\n"
 		"\tinput:                   %s\n"
@@ -487,6 +491,7 @@ static void ffmpeg_source_update(void *data, obs_data_t *settings)
 	s->seekable = obs_data_get_bool(settings, "seekable");
 	s->ffmpeg_options = ffmpeg_options ? bstrdup(ffmpeg_options) : NULL;
 	s->is_stinger = is_stinger;
+	s->log_changes = obs_data_get_bool(settings, "log_changes");
 
 	if (s->speed_percent < 1 || s->speed_percent > 200)
 		s->speed_percent = 100;


### PR DESCRIPTION
Allows plugins to disable the logging of settings every time the ffmpeg source is updated, by passing "log_changes" as true in the settings.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds "log_changes" to the ffmpeg source settings. If false, it will not log changes every time the settings of the media source is updated. This does not affect logging of errors and warnings. I did not add this to the properties window because I assume it's used in support channels to check the settings of media sources, so it would be bad if users can set this directly.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I am writing a playlist plugin that uses media sources internally, just as the Image Slideshow source uses Image sources internally. However, Media source spams the log when the settings are updated, which is not ideal for this sort of plugin. Image Slideshow does not have this problem because Image sources do not log their settings.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I made my plugin pass "log_changes" as false to see that it disables logging when the settings of the internal media source are modified. I also verified that Media Sources still log as usual, as users can't set the property.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 - Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
