### PR TITLE
updater: Add additional status messages

### DIFF
--- a/UI/win-update/updater/updater.cpp
+++ b/UI/win-update/updater/updater.cpp
@@ -1648,6 +1648,7 @@ static bool Update(wchar_t *cmdLine)
 	};
 
 	if (!bIsPortable) {
+		Status(L"Installing Virtual Camera...");
 		wchar_t regsvr[MAX_PATH];
 		wchar_t src[MAX_PATH];
 		wchar_t tmp[MAX_PATH];
@@ -1681,11 +1682,13 @@ static bool Update(wchar_t *cmdLine)
 	/* ------------------------------------- *
 	 * Update hook files and vulkan registry */
 
+	Status(L"Updating Game Capture hooks...");
 	UpdateHookFiles();
 
 	/* ------------------------------------- *
 	 * Finish                                */
 
+	Status(L"Cleaning up...");
 	/* If we get here, all updates installed successfully so we can purge
 	 * the old versions */
 	for (update_t &update : updates) {


### PR DESCRIPTION
### Description

Just adds a few more status messages to be more clear what the updater is doing.

### Motivation and Context

Updater would say "Installing v8something" until it finished. Since steps after installing updates can take a few seconds this just shows messages for what it's actually doing.

### How Has This Been Tested?

Ran updater, saw messages.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
