### PR TITLE
UI: Make T-Bar unclickable

### DIFF
--- a/UI/slider-ignorewheel.cpp
+++ b/UI/slider-ignorewheel.cpp
@@ -94,3 +94,42 @@ QAccessible::Role VolumeAccessibleInterface::role() const
 {
 	return QAccessible::Role::Slider;
 }
+
+void SliderIgnoreClick::mousePressEvent(QMouseEvent *event)
+{
+	QStyleOptionSlider styleOption;
+	initStyleOption(&styleOption);
+	QRect handle = style()->subControlRect(QStyle::CC_Slider, &styleOption,
+					       QStyle::SC_SliderHandle, this);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	QPointF pointExact = event->position();
+#endif
+	if (handle.contains(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		    QPoint(pointExact.x(), pointExact.y())
+#else
+		    // Ubuntu 20.04. Sigh.
+		    QPoint(event->x(), event->y())
+#endif
+			    )) {
+		SliderIgnoreScroll::mousePressEvent(event);
+		dragging = true;
+	} else {
+		event->accept();
+	}
+}
+
+void SliderIgnoreClick::mouseReleaseEvent(QMouseEvent *event)
+{
+	dragging = false;
+	SliderIgnoreScroll::mouseReleaseEvent(event);
+}
+
+void SliderIgnoreClick::mouseMoveEvent(QMouseEvent *event)
+{
+	if (dragging) {
+		SliderIgnoreScroll::mouseMoveEvent(event);
+	} else {
+		event->accept();
+	}
+}

--- a/UI/slider-ignorewheel.hpp
+++ b/UI/slider-ignorewheel.hpp
@@ -5,6 +5,7 @@
 #include <QInputEvent>
 #include <QtCore/QObject>
 #include <QAccessibleWidget>
+#include <QStyleOptionSlider>
 
 class SliderIgnoreScroll : public QSlider {
 	Q_OBJECT
@@ -48,4 +49,21 @@ private:
 protected:
 	virtual QAccessible::Role role() const override;
 	virtual QString text(QAccessible::Text t) const override;
+};
+
+class SliderIgnoreClick : public SliderIgnoreScroll {
+public:
+	inline SliderIgnoreClick(Qt::Orientation orientation,
+				 QWidget *parent = nullptr)
+		: SliderIgnoreScroll(orientation, parent)
+	{
+	}
+
+protected:
+	virtual void mousePressEvent(QMouseEvent *event) override;
+	virtual void mouseReleaseEvent(QMouseEvent *event) override;
+	virtual void mouseMoveEvent(QMouseEvent *event) override;
+
+private:
+	bool dragging = false;
 };

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -787,7 +787,7 @@ void OBSBasic::CreateProgramOptions()
 	mainButtonLayout->addWidget(transitionButton);
 	mainButtonLayout->addWidget(configTransitions);
 
-	tBar = new SliderIgnoreScroll(Qt::Horizontal);
+	tBar = new SliderIgnoreClick(Qt::Horizontal);
 	tBar->setMinimum(0);
 	tBar->setMaximum(T_BAR_PRECISION - 1);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the T-Bar so that it can only be dragged and not clicked at all.
Follow-up to #7347.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Requested by @Warchamp7 in off-thread discussions about #7347.
*Edit: Maybe. That was what I remembered at least. On the PR itself he wasn't completely sure. So we'll see, maybe this PR will get closed in the end.*

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.2
Tested by clicking on the T-Bar and seeing that nothing happens, and by dragging it and seeing that it still functions when dragging.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
