### PR TITLE
UI: Massively improve hotkey search performance

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4519,7 +4519,6 @@ void OBSBasicSettings::SearchHotkeys(const QString &text,
 	std::vector<obs_key_combination_t> combos;
 	bool showHotkey;
 	ui->hotkeyScrollArea->ensureVisible(0, 0);
-	ui->hotkeyScrollArea->setUpdatesEnabled(false);
 
 	QLayoutItem *hotkeysItem = ui->hotkeyFormLayout->itemAt(0);
 	QWidget *hotkeys = hotkeysItem->widget();
@@ -4528,6 +4527,9 @@ void OBSBasicSettings::SearchHotkeys(const QString &text,
 
 	QFormLayout *hotkeysLayout =
 		qobject_cast<QFormLayout *>(hotkeys->layout());
+	hotkeysLayout->setEnabled(false);
+
+	QString needle = text.toLower();
 
 	for (int i = 0; i < hotkeysLayout->rowCount(); i++) {
 		auto label = hotkeysLayout->itemAt(i, QFormLayout::LabelRole);
@@ -4539,18 +4541,19 @@ void OBSBasicSettings::SearchHotkeys(const QString &text,
 		if (!item)
 			continue;
 
-		item->widget->GetCombinations(combos);
 		QString fullname = item->property("fullName").value<QString>();
 
-		showHotkey = text.isEmpty() ||
-			     fullname.toLower().contains(text.toLower());
+		showHotkey = needle.isEmpty() ||
+			     fullname.toLower().contains(needle);
 
 		if (showHotkey && !obs_key_combination_is_empty(filterCombo)) {
 			showHotkey = false;
+
+			item->widget->GetCombinations(combos);
 			for (auto combo : combos) {
 				if (combo == filterCombo) {
 					showHotkey = true;
-					continue;
+					break;
 				}
 			}
 		}
@@ -4561,7 +4564,7 @@ void OBSBasicSettings::SearchHotkeys(const QString &text,
 		if (field)
 			field->widget()->setVisible(showHotkey);
 	}
-	ui->hotkeyScrollArea->setUpdatesEnabled(true);
+	hotkeysLayout->setEnabled(true);
 }
 
 void OBSBasicSettings::on_hotkeyFilterReset_clicked()


### PR DESCRIPTION
### Description

This PR significantly improves search performance in the hotkey settings tab.

The original author had the right idea with disabling updates so the list would not be continuously updated/redrawn while the search loop is updating visibilities, but they set it on the wrong element. Disabling the layout instead improves things significantly with large scene collections.

Also includes some smaller optimisations to avoid some operations (`toLower()`/getting combinations) unless necessary which speeds up the loop a tiny bit.

### Motivation and Context

Makes search usable with the example collection linked in #6081.

### How Has This Been Tested?

Searched some hotkeys, no longer was afraid of dying of old age while it updates

### Types of changes

- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
