### PR TITLE
Improve Flatpak and Linux session logging

### DIFF
--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -369,10 +369,19 @@ static void log_flatpak_info(void)
 
 static void log_desktop_session_info(void)
 {
-	char *session_ptr = getenv("XDG_SESSION_TYPE");
-	if (session_ptr) {
-		blog(LOG_INFO, "Session Type: %s", session_ptr);
-	}
+	char *current_desktop = getenv("XDG_CURRENT_DESKTOP");
+	char *session_desktop = getenv("XDG_SESSION_DESKTOP");
+	char *session_type = getenv("XDG_SESSION_TYPE");
+
+	if (current_desktop && session_desktop)
+		blog(LOG_INFO, "Desktop Environment: %s (%s)", current_desktop,
+		     session_desktop);
+	else if (current_desktop || session_desktop)
+		blog(LOG_INFO, "Desktop Environment: %s",
+		     current_desktop ? current_desktop : session_desktop);
+
+	if (session_type)
+		blog(LOG_INFO, "Session Type: %s", session_type);
 }
 #endif
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

#### Desktop Environment logging

Add `XDG_CURRENT_DESKTOP` and/or `XDG_SESSION_DESKTOP` to the log to identify the desktop environment.

Before:
```
info: Distribution: "Arch Linux" Unknown
info: Session Type: x11
```

After:
```
info: Distribution: "Arch Linux" Unknown
info: Desktop Environment: GNOME (gnome-xorg)
info: Session Type: x11
```

#### Flatpak info logging

In a Flatpak environment, a  file `.flatpak-info` is created in the root. This file contains information that the application can retrieve to log them.

Its syntax allows it to be read with `config_t`.

```
➜  ~ flatpak run --command=sh --devel com.obsproject.Studio//stable
[📦 com.obsproject.Studio ~]$ cat /.flatpak-info 
[Application]
name=com.obsproject.Studio
runtime=runtime/org.kde.Sdk/x86_64/6.4

[Instance]
instance-id=562527906
instance-path=/home/tytan652/.var/app/com.obsproject.Studio
app-path=/var/lib/flatpak/app/com.obsproject.Studio/x86_64/stable/b960563fb4a56f7482dc9453ba5fb204e101cd948af1
…
```

Before:
```
info: Kernel Version: Linux 6.1.9-zen1-1-zen
info: Distribution: "KDE Flatpak runtime" "5.15-21.08"
info: Session Type: x11
```

After:
```
info: Kernel Version: Linux 6.1.9-zen1-1-zen
info: Flatpak Branch: none
info: Flatpak Arch: x86_64
info: Flatpak Runtime: runtime/org.kde.Sdk/x86_64/6.4
info: App Extensions:
info:  - org.freedesktop.LinuxAudio.Plugins.DISTRHO-Ports
info: Runtime Extensions:
info:  - org.freedesktop.Platform.GL.default
info:  - org.freedesktop.Platform.GStreamer.gstreamer-vaapi
info:  - org.freedesktop.Platform.VAAPI.Intel
info:  - org.freedesktop.Platform.openh264
info:  - org.gtk.Gtk3theme.Adwaita-dark
info:  - org.kde.Sdk.Locale
info:  - org.freedesktop.Platform.GL.default
info: Flatpak Framework Version: 1.15.1
info: Session Type: x11
```

NOTE: `branch` is "none" because the Flatpak is built from GNOME Builder or flatpak-builder without branches.
The usual values are:
- "stable" if from Flathub
- "beta" if from Flathub beta
- "master" if CI artifacts

Example with the CI artifacts:
```
info: Kernel Version: Linux 6.1.9-zen1-1-zen
info: Flatpak Branch: master
info: Flatpak Arch: x86_64
info: Flatpak Runtime: runtime/org.kde.Platform/x86_64/6.4
info: App Extensions:
info:  - org.freedesktop.LinuxAudio.Plugins.DISTRHO-Ports
info: Runtime Extensions:
info:  - org.freedesktop.Platform.GL.default
info:  - org.freedesktop.Platform.GStreamer.gstreamer-vaapi
info:  - org.freedesktop.Platform.VAAPI.Intel
info:  - org.freedesktop.Platform.openh264
info:  - org.gtk.Gtk3theme.Adwaita-dark
info:  - org.kde.Platform.Locale
info:  - org.freedesktop.Platform.GL.default
info: Flatpak Framework Version: 1.15.1
info: Desktop Environment: GNOME (gnome-xorg)
info: Session Type: x11
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Improve logging on Linux.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

- Running the  non-Flatpak on my system.
- Running the Flatpak in GNOME builder and with flatpak-builder.

Information is correctly logged in all cases.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
