### PR TITLE
UI: Add confirmation dialog for resetting properties

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -382,6 +382,10 @@ ConfirmRemove.Title="Confirm Remove"
 ConfirmRemove.Text="Are you sure you wish to remove '%1'?"
 ConfirmRemove.TextMultiple="Are you sure you wish to remove %1 items?"
 
+# confirm reset to defaults dialog box
+ConfirmReset.Title="Reset Properties"
+ConfirmReset.Text="Are you sure you wish to reset current properties to their defaults?"
+
 # output start messages
 Output.StartStreamFailed="Failed to start streaming"
 Output.StartRecordingFailed="Failed to start recording"

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -1184,6 +1184,17 @@ void OBSBasicFilters::EffectFilterNameEdited(
 	UNUSED_PARAMETER(endHint);
 }
 
+static bool ConfirmReset(QWidget *parent)
+{
+	QMessageBox::StandardButton button;
+
+	button = OBSMessageBox::question(parent, QTStr("ConfirmReset.Title"),
+					 QTStr("ConfirmReset.Text"),
+					 QMessageBox::Yes | QMessageBox::No);
+
+	return button == QMessageBox::Yes;
+}
+
 void OBSBasicFilters::ResetFilters()
 {
 	QListWidget *list = isAsync ? ui->asyncFilters : ui->effectFilters;
@@ -1192,6 +1203,9 @@ void OBSBasicFilters::ResetFilters()
 	OBSSource filter = GetFilter(row, isAsync);
 
 	if (!filter)
+		return;
+
+	if (!ConfirmReset(this))
 		return;
 
 	OBSDataAutoRelease settings = obs_source_get_settings(filter);

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -301,6 +301,17 @@ void OBSBasicProperties::UpdateProperties(void *data, calldata_t *)
 				  "ReloadProperties");
 }
 
+static bool ConfirmReset(QWidget *parent)
+{
+	QMessageBox::StandardButton button;
+
+	button = OBSMessageBox::question(parent, QTStr("ConfirmReset.Title"),
+					 QTStr("ConfirmReset.Text"),
+					 QMessageBox::Yes | QMessageBox::No);
+
+	return button == QMessageBox::Yes;
+}
+
 void OBSBasicProperties::on_buttonBox_clicked(QAbstractButton *button)
 {
 	QDialogButtonBox::ButtonRole val = ui->buttonBox->buttonRole(button);
@@ -362,6 +373,9 @@ void OBSBasicProperties::on_buttonBox_clicked(QAbstractButton *button)
 		close();
 
 	} else if (val == QDialogButtonBox::ResetRole) {
+		if (!ConfirmReset(this))
+			return;
+
 		OBSDataAutoRelease settings = obs_source_get_settings(source);
 		obs_data_clear(settings);
 


### PR DESCRIPTION
### Description

Adds a confirmation dialog before resetting properties (filters or sources) to defaults:
![2023-01-29_13-41-40_VguCoa](https://user-images.githubusercontent.com/3123295/215326863-0dce6dfb-8cbe-463d-a812-5e9bf66881b1.png)

### Motivation and Context

Requested by @Warchamp7 

### How Has This Been Tested?

1. Clicked "Defaults"
2a. Clicked "No" => Nothing happened
2b. Clicked "Yes" => Properties reset

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
