### PR TITLE
UI, obs-ffmpeg: Set audio track titles for FFmpeg Output

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1984,8 +1984,25 @@ inline void AdvancedOutput::SetupFFmpeg()
 		config_get_int(main->Config(), "AdvOut", "FFAEncoderId");
 	const char *aEncCustom =
 		config_get_string(main->Config(), "AdvOut", "FFACustom");
+
+	OBSDataArrayAutoRelease audio_names = obs_data_array_create();
+
+	for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
+		string cfg_name = "Track";
+		cfg_name += to_string((int)i + 1);
+		cfg_name += "Name";
+
+		const char *audioName = config_get_string(
+			main->Config(), "AdvOut", cfg_name.c_str());
+
+		OBSDataAutoRelease item = obs_data_create();
+		obs_data_set_string(item, "name", audioName);
+		obs_data_array_push_back(audio_names, item);
+	}
+
 	OBSDataAutoRelease settings = obs_data_create();
 
+	obs_data_set_array(settings, "audio_names", audio_names);
 	obs_data_set_string(settings, "url", url);
 	obs_data_set_string(settings, "format_name", formatName);
 	obs_data_set_string(settings, "format_mime_type", mimeType);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.h
@@ -27,6 +27,7 @@ struct ffmpeg_cfg {
 	const char *audio_settings;
 	int audio_mix_count;
 	int audio_tracks;
+	const char *audio_stream_names[MAX_AUDIO_MIXES];
 	enum AVPixelFormat format;
 	enum AVColorRange color_range;
 	enum AVColorPrimaries color_primaries;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

1. Set audio tracks name to `settings` when setup FFmpeg output
2. Add `const char *audio_stream_names[MAX_AUDIO_MIXES]` member to `struct ffmpeg_cfg`.
3. Set *tracks name* from step1 `settings` to (`struct ffmpeg_cfg`) `config`.
4. Set *tracks name* in `config` to FFmpeg *stream metadata* `title` when valid(not null) via `av_dict_set`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

fixes #7658 
same as Standard Recording
set audio stream title via `av_dict_set` *title* in `ffmpeg-mux` via command-line
https://github.com/obsproject/obs-studio/blob/c648222332d1a7ce7ea55fd14fbe514a5f258f33/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c#L538

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Win10, latest OBS
via VLC

- audio mux 1,2,3,4

**SETTINGS** audio track names[1-4]:
mux, desk, mic, [empty]
before:
![before-Screenshot 2023-02-19 155636](https://user-images.githubusercontent.com/30559085/219936817-0c79b381-5d73-4406-b69f-5b5c49f81ea8.jpg)

after:
![after-Screenshot 2023-02-19 155142](https://user-images.githubusercontent.com/30559085/219936822-66d02559-934e-4397-9435-ad6d070966c0.jpg)

- audio mux 1,4,5

**SETTINGS** audio track names[1-5]:
mux, desk, mic, track4, track5

![145-Screenshot 2023-02-19 160249](https://user-images.githubusercontent.com/30559085/219936841-890c616f-5c79-4c35-a84a-decf7e458f38.jpg)


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

 - Bug fix (non-breaking change which fixes an issue) 
 - New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
