### PR TITLE
UI: Disable screenshot action if item has no video

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5689,8 +5689,12 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 		popup.addMenu(sourceProjector);
 		popup.addAction(QTStr("SourceWindow"), this,
 				SLOT(OpenSourceWindow()));
-		popup.addAction(QTStr("Screenshot.Source"), this,
-				SLOT(ScreenshotSelectedSource()));
+
+		QAction *screenshotAction =
+			popup.addAction(QTStr("Screenshot.Source"), this,
+					SLOT(ScreenshotSelectedSource()));
+		screenshotAction->setEnabled(flags & OBS_SOURCE_VIDEO);
+
 		popup.addSeparator();
 
 		if (flags & OBS_SOURCE_INTERACTION)


### PR DESCRIPTION
### Description
This disables the source screenshot action in the context menu if the source has no video.

### Motivation and Context
Better feedback to users.

### How Has This Been Tested?
Right clicked an audio source to make sure the action was disabled.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
