### PR TITLE
libobs: Fix non-exhaustive switch statements introduced by ProRes 4444 support 

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1638,6 +1638,11 @@ static inline enum convert_type get_convert_type(enum video_format format,
 
 	case VIDEO_FORMAT_P010:
 		return CONVERT_P010;
+
+	case VIDEO_FORMAT_P216:
+	case VIDEO_FORMAT_P416:
+		/* Unimplemented */
+		break;
 	}
 
 	return CONVERT_NONE;
@@ -2207,6 +2212,11 @@ static const char *select_conversion_technique(enum video_format format,
 			assert(false && "No conversion requested");
 		else
 			return "RGB_Limited";
+		break;
+
+	case VIDEO_FORMAT_P216:
+	case VIDEO_FORMAT_P416:
+		/* Unimplemented */
 		break;
 	}
 	return NULL;
@@ -3374,6 +3384,11 @@ static void copy_frame_data(struct obs_source_frame *dst,
 		copy_frame_data_plane(dst, src, 1, dst->height);
 		copy_frame_data_plane(dst, src, 2, dst->height);
 		copy_frame_data_plane(dst, src, 3, dst->height);
+		break;
+
+	case VIDEO_FORMAT_P216:
+	case VIDEO_FORMAT_P416:
+		/* Unimplemented */
 		break;
 	}
 }


### PR DESCRIPTION
### Description
Fixes compiler errors due to non-exhaustive switch statement for video formats introduced by https://github.com/obsproject/obs-studio/pull/7818.

### Motivation and Context
New video formats introduced for ProRes 4444 encoding have not been implemented in function calls used for video decoding, which makes the switch statements non-exhaustive.

This does not functionally change the status quo (decoding ProRes 4444 files could still be broken because libobs does not explicitly handle the colour format).

@jpark37 LMK if you feel like the formats should be properly implemented instead (if I'm not mistaken this does mainly affect ProRes 4444 + XQ playback, not recording).

### How Has This Been Tested?
Compiled on macOS with extended warnings enabled and checked ProRes 4444 recordings.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
