### PR TITLE
Dimidium Totius (in preparation for PipeWire camera and audio, part 1)

### DIFF
--- a/plugins/linux-pipewire/linux-pipewire.c
+++ b/plugins/linux-pipewire/linux-pipewire.c
@@ -43,6 +43,8 @@ bool obs_module_load(void)
 
 void obs_module_unload(void)
 {
+	screencast_portal_unload();
+
 #if PW_CHECK_VERSION(0, 3, 49)
 	pw_deinit();
 #endif

--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -53,7 +53,6 @@ struct format_info {
 };
 
 struct _obs_pipewire_data {
-	uint32_t pipewire_node;
 	int pipewire_fd;
 
 	gs_texture_t *texture;
@@ -805,7 +804,6 @@ obs_pipewire_data *obs_pipewire_create(int pipewire_fd, int pipewire_node,
 
 	obs_pw = bzalloc(sizeof(obs_pipewire_data));
 	obs_pw->pipewire_fd = pipewire_fd;
-	obs_pw->pipewire_node = pipewire_node;
 
 	init_format_info(obs_pw);
 
@@ -867,7 +865,7 @@ obs_pipewire_data *obs_pipewire_create(int pipewire_fd, int pipewire_node,
 	}
 
 	pw_stream_connect(
-		obs_pw->stream, PW_DIRECTION_INPUT, obs_pw->pipewire_node,
+		obs_pw->stream, PW_DIRECTION_INPUT, pipewire_node,
 		PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_MAP_BUFFERS, params,
 		n_params);
 

--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -868,7 +868,7 @@ static void play_pipewire_stream(obs_pipewire_data *obs_pw)
 
 /* obs_source_info methods */
 
-void *obs_pipewire_create(int pipewire_fd, int pipewire_node)
+obs_pipewire_data *obs_pipewire_create(int pipewire_fd, int pipewire_node)
 {
 	obs_pipewire_data *obs_pw = bzalloc(sizeof(obs_pipewire_data));
 

--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -836,6 +836,19 @@ obs_pipewire *obs_pipewire_create(int pipewire_fd)
 	return obs_pw;
 }
 
+void obs_pipewire_destroy(obs_pipewire *obs_pw)
+{
+	if (!obs_pw)
+		return;
+
+	teardown_pipewire(obs_pw);
+	destroy_session(obs_pw);
+
+	clear_format_info(obs_pw);
+
+	bfree(obs_pw);
+}
+
 void obs_pipewire_connect_stream(obs_pipewire *obs_pw, int pipewire_node,
 				 const char *stream_name,
 				 struct pw_properties *stream_properties)
@@ -880,19 +893,6 @@ void obs_pipewire_connect_stream(obs_pipewire *obs_pw, int pipewire_node,
 
 	pw_thread_loop_unlock(obs_pw->thread_loop);
 	bfree(params);
-}
-
-void obs_pipewire_destroy(obs_pipewire *obs_pw)
-{
-	if (!obs_pw)
-		return;
-
-	teardown_pipewire(obs_pw);
-	destroy_session(obs_pw);
-
-	clear_format_info(obs_pw);
-
-	bfree(obs_pw);
 }
 
 void obs_pipewire_show(obs_pipewire *obs_pw)

--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -791,7 +791,9 @@ static const struct pw_core_events core_events = {
 	.error = on_core_error_cb,
 };
 
-static void play_pipewire_stream(obs_pipewire_data *obs_pw)
+static void play_pipewire_stream(obs_pipewire_data *obs_pw,
+				 const char *stream_name,
+				 struct pw_properties *stream_properties)
 {
 	struct spa_pod_builder pod_builder;
 	const struct spa_pod **params = NULL;
@@ -834,11 +836,8 @@ static void play_pipewire_stream(obs_pipewire_data *obs_pw)
 	pw_thread_loop_wait(obs_pw->thread_loop);
 
 	/* Stream */
-	obs_pw->stream = pw_stream_new(
-		obs_pw->core, "OBS Studio",
-		pw_properties_new(PW_KEY_MEDIA_TYPE, "Video",
-				  PW_KEY_MEDIA_CATEGORY, "Capture",
-				  PW_KEY_MEDIA_ROLE, "Screen", NULL));
+	obs_pw->stream =
+		pw_stream_new(obs_pw->core, stream_name, stream_properties);
 	pw_stream_add_listener(obs_pw->stream, &obs_pw->stream_listener,
 			       &stream_events, obs_pw);
 	blog(LOG_INFO, "[pipewire] Created stream %p", obs_pw->stream);
@@ -868,7 +867,9 @@ static void play_pipewire_stream(obs_pipewire_data *obs_pw)
 
 /* obs_source_info methods */
 
-obs_pipewire_data *obs_pipewire_create(int pipewire_fd, int pipewire_node)
+obs_pipewire_data *obs_pipewire_create(int pipewire_fd, int pipewire_node,
+				       const char *stream_name,
+				       struct pw_properties *stream_properties)
 {
 	obs_pipewire_data *obs_pw = bzalloc(sizeof(obs_pipewire_data));
 
@@ -876,7 +877,7 @@ obs_pipewire_data *obs_pipewire_create(int pipewire_fd, int pipewire_node)
 	obs_pw->pipewire_node = pipewire_node;
 
 	init_format_info(obs_pw);
-	play_pipewire_stream(obs_pw);
+	play_pipewire_stream(obs_pw, stream_name, stream_properties);
 
 	return obs_pw;
 }

--- a/plugins/linux-pipewire/pipewire.h
+++ b/plugins/linux-pipewire/pipewire.h
@@ -28,10 +28,11 @@
 typedef struct _obs_pipewire obs_pipewire;
 
 obs_pipewire *obs_pipewire_create(int pipewire_fd);
+void obs_pipewire_destroy(obs_pipewire *obs_pw);
+
 void obs_pipewire_connect_stream(obs_pipewire *obs_pw, int pipewire_node,
 				 const char *stream_name,
 				 struct pw_properties *stream_properties);
-void obs_pipewire_destroy(obs_pipewire *obs_pw);
 
 void obs_pipewire_show(obs_pipewire *obs_pw);
 void obs_pipewire_hide(obs_pipewire *obs_pw);

--- a/plugins/linux-pipewire/pipewire.h
+++ b/plugins/linux-pipewire/pipewire.h
@@ -27,9 +27,10 @@
 
 typedef struct _obs_pipewire_data obs_pipewire_data;
 
-obs_pipewire_data *obs_pipewire_create(int pipewire_fd, int pipewire_node,
-				       const char *stream_name,
-				       struct pw_properties *stream_properties);
+obs_pipewire_data *obs_pipewire_create(int pipewire_fd);
+void obs_pipewire_connect_stream(obs_pipewire_data *obs_pw, int pipewire_node,
+				 const char *stream_name,
+				 struct pw_properties *stream_properties);
 void obs_pipewire_destroy(obs_pipewire_data *obs_pw);
 
 void obs_pipewire_show(obs_pipewire_data *obs_pw);

--- a/plugins/linux-pipewire/pipewire.h
+++ b/plugins/linux-pipewire/pipewire.h
@@ -24,7 +24,7 @@
 
 typedef struct _obs_pipewire_data obs_pipewire_data;
 
-void *obs_pipewire_create(int pipewire_fd, int pipewire_node);
+obs_pipewire_data *obs_pipewire_create(int pipewire_fd, int pipewire_node);
 void obs_pipewire_destroy(obs_pipewire_data *obs_pw);
 
 void obs_pipewire_show(obs_pipewire_data *obs_pw);

--- a/plugins/linux-pipewire/pipewire.h
+++ b/plugins/linux-pipewire/pipewire.h
@@ -25,19 +25,18 @@
 #include <pipewire/keys.h>
 #include <pipewire/properties.h>
 
-typedef struct _obs_pipewire_data obs_pipewire_data;
+typedef struct _obs_pipewire obs_pipewire;
 
-obs_pipewire_data *obs_pipewire_create(int pipewire_fd);
-void obs_pipewire_connect_stream(obs_pipewire_data *obs_pw, int pipewire_node,
+obs_pipewire *obs_pipewire_create(int pipewire_fd);
+void obs_pipewire_connect_stream(obs_pipewire *obs_pw, int pipewire_node,
 				 const char *stream_name,
 				 struct pw_properties *stream_properties);
-void obs_pipewire_destroy(obs_pipewire_data *obs_pw);
+void obs_pipewire_destroy(obs_pipewire *obs_pw);
 
-void obs_pipewire_show(obs_pipewire_data *obs_pw);
-void obs_pipewire_hide(obs_pipewire_data *obs_pw);
-uint32_t obs_pipewire_get_width(obs_pipewire_data *obs_pw);
-uint32_t obs_pipewire_get_height(obs_pipewire_data *obs_pw);
-void obs_pipewire_video_render(obs_pipewire_data *obs_pw, gs_effect_t *effect);
+void obs_pipewire_show(obs_pipewire *obs_pw);
+void obs_pipewire_hide(obs_pipewire *obs_pw);
+uint32_t obs_pipewire_get_width(obs_pipewire *obs_pw);
+uint32_t obs_pipewire_get_height(obs_pipewire *obs_pw);
+void obs_pipewire_video_render(obs_pipewire *obs_pw, gs_effect_t *effect);
 
-void obs_pipewire_set_cursor_visible(obs_pipewire_data *obs_pw,
-				     bool cursor_visible);
+void obs_pipewire_set_cursor_visible(obs_pipewire *obs_pw, bool cursor_visible);

--- a/plugins/linux-pipewire/pipewire.h
+++ b/plugins/linux-pipewire/pipewire.h
@@ -22,9 +22,14 @@
 
 #include <obs-module.h>
 
+#include <pipewire/keys.h>
+#include <pipewire/properties.h>
+
 typedef struct _obs_pipewire_data obs_pipewire_data;
 
-obs_pipewire_data *obs_pipewire_create(int pipewire_fd, int pipewire_node);
+obs_pipewire_data *obs_pipewire_create(int pipewire_fd, int pipewire_node,
+				       const char *stream_name,
+				       struct pw_properties *stream_properties);
 void obs_pipewire_destroy(obs_pipewire_data *obs_pw);
 
 void obs_pipewire_show(obs_pipewire_data *obs_pw);

--- a/plugins/linux-pipewire/screencast-portal.c
+++ b/plugins/linux-pipewire/screencast-portal.c
@@ -49,7 +49,7 @@ struct screencast_portal_capture {
 	uint32_t pipewire_node;
 	bool cursor_visible;
 
-	obs_pipewire_data *obs_pw;
+	obs_pipewire *obs_pw;
 };
 
 /* ------------------------------------------------- */

--- a/plugins/linux-pipewire/screencast-portal.c
+++ b/plugins/linux-pipewire/screencast-portal.c
@@ -880,3 +880,8 @@ void screencast_portal_load(void)
 	if (window_capture_available)
 		obs_register_source(&screencast_portal_window_capture_info);
 }
+
+void screencast_portal_unload(void)
+{
+	g_clear_object(&screencast_proxy);
+}

--- a/plugins/linux-pipewire/screencast-portal.c
+++ b/plugins/linux-pipewire/screencast-portal.c
@@ -245,8 +245,13 @@ static void on_pipewire_remote_opened_cb(GObject *source, GAsyncResult *res,
 		return;
 	}
 
-	capture->obs_pw = obs_pipewire_create(
-		pipewire_fd, capture->pipewire_node, "OBS Studio",
+	capture->obs_pw = obs_pipewire_create(pipewire_fd);
+
+	if (!capture->obs_pw)
+		return;
+
+	obs_pipewire_connect_stream(
+		capture->obs_pw, capture->pipewire_node, "OBS Studio",
 		pw_properties_new(PW_KEY_MEDIA_TYPE, "Video",
 				  PW_KEY_MEDIA_CATEGORY, "Capture",
 				  PW_KEY_MEDIA_ROLE, "Screen", NULL));

--- a/plugins/linux-pipewire/screencast-portal.c
+++ b/plugins/linux-pipewire/screencast-portal.c
@@ -245,8 +245,11 @@ static void on_pipewire_remote_opened_cb(GObject *source, GAsyncResult *res,
 		return;
 	}
 
-	capture->obs_pw =
-		obs_pipewire_create(pipewire_fd, capture->pipewire_node);
+	capture->obs_pw = obs_pipewire_create(
+		pipewire_fd, capture->pipewire_node, "OBS Studio",
+		pw_properties_new(PW_KEY_MEDIA_TYPE, "Video",
+				  PW_KEY_MEDIA_CATEGORY, "Capture",
+				  PW_KEY_MEDIA_ROLE, "Screen", NULL));
 	obs_pipewire_set_cursor_visible(capture->obs_pw,
 					capture->cursor_visible);
 }

--- a/plugins/linux-pipewire/screencast-portal.h
+++ b/plugins/linux-pipewire/screencast-portal.h
@@ -21,3 +21,4 @@
 #pragma once
 
 void screencast_portal_load(void);
+void screencast_portal_unload(void);


### PR DESCRIPTION
### Description

Various cleanups in preparation for making `linux-pipewire` handle cameras and audio. This pull request contains the "easy" half of https://github.com/obsproject/obs-studio/pull/6669 and should not be controversial.

What is done here is: 

 * Clean up a leftover object when the plugin is unloaded
 * Massage some functions to receive more parameters...
 * ... which then allow cleaning up the internal struct
 * Rename a struct to better represent its scope
 * Shuffle code around

### Motivation and Context

Prepare the `linux-pipewire` plugin to receive support for cameras and audio. This is also an effort to get https://github.com/obsproject/obs-studio/pull/6669 unstuck.

### How Has This Been Tested?

 - Run OBS Studio on Linux + Wayland, and notice it continues to work

### Types of changes

 - Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
