### PR TITLE
obs-ffmpeg: Update AMF SDK to v1.4.29

### DIFF
--- a/plugins/obs-ffmpeg/external/AMF/include/components/HQScaler.h
+++ b/plugins/obs-ffmpeg/external/AMF/include/components/HQScaler.h
@@ -43,9 +43,10 @@ enum  AMF_HQ_SCALER_ALGORITHM_ENUM
 {
     AMF_HQ_SCALER_ALGORITHM_BILINEAR = 0,
     AMF_HQ_SCALER_ALGORITHM_BICUBIC = 1,
-    AMF_HQ_SCALER_ALGORITHM_FSR = 2,
+    AMF_HQ_SCALER_ALGORITHM_FSR = 2, // deprecated
+    AMF_HQ_SCALER_ALGORITHM_VIDEOSR1_0 = 2,
     AMF_HQ_SCALER_ALGORITHM_POINT = 3,
-    AMF_HQ_SCALER_ALGORITHM_FSR1_1 = 4,
+    AMF_HQ_SCALER_ALGORITHM_VIDEOSR1_1 = 4,
 
 };
 
@@ -63,5 +64,6 @@ enum  AMF_HQ_SCALER_ALGORITHM_ENUM
 #define AMF_HQ_SCALER_FROM_SRGB          L"FromSRGB"                   //  bool (default=true) Convert to SRGB. 
 
 #define AMF_HQ_SCALER_SHARPNESS          L"HQScalerSharpness"   // Float in the range of [0.0, 2.0]
+#define AMF_HQ_SCALER_FRAME_RATE         L"HQScalerFrameRate"   // Frame rate (off, 15, 30, 60)
 
 #endif //#ifndef AMFHQScaler_h

--- a/plugins/obs-ffmpeg/external/AMF/include/components/SupportedCodecs.h
+++ b/plugins/obs-ffmpeg/external/AMF/include/components/SupportedCodecs.h
@@ -9,7 +9,7 @@
 // 
 // MIT license 
 // 
-// Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -30,20 +30,32 @@
 // THE SOFTWARE.
 //
 
-#ifndef __D3D12AMF_h__
-#define __D3D12AMF_h__
-#pragma once 
-#include "Platform.h"
-#if defined(_WIN32)||(defined(__linux) && defined(AMF_WSL))
-// syncronization properties set via SetPrivateData()
-AMF_WEAK GUID  AMFResourceStateGUID = { 0x452da9bf, 0x4ad7, 0x47a5, { 0xa6, 0x9b, 0x96, 0xd3, 0x23, 0x76, 0xf2, 0xf3 } };   // Current resource state value (D3D12_RESOURCE_STATES ), sizeof(UINT), set on ID3D12Resource 
-AMF_WEAK GUID  AMFFenceGUID         = { 0x910a7928, 0x57bd, 0x4b04, { 0x91, 0xa3, 0xe7, 0xb8, 0x04, 0x12, 0xcd, 0xa5 } };   // IUnknown (ID3D12Fence), set on ID3D12Resource  syncronization fence for this resource
-AMF_WEAK GUID  AMFFenceValueGUID    = { 0x62a693d3, 0xbb4a, 0x46c9, { 0xa5, 0x04, 0x9a, 0x8e, 0x97, 0xbf, 0xf0, 0x56 } };   // The last value to wait on the fence from AMFFenceGUID; sizeof(UINT64), set on ID3D12Fence 
+//-------------------------------------------------------------------------------------------------
+// An interface available on some components to provide information on supported input and output codecs 
+//-------------------------------------------------------------------------------------------------
+#ifndef AMF_SupportedCodecs_h
+#define AMF_SupportedCodecs_h
 
-AMF_WEAK GUID  AMFFenceD3D11GUID    = { 0xdffdf6e0, 0x85e0, 0x4645, { 0x9d, 0x7, 0xe6, 0x4a, 0x19, 0x6b, 0xc9, 0xbf } };   // IUnknown (ID3D11Fence) OpenSharedFence for interop
-AMF_WEAK GUID  AMFFenceValueD3D11GUID    = { 0x86581b71, 0x699f, 0x484b, { 0xb8, 0x75, 0x24, 0xda, 0x49, 0x8a, 0x74, 0xcf } };   // last value to wait on in d3d11
-AMF_WEAK GUID  AMFSharedHandleFenceGUID = { 0xca60dcc8, 0x76d1, 0x4088, 0xad, 0xd, 0x97, 0x71, 0xe7, 0xb0, 0x92, 0x49 };   // ID3D12Fence shared handle for D3D11 interop
+#pragma once
+
+#include "public/include/core/Interface.h"
+
+//properties on the returned AMFPropertyStorage
+#define SUPPORTEDCODEC_ID L"CodecId" //amf_int64
+#define SUPPORTEDCODEC_SAMPLERATE L"SampleRate" //amf_int32
+
+namespace amf
+{
+    class AMFSupportedCodecs : public AMFInterface
+    {
+    public:
+        AMF_DECLARE_IID(0xc1003a83, 0x7934, 0x408a, 0x95, 0x5b, 0xc4, 0xdd, 0x85, 0x9d, 0xf5, 0x61)
+
+        //call with increasing values until it returns AMF_OUT_OF_RANGE
+        virtual AMF_RESULT     AMF_STD_CALL GetInputCodecAt(amf_size index, AMFPropertyStorage** codec) const = 0;
+        virtual AMF_RESULT     AMF_STD_CALL GetOutputCodecAt(amf_size index, AMFPropertyStorage** codec) const = 0;
+    };
+    typedef AMFInterfacePtr_T<AMFSupportedCodecs> AMFSupportedCodecsPtr;
+}
 
 #endif
-
-#endif // __D3D12AMF_h__

--- a/plugins/obs-ffmpeg/external/AMF/include/components/VQEnhancer.h
+++ b/plugins/obs-ffmpeg/external/AMF/include/components/VQEnhancer.h
@@ -1,4 +1,4 @@
-//
+// 
 // Notice Regarding Standards.  AMD does not provide a license or sublicense to
 // any Intellectual Property Rights relating to any standards, including but not
 // limited to any audio and/or video codec technologies such as MPEG-2, MPEG-4;
@@ -6,9 +6,9 @@
 // (collectively, the "Media Technologies"). For clarity, you will pay any
 // royalties due for such third party technologies, which may include the Media
 // Technologies that are owed as a result of AMD providing the Software to you.
-//
-// MIT license
-//
+// 
+// MIT license 
+// 
 // Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -40,8 +40,9 @@
 #define AMFVQEnhancer L"AMFVQEnhancer"
 
 #define AMF_VIDEO_ENHANCER_ENGINE_TYPE       L"AMF_VIDEI_ENHANCER_ENGINE_TYPE"        // AMF_MEMORY_TYPE (DX11, DX12, OPENCL, VULKAN default : DX11)"                    - determines how the object is initialized and what kernels to use
-#define AMF_VIDEO_ENHANCER_OUTPUT_SIZE       L"AMF_VIDEO_ENHANCER_OUTPUT_SIZE"        // AMFSize
+#define AMF_VIDEO_ENHANCER_OUTPUT_SIZE       L"AMF_VIDEO_ENHANCER_OUTPUT_SIZE"        // AMFSize                       
 #define AMF_VE_FCR_ATTENUATION               L"AMF_VE_FCR_ATTENUATION"                // Float in the range of [0.02, 0.4], default : 0.1
 #define AMF_VE_FCR_RADIUS                    L"AMF_VE_FCR_RADIUS"                     // int  in the range of [1, 4]
+#define AMF_VE_FCR_SPLIT_VIEW                L"AMF_VE_FCR_SPLIT_VIEW"                 // FCR View split window
 
 #endif //#ifndef AMFVQEnhancer_h

--- a/plugins/obs-ffmpeg/external/AMF/include/components/VideoDecoderUVD.h
+++ b/plugins/obs-ffmpeg/external/AMF/include/components/VideoDecoderUVD.h
@@ -106,7 +106,7 @@ enum AMF_TIMESTAMP_MODE_ENUM
 
 // properties to be set on decoder if internal converter is used
 #define AMF_VIDEO_DECODER_OUTPUT_TRANSFER_CHARACTERISTIC        L"OutColorTransferChar"     // amf_int64(AMF_COLOR_TRANSFER_CHARACTERISTIC_ENUM); default = AMF_COLOR_TRANSFER_CHARACTERISTIC_UNDEFINED, ISO/IEC 23001-8_2013   7.2 See VideoDecoderUVD.h for enum 
-#define AMF_VIDEO_DECODER_OUTPUT_COLOR_PRIMARIES                L"OutputColorPrimaries"       // amf_int64(AMF_COLOR_PRIMARIES_ENUM); default = AMF_COLOR_PRIMARIES_UNDEFINED, ISO/IEC 23001-8_2013   7.1 See ColorSpace.h for enum 
+#define AMF_VIDEO_DECODER_OUTPUT_COLOR_PRIMARIES                L"OutputColorPrimaries"     // amf_int64(AMF_COLOR_PRIMARIES_ENUM); default = AMF_COLOR_PRIMARIES_UNDEFINED, ISO/IEC 23001-8_2013   7.1 See ColorSpace.h for enum 
 #define AMF_VIDEO_DECODER_OUTPUT_HDR_METADATA                   L"OutHDRMetadata"           // AMFBuffer containing AMFHDRMetadata; default NULL
 
 #define AMF_VIDEO_DECODER_LOW_LATENCY                           L"LowLatencyDecode"         // amf_bool; default = false; true = low latency decode, false = regular decode
@@ -119,5 +119,8 @@ enum AMF_TIMESTAMP_MODE_ENUM
 #if defined(__APPLE__)
 #define AMF_VIDEO_DECODER_NATIVEWINDOW                  L"AppleNativeWindow"  // amf_int64; default = 0; pointer to native window
 #endif //__APPLE__
+
+#define AMF_VIDEO_DECODER_ENABLE_SMART_ACCESS_VIDEO             L"EnableDecoderSmartAccessVideo"     // amf_bool; default = false; true = enables smart access video feature
+#define AMF_VIDEO_DECODER_SKIP_TRANSFER_SMART_ACCESS_VIDEO      L"SkipTransferSmartAccessVideo"      // amf_bool; default = false; true = keeps output on GPU where it ran
 
 #endif //#ifndef AMF_VideoDecoderUVD_h

--- a/plugins/obs-ffmpeg/external/AMF/include/components/VideoEncoderAV1.h
+++ b/plugins/obs-ffmpeg/external/AMF/include/components/VideoEncoderAV1.h
@@ -120,8 +120,8 @@ enum AMF_VIDEO_ENCODER_AV1_OUTPUT_FRAME_TYPE_ENUM
 
 enum AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_ENUM
 {
-    AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_HIGH_QUALITY   = 0,
-    AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_QUALITY        = 30,
+    AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_HIGH_QUALITY   = 0,    
+    AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_QUALITY        = 30,    
     AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_BALANCED       = 70,
     AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_SPEED          = 100
 };
@@ -163,13 +163,18 @@ enum AMF_VIDEO_ENCODER_AV1_INTRA_REFRESH_MODE_ENUM
     AMF_VIDEO_ENCODER_AV1_INTRA_REFRESH_MODE__GOP_ALIGNED = 1,
     AMF_VIDEO_ENCODER_AV1_INTRA_REFRESH_MODE__CONTINUOUS = 2
 };
+enum AMF_VIDEO_ENCODER_AV1_LTR_MODE_ENUM
+{
+    AMF_VIDEO_ENCODER_AV1_LTR_MODE_RESET_UNUSED     = 0,
+    AMF_VIDEO_ENCODER_AV1_LTR_MODE_KEEP_UNUSED      = 1
+};
 
 
-// *** Static properties - can be set only before Init() ***
+// *** Static properties - can be set only before Init() *** 
 
 // Encoder Engine Settings
 #define AMF_VIDEO_ENCODER_AV1_ENCODER_INSTANCE_INDEX                L"Av1EncoderInstanceIndex"          // amf_int64; default = 0; selected HW instance idx. The number of instances is queried by using AMF_VIDEO_ENCODER_AV1_CAP_NUM_OF_HW_INSTANCES
-#define AMF_VIDEO_ENCODER_AV1_ENCODING_LATENCY_MODE                 L"Av1EncodingLatencyMode"           // amf_int64(AMF_VIDEO_ENCODER_AV1_ENCODING_LATENCY_MODE_ENUM); default = depends on USAGE; The encoding latency mode.
+#define AMF_VIDEO_ENCODER_AV1_ENCODING_LATENCY_MODE                 L"Av1EncodingLatencyMode"           // amf_int64(AMF_VIDEO_ENCODER_AV1_ENCODING_LATENCY_MODE_ENUM); default = depends on USAGE; The encoding latency mode. 
 #define AMF_VIDEO_ENCODER_AV1_QUERY_TIMEOUT                         L"Av1QueryTimeout"                  // amf_int64; default = 0 (no wait); timeout for QueryOutput call in ms.
 
 // Usage Settings
@@ -184,7 +189,7 @@ enum AMF_VIDEO_ENCODER_AV1_INTRA_REFRESH_MODE_ENUM
 #define AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET                        L"Av1QualityPreset"                 // amf_int64(AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET_ENUM); default = depends on USAGE; Quality Preset
 
 // Codec Configuration
-#define AMF_VIDEO_ENCODER_AV1_SCREEN_CONTENT_TOOLS                  L"Av1ScreenContentTools"            // bool; default = depends on USAGE; If true, allow enabling screen content tools by AMF_VIDEO_ENCODER_AV1_PALETTE_MODE_ENABLE and AMF_VIDEO_ENCODER_AV1_FORCE_INTEGER_MV; if false, all screen content tools are disabled.
+#define AMF_VIDEO_ENCODER_AV1_SCREEN_CONTENT_TOOLS                  L"Av1ScreenContentTools"            // bool; default = depends on USAGE; If true, allow enabling screen content tools by AMF_VIDEO_ENCODER_AV1_PALETTE_MODE and AMF_VIDEO_ENCODER_AV1_FORCE_INTEGER_MV; if false, all screen content tools are disabled.
 #define AMF_VIDEO_ENCODER_AV1_ORDER_HINT                            L"Av1OrderHint"                     // bool; default = depends on USAGE; If true, code order hint; if false, don't code order hint
 #define AMF_VIDEO_ENCODER_AV1_FRAME_ID                              L"Av1FrameId"                       // bool; default = depends on USAGE; If true, code frame id; if false, don't code frame id
 #define AMF_VIDEO_ENCODER_AV1_TILE_GROUP_OBU                        L"Av1TileGroupObu"                  // bool; default = depends on USAGE; If true, code FrameHeaderObu + TileGroupObu and each TileGroupObu contains one tile; if false, code FrameObu.
@@ -207,6 +212,7 @@ enum AMF_VIDEO_ENCODER_AV1_INTRA_REFRESH_MODE_ENUM
 // Picture Management Configuration
 #define AMF_VIDEO_ENCODER_AV1_MAX_NUM_TEMPORAL_LAYERS               L"Av1MaxNumOfTemporalLayers"        // amf_int64; default = depends on USAGE; Max number of temporal layers might be enabled. The maximum value can be queried from AMF_VIDEO_ENCODER_AV1_CAP_MAX_NUM_TEMPORAL_LAYERS
 #define AMF_VIDEO_ENCODER_AV1_MAX_LTR_FRAMES                        L"Av1MaxNumLTRFrames"               // amf_int64; default = depends on USAGE; Max number of LTR frames. The maximum value can be queried from AMF_VIDEO_ENCODER_AV1_CAP_MAX_NUM_LTR_FRAMES
+#define AMF_VIDEO_ENCODER_AV1_LTR_MODE                              L"Av1LTRMode"                       // amf_int64(AMF_VIDEO_ENCODER_AV1_LTR_MODE_ENUM); default = AMF_VIDEO_ENCODER_AV1_LTR_MODE_RESET_UNUSED; remove/keep unused LTRs (not specified in property AMF_VIDEO_ENCODER_AV1_FORCE_LTR_REFERENCE_BITFIELD)
 #define AMF_VIDEO_ENCODER_AV1_MAX_NUM_REFRAMES                      L"Av1MaxNumRefFrames"               // amf_int64; default = 1; Maximum number of reference frames
 
 // color conversion
@@ -216,7 +222,7 @@ enum AMF_VIDEO_ENCODER_AV1_INTRA_REFRESH_MODE_ENUM
 #define AMF_VIDEO_ENCODER_AV1_EXTRA_DATA                            L"Av1ExtraData"                     // AMFInterface* - > AMFBuffer*; buffer to retrieve coded sequence header
 
 
-// *** Dynamic properties - can be set anytime ***
+// *** Dynamic properties - can be set anytime *** 
 
 // Codec Configuration
 #define AMF_VIDEO_ENCODER_AV1_PALETTE_MODE                          L"Av1PaletteMode"                   // bool; default = depends on USAGE; If true, enable palette mode; if false, disable palette mode. Valid only when AMF_VIDEO_ENCODER_AV1_SCREEN_CONTENT_TOOLS is true.
@@ -288,5 +294,7 @@ enum AMF_VIDEO_ENCODER_AV1_INTRA_REFRESH_MODE_ENUM
 #define AMF_VIDEO_ENCODER_AV1_CAP_MAX_LEVEL                         L"Av1MaxLevel"                      // amf_int64(AMF_VIDEO_ENCODER_AV1_LEVEL_ENUM); default = N/A; max value of codec level
 #define AMF_VIDEO_ENCODER_AV1_CAP_MAX_NUM_TEMPORAL_LAYERS           L"Av1CapMaxNumTemporalLayers"       // amf_int64; default = N/A; The cap of maximum number of temporal layers
 #define AMF_VIDEO_ENCODER_AV1_CAP_MAX_NUM_LTR_FRAMES                L"Av1CapMaxNumLTRFrames"            // amf_int64; default = N/A; The cap of maximum number of LTR frames. This value is calculated based on current value of AMF_VIDEO_ENCODER_AV1_MAX_NUM_TEMPORAL_LAYERS.
+
+#define AMF_VIDEO_ENCODER_AV1_ENABLE_SMART_ACCESS_VIDEO             L"Av1EnableEncoderSmartAccessVideo" // amf_bool; default = false; true = enables smart access video feature
 
 #endif //#ifndef AMF_VideoEncoderAV1_h

--- a/plugins/obs-ffmpeg/external/AMF/include/components/VideoEncoderHEVC.h
+++ b/plugins/obs-ffmpeg/external/AMF/include/components/VideoEncoderHEVC.h
@@ -302,4 +302,6 @@ enum AMF_VIDEO_ENCODER_HEVC_LTR_MODE_ENUM
 // properties set on AMFComponent to control component creation
 #define AMF_VIDEO_ENCODER_HEVC_MEMORY_TYPE                          L"HevcEncoderMemoryType"        // amf_int64(AMF_MEMORY_TYPE) , default is AMF_MEMORY_UNKNOWN, Values : AMF_MEMORY_DX11, AMF_MEMORY_DX9, AMF_MEMORY_UNKNOWN (auto)
 
+#define AMF_VIDEO_ENCODER_HEVC_ENABLE_SMART_ACCESS_VIDEO            L"HevcEnableEncoderSmartAccessVideo"         // amf_bool; default = false; true = enables smart access video feature
+
 #endif //#ifndef AMF_VideoEncoderHEVC_h

--- a/plugins/obs-ffmpeg/external/AMF/include/components/VideoEncoderVCE.h
+++ b/plugins/obs-ffmpeg/external/AMF/include/components/VideoEncoderVCE.h
@@ -66,6 +66,29 @@ enum AMF_VIDEO_ENCODER_PROFILE_ENUM
     AMF_VIDEO_ENCODER_PROFILE_CONSTRAINED_HIGH = 257
 };
 
+enum AMF_VIDEO_ENCODER_H264_LEVEL_ENUM
+{
+    AMF_H264_LEVEL__1   = 10,
+    AMF_H264_LEVEL__1_1 = 11,
+    AMF_H264_LEVEL__1_2 = 12,
+    AMF_H264_LEVEL__1_3 = 13,
+    AMF_H264_LEVEL__2   = 20,
+    AMF_H264_LEVEL__2_1 = 21,
+    AMF_H264_LEVEL__2_2 = 22,
+    AMF_H264_LEVEL__3   = 30,
+    AMF_H264_LEVEL__3_1 = 31,
+    AMF_H264_LEVEL__3_2 = 32,
+    AMF_H264_LEVEL__4   = 40,
+    AMF_H264_LEVEL__4_1 = 41,
+    AMF_H264_LEVEL__4_2 = 42,
+    AMF_H264_LEVEL__5   = 50,
+    AMF_H264_LEVEL__5_1 = 51,
+    AMF_H264_LEVEL__5_2 = 52,
+    AMF_H264_LEVEL__6   = 60,
+    AMF_H264_LEVEL__6_1 = 61,
+    AMF_H264_LEVEL__6_2 = 62
+};
+
 enum AMF_VIDEO_ENCODER_SCANTYPE_ENUM
 {
     AMF_VIDEO_ENCODER_SCANTYPE_PROGRESSIVE = 0,
@@ -151,7 +174,7 @@ enum AMF_VIDEO_ENCODER_LTR_MODE_ENUM
 #define AMF_VIDEO_ENCODER_EXTRADATA                             L"ExtraData"                // AMFInterface* - > AMFBuffer*; SPS/PPS buffer in Annex B format - read-only
 #define AMF_VIDEO_ENCODER_USAGE                                 L"Usage"                    // amf_int64(AMF_VIDEO_ENCODER_USAGE_ENUM); default = N/A; Encoder usage type. fully configures parameter set.
 #define AMF_VIDEO_ENCODER_PROFILE                               L"Profile"                  // amf_int64(AMF_VIDEO_ENCODER_PROFILE_ENUM) ; default = AMF_VIDEO_ENCODER_PROFILE_MAIN;  H264 profile
-#define AMF_VIDEO_ENCODER_PROFILE_LEVEL                         L"ProfileLevel"             // amf_int64; default = 42; H264 profile level
+#define AMF_VIDEO_ENCODER_PROFILE_LEVEL                         L"ProfileLevel"             // amf_int64(AMF_VIDEO_ENCODER_H264_LEVEL_ENUM); default = AMF_H264_LEVEL__4_2; H264 level
 #define AMF_VIDEO_ENCODER_MAX_LTR_FRAMES                        L"MaxOfLTRFrames"           // amf_int64; default = 0; Max number of LTR frames
 #define AMF_VIDEO_ENCODER_LTR_MODE                              L"LTRMode"                  // amf_int64(AMF_VIDEO_ENCODER_LTR_MODE_ENUM); default = AMF_VIDEO_ENCODER_LTR_MODE_RESET_UNUSED; remove/keep unused LTRs (not specified in property AMF_VIDEO_ENCODER_FORCE_LTR_REFERENCE_BITFIELD)
 #define AMF_VIDEO_ENCODER_SCANTYPE                              L"ScanType"                 // amf_int64(AMF_VIDEO_ENCODER_SCANTYPE_ENUM); default = AMF_VIDEO_ENCODER_SCANTYPE_PROGRESSIVE; indicates input stream type
@@ -325,5 +348,7 @@ enum AMF_VIDEO_ENCODER_LTR_MODE_ENUM
 
 // properties set on AMFComponent to control component creation
 #define AMF_VIDEO_ENCODER_MEMORY_TYPE                           L"EncoderMemoryType"        // amf_int64(AMF_MEMORY_TYPE) , default is AMF_MEMORY_UNKNOWN, Values : AMF_MEMORY_DX11, AMF_MEMORY_DX9, AMF_MEMORY_VULKAN or AMF_MEMORY_UNKNOWN (auto)
+
+#define AMF_VIDEO_ENCODER_ENABLE_SMART_ACCESS_VIDEO             L"EnableEncoderSmartAccessVideo"         // amf_bool; default = false; true = enables smart access video feature
 
 #endif //#ifndef AMF_VideoEncoderVCE_h

--- a/plugins/obs-ffmpeg/external/AMF/include/core/Factory.h
+++ b/plugins/obs-ffmpeg/external/AMF/include/core/Factory.h
@@ -114,7 +114,7 @@ extern "C"
         #define AMF_DLL_NAME    L"amfrt32.dll"
         #define AMF_DLL_NAMEA   "amfrt32.dll"
     #endif
-#elif defined(__ANDROID__)
+#elif defined(__ANDROID__) && !defined(AMF_ANDROID_ENCODER)
     #define AMF_DLL_NAME    L"libamf.so"
     #define AMF_DLL_NAMEA    "libamf.so"
 #elif defined(__APPLE__)

--- a/plugins/obs-ffmpeg/external/AMF/include/core/Platform.h
+++ b/plugins/obs-ffmpeg/external/AMF/include/core/Platform.h
@@ -72,7 +72,7 @@
 //     #error Need to define AMF_ALIGN
  #endif
 
-#if defined(__linux) || (__clang__)
+#ifndef _WIN32
 typedef signed int HRESULT;
 #define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
 #define FAILED(hr) (((HRESULT)(hr)) < 0)
@@ -184,9 +184,11 @@ typedef amf_uint32              amf_flags;
 
 #define AMF_SECOND          10000000L    // 1 second in 100 nanoseconds
 #define AMF_MILLISECOND		(AMF_SECOND / 1000)
+#define AMF_MICROSECOND     (AMF_MILLISECOND / 1000)
 
 #define AMF_MIN(a, b) ((a) < (b) ? (a) : (b))
 #define AMF_MAX(a, b) ((a) > (b) ? (a) : (b))
+#define AMF_CLAMP(x, a, b) (AMF_MIN(AMF_MAX(x, a), b))
 
 #define AMF_BITS_PER_BYTE 8
 
@@ -380,13 +382,10 @@ static AMF_INLINE struct AMFRatio AMFConstructRatio(amf_uint32 num, amf_uint32 d
 #pragma pack(push, 1)
 #if defined(_MSC_VER)
     #pragma warning( push )
-#endif
-#if defined(WIN32)
-#if defined(_MSC_VER)
     #pragma warning(disable : 4200)
     #pragma warning(disable : 4201)
 #endif
-#endif
+
 typedef struct AMFColor
 {
     union

--- a/plugins/obs-ffmpeg/external/AMF/include/core/Surface.h
+++ b/plugins/obs-ffmpeg/external/AMF/include/core/Surface.h
@@ -68,9 +68,11 @@ namespace amf
         AMF_SURFACE_Y410,               ///< 16 - packed 4:4:4 - 10 bit per YUV component, 2 bits per A, AVYU 
         AMF_SURFACE_Y416,               ///< 16 - packed 4:4:4 - 16 bit per component 4 bytes, AVYU
         AMF_SURFACE_GRAY32,             ///< 17 - single component - 32 bit
+        AMF_SURFACE_P012,               ///< 18 - planar 4:2:0 Y width x height + packed UV width/2 x height/2 - 12 bit per component (16 allocated, upper 12 bits are used)
+        AMF_SURFACE_P016,               ///< 19 - planar 4:2:0 Y width x height + packed UV width/2 x height/2 - 16 bit per component (16 allocated, all bits are used)
 
         AMF_SURFACE_FIRST = AMF_SURFACE_NV12,
-        AMF_SURFACE_LAST = AMF_SURFACE_GRAY32
+        AMF_SURFACE_LAST = AMF_SURFACE_P016
     } AMF_SURFACE_FORMAT;
     //----------------------------------------------------------------------------------------------
     // AMF_SURFACE_USAGE translates to D3D11_BIND_FLAG or VkImageUsageFlags

--- a/plugins/obs-ffmpeg/external/AMF/include/core/Variant.h
+++ b/plugins/obs-ffmpeg/external/AMF/include/core/Variant.h
@@ -366,6 +366,8 @@ namespace amf
         }
 
 #if (__cplusplus == 201103L) || defined(__GXX_EXPERIMENTAL_CXX0X) || (_MSC_VER >= 1600)
+#pragma warning (push)
+#pragma warning (disable : 26439) //This kind of function may not throw. Declare it 'noexcept'.
         String(String&& p_other) : m_Str(NULL)
         {
             operator=(p_other);
@@ -498,6 +500,7 @@ namespace amf
             p_other.m_Str = NULL;    //    Transfer the ownership
             return *this;
         }
+#pragma warning (pop)
 #endif
         wchar_t& operator[](size_t index)
         {
@@ -755,7 +758,7 @@ namespace amf
             switch(AMFVariantGetType(pSrc))
             {
             case AMF_VARIANT_EMPTY:
-                errRet = AMFVariantClear(pDest);
+                errRet = AMFVariantInit(pDest);
                 break;
             case AMF_VARIANT_BOOL:
                 errRet = AMFVariantAssignBool(pDest, AMFVariantBool(pSrc));
@@ -1201,21 +1204,21 @@ namespace amf
     {
         res = AMF_OK;
         char buff[0xFF];
-        sprintf(buff, "%d,%d", value.num, value.den);
+        sprintf(buff, "%u,%u", value.num, value.den);
         return buff;
     }
     static AMF_INLINE AMFVariant::String AMF_STD_CALL AMFConvertRatioToString(const AMFRatio& value, AMF_RESULT& res)
     {
         res = AMF_OK;
         char buff[0xFF];
-        sprintf(buff, "%d,%d", value.num, value.den);
+        sprintf(buff, "%u,%u", value.num, value.den);
         return buff;
     }
     static AMF_INLINE AMFVariant::String AMF_STD_CALL AMFConvertColorToString(const AMFColor& value, AMF_RESULT& res)
     {
         res = AMF_OK;
         char buff[0xFF];
-        sprintf(buff, "%d,%d,%d,%d", value.r, value.g, value.b, value.a);
+        sprintf(buff, "%u,%u,%u,%u", value.r, value.g, value.b, value.a);
         return buff;
     }
 
@@ -1346,7 +1349,7 @@ namespace amf
         int readElements = 0;
         if(value.size() > 0)
         {
-            readElements = sscanf(value.c_str(), "%d,%d", &tmp.num, &tmp.den);
+            readElements = sscanf(value.c_str(), "%u,%u", &tmp.num, &tmp.den);
         }
         if(readElements)
         {
@@ -1362,7 +1365,7 @@ namespace amf
         int readElements = 0;
         if(value.size() > 0)
         {
-            readElements = sscanf(value.c_str(), "%d,%d", &tmp.num, &tmp.den);
+            readElements = sscanf(value.c_str(), "%u,%u", &tmp.num, &tmp.den);
         }
         if(readElements)
         {
@@ -1581,7 +1584,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if(errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_BOOL;
@@ -1595,7 +1598,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if(errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_INT64;
@@ -1609,7 +1612,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if(errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_DOUBLE;
@@ -1623,7 +1626,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if (errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_FLOAT;
@@ -1638,7 +1641,7 @@ namespace amf
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pValue);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if(errRet == AMF_OK)
         {
             const size_t size = (strlen(pValue) + 1);
@@ -1662,7 +1665,7 @@ namespace amf
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pValue);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if(errRet == AMF_OK)
         {
             const size_t size = (wcslen(pValue) + 1);
@@ -1686,7 +1689,7 @@ namespace amf
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
         //AMF_VARIANT_RETURN_IF_INVALID_POINTER(pValue);//can be NULL
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if(errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_INTERFACE;
@@ -1715,7 +1718,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if(errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_RECT;
@@ -1736,7 +1739,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if(errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_SIZE;
@@ -1773,7 +1776,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if(errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_POINT;
@@ -1787,7 +1790,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if (errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_FLOAT_SIZE;
@@ -1801,7 +1804,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if (errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_FLOAT_POINT2D;
@@ -1815,7 +1818,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if (errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_FLOAT_POINT3D;
@@ -1829,7 +1832,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if (errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_FLOAT_VECTOR4D;
@@ -1850,7 +1853,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if(errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_RATE;
@@ -1871,7 +1874,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if(errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_RATIO;
@@ -1892,7 +1895,7 @@ namespace amf
         AMF_RESULT errRet = AMF_OK;
         AMF_VARIANT_RETURN_IF_INVALID_POINTER(pDest);
 
-        errRet = AMFVariantClear(pDest);
+        errRet = AMFVariantInit(pDest);
         if(errRet == AMF_OK)
         {
             pDest->type = AMF_VARIANT_COLOR;
@@ -1980,6 +1983,7 @@ namespace amf
     //-------------------------------------------------------------------------------------------------
     AMF_INLINE AMFVariant& AMFVariant::operator=(const AMFVariantStruct& other)
     {
+        AMFVariantClear(this);
         AMFVariantCopy(this, const_cast<AMFVariantStruct*>(&other));
         return *this;
     }
@@ -1988,6 +1992,7 @@ namespace amf
     {
         if(pOther != NULL)
         {
+            AMFVariantClear(this);
             AMFVariantCopy(this, const_cast<AMFVariantStruct*>(pOther));
         }
         return *this;
@@ -1995,6 +2000,7 @@ namespace amf
     //-------------------------------------------------------------------------------------------------
     AMF_INLINE AMFVariant& AMFVariant::operator=(const AMFVariant& other)
     {
+        AMFVariantClear(this);
         AMFVariantCopy(this,
                 const_cast<AMFVariantStruct*>(static_cast<const AMFVariantStruct*>(&other)));
         return *this;
@@ -2003,6 +2009,7 @@ namespace amf
     template<typename T>
     AMFVariant& AMFVariant::operator=(const AMFInterfacePtr_T<T>& value)
     {
+        AMFVariantClear(this);
         AMFVariantAssignInterface(this, value);
         return *this;
     }

--- a/plugins/obs-ffmpeg/external/AMF/include/core/VulkanAMF.h
+++ b/plugins/obs-ffmpeg/external/AMF/include/core/VulkanAMF.h
@@ -52,9 +52,9 @@ namespace amf
 
     typedef struct AMFVulkanSync
     {
-        amf_size            cbSizeof;           // sizeof(AMFVulkanSemaphore)
+        amf_size            cbSizeof;           // sizeof(AMFVulkanSync)
         void*               pNext;              // reserved for extensions
-        VkSemaphore         hSemaphore;
+        VkSemaphore         hSemaphore;         // VkSemaphore; can be nullptr
         bool                bSubmitted;         // if true - wait for hSemaphore. re-submit hSemaphore if not synced by other ways and set to true
         VkFence             hFence;             // To sync on CPU; can be nullptr. Submitted in vkQueueSubmit. If waited for hFence, null it, do not delete or reset.
     } AMFVulkanSync;
@@ -78,12 +78,12 @@ namespace amf
         amf_size            cbSizeof;           // sizeof(AMFVulkanSurface)
         void*               pNext;              // reserved for extensions
         // surface properties
-        VkImage             hImage;
-        VkDeviceMemory      hMemory;
+        VkImage             hImage;             // vulkan native image for which the surface is created
+        VkDeviceMemory      hMemory;            // memory for hImage, can be nullptr
         amf_int64           iSize;              // memory size
         amf_uint32          eFormat;            // VkFormat
-        amf_int32           iWidth;
-        amf_int32           iHeight;
+        amf_int32           iWidth;             // image width
+        amf_int32           iHeight;            // image height
         amf_uint32          eCurrentLayout;     // VkImageLayout
         amf_uint32          eUsage;             // AMF_SURFACE_USAGE
         amf_uint32          eAccess;            // AMF_MEMORY_CPU_ACCESS
@@ -92,7 +92,7 @@ namespace amf
 
     typedef struct AMFVulkanView
     {
-        amf_size            cbSizeof;           // sizeof(AMFVulkanSurface)
+        amf_size            cbSizeof;           // sizeof(AMFVulkanView)
         void*               pNext;              // reserved for extensions
         // surface properties
         AMFVulkanSurface    *pSurface;
@@ -102,6 +102,9 @@ namespace amf
         amf_int32           iPlaneWidthPitch;
         amf_int32           iPlaneHeightPitch;
     } AMFVulkanView;
+
+#define AMF_CONTEXT_VULKAN_COMPUTE_QUEUE  L"VulkanComputeQueue" // amf_int64; default=0; Compute queue index in range [0, (VkQueueFamilyProperties.queueCount-1)] of the compute queue family.
+
 #if defined(__cplusplus)
 } // namespace amf
 #endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Updated AMF SDK headers to v1.4.29.0.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Updating to AMF SDK v1.4.29.0 affects OBS in the following ways:
   - Smart Access Video support for the AVC / HEVC / AV1 encoders
   - New options for the AV1 encoder

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows 10 with a GPU + APU setup.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
