### PR TITLE
libobs: Write default values to config

### DIFF
--- a/libobs/util/config-file.c
+++ b/libobs/util/config-file.c
@@ -579,6 +579,16 @@ unlock:
 	pthread_mutex_unlock(&config->mutex);
 }
 
+static void config_set_item_default(config_t *config, const char *section,
+				    const char *name, char *value)
+{
+	config_set_item(config, &config->defaults, section, name, value);
+
+	if (!config_has_user_value(config, section, name))
+		config_set_item(config, &config->sections, section, name,
+				bstrdup(value));
+}
+
 void config_set_string(config_t *config, const char *section, const char *name,
 		       const char *value)
 {
@@ -626,8 +636,7 @@ void config_set_default_string(config_t *config, const char *section,
 {
 	if (!value)
 		value = "";
-	config_set_item(config, &config->defaults, section, name,
-			bstrdup(value));
+	config_set_item_default(config, section, name, bstrdup(value));
 }
 
 void config_set_default_int(config_t *config, const char *section,
@@ -636,7 +645,7 @@ void config_set_default_int(config_t *config, const char *section,
 	struct dstr str;
 	dstr_init(&str);
 	dstr_printf(&str, "%" PRId64, value);
-	config_set_item(config, &config->defaults, section, name, str.array);
+	config_set_item_default(config, section, name, str.array);
 }
 
 void config_set_default_uint(config_t *config, const char *section,
@@ -645,14 +654,14 @@ void config_set_default_uint(config_t *config, const char *section,
 	struct dstr str;
 	dstr_init(&str);
 	dstr_printf(&str, "%" PRIu64, value);
-	config_set_item(config, &config->defaults, section, name, str.array);
+	config_set_item_default(config, section, name, str.array);
 }
 
 void config_set_default_bool(config_t *config, const char *section,
 			     const char *name, bool value)
 {
 	char *str = bstrdup(value ? "true" : "false");
-	config_set_item(config, &config->defaults, section, name, str);
+	config_set_item_default(config, section, name, str);
 }
 
 void config_set_default_double(config_t *config, const char *section,
@@ -661,7 +670,7 @@ void config_set_default_double(config_t *config, const char *section,
 	struct dstr str;
 	dstr_init(&str);
 	dstr_printf(&str, "%g", value);
-	config_set_item(config, &config->defaults, section, name, str.array);
+	config_set_item_default(config, section, name, str.array);
 }
 
 const char *config_get_string(config_t *config, const char *section,


### PR DESCRIPTION
### Description

Changes the config file implementation to save default values in case no user-provided value has been set.

### Motivation and Context

Migrations make life diffcult when we change defaults. So just save values even if the users never changes them from default.

### How Has This Been Tested?

Locally in portable mode, checked that generated config had all keys with default values written.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
