### PR TITLE
graphics-hook: Stop trying to connect early

### DIFF
--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -244,8 +244,6 @@ static inline bool init_hook(HANDLE thread_handle)
 	_snwprintf(keepalive_name, sizeof(keepalive_name) / sizeof(wchar_t),
 		   L"%s%lu", WINDOW_HOOK_KEEPALIVE, GetCurrentProcessId());
 
-	init_pipe();
-
 	init_dummy_window_thread();
 	log_current_process();
 


### PR DESCRIPTION
### Description
It never works, and leaves a confusing message behind.

### Motivation and Context
Trying not to confuse game programmers.

### How Has This Been Tested?
Tried Vulkan and D3D11 samples, and they no longer show the message. They both connect to OBS in similar amounts of time whether the samples are started before or after OBS. Surprisingly, the message was still showing without this change even if OBS was launched first and waiting for the specific sample.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.