### PR TITLE
CI: Publish docs to Cloudflare Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,20 +4,34 @@ on:
   push:
     paths-ignore:
       - "cmake/**"
+    branches: ['*']
+    tags: ['*']
   pull_request:
     paths:
       - "docs/sphinx/**"
+  workflow_dispatch:
 
 jobs:
   docs:
     runs-on: ubuntu-latest
+    outputs:
+      commitHash: ${{ steps.setup.outputs.commitHash }}
+      commitBranch: ${{ steps.setup.outputs.commitBranch }}
+      fullCommitHash: ${{ steps.setup.outputs.fullCommitHash }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Setup Environment
         id: setup
         run: |
+          BRANCH=$(git describe --exact-match --tags 2> /dev/null || git branch --show-current)
+          # Remove patch version from tag
+          BRANCH=$(echo ${BRANCH} | sed -e 's/\.[0-9]*$//')
+          echo "commitBranch=${BRANCH}" >> $GITHUB_OUTPUT
           echo "commitHash=$(git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "fullCommitHash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
       - name: Bump Version Number
         shell: bash
         if: github.event_name == 'push'
@@ -40,6 +54,7 @@ jobs:
           SCOPY="copyright = '([A-Za-z0-9, ]+)'"
           RCOPY="copyright = '2017-$(date +"%Y"), Hugh Bailey'"
           sed -i -E -e "s/${SVER}/${RVER}/g" -e "s/${SREL}/${RREL}/g" -e "s/${SCOPY}/${RCOPY}/g" docs/sphinx/conf.py
+
       - uses: totaldebug/sphinx-publish-action@1.2.0
         with:
           sphinx_src: 'docs/sphinx'
@@ -47,9 +62,47 @@ jobs:
           target_branch: 'master'
           target_path: '../home/_build'
           pre_build_commands: 'pip install -Iv sphinx==5.1.1'
+
       - uses: actions/upload-artifact@v3
         with:
           name: 'OBS Studio Docs ${{ steps.setup.outputs.commitHash }}'
           path: |
             ${{ runner.temp }}/_github_home/_build
             !${{ runner.temp }}/_github_home/_build/.doctrees
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: docs
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.repository_owner == 'obsproject' && startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request') }}
+    environment:
+      name: cf-pages-deploy
+    concurrency:
+      group: "cf-pages-deployment"
+      cancel-in-progress: true
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: 'OBS Studio Docs ${{ needs.docs.outputs.commitHash }}'
+          path: docs
+
+      - name: Setup redirects
+        run: |
+          echo "/previous/27.2 https://obsproject.com/docs/27.2 302" >> docs/_redirects
+          echo "/previous/:major.:minor https://:major-:minor.${{ vars.CF_PAGES_PROJECT }}.pages.dev 302" >> docs/_redirects
+
+      - name: Publish to live page
+        uses: cloudflare/wrangler-action@4c10c1822abba527d820b29e6333e7f5dac2cabd
+        with:
+          workingDirectory: docs
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          command: pages publish . --project-name=${{ vars.CF_PAGES_PROJECT }} --commit-hash='${{ needs.docs.outputs.fullCommitHash }}'
+
+      - name: Publish to tag alias
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: cloudflare/wrangler-action@4c10c1822abba527d820b29e6333e7f5dac2cabd
+        with:
+          workingDirectory: docs
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          command: pages publish . --project-name=${{ vars.CF_PAGES_PROJECT }} --commit-hash='${{ needs.docs.outputs.fullCommitHash }}' --branch='${{ needs.docs.outputs.commitBranch }}'


### PR DESCRIPTION
### Description

Amends docs workflow to upload generated page to Cloudflare Pages when a tag is pushed or when manually triggered.

### Motivation and Context

Automated deploy, no worries about security policy affecting other obsproject sites.

### How Has This Been Tested?

On my fork:
- Workflow run: https://github.com/derrod/obs-studio/actions/runs/4037558811
- Deployed site: https://a00126b6.obs-docs-test.pages.dev/

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
