### PR TITLE
UI: Add scene grid mode to view menu

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -114,6 +114,8 @@ SourceProperties="Open Source Properties"
 SourceFilters="Open Source Filters"
 MixerToolbarMenu="Audio Mixer Menu"
 SceneFilters="Open Scene Filters"
+List="List"
+Grid="Grid"
 
 # warning for plugin load failures
 PluginsFailedToLoad.Title="Plugin Load Error"
@@ -796,6 +798,7 @@ Basic.MainMenu.View.StatusBar="&Status Bar"
 Basic.MainMenu.View.Fullscreen.Interface="Fullscreen Interface"
 Basic.MainMenu.View.ResetUI="&Reset UI"
 Basic.MainMenu.View.AlwaysOnTop="&Always On Top"
+Basic.MainMenu.View.SceneListMode="Scene List Mode"
 
 
 #basic mode docks menu

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -667,6 +667,13 @@
     <property name="title">
      <string>Basic.MainMenu.View</string>
     </property>
+    <widget class="QMenu" name="sceneListModeMenu">
+     <property name="title">
+      <string>Basic.MainMenu.View.SceneListMode</string>
+     </property>
+     <addaction name="actionSceneListMode"/>
+     <addaction name="actionSceneGridMode"/>
+    </widget>
     <action name="resetUI">
      <property name="text">
       <string>Basic.MainMenu.View.ResetUI</string>
@@ -683,6 +690,7 @@
     <addaction name="resetUI"/>
     <addaction name="actionFullscreenInterface"/>
     <addaction name="separator"/>
+    <addaction name="sceneListModeMenu"/>
     <addaction name="toggleListboxToolbars"/>
     <addaction name="toggleContextBar"/>
     <addaction name="toggleSourceIcons"/>
@@ -2298,6 +2306,22 @@
    </property>
    <property name="themeID" stdset="0">
     <string>filtersIcon</string>
+   </property>
+  </action>
+  <action name="actionSceneGridMode">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Grid</string>
+   </property>
+  </action>
+  <action name="actionSceneListMode">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>List</string>
    </property>
   </action>
  </widget>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -34,6 +34,7 @@
 #include <QSizePolicy>
 #include <QScrollBar>
 #include <QTextStream>
+#include <QActionGroup>
 
 #include <util/dstr.h>
 #include <util/util.hpp>
@@ -352,6 +353,11 @@ OBSBasic::OBSBasic(QWidget *parent)
 					 "gridMode");
 	ui->scenes->SetGridMode(sceneGrid);
 
+	if (sceneGrid)
+		ui->actionSceneGridMode->setChecked(true);
+	else
+		ui->actionSceneListMode->setChecked(true);
+
 	ui->scenes->setItemDelegate(new SceneRenameDelegate(ui->scenes));
 
 	auto displayResize = [this]() {
@@ -523,6 +529,10 @@ OBSBasic::OBSBasic(QWidget *parent)
 
 	connect(App(), &OBSApp::StyleChanged, this,
 		&OBSBasic::ResetProxyStyleSliders);
+
+	QActionGroup *actionGroup = new QActionGroup(this);
+	actionGroup->addAction(ui->actionSceneListMode);
+	actionGroup->addAction(ui->actionSceneGridMode);
 
 	UpdatePreviewSafeAreas();
 	UpdatePreviewSpacingHelpers();
@@ -5410,10 +5420,25 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 	popup.exec(QCursor::pos());
 }
 
+void OBSBasic::on_actionSceneListMode_triggered()
+{
+	ui->scenes->SetGridMode(false);
+}
+
+void OBSBasic::on_actionSceneGridMode_triggered()
+{
+	ui->scenes->SetGridMode(true);
+}
+
 void OBSBasic::GridActionClicked()
 {
 	bool gridMode = !ui->scenes->GetGridMode();
 	ui->scenes->SetGridMode(gridMode);
+
+	if (gridMode)
+		ui->actionSceneGridMode->setChecked(true);
+	else
+		ui->actionSceneListMode->setChecked(true);
 }
 
 void OBSBasic::on_actionAddScene_triggered()
@@ -9286,6 +9311,8 @@ void OBSBasic::on_resetUI_triggered()
 	ui->toggleContextBar->setChecked(true);
 	ui->toggleSourceIcons->setChecked(true);
 	ui->toggleStatusBar->setChecked(true);
+	ui->scenes->SetGridMode(false);
+	ui->actionSceneListMode->setChecked(true);
 }
 
 void OBSBasic::on_multiviewProjectorWindowed_triggered()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1060,6 +1060,8 @@ private slots:
 					  QListWidgetItem *prev);
 	void on_scenes_customContextMenuRequested(const QPoint &pos);
 	void GridActionClicked();
+	void on_actionSceneListMode_triggered();
+	void on_actionSceneGridMode_triggered();
 	void on_actionAddScene_triggered();
 	void on_actionRemoveScene_triggered();
 	void on_actionSceneUp_triggered();


### PR DESCRIPTION
### Description
Makes toggling of the scene list grid mode also available in the view menu.

![Screenshot 2023-02-08 04-36-55](https://user-images.githubusercontent.com/19962531/217507769-d223f035-2218-4a38-a71c-fcfeaea69f27.png)

### Motivation and Context
Not just in a context menu.

### How Has This Been Tested?
Toggled grid mode in the view menu.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
