### PR TITLE
UI: Avoid excessive config reads when drawing preview

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -488,6 +488,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 
 	UpdatePreviewSafeAreas();
 	UpdatePreviewSpacingHelpers();
+	UpdatePreviewOverflowSettings();
 }
 
 static void SaveAudioDevice(const char *name, int channel, obs_data_t *parent,
@@ -10283,6 +10284,20 @@ void OBSBasic::UpdatePreviewSafeAreas()
 {
 	drawSafeAreas = config_get_bool(App()->GlobalConfig(), "BasicWindow",
 					"ShowSafeAreas");
+}
+
+void OBSBasic::UpdatePreviewOverflowSettings()
+{
+	bool hidden = config_get_bool(App()->GlobalConfig(), "BasicWindow",
+				      "OverflowHidden");
+	bool select = config_get_bool(App()->GlobalConfig(), "BasicWindow",
+				      "OverflowSelectionHidden");
+	bool always = config_get_bool(App()->GlobalConfig(), "BasicWindow",
+				      "OverflowAlwaysVisible");
+
+	ui->preview->SetOverflowHidden(hidden);
+	ui->preview->SetOverflowSelectionHidden(select);
+	ui->preview->SetOverflowAlwaysVisible(always);
 }
 
 void OBSBasic::SetDisplayAffinity(QWindow *window)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -643,6 +643,8 @@ private:
 	std::string lastScreenshot;
 	std::string lastReplay;
 
+	void UpdatePreviewOverflowSettings();
+
 public slots:
 	void DeferSaveBegin();
 	void DeferSaveEnd();

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -1868,10 +1868,9 @@ bool OBSBasicPreview::DrawSelectedOverflow(obs_scene_t *scene,
 	if (!SceneItemHasVideo(item))
 		return true;
 
-	bool select = config_get_bool(GetGlobalConfig(), "BasicWindow",
-				      "OverflowSelectionHidden");
+	OBSBasicPreview *prev = reinterpret_cast<OBSBasicPreview *>(param);
 
-	if (!select && !obs_sceneitem_visible(item))
+	if (!prev->GetOverflowSelectionHidden() && !obs_sceneitem_visible(item))
 		return true;
 
 	if (obs_sceneitem_is_group(item)) {
@@ -1885,13 +1884,8 @@ bool OBSBasicPreview::DrawSelectedOverflow(obs_scene_t *scene,
 		gs_matrix_pop();
 	}
 
-	bool always = config_get_bool(GetGlobalConfig(), "BasicWindow",
-				      "OverflowAlwaysVisible");
-
-	if (!always && !obs_sceneitem_selected(item))
+	if (!prev->GetOverflowAlwaysVisible() && !obs_sceneitem_selected(item))
 		return true;
-
-	OBSBasicPreview *prev = reinterpret_cast<OBSBasicPreview *>(param);
 
 	matrix4 boxTransform;
 	matrix4 invBoxTransform;
@@ -2177,10 +2171,7 @@ void OBSBasicPreview::DrawOverflow()
 	if (locked)
 		return;
 
-	bool hidden = config_get_bool(GetGlobalConfig(), "BasicWindow",
-				      "OverflowHidden");
-
-	if (hidden)
+	if (overflowHidden)
 		return;
 
 	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DEFAULT, "DrawOverflow");

--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -73,6 +73,9 @@ private:
 	bool scrollMode = false;
 	bool fixedScaling = false;
 	bool selectionBox = false;
+	bool overflowHidden = false;
+	bool overflowSelectionHidden = false;
+	bool overflowAlwaysVisible = false;
 	int32_t scalingLevel = 0;
 	float scalingAmount = 1.0f;
 	float groupRot = 0.0f;
@@ -161,6 +164,25 @@ public:
 	}
 	inline float GetScrollX() const { return scrollingOffset.x; }
 	inline float GetScrollY() const { return scrollingOffset.y; }
+
+	inline void SetOverflowHidden(bool hidden) { overflowHidden = hidden; }
+	inline void SetOverflowSelectionHidden(bool hidden)
+	{
+		overflowSelectionHidden = hidden;
+	}
+	inline void SetOverflowAlwaysVisible(bool visible)
+	{
+		overflowAlwaysVisible = visible;
+	}
+
+	inline bool GetOverflowSelectionHidden() const
+	{
+		return overflowSelectionHidden;
+	}
+	inline bool GetOverflowAlwaysVisible() const
+	{
+		return overflowAlwaysVisible;
+	}
 
 	/* use libobs allocator for alignment because the matrices itemToScreen
 	 * and screenToItem may contain SSE data, which will cause SSE

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -3170,18 +3170,20 @@ void OBSBasicSettings::SaveGeneralSettings()
 	if (WidgetChanged(ui->snapDistance))
 		config_set_double(GetGlobalConfig(), "BasicWindow",
 				  "SnapDistance", ui->snapDistance->value());
-	if (WidgetChanged(ui->overflowAlwaysVisible))
+	if (WidgetChanged(ui->overflowAlwaysVisible) ||
+	    WidgetChanged(ui->overflowHide) ||
+	    WidgetChanged(ui->overflowSelectionHide)) {
 		config_set_bool(GetGlobalConfig(), "BasicWindow",
 				"OverflowAlwaysVisible",
 				ui->overflowAlwaysVisible->isChecked());
-	if (WidgetChanged(ui->overflowHide))
 		config_set_bool(GetGlobalConfig(), "BasicWindow",
 				"OverflowHidden",
 				ui->overflowHide->isChecked());
-	if (WidgetChanged(ui->overflowSelectionHide))
 		config_set_bool(GetGlobalConfig(), "BasicWindow",
 				"OverflowSelectionHidden",
 				ui->overflowSelectionHide->isChecked());
+		main->UpdatePreviewOverflowSettings();
+	}
 	if (WidgetChanged(ui->previewSafeAreas)) {
 		config_set_bool(GetGlobalConfig(), "BasicWindow",
 				"ShowSafeAreas",


### PR DESCRIPTION
### Description

Updates the overflow settings for the preview once on startup and when settings change isntead of querying every frame.

### Motivation and Context

Before the config would be queried twice per source per frame to see if the overflow options were set.

Discovered while checking config queries for capitalisation issues while working on #8229.

### How Has This Been Tested?

Verified config is no longer queried each frame and options still work

### Types of changes

- Tweak (non-breaking change to improve existing functionality)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
