### PR TITLE
UI: Defer creation of hotkey dupe icon until needed

### DIFF
--- a/UI/hotkey-edit.cpp
+++ b/UI/hotkey-edit.cpp
@@ -184,7 +184,13 @@ void OBSHotkeyEdit::ClearKey()
 
 void OBSHotkeyEdit::UpdateDuplicationState()
 {
-	if (dupeIcon && dupeIcon->isVisible() != hasDuplicate) {
+	if (!dupeIcon && !hasDuplicate)
+		return;
+
+	if (!dupeIcon)
+		CreateDupeIcon();
+
+	if (dupeIcon->isVisible() != hasDuplicate) {
 		dupeIcon->setVisible(hasDuplicate);
 		update();
 	}

--- a/UI/hotkey-edit.hpp
+++ b/UI/hotkey-edit.hpp
@@ -74,7 +74,6 @@ public:
 		setAttribute(Qt::WA_InputMethodEnabled, false);
 		setAttribute(Qt::WA_MacShowFocusRect, true);
 		InitSignalHandler();
-		CreateDupeIcon();
 		ResetKey();
 	}
 	OBSHotkeyEdit(QWidget *parent = nullptr)
@@ -102,7 +101,7 @@ public:
 
 protected:
 	OBSSignal layoutChanged;
-	QAction *dupeIcon;
+	QAction *dupeIcon = nullptr;
 
 	void InitSignalHandler();
 	void CreateDupeIcon();


### PR DESCRIPTION
### Description

Avoid creating the icon when not necessary.

### Motivation and Context

Shaves off a couple seconds when loading hotkeys for large scene collections.

### How Has This Been Tested?

Compared profiler results when loading hotkeys. It was slightly faster.

### Types of changes

- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
