### PR TITLE
Add CALM_DEPRECATION cmake option and fix some warnings

### DIFF
--- a/cmake/Modules/CompilerConfig.cmake
+++ b/cmake/Modules/CompilerConfig.cmake
@@ -90,6 +90,7 @@ else()
     set(CMAKE_CUDA_COMPILER_LAUNCHER "${CCACHE_PROGRAM}") # CMake 3.9+
   endif()
 
+  option(CALM_DEPRECATION "Keep deprecated-declarations as warnings" OFF)
   add_compile_options(
     -Werror
     -Wextra
@@ -107,7 +108,8 @@ else()
     "$<$<CONFIG:DEBUG>:-DDEBUG=1;-D_DEBUG=1>"
     "$<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wnull-conversion;-fcolor-diagnostics;-Wno-error=shorten-64-to-32>"
     "$<$<COMPILE_LANG_AND_ID:C,AppleClang,Clang>:-Wnull-conversion;-fcolor-diagnostics;-Wno-error=shorten-64-to-32>"
-    "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wconversion-null>")
+    "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wconversion-null>"
+    "$<$<BOOL:${CALM_DEPRECATION}>:-Wno-error=deprecated-declarations>")
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # GCC on aarch64 emits type-limits warnings that do not appear on x86_64

--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -438,8 +438,11 @@ bool mp_decode_next(struct mp_decode *d)
 				av_rescale_q(d->in_frame->best_effort_timestamp,
 					     d->stream->time_base,
 					     (AVRational){1, 1000000000});
-
+#if LIBAVUTIL_VERSION_MAJOR >= 57 && LIBAVUTIL_VERSION_MINOR >= 30
+		int64_t duration = d->in_frame->duration;
+#else
 		int64_t duration = d->in_frame->pkt_duration;
+#endif
 		if (!duration)
 			duration = get_estimated_duration(d, last_pts);
 		else

--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -1702,7 +1702,10 @@ bool obs_scripting_load_python(const char *python_path)
 	wchar_t *argv[] = {L"", NULL};
 	int argc = sizeof(argv) / sizeof(wchar_t *) - 1;
 
+	PRAGMA_WARN_PUSH
+	PRAGMA_WARN_DEPRECATION
 	PySys_SetArgv(argc, argv);
+	PRAGMA_WARN_POP
 
 #ifdef DEBUG_PYTHON_STARTUP
 	/* ---------------------------------------------- */

--- a/deps/obs-scripting/obs-scripting.c
+++ b/deps/obs-scripting/obs-scripting.c
@@ -461,6 +461,7 @@ bool obs_scripting_python_runtime_linked(void)
 
 void obs_scripting_python_version(char *version, size_t version_length)
 {
+	UNUSED_PARAMETER(version_length);
 	version[0] = 0;
 }
 #endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Contains a rework of #8113

Add an option `CALM_DEPRECATION` to enable `-Wno-error=deprecated-declarations` for Linux users that might use bleeding-edge dependencies compared to obs-deps.

Fix a few other warning/errors.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Improve #6759 and fix warnings/errors.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
