### PR TITLE
libobs-opengl: Fix projector crash with external macOS displays

### DIFF
--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -228,6 +228,10 @@ void gl_update(gs_device_t *device)
 	NSOpenGLContext *parent = device->plat->context;
 	NSOpenGLContext *context = swap->wi->context;
 	dispatch_async(dispatch_get_main_queue(), ^() {
+		if (!swap || !swap->wi) {
+			return;
+		}
+
 		CGLContextObj parent_obj = [parent CGLContextObj];
 		CGLLockContext(parent_obj);
 


### PR DESCRIPTION
### Description
Fixes a crash occurring whenever a full screen projector was placed on an attached display, which is then disconnected while OBS runs.

### Motivation and Context
When an external display is disconnected with a fullscreen projector attached to it, Qt will trigger a resize of the window twice, which makes the renderer queue 2 resize event blocks.

At the time when those blocks are run, Qt's window destructor will have reset all pointers, and the block directly accesses pointers within structures identified by pointers, which are invalid by that point.

This commit makes a block return early if the associated window has been destroyed already and also explicitly checks for valid pointers after.

### How Has This Been Tested?
Tested with an external display connected via HDMI on macOS Ventura.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
