### PR TITLE
libobs-opengl: Accelerate dmabuf import

### DIFF
--- a/libobs-opengl/gl-egl-common.c
+++ b/libobs-opengl/gl-egl-common.c
@@ -186,7 +186,7 @@ struct gs_texture *gl_egl_create_texture_from_eglimage(
 
 	struct gs_texture *texture = NULL;
 	texture = gs_texture_create(width, height, color_format, 1, NULL,
-				    GS_DYNAMIC);
+				    GS_GL_DUMMYTEX);
 	const GLuint gltex = *(GLuint *)gs_texture_get_obj(texture);
 
 	gl_bind_texture(GL_TEXTURE_2D, gltex);

--- a/libobs-opengl/gl-texture2d.c
+++ b/libobs-opengl/gl-texture2d.c
@@ -110,16 +110,7 @@ gs_texture_t *device_texture_create(gs_device_t *device, uint32_t width,
 		if (!gl_bind_texture(GL_TEXTURE_2D, tex->base.texture))
 			goto fail;
 
-		uint32_t row_size =
-			tex->width * gs_get_format_bpp(tex->base.format);
-		uint32_t tex_size = tex->height * row_size / 8;
-		bool compressed = gs_is_compressed_format(tex->base.format);
-		bool did_init = gl_init_face(GL_TEXTURE_2D, tex->base.gl_type,
-					     1, tex->base.gl_format,
-					     tex->base.gl_internal_format,
-					     compressed, tex->width,
-					     tex->height, tex_size, NULL);
-		did_init =
+		bool did_init =
 			gl_tex_param_i(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
 
 		bool did_unbind = gl_bind_texture(GL_TEXTURE_2D, 0);


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Previously we would actually initialize a texture memory that would then also have to be deleted when we bound the EGLImage to the texture during dmabuf import.

Instead simply do not create the dummy texture memory. One odd thing is that we must still query the texture to ensure its initialized or binding the EGLImage will not work. So we leave the TEXTURE_MAX_LEVEL check.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This makes screencapture up to 100x faster on discrete intel cards and likely has some performance benefit for amd/integrated cards. Without this dmabufs are actually slower than shared memory for these intel cards.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with screencapture and texture encoding (pending another PR) and both continue to work with this change. If someone on AMD wants to confirm a performance improvement that would be nice.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
