### PR TITLE
obs-ffmpeg: Tell FFmpeg that BGRA uses alpha

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -241,8 +241,10 @@ static bool create_video_stream(struct ffmpeg_data *data)
 
 	closest_format = data->config.format;
 	if (data->vcodec->pix_fmts) {
+		const int has_alpha = closest_format == AV_PIX_FMT_BGRA;
 		closest_format = avcodec_find_best_pix_fmt_of_list(
-			data->vcodec->pix_fmts, data->config.format, 0, NULL);
+			data->vcodec->pix_fmts, closest_format, has_alpha,
+			NULL);
 	}
 
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)


### PR DESCRIPTION
### Description
Prevents alpha from getting dropped with custom encoders.

Fixes #8133

### Motivation and Context
People are relying on this.

### How Has This Been Tested?
Davinci Resolve shows alpha is working again.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.