### PR TITLE
libobs: Fix SDR async video on non-SDR targets

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -1224,6 +1224,7 @@ static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 			target.monitorFriendlyDeviceName[0] = 0;
 		}
 
+		UINT bits_per_color = 8;
 		DXGI_COLOR_SPACE_TYPE type =
 			DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
 		FLOAT min_luminance = 0.f;
@@ -1231,6 +1232,7 @@ static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 		FLOAT max_full_frame_luminance = 0.f;
 		DXGI_OUTPUT_DESC1 desc1;
 		if (GetOutputDesc1(output, &desc1)) {
+			bits_per_color = desc1.BitsPerColor;
 			type = desc1.ColorSpace;
 			min_luminance = desc1.MinLuminance;
 			max_luminance = desc1.MaxLuminance;
@@ -1260,13 +1262,14 @@ static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 		     "\t    size={%d, %d}\n"
 		     "\t    attached=%s\n"
 		     "\t    refresh=%u\n"
+		     "\t    bits_per_color=%u\n"
 		     "\t    space=%s\n"
 		     "\t    sdr_white_nits=%lu\n"
 		     "\t    nit_range=[min=%f, max=%f, max_full_frame=%f]",
 		     i, target.monitorFriendlyDeviceName, rect.left, rect.top,
 		     rect.right - rect.left, rect.bottom - rect.top,
-		     desc.AttachedToDesktop ? "true" : "false", refresh, space,
-		     nits, min_luminance, max_luminance,
+		     desc.AttachedToDesktop ? "true" : "false", refresh,
+		     bits_per_color, space, nits, min_luminance, max_luminance,
 		     max_full_frame_luminance);
 	}
 }

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2478,6 +2478,8 @@ static inline void obs_source_render_async_video(obs_source_t *source)
 		bool nonlinear_alpha = false;
 		switch (source_space) {
 		case GS_CS_SRGB:
+			linear_srgb = linear_srgb ||
+				      (current_space != GS_CS_SRGB);
 			nonlinear_alpha = linear_srgb &&
 					  !source->async_linear_alpha;
 			switch (current_space) {
@@ -2492,7 +2494,6 @@ static inline void obs_source_render_async_video(obs_source_t *source)
 					nonlinear_alpha
 						? "DrawNonlinearAlphaMultiply"
 						: "DrawMultiply";
-				linear_srgb = true;
 				multiplier =
 					obs_get_video_sdr_white_level() / 80.0f;
 			}


### PR DESCRIPTION
### Description
Bug was seen when projecting SDR video capture on WCG displays.

Fixes #8032

### Motivation and Context
Want projectors to output the right colors.

### How Has This Been Tested?
Checked projector looks good on WCG, and hasn't regressed on SDR/HDR displays. Log output also looks good in all three cases.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.