### PR TITLE
UI: Fix editableList inherits background-color of the group

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -273,6 +273,10 @@ OBSBasicSettings #PropertiesContainer {
     background-color: palette(dark);
 }
 
+#PropertiesContainer QListWidget {
+    background-color: palette(button);
+}
+
 /* Dock Widget */
 OBSDock > QWidget {
     background: palette(dark);

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -273,6 +273,10 @@ OBSBasicSettings #PropertiesContainer {
     background-color: palette(dark);
 }
 
+#PropertiesContainer QListWidget {
+    background-color: palette(button);
+}
+
 /* Dock Widget */
 OBSDock > QWidget {
     background: palette(dark);

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -273,6 +273,10 @@ OBSBasicSettings #PropertiesContainer {
     background-color: palette(dark);
 }
 
+#PropertiesContainer QListWidget {
+    background-color: palette(button);
+}
+
 /* Dock Widget */
 OBSDock > QWidget {
     background: palette(dark);

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -277,6 +277,10 @@ OBSBasicSettings #PropertiesContainer {
     background-color: palette(dark);
 }
 
+#PropertiesContainer QListWidget {
+    background-color: palette(button);
+}
+
 /* Dock Widget */
 OBSDock > QWidget {
     background: palette(dark);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

In the Yami theme, when a ediableList (`QlistWidget`) inside a `QGroupBox`, the background color are same, not easy to distinguish.

So change the `QListWidget` background color to other (*the comboBox background color*).

after:
Yami
![Screenshot 2023-02-20 111930](https://user-images.githubusercontent.com/30559085/220005102-575da139-d357-4151-8286-68cef37ca6b1.jpg)

light:
![light-Screenshot 2023-02-21 003335](https://user-images.githubusercontent.com/30559085/220161541-c70daf2c-d20f-4f15-ae21-1a9297cdf6b7.jpg)

grey:
![Grey-Screenshot 2023-02-21 003300](https://user-images.githubusercontent.com/30559085/220161579-c28a148b-7d19-4b46-8036-7bf6efba31f0.jpg)

acri:
![Acri-Screenshot 2023-02-21 003223](https://user-images.githubusercontent.com/30559085/220161611-5b07e006-7d9e-4ae0-a2cf-f60203ff644c.jpg)



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

fixes #8302 

the background-color of `QListWidget`(`QAbstractItemView`) same to `QGroupBox` and `PropertiesContainer`

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Win10
Just rebuild and look at the background changes.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
