### PR TITLE
Add option to fully decode and preload stinger video files into RAM

### DIFF
--- a/deps/media-playback/CMakeLists.txt
+++ b/deps/media-playback/CMakeLists.txt
@@ -9,8 +9,14 @@ add_library(OBS::media-playback ALIAS media-playback)
 
 target_sources(
   media-playback
-  INTERFACE media-playback/media.c media-playback/media.h
-            media-playback/decode.c media-playback/decode.h
+  INTERFACE media-playback/media.c
+            media-playback/media.h
+            media-playback/cache.c
+            media-playback/cache.h
+            media-playback/decode.c
+            media-playback/decode.h
+            media-playback/media-playback.c
+            media-playback/media-playback.h
             media-playback/closest-format.h)
 
 target_link_libraries(media-playback INTERFACE FFmpeg::avcodec FFmpeg::avdevice

--- a/deps/media-playback/media-playback/cache.c
+++ b/deps/media-playback/media-playback/cache.c
@@ -1,0 +1,698 @@
+#include <media-io/audio-io.h>
+#include <util/platform.h>
+
+#include "media-playback.h"
+#include "cache.h"
+#include "media.h"
+
+extern bool mp_media_init2(mp_media_t *m);
+extern bool mp_media_prepare_frames(mp_media_t *m);
+extern bool mp_media_eof(mp_media_t *m);
+extern void mp_media_next_video(mp_media_t *m, bool preload);
+extern void mp_media_next_audio(mp_media_t *m);
+extern bool mp_media_reset(mp_media_t *m);
+
+static bool mp_cache_reset(mp_cache_t *c);
+
+static int64_t base_sys_ts = 0;
+
+#define v_eof(c) (c->cur_v_idx == c->video_frames.num)
+#define a_eof(c) (c->cur_a_idx == c->audio_segments.num)
+
+static inline int64_t mp_cache_get_next_min_pts(mp_cache_t *c)
+{
+	int64_t min_next_ns = 0x7FFFFFFFFFFFFFFFLL;
+
+	if (c->has_video && !v_eof(c)) {
+		min_next_ns = c->next_v_ts;
+	}
+	if (c->has_audio && !a_eof(c) && c->next_a_ts < min_next_ns) {
+		min_next_ns = c->next_a_ts;
+	}
+
+	return min_next_ns;
+}
+
+static inline int64_t mp_cache_get_base_pts(mp_cache_t *c)
+{
+	int64_t base_ts = 0;
+
+	if (c->has_video && c->next_v_ts > base_ts)
+		base_ts = c->next_v_ts;
+	if (c->has_audio && c->next_a_ts > base_ts)
+		base_ts = c->next_a_ts;
+
+	return base_ts;
+}
+
+static void reset_ts(mp_cache_t *c)
+{
+	c->base_ts += mp_cache_get_base_pts(c);
+	c->play_sys_ts = (int64_t)os_gettime_ns();
+	c->start_ts = c->next_pts_ns = mp_cache_get_next_min_pts(c);
+	c->next_ns = 0;
+}
+
+static inline bool mp_cache_sleep(mp_cache_t *c)
+{
+	bool timeout = false;
+
+	if (!c->next_ns) {
+		c->next_ns = os_gettime_ns();
+	} else {
+		const uint64_t t = os_gettime_ns();
+		if (c->next_ns > t) {
+			const uint32_t delta_ms =
+				(uint32_t)((c->next_ns - t + 500000) / 1000000);
+			if (delta_ms > 0) {
+				static const uint32_t timeout_ms = 200;
+				timeout = delta_ms > timeout_ms;
+				os_sleep_ms(timeout ? timeout_ms : delta_ms);
+			}
+		}
+	}
+
+	return timeout;
+}
+
+static bool mp_cache_eof(mp_cache_t *c)
+{
+	bool v_ended = !c->has_video || v_eof(c);
+	bool a_ended = !c->has_audio || a_eof(c);
+	bool eof = v_ended && a_ended;
+
+	if (!eof)
+		return false;
+
+	pthread_mutex_lock(&c->mutex);
+	if (!c->looping) {
+		c->active = false;
+		c->stopping = true;
+	}
+	pthread_mutex_unlock(&c->mutex);
+
+	mp_cache_reset(c);
+	return true;
+}
+
+bool mp_cache_decode(mp_cache_t *c)
+{
+	mp_media_t *m = &c->m;
+	bool success = false;
+
+	m->full_decode = true;
+
+	mp_media_reset(m);
+
+	while (!mp_media_eof(m)) {
+		if (m->has_video)
+			mp_media_next_video(m, false);
+		if (m->has_audio)
+			mp_media_next_audio(m);
+
+		if (!mp_media_prepare_frames(m))
+			goto fail;
+	}
+
+	success = true;
+
+	c->start_time = c->m.fmt->start_time;
+	if (c->start_time == AV_NOPTS_VALUE)
+		c->start_time = 0;
+
+fail:
+	mp_media_free(m);
+	return success;
+}
+
+static void seek_to(mp_cache_t *c, int64_t pos)
+{
+	size_t new_v_idx = 0;
+	size_t new_a_idx = 0;
+
+	if (pos > c->media_duration) {
+		blog(LOG_WARNING, "MP: Invalid seek position");
+		return;
+	}
+
+	if (c->has_video) {
+		struct obs_source_frame *v;
+
+		for (size_t i = 0; i < c->video_frames.num; i++) {
+			v = &c->video_frames.array[i];
+			new_v_idx = i;
+			if ((int64_t)v->timestamp >= pos) {
+				break;
+			}
+		}
+
+		size_t next_idx = new_v_idx + 1;
+		if (next_idx == c->video_frames.num) {
+			c->next_v_ts =
+				(int64_t)v->timestamp + c->final_v_duration;
+		} else {
+			struct obs_source_frame *next =
+				&c->video_frames.array[next_idx];
+			c->next_v_ts = (int64_t)next->timestamp;
+		}
+	}
+	if (c->has_audio) {
+		struct obs_source_audio *a;
+		for (size_t i = 0; i < c->audio_segments.num; i++) {
+			a = &c->audio_segments.array[i];
+			new_a_idx = i;
+			if ((int64_t)a->timestamp >= pos) {
+				break;
+			}
+		}
+
+		size_t next_idx = new_a_idx + 1;
+		if (next_idx == c->audio_segments.num) {
+			c->next_a_ts =
+				(int64_t)a->timestamp + c->final_a_duration;
+		} else {
+			struct obs_source_audio *next =
+				&c->audio_segments.array[next_idx];
+			c->next_a_ts = (int64_t)next->timestamp;
+		}
+	}
+
+	c->cur_v_idx = c->next_v_idx = new_v_idx;
+	c->cur_a_idx = c->next_a_idx = new_a_idx;
+}
+
+/* maximum timestamp variance in nanoseconds */
+#define MAX_TS_VAR 2000000000LL
+
+static inline bool mp_media_can_play_video(mp_cache_t *c)
+{
+	return !v_eof(c) && (c->next_v_ts <= c->next_pts_ns ||
+			     (c->next_v_ts - c->next_pts_ns > MAX_TS_VAR));
+}
+
+static inline bool mp_media_can_play_audio(mp_cache_t *c)
+{
+	return !a_eof(c) && (c->next_a_ts <= c->next_pts_ns ||
+			     (c->next_a_ts - c->next_pts_ns > MAX_TS_VAR));
+}
+
+static inline void calc_next_v_ts(mp_cache_t *c, struct obs_source_frame *frame)
+{
+	int64_t offset;
+	if (c->next_v_idx < c->video_frames.num) {
+		struct obs_source_frame *next =
+			&c->video_frames.array[c->next_v_idx];
+		offset = (int64_t)(next->timestamp - frame->timestamp);
+	} else {
+		offset = c->final_v_duration;
+	}
+
+	c->next_v_ts += offset;
+}
+
+static inline void calc_next_a_ts(mp_cache_t *c, struct obs_source_audio *audio)
+{
+	int64_t offset;
+	if (c->next_a_idx < c->audio_segments.num) {
+		struct obs_source_audio *next =
+			&c->audio_segments.array[c->next_a_idx];
+		offset = (int64_t)(next->timestamp - audio->timestamp);
+	} else {
+		offset = c->final_a_duration;
+	}
+
+	c->next_a_ts += offset;
+}
+
+static void mp_cache_next_video(mp_cache_t *c, bool preload)
+{
+	/* eof check */
+	if (c->next_v_idx == c->video_frames.num) {
+		if (mp_media_can_play_video(c))
+			c->cur_v_idx = c->next_v_idx;
+		return;
+	}
+
+	struct obs_source_frame *frame = &c->video_frames.array[c->next_v_idx];
+	struct obs_source_frame dup = *frame;
+
+	dup.timestamp = c->base_ts + dup.timestamp - c->start_ts +
+			c->play_sys_ts - base_sys_ts;
+
+	if (!preload) {
+		if (!mp_media_can_play_video(c))
+			return;
+
+		if (c->v_cb)
+			c->v_cb(c->opaque, &dup);
+
+		if (c->cur_v_idx < c->next_v_idx)
+			++c->cur_v_idx;
+		++c->next_v_idx;
+		calc_next_v_ts(c, frame);
+	} else {
+		if (c->seek_next_ts && c->v_seek_cb) {
+			c->v_seek_cb(c->opaque, &dup);
+		} else if (!c->request_preload) {
+			c->v_preload_cb(c->opaque, &dup);
+		}
+	}
+}
+
+static void mp_cache_next_audio(mp_cache_t *c)
+{
+	/* eof check */
+	if (c->next_a_idx == c->video_frames.num) {
+		if (mp_media_can_play_audio(c))
+			c->cur_a_idx = c->next_a_idx;
+		return;
+	}
+
+	if (!mp_media_can_play_audio(c))
+		return;
+
+	struct obs_source_audio *audio =
+		&c->audio_segments.array[c->next_a_idx];
+	struct obs_source_audio dup = *audio;
+
+	dup.timestamp = c->base_ts + dup.timestamp - c->start_ts +
+			c->play_sys_ts - base_sys_ts;
+	if (c->a_cb)
+		c->a_cb(c->opaque, &dup);
+
+	if (c->cur_a_idx < c->next_a_idx)
+		++c->cur_a_idx;
+	++c->next_a_idx;
+	calc_next_a_ts(c, audio);
+}
+
+static bool mp_cache_reset(mp_cache_t *c)
+{
+	bool stopping;
+	bool active;
+
+	int64_t next_ts = mp_cache_get_base_pts(c);
+	int64_t offset = next_ts - c->next_pts_ns;
+	int64_t start_time = c->start_time;
+
+	c->eof = false;
+	c->base_ts += next_ts;
+	c->seek_next_ts = false;
+
+	seek_to(c, start_time);
+
+	pthread_mutex_lock(&c->mutex);
+	stopping = c->stopping;
+	active = c->active;
+	c->stopping = false;
+	pthread_mutex_unlock(&c->mutex);
+
+	if (c->has_video) {
+		size_t next_idx = c->video_frames.num > 1 ? 1 : 0;
+		c->cur_v_idx = c->next_v_idx = 0;
+		c->next_v_ts = c->video_frames.array[next_idx].timestamp;
+	}
+	if (c->has_audio) {
+		size_t next_idx = c->audio_segments.num > 1 ? 1 : 0;
+		c->cur_a_idx = c->next_a_idx = 0;
+		c->next_a_ts = c->audio_segments.array[next_idx].timestamp;
+	}
+
+	if (active) {
+		if (!c->play_sys_ts)
+			c->play_sys_ts = (int64_t)os_gettime_ns();
+		c->start_ts = c->next_pts_ns = mp_cache_get_next_min_pts(c);
+		if (c->next_ns)
+			c->next_ns += offset;
+	} else {
+		c->start_ts = c->next_pts_ns = mp_cache_get_next_min_pts(c);
+		c->play_sys_ts = (int64_t)os_gettime_ns();
+		c->next_ns = 0;
+	}
+
+	c->pause = false;
+
+	if (!active && c->v_preload_cb)
+		mp_cache_next_video(c, true);
+	if (stopping && c->stop_cb)
+		c->stop_cb(c->opaque);
+	return true;
+}
+
+static void mp_cache_calc_next_ns(mp_cache_t *c)
+{
+	int64_t min_next_ns = mp_cache_get_next_min_pts(c);
+	int64_t delta = min_next_ns - c->next_pts_ns;
+
+	if (c->seek_next_ts) {
+		delta = 0;
+		c->seek_next_ts = false;
+	} else {
+#ifdef _DEBUG
+		assert(delta >= 0);
+#endif
+		if (delta < 0)
+			delta = 0;
+		if (delta > 3000000000)
+			delta = 0;
+	}
+
+	c->next_ns += delta;
+	c->next_pts_ns = min_next_ns;
+}
+
+static inline bool mp_cache_thread(mp_cache_t *c)
+{
+	os_set_thread_name("mp_cache_thread");
+
+	if (!mp_cache_decode(c)) {
+		return false;
+	}
+
+	for (;;) {
+		bool reset, kill, is_active, seek, pause, reset_time,
+			preload_frame;
+		int64_t seek_pos;
+		bool timeout = false;
+
+		pthread_mutex_lock(&c->mutex);
+		is_active = c->active;
+		pause = c->pause;
+		pthread_mutex_unlock(&c->mutex);
+
+		if (!is_active || pause) {
+			if (os_sem_wait(c->sem) < 0)
+				return false;
+			if (pause)
+				reset_ts(c);
+		} else {
+			timeout = mp_cache_sleep(c);
+		}
+
+		pthread_mutex_lock(&c->mutex);
+
+		reset = c->reset;
+		kill = c->kill;
+		c->reset = false;
+		c->kill = false;
+
+		preload_frame = c->preload_frame;
+		pause = c->pause;
+		seek_pos = c->seek_pos;
+		seek = c->seek;
+		reset_time = c->reset_ts;
+		c->preload_frame = false;
+		c->seek = false;
+		c->reset_ts = false;
+
+		pthread_mutex_unlock(&c->mutex);
+
+		if (kill) {
+			break;
+		}
+		if (reset) {
+			mp_cache_reset(c);
+			continue;
+		}
+
+		if (seek) {
+			c->seek_next_ts = true;
+			seek_to(c, seek_pos);
+			continue;
+		}
+
+		if (reset_time) {
+			reset_ts(c);
+			continue;
+		}
+
+		if (pause)
+			continue;
+
+		if (preload_frame)
+			c->v_preload_cb(c->opaque, &c->video_frames.array[0]);
+
+		/* frames are ready */
+		if (is_active && !timeout) {
+			if (c->has_video)
+				mp_cache_next_video(c, false);
+			if (c->has_audio)
+				mp_cache_next_audio(c);
+
+			if (mp_cache_eof(c))
+				continue;
+
+			mp_cache_calc_next_ns(c);
+		}
+	}
+
+	return true;
+}
+
+static void *mp_cache_thread_start(void *opaque)
+{
+	mp_cache_t *c = opaque;
+
+	if (!mp_cache_thread(c)) {
+		if (c->stop_cb) {
+			c->stop_cb(c->opaque);
+		}
+	}
+
+	return NULL;
+}
+
+static void fill_video(void *data, struct obs_source_frame *frame)
+{
+	mp_cache_t *c = data;
+	struct obs_source_frame dup;
+
+	obs_source_frame_init(&dup, frame->format, frame->width, frame->height);
+	obs_source_frame_copy(&dup, frame);
+
+	dup.timestamp = frame->timestamp;
+
+	c->final_v_duration = c->m.v.last_duration;
+
+	da_push_back(c->video_frames, &dup);
+}
+
+static void fill_audio(void *data, struct obs_source_audio *audio)
+{
+	mp_cache_t *c = data;
+	struct obs_source_audio dup = *audio;
+
+	size_t size =
+		get_total_audio_size(dup.format, dup.speakers, dup.frames);
+	dup.data[0] = bmalloc(size);
+
+	size_t planes = get_audio_planes(dup.format, dup.speakers);
+	if (planes > 1) {
+		size = get_audio_bytes_per_channel(dup.format) * dup.frames;
+		uint8_t *out = (uint8_t *)dup.data[0];
+
+		for (size_t i = 0; i < planes; i++) {
+			if (i > 0)
+				dup.data[i] = out;
+
+			memcpy(out, audio->data[i], size);
+			out += size;
+		}
+	} else {
+		memcpy((uint8_t *)dup.data[0], audio->data[0], size);
+	}
+
+	c->final_a_duration = c->m.a.last_duration;
+
+	da_push_back(c->audio_segments, &dup);
+}
+
+static inline bool mp_cache_init_internal(mp_cache_t *c,
+					  const struct mp_media_info *info)
+{
+	if (pthread_mutex_init(&c->mutex, NULL) != 0) {
+		blog(LOG_WARNING, "MP: Failed to init mutex");
+		return false;
+	}
+	if (os_sem_init(&c->sem, 0) != 0) {
+		blog(LOG_WARNING, "MP: Failed to init semaphore");
+		return false;
+	}
+
+	c->path = info->path ? bstrdup(info->path) : NULL;
+	c->format_name = info->format ? bstrdup(info->format) : NULL;
+
+	if (pthread_create(&c->thread, NULL, mp_cache_thread_start, c) != 0) {
+		blog(LOG_WARNING, "MP: Could not create media thread");
+		return false;
+	}
+
+	c->thread_valid = true;
+	return true;
+}
+
+bool mp_cache_init(mp_cache_t *c, const struct mp_media_info *info)
+{
+	struct mp_media_info info2 = *info;
+
+	info2.opaque = c;
+	info2.v_cb = fill_video;
+	info2.a_cb = fill_audio;
+	info2.v_preload_cb = NULL;
+	info2.v_seek_cb = NULL;
+	info2.stop_cb = NULL;
+	info2.full_decode = true;
+
+	mp_media_t *m = &c->m;
+	if (!mp_media_init(m, &info2)) {
+		mp_cache_free(c);
+		return false;
+	}
+	if (!mp_media_init2(m)) {
+		mp_cache_free(c);
+		return false;
+	}
+
+	pthread_mutex_init_value(&c->mutex);
+	c->opaque = info->opaque;
+	c->v_cb = info->v_cb;
+	c->a_cb = info->a_cb;
+	c->stop_cb = info->stop_cb;
+	c->ffmpeg_options = info->ffmpeg_options;
+	c->v_seek_cb = info->v_seek_cb;
+	c->v_preload_cb = info->v_preload_cb;
+	c->request_preload = info->request_preload;
+	c->speed = info->speed;
+	c->media_duration = m->fmt->duration;
+
+	c->has_video = m->has_video;
+	c->has_audio = m->has_audio;
+
+	if (!base_sys_ts)
+		base_sys_ts = (int64_t)os_gettime_ns();
+
+	if (!mp_cache_init_internal(c, info)) {
+		mp_cache_free(c);
+		return false;
+	}
+
+	return true;
+}
+
+static void mp_kill_thread(mp_cache_t *c)
+{
+	if (c->thread_valid) {
+		pthread_mutex_lock(&c->mutex);
+		c->kill = true;
+		pthread_mutex_unlock(&c->mutex);
+		os_sem_post(c->sem);
+
+		pthread_join(c->thread, NULL);
+	}
+}
+
+void mp_cache_free(mp_cache_t *c)
+{
+	if (!c)
+		return;
+
+	mp_cache_stop(c);
+	mp_kill_thread(c);
+
+	if (c->m.fmt)
+		mp_media_free(&c->m);
+
+	for (size_t i = 0; i < c->video_frames.num; i++) {
+		struct obs_source_frame *f = &c->video_frames.array[i];
+		obs_source_frame_free(f);
+	}
+	for (size_t i = 0; i < c->audio_segments.num; i++) {
+		struct obs_source_audio *a = &c->audio_segments.array[i];
+		bfree((void *)a->data[0]);
+	}
+	da_free(c->video_frames);
+	da_free(c->audio_segments);
+
+	bfree(c->path);
+	bfree(c->format_name);
+	pthread_mutex_destroy(&c->mutex);
+	os_sem_destroy(c->sem);
+	memset(c, 0, sizeof(*c));
+}
+
+void mp_cache_play(mp_cache_t *c, bool loop)
+{
+	pthread_mutex_lock(&c->mutex);
+
+	if (c->active)
+		c->reset = true;
+
+	c->looping = loop;
+	c->active = true;
+
+	pthread_mutex_unlock(&c->mutex);
+
+	os_sem_post(c->sem);
+}
+
+void mp_cache_play_pause(mp_cache_t *c, bool pause)
+{
+	pthread_mutex_lock(&c->mutex);
+	if (c->active) {
+		c->pause = pause;
+		c->reset_ts = !pause;
+	}
+	pthread_mutex_unlock(&c->mutex);
+
+	os_sem_post(c->sem);
+}
+
+void mp_cache_stop(mp_cache_t *c)
+{
+	pthread_mutex_lock(&c->mutex);
+	if (c->active) {
+		c->reset = true;
+		c->active = false;
+		c->stopping = true;
+	}
+	pthread_mutex_unlock(&c->mutex);
+
+	os_sem_post(c->sem);
+}
+
+void mp_cache_preload_frame(mp_cache_t *c)
+{
+	if (c->request_preload && c->thread_valid && c->v_preload_cb) {
+		pthread_mutex_lock(&c->mutex);
+		c->preload_frame = true;
+		pthread_mutex_unlock(&c->mutex);
+		os_sem_post(c->sem);
+	}
+}
+
+int64_t mp_cache_get_current_time(mp_cache_t *c)
+{
+	return mp_cache_get_base_pts(c) * (int64_t)c->speed / 100000000LL;
+}
+
+void mp_cache_seek(mp_cache_t *c, int64_t pos)
+{
+	pthread_mutex_lock(&c->mutex);
+	if (c->active) {
+		c->seek = true;
+		c->seek_pos = pos * 1000;
+	}
+	pthread_mutex_unlock(&c->mutex);
+
+	os_sem_post(c->sem);
+}
+
+int64_t mp_cache_get_frames(mp_cache_t *c)
+{
+	return c->video_frames.num;
+}
+
+int64_t mp_cache_get_duration(mp_cache_t *c)
+{
+	return c->media_duration;
+}

--- a/deps/media-playback/media-playback/cache.h
+++ b/deps/media-playback/media-playback/cache.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <util/threading.h>
+#include <util/darray.h>
+#include <obs.h>
+
+#include "media.h"
+
+struct mp_cache {
+	mp_video_cb v_preload_cb;
+	mp_video_cb v_seek_cb;
+	mp_stop_cb stop_cb;
+	mp_video_cb v_cb;
+	mp_audio_cb a_cb;
+	void *opaque;
+	bool request_preload;
+	bool has_video;
+	bool has_audio;
+
+	char *path;
+	char *format_name;
+	char *ffmpeg_options;
+	int buffering;
+	int speed;
+
+	pthread_mutex_t mutex;
+	os_sem_t *sem;
+	bool preload_frame;
+	bool stopping;
+	bool looping;
+	bool active;
+	bool reset;
+	bool kill;
+
+	bool thread_valid;
+	pthread_t thread;
+
+	DARRAY(struct obs_source_frame) video_frames;
+	DARRAY(struct obs_source_audio) audio_segments;
+
+	size_t cur_v_idx;
+	size_t cur_a_idx;
+	size_t next_v_idx;
+	size_t next_a_idx;
+	int64_t next_v_ts;
+	int64_t next_a_ts;
+
+	int64_t final_v_duration;
+	int64_t final_a_duration;
+
+	int64_t play_sys_ts;
+	int64_t next_pts_ns;
+	uint64_t next_ns;
+	int64_t start_ts;
+	int64_t base_ts;
+
+	bool pause;
+	bool reset_ts;
+	bool seek;
+	bool seek_next_ts;
+	bool eof;
+	int64_t seek_pos;
+	int64_t start_time;
+	int64_t media_duration;
+
+	mp_media_t m;
+};
+
+typedef struct mp_cache mp_cache_t;
+
+extern bool mp_cache_init(mp_cache_t *c, const struct mp_media_info *info);
+extern void mp_cache_free(mp_cache_t *c);
+
+extern void mp_cache_play(mp_cache_t *c, bool loop);
+extern void mp_cache_play_pause(mp_cache_t *c, bool pause);
+extern void mp_cache_stop(mp_cache_t *c);
+extern void mp_cache_preload_frame(mp_cache_t *c);
+extern int64_t mp_cache_get_current_time(mp_cache_t *c);
+extern void mp_cache_seek(mp_cache_t *c, int64_t pos);
+extern int64_t mp_cache_get_frames(mp_cache_t *c);
+extern int64_t mp_cache_get_duration(mp_cache_t *c);

--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -16,6 +16,7 @@
 
 #include "decode.h"
 
+#include "media-playback.h"
 #include "media.h"
 #include <libavutil/mastering_display_metadata.h>
 

--- a/deps/media-playback/media-playback/media-playback.c
+++ b/deps/media-playback/media-playback/media-playback.c
@@ -1,0 +1,144 @@
+#include "media-playback.h"
+#include "media.h"
+#include "cache.h"
+
+struct media_playback {
+	bool is_cached;
+	union {
+		mp_media_t media;
+		mp_cache_t cache;
+	};
+};
+
+media_playback_t *media_playback_create(const struct mp_media_info *info)
+{
+	media_playback_t *mp = bzalloc(sizeof(*mp));
+	mp->is_cached = info->is_local_file && info->full_decode;
+
+	if ((mp->is_cached && !mp_cache_init(&mp->cache, info)) ||
+	    (!mp->is_cached && !mp_media_init(&mp->media, info))) {
+		bfree(mp);
+		return NULL;
+	}
+
+	return mp;
+}
+
+void media_playback_destroy(media_playback_t *mp)
+{
+	if (!mp)
+		return;
+
+	if (mp->is_cached)
+		mp_cache_free(&mp->cache);
+	else
+		mp_media_free(&mp->media);
+	bfree(mp);
+}
+
+void media_playback_play(media_playback_t *mp, bool looping, bool reconnecting)
+{
+	if (!mp)
+		return;
+
+	if (mp->is_cached)
+		mp_cache_play(&mp->cache, looping);
+	else
+		mp_media_play(&mp->media, looping, reconnecting);
+}
+
+void media_playback_play_pause(media_playback_t *mp, bool pause)
+{
+	if (!mp)
+		return;
+
+	if (mp->is_cached)
+		mp_cache_play_pause(&mp->cache, pause);
+	else
+		mp_media_play_pause(&mp->media, pause);
+}
+
+void media_playback_stop(media_playback_t *mp)
+{
+	if (!mp)
+		return;
+
+	if (mp->is_cached)
+		mp_cache_stop(&mp->cache);
+	else
+		mp_media_stop(&mp->media);
+}
+
+void media_playback_preload_frame(media_playback_t *mp)
+{
+	if (!mp)
+		return;
+
+	if (mp->is_cached)
+		mp_cache_preload_frame(&mp->cache);
+	else
+		mp_media_preload_frame(&mp->media);
+}
+
+int64_t media_playback_get_current_time(media_playback_t *mp)
+{
+	if (!mp)
+		return 0;
+
+	if (mp->is_cached)
+		return mp_cache_get_current_time(&mp->cache);
+	else
+		return mp_media_get_current_time(&mp->media);
+}
+
+void media_playback_seek(media_playback_t *mp, int64_t pos)
+{
+	if (mp->is_cached)
+		mp_cache_seek(&mp->cache, pos);
+	else
+		mp_media_seek(&mp->media, pos);
+}
+
+int64_t media_playback_get_frames(media_playback_t *mp)
+{
+	if (!mp)
+		return 0;
+
+	if (mp->is_cached)
+		return mp_cache_get_frames(&mp->cache);
+	else
+		return mp_media_get_frames(&mp->media);
+}
+
+int64_t media_playback_get_duration(media_playback_t *mp)
+{
+	if (!mp)
+		return 0;
+
+	if (mp->is_cached)
+		return mp_cache_get_duration(&mp->cache);
+	else
+		return mp_media_get_duration(&mp->media);
+}
+
+bool media_playback_has_video(media_playback_t *mp)
+{
+	if (!mp)
+		return false;
+
+	if (mp->is_cached)
+		return mp->cache.has_video;
+	else
+		return mp->media.has_video;
+}
+
+bool media_playback_has_audio(media_playback_t *mp)
+{
+	if (!mp)
+		return false;
+
+	if (mp->is_cached)
+		return mp->cache.has_audio;
+	else
+		return mp->media.has_audio;
+}

--- a/deps/media-playback/media-playback/media-playback.h
+++ b/deps/media-playback/media-playback/media-playback.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <obs.h>
+
+struct media_playback;
+typedef struct media_playback media_playback_t;
+
+typedef void (*mp_video_cb)(void *opaque, struct obs_source_frame *frame);
+typedef void (*mp_audio_cb)(void *opaque, struct obs_source_audio *audio);
+typedef void (*mp_stop_cb)(void *opaque);
+
+struct mp_media_info {
+	void *opaque;
+
+	mp_video_cb v_cb;
+	mp_video_cb v_preload_cb;
+	mp_video_cb v_seek_cb;
+	mp_audio_cb a_cb;
+	mp_stop_cb stop_cb;
+
+	const char *path;
+	const char *format;
+	char *ffmpeg_options;
+	int buffering;
+	int speed;
+	enum video_range_type force_range;
+	bool is_linear_alpha;
+	bool hardware_decoding;
+	bool is_local_file;
+	bool reconnecting;
+	bool request_preload;
+	bool full_decode;
+};
+
+extern media_playback_t *
+media_playback_create(const struct mp_media_info *info);
+extern void media_playback_destroy(media_playback_t *mp);
+
+extern void media_playback_play(media_playback_t *mp, bool looping,
+				bool reconnecting);
+extern void media_playback_play_pause(media_playback_t *mp, bool pause);
+extern void media_playback_stop(media_playback_t *mp);
+extern void media_playback_preload_frame(media_playback_t *mp);
+extern int64_t media_playback_get_current_time(media_playback_t *mp);
+extern void media_playback_seek(media_playback_t *mp, int64_t pos);
+extern int64_t media_playback_get_frames(media_playback_t *mp);
+extern int64_t media_playback_get_duration(media_playback_t *mp);
+extern bool media_playback_has_video(media_playback_t *mp);
+extern bool media_playback_has_audio(media_playback_t *mp);

--- a/plugins/obs-transitions/data/locale/en-US.ini
+++ b/plugins/obs-transitions/data/locale/en-US.ini
@@ -28,6 +28,7 @@ TrackMatteLayoutHorizontal="Same file, side-by-side (stinger on the left, track 
 TrackMatteLayoutVertical="Same file, stacked (stinger on top, track matte at the bottom)"
 TrackMatteLayoutSeparateFile="Separate file (warning: matte can get out of sync)"
 TrackMatteLayoutMask="Mask only"
+PreloadVideoToRam="Preload Video to RAM"
 AudioFadeStyle="Audio Fade Style"
 AudioFadeStyle.FadeOutFadeIn="Fade out to transition point then fade in"
 AudioFadeStyle.CrossFade="Crossfade"

--- a/plugins/obs-transitions/transition-stinger.c
+++ b/plugins/obs-transitions/transition-stinger.c
@@ -69,11 +69,14 @@ static void stinger_update(void *data, obs_data_t *settings)
 	struct stinger_info *s = data;
 	const char *path = obs_data_get_string(settings, "path");
 	bool hw_decode = obs_data_get_bool(settings, "hw_decode");
+	bool preload = obs_data_get_bool(settings, "preload");
 
 	obs_data_t *media_settings = obs_data_create();
 	obs_data_set_string(media_settings, "local_file", path);
 	obs_data_set_bool(media_settings, "hw_decode", hw_decode);
 	obs_data_set_bool(media_settings, "looping", false);
+	obs_data_set_bool(media_settings, "full_decode", preload);
+	obs_data_set_bool(media_settings, "is_stinger", true);
 
 	obs_source_release(s->media_source);
 	struct dstr name;
@@ -630,6 +633,11 @@ static void stinger_transition_stop(void *data)
 	if (s->matte_source)
 		obs_source_remove_active_child(s->source, s->matte_source);
 
+	proc_handler_t *ph = obs_source_get_proc_handler(s->media_source);
+
+	calldata_t cd = {0};
+	proc_handler_call(ph, "preload_first_frame", &cd);
+
 	s->transitioning = false;
 }
 
@@ -737,6 +745,8 @@ static obs_properties_t *stinger_properties(void *data)
 		OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
 	obs_properties_add_bool(ppts, "hw_decode",
 				obs_module_text("HardwareDecode"));
+	obs_properties_add_bool(ppts, "preload",
+				obs_module_text("PreloadVideoToRam"));
 	obs_property_list_add_int(p, obs_module_text("TransitionPointTypeTime"),
 				  TIMING_TIME);
 	obs_property_list_add_int(


### PR DESCRIPTION
### Description
Adds the ability to fully preload stinger videos to RAM before playback, greatly improving stinger playback performance.

### Motivation and Context
Stingers -- and especially track matte stingers -- are subject to real time decoding, thus if there are not enough computing power available, decoding can lag, causing stingers to play back slowly or stutter, which just kind of ruins a nice broadcast. It's even worse when track matte stingers are in use, because they require twice the decoding power of normal videos.

To solve this, add an option to fully decode and preload video files into RAM to completely eliminate decoding from the equation, and ensure smooth playback of the stinger's video and greatly improving stinger playback performance (at the cost of RAM usage, of course).

### How Has This Been Tested?
Tested with various stinger transition and track matte stinger video files.

### Types of changes
- New feature (non-breaking change which adds functionality)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
