### PR TITLE
mac-virtualcam: Fix incorrect PTS on Apple Silicon as well as PTS being rounded

### DIFF
--- a/plugins/mac-virtualcam/src/dal-plugin/CMSampleBufferUtils.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/CMSampleBufferUtils.mm
@@ -13,7 +13,7 @@ CMSampleTimingInfo CMSampleTimingInfoForTimestamp(uint64_t timestampNanos,
 {
 	// The timing here is quite important. For frames to be delivered correctly and successfully be recorded by apps
 	// like QuickTime Player, we need to be accurate in both our timestamps _and_ have a sensible scale. Using large
-	// timestamps and scales like mach_absolute_time() and NSEC_PER_SEC will work for display, but will error out
+	// timestamps and scales like clock_gettime_nsec_np() and NSEC_PER_SEC will work for display, but will error out
 	// when trying to record.
 	//
 	// 600 is a common default in Apple's docs https://developer.apple.com/documentation/avfoundation/avmutablemovie/1390622-timescale

--- a/plugins/mac-virtualcam/src/dal-plugin/CMSampleBufferUtils.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/CMSampleBufferUtils.mm
@@ -21,9 +21,8 @@ CMSampleTimingInfo CMSampleTimingInfoForTimestamp(uint64_t timestampNanos,
 	CMSampleTimingInfo timing;
 	timing.duration =
 		CMTimeMake(fpsDenominator * scale, fpsNumerator * scale);
-	timing.presentationTimeStamp = CMTimeMake(
-		((int64_t)(timestampNanos / (double)NSEC_PER_SEC) * scale),
-		scale);
+	timing.presentationTimeStamp = CMTimeMakeWithSeconds(
+		timestampNanos / (double)NSEC_PER_SEC, scale);
 	timing.decodeTimeStamp = kCMTimeInvalid;
 	return timing;
 }

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
@@ -316,7 +316,7 @@
 	CVPixelBufferRef pixelBuffer =
 		[self createPixelBufferWithTestAnimation];
 
-	uint64_t hostTime = mach_absolute_time();
+	uint64_t hostTime = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
 	CMSampleTimingInfo timingInfo =
 		CMSampleTimingInfoForTimestamp(hostTime, (uint32_t)self.fps, 1);
 
@@ -365,9 +365,9 @@
 	CMSampleTimingInfo timingInfo = CMSampleTimingInfoForTimestamp(
 		timestamp, fpsNumerator, fpsDenominator);
 
-	err = CMIOStreamClockPostTimingEvent(timingInfo.presentationTimeStamp,
-					     mach_absolute_time(), true,
-					     self.clock);
+	err = CMIOStreamClockPostTimingEvent(
+		timingInfo.presentationTimeStamp,
+		clock_gettime_nsec_np(CLOCK_UPTIME_RAW), true, self.clock);
 	if (err != noErr) {
 		DLog(@"CMIOStreamClockPostTimingEvent err %d", err);
 	}


### PR DESCRIPTION
<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->
👋 First time contributing to the OBS project, please let me know if anything is unclear or needs improvement. Happy to improve this PR where necessary to get this merged.

### Description

#### 1. Stable presentation time stamp on Apple Silicon
The `fillFrame` method of the mac-virtualcam plugin is creating samples directly using the value from `mach_absolute_time()` as `hostTime`. This assumes this value is in nanoseconds, while it is in fact in mach tick units. On Intel macs mach tick units will be exactly 1 nanosecond resulting in valid values, but on Apple Silicon macs this is no longer the case.

This results in sample buffers with the placeholder image that have much lower presentation time stamps than the samples containing content produced by OBS. In previews/live streams this shows due to the last content sample being shown frozen until the whole buffer is filled with samples containing the placeholder image. Applications recording the video stream are even more confused and crash or record videos with wildly incorrect lengths.

In this PR ~`mach_timebase_info`~ `clock_gettime_nsec_np` is used to convert from mach tick units to nanoseconds. This will make sure the `hostTime` value is correct on both Apple Silicon and Intel macs. Making sure we produce stable presentation time stamps from the virtual webcam plugin at all times.

#### 2. Prevent rounding of presentation time stamp to whole seconds
All presentation time stamps are rounded to whole seconds during the convertion from nanoseconds to seconds, because of the immediate cast to `int64_t`. This results in the same presentation time stamp being send to consumers for a whole second.

In previews/live streams this isn’t super visible as last frame is often assumed to be the newest and the stream is updated. It’s more problematic when recording since APIs like Apples AVFoundation don’t allow duplicate presentation time stamps or it can look like frames are produces in huge bursts once per second.

In this PR `CMTimeMakeWithSeconds` is used instead of `CMTimeMake` to make sure the conversion is done correctly and simplify the calculation we have to do a little.

### Motivation and Context
- Solves incorrect length in recordings when the recording is started with a stopped virtual camera
- Some recorders will also crash if they expect presentation time stamps to increase/be in reasonable range of each other
- Prevents seconds long delay before placeholder shows up when stopping the virtual webcam/closing OBS

Further reading:
- [`mach_absolute_time` documentation](https://developer.apple.com/documentation/driverkit/3438076-mach_absolute_time)
- [`mach_timebase_info` documentation](https://developer.apple.com/documentation/driverkit/3433733-mach_timebase_info)
- [Blogpost about the clock change between Intel & Apple Silicon macs](https://eclecticlight.co/2020/09/08/changing-the-clock-in-apple-silicon-macs/)

### How Has This Been Tested?
Tested on both an Apple Silicon Mac with macOS 13 and an Intel Mac with macOS 11.
Recorded and observed the samples outputted from the virtual camera to a 3rd party app in different scenarios;
- OBS app not started
- OBS started + virtual webcam live
- OBS started + virtual webcam stopped

Also transitioned between these states while observing the stream. All looks good with this change.

### Types of changes
- Bug fix

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
