### PR TITLE
obs-scripting: Add PyType_Modified import for Swig 4.1.1 compatibility

### DIFF
--- a/deps/obs-scripting/obs-scripting-python-import.c
+++ b/deps/obs-scripting/obs-scripting-python-import.c
@@ -116,6 +116,7 @@ bool import_python(const char *python_path, python_version_t *python_version)
 	} while (false)
 
 	IMPORT_FUNC(PyType_Ready);
+	IMPORT_FUNC(PyType_Modified);
 	IMPORT_FUNC(PyObject_GenericGetAttr);
 	IMPORT_FUNC(PyObject_IsTrue);
 	IMPORT_FUNC(Py_DecRef);

--- a/deps/obs-scripting/obs-scripting-python-import.h
+++ b/deps/obs-scripting/obs-scripting-python-import.h
@@ -57,6 +57,7 @@ typedef struct python_version {
 
 PY_EXTERN int (*Import_PyType_Ready)(PyTypeObject *);
 PY_EXTERN PyObject *(*Import_PyObject_GenericGetAttr)(PyObject *, PyObject *);
+PY_EXTERN void (*Import_PyType_Modified)(PyTypeObject *);
 PY_EXTERN int (*Import_PyObject_IsTrue)(PyObject *);
 PY_EXTERN void (*Import_Py_DecRef)(PyObject *);
 PY_EXTERN void *(*Import_PyObject_Malloc)(size_t size);
@@ -153,6 +154,7 @@ extern bool import_python(const char *python_path,
 #ifndef NO_REDEFS
 #define PyType_Ready Import_PyType_Ready
 #define PyType_GetFlags Import_PyType_GetFlags
+#define PyType_Modified Import_PyType_Modified
 #define PyObject_GenericGetAttr Import_PyObject_GenericGetAttr
 #define PyObject_IsTrue Import_PyObject_IsTrue
 #define Py_DecRef Import_Py_DecRef


### PR DESCRIPTION
### Description
Adds necessary Python 3 symbols for use with Swig 4.1.1.

### Motivation and Context
Swig merged in partial support for Python's stable ABI, which require `PyType_Modified` to be available at compile time.

Required for https://github.com/obsproject/obs-deps/pull/154

### How Has This Been Tested?
* Tested on Windows 11 (Windows being the only OS that requires the symbols to be resolved at link time)

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
