### PR TITLE
libobs-d3d11: Log display DPI and scale factor

### DIFF
--- a/libobs-d3d11/CMakeLists.txt
+++ b/libobs-d3d11/CMakeLists.txt
@@ -45,7 +45,7 @@ else()
                          GPU_PRIORITY_VAL=${GPU_PRIORITY_VAL})
 endif()
 
-target_link_libraries(libobs-d3d11 PRIVATE OBS::libobs d3d9 d3d11 dxgi)
+target_link_libraries(libobs-d3d11 PRIVATE OBS::libobs d3d9 d3d11 dxgi shcore)
 
 set_target_properties(
   libobs-d3d11


### PR DESCRIPTION
### Description

Log display DPI.

Example (100% scaling):
```
23:08:35.567: 	  output 2:
23:08:35.567: 	    name=DELL U2715H
23:08:35.567: 	    pos={-2560, 0}
23:08:35.567: 	    size={2560, 1440}
23:08:35.567: 	    attached=true
23:08:35.567: 	    refresh=59
23:08:35.567: 	    bits_per_color=8
23:08:35.567: 	    space=RGB_FULL_G22_NONE_P709
23:08:35.567: 	    sdr_white_nits=80
23:08:35.567: 	    nit_range=[min=0.500000, max=270.000000, max_full_frame=270.000000]
23:08:35.567: 	    dpi=96 (100%)
```

### Motivation and Context

Users do funny things.

### How Has This Been Tested?

Ran on my machine, seems to log correct info, but who knows.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
