### PR TITLE
UI: Support drag and move projector when clicking inside the window

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -287,7 +287,7 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 				&OBSProjector::EscapeTriggered);
 		popup.exec(QCursor::pos());
 	} else if (event->button() == Qt::LeftButton) {
-		onMousePressMouseOffset = event->pos();
+		onMousePressMouseOffset = event->globalPosition();
 
 		// Only MultiView projectors handle left click
 		if (this->type != ProjectorType::Multiview)
@@ -311,8 +311,10 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 void OBSProjector::mouseMoveEvent(QMouseEvent *event)
 {
 	if (!isFullScreen() && (event->buttons() & Qt::LeftButton)) {
-		QPoint diff = event->pos() - onMousePressMouseOffset;
-		this->window()->move(this->window()->pos() + diff);
+		QPointF diff =
+			event->globalPosition() - onMousePressMouseOffset;
+		window()->move(window()->pos() + diff.toPoint());
+		onMousePressMouseOffset = event->globalPosition();
 	}
 }
 

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -287,6 +287,8 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 				&OBSProjector::EscapeTriggered);
 		popup.exec(QCursor::pos());
 	} else if (event->button() == Qt::LeftButton) {
+		onMousePressMouseOffset = event->pos();
+
 		// Only MultiView projectors handle left click
 		if (this->type != ProjectorType::Multiview)
 			return;
@@ -304,6 +306,26 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 		if (main->GetCurrentSceneSource() != src)
 			main->SetCurrentScene(src, false);
 	}
+}
+
+void OBSProjector::mouseMoveEvent(QMouseEvent *event)
+{
+	if (!isFullScreen() && (event->buttons() & Qt::LeftButton)) {
+		QPoint diff = event->pos() - onMousePressMouseOffset;
+		this->window()->move(this->window()->pos() + diff);
+	}
+}
+
+void OBSProjector::enterEvent(QEnterEvent *)
+{
+	if (!isFullScreen()) {
+		setCursor(Qt::SizeAllCursor);
+	}
+}
+
+void OBSProjector::leaveEvent(QEvent *)
+{
+	setCursor(Qt::ArrowCursor);
 }
 
 void OBSProjector::EscapeTriggered()

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -49,7 +49,7 @@ private:
 
 	QScreen *screen = nullptr;
 
-	QPoint onMousePressMouseOffset;
+	QPointF onMousePressMouseOffset;
 
 private slots:
 	void EscapeTriggered();

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -26,7 +26,10 @@ private:
 	static void OBSSourceDestroyed(void *data, calldata_t *params);
 
 	void mousePressEvent(QMouseEvent *event) override;
+	void mouseMoveEvent(QMouseEvent *event) override;
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
+	void enterEvent(QEnterEvent *) override;
+	void leaveEvent(QEvent *) override;
 	void closeEvent(QCloseEvent *event) override;
 
 	bool isAlwaysOnTop;
@@ -45,6 +48,8 @@ private:
 	void SetMonitor(int monitor);
 
 	QScreen *screen = nullptr;
+
+	QPoint onMousePressMouseOffset;
 
 private slots:
 	void EscapeTriggered();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Support drag and move projector when clicking inside the window.

This is based on https://github.com/WizardCM/obs-studio/commit/9ee79acaf8d62ba9c12fb4b2a497fa1ad912cfba which is mentioned in https://github.com/obsproject/obs-studio/pull/5818#issuecomment-1013971920
but I changed how the new location is computed when dragging:

~~It is now computed by comparing initial mouse absolute position and the current mouse absolute position, and the diff is always applied to the initial window position. This way, the window's top left corner doesn't snap to mouse cursor like the mentioned commit, the behavior is now the same as dragging by clicking the window title.~~

#### 08.14.2023 Update

Redco the PR with following changes:
1. Use `this->window()->move()` to move window instead of `this->move()`. This is much smoother and works well by only computing diff based on mouse event position. Ref: https://stackoverflow.com/a/39821779/3973896
2. Show drag icon when mouse is hovered on widget
3. Disable drag to move when it's in full screen mode

Note: I can't change target branch to be another PR branch, so currently I can't enable drag to move only for frameless window. Will need to wait until related PR is merged in.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I suppose this functionality is essential for frameless window support (#5818, #7892, or #9430), which I look forward to, so I made this PR.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Built the code on my Windows 10 Machine and manually tested my changes.

```
Edition	Windows 10 Pro
Version	21H2
Installed on	‎6/‎6/‎2020
OS build	19044.2251
Experience	Windows Feature Experience Pack 120.2212.4180.0
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
  - (No projector documentation per my knowledge)
