### PR TITLE
UI: Remove workaround for current scene being deselectable on Qt 6.4.3+

### DIFF
--- a/UI/item-widget-helpers.cpp
+++ b/UI/item-widget-helpers.cpp
@@ -37,8 +37,10 @@ void DeleteListItem(QListWidget *widget, QListWidgetItem *item)
 
 void ClearListItems(QListWidget *widget)
 {
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 3)
 	// Workaround for the SceneTree workaround for QTBUG-105870
 	widget->setProperty("clearing", true);
+#endif
 
 	widget->setCurrentItem(nullptr, QItemSelectionModel::Clear);
 
@@ -46,5 +48,8 @@ void ClearListItems(QListWidget *widget)
 		delete widget->itemWidget(widget->item(i));
 
 	widget->clear();
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 3)
+	// Workaround for the SceneTree workaround for QTBUG-105870
 	widget->setProperty("clearing", false);
+#endif
 }

--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -248,6 +248,7 @@ void SceneTree::rowsInserted(const QModelIndex &parent, int start, int end)
 	QListWidget::rowsInserted(parent, start, end);
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 3)
 // Workaround for QTBUG-105870. Remove once that is solved upstream.
 void SceneTree::selectionChanged(const QItemSelection &selected,
 				 const QItemSelection &deselected)
@@ -256,3 +257,4 @@ void SceneTree::selectionChanged(const QItemSelection &selected,
 	    !property("clearing").toBool())
 		setCurrentRow(deselected.indexes().front().row());
 }
+#endif

--- a/UI/scene-tree.hpp
+++ b/UI/scene-tree.hpp
@@ -38,9 +38,11 @@ protected:
 	virtual void dragLeaveEvent(QDragLeaveEvent *event) override;
 	virtual void rowsInserted(const QModelIndex &parent, int start,
 				  int end) override;
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 3)
 	virtual void
 	selectionChanged(const QItemSelection &selected,
 			 const QItemSelection &deselected) override;
+#endif
 
 signals:
 	void scenesReordered();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Qt 6.2 introduced an issue where SingleSelection item views would deselect the current item if the user clicked on empty area in the widget.
This was very confusing in the scene tree as it was now possible to unselect the current scene. A workaround for this in OBS was added in 08e4ee6 (#7200) and expanded on in dc30cf0 (#7499), but being quite hacky it never was the perfect solution.

I since dug into Qt and fixed the issue upstream at [Qt Gerrit 459511](https://codereview.qt-project.org/c/qt/qtbase/+/459511). ~~That hasn't actually landed in Qt (yet), but first review by the maintainer suggests it's in relatively decent shape, so I'm preparing this PR now.~~ That patch has now landed.
It's being cherry-picked to 6.4 and 6.5, so it will be in 6.4.3 and newer meaning we can remove the workaround when using those versions with the long term goal of removing the code altogether (In 6.5 it will only be in Beta 3 or newer (since 1 and 2 are already out), but I don't care a lot about people using Beta Qt with OBS).

~~TODO: Wait until the patch actually lands. Fix the commit description to reference the actual commit in qtbase and potentially adjust the version in code.~~ Done.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We should be fixing issues upstream instead of working around them downstream when possible. This improves both our lives by reducing the need for workarounds and the lives of other people using the same dependencies.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.1, Qt dev branch.
It's no longer possible to unselect the current scene by clicking on empty area below the scenes, as well as the current page in the settings window (which we didn't work around in the first place since it wasn't particularly important and not worth the extra complexity).
Verified #7280 didn't magically regress somehow by changing scene collections and changing transitions.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
