### PR TITLE
obs-ffmpeg: Fix encoding of 2.1 with FFmpeg aac encoder

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
@@ -235,6 +235,9 @@ static void *enc_create(obs_data_t *settings, obs_encoder_t *encoder,
 	if (aoi->speakers == SPEAKERS_4POINT1)
 		enc->context->ch_layout =
 			(AVChannelLayout)AV_CHANNEL_LAYOUT_4POINT1;
+	if (aoi->speakers == SPEAKERS_2POINT1)
+		enc->context->ch_layout =
+			(AVChannelLayout)AV_CHANNEL_LAYOUT_SURROUND;
 #endif
 
 	enc->context->sample_rate = audio_output_get_sample_rate(audio);


### PR DESCRIPTION
### Description
The aac spec has a list of default channel layouts that are implemented by all aac encoders / decoders.
Unfortunately 2.1 is not in that list. When I wrote the surround sound support into OBS, as a workaround I decided to encode 2.1 as AV_CH_LAYOUT_SURROUND = FL+FR+FC.
The LFE channel is encoded as a regular audio channel which uses more bits but this allows compatibility with all aac decoders. Recently we updated to the new channel layout API of FFmpeg, but the mapping of 2.1 to AV_CH_LAYOUT_SURROUND was forgotten in the FFmpeg native aac encoder. This is remedied here.
Fixes #8225 

### Motivation and Context
Fix bug.

### How Has This Been Tested?
Both streaming to Twitch and recording work fine when encoding with 2.1 speaker layout.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
