### PR TITLE
UI: Use native combobox popup on macOS

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1242,6 +1242,10 @@ bool OBSApp::SetTheme(std::string name, std::string path)
 		themeDarkMode = !(color.redF() < 0.5);
 	}
 
+#ifdef __APPLE__
+	SetMacOSDarkMode(themeDarkMode);
+#endif
+
 	emit StyleChanged();
 	return true;
 }

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1249,7 +1249,7 @@ bool OBSApp::SetTheme(std::string name, std::string path)
 bool OBSApp::InitTheme()
 {
 	defaultPalette = palette();
-	setStyle(new OBSIgnoreWheelProxyStyle());
+	setStyle(new OBSProxyStyle());
 
 	const char *themeName =
 		config_get_string(globalConfig, "General", "CurrentTheme3");

--- a/UI/obs-proxy-style.cpp
+++ b/UI/obs-proxy-style.cpp
@@ -77,13 +77,16 @@ OBSContextBarProxyStyle::generatedIconPixmap(QIcon::Mode iconMode,
 	return QProxyStyle::generatedIconPixmap(iconMode, pixmap, option);
 }
 
-int OBSIgnoreWheelProxyStyle::styleHint(StyleHint hint,
-					const QStyleOption *option,
-					const QWidget *widget,
-					QStyleHintReturn *returnData) const
+int OBSProxyStyle::styleHint(StyleHint hint, const QStyleOption *option,
+			     const QWidget *widget,
+			     QStyleHintReturn *returnData) const
 {
 	if (hint == SH_ComboBox_AllowWheelScrolling)
 		return 0;
+#ifdef __APPLE__
+	if (hint == SH_ComboBox_UseNativePopup)
+		return 1;
+#endif
 
 	return QProxyStyle::styleHint(hint, option, widget, returnData);
 }

--- a/UI/obs-proxy-style.hpp
+++ b/UI/obs-proxy-style.hpp
@@ -2,14 +2,14 @@
 
 #include <QProxyStyle>
 
-class OBSIgnoreWheelProxyStyle : public QProxyStyle {
+class OBSProxyStyle : public QProxyStyle {
 public:
 	int styleHint(StyleHint hint, const QStyleOption *option,
 		      const QWidget *widget,
 		      QStyleHintReturn *returnData) const override;
 };
 
-class OBSContextBarProxyStyle : public OBSIgnoreWheelProxyStyle {
+class OBSContextBarProxyStyle : public OBSProxyStyle {
 public:
 	QPixmap generatedIconPixmap(QIcon::Mode iconMode, const QPixmap &pixmap,
 				    const QStyleOption *option) const override;

--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -384,6 +384,17 @@ void OpenMacOSPrivacyPreferences(const char *tab)
 	[[NSWorkspace sharedWorkspace] openURL:url];
 }
 
+void SetMacOSDarkMode(bool dark)
+{
+	if (dark) {
+		NSApp.appearance =
+			[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
+	} else {
+		NSApp.appearance =
+			[NSAppearance appearanceNamed:NSAppearanceNameAqua];
+	}
+}
+
 void TaskbarOverlayInit() {}
 void TaskbarOverlaySetStatus(TaskbarOverlayStatus status)
 {

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -101,6 +101,7 @@ bool isInBundle();
 void InstallNSApplicationSubclass();
 void InstallNSThreadLocks();
 void disableColorSpaceConversion(QWidget *window);
+void SetMacOSDarkMode(bool dark);
 
 MacPermissionStatus CheckPermissionWithPrompt(MacPermissionType type,
 					      bool prompt_for_permission);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Sets the `SH_ComboBox_UseNativePopup` to true on macOS. By doing this, Qt's combobox popups get replaced by native macOS ones. Before/After:
<p>
<img width="189" alt="image" src="https://user-images.githubusercontent.com/59806498/215128641-025d7a04-ff74-471b-ba4c-750cc85b585d.png">
<img width="205" alt="image" src="https://user-images.githubusercontent.com/59806498/215128196-9e62a212-43f3-49aa-9c95-87a3d578ebb8.png">
</p>



This flag currently only has an effect on macOS, but it's still probably safer to ifdef-guard it.

As recommended by Qt on QTBUG-106162, this fixes QComboBox popups not working with VoiceOver.
Together with Qt 6.5 (which fixes comboboxes not opening in the first place, see [QTBUG-106162](https://bugreports.qt.io/browse/QTBUG-106162)) this should make non-editable comboboxes work flawlessly.

Renamed `OBSIgnoreWheelProxyStyle` to `OBSProxyStyle` since it's no longer exclusive to ignoring wheel scrolling.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want OBS to be more accessible. Making VoiceOver work properly is a long and difficult (maybe impossible) road, but every step counts.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.1
Tested with Qt dev branch and this PR that comboboxes work well now with VoiceOver.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
