### PR TITLE
flatpak: Override PipeWire to 0.3.65

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -331,6 +331,38 @@
       ]
     },
     {
+      "name": "pipewire",
+      "buildsystem": "meson",
+      "config-opts": [
+        "-Daudiotestsrc=disabled",
+        "-Droc=disabled",
+        "-Dvideotestsrc=disabled",
+        "-Dvolume=disabled",
+        "-Dvulkan=disabled",
+        "-Ddocs=disabled",
+        "-Dman=disabled",
+        "-Dbluez5-codec-ldac=disabled",
+        "-Dbluez5-codec-aptx=disabled",
+        "-Dlibcamera=disabled",
+        "-Dudevrulesdir=/app/lib/udev/rules.d/",
+        "-Dsession-managers=[]",
+        "-Dtests=disabled",
+        "-Dexamples=disabled",
+        "-Dpw-cat=disabled"
+      ],
+      "cleanup": [
+        "/bin"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/pipewire/pipewire.git",
+          "tag": "0.3.65",
+          "commit": "9558a5d5e0360d8af822431c76ee858a8c7495ac"
+        }
+      ]
+    },
+    {
       "name": "ntv2",
       "buildsystem": "cmake-ninja",
       "builddir": true,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixes #7849

Fixes crashes with 0.3.48/49 daemons.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Because of the unstable nature of the JACK ABI, Freedesktop will not update PipeWire on their side immediately.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
