### PR TITLE
CI/docs: Some fixes for CF Pages publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Bump Version Number
         shell: bash
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         run: |
           VERTEST="\#define\sLIBOBS_API_\w+_VER\s([0-9]{1,2})"
           VER=""
@@ -91,6 +91,7 @@ jobs:
           echo "/previous/:major.:minor https://:major-:minor.${{ vars.CF_PAGES_PROJECT }}.pages.dev 302" >> docs/_redirects
 
       - name: Publish to live page
+        if: ${{ !contains(needs.docs.outputs.commitBranch, 'beta') && !contains(needs.docs.outputs.commitBranch, 'rc') }}
         uses: cloudflare/wrangler-action@4c10c1822abba527d820b29e6333e7f5dac2cabd
         with:
           workingDirectory: docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,8 @@ jobs:
       commitHash: ${{ steps.setup.outputs.commitHash }}
       commitBranch: ${{ steps.setup.outputs.commitBranch }}
       fullCommitHash: ${{ steps.setup.outputs.fullCommitHash }}
+    env:
+      BUILD_CF_ARTIFACT: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -63,12 +65,37 @@ jobs:
           target_path: '../home/_build'
           pre_build_commands: 'pip install -Iv sphinx==5.1.1'
 
+      - name: Disable link extensions
+        shell: bash
+        if: ${{ env.BUILD_CF_ARTIFACT == 'true' }}
+        run: |
+          SOPT="html_link_suffix = None"
+          ROPT="html_link_suffix = ''"
+          sed -i -e "s/${SOPT}/${ROPT}/g" docs/sphinx/conf.py
+
+      - uses: totaldebug/sphinx-publish-action@1.2.0
+        if: ${{ env.BUILD_CF_ARTIFACT == 'true' }}
+        with:
+          sphinx_src: 'docs/sphinx'
+          build_only: True
+          target_branch: 'master'
+          target_path: '../home/_build_cf'
+          pre_build_commands: 'pip install -Iv sphinx==5.1.1'
+
       - uses: actions/upload-artifact@v3
         with:
           name: 'OBS Studio Docs ${{ steps.setup.outputs.commitHash }}'
           path: |
             ${{ runner.temp }}/_github_home/_build
             !${{ runner.temp }}/_github_home/_build/.doctrees
+
+      - uses: actions/upload-artifact@v3
+        if: ${{ env.BUILD_CF_ARTIFACT == 'true' }}
+        with:
+          name: 'CF Pages ${{ steps.setup.outputs.commitHash }}'
+          path: |
+            ${{ runner.temp }}/_github_home/_build_cf
+            !${{ runner.temp }}/_github_home/_build_cf/.doctrees
 
   deploy:
     runs-on: ubuntu-latest
@@ -82,7 +109,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: 'OBS Studio Docs ${{ needs.docs.outputs.commitHash }}'
+          name: 'CF Pages ${{ needs.docs.outputs.commitHash }}'
           path: docs
 
       - name: Setup redirects

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -143,6 +143,7 @@ html_sidebars = {
     ]
 }
 
+html_link_suffix = None
 
 # -- Options for HTMLHelp output ------------------------------------------
 


### PR DESCRIPTION
### Description

- Disables beta/rc tags being published to live page
- Runs version update step for `workflow_dispatch` as well
- Sphinx output is now created without `.html` suffix in Links to avoid unnecessary redirects on CF's platform

Note: This would break browing the docs locally unless they're hosted on a webserver that is configured to support extension-less URLs.

### Motivation and Context

Fixing good.

### How Has This Been Tested?

Tested on my fork: https://obs-docs-test.pages.dev/

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
