### PR TITLE
UI: Add tabbed properties

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -115,6 +115,9 @@ MixerToolbarMenu="Audio Mixer Menu"
 SceneFilters="Open Scene Filters"
 List="List"
 Grid="Grid"
+Mode="Mode"
+AudioVideo="Audio/Video"
+Effects="Effects"
 
 # warning for plugin load failures
 PluginsFailedToLoad.Title="Plugin Load Error"
@@ -556,6 +559,7 @@ Deinterlacing.Yadif="Yadif"
 Deinterlacing.Yadif2x="Yadif 2x"
 Deinterlacing.TopFieldFirst="Top Field First"
 Deinterlacing.BottomFieldFirst="Bottom Field First"
+Deinterlacing.FieldOrder="Field Order"
 
 # volume control accessibility text
 VolControl.SliderUnmuted="Volume slider for '%1':"

--- a/UI/forms/OBSBasicFilters.ui
+++ b/UI/forms/OBSBasicFilters.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>OBSBasicFilters</class>
- <widget class="QDialog" name="OBSBasicFilters">
+ <widget class="QWidget" name="OBSBasicFilters">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -10,35 +10,63 @@
     <height>726</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Basic.Filters</string>
-  </property>
-  <property name="sizeGripEnabled">
-   <bool>true</bool>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="2,5">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,10">
-     <property name="sizeConstraint">
-      <enum>QLayout::SetMinimumSize</enum>
+    <widget class="QStackedWidget" name="stackedWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+     <widget class="QWidget" name="asyncWidget">
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item>
-        <widget class="QFrame" name="asyncWidget">
+        <widget class="QListWidget" name="filtersList">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="minimumSize">
-          <size>
-           <width>255</width>
-           <height>0</height>
-          </size>
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="spacing">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="widget">
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <property name="spacing">
+           <number>4</number>
+          </property>
           <property name="leftMargin">
            <number>0</number>
           </property>
@@ -52,543 +80,178 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="QLabel" name="asyncLabel">
+           <widget class="QPushButton" name="addFilter">
+            <property name="maximumSize">
+             <size>
+              <width>22</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="accessibleName">
+             <string>Add</string>
+            </property>
             <property name="text">
-             <string>Basic.Filters.AsyncFilters</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="obs.qrc">
+              <normaloff>:/res/images/plus.svg</normaloff>:/res/images/plus.svg</iconset>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+            <property name="flat">
+             <bool>true</bool>
+            </property>
+            <property name="themeID" stdset="0">
+             <string>addIconSmall</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="FocusList" name="asyncFilters">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+           <widget class="QPushButton" name="removeFilter">
+            <property name="maximumSize">
+             <size>
+              <width>22</width>
+              <height>22</height>
+             </size>
             </property>
-            <property name="contextMenuPolicy">
-             <enum>Qt::CustomContextMenu</enum>
+            <property name="accessibleName">
+             <string>Remove</string>
             </property>
-            <property name="spacing">
-             <number>1</number>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QFrame" name="widget">
-            <layout class="QHBoxLayout" name="horizontalLayout_4">
-             <property name="spacing">
-              <number>4</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QPushButton" name="addAsyncFilter">
-               <property name="maximumSize">
-                <size>
-                 <width>22</width>
-                 <height>22</height>
-                </size>
-               </property>
-               <property name="accessibleName">
-                <string>Add</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>:/res/images/plus.svg</normaloff>:/res/images/plus.svg</iconset>
-               </property>
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="flat">
-                <bool>true</bool>
-               </property>
-               <property name="themeID" stdset="0">
-                <string>addIconSmall</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="removeAsyncFilter">
-               <property name="maximumSize">
-                <size>
-                 <width>22</width>
-                 <height>22</height>
-                </size>
-               </property>
-               <property name="accessibleName">
-                <string>Remove</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>:/res/images/minus.svg</normaloff>:/res/images/minus.svg</iconset>
-               </property>
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="flat">
-                <bool>true</bool>
-               </property>
-               <property name="themeID" stdset="0">
-                <string>removeIconSmall</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="moveAsyncFilterUp">
-               <property name="maximumSize">
-                <size>
-                 <width>22</width>
-                 <height>22</height>
-                </size>
-               </property>
-               <property name="accessibleName">
-                <string>MoveUp</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>:/res/images/up.svg</normaloff>:/res/images/up.svg</iconset>
-               </property>
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="flat">
-                <bool>true</bool>
-               </property>
-               <property name="themeID" stdset="0">
-                <string>upArrowIconSmall</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="moveAsyncFilterDown">
-               <property name="maximumSize">
-                <size>
-                 <width>22</width>
-                 <height>22</height>
-                </size>
-               </property>
-               <property name="accessibleName">
-                <string>MoveDown</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>:/res/images/down.svg</normaloff>:/res/images/down.svg</iconset>
-               </property>
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="flat">
-                <bool>true</bool>
-               </property>
-               <property name="themeID" stdset="0">
-                <string>downArrowIconSmall</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="asyncToolbarSpacer">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Expanding</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>0</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="separatorLine">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QFrame" name="effectWidget">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>255</width>
-           <height>0</height>
-          </size>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="label_2">
             <property name="text">
-             <string>Basic.Filters.EffectFilters</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="obs.qrc">
+              <normaloff>:/res/images/minus.svg</normaloff>:/res/images/minus.svg</iconset>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+            <property name="flat">
+             <bool>true</bool>
+            </property>
+            <property name="themeID" stdset="0">
+             <string>removeIconSmall</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="FocusList" name="effectFilters">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+           <widget class="QPushButton" name="moveFilterUp">
+            <property name="maximumSize">
+             <size>
+              <width>22</width>
+              <height>22</height>
+             </size>
             </property>
-            <property name="contextMenuPolicy">
-             <enum>Qt::CustomContextMenu</enum>
+            <property name="accessibleName">
+             <string>MoveUp</string>
             </property>
-            <property name="spacing">
-             <number>1</number>
+            <property name="text">
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="obs.qrc">
+              <normaloff>:/res/images/up.svg</normaloff>:/res/images/up.svg</iconset>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+            <property name="flat">
+             <bool>true</bool>
+            </property>
+            <property name="themeID" stdset="0">
+             <string>upArrowIconSmall</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QFrame" name="widget_2">
-            <layout class="QHBoxLayout" name="horizontalLayout_6">
-             <property name="spacing">
-              <number>4</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QPushButton" name="addEffectFilter">
-               <property name="maximumSize">
-                <size>
-                 <width>22</width>
-                 <height>22</height>
-                </size>
-               </property>
-               <property name="accessibleName">
-                <string>Add</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>:/res/images/plus.svg</normaloff>:/res/images/plus.svg</iconset>
-               </property>
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="flat">
-                <bool>true</bool>
-               </property>
-               <property name="themeID" stdset="0">
-                <string>addIconSmall</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="removeEffectFilter">
-               <property name="maximumSize">
-                <size>
-                 <width>22</width>
-                 <height>22</height>
-                </size>
-               </property>
-               <property name="accessibleName">
-                <string>Remove</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>:/res/images/minus.svg</normaloff>:/res/images/minus.svg</iconset>
-               </property>
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="flat">
-                <bool>true</bool>
-               </property>
-               <property name="themeID" stdset="0">
-                <string>removeIconSmall</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="moveEffectFilterUp">
-               <property name="maximumSize">
-                <size>
-                 <width>22</width>
-                 <height>22</height>
-                </size>
-               </property>
-               <property name="accessibleName">
-                <string>MoveUp</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>:/res/images/up.svg</normaloff>:/res/images/up.svg</iconset>
-               </property>
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="flat">
-                <bool>true</bool>
-               </property>
-               <property name="themeID" stdset="0">
-                <string>upArrowIconSmall</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="moveEffectFilterDown">
-               <property name="maximumSize">
-                <size>
-                 <width>22</width>
-                 <height>22</height>
-                </size>
-               </property>
-               <property name="accessibleName">
-                <string>MoveDown</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset>
-                 <normaloff>:/res/images/down.svg</normaloff>:/res/images/down.svg</iconset>
-               </property>
-               <property name="autoDefault">
-                <bool>false</bool>
-               </property>
-               <property name="flat">
-                <bool>true</bool>
-               </property>
-               <property name="themeID" stdset="0">
-                <string>downArrowIconSmall</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="effectToolbarSpacer">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Expanding</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>0</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
+           <widget class="QPushButton" name="moveFilterDown">
+            <property name="maximumSize">
+             <size>
+              <width>22</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="accessibleName">
+             <string>MoveDown</string>
+            </property>
+            <property name="text">
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="obs.qrc">
+              <normaloff>:/res/images/down.svg</normaloff>:/res/images/down.svg</iconset>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+            <property name="flat">
+             <bool>true</bool>
+            </property>
+            <property name="themeID" stdset="0">
+             <string>downArrowIconSmall</string>
+            </property>
            </widget>
+          </item>
+          <item>
+           <spacer name="asyncToolbarSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Expanding</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
        </item>
       </layout>
-     </item>
-     <item>
-      <widget class="QFrame" name="rightContainerLayout">
-       <property name="minimumSize">
-        <size>
-         <width>200</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Plain</enum>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_6">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QSplitter" name="rightLayout">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>400</height>
-           </size>
-          </property>
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="childrenCollapsible">
-           <bool>false</bool>
-          </property>
-          <widget class="QFrame" name="previewFrame">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Plain</enum>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_7">
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="OBSQTDisplay" name="preview" native="true">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>150</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-          <widget class="QFrame" name="propertiesFrame">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Plain</enum>
-           </property>
-           <layout class="QVBoxLayout" name="propertiesLayout">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <property name="spacing">
-           <number>4</number>
-          </property>
-          <property name="sizeConstraint">
-           <enum>QLayout::SetMaximumSize</enum>
-          </property>
-          <item>
-           <widget class="QDialogButtonBox" name="buttonBox">
-            <property name="standardButtons">
-             <set>QDialogButtonBox::Close|QDialogButtonBox::RestoreDefaults</set>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-    </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="propertiesFrame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QVBoxLayout" name="propertiesLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+     </layout>
+    </widget>
    </item>
   </layout>
   <action name="actionRemoveFilter">
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/minus.svg</normaloff>:/res/images/minus.svg</iconset>
    </property>
    <property name="text">
@@ -603,7 +266,7 @@
   </action>
   <action name="actionMoveUp">
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/up.svg</normaloff>:/res/images/up.svg</iconset>
    </property>
    <property name="text">
@@ -615,7 +278,7 @@
   </action>
   <action name="actionMoveDown">
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/down.svg</normaloff>:/res/images/down.svg</iconset>
    </property>
    <property name="text">
@@ -631,19 +294,7 @@
    </property>
   </action>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>OBSQTDisplay</class>
-   <extends>QWidget</extends>
-   <header>qt-display.hpp</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>FocusList</class>
-   <extends>QListWidget</extends>
-   <header>focus-list.hpp</header>
-  </customwidget>
- </customwidgets>
+ <customwidgets/>
  <resources>
   <include location="obs.qrc"/>
  </resources>

--- a/UI/forms/OBSBasicProperties.ui
+++ b/UI/forms/OBSBasicProperties.ui
@@ -65,7 +65,7 @@
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
-           <verstretch>1</verstretch>
+           <verstretch>0</verstretch>
           </sizepolicy>
          </property>
          <property name="minimumSize">
@@ -78,33 +78,223 @@
        </item>
       </layout>
      </widget>
-     <widget class="QFrame" name="propertiesFrame">
+     <widget class="QTabWidget" name="tabWidget">
       <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>0</horstretch>
         <verstretch>1</verstretch>
        </sizepolicy>
       </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
+      <property name="currentIndex">
+       <number>0</number>
       </property>
-      <property name="frameShadow">
-       <enum>QFrame::Plain</enum>
+      <property name="tabBarAutoHide">
+       <bool>false</bool>
       </property>
-      <layout class="QVBoxLayout" name="propertiesLayout">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-      </layout>
+      <widget class="QWidget" name="propertiesTab">
+       <attribute name="title">
+        <string>Properties</string>
+       </attribute>
+       <layout class="QGridLayout" name="gridLayout">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QFrame" name="propertiesFrame">
+          <property name="frameShape">
+           <enum>QFrame::StyledPanel</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Raised</enum>
+          </property>
+          <layout class="QVBoxLayout" name="propertiesLayout">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="asyncFiltersTab">
+       <attribute name="title">
+        <string>Basic.Filters.AsyncFilters</string>
+       </attribute>
+       <layout class="QGridLayout" name="gridLayout_3">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QFrame" name="asyncFiltersFrame">
+          <property name="frameShape">
+           <enum>QFrame::StyledPanel</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Sunken</enum>
+          </property>
+          <layout class="QVBoxLayout" name="asyncFiltersLayout"/>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="effectFiltersTab">
+       <attribute name="title">
+        <string>Basic.Filters.EffectFilters</string>
+       </attribute>
+       <layout class="QGridLayout" name="gridLayout_4">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QFrame" name="effectFiltersFrame">
+          <property name="frameShape">
+           <enum>QFrame::StyledPanel</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Sunken</enum>
+          </property>
+          <layout class="QVBoxLayout" name="effectFiltersLayout"/>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="advancedTab">
+       <attribute name="title">
+        <string>Basic.Settings.Advanced</string>
+       </attribute>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QScrollArea" name="scrollArea">
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollAreaWidgetContents">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>696</width>
+             <height>271</height>
+            </rect>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <item>
+             <widget class="QGroupBox" name="groupBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="title">
+               <string>Deinterlacing</string>
+              </property>
+              <layout class="QFormLayout" name="formLayout">
+               <property name="labelAlignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+               <item row="1" column="0">
+                <widget class="QLabel" name="label">
+                 <property name="text">
+                  <string>Mode</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QComboBox" name="deinterlaceMode"/>
+               </item>
+               <item row="2" column="1">
+                <widget class="QComboBox" name="deinterlaceOrder"/>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="label_5">
+                 <property name="text">
+                  <string>Deinterlacing.FieldOrder</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </widget>
    </item>

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -17,8 +17,7 @@
 
 #pragma once
 
-#include <QDialog>
-#include <QDialogButtonBox>
+#include <QWidget>
 #include <memory>
 #include <obs.hpp>
 
@@ -29,7 +28,7 @@ class QMenu;
 
 #include "ui_OBSBasicFilters.h"
 
-class OBSBasicFilters : public QDialog {
+class OBSBasicFilters : public QWidget {
 	Q_OBJECT
 
 private:
@@ -43,32 +42,25 @@ private:
 	OBSSignal removeSignal;
 	OBSSignal reorderSignal;
 
-	OBSSignal removeSourceSignal;
-	OBSSignal renameSourceSignal;
 	OBSSignal updatePropertiesSignal;
 
-	inline OBSSource GetFilter(int row, bool async);
+	inline OBSSource GetFilter(int row);
 
 	void UpdateFilters();
-	void UpdateSplitter();
-	void UpdateSplitter(bool show_splitter_frame);
-	void UpdatePropertiesView(int row, bool async);
+	void UpdatePropertiesView(int row);
 
 	static void OBSSourceFilterAdded(void *param, calldata_t *data);
 	static void OBSSourceFilterRemoved(void *param, calldata_t *data);
 	static void OBSSourceReordered(void *param, calldata_t *data);
-	static void SourceRemoved(void *param, calldata_t *data);
-	static void SourceRenamed(void *param, calldata_t *data);
 	static void UpdateProperties(void *data, calldata_t *params);
-	static void DrawPreview(void *data, uint32_t cx, uint32_t cy);
 
-	QMenu *CreateAddFilterPopupMenu(bool async);
+	QMenu *CreateAddFilterPopupMenu();
 
 	void AddNewFilter(const char *id);
 	void ReorderFilter(QListWidget *list, obs_source_t *filter, size_t idx);
 
-	void CustomContextMenu(const QPoint &pos, bool async);
-	void EditItem(QListWidgetItem *item, bool async);
+	void CustomContextMenu(const QPoint &pos);
+	void EditItem(QListWidgetItem *item);
 	void DuplicateItem(QListWidgetItem *item);
 
 	void FilterNameEdited(QWidget *editor, QListWidget *list);
@@ -77,37 +69,23 @@ private:
 
 	bool isAsync;
 
-	int noPreviewMargin;
-
 	bool editActive = false;
 
 private slots:
 	void AddFilter(OBSSource filter, bool focus = true);
 	void RemoveFilter(OBSSource filter);
 	void ReorderFilters();
-	void RenameAsyncFilter();
-	void RenameEffectFilter();
-	void DuplicateAsyncFilter();
-	void DuplicateEffectFilter();
-	void ResetFilters();
+	void RenameFilter();
+	void DuplicateFilter();
 
 	void AddFilterFromAction();
 
-	void on_addAsyncFilter_clicked();
-	void on_removeAsyncFilter_clicked();
-	void on_moveAsyncFilterUp_clicked();
-	void on_moveAsyncFilterDown_clicked();
-	void on_asyncFilters_currentRowChanged(int row);
-	void on_asyncFilters_customContextMenuRequested(const QPoint &pos);
-	void on_asyncFilters_GotFocus();
-
-	void on_addEffectFilter_clicked();
-	void on_removeEffectFilter_clicked();
-	void on_moveEffectFilterUp_clicked();
-	void on_moveEffectFilterDown_clicked();
-	void on_effectFilters_currentRowChanged(int row);
-	void on_effectFilters_customContextMenuRequested(const QPoint &pos);
-	void on_effectFilters_GotFocus();
+	void on_addFilter_clicked();
+	void on_removeFilter_clicked();
+	void on_moveFilterUp_clicked();
+	void on_moveFilterDown_clicked();
+	void on_filtersList_currentRowChanged(int row);
+	void on_filtersList_customContextMenuRequested(const QPoint &pos);
 
 	void on_actionRemoveFilter_triggered();
 	void on_actionMoveUp_triggered();
@@ -115,17 +93,17 @@ private slots:
 
 	void on_actionRenameFilter_triggered();
 
-	void AsyncFilterNameEdited(QWidget *editor);
-	void EffectFilterNameEdited(QWidget *editor);
+	void FilterNameEdited(QWidget *editor);
 
 	void CopyFilter();
 	void PasteFilter();
 
-public:
-	OBSBasicFilters(QWidget *parent, OBSSource source_);
-	~OBSBasicFilters();
+public slots:
+	void ResetFilters();
 
-	void Init();
+public:
+	OBSBasicFilters(QWidget *parent, OBSSource source_, bool isAsync);
+	~OBSBasicFilters();
 
 	inline void UpdateSource(obs_source_t *target)
 	{
@@ -134,7 +112,6 @@ public:
 	}
 
 protected:
-	virtual void closeEvent(QCloseEvent *event) override;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	virtual bool nativeEvent(const QByteArray &eventType, void *message,
 				 qintptr *result) override;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3040,7 +3040,7 @@ void OBSBasic::CreateInteractionWindow(obs_source_t *source)
 	interaction->setAttribute(Qt::WA_DeleteOnClose, true);
 }
 
-void OBSBasic::CreatePropertiesWindow(obs_source_t *source)
+void OBSBasic::CreatePropertiesWindow(obs_source_t *source, bool filters)
 {
 	bool closed = true;
 	if (properties)
@@ -3049,23 +3049,14 @@ void OBSBasic::CreatePropertiesWindow(obs_source_t *source)
 	if (!closed)
 		return;
 
-	properties = new OBSBasicProperties(this, source);
+	properties = new OBSBasicProperties(this, source, filters);
 	properties->Init();
 	properties->setAttribute(Qt::WA_DeleteOnClose, true);
 }
 
 void OBSBasic::CreateFiltersWindow(obs_source_t *source)
 {
-	bool closed = true;
-	if (filters)
-		closed = filters->close();
-
-	if (!closed)
-		return;
-
-	filters = new OBSBasicFilters(this, source);
-	filters->Init();
-	filters->setAttribute(Qt::WA_DeleteOnClose, true);
+	CreatePropertiesWindow(source, true);
 }
 
 /* Qt callbacks for invokeMethod */

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -966,7 +966,7 @@ public:
 	void OpenSavedProjectors();
 
 	void CreateInteractionWindow(obs_source_t *source);
-	void CreatePropertiesWindow(obs_source_t *source);
+	void CreatePropertiesWindow(obs_source_t *source, bool filters = false);
 	void CreateFiltersWindow(obs_source_t *source);
 	void CreateEditTransformWindow(obs_sceneitem_t *item);
 

--- a/UI/window-basic-properties.hpp
+++ b/UI/window-basic-properties.hpp
@@ -25,6 +25,7 @@
 #include <obs.hpp>
 
 class OBSPropertiesView;
+class OBSBasicFilters;
 class OBSBasic;
 
 #include "ui_OBSBasicProperties.h"
@@ -44,6 +45,8 @@ private:
 	OBSSignal updatePropertiesSignal;
 	OBSData oldSettings;
 	OBSPropertiesView *view;
+	OBSBasicFilters *asyncFilters;
+	OBSBasicFilters *effectFilters;
 	QDialogButtonBox *buttonBox;
 	QSplitter *windowSplitter;
 
@@ -62,12 +65,20 @@ private:
 	int CheckSettings();
 	void Cleanup();
 
+	obs_deinterlace_mode origDeinterlaceMode;
+	obs_deinterlace_field_order origDeinterlaceOrder;
+	void SetupDeinterlacing();
+
 private slots:
 	void on_buttonBox_clicked(QAbstractButton *button);
 	void AddPreviewButton();
 
+	void on_deinterlaceMode_currentIndexChanged(int index);
+	void on_deinterlaceOrder_currentIndexChanged(int index);
+
 public:
-	OBSBasicProperties(QWidget *parent, OBSSource source_);
+	OBSBasicProperties(QWidget *parent, OBSSource source_,
+			   bool openFilters = false);
 	~OBSBasicProperties();
 
 	void Init();


### PR DESCRIPTION
### Description
This adds tabbed properties for sources. The tabs are properties, filters and advanced (deinterlace settings).

Properties:
![Screenshot from 2023-06-18 03-20-03](https://github.com/obsproject/obs-studio/assets/19962531/319efdfd-f270-434f-b345-84929a5cc312)

Filters:
![Screenshot from 2023-06-18 03-24-24](https://github.com/obsproject/obs-studio/assets/19962531/55cadfd7-10aa-48cd-b603-029ebcb4e00f)

![Screenshot from 2023-06-18 03-25-18](https://github.com/obsproject/obs-studio/assets/19962531/8d47895c-92cf-4465-b572-b63e3cdebc61)

Advanced:
![Screenshot from 2023-06-18 03-26-08](https://github.com/obsproject/obs-studio/assets/19962531/22393f0b-a6df-4aef-b171-57b4dfe874f5)

### Motivation and Context
Redo of #1254

This one is simpler because it only is done for sources, not scene items. Scene items properties can be done in the future.

### How Has This Been Tested?
Opened properties of different sources.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
