### PR TITLE
obs-filters: Improve NVIDIA effects SDK version checks

### DIFF
--- a/plugins/obs-filters/noise-suppress-filter.c
+++ b/plugins/obs-filters/noise-suppress-filter.c
@@ -634,7 +634,7 @@ bool load_nvafx(void)
 		blog(LOG_INFO,
 		     "[noise suppress]: NVIDIA AUDIO FX version: %i.%i.%i.%i",
 		     major, minor, build, revision);
-		if (version < (MIN_AFX_SDK_VERSION)) {
+		if (version < MIN_AFX_SDK_VERSION) {
 			blog(LOG_INFO,
 			     "[noise suppress]: NVIDIA AUDIO Effects SDK is outdated. Please update both audio & video SDK.");
 		}
@@ -1227,7 +1227,7 @@ static obs_properties_t *noise_suppress_properties(void *data)
 						1.0f, 0.01f);
 	}
 	unsigned int version = get_lib_version();
-	if (version < (MIN_AFX_SDK_VERSION)) {
+	if (version && version < MIN_AFX_SDK_VERSION) {
 		obs_property_t *warning = obs_properties_add_text(
 			ppts, "deprecation", NULL, OBS_TEXT_INFO);
 		obs_property_text_set_info_type(warning, OBS_TEXT_INFO_WARNING);

--- a/plugins/obs-filters/nvafx-load.h
+++ b/plugins/obs-filters/nvafx-load.h
@@ -9,7 +9,7 @@
 #define NVAFX_API
 
 #ifdef LIBNVAFX_ENABLED
-#define MIN_AFX_SDK_VERSION 1 << 24 | 2 << 16 | 13 << 0
+#define MIN_AFX_SDK_VERSION (1 << 24 | 2 << 16 | 13 << 0)
 static HMODULE nv_audiofx = NULL;
 static HMODULE nv_cuda = NULL;
 
@@ -312,15 +312,26 @@ static bool load_lib(void)
 
 static unsigned int get_lib_version(void)
 {
+	static unsigned int version = 0;
+	static bool version_checked = false;
+
+	if (version_checked)
+		return version;
+
+	version_checked = true;
+
 	char path[MAX_PATH];
 	if (!nvafx_get_sdk_path(path, sizeof(path)))
 		return 0;
 
 	SetDllDirectoryA(path);
+
 	struct win_version_info nto_ver = {0};
-	get_dll_ver(L"NVAudioEffects.dll", &nto_ver);
-	unsigned int version = nto_ver.major << 24 | nto_ver.minor << 16 |
-			       nto_ver.build << 8 | nto_ver.revis << 0;
+	if (get_dll_ver(L"NVAudioEffects.dll", &nto_ver))
+		version = nto_ver.major << 24 | nto_ver.minor << 16 |
+			  nto_ver.build << 8 | nto_ver.revis << 0;
+
+	SetDllDirectoryA(NULL);
 	return version;
 }
 #endif

--- a/plugins/obs-filters/nvidia-greenscreen-filter.c
+++ b/plugins/obs-filters/nvidia-greenscreen-filter.c
@@ -479,7 +479,7 @@ static void *nv_greenscreen_filter_create(obs_data_t *settings,
 		uint8_t build = (filter->version >> 8) & 0x0000ff;
 		uint8_t revision = (filter->version >> 0) & 0x000000ff;
 		// sanity check
-		nvvfx_new_sdk = filter->version >= (MIN_VFX_SDK_VERSION) &&
+		nvvfx_new_sdk = filter->version >= MIN_VFX_SDK_VERSION &&
 				nvvfx_new_sdk;
 	}
 
@@ -551,7 +551,7 @@ static obs_properties_t *nv_greenscreen_filter_properties(void *data)
 		props, S_PROCESSING, TEXT_PROCESSING, 1, 4, 1);
 	obs_property_set_long_description(partial, TEXT_PROCESSING_HINT);
 	unsigned int version = get_lib_version();
-	if (version < (MIN_VFX_SDK_VERSION)) {
+	if (version && version < MIN_VFX_SDK_VERSION) {
 		obs_property_t *warning = obs_properties_add_text(
 			props, "deprecation", NULL, OBS_TEXT_INFO);
 		obs_property_text_set_info_type(warning, OBS_TEXT_INFO_WARNING);
@@ -895,7 +895,7 @@ bool load_nvvfx(void)
 		blog(LOG_INFO,
 		     "[NVIDIA VIDEO FX]: NVIDIA VIDEO FX version: %i.%i.%i.%i",
 		     major, minor, build, revision);
-		if (version < (MIN_VFX_SDK_VERSION)) {
+		if (version < MIN_VFX_SDK_VERSION) {
 			blog(LOG_INFO,
 			     "[NVIDIA VIDEO FX]: NVIDIA VIDEO Effects SDK is outdated. Please update both audio & video SDK.");
 		}

--- a/plugins/obs-filters/nvvfx-load.h
+++ b/plugins/obs-filters/nvvfx-load.h
@@ -39,7 +39,7 @@ extern "C" {
 #define CUDARTAPI
 
 #ifdef LIBNVVFX_ENABLED
-#define MIN_VFX_SDK_VERSION 0 << 24 | 7 << 16 | 1 << 8 | 0 << 0
+#define MIN_VFX_SDK_VERSION (0 << 24 | 7 << 16 | 1 << 8 | 0 << 0)
 static HMODULE nv_videofx = NULL;
 static HMODULE nv_cvimage = NULL;
 static HMODULE nv_cudart = NULL;
@@ -817,14 +817,25 @@ static inline bool load_nv_vfx_libs()
 
 static unsigned int get_lib_version(void)
 {
+	static unsigned int version = 0;
+	static bool version_checked = false;
+
+	if (version_checked)
+		return version;
+
+	version_checked = true;
+
 	char path[MAX_PATH];
 	nvvfx_get_sdk_path(path, sizeof(path));
 
 	SetDllDirectoryA(path);
+
 	struct win_version_info nto_ver = {0};
-	get_dll_ver(L"NVVideoEffects.dll", &nto_ver);
-	unsigned int version = nto_ver.major << 24 | nto_ver.minor << 16 |
-			       nto_ver.build << 8 | nto_ver.revis << 0;
+	if (get_dll_ver(L"NVVideoEffects.dll", &nto_ver))
+		version = nto_ver.major << 24 | nto_ver.minor << 16 |
+			  nto_ver.build << 8 | nto_ver.revis << 0;
+
+	SetDllDirectoryA(NULL);
 	return version;
 }
 #endif


### PR DESCRIPTION
### Description
- Don't repeatedly query version at runtime in case a user installs the SDK while OBS is running
- Restore default DLL search directory
- Don't show outdated SDK message if the SDK is not found
- Protect minimum version macro with brackets

### Motivation and Context
Don't want to show warning to users without the SDK installed. Cleaned up other things while working on the code.

### How Has This Been Tested?
Ran OBS on a GPU supporting NVIDIA effects SDK and verified in debugger.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
