### PR TITLE
UI: Set QT_NO_SUBTRACTOPAQUESIBLINGS env var 

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2329,6 +2329,13 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 #endif
 #endif
 
+	/* NOTE: This disables an optimisation in Qt that attempts to determine if
+	 * any "siblings" intersect with a widget when determining the approximate
+	 * visible/unobscured area. However, by Qt's own admission this is slow
+	 * and in the case of OBS it significantly slows down lists with many
+	 * elements (e.g. Hotkeys) and it is actually faster to disable it. */
+	qputenv("QT_NO_SUBTRACTOPAQUESIBLINGS", "1");
+
 	OBSApp program(argc, argv, profilerNameStore.get());
 	try {
 		QAccessible::installFactory(accessibleFactory);


### PR DESCRIPTION
### Description

This feels like a dirty hack, and it probably is, but it doesn't seem to break anything (as far as I tested).

The function in Qt this effectively disables is annotated with `this is too expensive !!!` - they're right about that one!

### Motivation and Context

Make hotkeys faster for large scene collections.

### How Has This Been Tested?

Checked with profiler. This function used to be the single slowest thing and now it's gone.

For my favourite stress test (`Massive.json`) this speeds up loading the hotkeys list by eleminating most of the time the UI would spend unresponsive *after* it has finished creating all the widgets (creating the widgets itself is still slow tho).

### Types of changes

- Performance enhancement (non-breaking change which improves efficiency) 

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
