### PR TITLE
libobs: Avoid position underflow when mixing audio sources

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1472,6 +1472,12 @@ static bool scene_audio_render(void *data, uint64_t *ts_out,
 
 		pos = (size_t)ns_to_audio_frames(sample_rate,
 						 source_ts - timestamp);
+
+		if (pos >= AUDIO_OUTPUT_FRAMES) {
+			item = item->next;
+			continue;
+		}
+
 		count = AUDIO_OUTPUT_FRAMES - pos;
 
 		if (!apply_buf && !item->visible &&


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When `AUDIO_OUTPUT_FRAMES - pos` is not positive, skip the later audio process.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When a variable `pos` became larger than `AUDIO_OUTPUT_FRAMES`, `count` will get overflowed number. We should avoid such an underflow number going to later processing.

Since the pointer while processing audio is compared by the operator `<`, the underflow should be safely handled in the usual architectures. However, I don't think it's reliable for any architecture.
https://github.com/obsproject/obs-studio/blob/f81f580d26366dec262f0ef2144cf7a77ae86393/libobs/obs-scene.c#L1388-L1393

This issue was found while debugging #8002 but this is independent issue.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: Fedora 36

1. Create an empty scene collection.
2. Add `Audio Input Capture (Pulse)` to the scene.
3. Add `Media Source` with a audio file.
4. Start recording
5. Wait until the media source stops.
6. Replay the media source by clicking the replay button.
7. Go to 5 until `pos` becomes larger than `AUDIO_OUTPUT_FRAMES`.

I tested with a log below to check the new condition is hit.
```patch
                pos = (size_t)ns_to_audio_frames(sample_rate,
                                                 source_ts - timestamp);
 
+               if (pos) blog(LOG_INFO, "%s: '%s' pos=%d mixers=%d", __func__, item->source->context.name, (int)pos, mixers);
+
                if (pos >= AUDIO_OUTPUT_FRAMES) {
                        item = item->next;
                        continue;
                }
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
