### PR TITLE
obs-ffmpeg: Relax 'lookahead' constraint when bitrate is updated

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -645,8 +645,7 @@ static bool init_encoder_base(struct nvenc_data *enc, obs_data_t *settings,
 	/* rate control               */
 
 	enc->can_change_bitrate =
-		nv_get_cap(enc, NV_ENC_CAPS_SUPPORT_DYN_BITRATE_CHANGE) &&
-		!lookahead;
+		nv_get_cap(enc, NV_ENC_CAPS_SUPPORT_DYN_BITRATE_CHANGE);
 
 	config->rcParams.rateControlMode = NV_ENC_PARAMS_RC_VBR;
 


### PR DESCRIPTION
### Description
When bitrate is updated, a check against 'lookahead' setting is done. If 'lookahead' is enabled, the bitrate update is disabled. We indeed used to observe crashes with nvenc when frequent bitrate resettings were effected while lookahead option was enabled. But recent tests have shown that the issue is gone. As a result this commit allows 'lookahead' with bitrate live update.

### Motivation and Context
The need for a fix was raised when a user reported that bitrate live update did not work with P6 or P7 presets for jim-nvenc.
These presets enable 'lookahead' option which before this commit would disable bitrate live update
(either dynamic bitrate or manual update through the Settings > Output menu).
Fixes https://github.com/obsproject/obs-studio/issues/8268

### How Has This Been Tested?
Tested by @notr1ch who had 15k bitrate changes on P7 preset with drivers:
31.0.15.2802

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
