### PR TITLE
Add Linux QSV Implementation

### DIFF
--- a/CI/linux/01_install_dependencies.sh
+++ b/CI/linux/01_install_dependencies.sh
@@ -93,13 +93,14 @@ install_dependencies() {
          libswscale-dev libx264-dev libcurl4-openssl-dev libmbedtls-dev libgl1-mesa-dev libjansson-dev \
          libluajit-5.1-dev python3-dev libx11-dev libxcb-randr0-dev libxcb-shm0-dev libxcb-xinerama0-dev \
          libxcb-composite0-dev libxinerama-dev libxcb1-dev libx11-xcb-dev libxcb-xfixes0-dev swig libcmocka-dev \
-         libpci-dev libxss-dev libglvnd-dev libgles2-mesa libgles2-mesa-dev libwayland-dev libxkbcommon-dev"
+         libpci-dev libxss-dev libglvnd-dev libgles2-mesa libgles2-mesa-dev libwayland-dev \
+         libxkbcommon-dev"
         "qt5-deps qtbase5-dev qtbase5-private-dev libqt5svg5-dev qtwayland5"
         "qt6-deps qt6-base-dev qt6-base-private-dev libqt6svg6-dev qt6-wayland"
         "cef ${LINUX_CEF_BUILD_VERSION:-${CI_LINUX_CEF_VERSION}}"
         "plugin-deps libasound2-dev libfdk-aac-dev libfontconfig-dev libfreetype6-dev libjack-jackd2-dev \
          libpulse-dev libsndio-dev libspeexdsp-dev libudev-dev libv4l-dev libva-dev libvlc-dev libdrm-dev \
-         nlohmann-json3-dev libwebsocketpp-dev libasio-dev"
+         nlohmann-json3-dev libwebsocketpp-dev libasio-dev libvpl-dev"
     )
 
     sudo apt-get -qq update

--- a/CI/linux/02_build_obs.sh
+++ b/CI/linux/02_build_obs.sh
@@ -53,6 +53,10 @@ _configure_obs() {
         PIPEWIRE_OPTION="-DENABLE_PIPEWIRE=OFF"
     fi
 
+    if [ "${DISABLE_QSV}" ]; then
+        QSV_OPTION="-DENABLE_QSV11=OFF"
+    fi
+
     cmake -S . -B ${BUILD_DIR} -G Ninja \
         -DCEF_ROOT_DIR="${DEPS_BUILD_DIR}/cef_binary_${LINUX_CEF_BUILD_VERSION:-${CI_LINUX_CEF_VERSION}}_linux64" \
         -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} \
@@ -61,6 +65,7 @@ _configure_obs() {
         -DENABLE_NEW_MPEGTS_OUTPUT=OFF \
         -DENABLE_WEBRTC=OFF \
         ${PIPEWIRE_OPTION} \
+        ${QSV_OPTION} \
         ${YOUTUBE_OPTIONS} \
         ${TWITCH_OPTIONS} \
         ${RESTREAM_OPTIONS} \
@@ -116,6 +121,7 @@ build-obs-main() {
                 -v | --verbose ) export VERBOSE=TRUE; shift ;;
                 -p | --portable ) export PORTABLE=TRUE; shift ;;
                 --disable-pipewire ) DISABLE_PIPEWIRE=TRUE; shift ;;
+                --disable-qsv ) DISABLE_QSV=TRUE; shift ;;
                 --build-dir ) BUILD_DIR="${2}"; shift 2 ;;
                 -- ) shift; break ;;
                 * ) break ;;

--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -839,10 +839,12 @@ void OBSBasic::CheckForSimpleModeX264Fallback()
 	while (obs_enum_encoder_types(idx++, &id)) {
 		if (strcmp(id, "amd_amf_h264") == 0)
 			amd_supported = true;
+#ifdef _WIN32
 		else if (strcmp(id, "obs_qsv11") == 0)
 			qsv_supported = true;
 		else if (strcmp(id, "obs_qsv11_av1") == 0)
 			qsv_av1_supported = true;
+#endif
 		else if (strcmp(id, "ffmpeg_nvenc") == 0)
 			nve_supported = true;
 #ifdef ENABLE_HEVC

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -1652,6 +1652,7 @@ void OBSBasicSettings::ResetEncoders(bool streamOnly)
 
 	ui->simpleOutStrEncoder->addItem(ENCODER_STR("Software"),
 					 QString(SIMPLE_ENCODER_X264));
+#ifdef _WIN32
 	if (service_supports_encoder(vcodecs, "obs_qsv11"))
 		ui->simpleOutStrEncoder->addItem(
 			ENCODER_STR("Hardware.QSV.H264"),
@@ -1660,6 +1661,7 @@ void OBSBasicSettings::ResetEncoders(bool streamOnly)
 		ui->simpleOutStrEncoder->addItem(
 			ENCODER_STR("Hardware.QSV.AV1"),
 			QString(SIMPLE_ENCODER_QSV_AV1));
+#endif
 	if (service_supports_encoder(vcodecs, "ffmpeg_nvenc"))
 		ui->simpleOutStrEncoder->addItem(
 			ENCODER_STR("Hardware.NVENC.H264"),

--- a/build-aux/com.obsproject.Studio.json
+++ b/build-aux/com.obsproject.Studio.json
@@ -81,7 +81,8 @@
                 "-DENABLE_RTMPS=ON",
                 "-DENABLE_VLC=OFF",
                 "-DENABLE_AJA=ON",
-                "-DENABLE_LIBFDK=ON"
+                "-DENABLE_LIBFDK=ON",
+                "-DENABLE_QSV11=OFF"
             ],
             "secret-opts": [
                 "-DRESTREAM_CLIENTID=$RESTREAM_CLIENTID",

--- a/cmake/Modules/FindVPL.cmake
+++ b/cmake/Modules/FindVPL.cmake
@@ -1,0 +1,47 @@
+# * Try to find libvpl
+#
+# Once done this will define
+#
+# VPL_FOUND - system has intel media sdk VPL_INCLUDE_DIRS - the intel media sdk include directory VPL_LIBRARIES - the
+# libraries needed to use intel media sdk VPL_DEFINITIONS - Compiler switches required for using intel media sdk
+
+# Use pkg-config to get the directories and then use these values in the find_path() and find_library() calls
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(_VPL vpl)
+endif()
+
+find_path(
+  VPL_INCLUDE_DIR
+  NAMES mfxstructures.h
+  HINTS ${_VPL_INCLUDE_DIRS} ${_VPL_INCLUDE_DIRS}
+  PATHS /usr/include /usr/local/include /opt/local/include /sw/include
+  PATH_SUFFIXES vpl/)
+
+find_library(
+  VPL_LIB
+  NAMES ${_VPL_LIBRARIES} ${_VPL_LIBRARIES} vpl
+  HINTS ${_VPL_LIBRARY_DIRS} ${_VPL_LIBRARY_DIRS}
+  PATHS /usr/lib /usr/local/lib /opt/local/lib /sw/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(VPL REQUIRED_VARS VPL_LIB VPL_INCLUDE_DIR)
+mark_as_advanced(VPL_INCLUDE_DIR VPL_LIB)
+
+if(VPL_FOUND)
+  set(VPL_INCLUDE_DIRS ${VPL_INCLUDE_DIR})
+  set(VPL_LIBRARIES ${VPL_LIB})
+
+  if(NOT TARGET VPL::VPL)
+    if(IS_ABSOLUTE "${VPL_LIBRARIES}")
+      add_library(VPL::VPL UNKNOWN IMPORTED)
+      set_target_properties(VPL::VPL PROPERTIES IMPORTED_LOCATION "${VPL_LIBRARIES}")
+    else()
+      add_library(VPL::VPL INTERFACE IMPORTED)
+      set_target_properties(VPL::VPL PROPERTIES IMPORTED_LIBNAME "${VPL_LIBRARIES}")
+    endif()
+
+    set_target_properties(VPL::VPL PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${VPL_INCLUDE_DIRS}")
+  endif()
+endif()

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -153,6 +153,7 @@ elseif(OS_LINUX)
   add_subdirectory(vlc-video)
   add_subdirectory(sndio)
   add_subdirectory(obs-vst)
+  add_subdirectory(obs-qsv11)
 
   check_obs_browser()
 elseif(OS_FREEBSD)

--- a/plugins/obs-qsv11/CMakeLists.txt
+++ b/plugins/obs-qsv11/CMakeLists.txt
@@ -9,74 +9,14 @@ if(NOT ENABLE_QSV11)
   return()
 endif()
 
-add_library(libmfx INTERFACE)
-add_library(OBS::libmfx ALIAS libmfx)
-
-target_sources(
-  libmfx
-  INTERFACE # cmake-format: sortable
-            libmfx/include/mfx_critical_section.h
-            libmfx/include/mfx_dispatcher.h
-            libmfx/include/mfx_dispatcher_defs.h
-            libmfx/include/mfx_dispatcher_log.h
-            libmfx/include/mfx_driver_store_loader.h
-            libmfx/include/mfx_dxva2_device.h
-            libmfx/include/mfx_exposed_functions_list.h
-            libmfx/include/mfx_library_iterator.h
-            libmfx/include/mfx_load_dll.h
-            libmfx/include/mfx_load_plugin.h
-            libmfx/include/mfx_plugin_hive.h
-            libmfx/include/mfx_vector.h
-            libmfx/include/mfx_win_reg_key.h
-            libmfx/include/mfxaudio_exposed_functions_list.h
-            libmfx/include/msdk/include/mfxadapter.h
-            libmfx/include/msdk/include/mfxastructures.h
-            libmfx/include/msdk/include/mfxaudio++.h
-            libmfx/include/msdk/include/mfxaudio.h
-            libmfx/include/msdk/include/mfxcommon.h
-            libmfx/include/msdk/include/mfxdefs.h
-            libmfx/include/msdk/include/mfxjpeg.h
-            libmfx/include/msdk/include/mfxmvc.h
-            libmfx/include/msdk/include/mfxplugin++.h
-            libmfx/include/msdk/include/mfxplugin.h
-            libmfx/include/msdk/include/mfxsession.h
-            libmfx/include/msdk/include/mfxstructures.h
-            libmfx/include/msdk/include/mfxvideo++.h
-            libmfx/include/msdk/include/mfxvideo.h
-            libmfx/include/msdk/include/mfxvstructures.h
-            libmfx/src/main.cpp
-            libmfx/src/mfx_critical_section.cpp
-            libmfx/src/mfx_dispatcher.cpp
-            libmfx/src/mfx_dispatcher_log.cpp
-            libmfx/src/mfx_driver_store_loader.cpp
-            libmfx/src/mfx_dxva2_device.cpp
-            libmfx/src/mfx_function_table.cpp
-            libmfx/src/mfx_library_iterator.cpp
-            libmfx/src/mfx_load_dll.cpp
-            libmfx/src/mfx_load_plugin.cpp
-            libmfx/src/mfx_plugin_hive.cpp
-            libmfx/src/mfx_win_reg_key.cpp)
-
-target_include_directories(libmfx INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/libmfx/include/msdk/include"
-                                            "${CMAKE_CURRENT_SOURCE_DIR}/libmfx/include")
-
 add_library(obs-qsv11 MODULE)
 add_library(OBS::qsv11 ALIAS obs-qsv11)
 
 target_sources(
   obs-qsv11
   PRIVATE # cmake-format: sortable
-          bits/linux_defs.h
-          bits/windows_defs.h
-          common_directx11.cpp
-          common_directx11.h
-          common_directx9.cpp
-          common_directx9.h
           common_utils.cpp
           common_utils.h
-          common_utils_windows.cpp
-          device_directx9.cpp
-          device_directx9.h
           obs-qsv11-plugin-main.c
           obs-qsv11.c
           QSV_Encoder.cpp
@@ -84,29 +24,98 @@ target_sources(
           QSV_Encoder_Internal.cpp
           QSV_Encoder_Internal.h)
 
-configure_file(cmake/windows/obs-module.rc.in obs-qsv11.rc)
-target_sources(obs-qsv11 PRIVATE obs-qsv11.rc)
-
-target_compile_definitions(obs-qsv11 PRIVATE DX11_D3D)
-
-target_link_libraries(
-  obs-qsv11
-  PRIVATE OBS::libobs
-          OBS::libmfx
-          d3d9
-          d3d11
-          dxva2
-          dxgi
-          dxguid)
-
-add_subdirectory(obs-qsv-test)
+target_link_libraries(obs-qsv11 PRIVATE OBS::libobs)
 
 # cmake-format: off
 set_target_properties_obs(obs-qsv11 PROPERTIES FOLDER plugins/obs-qsv11 PREFIX "")
 # cmake-format: on
 
-get_target_property(target_sources libmfx SOURCES)
+if(OS_WINDOWS)
+  add_subdirectory(obs-qsv-test)
+
+  add_library(libmfx INTERFACE)
+  add_library(OBS::libmfx ALIAS libmfx)
+
+  target_sources(
+    libmfx
+    INTERFACE # cmake-format: sortable
+              libmfx/include/mfx_critical_section.h
+              libmfx/include/mfx_dispatcher.h
+              libmfx/include/mfx_dispatcher_defs.h
+              libmfx/include/mfx_dispatcher_log.h
+              libmfx/include/mfx_driver_store_loader.h
+              libmfx/include/mfx_dxva2_device.h
+              libmfx/include/mfx_exposed_functions_list.h
+              libmfx/include/mfx_library_iterator.h
+              libmfx/include/mfx_load_dll.h
+              libmfx/include/mfx_load_plugin.h
+              libmfx/include/mfx_plugin_hive.h
+              libmfx/include/mfx_vector.h
+              libmfx/include/mfx_win_reg_key.h
+              libmfx/include/mfxaudio_exposed_functions_list.h
+              libmfx/include/msdk/include/mfxadapter.h
+              libmfx/include/msdk/include/mfxastructures.h
+              libmfx/include/msdk/include/mfxaudio++.h
+              libmfx/include/msdk/include/mfxaudio.h
+              libmfx/include/msdk/include/mfxcommon.h
+              libmfx/include/msdk/include/mfxdefs.h
+              libmfx/include/msdk/include/mfxjpeg.h
+              libmfx/include/msdk/include/mfxmvc.h
+              libmfx/include/msdk/include/mfxplugin++.h
+              libmfx/include/msdk/include/mfxplugin.h
+              libmfx/include/msdk/include/mfxsession.h
+              libmfx/include/msdk/include/mfxstructures.h
+              libmfx/include/msdk/include/mfxvideo++.h
+              libmfx/include/msdk/include/mfxvideo.h
+              libmfx/include/msdk/include/mfxvstructures.h
+              libmfx/src/main.cpp
+              libmfx/src/mfx_critical_section.cpp
+              libmfx/src/mfx_dispatcher.cpp
+              libmfx/src/mfx_dispatcher_log.cpp
+              libmfx/src/mfx_driver_store_loader.cpp
+              libmfx/src/mfx_dxva2_device.cpp
+              libmfx/src/mfx_function_table.cpp
+              libmfx/src/mfx_library_iterator.cpp
+              libmfx/src/mfx_load_dll.cpp
+              libmfx/src/mfx_load_plugin.cpp
+              libmfx/src/mfx_plugin_hive.cpp
+              libmfx/src/mfx_win_reg_key.cpp)
+
+  target_include_directories(libmfx INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/libmfx/include/msdk/include"
+                                              "${CMAKE_CURRENT_SOURCE_DIR}/libmfx/include")
+  get_target_property(mfx_sources libmfx SOURCES)
+  list(FILTER mfx_sources INCLUDE REGEX ".*\\.(m|c[cp]?p?|swift)")
+  list(FILTER mfx_headers INCLUDE REGEX ".*\\.h(pp)?")
+  source_group("libmfx\\Source Files" FILES ${mfx_sources})
+  source_group("libmfx\\Header Files" FILES ${mfx_headers})
+
+  configure_file(cmake/windows/obs-module.rc.in obs-qsv11.rc)
+  target_sources(obs-qsv11 PRIVATE obs-qsv11.rc)
+
+  target_compile_definitions(obs-qsv11 PRIVATE DX11_D3D)
+
+  target_sources(
+    obs-qsv11
+    PRIVATE # cmake-format: sortable
+            common_directx11.cpp
+            common_directx11.h
+            common_directx9.cpp
+            common_directx9.h
+            common_utils_windows.cpp
+            device_directx9.cpp
+            device_directx9.h)
+
+  target_link_libraries(obs-qsv11 PRIVATE OBS::libmfx d3d9 d3d11 dxva2 dxgi dxguid)
+elseif(OS_LINUX)
+  find_package(VPL REQUIRED)
+
+  target_sources(obs-qsv11 PRIVATE common_utils_linux.cpp)
+
+  target_link_libraries(obs-qsv11 PRIVATE VPL::VPL)
+endif()
+
+get_target_property(target_sources obs-qsv11 SOURCES)
 list(FILTER target_sources INCLUDE REGEX ".*\\.(m|c[cp]?p?|swift)")
 list(FILTER target_headers INCLUDE REGEX ".*\\.h(pp)?")
-source_group("libmfx\\Source Files" FILES ${target_sources})
-source_group("libmfx\\Header Files" FILES ${target_headers})
+source_group("obs-qsv11\\Source Files" FILES ${target_sources})
+source_group("obs-qsv11\\Header Files" FILES ${target_headers})

--- a/plugins/obs-qsv11/QSV_Encoder.h
+++ b/plugins/obs-qsv11/QSV_Encoder.h
@@ -89,22 +89,11 @@ static const char *const qsv_latency_names[] = {"ultra-low", "low", "normal",
 						0};
 typedef struct qsv_t qsv_t;
 
-struct adapter_info {
-	bool is_intel;
-	bool is_dgpu;
-	bool supports_av1;
-	bool supports_hevc;
-};
-
 enum qsv_codec {
 	QSV_CODEC_AVC,
 	QSV_CODEC_AV1,
 	QSV_CODEC_HEVC,
 };
-
-#define MAX_ADAPTERS 10
-extern struct adapter_info adapters[MAX_ADAPTERS];
-extern size_t adapter_count;
 
 typedef struct {
 	mfxU16 nTargetUsage; /* 1 through 7, 1 being best quality and 7

--- a/plugins/obs-qsv11/QSV_Encoder.h
+++ b/plugins/obs-qsv11/QSV_Encoder.h
@@ -56,10 +56,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "mfxstructures.h"
-#include "mfxadapter.h"
+#include <mfxadapter.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -56,8 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "QSV_Encoder_Internal.h"
 #include "QSV_Encoder.h"
-#include "mfxastructures.h"
-#include "mfxvideo++.h"
+#include <mfxvideo++.h>
 #include <obs-module.h>
 
 #define do_log(level, format, ...) \
@@ -86,25 +85,36 @@ QSV_Encoder_Internal::QSV_Encoder_Internal(mfxIMPL &impl, mfxVersion &version,
 	mfxIMPL tempImpl;
 	mfxStatus sts;
 
+#if defined(_WIN32)
 	m_bUseD3D11 = true;
 	m_bD3D9HACK = true;
 	m_bUseTexAlloc = true;
 
 	tempImpl = impl | MFX_IMPL_VIA_D3D11;
+	const char *sImpl = "D3D11";
+#else
+	m_bUseTexAlloc = false;
+	tempImpl = impl | MFX_IMPL_VIA_VAAPI;
+	const char *sImpl = "VAAPI";
+#endif
 	sts = m_session.Init(tempImpl, &version);
 	if (sts == MFX_ERR_NONE) {
 		m_session.QueryVersion(&version);
 		m_session.Close();
 
-		blog(LOG_INFO, "\timpl:           D3D11\n"
-			       "\tsurf:           D3D11");
+		blog(LOG_INFO,
+		     "\timpl:           %s\n"
+		     "\tsurf:           %s",
+		     sImpl, m_bUseTexAlloc ? "Texture" : "SysMem");
 
 		m_impl = tempImpl;
 		m_ver = version;
 		return;
 	}
 
+#if defined(_WIN32)
 	// D3D11 failed at this point.
+	m_bUseD3D11 = false;
 	tempImpl = impl | MFX_IMPL_VIA_D3D9;
 	sts = m_session.Init(tempImpl, &version);
 	if (sts == MFX_ERR_NONE) {
@@ -118,6 +128,7 @@ QSV_Encoder_Internal::QSV_Encoder_Internal(mfxIMPL &impl, mfxVersion &version,
 		m_ver = version;
 		m_bUseD3D11 = false;
 	}
+#endif
 }
 
 QSV_Encoder_Internal::~QSV_Encoder_Internal()
@@ -130,6 +141,7 @@ mfxStatus QSV_Encoder_Internal::Open(qsv_param_t *pParams, enum qsv_codec codec)
 {
 	mfxStatus sts = MFX_ERR_NONE;
 
+#if defined(_WIN32)
 	if (m_bUseD3D11)
 		// Use D3D11 surface
 		sts = Initialize(m_impl, m_ver, &m_session, &m_mfxAllocator,
@@ -140,6 +152,9 @@ mfxStatus QSV_Encoder_Internal::Open(qsv_param_t *pParams, enum qsv_codec codec)
 				 &g_DX_Handle, false, true);
 	else
 		sts = Initialize(m_impl, m_ver, &m_session, NULL);
+#else
+	sts = Initialize(m_impl, m_ver, &m_session, NULL, NULL, false, false);
+#endif
 
 	MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
@@ -215,6 +230,8 @@ mfxStatus QSV_Encoder_Internal::InitParams(qsv_param_t *pParams,
 	if (codec == QSV_CODEC_HEVC)
 		m_mfxEncParams.mfx.LowPower = MFX_CODINGOPTION_OFF;
 
+#if defined(_WIN32)
+	// TODO: Why isn't LowPower coding supported on VAAPI backend.
 	enum qsv_cpu_platform qsv_platform = qsv_get_cpu_platform();
 	if ((m_isDGPU || qsv_platform >= QSV_CPU_PLATFORM_ICL ||
 	     qsv_platform == QSV_CPU_PLATFORM_UNKNOWN) &&
@@ -226,6 +243,7 @@ mfxStatus QSV_Encoder_Internal::InitParams(qsv_param_t *pParams,
 		    pParams->nRateControl == MFX_RATECONTROL_LA)
 			pParams->nRateControl = MFX_RATECONTROL_VBR;
 	}
+#endif
 
 	m_mfxEncParams.mfx.RateControlMethod = pParams->nRateControl;
 
@@ -322,6 +340,8 @@ mfxStatus QSV_Encoder_Internal::InitParams(qsv_param_t *pParams,
 		}
 	}
 
+#if defined(_WIN32)
+	// TODO: Ask about this one on VAAPI too.
 	memset(&m_ExtVideoSignalInfo, 0, sizeof(m_ExtVideoSignalInfo));
 	m_ExtVideoSignalInfo.Header.BufferId = MFX_EXTBUFF_VIDEO_SIGNAL_INFO;
 	m_ExtVideoSignalInfo.Header.BufferSz = sizeof(m_ExtVideoSignalInfo);
@@ -333,6 +353,7 @@ mfxStatus QSV_Encoder_Internal::InitParams(qsv_param_t *pParams,
 		pParams->TransferCharacteristics;
 	m_ExtVideoSignalInfo.MatrixCoefficients = pParams->MatrixCoefficients;
 	extendedBuffers.push_back((mfxExtBuffer *)&m_ExtVideoSignalInfo);
+#endif
 
 /* TODO: Ask Intel why this is MFX_ERR_UNSUPPORTED */
 #if 0
@@ -813,8 +834,9 @@ mfxStatus QSV_Encoder_Internal::Encode_tex(uint64_t ts, uint32_t tex_handle,
 	//copy to default surface directly
 	pSurface->Data.TimeStamp = ts;
 	if (m_bUseTexAlloc) {
+		// mfxU64 isn't consistent with stdint, requiring a cast to be multi-platform.
 		sts = simple_copytex(m_mfxAllocator.pthis, pSurface->Data.MemId,
-				     tex_handle, lock_key, next_key);
+				     tex_handle, lock_key, (mfxU64 *)next_key);
 		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 	}
 

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.h
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.h
@@ -54,8 +54,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
-#include "mfxastructures.h"
-#include "mfxvideo++.h"
+#include <mfxvideo++.h>
 #include "QSV_Encoder.h"
 #include "common_utils.h"
 

--- a/plugins/obs-qsv11/bits/linux_defs.h
+++ b/plugins/obs-qsv11/bits/linux_defs.h
@@ -6,4 +6,4 @@
 #define MSDK_FOPEN(FH, FN, M)           { FH=fopen(FN,M); }
 #define MSDK_SLEEP(X)                   { usleep(1000*(X)); }
 
-typedef timespec mfxTime;
+typedef struct timespec mfxTime;

--- a/plugins/obs-qsv11/cmake/legacy.cmake
+++ b/plugins/obs-qsv11/cmake/legacy.cmake
@@ -64,15 +64,8 @@ target_sources(
   obs-qsv11
   PRIVATE obs-qsv11.c
           obs-qsv11-plugin-main.c
-          common_directx9.cpp
-          common_directx9.h
-          common_directx11.cpp
-          common_directx11.h
           common_utils.cpp
           common_utils.h
-          common_utils_windows.cpp
-          device_directx9.cpp
-          device_directx9.h
           QSV_Encoder.cpp
           QSV_Encoder.h
           QSV_Encoder_Internal.cpp
@@ -80,27 +73,36 @@ target_sources(
           bits/linux_defs.h
           bits/windows_defs.h)
 
-target_link_libraries(
-  obs-qsv11
-  PRIVATE OBS::libobs
-          OBS::libmfx
-          d3d9
-          d3d11
-          dxva2
-          dxgi
-          dxguid)
-
-target_compile_definitions(obs-qsv11 PRIVATE DX11_D3D)
+target_link_libraries(obs-qsv11 PRIVATE OBS::libobs)
 
 if(OS_WINDOWS)
   add_subdirectory(obs-qsv-test)
 
+  target_compile_definitions(obs-qsv11 PRIVATE DX11_D3D)
+
   set(MODULE_DESCRIPTION "OBS QSV encoder")
   configure_file(${CMAKE_SOURCE_DIR}/cmake/bundle/windows/obs-module.rc.in obs-qsv11.rc)
 
-  target_sources(obs-qsv11 PRIVATE obs-qsv11.rc)
+  target_sources(
+    obs-qsv11
+    PRIVATE obs-qsv11.rc
+            common_directx9.cpp
+            common_directx9.h
+            common_directx11.cpp
+            common_directx11.h
+            common_utils_windows.cpp
+            device_directx9.cpp
+            device_directx9.h)
+
+  target_link_libraries(obs-qsv11 PRIVATE OBS::libmfx d3d9 d3d11 dxva2 dxgi dxguid)
 
   target_compile_definitions(obs-qsv11 PRIVATE UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS)
+elseif(OS_LINUX)
+  find_package(VPL REQUIRED)
+
+  target_sources(obs-qsv11 PRIVATE common_utils_linux.cpp)
+
+  target_link_libraries(obs-qsv11 PRIVATE VPL::VPL)
 endif()
 
 set_target_properties(obs-qsv11 PROPERTIES FOLDER "plugins/obs-qsv11")

--- a/plugins/obs-qsv11/common_utils.cpp
+++ b/plugins/obs-qsv11/common_utils.cpp
@@ -4,6 +4,9 @@
 // Utility functions, not directly tied to Intel Media SDK functionality
 //
 
+struct adapter_info adapters[MAX_ADAPTERS] = {0};
+size_t adapter_count = 0;
+
 void PrintErrString(int err, const char *filestr, int line)
 {
 	switch (err) {

--- a/plugins/obs-qsv11/common_utils.h
+++ b/plugins/obs-qsv11/common_utils.h
@@ -2,6 +2,9 @@
 
 #include <stdio.h>
 
+// Most of this file shouldnt be accessed from C.
+#ifdef __cplusplus
+
 #include <mfxvideo++.h>
 
 // =================================================================
@@ -143,4 +146,24 @@ void mfxGetTime(mfxTime *timestamp);
 
 //void mfxInitTime();  might need this for Windows
 double TimeDiffMsec(mfxTime tfinish, mfxTime tstart);
-extern "C" void util_cpuid(int cpuinfo[4], int flags);
+
+extern "C" {
+#endif // __cplusplus
+
+struct adapter_info {
+	bool is_intel;
+	bool is_dgpu;
+	bool supports_av1;
+	bool supports_hevc;
+};
+
+#define MAX_ADAPTERS 10
+extern struct adapter_info adapters[MAX_ADAPTERS];
+extern size_t adapter_count;
+
+void util_cpuid(int cpuinfo[4], int flags);
+void check_adapters(struct adapter_info *adapters, size_t *adapter_count);
+
+#ifdef __cplusplus
+}
+#endif

--- a/plugins/obs-qsv11/common_utils.h
+++ b/plugins/obs-qsv11/common_utils.h
@@ -2,7 +2,7 @@
 
 #include <stdio.h>
 
-#include "mfxvideo++.h"
+#include <mfxvideo++.h>
 
 // =================================================================
 // OS-specific definitions of types, macro, etc...

--- a/plugins/obs-qsv11/common_utils_linux.cpp
+++ b/plugins/obs-qsv11/common_utils_linux.cpp
@@ -1,7 +1,17 @@
 #include "common_utils.h"
+
 #include <time.h>
 #include <cpuid.h>
 #include <util/c99defs.h>
+#include <util/dstr.h>
+#include <va/va_drm.h>
+#include <va/va_str.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <dirent.h>
 
 mfxStatus simple_alloc(mfxHDL pthis, mfxFrameAllocRequest *request,
 		       mfxFrameAllocResponse *response)
@@ -97,4 +107,173 @@ extern "C" void util_cpuid(int cpuinfo[4], int level)
 	__get_cpuid(level, (unsigned int *)&cpuinfo[0],
 		    (unsigned int *)&cpuinfo[1], (unsigned int *)&cpuinfo[2],
 		    (unsigned int *)&cpuinfo[3]);
+}
+
+struct vaapi_device {
+	int fd;
+	VADisplay display;
+	const char *driver;
+};
+
+void vaapi_open(char *device_path, struct vaapi_device *device)
+{
+	int fd = open(device_path, O_RDWR);
+	if (fd < 0) {
+		return;
+	}
+
+	VADisplay display = vaGetDisplayDRM(fd);
+	if (!display) {
+		close(fd);
+		return;
+	}
+
+	// VA-API is noisy by default.
+	vaSetInfoCallback(display, nullptr, nullptr);
+	vaSetErrorCallback(display, nullptr, nullptr);
+
+	int major;
+	int minor;
+	if (vaInitialize(display, &major, &minor) != VA_STATUS_SUCCESS) {
+		vaTerminate(display);
+		close(fd);
+		return;
+	}
+
+	const char *driver = vaQueryVendorString(display);
+	if (strstr(driver, "Intel i965 driver") != nullptr) {
+		blog(LOG_WARNING,
+		     "Legacy intel-vaapi-driver detected, incompatible with QSV");
+		vaTerminate(display);
+		close(fd);
+		return;
+	}
+
+	device->fd = fd;
+	device->display = display;
+	device->driver = driver;
+}
+
+void vaapi_close(struct vaapi_device *device)
+{
+	vaTerminate(device->display);
+	close(device->fd);
+}
+
+static uint32_t vaapi_check_support(VADisplay display, VAProfile profile,
+				    VAEntrypoint entrypoint)
+{
+	bool ret = false;
+	VAConfigAttrib attrib[1];
+	attrib->type = VAConfigAttribRateControl;
+
+	VAStatus va_status =
+		vaGetConfigAttributes(display, profile, entrypoint, attrib, 1);
+
+	uint32_t rc = 0;
+	switch (va_status) {
+	case VA_STATUS_SUCCESS:
+		rc = attrib->value;
+		break;
+	case VA_STATUS_ERROR_UNSUPPORTED_PROFILE:
+	case VA_STATUS_ERROR_UNSUPPORTED_ENTRYPOINT:
+	default:
+		break;
+	}
+
+	return (rc & VA_RC_CBR || rc & VA_RC_CQP || rc & VA_RC_VBR);
+}
+
+bool vaapi_supports_h264(VADisplay display)
+{
+	bool ret = false;
+	ret |= vaapi_check_support(display, VAProfileH264ConstrainedBaseline,
+				   VAEntrypointEncSlice);
+	ret |= vaapi_check_support(display, VAProfileH264Main,
+				   VAEntrypointEncSlice);
+	ret |= vaapi_check_support(display, VAProfileH264High,
+				   VAEntrypointEncSlice);
+
+	if (!ret) {
+		ret |= vaapi_check_support(display,
+					   VAProfileH264ConstrainedBaseline,
+					   VAEntrypointEncSliceLP);
+		ret |= vaapi_check_support(display, VAProfileH264Main,
+					   VAEntrypointEncSliceLP);
+		ret |= vaapi_check_support(display, VAProfileH264High,
+					   VAEntrypointEncSliceLP);
+	}
+
+	return ret;
+}
+
+bool vaapi_supports_av1(VADisplay display)
+{
+	bool ret = false;
+	// Are there any devices with non-LowPower entrypoints?
+	ret |= vaapi_check_support(display, VAProfileAV1Profile0,
+				   VAEntrypointEncSlice);
+	ret |= vaapi_check_support(display, VAProfileAV1Profile0,
+				   VAEntrypointEncSliceLP);
+	return ret;
+}
+
+bool vaapi_supports_hevc(VADisplay display)
+{
+	bool ret = false;
+	ret |= vaapi_check_support(display, VAProfileHEVCMain,
+				   VAEntrypointEncSlice);
+	ret |= vaapi_check_support(display, VAProfileHEVCMain,
+				   VAEntrypointEncSliceLP);
+	return ret;
+}
+
+void check_adapters(struct adapter_info *adapters, size_t *adapter_count)
+{
+	struct dstr full_path;
+	struct dirent **namelist;
+	int no;
+	int adapter_idx;
+	const char *base_dir = "/dev/dri/";
+
+	dstr_init(&full_path);
+	if ((no = scandir(base_dir, &namelist, 0, alphasort)) > 0) {
+		for (int i = 0; i < no; i++) {
+			struct adapter_info *adapter;
+			struct dirent *dp;
+			struct vaapi_device device = {0};
+
+			dp = namelist[i];
+			if (strstr(dp->d_name, "renderD") == nullptr)
+				goto next_entry;
+
+			adapter_idx = atoi(&dp->d_name[7]) - 128;
+			if (adapter_idx >= (ssize_t)*adapter_count ||
+			    adapter_idx < 0)
+				goto next_entry;
+
+			*adapter_count = adapter_idx + 1;
+			dstr_copy(&full_path, base_dir);
+			dstr_cat(&full_path, dp->d_name);
+			vaapi_open(full_path.array, &device);
+			if (!device.display)
+				goto next_entry;
+
+			adapter = &adapters[adapter_idx];
+			adapter->is_intel = strstr(device.driver, "Intel") !=
+					    nullptr;
+			// This is currently only used for LowPower coding which is busted on VA-API anyway.
+			adapter->is_dgpu = false;
+			adapter->supports_av1 =
+				vaapi_supports_av1(device.display);
+			adapter->supports_hevc =
+				vaapi_supports_hevc(device.display);
+			vaapi_close(&device);
+
+		next_entry:
+			free(dp);
+		}
+		free(namelist);
+	}
+	dstr_free(&full_path);
 }

--- a/plugins/obs-qsv11/common_utils_linux.cpp
+++ b/plugins/obs-qsv11/common_utils_linux.cpp
@@ -1,0 +1,100 @@
+#include "common_utils.h"
+#include <time.h>
+#include <cpuid.h>
+#include <util/c99defs.h>
+
+mfxStatus simple_alloc(mfxHDL pthis, mfxFrameAllocRequest *request,
+		       mfxFrameAllocResponse *response)
+{
+	UNUSED_PARAMETER(pthis);
+	UNUSED_PARAMETER(request);
+	UNUSED_PARAMETER(response);
+	return MFX_ERR_UNSUPPORTED;
+}
+
+mfxStatus simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
+{
+	UNUSED_PARAMETER(pthis);
+	UNUSED_PARAMETER(mid);
+	UNUSED_PARAMETER(ptr);
+	return MFX_ERR_UNSUPPORTED;
+}
+
+mfxStatus simple_unlock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
+{
+	UNUSED_PARAMETER(pthis);
+	UNUSED_PARAMETER(mid);
+	UNUSED_PARAMETER(ptr);
+	return MFX_ERR_UNSUPPORTED;
+}
+
+mfxStatus simple_gethdl(mfxHDL pthis, mfxMemId mid, mfxHDL *handle)
+{
+	UNUSED_PARAMETER(pthis);
+	UNUSED_PARAMETER(mid);
+	UNUSED_PARAMETER(handle);
+	return MFX_ERR_UNSUPPORTED;
+}
+
+mfxStatus simple_free(mfxHDL pthis, mfxFrameAllocResponse *response)
+{
+	UNUSED_PARAMETER(pthis);
+	UNUSED_PARAMETER(response);
+	return MFX_ERR_UNSUPPORTED;
+}
+
+mfxStatus simple_copytex(mfxHDL pthis, mfxMemId mid, mfxU32 tex_handle,
+			 mfxU64 lock_key, mfxU64 *next_key)
+{
+	UNUSED_PARAMETER(pthis);
+	UNUSED_PARAMETER(mid);
+	UNUSED_PARAMETER(tex_handle);
+	UNUSED_PARAMETER(lock_key);
+	UNUSED_PARAMETER(next_key);
+	return MFX_ERR_UNSUPPORTED;
+}
+
+#if 0
+void ClearYUVSurfaceVMem(mfxMemId memId);
+void ClearRGBSurfaceVMem(mfxMemId memId);
+#endif
+
+// Initialize Intel Media SDK Session, device/display and memory manager
+mfxStatus Initialize(mfxIMPL impl, mfxVersion ver, MFXVideoSession *pSession,
+		     mfxFrameAllocator *pmfxAllocator, mfxHDL *deviceHandle,
+		     bool bCreateSharedHandles, bool dx9hack)
+{
+	UNUSED_PARAMETER(pmfxAllocator);
+	UNUSED_PARAMETER(deviceHandle);
+	UNUSED_PARAMETER(bCreateSharedHandles);
+	UNUSED_PARAMETER(dx9hack);
+	mfxStatus sts = MFX_ERR_NONE;
+
+	// Initialize Intel Media SDK Session
+	sts = pSession->Init(impl, &ver);
+	MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+	return sts;
+}
+
+// Release resources (device/display)
+void Release(){};
+
+void mfxGetTime(mfxTime *timestamp)
+{
+	clock_gettime(CLOCK_MONOTONIC, timestamp);
+}
+
+double TimeDiffMsec(mfxTime tfinish, mfxTime tstart)
+{
+	UNUSED_PARAMETER(tfinish);
+	UNUSED_PARAMETER(tstart);
+	//TODO, unused so far it seems
+	return 0.0;
+}
+
+extern "C" void util_cpuid(int cpuinfo[4], int level)
+{
+	__get_cpuid(level, (unsigned int *)&cpuinfo[0],
+		    (unsigned int *)&cpuinfo[1], (unsigned int *)&cpuinfo[2],
+		    (unsigned int *)&cpuinfo[3]);
+}

--- a/plugins/obs-qsv11/common_utils_windows.cpp
+++ b/plugins/obs-qsv11/common_utils_windows.cpp
@@ -9,7 +9,14 @@
 #include "common_directx9.h"
 #endif
 
+#include <util/windows/device-enum.h>
+#include <util/config-file.h>
+#include <util/platform.h>
+#include <util/pipe.h>
+#include <util/dstr.h>
+
 #include <intrin.h>
+#include <inttypes.h>
 
 /* =======================================================
  * Windows implementation of OS-specific utility functions
@@ -123,6 +130,88 @@ double TimeDiffMsec(mfxTime tfinish, mfxTime tstart)
 void util_cpuid(int cpuinfo[4], int flags)
 {
 	return __cpuid(cpuinfo, flags);
+}
+
+static bool enum_luids(void *param, uint32_t idx, uint64_t luid)
+{
+	struct dstr *cmd = (struct dstr *)param;
+	dstr_catf(cmd, " %" PRIx64, luid);
+	UNUSED_PARAMETER(idx);
+	return true;
+}
+
+void check_adapters(struct adapter_info *adapters, size_t *adapter_count)
+{
+	char *test_exe = os_get_executable_path_ptr("obs-qsv-test.exe");
+	struct dstr cmd = {0};
+	struct dstr caps_str = {0};
+	os_process_pipe_t *pp = nullptr;
+	config_t *config = nullptr;
+	const char *error = nullptr;
+	size_t config_adapter_count;
+
+	dstr_copy(&cmd, test_exe);
+	enum_graphics_device_luids(enum_luids, &cmd);
+
+	pp = os_process_pipe_create(cmd.array, "r");
+	if (!pp) {
+		blog(LOG_INFO, "Failed to launch the QSV test process I guess");
+		goto fail;
+	}
+
+	for (;;) {
+		char data[2048];
+		size_t len =
+			os_process_pipe_read(pp, (uint8_t *)data, sizeof(data));
+		if (!len)
+			break;
+
+		dstr_ncat(&caps_str, data, len);
+	}
+
+	if (dstr_is_empty(&caps_str)) {
+		blog(LOG_INFO, "Seems the QSV test subprocess crashed. "
+			       "Better there than here I guess. "
+			       "Let's just skip loading QSV then I suppose.");
+		goto fail;
+	}
+
+	if (config_open_string(&config, caps_str.array) != 0) {
+		blog(LOG_INFO, "Couldn't open QSV configuration string");
+		goto fail;
+	}
+
+	error = config_get_string(config, "error", "string");
+	if (error) {
+		blog(LOG_INFO, "Error querying QSV support: %s", error);
+		goto fail;
+	}
+
+	config_adapter_count = config_num_sections(config);
+
+	if (config_adapter_count < *adapter_count)
+		*adapter_count = config_adapter_count;
+
+	for (size_t i = 0; i < *adapter_count; i++) {
+		char section[16];
+		snprintf(section, sizeof(section), "%d", (int)i);
+
+		struct adapter_info *adapter = &adapters[i];
+		adapter->is_intel =
+			config_get_bool(config, section, "is_intel");
+		adapter->is_dgpu = config_get_bool(config, section, "is_dgpu");
+		adapter->supports_av1 =
+			config_get_bool(config, section, "supports_av1");
+		adapter->supports_hevc =
+			config_get_bool(config, section, "supports_hevc");
+	}
+
+fail:
+	config_close(config);
+	dstr_free(&caps_str);
+	dstr_free(&cmd);
+	os_process_pipe_destroy(pp);
+	bfree(test_exe);
 }
 
 /* (Lain) Functions currently unused */

--- a/plugins/obs-qsv11/obs-qsv11-plugin-main.c
+++ b/plugins/obs-qsv11/obs-qsv11-plugin-main.c
@@ -93,6 +93,7 @@ static bool enum_luids(void *param, uint32_t idx, uint64_t luid)
 
 bool obs_module_load(void)
 {
+#if defined(_WIN32)
 	char *test_exe = os_get_executable_path_ptr("obs-qsv-test.exe");
 	struct dstr cmd = {0};
 	struct dstr caps_str = {0};
@@ -161,6 +162,18 @@ bool obs_module_load(void)
 		av1_supported |= adapter->supports_av1;
 		hevc_supported |= adapter->supports_hevc;
 	}
+#else
+	// We could lift the VA-API query from obs-ffmpeg here.
+	adapter_count = 1;
+	struct adapter_info *adapter = &adapters[0];
+	adapter->is_intel = true;
+	adapter->is_dgpu = true;
+	adapter->supports_av1 = true;
+	adapter->supports_hevc = true;
+	bool avc_supported = true;
+	bool hevc_supported = true;
+	bool av1_supported = true;
+#endif
 
 	if (avc_supported) {
 		obs_register_encoder(&obs_qsv_encoder_tex_v2);
@@ -180,11 +193,13 @@ bool obs_module_load(void)
 #endif
 
 fail:
+#if defined(_WIN32)
 	config_close(config);
 	dstr_free(&caps_str);
 	dstr_free(&cmd);
 	os_process_pipe_destroy(pp);
 	bfree(test_exe);
+#endif
 
 	return true;
 }

--- a/plugins/obs-qsv11/obs-qsv11-plugin-main.c
+++ b/plugins/obs-qsv11/obs-qsv11-plugin-main.c
@@ -53,14 +53,9 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-#include <inttypes.h>
 #include <obs-module.h>
-#include <util/windows/device-enum.h>
-#include <util/config-file.h>
-#include <util/platform.h>
-#include <util/pipe.h>
-#include <util/dstr.h>
-#include "QSV_Encoder.h"
+
+#include "common_utils.h"
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-qsv11", "en-US")
@@ -78,102 +73,20 @@ extern struct obs_encoder_info obs_qsv_av1_encoder;
 extern struct obs_encoder_info obs_qsv_hevc_encoder_tex;
 extern struct obs_encoder_info obs_qsv_hevc_encoder;
 
-extern bool av1_supported(mfxIMPL impl);
-
-struct adapter_info adapters[MAX_ADAPTERS] = {0};
-size_t adapter_count = 0;
-
-static bool enum_luids(void *param, uint32_t idx, uint64_t luid)
-{
-	struct dstr *cmd = param;
-	dstr_catf(cmd, " %" PRIx64, luid);
-	UNUSED_PARAMETER(idx);
-	return true;
-}
-
 bool obs_module_load(void)
 {
-#if defined(_WIN32)
-	char *test_exe = os_get_executable_path_ptr("obs-qsv-test.exe");
-	struct dstr cmd = {0};
-	struct dstr caps_str = {0};
-	os_process_pipe_t *pp = NULL;
-	config_t *config = NULL;
+	adapter_count = MAX_ADAPTERS;
+	check_adapters(adapters, &adapter_count);
 
-	dstr_copy(&cmd, test_exe);
-	enum_graphics_device_luids(enum_luids, &cmd);
-
-	pp = os_process_pipe_create(cmd.array, "r");
-	if (!pp) {
-		blog(LOG_INFO, "Failed to launch the QSV test process I guess");
-		goto fail;
-	}
-
-	for (;;) {
-		char data[2048];
-		size_t len =
-			os_process_pipe_read(pp, (uint8_t *)data, sizeof(data));
-		if (!len)
-			break;
-
-		dstr_ncat(&caps_str, data, len);
-	}
-
-	if (dstr_is_empty(&caps_str)) {
-		blog(LOG_INFO, "Seems the QSV test subprocess crashed. "
-			       "Better there than here I guess. "
-			       "Let's just skip loading QSV then I suppose.");
-		goto fail;
-	}
-
-	if (config_open_string(&config, caps_str.array) != 0) {
-		blog(LOG_INFO, "Couldn't open QSV configuration string");
-		goto fail;
-	}
-
-	const char *error = config_get_string(config, "error", "string");
-	if (error) {
-		blog(LOG_INFO, "Error querying QSV support: %s", error);
-		goto fail;
-	}
-
-	adapter_count = config_num_sections(config);
 	bool avc_supported = false;
 	bool av1_supported = false;
 	bool hevc_supported = false;
-
-	if (adapter_count > MAX_ADAPTERS)
-		adapter_count = MAX_ADAPTERS;
-
 	for (size_t i = 0; i < adapter_count; i++) {
-		char section[16];
-		snprintf(section, sizeof(section), "%d", (int)i);
-
 		struct adapter_info *adapter = &adapters[i];
-		adapter->is_intel =
-			config_get_bool(config, section, "is_intel");
-		adapter->is_dgpu = config_get_bool(config, section, "is_dgpu");
-		adapter->supports_av1 =
-			config_get_bool(config, section, "supports_av1");
-		adapter->supports_hevc =
-			config_get_bool(config, section, "supports_hevc");
-
 		avc_supported |= adapter->is_intel;
 		av1_supported |= adapter->supports_av1;
 		hevc_supported |= adapter->supports_hevc;
 	}
-#else
-	// We could lift the VA-API query from obs-ffmpeg here.
-	adapter_count = 1;
-	struct adapter_info *adapter = &adapters[0];
-	adapter->is_intel = true;
-	adapter->is_dgpu = true;
-	adapter->supports_av1 = true;
-	adapter->supports_hevc = true;
-	bool avc_supported = true;
-	bool hevc_supported = true;
-	bool av1_supported = true;
-#endif
 
 	if (avc_supported) {
 		obs_register_encoder(&obs_qsv_encoder_tex_v2);
@@ -190,15 +103,6 @@ bool obs_module_load(void)
 		obs_register_encoder(&obs_qsv_hevc_encoder_tex);
 		obs_register_encoder(&obs_qsv_hevc_encoder);
 	}
-#endif
-
-fail:
-#if defined(_WIN32)
-	config_close(config);
-	dstr_free(&caps_str);
-	dstr_free(&cmd);
-	os_process_pipe_destroy(pp);
-	bfree(test_exe);
 #endif
 
 	return true;

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -65,6 +65,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <obs-avc.h>
 
 #include "QSV_Encoder.h"
+#include "common_utils.h"
 
 #define do_log(level, format, ...)                 \
 	blog(level, "[qsv encoder: '%s'] " format, \
@@ -517,7 +518,7 @@ static void update_params(struct obs_qsv *obsqsv, obs_data_t *settings)
 	bool cbr_override = obs_data_get_bool(settings, "cbr");
 	int bFrames = (int)obs_data_get_int(settings, "bframes");
 	bool enhancements = obs_data_get_bool(settings, "enhancements");
-	const char *codec;
+	const char *codec = "";
 
 	if (obs_data_has_user_value(settings, "bf"))
 		bFrames = (int)obs_data_get_int(settings, "bf");

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -75,6 +75,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define info(format, ...) do_log(LOG_INFO, format, ##__VA_ARGS__)
 #define debug(format, ...) do_log(LOG_DEBUG, format, ##__VA_ARGS__)
 
+#ifndef GS_INVALID_HANDLE
+#define GS_INVALID_HANDLE (uint32_t) - 1
+#endif
+
 /* ------------------------------------------------------------------------- */
 
 struct obs_qsv {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This is built on top of #8014, so the first 3 commits are from there and enables the non-texture encoding path for linux.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
ffmpeg's vaapi encoding implementation seems to not be making much progress in av1, so we can enable it through this. This also helps reduce confusion as the typical QSV UI on windows is now applicable on linux as well.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on a750 and a i3-7100U, there are some parts of mfx/vpl that seem broken on va-api and have been marked windows only but the largely everything works as it does on windows.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
