### PR TITLE
linux-jack: Prepend devices with "OBS Studio: "

### DIFF
--- a/plugins/linux-jack/jack-input.c
+++ b/plugins/linux-jack/jack-input.c
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "jack-wrapper.h"
 
 #include <obs-module.h>
+#include <util/dstr.h>
 
 /**
  * Returns the name of the plugin
@@ -76,8 +77,13 @@ static void jack_update(void *vptr, obs_data_t *settings)
 	if (!data->device || strcmp(data->device, new_device) != 0) {
 		if (data->device)
 			bfree(data->device);
-		data->device = bstrdup(new_device);
+		/* prefix all devices to make it clear that they belong to obs */
+		struct dstr device;
+		dstr_init(&device);
+		dstr_catf(&device, "OBS Studio: %s", new_device);
+		data->device = bstrdup(device.array);
 		settings_changed = true;
+		dstr_free(&device);
 	}
 
 	if (settings_changed) {


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Prepends all devices created by the jack input client source with "OBS Studio: ".

### Motivation and Context
This makes it more clear that the device belongs to OBS.
Fixes #7988

![screenshot](https://user-images.githubusercontent.com/8353672/210140694-49f359c9-2e9a-4651-9de0-fc2884b26ff2.png)

Since this changes the name of the clients this might impact existing setups that rely on the old device names without the prefix. 

### How Has This Been Tested?
- Created a Jack Input Client source
- Checked qpwgraph or any other patch bay for the prefix
- Exited obs and checked log to make sure there are no memory leaks

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
