### PR TITLE
UI: Use source select dialog for scenes

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -588,6 +588,7 @@ Basic.Main.PreviewDisabled="Preview is currently disabled"
 
 # add source dialog
 Basic.SourceSelect="Create/Select Source"
+Basic.SourceSelect.Scene="Create/Duplicate Scene"
 Basic.SourceSelect.CreateNew="Create new"
 Basic.SourceSelect.AddExisting="Add Existing"
 Basic.SourceSelect.AddVisible="Make source visible"

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -485,7 +485,6 @@ private:
 
 	void SetPreviewProgramMode(bool enabled);
 	void ResizeProgram(uint32_t cx, uint32_t cy);
-	void SetCurrentScene(obs_scene_t *scene, bool force = false);
 	static void RenderProgram(void *data, uint32_t cx, uint32_t cy);
 
 	std::vector<QuickTransition> quickTransitions;
@@ -832,7 +831,7 @@ private:
 
 	void ResizePreview(uint32_t cx, uint32_t cy);
 
-	void AddSource(const char *id);
+	void AddSource(const char *id, bool sceneList = false);
 	QMenu *CreateAddSourcePopupMenu();
 	void AddSourcePopupMenu(const QPoint &pos);
 	void copyActionsDynamicProperties();
@@ -988,6 +987,9 @@ public:
 	void SetDisplayAffinity(QWindow *window);
 
 	QColor GetSelectionColor() const;
+
+	bool DuplicateScene(OBSScene scene);
+	void SetCurrentScene(obs_scene_t *scene, bool force = false);
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;

--- a/UI/window-basic-source-select.hpp
+++ b/UI/window-basic-source-select.hpp
@@ -33,6 +33,7 @@ private:
 	std::unique_ptr<Ui::OBSBasicSourceSelect> ui;
 	const char *id;
 	undo_stack &undo_s;
+	bool sceneList = false;
 
 	static bool EnumSources(void *data, obs_source_t *source);
 	static bool EnumGroups(void *data, obs_source_t *source);
@@ -49,7 +50,7 @@ private slots:
 
 public:
 	OBSBasicSourceSelect(OBSBasic *parent, const char *id,
-			     undo_stack &undo_s);
+			     undo_stack &undo_s, bool sceneList_);
 
 	OBSSource newSource;
 


### PR DESCRIPTION
### Description
This makes the adding scene workflow similar to the source one. This also makes duplicating a scene a part of this dialog, so it is no longer in a context menu.

![Screenshot from 2023-01-23 04-13-58](https://user-images.githubusercontent.com/19962531/214016106-fabfa49e-e7ce-4bca-9b63-2296ce6e8842.png)

### Motivation and Context
Make UI better.

### How Has This Been Tested?
Added/duplicated scenes.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
