### PR TITLE
libobs: Allow gs_texrender_t shared texture creation

### DIFF
--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -465,6 +465,8 @@ EXPORT void gs_effect_set_color(gs_eparam_t *param, uint32_t argb);
 
 EXPORT gs_texrender_t *gs_texrender_create(enum gs_color_format format,
 					   enum gs_zstencil_format zsformat);
+EXPORT gs_texrender_t *gs_texrender_create2(enum gs_color_format format,
+					    enum gs_zstencil_format zsformat);
 EXPORT void gs_texrender_destroy(gs_texrender_t *texrender);
 EXPORT bool gs_texrender_begin(gs_texrender_t *texrender, uint32_t cx,
 			       uint32_t cy);
@@ -476,6 +478,7 @@ EXPORT void gs_texrender_reset(gs_texrender_t *texrender);
 EXPORT gs_texture_t *gs_texrender_get_texture(const gs_texrender_t *texrender);
 EXPORT enum gs_color_format
 gs_texrender_get_format(const gs_texrender_t *texrender);
+EXPORT bool gs_texrender_has_shared_texture(const gs_texrender_t *texrender);
 
 /* ---------------------------------------------------
  * graphics subsystem


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
A new `gs_texrender_create2()` function adds the ability for an underlying texrender texture to be created with and additional `GS_SHARED_TEX` flag.

- Add `boolean` named `share` to `gs_texrender_t` struct to provide ability to set `GS_SHARED_TEX` flag on texture creation.
- Adds `gs_texrender_create2()` to build `gs_texrender_t` struct with new shared boolean set to true.
- Modifies `texrender_resetbuffer()` to check if texture is shared and adds `GS_SHARED_TEX` to texture creation flags.
- Adds helper function `gs_texrender_has_shared_texture()` which returns  a `bool` value set in original `gs_texrender _t` creation.

### Motivation and Context
This change allows plugins to create a texture which can be shared with external processes without creating and additional texture and without requiring and additional copy to that texture.

### How Has This Been Tested?
The changes have been tested only locally on my windows 11 machine. My current dev machine is an AMD 2700, Nvidia 1070, 32GB, Windows 11 Home.

I have tested the changes for many hours against various directx software processes.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
