### PR TITLE
UI: Set flathub::manifest to manifest used to build Flatpak

### DIFF
--- a/UI/xdg-data/CMakeLists.txt
+++ b/UI/xdg-data/CMakeLists.txt
@@ -11,6 +11,18 @@ if(NOT DEFINED APPDATA_RELEASE_DATE)
   endif()
 endif()
 
+if(NOT DEFINED GIT_HASH)
+  if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    execute_process(
+      COMMAND git rev-parse HEAD
+      OUTPUT_VARIABLE GIT_HASH
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+  else()
+    set(GIT_HASH "master")
+  endif()
+endif()
+
 configure_file(com.obsproject.Studio.appdata.xml.in
                com.obsproject.Studio.appdata.xml)
 

--- a/UI/xdg-data/com.obsproject.Studio.appdata.xml.in
+++ b/UI/xdg-data/com.obsproject.Studio.appdata.xml.in
@@ -43,4 +43,7 @@
   <releases>
     <release version="@OBS_VERSION@" date="@APPDATA_RELEASE_DATE@"/>
   </releases>
+  <custom>
+    <value key="flathub::manifest">https://github.com/obsproject/obs-studio/blob/@GIT_HASH@/CI/flatpak/com.obsproject.Studio.json</value>
+  </custom>
 </component>


### PR DESCRIPTION
### Description
Set the `flathub::manifest` key in the AppStream file.

### Motivation and Context

Currently, the manifest URL on Flathub Beta points to the deprecated manifest hosted on Flathub. The flathub::manifest key is an undocumented attribute that will update the website to use the proper location.

### How Has This Been Tested?

 - Tag and release OBS 
 - Notice the CI workflow in the tags generate AppStream metadata with the commit hash

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.