### PR TITLE
UI: Support platform-specific WhatsNew entries

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2194,6 +2194,20 @@ void OBSBasic::ReceivedIntroJson(const QString &text)
 	/* check to see if there's an info page for this version */
 	const Json::array &items = json.array_items();
 	for (const Json &item : items) {
+		if (item["os"].is_object()) {
+			Json::object platforms = item["os"].object_items();
+#ifdef _WIN32
+			if (!platforms["windows"].bool_value())
+				continue;
+#elif defined(__APPLE__)
+			if (!platforms["macos"].bool_value())
+				continue;
+#else
+			if (!platforms["linux"].bool_value())
+				continue;
+#endif
+		}
+
 		const std::string &version = item["version"].string_value();
 		const std::string &url = item["url"].string_value();
 		int increment = item["increment"].int_value();


### PR DESCRIPTION
### Description

Adds support for targeting specific platforms with WhatsNew entries, e.g. in case an issue or feature only applies to one or multiple but not all.

It adds a simple `os` object that can be added to each entry. If `os` is unspecified, an entry is assumed to be OS-agnostic. If an OS is ommited from the list it is implicitly assumed to be `false`.

Example:
```diff
[
  {
    "version": "29.0.0",
    "url": "https://obsproject.com/startup/hypothetical-windows-issue",
    "increment": 2,
+   "os": {
+     "windows": true,
+     "macos": false
+   }
  }
]
```

### Motivation and Context

Without this we'd rely on users reading comprehension, which is a bad idea.

### How Has This Been Tested?

Tested whatsnew files with various combinations, verified the notification only shows when it should.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
