### PR TITLE
UI: Connect Reset button in Transform menu with main window directly

### DIFF
--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -65,7 +65,8 @@ OBSBasicTransform::OBSBasicTransform(OBSSceneItem item, OBSBasic *parent)
 	ui->buttonBox->button(QDialogButtonBox::Close)->setDefault(true);
 
 	connect(ui->buttonBox->button(QDialogButtonBox::Reset),
-		SIGNAL(clicked()), this, SLOT(on_resetButton_clicked()));
+		&QPushButton::clicked, main,
+		&OBSBasic::on_actionResetTransform_triggered);
 
 	installEventFilter(CreateShortcutFilter());
 
@@ -340,11 +341,6 @@ void OBSBasicTransform::OnCropChanged()
 	ignoreTransformSignal = true;
 	obs_sceneitem_set_crop(item, &crop);
 	ignoreTransformSignal = false;
-}
-
-void OBSBasicTransform::on_resetButton_clicked()
-{
-	main->on_actionResetTransform_triggered();
 }
 
 template<typename T> static T GetOBSRef(QListWidgetItem *item)

--- a/UI/window-basic-transform.hpp
+++ b/UI/window-basic-transform.hpp
@@ -45,7 +45,6 @@ private slots:
 	void OnBoundsType(int index);
 	void OnControlChanged();
 	void OnCropChanged();
-	void on_resetButton_clicked();
 
 public:
 	OBSBasicTransform(OBSSceneItem item, OBSBasic *parent);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes the detour of going via an extra slot and connects the clicked signal of the reset button in the Edit Transform dialog to the main window directly.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Qt threw `QMetaObject::connectSlotsByName: No matching signal for on_resetButton_clicked` at us because the slot wasn't connected automatically. This made me sad.
I was going to just rename it (which would be a correct fix, the `on_foo_bar` names should only be used if the signal is (primarily) connected automatically), however I noticed that the slot function just called a slot of the main window. We can get rid of this complication by connecting directly.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested that "Reset" button in the Edit Transform menu still works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
