### PR TITLE
libobs-opengl: Fixup dmabuf queries on X11

### DIFF
--- a/libobs-opengl/gl-x11-egl.c
+++ b/libobs-opengl/gl-x11-egl.c
@@ -590,7 +590,7 @@ static bool gl_x11_egl_device_query_dmabuf_capabilities(
 {
 	struct gl_platform *plat = device->plat;
 
-	return gl_egl_query_dmabuf_capabilities(plat->xdisplay, dmabuf_flags,
+	return gl_egl_query_dmabuf_capabilities(plat->edisplay, dmabuf_flags,
 						drm_formats, n_formats);
 }
 
@@ -601,7 +601,7 @@ static bool gl_x11_egl_device_query_dmabuf_modifiers_for_format(
 	struct gl_platform *plat = device->plat;
 
 	return gl_egl_query_dmabuf_modifiers_for_format(
-		plat->xdisplay, drm_format, modifiers, n_modifiers);
+		plat->edisplay, drm_format, modifiers, n_modifiers);
 }
 
 static const struct gl_winsys_vtable egl_x11_winsys_vtable = {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Previously we passed the wrong display and formats/modifiers could not be queried. This prevented pipewire sources from negotiating texture sharing on x11.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Maybe fast screencapture on X11 for compositors that support it, resolves the error in the logs when users attempted screencapture on x11.

Fixes totally busted dmabuf support if anyone was trying to use it on x11.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Ran on gnome and observed the error was resolved (though it didnt negotiate a dmabuf).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
