### PR TITLE
UI: Add preview scaling shortcuts

### DIFF
--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -122,6 +122,15 @@ private:
 	OBSDataAutoRelease wrapper = nullptr;
 	bool changed;
 
+private slots:
+	void ZoomIn();
+	void ZoomOut();
+	void ZoomReset();
+	void MoveUp();
+	void MoveDown();
+	void MoveLeft();
+	void MoveRight();
+
 public:
 	OBSBasicPreview(QWidget *parent,
 			Qt::WindowFlags flags = Qt::WindowFlags());


### PR DESCRIPTION
### Description
Adds the following shorcuts to the preview, when in fixed scaling mode:
- Ctrl + Plus: zoom in
- Ctrl + Minus: zoom out
- Ctrl + 0: reset zoom
- Ctrl + Up, Down, Left, Right: move preview around

### Motivation and Context
Make preview scaling / scrolling easier to use

### How Has This Been Tested?
Enter fixed scaling mode, and zoomed / moved the preview.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
