### PR TITLE
pipewire: calc spa buffer size

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -144,6 +144,41 @@ static void update_pw_versions(obs_pipewire *obs_pw, const char *version)
 		blog(LOG_WARNING, "[pipewire] failed to parse server version");
 }
 
+static uint32_t calc_spa_enumformat_buffer_size(obs_pipewire *obs_pw)
+{
+	// from spa/pod/pod.h
+	uint32_t spa_pod_object_size = sizeof(struct spa_pod_object);
+	uint32_t spa_pod_prop_size = sizeof(struct spa_pod_prop);
+	uint32_t spa_pod_value_size = 1 * sizeof(uint64_t);
+	uint32_t spa_pod_choice_size = 2 * sizeof(uint64_t);
+	// This is counted from the build_format function
+	uint32_t n_objects = 0;
+	uint32_t n_props = 0;
+	uint32_t n_values = 0;
+	uint32_t n_choices = 0;
+	uint32_t size;
+
+	for (size_t i = 0; i < obs_pw->format_info.num; i++) {
+		if (obs_pw->format_info.array[i].modifiers.num == 0)
+			continue;
+		n_objects += 1;
+		n_props += 5 + 1;
+		n_values += 9 + 2 + obs_pw->format_info.array[i].modifiers.num;
+		n_choices += 2 + 1;
+	}
+	for (size_t i = 0; i < obs_pw->format_info.num; i++) {
+		n_objects += 1;
+		n_props += 5;
+		n_values += 9;
+		n_choices += 2;
+	}
+	size = n_objects * spa_pod_object_size + n_props * spa_pod_prop_size +
+	       n_values * spa_pod_value_size + n_choices * spa_pod_choice_size;
+	blog(LOG_DEBUG, "[pipewire]: calculated spa enumFormat buffer size %u",
+	     size);
+	return size;
+}
+
 static void teardown_pipewire(obs_pipewire *obs_pw)
 {
 	if (obs_pw->thread_loop) {
@@ -408,6 +443,10 @@ static bool build_format_params(obs_pipewire *obs_pw,
 			obs_pw->format_info.array[i].spa_format,
 			obs_pw->format_info.array[i].modifiers.array,
 			obs_pw->format_info.array[i].modifiers.num);
+		if (!params[params_count - 1]) {
+			blog(LOG_ERROR, "[pipewire] Failed to format param");
+			return false;
+		}
 	}
 
 build_shm:
@@ -415,6 +454,10 @@ build_shm:
 		params[params_count++] = build_format(
 			pod_builder, &obs_pw->video_info,
 			obs_pw->format_info.array[i].spa_format, NULL, 0);
+		if (!params[params_count - 1]) {
+			blog(LOG_ERROR, "[pipewire] Failed to format param");
+			return false;
+		}
 	}
 	*param_list = params;
 	*n_params = params_count;
@@ -521,7 +564,7 @@ static void renegotiate_format(void *data, uint64_t expirations)
 
 	pw_thread_loop_lock(obs_pw->thread_loop);
 
-	uint8_t params_buffer[2048];
+	uint8_t params_buffer[calc_spa_enumformat_buffer_size(obs_pw)];
 	struct spa_pod_builder pod_builder =
 		SPA_POD_BUILDER_INIT(params_buffer, sizeof(params_buffer));
 	uint32_t n_params;
@@ -970,7 +1013,7 @@ void obs_pipewire_connect_stream(obs_pipewire *obs_pw, int pipewire_node,
 	struct spa_pod_builder pod_builder;
 	const struct spa_pod **params = NULL;
 	uint32_t n_params;
-	uint8_t params_buffer[2048];
+	uint8_t params_buffer[calc_spa_enumformat_buffer_size(obs_pw)];
 
 	pw_thread_loop_lock(obs_pw->thread_loop);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Calculate dynamically the size for the PipeWire params.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Modern GPUs might support a lot of modifiers. As such the hardcoded size for the ENUM_Formats PipeWire params are not enough and we should calculate the required size manually.

Added logs if a ENUM_Format can't be assembled, which happens when the buffer size was not large enough.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Start a screencast. If the buffer is to small for all formats, it will quit it.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
