### PR TITLE
UI: Don't open properties dialog if item is scene

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -328,7 +328,7 @@ void SourceTreeItem::mouseDoubleClickEvent(QMouseEvent *event)
 		obs_source_t *source = obs_sceneitem_get_source(sceneitem);
 		OBSBasic *main =
 			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
-		if (source) {
+		if (obs_source_configurable(source)) {
 			main->CreatePropertiesWindow(source);
 		}
 	}


### PR DESCRIPTION
### Description
This disables opening of the properties dialog if a scene is double clicked in the source tree.

### Motivation and Context
The scene properties dialog is empty, so it is unnecessary to open it.

### How Has This Been Tested?
Double clicked scene item that was scene.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
