### PR TITLE
rtmp-services: Added Enchant.events to service list

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v4",
-    "version": 218,
+    "version": 219,
     "files": [
         {
             "name": "services.json",
-            "version": 218
+            "version": 219
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2523,6 +2523,24 @@
             "recommended": {
                 "keyint": 2
             }
+        },
+        {
+            "name": "Enchant.events",
+            "more_info_link": "https://docs.enchant.events/knowledge-base-y4pOb",
+            "supported video codecs": ["h264"],
+            "supported audio codecs": ["aac"],
+            "servers": [
+                {
+                    "name": "Primary RTMPS",
+                    "url": "rtmps://stream.enchant.cloud:443/live"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "profile": "high",
+                "max video bitrate": 9000,
+                "max audio bitrate": 192
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
Added a new service, Enchant.events, to the rtmp-services list.

### Motivation and Context
Help users to connect to Enchant easier.

### How Has This Been Tested?
Tried on a local build and confirmed working.

### Types of changes
Incremented version on rtmp-services/data/package.json
Added service info to rtmp-services/data/services.json

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
