### PR TITLE
UI: Fix transform dialog not being closable

### DIFF
--- a/UI/forms/OBSBasicTransform.ui
+++ b/UI/forms/OBSBasicTransform.ui
@@ -15,510 +15,628 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,5,0">
    <item>
-    <layout class="QFormLayout" name="formLayout">
-     <property name="fieldGrowthPolicy">
-      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-     </property>
-     <property name="labelAlignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>170</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="accessibleName">
-        <string>Basic.TransformWindow.Position</string>
-       </property>
-       <property name="text">
-        <string>Basic.TransformWindow.Position</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QFrame" name="widget">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <property name="leftMargin">
-         <number>0</number>
+    <widget class="QWidget" name="container" native="true">
+     <layout class="QFormLayout" name="formLayout">
+      <property name="fieldGrowthPolicy">
+       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+      </property>
+      <property name="labelAlignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="horizontalSpacing">
+       <number>4</number>
+      </property>
+      <property name="verticalSpacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="topMargin">
-         <number>0</number>
+        <property name="minimumSize">
+         <size>
+          <width>170</width>
+          <height>0</height>
+         </size>
         </property>
-        <property name="rightMargin">
-         <number>0</number>
+        <property name="accessibleName">
+         <string>Basic.TransformWindow.Position</string>
         </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QDoubleSpinBox" name="positionX">
-          <property name="minimumSize">
-           <size>
-            <width>120</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>100</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="accessibleName">
-           <string>Basic.TransformWindow.PositionX</string>
-          </property>
-          <property name="suffix">
-           <string> px</string>
-          </property>
-          <property name="decimals">
-           <number>4</number>
-          </property>
-          <property name="minimum">
-           <double>-90001.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>90001.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QDoubleSpinBox" name="positionY">
-          <property name="minimumSize">
-           <size>
-            <width>120</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>100</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="accessibleName">
-           <string>Basic.TransformWindow.PositionY</string>
-          </property>
-          <property name="suffix">
-           <string> px</string>
-          </property>
-          <property name="decimals">
-           <number>4</number>
-          </property>
-          <property name="minimum">
-           <double>-90001.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>90001.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="accessibleName">
-        <string>Basic.TransformWindow.Rotation</string>
-       </property>
-       <property name="text">
-        <string>Basic.TransformWindow.Rotation</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QDoubleSpinBox" name="rotation">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>120</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>100</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="accessibleName">
-        <string>Basic.TransformWindow.Rotation</string>
-       </property>
-       <property name="suffix">
-        <string>°</string>
-       </property>
-       <property name="minimum">
-        <double>-360.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="accessibleName">
-        <string>Basic.TransformWindow.Size</string>
-       </property>
-       <property name="text">
-        <string>Basic.TransformWindow.Size</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QFrame" name="widget_2">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QDoubleSpinBox" name="sizeX">
-          <property name="minimumSize">
-           <size>
-            <width>120</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>100</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="accessibleName">
-           <string>Basic.TransformWindow.Width</string>
-          </property>
-          <property name="suffix">
-           <string> px</string>
-          </property>
-          <property name="decimals">
-           <number>4</number>
-          </property>
-          <property name="minimum">
-           <double>-90001.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>90001.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QDoubleSpinBox" name="sizeY">
-          <property name="minimumSize">
-           <size>
-            <width>120</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>100</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="accessibleName">
-           <string>Basic.TransformWindow.Height</string>
-          </property>
-          <property name="suffix">
-           <string> px</string>
-          </property>
-          <property name="decimals">
-           <number>4</number>
-          </property>
-          <property name="minimum">
-           <double>-90001.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>90001.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="accessibleName">
-        <string>Basic.TransformWindow.Alignment</string>
-       </property>
-       <property name="text">
-        <string>Basic.TransformWindow.Alignment</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QComboBox" name="align">
-       <property name="accessibleName">
-        <string>Basic.TransformWindow.Alignment</string>
-       </property>
-       <property name="currentText">
-        <string>Basic.TransformWindow.Alignment.TopLeft</string>
-       </property>
-       <item>
         <property name="text">
+         <string>Basic.TransformWindow.Position</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QFrame" name="widget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QDoubleSpinBox" name="positionX">
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="accessibleName">
+            <string>Basic.TransformWindow.PositionX</string>
+           </property>
+           <property name="suffix">
+            <string> px</string>
+           </property>
+           <property name="decimals">
+            <number>4</number>
+           </property>
+           <property name="minimum">
+            <double>-90001.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>90001.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="positionY">
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="accessibleName">
+            <string>Basic.TransformWindow.PositionY</string>
+           </property>
+           <property name="suffix">
+            <string> px</string>
+           </property>
+           <property name="decimals">
+            <number>4</number>
+           </property>
+           <property name="minimum">
+            <double>-90001.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>90001.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="accessibleName">
+         <string>Basic.TransformWindow.Rotation</string>
+        </property>
+        <property name="text">
+         <string>Basic.TransformWindow.Rotation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="rotation">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>100</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="accessibleName">
+         <string>Basic.TransformWindow.Rotation</string>
+        </property>
+        <property name="suffix">
+         <string>°</string>
+        </property>
+        <property name="minimum">
+         <double>-360.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>360.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="accessibleName">
+         <string>Basic.TransformWindow.Size</string>
+        </property>
+        <property name="text">
+         <string>Basic.TransformWindow.Size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QFrame" name="widget_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QDoubleSpinBox" name="sizeX">
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="accessibleName">
+            <string>Basic.TransformWindow.Width</string>
+           </property>
+           <property name="suffix">
+            <string> px</string>
+           </property>
+           <property name="decimals">
+            <number>4</number>
+           </property>
+           <property name="minimum">
+            <double>-90001.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>90001.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>1.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="sizeY">
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="accessibleName">
+            <string>Basic.TransformWindow.Height</string>
+           </property>
+           <property name="suffix">
+            <string> px</string>
+           </property>
+           <property name="decimals">
+            <number>4</number>
+           </property>
+           <property name="minimum">
+            <double>-90001.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>90001.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>1.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="accessibleName">
+         <string>Basic.TransformWindow.Alignment</string>
+        </property>
+        <property name="text">
+         <string>Basic.TransformWindow.Alignment</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="align">
+        <property name="accessibleName">
+         <string>Basic.TransformWindow.Alignment</string>
+        </property>
+        <property name="currentText">
          <string>Basic.TransformWindow.Alignment.TopLeft</string>
         </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.TopCenter</string>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.TopLeft</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.TopCenter</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.TopRight</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.CenterLeft</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.Center</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.CenterRight</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.BottomLeft</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.BottomCenter</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.BottomRight</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
         </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.TopRight</string>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>10</width>
+          <height>10</height>
+         </size>
         </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.CenterLeft</string>
+       </spacer>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="accessibleName">
+         <string>Basic.TransformWindow.BoundsType</string>
         </property>
-       </item>
-       <item>
         <property name="text">
-         <string>Basic.TransformWindow.Alignment.Center</string>
+         <string>Basic.TransformWindow.BoundsType</string>
         </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.CenterRight</string>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QComboBox" name="boundsType">
+        <property name="accessibleName">
+         <string>Basic.TransformWindow.BoundsType</string>
         </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.BottomLeft</string>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.BoundsType.None</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.BoundsType.Stretch</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.BoundsType.ScaleInner</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.BoundsType.ScaleOuter</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.BoundsType.ScaleToWidth</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.BoundsType.ScaleToHeight</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.BoundsType.MaxOnly</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="accessibleName">
+         <string>Basic.TransformWindow.BoundsAlignment</string>
         </property>
-       </item>
-       <item>
         <property name="text">
-         <string>Basic.TransformWindow.Alignment.BottomCenter</string>
+         <string>Basic.TransformWindow.BoundsAlignment</string>
         </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.BottomRight</string>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QComboBox" name="boundsAlign">
+        <property name="enabled">
+         <bool>false</bool>
         </property>
-       </item>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>10</width>
-         <height>10</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="accessibleName">
-        <string>Basic.TransformWindow.BoundsType</string>
-       </property>
-       <property name="text">
-        <string>Basic.TransformWindow.BoundsType</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QComboBox" name="boundsType">
-       <property name="accessibleName">
-        <string>Basic.TransformWindow.BoundsType</string>
-       </property>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.BoundsType.None</string>
+        <property name="accessibleName">
+         <string>Basic.TransformWindow.BoundsAlignment</string>
         </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.BoundsType.Stretch</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.BoundsType.ScaleInner</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.BoundsType.ScaleOuter</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.BoundsType.ScaleToWidth</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.BoundsType.ScaleToHeight</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.BoundsType.MaxOnly</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="accessibleName">
-        <string>Basic.TransformWindow.BoundsAlignment</string>
-       </property>
-       <property name="text">
-        <string>Basic.TransformWindow.BoundsAlignment</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QComboBox" name="boundsAlign">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="accessibleName">
-        <string>Basic.TransformWindow.BoundsAlignment</string>
-       </property>
-       <property name="currentText">
-        <string>Basic.TransformWindow.Alignment.TopLeft</string>
-       </property>
-       <item>
-        <property name="text">
+        <property name="currentText">
          <string>Basic.TransformWindow.Alignment.TopLeft</string>
         </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.TopCenter</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.TopRight</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.CenterLeft</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.Center</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.CenterRight</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.BottomLeft</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.BottomCenter</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Basic.TransformWindow.Alignment.BottomRight</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="label_7">
-       <property name="accessibleName">
-        <string>Basic.TransformWindow.Bounds</string>
-       </property>
-       <property name="text">
-        <string>Basic.TransformWindow.Bounds</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="QFrame" name="widget_3">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
         <item>
-         <widget class="QDoubleSpinBox" name="boundsWidth">
-          <property name="enabled">
-           <bool>false</bool>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.TopLeft</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.TopCenter</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.TopRight</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.CenterLeft</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.Center</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.CenterRight</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.BottomLeft</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.BottomCenter</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Basic.TransformWindow.Alignment.BottomRight</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="accessibleName">
+         <string>Basic.TransformWindow.Bounds</string>
+        </property>
+        <property name="text">
+         <string>Basic.TransformWindow.Bounds</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QFrame" name="widget_3">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QDoubleSpinBox" name="boundsWidth">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="accessibleName">
+            <string>Basic.TransformWindow.BoundsWidth</string>
+           </property>
+           <property name="suffix">
+            <string> px</string>
+           </property>
+           <property name="decimals">
+            <number>4</number>
+           </property>
+           <property name="minimum">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>90001.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="boundsHeight">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="accessibleName">
+            <string>Basic.TransformWindow.BoundsHeight</string>
+           </property>
+           <property name="suffix">
+            <string> px</string>
+           </property>
+           <property name="decimals">
+            <number>4</number>
+           </property>
+           <property name="minimum">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>90001.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>10</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="accessibleName">
+         <string>Basic.TransformWindow.Crop</string>
+        </property>
+        <property name="text">
+         <string>Basic.TransformWindow.Crop</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="1">
+         <widget class="QSpinBox" name="cropLeft">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>120</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -529,30 +647,27 @@
            </size>
           </property>
           <property name="accessibleName">
-           <string>Basic.TransformWindow.BoundsWidth</string>
+           <string>Basic.TransformWindow.CropLeft</string>
           </property>
           <property name="suffix">
            <string> px</string>
           </property>
-          <property name="decimals">
-           <number>4</number>
-          </property>
-          <property name="minimum">
-           <double>1.000000000000000</double>
-          </property>
           <property name="maximum">
-           <double>90001.000000000000000</double>
+           <number>100000</number>
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QDoubleSpinBox" name="boundsHeight">
-          <property name="enabled">
-           <bool>false</bool>
+        <item row="0" column="3">
+         <widget class="QSpinBox" name="cropRight">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>120</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -563,242 +678,147 @@
            </size>
           </property>
           <property name="accessibleName">
-           <string>Basic.TransformWindow.BoundsHeight</string>
+           <string>Basic.TransformWindow.CropRight</string>
           </property>
           <property name="suffix">
            <string> px</string>
           </property>
-          <property name="decimals">
-           <number>4</number>
-          </property>
-          <property name="minimum">
-           <double>1.000000000000000</double>
-          </property>
           <property name="maximum">
-           <double>90001.000000000000000</double>
+           <number>100000</number>
           </property>
          </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_9">
+          <property name="text">
+           <string>Left</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+           <cstring>cropLeft</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QLabel" name="label_12">
+          <property name="text">
+           <string>Bottom</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+           <cstring>cropBottom</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="cropTop">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="accessibleName">
+           <string>Basic.TransformWindow.CropTop</string>
+          </property>
+          <property name="suffix">
+           <string> px</string>
+          </property>
+          <property name="maximum">
+           <number>100000</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="3">
+         <widget class="QSpinBox" name="cropBottom">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="accessibleName">
+           <string>Basic.TransformWindow.CropBottom</string>
+          </property>
+          <property name="suffix">
+           <string> px</string>
+          </property>
+          <property name="maximum">
+           <number>100000</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_11">
+          <property name="text">
+           <string>Top</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+           <cstring>cropTop</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QLabel" name="label_10">
+          <property name="text">
+           <string>Right</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+           <cstring>cropRight</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="4">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <spacer name="verticalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>10</width>
-         <height>10</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="label_8">
-       <property name="accessibleName">
-        <string>Basic.TransformWindow.Crop</string>
-       </property>
-       <property name="text">
-        <string>Basic.TransformWindow.Crop</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="1">
-        <widget class="QSpinBox" name="cropLeft">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>100</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="accessibleName">
-          <string>Basic.TransformWindow.CropLeft</string>
-         </property>
-         <property name="suffix">
-          <string> px</string>
-         </property>
-         <property name="maximum">
-          <number>100000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="3">
-        <widget class="QSpinBox" name="cropRight">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>100</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="accessibleName">
-          <string>Basic.TransformWindow.CropRight</string>
-         </property>
-         <property name="suffix">
-          <string> px</string>
-         </property>
-         <property name="maximum">
-          <number>100000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_9">
-         <property name="text">
-          <string>Left</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-         <property name="buddy">
-          <cstring>cropLeft</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="QLabel" name="label_12">
-         <property name="text">
-          <string>Bottom</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-         <property name="buddy">
-          <cstring>cropBottom</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QSpinBox" name="cropTop">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>100</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="accessibleName">
-          <string>Basic.TransformWindow.CropTop</string>
-         </property>
-         <property name="suffix">
-          <string> px</string>
-         </property>
-         <property name="maximum">
-          <number>100000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="3">
-        <widget class="QSpinBox" name="cropBottom">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>100</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>100</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="accessibleName">
-          <string>Basic.TransformWindow.CropBottom</string>
-         </property>
-         <property name="suffix">
-          <string> px</string>
-         </property>
-         <property name="maximum">
-          <number>100000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_11">
-         <property name="text">
-          <string>Top</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-         <property name="buddy">
-          <cstring>cropTop</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QLabel" name="label_10">
-         <property name="text">
-          <string>Right</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-         <property name="buddy">
-          <cstring>cropRight</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="4">
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-    </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <spacer name="transformSpacer">

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -144,7 +144,9 @@ void OBSBasicTransform::SetItemQt(OBSSceneItem newItem)
 	if (item)
 		RefreshControls();
 
-	setEnabled(!!item);
+	bool enable = !!item;
+	ui->container->setEnabled(enable);
+	ui->buttonBox->button(QDialogButtonBox::Reset)->setEnabled(enable);
 }
 
 void OBSBasicTransform::OBSChannelChanged(void *param, calldata_t *data)


### PR DESCRIPTION
### Description
If the user clicked away from the source, while the transform dialog is open, the whole dialog would be disabled. The user then couldn't click close or press escape to close the dialog. The only way for them to close it was to click on another source to re-enable it.

### Motivation and Context
Fixes bug I've found.

### How Has This Been Tested?
Click away from a source and made sure the dialog was closable.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
