### PR TITLE
UI: Add new scene at current row

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2872,7 +2872,7 @@ void OBSBasic::AddScene(OBSSource source)
 
 	QListWidgetItem *item = new QListWidgetItem(QT_UTF8(name));
 	SetOBSRef(item, OBSScene(scene));
-	ui->scenes->addItem(item);
+	ui->scenes->insertItem(ui->scenes->currentRow() + 1, item);
 
 	obs_hotkey_register_source(
 		source, "OBSBasic.SelectScene",


### PR DESCRIPTION
### Description
Instead of having a new scene at the bottom of the list, have it added after the current item.

### Motivation and Context
https://ideas.obsproject.com/posts/2111/new-scene-here

### How Has This Been Tested?
Added new scene to see where it was added in the list

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
