### PR TITLE
UI: Remove bitness strings

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1722,11 +1722,6 @@ string OBSApp::GetVersionString() const
 	ver << " (";
 
 #ifdef _WIN32
-	if (sizeof(void *) == 8)
-		ver << "64-bit, ";
-	else
-		ver << "32-bit, ";
-
 	ver << "windows)";
 #elif __APPLE__
 	ver << "mac)";

--- a/UI/window-basic-about.cpp
+++ b/UI/window-basic-about.cpp
@@ -15,13 +15,7 @@ OBSAbout::OBSAbout(QWidget *parent) : QDialog(parent), ui(new Ui::OBSAbout)
 
 	ui->setupUi(this);
 
-	QString bitness;
 	QString ver;
-
-	if (sizeof(void *) == 4)
-		bitness = " (32 bit)";
-	else if (sizeof(void *) == 8)
-		bitness = " (64 bit)";
 
 #ifdef HAVE_OBSCONFIG_H
 	ver += OBS_VERSION;
@@ -30,7 +24,7 @@ OBSAbout::OBSAbout(QWidget *parent) : QDialog(parent), ui(new Ui::OBSAbout)
 	       LIBOBS_API_PATCH_VER;
 #endif
 
-	ui->version->setText(ver + bitness);
+	ui->version->setText(ver);
 
 	ui->contribute->setText(QTStr("About.Contribute"));
 


### PR DESCRIPTION
### Description
This removes the bitness strings from the title bar and about dialog.

### Motivation and Context
These are now pointless because we are now only 64 bit.

### How Has This Been Tested?
Checked UI to see if the strings were removed.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
