### PR TITLE
UI: Remove UNUSED_PARAMETER where unnecessary

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -291,18 +291,16 @@ void OBSAdvAudioCtrl::ShowAudioControl(QGridLayout *layout)
 /* ------------------------------------------------------------------------- */
 /* OBS source callbacks */
 
-void OBSAdvAudioCtrl::OBSSourceActivated(void *param, calldata_t *calldata)
+void OBSAdvAudioCtrl::OBSSourceActivated(void *param, calldata_t *)
 {
 	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param),
 				  "SourceActiveChanged", Q_ARG(bool, true));
-	UNUSED_PARAMETER(calldata);
 }
 
-void OBSAdvAudioCtrl::OBSSourceDeactivated(void *param, calldata_t *calldata)
+void OBSAdvAudioCtrl::OBSSourceDeactivated(void *param, calldata_t *)
 {
 	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param),
 				  "SourceActiveChanged", Q_ARG(bool, false));
-	UNUSED_PARAMETER(calldata);
 }
 
 void OBSAdvAudioCtrl::OBSSourceFlagsChanged(void *param, calldata_t *calldata)

--- a/UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp
+++ b/UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp
@@ -292,12 +292,9 @@ static void toggle_multi_view(CNTV2Card *card, NTV2InputSource src, bool enable)
 	}
 }
 
-bool on_multi_view_toggle(void *data, obs_properties_t *props,
-			  obs_property_t *list, obs_data_t *settings)
+bool on_multi_view_toggle(void *data, obs_properties_t *, obs_property_t *,
+			  obs_data_t *settings)
 {
-	UNUSED_PARAMETER(props);
-	UNUSED_PARAMETER(list);
-
 	bool multiViewEnabled =
 		obs_data_get_bool(settings, kUIPropMultiViewEnable.id) &&
 		!main_output_running && !preview_output_running;
@@ -345,11 +342,8 @@ void on_preview_scene_changed(enum obs_frontend_event event, void *param)
 	}
 }
 
-void render_preview_source(void *param, uint32_t cx, uint32_t cy)
+void render_preview_source(void *param, uint32_t, uint32_t)
 {
-	UNUSED_PARAMETER(cx);
-	UNUSED_PARAMETER(cy);
-
 	auto ctx = (struct preview_output *)param;
 
 	if (!ctx->current_source)

--- a/UI/frontend-plugins/decklink-captions/decklink-captions.cpp
+++ b/UI/frontend-plugins/decklink-captions/decklink-captions.cpp
@@ -67,11 +67,9 @@ void DecklinkCaptionsUI::on_source_currentIndexChanged(int)
 	captions->start();
 }
 
-static void caption_callback(void *param, obs_source_t *source,
+static void caption_callback(void * /* param */, obs_source_t * /* source */,
 			     const struct obs_source_cea_708 *captions)
 {
-	UNUSED_PARAMETER(param);
-	UNUSED_PARAMETER(source);
 	obs_output *output = obs_frontend_get_streaming_output();
 	if (output) {
 		if (obs_frontend_streaming_active() &&

--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
@@ -171,10 +171,8 @@ OBSData load_preview_settings()
 
 void on_preview_scene_changed(enum obs_frontend_event event, void *param);
 
-static void decklink_ui_tick(void *param, float sec)
+static void decklink_ui_tick(void *param, float /* sec */)
 {
-	UNUSED_PARAMETER(sec);
-
 	auto ctx = (struct decklink_ui_output *)param;
 
 	if (ctx->texrender_premultiplied)

--- a/UI/frontend-plugins/frontend-tools/captions-mssapi-stream.cpp
+++ b/UI/frontend-plugins/frontend-tools/captions-mssapi-stream.cpp
@@ -138,7 +138,6 @@ STDMETHODIMP CaptionStream::Read(void *data, ULONG bytes, ULONG *read_bytes)
 STDMETHODIMP CaptionStream::Write(const void *, ULONG bytes, ULONG *)
 {
 	debugfunc("data, %lu, written_bytes", bytes);
-	UNUSED_PARAMETER(bytes);
 
 	return STG_E_INVALIDFUNCTION;
 }
@@ -149,8 +148,6 @@ STDMETHODIMP CaptionStream::Seek(LARGE_INTEGER move, DWORD origin,
 				 ULARGE_INTEGER *new_pos)
 {
 	debugfunc("%lld, %lx, new_pos", move, origin);
-	UNUSED_PARAMETER(move);
-	UNUSED_PARAMETER(origin);
 
 	if (!new_pos)
 		return E_POINTER;
@@ -165,7 +162,6 @@ STDMETHODIMP CaptionStream::Seek(LARGE_INTEGER move, DWORD origin,
 STDMETHODIMP CaptionStream::SetSize(ULARGE_INTEGER new_size)
 {
 	debugfunc("%llu", new_size);
-	UNUSED_PARAMETER(new_size);
 	return STG_E_INVALIDFUNCTION;
 }
 
@@ -201,7 +197,6 @@ STDMETHODIMP CaptionStream::CopyTo(IStream *stream, ULARGE_INTEGER bytes,
 STDMETHODIMP CaptionStream::Commit(DWORD commit_flags)
 {
 	debugfunc("%lx", commit_flags);
-	UNUSED_PARAMETER(commit_flags);
 	/* TODO? */
 	return S_OK;
 }
@@ -216,9 +211,6 @@ STDMETHODIMP CaptionStream::LockRegion(ULARGE_INTEGER offset,
 				       ULARGE_INTEGER size, DWORD type)
 {
 	debugfunc("%llu, %llu, %ld", offset, size, type);
-	UNUSED_PARAMETER(offset);
-	UNUSED_PARAMETER(size);
-	UNUSED_PARAMETER(type);
 	/* TODO? */
 	return STG_E_INVALIDFUNCTION;
 }
@@ -227,9 +219,6 @@ STDMETHODIMP CaptionStream::UnlockRegion(ULARGE_INTEGER offset,
 					 ULARGE_INTEGER size, DWORD type)
 {
 	debugfunc("%llu, %llu, %ld", offset, size, type);
-	UNUSED_PARAMETER(offset);
-	UNUSED_PARAMETER(size);
-	UNUSED_PARAMETER(type);
 	/* TODO? */
 	return STG_E_INVALIDFUNCTION;
 }

--- a/UI/importers/importers.hpp
+++ b/UI/importers/importers.hpp
@@ -87,11 +87,7 @@ public:
 	int ImportScenes(const std::string &path, std::string &name,
 			 json11::Json &res);
 	bool Check(const std::string &path);
-	std::string Name(const std::string &path)
-	{
-		return "XSplit Import";
-		UNUSED_PARAMETER(path);
-	};
+	std::string Name(const std::string &) { return "XSplit Import"; };
 	OBSImporterFiles FindFiles();
 };
 

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1864,8 +1864,8 @@ skip:
 	return QApplication::notify(receiver, e);
 }
 
-QString OBSTranslator::translate(const char *context, const char *sourceText,
-				 const char *disambiguation, int n) const
+QString OBSTranslator::translate(const char *, const char *sourceText,
+				 const char *, int) const
 {
 	const char *out = nullptr;
 	QString str(sourceText);
@@ -1873,9 +1873,6 @@ QString OBSTranslator::translate(const char *context, const char *sourceText,
 	if (!App()->TranslateString(QT_TO_UTF8(str), &out))
 		return QString(sourceText);
 
-	UNUSED_PARAMETER(context);
-	UNUSED_PARAMETER(disambiguation);
-	UNUSED_PARAMETER(n);
 	return QT_UTF8(out);
 }
 
@@ -2522,7 +2519,8 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 	"Woops, OBS has crashed!\n\nWould you like to copy the crash log " \
 	"to the clipboard? The crash log will still be saved to:\n\n%s"
 
-static void main_crash_handler(const char *format, va_list args, void *param)
+static void main_crash_handler(const char *format, va_list args,
+			       void * /* param */)
 {
 	char *text = new char[MAX_CRASH_REPORT_SIZE];
 
@@ -2588,8 +2586,6 @@ static void main_crash_handler(const char *format, va_list args, void *param)
 	}
 
 	exit(-1);
-
-	UNUSED_PARAMETER(param);
 }
 
 static void load_debug_privilege(void)

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -671,11 +671,8 @@ void OBSPropertiesView::AddEditableList(obs_property_t *prop,
 	WidgetInfo *info = new WidgetInfo(this, prop, list);
 
 	list->setDragDropMode(QAbstractItemView::InternalMove);
-	connect(list->model(),
-		SIGNAL(rowsMoved(QModelIndex, int, int, QModelIndex, int)),
-		info,
-		SLOT(EditListReordered(const QModelIndex &, int, int,
-				       const QModelIndex &, int)));
+	connect(list->model(), SIGNAL(rowsMoved()), info,
+		SLOT(EditListReordered()));
 
 	QVBoxLayout *sideLayout = new QVBoxLayout();
 	NewButton(sideLayout, info, "addIconSmall", &WidgetInfo::EditListAdd);
@@ -1913,16 +1910,8 @@ void WidgetInfo::GroupChanged(const char *setting)
 						  : true);
 }
 
-void WidgetInfo::EditListReordered(const QModelIndex &parent, int start,
-				   int end, const QModelIndex &destination,
-				   int row)
+void WidgetInfo::EditListReordered()
 {
-	UNUSED_PARAMETER(parent);
-	UNUSED_PARAMETER(start);
-	UNUSED_PARAMETER(end);
-	UNUSED_PARAMETER(destination);
-	UNUSED_PARAMETER(row);
-
 	EditableListChanged();
 }
 

--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -77,8 +77,7 @@ public slots:
 	void EditListEdit();
 	void EditListUp();
 	void EditListDown();
-	void EditListReordered(const QModelIndex &parent, int start, int end,
-			       const QModelIndex &destination, int row);
+	void EditListReordered();
 };
 
 /* ------------------------------------------------------------------------- */

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -88,18 +88,12 @@ OBSBasicFilters::OBSBasicFilters(QWidget *parent, OBSSource source_)
 	installEventFilter(CreateShortcutFilter());
 
 	connect(ui->asyncFilters->itemDelegate(),
-		SIGNAL(closeEditor(QWidget *,
-				   QAbstractItemDelegate::EndEditHint)),
-		this,
-		SLOT(AsyncFilterNameEdited(
-			QWidget *, QAbstractItemDelegate::EndEditHint)));
+		SIGNAL(closeEditor(QWidget *)), this,
+		SLOT(AsyncFilterNameEdited(QWidget *)));
 
 	connect(ui->effectFilters->itemDelegate(),
-		SIGNAL(closeEditor(QWidget *,
-				   QAbstractItemDelegate::EndEditHint)),
-		this,
-		SLOT(EffectFilterNameEdited(
-			QWidget *, QAbstractItemDelegate::EndEditHint)));
+		SIGNAL(closeEditor(QWidget *)), this,
+		SLOT(EffectFilterNameEdited(QWidget *)));
 
 	QPushButton *close = ui->buttonBox->button(QDialogButtonBox::Close);
 	connect(close, SIGNAL(clicked()), this, SLOT(close()));
@@ -754,18 +748,14 @@ void OBSBasicFilters::OBSSourceFilterRemoved(void *param, calldata_t *data)
 				  Q_ARG(OBSSource, OBSSource(filter)));
 }
 
-void OBSBasicFilters::OBSSourceReordered(void *param, calldata_t *data)
+void OBSBasicFilters::OBSSourceReordered(void *param, calldata_t *)
 {
 	QMetaObject::invokeMethod(reinterpret_cast<OBSBasicFilters *>(param),
 				  "ReorderFilters");
-
-	UNUSED_PARAMETER(data);
 }
 
-void OBSBasicFilters::SourceRemoved(void *param, calldata_t *data)
+void OBSBasicFilters::SourceRemoved(void *param, calldata_t *)
 {
-	UNUSED_PARAMETER(data);
-
 	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param),
 				  "close");
 }
@@ -1171,18 +1161,14 @@ void OBSBasicFilters::FilterNameEdited(QWidget *editor, QListWidget *list)
 	editActive = false;
 }
 
-void OBSBasicFilters::AsyncFilterNameEdited(
-	QWidget *editor, QAbstractItemDelegate::EndEditHint endHint)
+void OBSBasicFilters::AsyncFilterNameEdited(QWidget *editor)
 {
 	FilterNameEdited(editor, ui->asyncFilters);
-	UNUSED_PARAMETER(endHint);
 }
 
-void OBSBasicFilters::EffectFilterNameEdited(
-	QWidget *editor, QAbstractItemDelegate::EndEditHint endHint)
+void OBSBasicFilters::EffectFilterNameEdited(QWidget *editor)
 {
 	FilterNameEdited(editor, ui->effectFilters);
-	UNUSED_PARAMETER(endHint);
 }
 
 static bool ConfirmReset(QWidget *parent)

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -113,10 +113,8 @@ private slots:
 	void on_actionMoveUp_triggered();
 	void on_actionMoveDown_triggered();
 
-	void AsyncFilterNameEdited(QWidget *editor,
-				   QAbstractItemDelegate::EndEditHint endHint);
-	void EffectFilterNameEdited(QWidget *editor,
-				    QAbstractItemDelegate::EndEditHint endHint);
+	void AsyncFilterNameEdited(QWidget *editor);
+	void EffectFilterNameEdited(QWidget *editor);
 
 	void CopyFilter();
 	void PasteFilter();

--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -83,9 +83,7 @@ OBSBasicInteraction::~OBSBasicInteraction()
 
 OBSEventFilter *OBSBasicInteraction::BuildEventFilter()
 {
-	return new OBSEventFilter([this](QObject *obj, QEvent *event) {
-		UNUSED_PARAMETER(obj);
-
+	return new OBSEventFilter([this](QObject *, QEvent *event) {
 		switch (event->type()) {
 		case QEvent::MouseButtonPress:
 		case QEvent::MouseButtonRelease:
@@ -115,12 +113,10 @@ OBSEventFilter *OBSBasicInteraction::BuildEventFilter()
 	});
 }
 
-void OBSBasicInteraction::SourceRemoved(void *data, calldata_t *params)
+void OBSBasicInteraction::SourceRemoved(void *data, calldata_t *)
 {
 	QMetaObject::invokeMethod(static_cast<OBSBasicInteraction *>(data),
 				  "close");
-
-	UNUSED_PARAMETER(params);
 }
 
 void OBSBasicInteraction::SourceRenamed(void *data, calldata_t *params)

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -47,14 +47,12 @@ static void OBSStreamStopping(void *data, calldata_t *params)
 					  Q_ARG(int, sec));
 }
 
-static void OBSStartStreaming(void *data, calldata_t *params)
+static void OBSStartStreaming(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
 	output->streamingActive = true;
 	os_atomic_set_bool(&streaming_active, true);
 	QMetaObject::invokeMethod(output->main, "StreamingStart");
-
-	UNUSED_PARAMETER(params);
 }
 
 static void OBSStopStreaming(void *data, calldata_t *params)
@@ -73,15 +71,13 @@ static void OBSStopStreaming(void *data, calldata_t *params)
 				  Q_ARG(QString, arg_last_error));
 }
 
-static void OBSStartRecording(void *data, calldata_t *params)
+static void OBSStartRecording(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
 
 	output->recordingActive = true;
 	os_atomic_set_bool(&recording_active, true);
 	QMetaObject::invokeMethod(output->main, "RecordingStart");
-
-	UNUSED_PARAMETER(params);
 }
 
 static void OBSStopRecording(void *data, calldata_t *params)
@@ -100,12 +96,10 @@ static void OBSStopRecording(void *data, calldata_t *params)
 				  Q_ARG(QString, arg_last_error));
 }
 
-static void OBSRecordStopping(void *data, calldata_t *params)
+static void OBSRecordStopping(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
 	QMetaObject::invokeMethod(output->main, "RecordStopping");
-
-	UNUSED_PARAMETER(params);
 }
 
 static void OBSRecordFileChanged(void *data, calldata_t *params)
@@ -122,15 +116,13 @@ static void OBSRecordFileChanged(void *data, calldata_t *params)
 	output->lastRecordingPath = next_file;
 }
 
-static void OBSStartReplayBuffer(void *data, calldata_t *params)
+static void OBSStartReplayBuffer(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
 
 	output->replayBufferActive = true;
 	os_atomic_set_bool(&replaybuf_active, true);
 	QMetaObject::invokeMethod(output->main, "ReplayBufferStart");
-
-	UNUSED_PARAMETER(params);
 }
 
 static void OBSStopReplayBuffer(void *data, calldata_t *params)
@@ -144,30 +136,26 @@ static void OBSStopReplayBuffer(void *data, calldata_t *params)
 				  Q_ARG(int, code));
 }
 
-static void OBSReplayBufferStopping(void *data, calldata_t *params)
+static void OBSReplayBufferStopping(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
 	QMetaObject::invokeMethod(output->main, "ReplayBufferStopping");
-
-	UNUSED_PARAMETER(params);
 }
 
-static void OBSReplayBufferSaved(void *data, calldata_t *)
+static void OBSReplayBufferSaved(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
 	QMetaObject::invokeMethod(output->main, "ReplayBufferSaved",
 				  Qt::QueuedConnection);
 }
 
-static void OBSStartVirtualCam(void *data, calldata_t *params)
+static void OBSStartVirtualCam(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
 
 	output->virtualCamActive = true;
 	os_atomic_set_bool(&virtualcam_active, true);
 	QMetaObject::invokeMethod(output->main, "OnVirtualCamStart");
-
-	UNUSED_PARAMETER(params);
 }
 
 static void OBSStopVirtualCam(void *data, calldata_t *params)

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -109,7 +109,7 @@ void OBSBasic::AddQuickTransitionHotkey(QuickTransition *qt)
 						  (void *)(uintptr_t)qt->id);
 }
 
-void QuickTransition::SourceRenamed(void *param, calldata_t *data)
+void QuickTransition::SourceRenamed(void *param, calldata_t *)
 {
 	QuickTransition *qt = reinterpret_cast<QuickTransition *>(param);
 
@@ -117,8 +117,6 @@ void QuickTransition::SourceRenamed(void *param, calldata_t *data)
 				     .arg(MakeQuickTransitionText(qt));
 
 	obs_hotkey_set_description(qt->hotkey, QT_TO_UTF8(hotkeyName));
-
-	UNUSED_PARAMETER(data);
 }
 
 void OBSBasic::TriggerQuickTransition(int id)
@@ -630,13 +628,11 @@ void OBSBasic::on_transitionProps_clicked()
 	menu.exec(QCursor::pos());
 }
 
-void OBSBasic::on_transitionDuration_valueChanged(int value)
+void OBSBasic::on_transitionDuration_valueChanged()
 {
 	if (api) {
 		api->on_event(OBS_FRONTEND_EVENT_TRANSITION_DURATION_CHANGED);
 	}
-
-	UNUSED_PARAMETER(value);
 }
 
 QuickTransition *OBSBasic::GetQuickTransition(int id)
@@ -1696,7 +1692,7 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 	UpdateTitleBar();
 }
 
-void OBSBasic::RenderProgram(void *data, uint32_t cx, uint32_t cy)
+void OBSBasic::RenderProgram(void *data, uint32_t, uint32_t)
 {
 	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DEFAULT, "RenderProgram");
 
@@ -1727,9 +1723,6 @@ void OBSBasic::RenderProgram(void *data, uint32_t cx, uint32_t cy)
 	gs_viewport_pop();
 
 	GS_DEBUG_MARKER_END();
-
-	UNUSED_PARAMETER(cx);
-	UNUSED_PARAMETER(cy);
 }
 
 void OBSBasic::ResizeProgram(uint32_t cx, uint32_t cy)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1099,9 +1099,9 @@ private slots:
 	void on_actionWebsite_triggered();
 	void on_actionDiscord_triggered();
 
-	void on_preview_customContextMenuRequested(const QPoint &pos);
-	void ProgramViewContextMenuRequested(const QPoint &pos);
-	void PreviewDisabledMenu(const QPoint &pos);
+	void on_preview_customContextMenuRequested();
+	void ProgramViewContextMenuRequested();
+	void on_previewDisabledWidget_customContextMenuRequested();
 
 	void on_actionNewSceneCollection_triggered();
 	void on_actionDupSceneCollection_triggered();
@@ -1131,7 +1131,7 @@ private slots:
 	void on_transitionAdd_clicked();
 	void on_transitionRemove_clicked();
 	void on_transitionProps_clicked();
-	void on_transitionDuration_valueChanged(int value);
+	void on_transitionDuration_valueChanged();
 
 	void ShowTransitionProperties();
 	void HideTransitionProperties();
@@ -1167,8 +1167,7 @@ private slots:
 	void EditSceneName();
 	void EditSceneItemName();
 
-	void SceneNameEdited(QWidget *editor,
-			     QAbstractItemDelegate::EndEditHint endHint);
+	void SceneNameEdited(QWidget *editor);
 
 	void OpenSceneFilters();
 	void OpenFilters(OBSSource source = nullptr);

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -111,7 +111,7 @@ static bool CloseFloat(float a, float b, float epsilon = 0.01)
 	return abs(a - b) <= epsilon;
 }
 
-static bool FindItemAtPos(obs_scene_t *scene, obs_sceneitem_t *item,
+static bool FindItemAtPos(obs_scene_t * /* scene */, obs_sceneitem_t *item,
 			  void *param)
 {
 	SceneFindData *data = reinterpret_cast<SceneFindData *>(param);
@@ -147,7 +147,6 @@ static bool FindItemAtPos(obs_scene_t *scene, obs_sceneitem_t *item,
 		data->item = item;
 	}
 
-	UNUSED_PARAMETER(scene);
 	return true;
 }
 
@@ -238,7 +237,7 @@ OBSSceneItem OBSBasicPreview::GetItemAtPos(const vec2 &pos, bool selectBelow)
 	return data.item;
 }
 
-static bool CheckItemSelected(obs_scene_t *scene, obs_sceneitem_t *item,
+static bool CheckItemSelected(obs_scene_t * /* scene */, obs_sceneitem_t *item,
 			      void *param)
 {
 	SceneFindData *data = reinterpret_cast<SceneFindData *>(param);
@@ -280,7 +279,6 @@ static bool CheckItemSelected(obs_scene_t *scene, obs_sceneitem_t *item,
 		}
 	}
 
-	UNUSED_PARAMETER(scene);
 	return true;
 }
 
@@ -335,7 +333,7 @@ struct HandleFindData {
 	}
 };
 
-static bool FindHandleAtPos(obs_scene_t *scene, obs_sceneitem_t *item,
+static bool FindHandleAtPos(obs_scene_t * /* scene */, obs_sceneitem_t *item,
 			    void *param)
 {
 	HandleFindData &data = *reinterpret_cast<HandleFindData *>(param);
@@ -423,7 +421,6 @@ static bool FindHandleAtPos(obs_scene_t *scene, obs_sceneitem_t *item,
 		}
 	}
 
-	UNUSED_PARAMETER(scene);
 	return true;
 }
 
@@ -671,7 +668,8 @@ void OBSBasicPreview::UpdateCursor(uint32_t &flags)
 		setCursor(Qt::OpenHandCursor);
 }
 
-static bool select_one(obs_scene_t *scene, obs_sceneitem_t *item, void *param)
+static bool select_one(obs_scene_t * /* scene */, obs_sceneitem_t *item,
+		       void *param)
 {
 	obs_sceneitem_t *selectedItem =
 		reinterpret_cast<obs_sceneitem_t *>(param);
@@ -680,7 +678,6 @@ static bool select_one(obs_scene_t *scene, obs_sceneitem_t *item, void *param)
 
 	obs_sceneitem_select(item, (selectedItem == item));
 
-	UNUSED_PARAMETER(scene);
 	return true;
 }
 
@@ -816,7 +813,7 @@ struct SelectedItemBounds {
 	vec3 tl, br;
 };
 
-static bool AddItemBounds(obs_scene_t *scene, obs_sceneitem_t *item,
+static bool AddItemBounds(obs_scene_t * /* scene */, obs_sceneitem_t *item,
 			  void *param)
 {
 	SelectedItemBounds *data =
@@ -867,7 +864,6 @@ static bool AddItemBounds(obs_scene_t *scene, obs_sceneitem_t *item,
 	t[3] = GetTransformedPos(1.0f, 1.0f, boxTransform);
 	add_bounds();
 
-	UNUSED_PARAMETER(scene);
 	return true;
 }
 
@@ -876,8 +872,8 @@ struct OffsetData {
 	vec3 tl, br, offset;
 };
 
-static bool GetSourceSnapOffset(obs_scene_t *scene, obs_sceneitem_t *item,
-				void *param)
+static bool GetSourceSnapOffset(obs_scene_t * /* scene */,
+				obs_sceneitem_t *item, void *param)
 {
 	OffsetData *data = reinterpret_cast<OffsetData *>(param);
 
@@ -925,7 +921,6 @@ static bool GetSourceSnapOffset(obs_scene_t *scene, obs_sceneitem_t *item,
 	EDGE_SNAP(br, tl, y, x);
 #undef EDGE_SNAP
 
-	UNUSED_PARAMETER(scene);
 	return true;
 }
 
@@ -979,7 +974,8 @@ void OBSBasicPreview::SnapItemMovement(vec2 &offset)
 	}
 }
 
-static bool move_items(obs_scene_t *scene, obs_sceneitem_t *item, void *param)
+static bool move_items(obs_scene_t * /* scene */, obs_sceneitem_t *item,
+		       void *param)
 {
 	if (obs_sceneitem_locked(item))
 		return true;
@@ -1006,7 +1002,6 @@ static bool move_items(obs_scene_t *scene, obs_sceneitem_t *item, void *param)
 		obs_sceneitem_set_pos(item, &pos);
 	}
 
-	UNUSED_PARAMETER(scene);
 	return true;
 }
 
@@ -1096,7 +1091,7 @@ static bool IntersectBox(matrix4 transform, float x1, float x2, float y1,
 }
 #undef PI
 
-bool OBSBasicPreview::FindSelected(obs_scene_t *scene, obs_sceneitem_t *item,
+bool OBSBasicPreview::FindSelected(obs_scene_t *, obs_sceneitem_t *item,
 				   void *param)
 {
 	SceneFindBoxData *data = reinterpret_cast<SceneFindBoxData *>(param);
@@ -1104,11 +1099,10 @@ bool OBSBasicPreview::FindSelected(obs_scene_t *scene, obs_sceneitem_t *item,
 	if (obs_sceneitem_selected(item))
 		data->sceneItems.push_back(item);
 
-	UNUSED_PARAMETER(scene);
 	return true;
 }
 
-static bool FindItemsInBox(obs_scene_t *scene, obs_sceneitem_t *item,
+static bool FindItemsInBox(obs_scene_t * /* scene */, obs_sceneitem_t *item,
 			   void *param)
 {
 	SceneFindBoxData *data = reinterpret_cast<SceneFindBoxData *>(param);
@@ -1198,7 +1192,6 @@ static bool FindItemsInBox(obs_scene_t *scene, obs_sceneitem_t *item,
 		return true;
 	}
 
-	UNUSED_PARAMETER(scene);
 	return true;
 }
 
@@ -1860,8 +1853,8 @@ static inline bool crop_enabled(const obs_sceneitem_crop *crop)
 	       crop->bottom > 0;
 }
 
-bool OBSBasicPreview::DrawSelectedOverflow(obs_scene_t *scene,
-					   obs_sceneitem_t *item, void *param)
+bool OBSBasicPreview::DrawSelectedOverflow(obs_scene_t *, obs_sceneitem_t *item,
+					   void *param)
 {
 	if (obs_sceneitem_locked(item))
 		return true;
@@ -1940,12 +1933,11 @@ bool OBSBasicPreview::DrawSelectedOverflow(obs_scene_t *scene,
 
 	GS_DEBUG_MARKER_END();
 
-	UNUSED_PARAMETER(scene);
 	return true;
 }
 
-bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *scene,
-				       obs_sceneitem_t *item, void *param)
+bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *, obs_sceneitem_t *item,
+				       void *param)
 {
 	if (obs_sceneitem_locked(item))
 		return true;
@@ -2121,7 +2113,6 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *scene,
 
 	GS_DEBUG_MARKER_END();
 
-	UNUSED_PARAMETER(scene);
 	return true;
 }
 

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -278,12 +278,10 @@ static void CreateTransitionScene(OBSSource scene, const char *text,
 	obs_sceneitem_set_bounds_type(item, OBS_BOUNDS_SCALE_INNER);
 }
 
-void OBSBasicProperties::SourceRemoved(void *data, calldata_t *params)
+void OBSBasicProperties::SourceRemoved(void *data, calldata_t *)
 {
 	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data),
 				  "close");
-
-	UNUSED_PARAMETER(params);
 }
 
 void OBSBasicProperties::SourceRenamed(void *data, calldata_t *params)

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4283,7 +4283,7 @@ void OBSBasicSettings::on_advOutFFPathBrowse_clicked()
 	ui->advOutFFRecPath->setText(dir);
 }
 
-void OBSBasicSettings::on_advOutEncoder_currentIndexChanged(int idx)
+void OBSBasicSettings::on_advOutEncoder_currentIndexChanged()
 {
 	QString encoder = GetComboData(ui->advOutEncoder);
 	if (!loading) {
@@ -4300,8 +4300,6 @@ void OBSBasicSettings::on_advOutEncoder_currentIndexChanged(int idx)
 
 	ui->advOutUseRescale->setVisible(true);
 	ui->advOutRescale->setVisible(true);
-
-	UNUSED_PARAMETER(idx);
 }
 
 void OBSBasicSettings::on_advOutRecEncoder_currentIndexChanged(int idx)

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -392,7 +392,7 @@ private slots:
 	void on_simpleOutputBrowse_clicked();
 	void on_advOutRecPathBrowse_clicked();
 	void on_advOutFFPathBrowse_clicked();
-	void on_advOutEncoder_currentIndexChanged(int idx);
+	void on_advOutEncoder_currentIndexChanged();
 	void on_advOutRecEncoder_currentIndexChanged(int idx);
 	void on_advOutFFIgnoreCompat_stateChanged(int state);
 	void on_advOutFFFormat_currentIndexChanged(int idx);

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -263,8 +263,7 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 		const char *scene_name =
 			obs_source_get_name(main->GetCurrentSceneSource());
 
-		auto undo = [scene_name, main](const std::string &data) {
-			UNUSED_PARAMETER(data);
+		auto undo = [scene_name, main](const std::string &) {
 			obs_source_t *scene_source =
 				obs_get_source_by_name(scene_name);
 			main->SetCurrentScene(scene_source, true);
@@ -272,9 +271,8 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 
 			obs_scene_t *scene = obs_get_scene_by_name(scene_name);
 			OBSSceneItem item;
-			auto cb = [](obs_scene_t *scene,
-				     obs_sceneitem_t *sceneitem, void *data) {
-				UNUSED_PARAMETER(scene);
+			auto cb = [](obs_scene_t *, obs_sceneitem_t *sceneitem,
+				     void *data) {
 				OBSSceneItem &last =
 					*reinterpret_cast<OBSSceneItem *>(data);
 				last = sceneitem;
@@ -287,8 +285,7 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 		};
 
 		auto redo = [scene_name, main, source_name,
-			     visible](const std::string &data) {
-			UNUSED_PARAMETER(data);
+			     visible](const std::string &) {
 			obs_source_t *scene_source =
 				obs_get_source_by_name(scene_name);
 			main->SetCurrentScene(scene_source, true);

--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -364,14 +364,12 @@ void OBSBasicStatusBar::OBSOutputReconnect(void *data, calldata_t *params)
 	QMetaObject::invokeMethod(statusBar, "Reconnect", Q_ARG(int, seconds));
 }
 
-void OBSBasicStatusBar::OBSOutputReconnectSuccess(void *data,
-						  calldata_t *params)
+void OBSBasicStatusBar::OBSOutputReconnectSuccess(void *data, calldata_t *)
 {
 	OBSBasicStatusBar *statusBar =
 		reinterpret_cast<OBSBasicStatusBar *>(data);
 
 	QMetaObject::invokeMethod(statusBar, "ReconnectSuccess");
-	UNUSED_PARAMETER(params);
 }
 
 void OBSBasicStatusBar::Reconnect(int seconds)

--- a/UI/window-missing-files.cpp
+++ b/UI/window-missing-files.cpp
@@ -49,7 +49,7 @@ MissingFilesPathItemDelegate::MissingFilesPathItemDelegate(
 
 QWidget *MissingFilesPathItemDelegate::createEditor(
 	QWidget *parent, const QStyleOptionViewItem & /* option */,
-	const QModelIndex &index) const
+	const QModelIndex &) const
 {
 	QSizePolicy buttonSizePolicy(QSizePolicy::Policy::Minimum,
 				     QSizePolicy::Policy::Expanding,
@@ -98,8 +98,6 @@ QWidget *MissingFilesPathItemDelegate::createEditor(
 
 	container->setLayout(layout);
 	container->setFocusProxy(text);
-
-	UNUSED_PARAMETER(index);
 
 	return container;
 }

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -208,11 +208,10 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 	endRegion();
 }
 
-void OBSProjector::OBSSourceDestroyed(void *data, calldata_t *params)
+void OBSProjector::OBSSourceDestroyed(void *data, calldata_t *)
 {
 	OBSProjector *window = reinterpret_cast<OBSProjector *>(data);
 	QMetaObject::invokeMethod(window, "EscapeTriggered");
-	UNUSED_PARAMETER(params);
 }
 
 void OBSProjector::mouseDoubleClickEvent(QMouseEvent *event)


### PR DESCRIPTION
### Description
Since cpp allows removing the unused parameters from the function name, UNUSED_PARAMETER is not needed, unless it is in an ifdef.

### Motivation and Context
Less code

### How Has This Been Tested?
Compiled OBS to make sure there were no warnings.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
