### PR TITLE
virtualcam-module: Update filter size immediately when used in OBS

### DIFF
--- a/plugins/win-dshow/virtualcam-module/virtualcam-filter.cpp
+++ b/plugins/win-dshow/virtualcam-module/virtualcam-filter.cpp
@@ -270,6 +270,11 @@ void VCamFilter::Frame(uint64_t ts)
 			   the format we present to match */
 			SetVideoFormat(GetVideoFormat(), new_obs_cx, new_obs_cy,
 				       new_obs_interval);
+
+			/* Update the new filter size immediately since we
+			   know it just changed above */
+			new_filter_cx = new_obs_cx;
+			new_filter_cy = new_obs_cy;
 		}
 
 		/* Re-initialize the main scaler to use the new resolution */


### PR DESCRIPTION
### Description
Fixes a crash when the virtualcamera filter size changes when used inside OBS. This was due to the `in_obs` code path that changed the filter size, but the `new_filter_cx` / `new_filter_cy` were already read from the filter so the scaler used the wrong values.

Reported in v29 after the resolution change fixes in the Discord support channel.

### Motivation and Context
Crashes are bad.

### How Has This Been Tested?
Ran OBS at 1080p, started camera, stopped, dropped to 360p, started camera and observed no more crashes.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
