### PR TITLE
UI: Scroll source list to top when adding source

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -1160,6 +1160,19 @@ void SourceTree::SelectItem(obs_sceneitem_t *sceneitem, bool select)
 				      : QItemSelectionModel::Deselect);
 }
 
+QModelIndex SourceTree::FindIndexByItem(OBSSceneItem item)
+{
+	SourceTreeModel *stm = GetStm();
+	int i = 0;
+
+	for (; i < stm->items.count(); i++) {
+		if (stm->items[i] == item)
+			break;
+	}
+
+	return stm->createIndex(i, 0);
+}
+
 Q_DECLARE_METATYPE(OBSSceneItem);
 
 void SourceTree::mouseDoubleClickEvent(QMouseEvent *event)

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -198,6 +198,8 @@ public:
 	void UpdateIcons();
 	void SetIconsVisible(bool visible);
 
+	QModelIndex FindIndexByItem(OBSSceneItem item);
+
 public slots:
 	inline void ReorderItems() { GetStm()->ReorderItems(); }
 	inline void RefreshItems() { GetStm()->SceneChanged(); }

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3000,8 +3000,16 @@ void OBSBasic::AddSceneItem(OBSSceneItem item)
 {
 	obs_scene_t *scene = obs_sceneitem_get_scene(item);
 
-	if (GetCurrentScene() == scene)
+	if (GetCurrentScene() == scene) {
 		ui->sources->Add(item);
+
+		if (!disableSaving) {
+			QModelIndex idx = ui->sources->FindIndexByItem(item);
+
+			if (idx.isValid())
+				ui->sources->scrollTo(idx);
+		}
+	}
 
 	SaveProject();
 


### PR DESCRIPTION
### Description
If the source list is scrolled to the bottom, and a source is added, the user has to scroll all the way to the top to see the new source. This automatically scrolls the list to the top.

### Motivation and Context
Users might not know the new source is added, if they are scrolled to the bottom of the list.

### How Has This Been Tested?
Added new source to make sure the source list scrolled to the top.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
