### PR TITLE
plugins: Add debug-level logging of FCUnpublish/DeleteStream

### DIFF
--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -1972,6 +1972,8 @@ SendFCUnpublish(RTMP *r, int streamIdx)
 
     packet.m_nBodySize = enc - packet.m_body;
 
+    RTMP_Log(RTMP_LOGDEBUG, "Sending FCUnpublish packet");
+
     return RTMP_SendPacket(r, &packet, FALSE);
 }
 
@@ -2035,6 +2037,8 @@ SendDeleteStream(RTMP *r, double dStreamId)
     enc = AMF_EncodeNumber(enc, pend, dStreamId);
 
     packet.m_nBodySize = enc - packet.m_body;
+
+	RTMP_Log(RTMP_LOGDEBUG, "Sending DeleteStream packet");
 
     /* no response expected */
     return RTMP_SendPacket(r, &packet, FALSE);

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -46,8 +46,9 @@ static const char *rtmp_stream_getname(void *unused)
 
 static void log_rtmp(int level, const char *format, va_list args)
 {
-	if (level > RTMP_LOGWARNING)
-		return;
+	// Filter temporary disabled
+	//if (level > RTMP_LOGWARNING)
+	//	return;
 
 	blogva(LOG_INFO, format, args);
 }


### PR DESCRIPTION
### Description
OBS may be sending FCUnpublish on reconnect. This will help diagnose those issues.

### Motivation and Context
-

### How Has This Been Tested?
-

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
