### PR TITLE
CI: Switch to curl for dependency downloads

### DIFF
--- a/CI/windows/01_install_dependencies.ps1
+++ b/CI/windows/01_install_dependencies.ps1
@@ -31,9 +31,7 @@ Function Install-obs-deps {
     if (!(Test-Path "${DepsBuildDir}/windows-deps-${Version}-${ArchSuffix}")) {
 
         Write-Step "Download..."
-        $ProgressPreference = $(if ($Quiet.isPresent) { "SilentlyContinue" } else { "Continue" })
-        Invoke-WebRequest -Uri "https://github.com/obsproject/obs-deps/releases/download/${Version}/windows-deps-${Version}-${ArchSuffix}.zip" -UseBasicParsing -OutFile "windows-deps-${Version}-${ArchSuffix}.zip"
-        $ProgressPreference = "Continue"
+        curl.exe -Lf "https://github.com/obsproject/obs-deps/releases/download/${Version}/windows-deps-${Version}-${ArchSuffix}.zip" -o "windows-deps-${Version}-${ArchSuffix}.zip" $(if ($Quiet.isPresent) { "-s" })
 
         Write-Step "Unpack..."
 
@@ -57,9 +55,7 @@ function Install-qt-deps {
     if (!(Test-Path "${DepsBuildDir}/windows-deps-${Version}-${ArchSuffix}/mkspecs")) {
 
         Write-Step "Download..."
-        $ProgressPreference = $(if ($Quiet.isPresent) { 'SilentlyContinue' } else { 'Continue' })
-        Invoke-WebRequest -Uri "https://github.com/obsproject/obs-deps/releases/download/${Version}/windows-deps-qt6-${Version}-${ArchSuffix}.zip" -UseBasicParsing -OutFile "windows-deps-qt6-${Version}-${ArchSuffix}.zip"
-        $ProgressPreference = "Continue"
+        curl.exe -Lf "https://github.com/obsproject/obs-deps/releases/download/${Version}/windows-deps-qt6-${Version}-${ArchSuffix}.zip" -o "windows-deps-qt6-${Version}-${ArchSuffix}.zip" $(if ($Quiet.isPresent) { "-s" })
 
         Write-Step "Unpack..."
 
@@ -80,9 +76,7 @@ function Install-vlc {
 
     if (!((Test-Path "$DepsBuildDir/vlc-${Version}") -and (Test-Path "$DepsBuildDir/vlc-${Version}/include/vlc/vlc.h"))) {
         Write-Step "Download..."
-        $ProgressPreference = $(if ($Quiet.isPresent) { 'SilentlyContinue' } else { 'Continue' })
-        Invoke-WebRequest -Uri "https://cdn-fastly.obsproject.com/downloads/vlc.zip" -UseBasicParsing -OutFile "vlc_${Version}.zip"
-        $ProgressPreference = "Continue"
+        curl.exe -Lf "https://cdn-fastly.obsproject.com/downloads/vlc.zip" -o "vlc_${Version}.zip" $(if ($Quiet.isPresent) { "-s" })
 
         Write-Step "Unpack..."
         # Expand-Archive -Path "vlc_${Version}.zip"
@@ -105,9 +99,7 @@ function Install-cef {
 
     if (!((Test-Path "${DepsBuildDir}/cef_binary_${Version}_windows_${ArchSuffix}") -and (Test-Path "${DepsBuildDir}/cef_binary_${Version}_windows_${ArchSuffix}/build/libcef_dll_wrapper/Release/libcef_dll_wrapper.lib"))) {
         Write-Step "Download..."
-        $ProgressPreference = $(if ($Quiet.isPresent) { 'SilentlyContinue' } else { 'Continue' })
-        Invoke-WebRequest -Uri "https://cdn-fastly.obsproject.com/downloads/cef_binary_${Version}_windows_${ArchSuffix}.zip" -UseBasicParsing -OutFile "cef_binary_${Version}_windows_${ArchSuffix}.zip"
-        $ProgressPreference = "Continue"
+        curl.exe -Lf "https://cdn-fastly.obsproject.com/downloads/cef_binary_${Version}_windows_${ArchSuffix}.zip" -o "cef_binary_${Version}_windows_${ArchSuffix}.zip" $(if ($Quiet.isPresent) { "-s" })
 
         Write-Step "Unpack..."
         Expand-Archive -Path "cef_binary_${Version}_windows_${ArchSuffix}.zip" -Force


### PR DESCRIPTION
### Description

Switches to curl for downloading dependencies rather than powershell itself.

Bypasses whatever issue is causing build failures when using `Invoke-WebRequest`. Also see issue on GitHub's repo for reference: https://github.com/actions/runner-images/issues/7007

### Motivation and Context

Despair.

### How Has This Been Tested?

Many runs on my fork that all succeeded.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
