### PR TITLE
A first foray into reproducible builds

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -82,6 +82,10 @@ set_target_properties(
              AUTORCC ON
              AUTOUIC_SEARCH_PATHS "forms;forms/source-toolbar")
 
+if(_QT_VERSION EQUAL 6 AND OS_WINDOWS)
+  set_target_properties(obs PROPERTIES AUTORCC_OPTIONS "--format-version;1")
+endif()
+
 target_include_directories(obs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
                                        ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
@@ -18,6 +18,11 @@ set_target_properties(
              AUTORCC ON
              AUTOUIC_SEARCH_PATHS "forms")
 
+if(_QT_VERSION EQUAL 6 AND OS_WINDOWS)
+  set_target_properties(aja-output-ui PROPERTIES AUTORCC_OPTIONS
+                                                 "--format-version;1")
+endif()
+
 target_sources(aja-output-ui PRIVATE forms/output.ui)
 
 target_sources(

--- a/UI/frontend-plugins/decklink-captions/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-captions/CMakeLists.txt
@@ -18,6 +18,11 @@ set_target_properties(
              AUTORCC ON
              AUTOUIC_SEARCH_PATHS "forms")
 
+if(_QT_VERSION EQUAL 6 AND OS_WINDOWS)
+  set_target_properties(decklink-captions PROPERTIES AUTORCC_OPTIONS
+                                                     "--format-version;1")
+endif()
+
 target_compile_features(decklink-captions PRIVATE cxx_std_17)
 
 target_sources(decklink-captions PRIVATE forms/captions.ui)

--- a/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
@@ -16,6 +16,11 @@ set_target_properties(
              AUTORCC ON
              AUTOUIC_SEARCH_PATHS "forms")
 
+if(_QT_VERSION EQUAL 6 AND OS_WINDOWS)
+  set_target_properties(decklink-output-ui PROPERTIES AUTORCC_OPTIONS
+                                                      "--format-version;1")
+endif()
+
 target_sources(decklink-output-ui PRIVATE forms/output.ui)
 
 target_sources(

--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -12,6 +12,11 @@ set_target_properties(
              AUTORCC ON
              AUTOUIC_SEARCH_PATHS "forms")
 
+if(_QT_VERSION EQUAL 6 AND OS_WINDOWS)
+  set_target_properties(frontend-tools PROPERTIES AUTORCC_OPTIONS
+                                                  "--format-version;1")
+endif()
+
 target_sources(
   frontend-tools PRIVATE forms/auto-scene-switcher.ui forms/captions.ui
                          forms/output-timer.ui forms/scripts.ui)

--- a/cmake/Modules/CompilerConfig.cmake
+++ b/cmake/Modules/CompilerConfig.cmake
@@ -52,6 +52,7 @@ if(OS_WINDOWS AND MSVC)
   endif()
 
   add_compile_options(
+    /Brepro
     /MP
     /W3
     /WX
@@ -75,6 +76,7 @@ if(OS_WINDOWS AND MSVC)
     /std:c17)
 
   add_link_options(
+    "LINKER:/Brepro"
     "LINKER:/OPT:REF"
     "LINKER:/WX"
     "$<$<NOT:$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>>:LINKER\:/SAFESEH\:NO>"

--- a/cmake/Modules/ObsHelpers_Windows.cmake
+++ b/cmake/Modules/ObsHelpers_Windows.cmake
@@ -29,6 +29,9 @@ function(setup_binary_target target)
   endif()
 
   if(MSVC)
+    target_link_options(${target} PRIVATE
+                        /PDBALTPATH:$<TARGET_PDB_FILE_NAME:${target}>)
+
     install(
       FILES $<TARGET_PDB_FILE:${target}>
       CONFIGURATIONS "RelWithDebInfo" "Debug"
@@ -56,6 +59,9 @@ function(setup_plugin_target target)
   _setup_plugin_target(${ARGV})
 
   if(MSVC)
+    target_link_options(${target} PRIVATE
+                        /PDBALTPATH:$<TARGET_PDB_FILE_NAME:${target}>)
+
     install(
       FILES $<TARGET_PDB_FILE:${target}>
       CONFIGURATIONS "RelWithDebInfo" "Debug"
@@ -97,6 +103,9 @@ function(setup_script_plugin_target target)
   _setup_script_plugin_target(${ARGV})
 
   if(MSVC)
+    target_link_options(${target} PRIVATE
+                        /PDBALTPATH:$<TARGET_PDB_FILE_NAME:${target}>)
+
     install(
       FILES $<TARGET_PDB_FILE:${target}>
       CONFIGURATIONS "RelWithDebInfo" "Debug"

--- a/plugins/obs-vst/CMakeLists.txt
+++ b/plugins/obs-vst/CMakeLists.txt
@@ -21,9 +21,12 @@ set_target_properties(
              AUTOUIC ON
              AUTORCC ON)
 
-target_include_directories(
-  obs-vst PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-                  ${CMAKE_CURRENT_BINARY_DIR})
+if(_QT_VERSION EQUAL 6 AND OS_WINDOWS)
+  set_target_properties(obs-vst PROPERTIES AUTORCC_OPTIONS "--format-version;1")
+endif()
+
+target_include_directories(obs-vst PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                                           ${CMAKE_CURRENT_BINARY_DIR})
 
 target_sources(
   obs-vst
@@ -33,8 +36,7 @@ target_sources(
 
 target_link_libraries(obs-vst PRIVATE OBS::libobs Qt::Widgets)
 
-target_include_directories(
-  obs-vst PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/headers)
+target_include_directories(obs-vst PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/headers)
 
 target_compile_features(obs-vst PRIVATE cxx_std_17)
 


### PR DESCRIPTION
### Description

Makes Windows builds *mostly* reproducible using undocumented (but working) MSVC compiler/linker options and dropping the Qt Resource Compiler version to 1 (since 2+ includes last-modified timestamps).

PDBs won't be identical due to lambdas having random identifiers but they are compatible, meaning that it would be possible to also create debug symbols for any build after the fact.

ToDo:
- [x] Figure out how to make cmake behave when it comes to escaping the `/PDBALTPATH` linker option
  + CMake bug: https://gitlab.kitware.com/cmake/cmake/-/issues/15865 (7 years old D:)
  + Possible workaround: https://github.com/boostorg/stacktrace/issues/55#issuecomment-984782636
- [x] Figure out why `coreaudio-encoder` is not currently reproducible
  + Seems to be fixed by #8377 

### Motivation and Context

We eventually want to have fully reproducible builds for OBS and its dependencies. For the reason why you may want that, see https://reproducible-builds.org/docs/buy-in/

Aside from the security implications and verifiability, a side-benefit of reproducible builds would be that delta patches as we employ on Windows (and possibly macOS in the future) would be smaller, and determining which files haven't changed to exclude them from an update could be more easily automated. (Note: Ensuring that timestamps are always the same even for adjacent builds [ducible](https://github.com/jasonwhite/ducible) may still be a required, it can be added to CMake for example like so: https://github.com/derrod/obs-studio/commit/5f4dee7423f50ea47f073831fdd7165cd1d10e67)

Getting OBS itself into a state where building it with our precompiled Windows and macOS dependencies will create identical binaries is a first step.

### How Has This Been Tested?

Ran various tests on my fork, for the same commit, all binaries except `obs-websocket` and `coreaudio-encoder` generate identical files (sha512 checked).

A workflow run with only two x64 Windows jobs that have produced mostly-identical builds is here: https://github.com/derrod/obs-studio/actions/runs/4099136967

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
