### PR TITLE
RFC 45-3: Use protocol for video codec selections

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -1232,23 +1232,6 @@ bool OBSBasicSettings::UpdateResFPSLimits()
 	return true;
 }
 
-bool OBSBasicSettings::IsServiceOutputHasNetworkFeatures()
-{
-	if (IsCustomService())
-		return ui->customServer->text().startsWith("rtmp");
-
-	OBSServiceAutoRelease service = SpawnTempService();
-	const char *output = obs_service_get_output_type(service);
-
-	if (!output)
-		return true;
-
-	if (strcmp(output, "rtmp_output") == 0)
-		return true;
-
-	return false;
-}
-
 static bool service_supports_codec(const char **codecs, const char *codec)
 {
 	if (!codecs)

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -1447,27 +1447,13 @@ void OBSBasicSettings::ResetEncoders(bool streamOnly)
 		if (obs_get_encoder_type(type) != OBS_ENCODER_VIDEO)
 			continue;
 
-		const char *streaming_codecs[] = {
-			"h264",
-#ifdef ENABLE_HEVC
-			"hevc",
-#endif
-		};
-
-		bool is_streaming_codec = false;
-		for (const char *test_codec : streaming_codecs) {
-			if (strcmp(codec, test_codec) == 0) {
-				is_streaming_codec = true;
-				break;
-			}
-		}
 		if ((caps & ENCODER_HIDE_FLAGS) != 0)
 			continue;
 
 		QString qName = QT_UTF8(name);
 		QString qType = QT_UTF8(type);
 
-		if (is_streaming_codec && service_supports_codec(codecs, codec))
+		if (service_supports_codec(codecs, codec))
 			ui->advOutEncoder->addItem(qName, qType);
 		if (!streamOnly)
 			ui->advOutRecEncoder->addItem(qName, qType);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -5621,7 +5621,7 @@ void OBSBasicSettings::RecreateOutputResolutionWidget()
 
 void OBSBasicSettings::UpdateAdvNetworkGroup()
 {
-	bool enabled = IsServiceOutputHasNetworkFeatures();
+	bool enabled = protocol.contains("RTMP");
 
 	ui->advNetworkDisabled->setVisible(!enabled);
 

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -263,14 +263,18 @@ private:
 	QString lastService;
 	int prevLangIndex;
 	bool prevBrowserAccel;
-private slots:
+
+	void ServiceChanged();
 	void UpdateServerList();
 	void UpdateKeyLink();
 	void UpdateVodTrackSetting();
 	void UpdateServiceRecommendations();
-	void RecreateOutputResolutionWidget();
-	void UpdateResFPSLimits();
 	void UpdateMoreInfoLink();
+	void UpdateAdvNetworkGroup();
+
+private slots:
+	void RecreateOutputResolutionWidget();
+	bool UpdateResFPSLimits();
 	void DisplayEnforceWarning(bool checked);
 	void on_show_clicked();
 	void on_authPwShow_clicked();
@@ -382,6 +386,7 @@ private slots:
 	void on_buttonBox_clicked(QAbstractButton *button);
 
 	void on_service_currentIndexChanged(int idx);
+	void on_customServer_textChanged(const QString &text);
 	void on_simpleOutputBrowse_clicked();
 	void on_advOutRecPathBrowse_clicked();
 	void on_advOutFFPathBrowse_clicked();
@@ -434,8 +439,6 @@ private slots:
 	void AdvancedChangedRestart();
 
 	void UpdateStreamDelayEstimate();
-
-	void UpdateAdvNetworkGroup();
 
 	void UpdateAutomaticReplayBufferCheckboxes();
 

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -261,10 +261,13 @@ private:
 	void OnOAuthStreamKeyConnected();
 	void OnAuthConnected();
 	QString lastService;
+	QString protocol;
+	QString lastCustomServer;
 	int prevLangIndex;
 	bool prevBrowserAccel;
 
 	void ServiceChanged();
+	QString FindProtocol();
 	void UpdateServerList();
 	void UpdateKeyLink();
 	void UpdateVodTrackSetting();

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -377,8 +377,6 @@ private:
 
 	OBSService GetStream1Service();
 
-	bool IsServiceOutputHasNetworkFeatures();
-
 	bool ServiceAndCodecCompatible();
 	bool ServiceSupportsCodecCheck();
 

--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -679,7 +679,9 @@ General Output Functions
 ---------------------
 
 .. function:: const char *obs_output_get_supported_video_codecs(const obs_output_t *output)
+              const char *obs_get_output_supported_video_codecs(const char *id)
               const char *obs_output_get_supported_audio_codecs(const obs_output_t *output)
+              const char *obs_get_output_supported_video_codecs(const char *id)
 
    :return: Supported video/audio codecs of an encoded output, separated
             by semicolon

--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -709,6 +709,24 @@ General Output Functions
 
 ---------------------
 
+.. function:: bool obs_enum_output_protocols(size_t idx, char **protocol)
+
+   Enumerates all registered protocol.
+
+---------------------
+
+.. function:: void obs_enum_output_types_with_protocol(const char *protocol, void *data, bool (*enum_cb)(void *data, const char *id))
+
+   Enumerates through a callback all available output types for the given protocol.
+
+   :param protocol: Protocol of the outputs to enumerate
+   :param data:     Data passed to the callback
+   :param enum_cb:  Callback used when a matching output is found, the id
+                    of the output is passed to the callback
+   :return:         When all outputs are enumerated or if the callback return *false*
+
+---------------------
+
 Functions used by outputs
 -------------------------
 

--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -234,7 +234,15 @@ Output Definition Structure (obs_output_info)
    This variable specifies which codecs are supported by an encoded
    output, separated by semicolon.
 
-   (Optional, though recommended)
+   Required if **OBS_OUTPUT_SERVICE** flag is set, otherwise
+   recommended.
+
+.. member:: const char *obs_output_info.protocols
+
+   This variable specifies which protocols are supported by an output,
+   separated by semicolon.
+
+   Required only if **OBS_OUTPUT_SERVICE** flag is set.
 
 .. _output_signal_handler_reference:
 
@@ -682,6 +690,22 @@ General Output Functions
               uint32_t obs_get_output_flags(const char *id)
 
    :return: The output capability flags
+
+---------------------
+
+.. function:: const char *obs_output_get_protocols(const obs_output_t *output)
+
+   :return: Supported protocols, separated by semicolon. Always NULL if the
+            output is not **OBS_OUTPUT_SERVICE**.
+
+---------------------
+
+.. function:: bool obs_is_output_protocol_registered(const char *protocol)
+
+   Check if one of the registered output use the given protocol.
+
+   :return:                 A boolean showing if an output with the given
+                            protocol is registered
 
 ---------------------
 

--- a/docs/sphinx/reference-services.rst
+++ b/docs/sphinx/reference-services.rst
@@ -148,6 +148,10 @@ Service Definition Structure
             the data manually (typically best to use strlist_split to
             generate this)
 
+.. member:: const char *(*obs_service_info.get_protocol)(void *data)
+
+   :return: The protocol used by the service
+
 
 General Service Functions
 -------------------------
@@ -304,6 +308,12 @@ General Service Functions
    :return: An array of string pointers containing the supported codecs
             for the service, terminated with a *NULL* pointer. Does not
             need to be freed
+
+---------------------
+
+.. function:: const char *obs_service_get_protocol(const obs_service_t *service)
+
+   :return: Protocol currently used for this service
 
 .. ---------------------------------------------------------------------------
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -411,6 +411,8 @@ struct obs_core_data {
 	obs_data_t *private_data;
 
 	volatile bool valid;
+
+	DARRAY(char *) protocols;
 };
 
 /* user hotkeys */

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -928,6 +928,7 @@ void obs_register_service_s(const struct obs_service_info *info, size_t size)
 	CHECK_REQUIRED_VAL_(info, get_name, obs_register_service);
 	CHECK_REQUIRED_VAL_(info, create, obs_register_service);
 	CHECK_REQUIRED_VAL_(info, destroy, obs_register_service);
+	CHECK_REQUIRED_VAL_(info, get_protocol, obs_register_service);
 #undef CHECK_REQUIRED_VAL_
 
 	REGISTER_OBS_DEF(size, obs_service_info, obs->service_types, info);

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -836,6 +836,9 @@ void obs_register_output_s(const struct obs_output_info *info, size_t size)
 	CHECK_REQUIRED_VAL_(info, start, obs_register_output);
 	CHECK_REQUIRED_VAL_(info, stop, obs_register_output);
 
+	if (info->flags & OBS_OUTPUT_SERVICE)
+		CHECK_REQUIRED_VAL_(info, protocols, obs_register_output);
+
 	if (info->flags & OBS_OUTPUT_ENCODED) {
 		CHECK_REQUIRED_VAL_(info, encoded_packet, obs_register_output);
 	} else {
@@ -856,6 +859,24 @@ void obs_register_output_s(const struct obs_output_info *info, size_t size)
 #undef CHECK_REQUIRED_VAL_
 
 	REGISTER_OBS_DEF(size, obs_output_info, obs->output_types, info);
+
+	if (info->flags & OBS_OUTPUT_SERVICE) {
+		char **protocols = strlist_split(info->protocols, ';', false);
+		for (char **protocol = protocols; *protocol; ++protocol) {
+			bool skip = false;
+			for (size_t i = 0; i < obs->data.protocols.num; i++) {
+				if (strcmp(*protocol,
+					   obs->data.protocols.array[i]) == 0)
+					skip = true;
+			}
+
+			if (skip)
+				continue;
+			char *new_prtcl = bstrdup(*protocol);
+			da_push_back(obs->data.protocols, &new_prtcl);
+		}
+		strlist_free(protocols);
+	}
 	return;
 
 error:

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2713,3 +2713,13 @@ const char *obs_output_get_supported_audio_codecs(const obs_output_t *output)
 		       ? output->info.encoded_audio_codecs
 		       : NULL;
 }
+
+const char *obs_output_get_protocols(const obs_output_t *output)
+{
+	if (!obs_output_valid(output, "obs_output_get_protocols"))
+		return NULL;
+
+	return (output->info.flags & OBS_OUTPUT_SERVICE)
+		       ? output->info.protocols
+		       : NULL;
+}

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2751,3 +2751,15 @@ void obs_enum_output_types_with_protocol(const char *protocol, void *data,
 		}
 	}
 }
+
+const char *obs_get_output_supported_video_codecs(const char *id)
+{
+	const struct obs_output_info *info = find_output(id);
+	return info ? info->encoded_video_codecs : NULL;
+}
+
+const char *obs_get_output_supported_audio_codecs(const char *id)
+{
+	const struct obs_output_info *info = find_output(id);
+	return info ? info->encoded_audio_codecs : NULL;
+}

--- a/libobs/obs-output.h
+++ b/libobs/obs-output.h
@@ -77,6 +77,9 @@ struct obs_output_info {
 
 	/* raw audio callback for multi track outputs */
 	void (*raw_audio2)(void *data, size_t idx, struct audio_data *frames);
+
+	/* required if OBS_OUTPUT_SERVICE */
+	const char *protocols;
 };
 
 EXPORT void obs_register_output_s(const struct obs_output_info *info,

--- a/libobs/obs-service.c
+++ b/libobs/obs-service.c
@@ -477,3 +477,11 @@ obs_service_get_supported_video_codecs(const obs_service_t *service)
 			service->context.data);
 	return NULL;
 }
+
+const char *obs_service_get_protocol(const obs_service_t *service)
+{
+	if (!obs_service_valid(service, "obs_service_get_protocol"))
+		return NULL;
+
+	return service->info.get_protocol(service->context.data);
+}

--- a/libobs/obs-service.h
+++ b/libobs/obs-service.h
@@ -88,6 +88,8 @@ struct obs_service_info {
 				int *audio_bitrate);
 
 	const char **(*get_supported_video_codecs)(void *data);
+
+	const char *(*get_protocol)(void *data);
 };
 
 EXPORT void obs_register_service_s(const struct obs_service_info *info,

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1078,6 +1078,10 @@ static void obs_free_data(void)
 	da_free(data->draw_callbacks);
 	da_free(data->tick_callbacks);
 	obs_data_release(data->private_data);
+
+	for (size_t i = 0; i < data->protocols.num; i++)
+		bfree(data->protocols.array[i]);
+	da_free(data->protocols);
 }
 
 static const char *obs_signals[] = {
@@ -3451,4 +3455,14 @@ bool obs_weak_object_references_object(obs_weak_object_t *weak,
 				       obs_object_t *object)
 {
 	return weak && object && weak->object == object;
+}
+
+bool obs_is_output_protocol_registered(const char *protocol)
+{
+	for (size_t i = 0; i < obs->data.protocols.num; i++) {
+		if (strcmp(protocol, obs->data.protocols.array[i]) == 0)
+			return true;
+	}
+
+	return false;
 }

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -3466,3 +3466,12 @@ bool obs_is_output_protocol_registered(const char *protocol)
 
 	return false;
 }
+
+bool obs_enum_output_protocols(size_t idx, char **protocol)
+{
+	if (idx >= obs->data.protocols.num)
+		return false;
+
+	*protocol = obs->data.protocols.array[idx];
+	return true;
+}

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2221,6 +2221,10 @@ EXPORT void obs_enum_output_types_with_protocol(
 	const char *protocol, void *data,
 	bool (*enum_cb)(void *data, const char *id));
 
+EXPORT const char *obs_get_output_supported_video_codecs(const char *id);
+
+EXPORT const char *obs_get_output_supported_audio_codecs(const char *id);
+
 /* ------------------------------------------------------------------------- */
 /* Functions used by outputs */
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2211,6 +2211,10 @@ obs_output_get_supported_video_codecs(const obs_output_t *output);
 EXPORT const char *
 obs_output_get_supported_audio_codecs(const obs_output_t *output);
 
+EXPORT const char *obs_output_get_protocols(const obs_output_t *output);
+
+EXPORT bool obs_is_output_protocol_registered(const char *protocol);
+
 /* ------------------------------------------------------------------------- */
 /* Functions used by outputs */
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2539,6 +2539,9 @@ obs_service_get_supported_video_codecs(const obs_service_t *service);
  * date. */
 EXPORT const char *obs_service_get_output_type(const obs_service_t *service);
 
+/** Returns the protocol for this service context */
+EXPORT const char *obs_service_get_protocol(const obs_service_t *service);
+
 /* ------------------------------------------------------------------------- */
 /* Source frame allocation functions */
 EXPORT void obs_source_frame_init(struct obs_source_frame *frame,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2215,6 +2215,12 @@ EXPORT const char *obs_output_get_protocols(const obs_output_t *output);
 
 EXPORT bool obs_is_output_protocol_registered(const char *protocol);
 
+EXPORT bool obs_enum_output_protocols(size_t idx, char **protocol);
+
+EXPORT void obs_enum_output_types_with_protocol(
+	const char *protocol, void *data,
+	bool (*enum_cb)(void *data, const char *id));
+
 /* ------------------------------------------------------------------------- */
 /* Functions used by outputs */
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
@@ -331,6 +331,7 @@ struct obs_output_info ffmpeg_hls_muxer = {
 	.id = "ffmpeg_hls_muxer",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_MULTI_TRACK |
 		 OBS_OUTPUT_SERVICE,
+	.protocols = "HLS",
 #ifdef ENABLE_HEVC
 	.encoded_video_codecs = "h264;hevc",
 #else

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -1289,6 +1289,7 @@ struct obs_output_info ffmpeg_mpegts_muxer = {
 	.id = "ffmpeg_mpegts_muxer",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_MULTI_TRACK |
 		 OBS_OUTPUT_SERVICE,
+	.protocols = "SRT;RIST",
 #ifdef ENABLE_HEVC
 	.encoded_video_codecs = "h264;hevc;av1",
 #else

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -1291,9 +1291,9 @@ struct obs_output_info ffmpeg_mpegts_muxer = {
 		 OBS_OUTPUT_SERVICE,
 	.protocols = "SRT;RIST",
 #ifdef ENABLE_HEVC
-	.encoded_video_codecs = "h264;hevc;av1",
+	.encoded_video_codecs = "h264;hevc",
 #else
-	.encoded_video_codecs = "h264;av1",
+	.encoded_video_codecs = "h264",
 #endif
 	.encoded_audio_codecs = "aac",
 	.get_name = ffmpeg_mpegts_getname,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -944,6 +944,7 @@ struct obs_output_info ffmpeg_mpegts_muxer = {
 	.id = "ffmpeg_mpegts_muxer",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_MULTI_TRACK |
 		 OBS_OUTPUT_SERVICE,
+	.protocols = "SRT;RIST",
 	.encoded_video_codecs = "h264;av1",
 	.encoded_audio_codecs = "aac",
 	.get_name = ffmpeg_mpegts_mux_getname,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -945,7 +945,7 @@ struct obs_output_info ffmpeg_mpegts_muxer = {
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_MULTI_TRACK |
 		 OBS_OUTPUT_SERVICE,
 	.protocols = "SRT;RIST",
-	.encoded_video_codecs = "h264;av1",
+	.encoded_video_codecs = "h264",
 	.encoded_audio_codecs = "aac",
 	.get_name = ffmpeg_mpegts_mux_getname,
 	.create = ffmpeg_mux_create,

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -1159,6 +1159,7 @@ static int _ftl_error_to_obs_error(int status)
 struct obs_output_info ftl_output_info = {
 	.id = "ftl_output",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_SERVICE,
+	.protocols = "FTL",
 	.encoded_video_codecs = "h264",
 	.encoded_audio_codecs = "opus",
 	.get_name = ftl_stream_getname,

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -1642,6 +1642,11 @@ struct obs_output_info rtmp_output_info = {
 	.id = "rtmp_output",
 	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_SERVICE |
 		 OBS_OUTPUT_MULTI_TRACK,
+#ifdef NO_CRYPTO
+	.protocols = "RTMP",
+#else
+	.protocols = "RTMP;RTMPS",
+#endif
 	.encoded_video_codecs = "h264",
 	.encoded_audio_codecs = "aac",
 	.get_name = rtmp_stream_getname,

--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v4",
-    "version": 220,
+    "version": 221,
     "files": [
         {
             "name": "services.json",
-            "version": 220
+            "version": 221
         }
     ]
 }

--- a/plugins/rtmp-services/data/schema/service-schema-v4.json
+++ b/plugins/rtmp-services/data/schema/service-schema-v4.json
@@ -16,6 +16,18 @@
                         "description": "Name of the streaming service. Will be displayed in the Service dropdown.",
                         "minLength": 1
                     },
+                    "protocol" : {
+                        "type": "string",
+                        "description": "Protocol used by the service. If missing the service is considered using RTMP or RTMPS.",
+                        "enum": [
+                            "RTMP",
+                            "RTMPS",
+                            "HLS",
+                            "FTL",
+                            "SRT",
+                            "RIST"
+                        ]
+                    },
                     "common": {
                         "type": "boolean",
                         "description": "Whether or not the service is shown in the list before it is expanded to all services by the user.",
@@ -200,6 +212,18 @@
                 "required": [
                     "name",
                     "servers"
+		],
+                "allOf": [
+                    {
+                        "$comment": "Require protocol field if not an RTMP(S) URL",
+                        "if": { "not": { "properties": { "servers": { "items": { "properties": { "url": { "format": "uri", "pattern": "^rtmps?://" } } } } } } },
+                        "then": { "required": ["protocol"] }
+                    },
+                    {
+                        "$comment": "Require recommended output field if protocol field is not RTMP(S)",
+                        "if": { "required": ["protocol"], "properties": { "protocol": { "pattern": "^(HLS|SRT|RIST|FTL)$" } } },
+                        "then": { "properties": { "recommended": { "required": ["output"] } } }
+                    }
                 ]
             },
             "additionalItems": true

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -204,6 +204,7 @@
             "common": false,
             "more_info_link": "https://developers.google.com/youtube/v3/live/guides/ingestion-protocol-comparison",
             "stream_key_link": "https://www.youtube.com/live_dashboard",
+            "protocol": "HLS",
             "supported video codecs": [
                 "h264",
                 "hevc"
@@ -1445,6 +1446,7 @@
         {
             "name": "YouNow",
             "common": false,
+            "protocol": "FTL",
             "supported audio codecs": [
                 "opus"
             ],
@@ -1687,6 +1689,7 @@
         },
         {
             "name": "SHOWROOM",
+            "protocol": "RTMP",
             "servers": [
                 {
                     "name": "Default",
@@ -1821,6 +1824,7 @@
         {
             "name": "Glimesh",
             "stream_key_link": "https://glimesh.tv/users/settings/stream",
+            "protocol": "FTL",
             "supported audio codecs": [
                 "opus"
             ],
@@ -2024,6 +2028,7 @@
         },
         {
             "name": "Dacast",
+            "protocol": "RTMP",
             "servers": [
                 {
                     "name": "Default",

--- a/plugins/rtmp-services/rtmp-custom.c
+++ b/plugins/rtmp-services/rtmp-custom.c
@@ -110,6 +110,30 @@ static const char *rtmp_custom_password(void *data)
 	return service->password;
 }
 
+#define RTMPS_PREFIX "rtmps://"
+#define FTL_PREFIX "ftl://"
+#define SRT_PREFIX "srt://"
+#define RIST_PREFIX "rist://"
+
+static const char *rtmp_custom_get_protocol(void *data)
+{
+	struct rtmp_custom *service = data;
+
+	if (strncmp(service->server, RTMPS_PREFIX, strlen(RTMPS_PREFIX)) == 0)
+		return "RTMPS";
+
+	if (strncmp(service->server, FTL_PREFIX, strlen(FTL_PREFIX)) == 0)
+		return "FTL";
+
+	if (strncmp(service->server, SRT_PREFIX, strlen(SRT_PREFIX)) == 0)
+		return "SRT";
+
+	if (strncmp(service->server, RIST_PREFIX, strlen(RIST_PREFIX)) == 0)
+		return "RIST";
+
+	return "RTMP";
+}
+
 #define RTMP_PROTOCOL "rtmp"
 
 static void rtmp_custom_apply_settings(void *data, obs_data_t *video_settings,
@@ -131,6 +155,7 @@ struct obs_service_info rtmp_custom_service = {
 	.destroy = rtmp_custom_destroy,
 	.update = rtmp_custom_update,
 	.get_properties = rtmp_custom_properties,
+	.get_protocol = rtmp_custom_get_protocol,
 	.get_url = rtmp_custom_url,
 	.get_key = rtmp_custom_key,
 	.get_username = rtmp_custom_username,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

**This PR is about the [RFC 45](https://github.com/obsproject/rfcs/pull/45).**

Depends on:
- https://github.com/obsproject/obs-studio/pull/5104
- https://github.com/obsproject/obs-studio/pull/8087

Make OBS Studio rely on the notion of protocol and service compatibility to enable some codec to be used with the stream service.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Part of the implementation of the RFC 45.

Remove the hardcoded list and allow AV1 on SRT/RIST once MPEG-TS has it's standard ready.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Changing services and check if codecs shown match with compatible ones.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
