### PR TITLE
UI: Don't double-delete children of deleted widgets

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -577,14 +577,11 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	ui->advOutFFABitrate->setSuffix(" Kbps");
 
 #if !defined(_WIN32) && !defined(__APPLE__)
-	delete ui->enableAutoUpdates;
-	ui->enableAutoUpdates = nullptr;
-	delete ui->updateChannelBox;
-	ui->updateChannelBox = nullptr;
 	delete ui->updateSettingsGroupBox;
 	ui->updateSettingsGroupBox = nullptr;
-	delete ui->updateChannelLabel;
 	ui->updateChannelLabel = nullptr;
+	ui->updateChannelBox = nullptr;
+	ui->enableAutoUpdates = nullptr;
 #else
 	// Hide update section if disabled
 	if (App()->IsUpdaterDisabled())


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

These widgets are all children of updateSettingsGroupBox, meaning they get deleted when updateSettingsGroupBox gets deleted. This means that the first two calls are unnecessary and the third one segfaults as updateChannelLabel is gone already.
Just delete the parent widget instead.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed by @fzwoch in https://github.com/obsproject/obs-studio/commit/12a27d8b99473d00d8939a78601c3ebcd6b2a2a9#r101210111.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Hasn't.
But should work according to my knowledge of Qt and also it can't get any worse than segfaulting.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
