### PR TITLE
libobs: Fix loading of custom_size for empty scenes

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1103,6 +1103,12 @@ static void scene_load(void *data, obs_data_t *settings)
 
 	remove_all_items(scene);
 
+	if (obs_data_get_bool(settings, "custom_size")) {
+		scene->cx = (uint32_t)obs_data_get_int(settings, "cx");
+		scene->cy = (uint32_t)obs_data_get_int(settings, "cy");
+		scene->custom_size = true;
+	}
+
 	if (!items)
 		return;
 
@@ -1116,12 +1122,6 @@ static void scene_load(void *data, obs_data_t *settings)
 
 	if (obs_data_has_user_value(settings, "id_counter"))
 		scene->id_counter = obs_data_get_int(settings, "id_counter");
-
-	if (obs_data_get_bool(settings, "custom_size")) {
-		scene->cx = (uint32_t)obs_data_get_int(settings, "cx");
-		scene->cy = (uint32_t)obs_data_get_int(settings, "cy");
-		scene->custom_size = true;
-	}
 
 	obs_data_array_release(items);
 }


### PR DESCRIPTION
### Description
This moves the `custom_size` code above the return statement, to allow scenes to be set to a custom size if they are missing the `items` array (aka coming from a default configuration).

### Motivation and Context
Previously, `custom_size` was checked at the end of the `scene_load` function. If the scene contained no "items" array, the `custom_scene` loading code would never be run.

### How Has This Been Tested?
Before: Custom size did not work without `items` defined
After: It works without `items` defined

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
