### PR TITLE
UI: Fix properties widget being cut off until resize

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -138,6 +138,7 @@ void OBSPropertiesView::RefreshProperties()
 	setWidget(widget);
 	SetScrollPos(h, v);
 	setSizePolicy(mainPolicy);
+	adjustSize();
 
 	lastFocused.clear();
 	if (lastWidget) {


### PR DESCRIPTION
### Description

Ensure the properties widget is correctly sized when it is created/updated.

**Before:**
![2023-02-05_17-36-31_4BjSqc](https://user-images.githubusercontent.com/3123295/216832134-2b03a205-8f29-4038-bd73-8eaac350cc0b.png)
**After:**
![2023-02-05_17-37-21_VHLtzb](https://user-images.githubusercontent.com/3123295/216832089-d32bceab-33ed-4574-b0aa-2fb877dfbd61.png)

### Motivation and Context

Don't want properties widgets being cut off. This affects all widgets, but is most noticeable with labels.

Mostly noticed during work on #8080 as the warnings were cut off and only wrapped once the window was manually resized.

### How Has This Been Tested?

Opening and closing properties.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
