### PR TITLE
UI: Add obs_frontend_open_sceneitem_edit_transform

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -630,6 +630,14 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 					  Q_ARG(OBSSource, OBSSource(source)));
 	}
 
+	void obs_frontend_open_sceneitem_edit_transform(
+		obs_sceneitem_t *item) override
+	{
+		QMetaObject::invokeMethod(main, "OpenEditTransform",
+					  Q_ARG(OBSSceneItem,
+						OBSSceneItem(item)));
+	}
+
 	char *obs_frontend_get_current_record_output_path(void) override
 	{
 		const char *recordOutputPath = main->GetCurrentOutputPath();

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -559,6 +559,12 @@ void obs_frontend_open_source_interaction(obs_source_t *source)
 		c->obs_frontend_open_source_interaction(source);
 }
 
+void obs_frontend_open_sceneitem_edit_transform(obs_sceneitem_t *item)
+{
+	if (callbacks_valid())
+		c->obs_frontend_open_sceneitem_edit_transform(item);
+}
+
 char *obs_frontend_get_current_record_output_path(void)
 {
 	return !!callbacks_valid()

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -226,6 +226,7 @@ EXPORT void obs_frontend_reset_video(void);
 EXPORT void obs_frontend_open_source_properties(obs_source_t *source);
 EXPORT void obs_frontend_open_source_filters(obs_source_t *source);
 EXPORT void obs_frontend_open_source_interaction(obs_source_t *source);
+EXPORT void obs_frontend_open_sceneitem_edit_transform(obs_sceneitem_t *item);
 
 EXPORT char *obs_frontend_get_current_record_output_path(void);
 EXPORT const char *obs_frontend_get_locale_string(const char *string);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -141,6 +141,8 @@ struct obs_frontend_callbacks {
 	virtual void obs_frontend_open_source_filters(obs_source_t *source) = 0;
 	virtual void
 	obs_frontend_open_source_interaction(obs_source_t *source) = 0;
+	virtual void
+	obs_frontend_open_sceneitem_edit_transform(obs_sceneitem_t *item) = 0;
 
 	virtual char *obs_frontend_get_current_record_output_path(void) = 0;
 	virtual const char *

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6391,6 +6391,15 @@ void OBSBasic::OpenInteraction(OBSSource source)
 	CreateInteractionWindow(source);
 }
 
+void OBSBasic::OpenEditTransform(OBSSceneItem item)
+{
+	if (!item)
+		item = GetCurrentSceneItem();
+	if (!item)
+		return;
+	CreateEditTransformWindow(item);
+}
+
 void OBSBasic::OpenSceneFilters()
 {
 	OBSScene scene = GetCurrentScene();
@@ -8058,13 +8067,17 @@ void OBSBasic::UpdateEditMenu()
 
 void OBSBasic::on_actionEditTransform_triggered()
 {
+	const auto item = GetCurrentSceneItem();
+	if (!item)
+		return;
+	CreateEditTransformWindow(item);
+}
+
+void OBSBasic::CreateEditTransformWindow(obs_sceneitem_t *item)
+{
 	if (transformWindow)
 		transformWindow->close();
-
-	if (!GetCurrentSceneItem())
-		return;
-
-	transformWindow = new OBSBasicTransform(this);
+	transformWindow = new OBSBasicTransform(item, this);
 	connect(ui->scenes, &QListWidget::currentItemChanged, transformWindow,
 		&OBSBasicTransform::OnSceneChanged);
 	transformWindow->show();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -945,6 +945,7 @@ public:
 	void CreateInteractionWindow(obs_source_t *source);
 	void CreatePropertiesWindow(obs_source_t *source);
 	void CreateFiltersWindow(obs_source_t *source);
+	void CreateEditTransformWindow(obs_sceneitem_t *item);
 
 	QAction *AddDockWidget(QDockWidget *dock);
 
@@ -1157,6 +1158,7 @@ private slots:
 	void OpenFilters(OBSSource source = nullptr);
 	void OpenProperties(OBSSource source = nullptr);
 	void OpenInteraction(OBSSource source = nullptr);
+	void OpenEditTransform(OBSSceneItem item = nullptr);
 
 	void EnablePreviewDisplay(bool enable);
 	void TogglePreview();

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -40,7 +40,7 @@ void OBSBasicTransform::HookWidget(QWidget *widget, const char *signal,
 #define ISCROLL_CHANGED SIGNAL(valueChanged(int))
 #define DSCROLL_CHANGED SIGNAL(valueChanged(double))
 
-OBSBasicTransform::OBSBasicTransform(OBSBasic *parent)
+OBSBasicTransform::OBSBasicTransform(OBSSceneItem item, OBSBasic *parent)
 	: QDialog(parent), ui(new Ui::OBSBasicTransform), main(parent)
 {
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -69,7 +69,6 @@ OBSBasicTransform::OBSBasicTransform(OBSBasic *parent)
 
 	installEventFilter(CreateShortcutFilter());
 
-	OBSSceneItem item = FindASelectedItem(main->GetCurrentScene());
 	OBSScene scene = obs_sceneitem_get_scene(item);
 	SetScene(scene);
 	SetItem(item);

--- a/UI/window-basic-transform.hpp
+++ b/UI/window-basic-transform.hpp
@@ -48,7 +48,7 @@ private slots:
 	void on_resetButton_clicked();
 
 public:
-	OBSBasicTransform(OBSBasic *parent);
+	OBSBasicTransform(OBSSceneItem item, OBSBasic *parent);
 	~OBSBasicTransform();
 
 public slots:

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -794,6 +794,14 @@ Functions
 
 ---------------------------------------
 
+.. function:: void *obs_frontend_open_sceneitem_edit_transform(obs_sceneitem_t *item)
+
+   Opens the edit transform window of the specified sceneitem.
+
+   :param item: The sceneitem to open the edit transform window of
+
+---------------------------------------
+
 .. function:: char *obs_frontend_get_current_record_output_path(void)
 
    :return: A new pointer to the current record output path.  Free


### PR DESCRIPTION
### Description
Add `obs_frontend_open_sceneitem_edit_transform(obs_sceneitem_t *item)`

### Motivation and Context
Allow scripts and plugins to open the edit transform dialog for a specific scene item

### How Has This Been Tested?
On windows 64 bit by calling the function from a plugin.

### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
