### PR TITLE
vlc-video: Refactor playback behavior

### DIFF
--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -16,9 +16,6 @@
 #define S_LOOP                         "loop"
 #define S_SHUFFLE                      "shuffle"
 #define S_BEHAVIOR                     "playback_behavior"
-#define S_BEHAVIOR_STOP_RESTART        "stop_restart"
-#define S_BEHAVIOR_PAUSE_UNPAUSE       "pause_unpause"
-#define S_BEHAVIOR_ALWAYS_PLAY         "always_play"
 #define S_NETWORK_CACHING              "network_caching"
 #define S_TRACK                        "track"
 #define S_SUBTITLE_ENABLE              "subtitle_enable"
@@ -629,7 +626,6 @@ static void vlcs_update(void *data, obs_data_t *settings)
 	libvlc_media_list_t *media_list;
 	struct vlc_source *c = data;
 	obs_data_array_t *array;
-	const char *behavior;
 	size_t count;
 	int network_caching;
 	int track_index;
@@ -644,7 +640,9 @@ static void vlcs_update(void *data, obs_data_t *settings)
 
 	c->loop = obs_data_get_bool(settings, S_LOOP);
 
-	behavior = obs_data_get_string(settings, S_BEHAVIOR);
+	c->behavior = obs_data_get_int(settings, S_BEHAVIOR);
+	if (c->behavior > BEHAVIOR_ALWAYS_PLAY)
+		c->behavior = BEHAVIOR_ALWAYS_PLAY;
 
 	network_caching = (int)obs_data_get_int(settings, S_NETWORK_CACHING);
 
@@ -653,14 +651,6 @@ static void vlcs_update(void *data, obs_data_t *settings)
 	subtitle_index = (int)obs_data_get_int(settings, S_SUBTITLE_TRACK);
 
 	subtitle_enable = obs_data_get_bool(settings, S_SUBTITLE_ENABLE);
-
-	if (astrcmpi(behavior, S_BEHAVIOR_PAUSE_UNPAUSE) == 0) {
-		c->behavior = BEHAVIOR_PAUSE_UNPAUSE;
-	} else if (astrcmpi(behavior, S_BEHAVIOR_ALWAYS_PLAY) == 0) {
-		c->behavior = BEHAVIOR_ALWAYS_PLAY;
-	} else { /* S_BEHAVIOR_STOP_RESTART */
-		c->behavior = BEHAVIOR_STOP_RESTART;
-	}
 
 	/* ------------------------------------- */
 	/* create new list of sources */
@@ -1057,8 +1047,7 @@ static void vlcs_defaults(obs_data_t *settings)
 {
 	obs_data_set_default_bool(settings, S_LOOP, true);
 	obs_data_set_default_bool(settings, S_SHUFFLE, false);
-	obs_data_set_default_string(settings, S_BEHAVIOR,
-				    S_BEHAVIOR_STOP_RESTART);
+	obs_data_set_default_int(settings, S_BEHAVIOR, BEHAVIOR_STOP_RESTART);
 	obs_data_set_default_int(settings, S_NETWORK_CACHING, 400);
 	obs_data_set_default_int(settings, S_TRACK, 1);
 	obs_data_set_default_bool(settings, S_SUBTITLE_ENABLE, false);
@@ -1094,14 +1083,13 @@ static obs_properties_t *vlcs_properties(void *data)
 	}
 
 	p = obs_properties_add_list(ppts, S_BEHAVIOR, T_BEHAVIOR,
-				    OBS_COMBO_TYPE_LIST,
-				    OBS_COMBO_FORMAT_STRING);
-	obs_property_list_add_string(p, T_BEHAVIOR_STOP_RESTART,
-				     S_BEHAVIOR_STOP_RESTART);
-	obs_property_list_add_string(p, T_BEHAVIOR_PAUSE_UNPAUSE,
-				     S_BEHAVIOR_PAUSE_UNPAUSE);
-	obs_property_list_add_string(p, T_BEHAVIOR_ALWAYS_PLAY,
-				     S_BEHAVIOR_ALWAYS_PLAY);
+				    OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+	obs_property_list_add_int(p, T_BEHAVIOR_STOP_RESTART,
+				  BEHAVIOR_STOP_RESTART);
+	obs_property_list_add_int(p, T_BEHAVIOR_PAUSE_UNPAUSE,
+				  BEHAVIOR_PAUSE_UNPAUSE);
+	obs_property_list_add_int(p, T_BEHAVIOR_ALWAYS_PLAY,
+				  BEHAVIOR_ALWAYS_PLAY);
 
 	dstr_cat(&filter, "Media Files (");
 	dstr_copy(&exts, EXTENSIONS_MEDIA);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Used the enum behavior directly, converting the list from using strings internally to just ints. Added check if behavior is greater than `BEHAVIOR_ALWAYS_PLAY` (last enum item) to set it back to `BEHAVIOR_ALWAYS_PLAY`, to keep previous behavior (even though this case is only achievable if user edits the json file directly, or a script/plugin sets behavior to an invalid value.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Removes unnecessary code and string comparison, although performance difference should be negligible.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Verified that changing the behavior works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
 - Code cleanup (non-breaking change which makes code smaller or more readable)
 - Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->
Probably a breaking change only for plugins that set the behavior. If this change is not worth it, it's fine.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
