### PR TITLE
libobs-opengl:  Do not close X11 platform display on error

### DIFF
--- a/libobs-opengl/gl-x11-egl.c
+++ b/libobs-opengl/gl-x11-egl.c
@@ -385,6 +385,8 @@ static void gl_x11_egl_platform_destroy(struct gl_platform *plat)
 
 	gl_context_destroy(plat);
 	eglTerminate(plat->edisplay);
+	if (plat->close_xdisplay)
+		XCloseDisplay(plat->xdisplay);
 	bfree(plat);
 }
 

--- a/libobs/obs-nix-x11.c
+++ b/libobs/obs-nix-x11.c
@@ -878,6 +878,7 @@ static void obs_nix_x11_hotkeys_platform_free(struct obs_core_hotkeys *hotkeys)
 		da_free(context->keycodes[i].list);
 
 	bfree(context->keysyms);
+	XCloseDisplay(context->display);
 	bfree(context);
 
 	hotkeys->platform_context = NULL;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

The platform display retrieved in `OBSApp::OBSInit()` belongs to Qt, therefore libobs components should not destroy it. Because when it is destroyed, it may result in UAFs when Qt components try to use it. Not closing the platform display is the main change, but there are also two other small changes that close X displays that weren't previously closed. See the commit messages for more details.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fixes a use-after-free issue that manifests itself when `gl_x11_egl_platform_create()` fails.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested locally on top of the master branch. Linux 6.1.7, with X11, NVIDIA.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

-- 

@GeorgesStavracas @kkartaltepe 