### PR TITLE
Add pause callbacks for coreaudio

### DIFF
--- a/libobs/audio-monitoring/osx/coreaudio-output.c
+++ b/libobs/audio-monitoring/osx/coreaudio-output.c
@@ -54,6 +54,15 @@ static inline bool fill_buffer(struct audio_monitor *monitor)
 	return true;
 }
 
+static void on_audio_pause(void *data, calldata_t *calldata)
+{
+	UNUSED_PARAMETER(calldata);
+	struct audio_monitor *monitor = data;
+	pthread_mutex_lock(&monitor->mutex);
+	circlebuf_free(&monitor->new_data);
+	pthread_mutex_unlock(&monitor->mutex);
+}
+
 static void on_audio_playback(void *param, obs_source_t *source,
 			      const struct audio_data *audio_data, bool muted)
 {
@@ -261,6 +270,8 @@ static void audio_monitor_free(struct audio_monitor *monitor)
 	if (monitor->source) {
 		obs_source_remove_audio_capture_callback(
 			monitor->source, on_audio_playback, monitor);
+		obs_source_remove_audio_pause_callback(monitor->source,
+						       on_audio_pause, monitor);
 	}
 	if (monitor->active) {
 		AudioQueueStop(monitor->queue, true);
@@ -288,6 +299,8 @@ static void audio_monitor_init_final(struct audio_monitor *monitor)
 
 	obs_source_add_audio_capture_callback(monitor->source,
 					      on_audio_playback, monitor);
+	obs_source_add_audio_pause_callback(monitor->source, on_audio_pause,
+					    monitor);
 }
 
 struct audio_monitor *audio_monitor_create(obs_source_t *source)

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -5732,6 +5732,32 @@ void obs_source_get_audio_mix(const obs_source_t *source,
 	}
 }
 
+void obs_source_add_audio_pause_callback(obs_source_t *source,
+					 signal_callback_t callback,
+					 void *param)
+{
+	if (!obs_source_valid(source, "obs_source_add_audio_pause_callback"))
+		return;
+
+	signal_handler_t *handler = obs_source_get_signal_handler(source);
+
+	signal_handler_connect(handler, "media_pause", callback, param);
+	signal_handler_connect(handler, "media_stopped", callback, param);
+}
+
+void obs_source_remove_audio_pause_callback(obs_source_t *source,
+					    signal_callback_t callback,
+					    void *param)
+{
+	if (!obs_source_valid(source, "obs_source_remove_audio_pause_callback"))
+		return;
+
+	signal_handler_t *handler = obs_source_get_signal_handler(source);
+
+	signal_handler_disconnect(handler, "media_pause", callback, param);
+	signal_handler_disconnect(handler, "media_stopped", callback, param);
+}
+
 void obs_source_add_audio_capture_callback(obs_source_t *source,
 					   obs_source_audio_capture_t callback,
 					   void *param)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1311,6 +1311,12 @@ typedef void (*obs_source_audio_capture_t)(void *param, obs_source_t *source,
 					   const struct audio_data *audio_data,
 					   bool muted);
 
+EXPORT void obs_source_add_audio_pause_callback(obs_source_t *source,
+						signal_callback_t callback,
+						void *param);
+EXPORT void obs_source_remove_audio_pause_callback(obs_source_t *source,
+						   signal_callback_t callback,
+						   void *param);
 EXPORT void obs_source_add_audio_capture_callback(
 	obs_source_t *source, obs_source_audio_capture_t callback, void *param);
 EXPORT void obs_source_remove_audio_capture_callback(


### PR DESCRIPTION
### Description
When playing VLC source on MacOS audio starts lagging after pause, stop or timeline seeking actions.
This is caused by VLC delaying the call to `buffer_audio()` callback. After each pause or stop the delay keeps adding up resulting in audio lag.
This change is adding an additional callback for "media_pause" and "media_stop" events to clean the `monitor->new_data` buffer and prevent audio data accumulation caused by VLC callback delay.

### Motivation and Context
Fixes issue #7552

### How Has This Been Tested?
Tested on MacBook Air M1 with different files in multiple sources including VLC

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
