### PR TITLE
UI: Add settings reset button

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -890,6 +890,8 @@ Basic.Settings.General.MultiviewLayout.4Scene="Scenes only (4 Scenes)"
 Basic.Settings.General.MultiviewLayout.9Scene="Scenes only (9 Scenes)"
 Basic.Settings.General.MultiviewLayout.16Scene="Scenes only (16 Scenes)"
 Basic.Settings.General.MultiviewLayout.25Scene="Scenes only (25 Scenes)"
+Basic.Settings.General.Reset.Title="Reset General Settings"
+Basic.Settings.General.Reset.Text="Are you sure you want to reset the general settings?"
 
 # default channel name translations
 Basic.Settings.General.ChannelName.stable="Stable"
@@ -923,6 +925,8 @@ Basic.Settings.Stream.Recommended.MaxVideoBitrate="Maximum Video Bitrate: %1 kbp
 Basic.Settings.Stream.Recommended.MaxAudioBitrate="Maximum Audio Bitrate: %1 kbps"
 Basic.Settings.Stream.Recommended.MaxResolution="Maximum Resolution: %1"
 Basic.Settings.Stream.Recommended.MaxFPS="Maximum FPS: %1"
+Basic.Settings.Stream.Reset.Title="Reset Stream Settings"
+Basic.Settings.Stream.Reset.Text="Are you sure you want to reset the stream settings?"
 
 # basic mode 'output' settings
 Basic.Settings.Output="Output"
@@ -990,6 +994,8 @@ Basic.Settings.Output.EncoderPreset.fast="%1 (high CPU usage, high quality)"
 Basic.Settings.Output.CustomEncoderSettings="Custom Encoder Settings"
 Basic.Settings.Output.CustomMuxerSettings="Custom Muxer Settings"
 Basic.Settings.Output.NoSpaceFileName="Generate File Name without Space"
+Basic.Settings.Output.Reset.Title="Reset Output Settings"
+Basic.Settings.Output.Reset.Text="Are you sure you want to reset the output settings?"
 
 # basic mode 'output' settings - advanced section
 Basic.Settings.Output.Adv.Rescale="Rescale Output"
@@ -1074,6 +1080,8 @@ Basic.Settings.Video.Denominator="Denominator"
 Basic.Settings.Video.Renderer="Renderer"
 Basic.Settings.Video.InvalidResolution="Invalid resolution value. Must be [width]x[height] (i.e. 1920x1080)"
 Basic.Settings.Video.CurrentlyActive="Video output is currently active. Please turn off any outputs to change video settings."
+Basic.Settings.Video.Reset.Title="Reset Video Settings"
+Basic.Settings.Video.Reset.Text="Are you sure you want to reset the video settings?"
 
 # scale filters
 Basic.Settings.Video.DownscaleFilter.Bilinear="Bilinear (Fastest, but blurry if scaling)"
@@ -1115,6 +1123,8 @@ Basic.Settings.Audio.LowLatencyBufferingWarning.Enabled="WARNING: Low latency au
 Basic.Settings.Audio.LowLatencyBufferingWarning="Low latency audio buffering mode may cause audio to glitch or stop playing from some sources."
 Basic.Settings.Audio.LowLatencyBufferingWarning.Title="Enable low latency audio buffering mode?"
 Basic.Settings.Audio.LowLatencyBufferingWarning.Confirm="Are you sure you want to enable low latency audio buffering mode?"
+Basic.Settings.Audio.Reset.Title="Reset Audio Settings"
+Basic.Settings.Audio.Reset.Text="Are you sure you want to reset the audio settings?"
 
 # basic mode 'accessibility' settings
 Basic.Settings.Accessibility="Accessibility"
@@ -1132,6 +1142,8 @@ Basic.Settings.Accessibility.ColorOverrides.Preset="Color Preset"
 Basic.Settings.Accessibility.ColorOverrides.Preset.Default="Default"
 Basic.Settings.Accessibility.ColorOverrides.Preset.Custom="Custom"
 Basic.Settings.Accessibility.ColorOverrides.Preset.ColorBlind1="Color Blind Alternative"
+Basic.Settings.Accessibility.Reset.Title="Reset Accessiblity Settings"
+Basic.Settings.Accessibility.Reset.Text="Are you sure you want to reset the accessiblity settings?"
 
 # basic mode 'advanced' settings
 Basic.Settings.Advanced="Advanced"
@@ -1183,6 +1195,8 @@ Basic.Settings.Advanced.Hotkeys.DisableHotkeysInFocus="Disable hotkeys when main
 Basic.Settings.Advanced.Hotkeys.DisableHotkeysOutOfFocus="Disable hotkeys when main window is not in focus"
 Basic.Settings.Advanced.AutoRemux="Automatically remux to %1"
 Basic.Settings.Advanced.AutoRemux.MP4="(record as mkv)"
+Basic.Settings.Advanced.Reset.Title="Reset Advanced Settings"
+Basic.Settings.Advanced.Reset.Text="Are you sure you want to reset the advanced settings?"
 
 # advanced audio properties
 Basic.AdvAudio="Advanced Audio Properties"
@@ -1210,6 +1224,8 @@ Basic.Settings.Hotkeys.Filter="Filter"
 Basic.Settings.Hotkeys.FilterByHotkey="Filter by Hotkey"
 Basic.Settings.Hotkeys.DuplicateWarning="This hotkey is shared by one or more other actions, click to show conflicts"
 Basic.Settings.Hotkeys.PleaseWait="Loading hotkeys, please wait..."
+Basic.Settings.Hotkeys.Reset.Title="Reset Hotkey Settings"
+Basic.Settings.Hotkeys.Reset.Text="Are you sure you want to reset the hotkey settings?"
 
 # basic mode hotkeys
 Basic.Hotkeys.SelectScene="Switch to scene"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -7517,7 +7517,7 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
      </property>
     </widget>
    </item>

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -424,6 +424,8 @@ bool OBSApp::InitGlobalConfigDefaults()
 {
 	config_set_default_string(globalConfig, "General", "Language",
 				  DEFAULT_LANG);
+	config_set_default_string(globalConfig, "General", "CurrentTheme3",
+				  DEFAULT_THEME);
 	config_set_default_uint(globalConfig, "General", "MaxLogs", 10);
 	config_set_default_int(globalConfig, "General", "InfoIncrement", -1);
 	config_set_default_string(globalConfig, "General", "ProcessPriority",

--- a/UI/window-basic-settings-a11y.cpp
+++ b/UI/window-basic-settings-a11y.cpp
@@ -51,15 +51,15 @@ void OBSBasicSettings::LoadA11ySettings(bool presetChange)
 	config_t *config = GetGlobalConfig();
 
 	if (!presetChange) {
-		preset = config_get_int(config, "Accessibility", "ColorPreset");
+		preset = GetInt(config, "Accessibility", "ColorPreset");
 
 		bool block = ui->colorPreset->blockSignals(true);
 		ui->colorPreset->setCurrentIndex(std::min(
 			preset, (uint32_t)ui->colorPreset->count() - 1));
 		ui->colorPreset->blockSignals(block);
 
-		bool checked = config_get_bool(config, "Accessibility",
-					       "OverrideColors");
+		bool checked =
+			GetBool(config, "Accessibility", "OverrideColors");
 
 		ui->colorsGroupBox->setChecked(checked);
 	}
@@ -85,25 +85,20 @@ void OBSBasicSettings::LoadA11ySettings(bool presetChange)
 	} else if (preset == COLOR_PRESET_CUSTOM) {
 		SetDefaultColors();
 
-		selectRed =
-			config_get_int(config, "Accessibility", "SelectRed");
-		selectGreen =
-			config_get_int(config, "Accessibility", "SelectGreen");
-		selectBlue =
-			config_get_int(config, "Accessibility", "SelectBlue");
+		selectRed = GetInt(config, "Accessibility", "SelectRed");
+		selectGreen = GetInt(config, "Accessibility", "SelectGreen");
+		selectBlue = GetInt(config, "Accessibility", "SelectBlue");
 
-		mixerGreen =
-			config_get_int(config, "Accessibility", "MixerGreen");
-		mixerYellow =
-			config_get_int(config, "Accessibility", "MixerYellow");
-		mixerRed = config_get_int(config, "Accessibility", "MixerRed");
+		mixerGreen = GetInt(config, "Accessibility", "MixerGreen");
+		mixerYellow = GetInt(config, "Accessibility", "MixerYellow");
+		mixerRed = GetInt(config, "Accessibility", "MixerRed");
 
-		mixerGreenActive = config_get_int(config, "Accessibility",
-						  "MixerGreenActive");
-		mixerYellowActive = config_get_int(config, "Accessibility",
-						   "MixerYellowActive");
-		mixerRedActive = config_get_int(config, "Accessibility",
-						"MixerRedActive");
+		mixerGreenActive =
+			GetInt(config, "Accessibility", "MixerGreenActive");
+		mixerYellowActive =
+			GetInt(config, "Accessibility", "MixerYellowActive");
+		mixerRedActive =
+			GetInt(config, "Accessibility", "MixerRedActive");
 	}
 
 	UpdateA11yColors();

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -117,6 +117,7 @@ private:
 	bool hotkeysChanged = false;
 	bool a11yChanged = false;
 	bool advancedChanged = false;
+	bool resetDefaults = false;
 	int pageIndex = 0;
 	bool loading = true;
 	bool forceAuthReload = false;
@@ -375,6 +376,10 @@ private:
 	bool ServiceAndCodecCompatible();
 	bool ServiceSupportsCodecCheck();
 
+	void ResetHotkeys();
+	bool ConfirmReset(int index);
+	void ResetToDefaults();
+
 private slots:
 	void on_theme_activated(int idx);
 
@@ -476,4 +481,13 @@ public:
 	{
 		return hotkeyConflictIcon;
 	}
+
+	const char *GetString(config_t *config, const char *section,
+			      const char *name);
+	int GetInt(config_t *config, const char *section, const char *name);
+	uint32_t GetUint(config_t *config, const char *section,
+			 const char *name);
+	bool GetBool(config_t *config, const char *section, const char *name);
+	double GetDouble(config_t *config, const char *section,
+			 const char *name);
 };


### PR DESCRIPTION
### Description
This adds a reset button in the settings dialog to reset the current tab to its default settings.

![Screenshot from 2023-02-16 15-13-55](https://user-images.githubusercontent.com/19962531/219488343-bdb226b6-7c44-4f92-a92b-7505a0171aa9.png)

### Motivation and Context
Currently there is no way to reset the settings to defaults.

### How Has This Been Tested?
Clicked the reset button to make sure the settings were set to the defaults.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
