### PR TITLE
UI: Fix scene item edit drag & drop bug

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -413,7 +413,7 @@ void SourceTreeItem::ExitEditModeInternal(bool save)
 	editor = nullptr;
 	setFocusPolicy(Qt::NoFocus);
 	boxLayout->insertWidget(index, label);
-	label->setFocus();
+	setFocus();
 
 	/* ----------------------------------------- */
 	/* check for empty string                    */


### PR DESCRIPTION
### Description
If an user exits the source tree edit mode, without changing the name, the scene item would become undraggable until the scene is refreshed.

### Motivation and Context
Bug reported by @Warchamp7 

### How Has This Been Tested?
Entered the source tree edit mode and exited, without changing the name, and made sure the item was draggable.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
