### PR TITLE
updater: Deduplicate Delta Patch Downloads

### DIFF
--- a/UI/win-update/updater/updater.cpp
+++ b/UI/win-update/updater/updater.cpp
@@ -1637,9 +1637,6 @@ static bool Update(wchar_t *cmdLine)
 
 	unordered_set<wstring> tempFiles;
 	for (update_t &update : updates) {
-		if (update.patchable)
-			continue;
-
 		if (tempFiles.count(update.tempPath)) {
 			update.state = STATE_ALREADY_DOWNLOADED;
 			totalFileSize -= update.fileSize;

--- a/UI/win-update/updater/updater.cpp
+++ b/UI/win-update/updater/updater.cpp
@@ -952,16 +952,12 @@ static void UpdateWithPatchIfAvailable(const char *name, const char *hash,
 		update.fileSize = size;
 		update.patchable = true;
 
-		/* ensure the filename is unique */
-		static long increment = 0;
-
 		/* Since the patch depends on the previous version, we can
 		 * no longer rely on the temp name being unique to the
 		 * new file's hash */
 		update.tempPath = tempPath;
 		update.tempPath += L"\\";
 		update.tempPath += patchHashStr;
-		update.tempPath += std::to_wstring(increment++);
 		break;
 	}
 }


### PR DESCRIPTION
### Description

Reverts 7396c211be75da3bce74cf8d2661a481a5c10fff and enables deduplication for delta patch files as well.

### Motivation and Context

Fixes the same issue as 7396c211be75da3bce74cf8d2661a481a5c10fff but with the new deduplication feature.

### How Has This Been Tested?

Updated locally from 28.1.2 and 27.2.4 to 29.0.0.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)
- Performance enhancement (non-breaking change which improves efficiency)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
