### PR TITLE
UI: Add obs_frontend_add_undo_redo_action

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -662,6 +662,20 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		return bstrdup(main->lastReplay.c_str());
 	}
 
+	void obs_frontend_add_undo_redo_action(const char *name,
+					       const undo_redo_cb undo,
+					       const undo_redo_cb redo,
+					       const char *undo_data,
+					       const char *redo_data,
+					       bool repeatable) override
+	{
+		main->undo_s.add_action(
+			name,
+			[undo](const std::string &data) { undo(data.c_str()); },
+			[redo](const std::string &data) { redo(data.c_str()); },
+			undo_data, redo_data, repeatable);
+	}
+
 	void on_load(obs_data_t *settings) override
 	{
 		for (size_t i = saveCallbacks.size(); i > 0; i--) {

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -594,3 +594,14 @@ char *obs_frontend_get_last_replay(void)
 	return !!callbacks_valid() ? c->obs_frontend_get_last_replay()
 				   : nullptr;
 }
+
+void obs_frontend_add_undo_redo_action(const char *name,
+				       const undo_redo_cb undo,
+				       const undo_redo_cb redo,
+				       const char *undo_data,
+				       const char *redo_data, bool repeatable)
+{
+	if (callbacks_valid())
+		c->obs_frontend_add_undo_redo_action(
+			name, undo, redo, undo_data, redo_data, repeatable);
+}

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -236,6 +236,11 @@ EXPORT char *obs_frontend_get_last_recording(void);
 EXPORT char *obs_frontend_get_last_screenshot(void);
 EXPORT char *obs_frontend_get_last_replay(void);
 
+typedef void (*undo_redo_cb)(const char *data);
+EXPORT void obs_frontend_add_undo_redo_action(
+	const char *name, const undo_redo_cb undo, const undo_redo_cb redo,
+	const char *undo_data, const char *redo_data, bool repeatable);
+
 /* ------------------------------------------------------------------------- */
 
 #ifdef __cplusplus

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -151,6 +151,13 @@ struct obs_frontend_callbacks {
 	virtual char *obs_frontend_get_last_recording(void) = 0;
 	virtual char *obs_frontend_get_last_screenshot(void) = 0;
 	virtual char *obs_frontend_get_last_replay(void) = 0;
+
+	virtual void obs_frontend_add_undo_redo_action(const char *name,
+						       const undo_redo_cb undo,
+						       const undo_redo_cb redo,
+						       const char *undo_data,
+						       const char *redo_data,
+						       bool repeatable) = 0;
 };
 
 EXPORT void

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -226,6 +226,10 @@ Structures/Enumerations
 
    Translation callback
 
+.. type::  void (*undo_redo_cb)(const char *data)
+
+   Undo redo callback
+
 
 Functions
 ---------
@@ -838,3 +842,15 @@ Functions
             :c:func:`bfree()`
 
    .. versionadded:: 29.0.0
+
+---------------------------------------
+
+.. function:: void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo, const undo_redo_cb redo, const char *undo_data, const char *redo_data, bool repeatable)
+
+   :param name: The name of the undo redo action
+   :param undo: Callback to use for undo
+   :param redo: Callback to use for redo
+   :param undo_data: String with data for the undo callback
+   :param redo_data: String with data for the redo callback
+   :param repeatable: Allow multiple actions with the same name to be merged to 1 undo redo action.
+                      This uses the undo action from the first and the redo action from the last action.


### PR DESCRIPTION
### Description
Add `void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo, const undo_redo_cb redo,	const char *undo_data, const char *redo_data, bool repeatable)`

### Motivation and Context
Allow plugins to add undo and redo actions

### How Has This Been Tested?
On windows 64 bit calling it from a plugin

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
