### PR TITLE
UI: Add screenshot button to source context bar

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1046,7 +1046,7 @@ Basic.Settings.Output.SplitFile.Time="Split Time"
 Basic.Settings.Output.SplitFile.Size="Split Size"
 
 # Screenshot
-Screenshot="Screenshot Output"
+Screenshot="Screenshot"
 Screenshot.SourceHotkey="Screenshot Selected Source"
 Screenshot.StudioProgram="Screenshot (Program)"
 Screenshot.Preview="Screenshot (Preview)"

--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -528,6 +528,10 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/filter.svg);
 }
 
+* [themeID="cameraIcon"] {
+    qproperty-icon: url(./Dark/sources/camera.svg);
+}
+
 QToolBarExtension {
     background: palette(button);
     min-width: 12px;

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -332,6 +332,10 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/filter.svg);
 }
 
+* [themeID="cameraIcon"] {
+    qproperty-icon: url(./Dark/sources/camera.svg);
+}
+
 /* Tab Widget */
 
 QTabWidget::pane { /* The tab widget frame */

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -526,6 +526,10 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/filter.svg);
 }
 
+* [themeID="cameraIcon"] {
+    qproperty-icon: url(./Dark/sources/camera.svg);
+}
+
 QToolBarExtension {
     background: palette(button);
     min-width: 12px;

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -526,6 +526,10 @@ QToolButton:pressed {
     qproperty-icon: url(./Light/filter.svg);
 }
 
+* [themeID="cameraIcon"] {
+    qproperty-icon: url(./Dark/sources/camera.svg);
+}
+
 QToolBarExtension {
     background: palette(button);
     min-width: 12px;

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -534,6 +534,10 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/filter.svg);
 }
 
+* [themeID="cameraIcon"] {
+    qproperty-icon: url(./Dark/sources/camera.svg);
+}
+
 QToolBarExtension {
     background: palette(button);
     min-width: 12px;

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -62,6 +62,10 @@ OBSThemeMeta {
     qproperty-icon: url(:/res/images/filter.svg);
 }
 
+* [themeID="cameraIcon"] {
+    qproperty-icon: url(:/res/images/sources/camera.svg);
+}
+
 MuteCheckBox {
     outline: none;
 }

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -530,6 +530,10 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/filter.svg);
 }
 
+* [themeID="cameraIcon"] {
+    qproperty-icon: url(./Dark/sources/camera.svg);
+}
+
 QToolBarExtension {
     background: palette(button);
     min-width: 12px;

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -434,6 +434,32 @@
            </widget>
           </item>
           <item>
+           <widget class="QPushButton" name="sourceScreenshotButton">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Screenshot</string>
+            </property>
+            <property name="toolTip">
+             <string>Screenshot.Source</string>
+            </property>
+            <property name="icon">
+             <iconset resource="obs.qrc">
+              <normaloff>:/res/images/sources/camera.svg</normaloff>:/res/images/sources/camera.svg</iconset>
+            </property>
+            <property name="themeID" stdset="0">
+             <string>cameraIcon</string>
+            </property>
+            <property name="themeID2" stdset="0">
+             <string>contextBarButton</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="Line" name="line">
             <property name="orientation">
              <enum>Qt::Vertical</enum>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3243,6 +3243,8 @@ void OBSBasic::UpdateContextBar(bool force)
 		ui->sourceFiltersButton->setEnabled(true);
 		ui->sourcePropertiesButton->setEnabled(
 			obs_source_configurable(source));
+		ui->sourceScreenshotButton->setEnabled(flags &
+						       OBS_SOURCE_VIDEO);
 	} else {
 		ClearContextBar();
 		ui->contextSourceIcon->hide();
@@ -3253,16 +3255,19 @@ void OBSBasic::UpdateContextBar(bool force)
 		ui->sourceFiltersButton->setEnabled(false);
 		ui->sourcePropertiesButton->setEnabled(false);
 		ui->sourceInteractButton->setVisible(false);
+		ui->sourceScreenshotButton->setEnabled(false);
 	}
 
 	if (contextBarSize == ContextBarSize_Normal) {
 		ui->sourcePropertiesButton->setText(QTStr("Properties"));
 		ui->sourceFiltersButton->setText(QTStr("Filters"));
 		ui->sourceInteractButton->setText(QTStr("Interact"));
+		ui->sourceScreenshotButton->setText(QTStr("Screenshot"));
 	} else {
 		ui->sourcePropertiesButton->setText("");
 		ui->sourceFiltersButton->setText("");
 		ui->sourceInteractButton->setText("");
+		ui->sourceScreenshotButton->setText("");
 	}
 }
 
@@ -10233,6 +10238,11 @@ void OBSBasic::on_actionSceneFilters_triggered()
 void OBSBasic::on_sourceInteractButton_clicked()
 {
 	on_actionInteract_triggered();
+}
+
+void OBSBasic::on_sourceScreenshotButton_clicked()
+{
+	ScreenshotSelectedSource();
 }
 
 void OBSBasic::ShowStatusBarMessage(const QString &message)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1125,6 +1125,7 @@ private slots:
 	void on_sourcePropertiesButton_clicked();
 	void on_sourceFiltersButton_clicked();
 	void on_sourceInteractButton_clicked();
+	void on_sourceScreenshotButton_clicked();
 
 	void on_autoConfigure_triggered();
 	void on_stats_triggered();


### PR DESCRIPTION
### Description
This adds a screenshot button to the source context bar.

![Screenshot from 2023-01-21 15-28-27](https://user-images.githubusercontent.com/19962531/213887956-f1f3510f-bec2-45ce-90d4-3cfb2f88ddd3.png)

### Motivation and Context
Makes sure the feature is not only in a context menu.

### How Has This Been Tested?
Clicked on button to make sure it took the source screenshot.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
