### PR TITLE
UI: Defer loading hotkeys until tab is switched

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1209,6 +1209,7 @@ Basic.Settings.Hotkeys.Pair="Key combinations shared with '%1' act as toggles"
 Basic.Settings.Hotkeys.Filter="Filter"
 Basic.Settings.Hotkeys.FilterByHotkey="Filter by Hotkey"
 Basic.Settings.Hotkeys.DuplicateWarning="This hotkey is shared by one or more other actions, click to show conflicts"
+Basic.Settings.Hotkeys.PleaseWait="Loading hotkeys, please wait..."
 
 # basic mode hotkeys
 Basic.Hotkeys.SelectScene="Switch to scene"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -5692,6 +5692,25 @@
              <property name="bottomMargin">
               <number>9</number>
              </property>
+             <item row="0" column="0" colspan="2">
+              <widget class="QLabel" name="pleaseWaitLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Basic.Settings.Hotkeys.PleaseWait</string>
+               </property>
+               <property name="scaledContents">
+                <bool>false</bool>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </widget>

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -3074,6 +3074,13 @@ void OBSBasicSettings::LoadHotkeySettings(obs_hotkey_id ignoreKey)
 	AddHotkeys(*hotkeysLayout, obs_service_get_name, services);
 
 	ScanDuplicateHotkeys(hotkeysLayout);
+
+	/* After this function returns the UI can still be unresponsive for a bit.
+	 * So by deferring the call to unsetCursor() to the Qt event loop it will
+	 * take until it has actually finished processing the created widgets
+	 * before the cursor is reset. */
+	QTimer::singleShot(1, this, &OBSBasicSettings::unsetCursor);
+	hotkeysLoaded = true;
 }
 
 void OBSBasicSettings::LoadSettings(bool changedOnly)
@@ -3088,8 +3095,6 @@ void OBSBasicSettings::LoadSettings(bool changedOnly)
 		LoadAudioSettings();
 	if (!changedOnly || videoChanged)
 		LoadVideoSettings();
-	if (!changedOnly || hotkeysChanged)
-		LoadHotkeySettings();
 	if (!changedOnly || a11yChanged)
 		LoadA11ySettings();
 	if (!changedOnly || advancedChanged)
@@ -3994,6 +3999,20 @@ void OBSBasicSettings::on_listWidget_itemSelectionChanged()
 	if (loading || row == pageIndex)
 		return;
 
+	if (!hotkeysLoaded && row == 5) {
+		setCursor(Qt::BusyCursor);
+		/* Look, I know this /feels/ wrong, but the specific issue we're dealing with
+		 * here means that the UI locks up immediately even when using "invokeMethod".
+		 * So the only way for the user to see the loading message on the page is to
+		 * give the Qt event loop a tiny bit of time to switch to the hotkey page,
+		 * and only then start loading. This could maybe be done by subclassing QWidget
+		 * for the hotkey page and then using showEvent() but I *really* don't want
+		 * to deal with that right now. I've got better things to do with my life
+		 * than to work around this god damn stupid issue for something we'll remove
+		 * soon enough anyway. So this solution it is. */
+		QTimer::singleShot(1, this, [&]() { LoadHotkeySettings(); });
+	}
+
 	pageIndex = row;
 }
 
@@ -4627,6 +4646,8 @@ bool OBSBasicSettings::ScanDuplicateHotkeys(QFormLayout *layout)
 
 void OBSBasicSettings::ReloadHotkeys(obs_hotkey_id ignoreKey)
 {
+	if (!hotkeysLoaded)
+		return;
 	LoadHotkeySettings(ignoreKey);
 }
 

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -125,6 +125,7 @@ private:
 	int sampleRateIndex = 0;
 	int channelIndex = 0;
 	bool llBufferingEnabled = false;
+	bool hotkeysLoaded = false;
 
 	int lastSimpleRecQualityIdx = 0;
 	int lastServiceIdx = -1;


### PR DESCRIPTION
### Description

Waits with loading hotkeys until the user clicks on the settings tab.

The user sees a message while the tab is still loading:
![2023-02-12_01-37-46_fIunMq](https://user-images.githubusercontent.com/3123295/218287131-38387a08-92f4-4c9f-a180-132a3829a90c.png)

### Motivation and Context

Enables the settings window to still open really quickly even with tons of hotkeys (like #6081).

### How Has This Been Tested?

Opened settings, it was quick!

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
