### PR TITLE
UI: Work around Qt dock restore crash

### DIFF
--- a/UI/auth-restream.cpp
+++ b/UI/auth-restream.cpp
@@ -200,7 +200,9 @@ void RestreamAuth::LoadUI()
 			main->Config(), service(), "DockState");
 		QByteArray dockState =
 			QByteArray::fromBase64(QByteArray(dockStateStr));
-		main->restoreState(dockState);
+
+		if (main->isVisible() || !main->isMaximized())
+			main->restoreState(dockState);
 	}
 
 	uiLoaded = true;

--- a/UI/auth-twitch.cpp
+++ b/UI/auth-twitch.cpp
@@ -276,7 +276,9 @@ void TwitchAuth::LoadUI()
 			main->Config(), service(), "DockState");
 		QByteArray dockState =
 			QByteArray::fromBase64(QByteArray(dockStateStr));
-		main->restoreState(dockState);
+
+		if (main->isVisible() || !main->isMaximized())
+			main->restoreState(dockState);
 	}
 
 	TryLoadSecondaryUIPanes();
@@ -405,7 +407,9 @@ void TwitchAuth::LoadSecondaryUIPanes()
 			main->Config(), service(), "DockState");
 		QByteArray dockState =
 			QByteArray::fromBase64(QByteArray(dockStateStr));
-		main->restoreState(dockState);
+
+		if (main->isVisible() || !main->isMaximized())
+			main->restoreState(dockState);
 	}
 }
 

--- a/UI/auth-youtube.cpp
+++ b/UI/auth-youtube.cpp
@@ -164,7 +164,9 @@ void YoutubeAuth::LoadUI()
 			main->Config(), service(), "DockState");
 		QByteArray dockState =
 			QByteArray::fromBase64(QByteArray(dockStateStr));
-		main->restoreState(dockState);
+
+		if (main->isVisible() || !main->isMaximized())
+			main->restoreState(dockState);
 	}
 #endif
 


### PR DESCRIPTION
### Description

This is a workaround for #7348. It doesn't fix it, but at least gets OBS up and running again by not attempting to restore the integration docks when OBS is in a state that would cause the crash (not visible but maximised).

### Motivation and Context

Want to keep users at least up and running, even with the minor inconvenience of having their docks fucked up.

### How Has This Been Tested?

Tested in debugger to ensure no crashes.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
