### PR TITLE
obs-vst: Use uniqueID instead of MD5

### DIFF
--- a/plugins/obs-vst/VSTPlugin.cpp
+++ b/plugins/obs-vst/VSTPlugin.cpp
@@ -369,6 +369,11 @@ void VSTPlugin::closeEditor()
 		editorWidget->close();
 }
 
+int32_t VSTPlugin::getUniqueID()
+{
+	return effect ? effect->uniqueID : 0;
+}
+
 std::string VSTPlugin::getEffectPath()
 {
 	return pluginPath;

--- a/plugins/obs-vst/headers/VSTPlugin.h
+++ b/plugins/obs-vst/headers/VSTPlugin.h
@@ -99,6 +99,7 @@ public:
 	obs_audio_data *process(struct obs_audio_data *audio);
 	bool openInterfaceWhenActive = false;
 	bool vstLoaded();
+	int32_t getUniqueID();
 
 	bool isEditorOpen();
 	void onEditorClosed();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
For some reason, obs-vst used MD5 to validate that the vst plugin is indeed the same as was saved.
If it isn't the exact same file, the plugin state (aka 'chunk') is not set and the vst plugin loads with its default values.
To identify vst plugins in saved sessions, the vst SDK introduced the uniqueID.

Fixes #8120

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
The outcome of relying on MD5 instead of the plugin's uniqueID is that the user loses the vst plugin settings each time they update the plugin.
This should solve issue #8120.
Note that once introduced to code, it will cause current saved sessions not to load, since they are not saved with the plugin's uniqueID. But since current behavior allows ignoring of plugin settings on-going (per the frequency of their plugin updates), perhaps a one (and last) time is not so bad (?).
We can of course introduce the uniqueID without this break, by asking on load for the uniqueID and if doesn't exist try the MD5. And save only uniqueID. But then we will have a code that in time will become completely useless.
Up to your consideration.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Tested locally and verified that going between plugin versions, we keep the settings.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
