### PR TITLE
UI: Add native dark titlebar capability on Windows

### DIFF
--- a/UI/forms/obs.qrc
+++ b/UI/forms/obs.qrc
@@ -80,4 +80,7 @@
     <file>fonts/OpenSans-Bold.ttf</file>
     <file>fonts/OpenSans-Italic.ttf</file>
   </qresource>
+  <qresource prefix="/qt/etc/">
+	<file>qt.conf</file>
+  </qresource>
 </RCC>

--- a/UI/forms/qt.conf
+++ b/UI/forms/qt.conf
@@ -1,0 +1,2 @@
+[Platforms]
+WindowsArguments = darkmode=1


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR is a simple change that allows the titlebar/caption of OBS on Windows 10 and up to be natively dark. It was done using qt's built-in system and a `qt.conf` file that just specifies the appropriate settings/toggle. Doing it using qt means that the titlebar of obs is now based on the user's **system** color theme:

![obs_dark](https://user-images.githubusercontent.com/1361714/221086970-23abeb2f-671e-420f-a5f9-66d94cd3c86c.PNG)


It's important to note that because this feature using qt's built-in functionality, **the titlebar color is independent of the theme set in OBS**, and only relies on the color set in the user's system settings (or the "default app mode" if a custom color theme is used). This means that, for example, if a user has "light" as their system theme in Window's system setting, but is using a light obs theme, it will be "mismatched" once again:

![obs_light_mismatch_vice_versa](https://user-images.githubusercontent.com/1361714/221087282-473b7561-1e28-47c8-bdc9-d92ccce89b65.PNG)

And vice versa:
![obs_light_mismatch](https://user-images.githubusercontent.com/1361714/221087230-2dc86f5d-aec3-46aa-8172-f2e76f9e9101.PNG)

This may seem like a bug, but I would actually argue that basing the titlebar color on the system setting (rather than the obs theme) should be intentional; This is how most Win32 applications do it, and it would make more sense IMO if obs stayed consistent with the system theme. Doing it based on obs' theme instead would be significantly more complicated, requiring manually changing it by leveraging the Desktop Window Manager API within the Windows SDK (a la [`DwmSetWindowAttribute`](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/nf-dwmapi-dwmsetwindowattribute) and [`DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE`](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute) in `dwmapi.h`).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Before this change, on Windows 10, the titlebar is always light regardless of the obs theme or system setting; obs "ignores" (since it has no way to tell the system color) both the theme and system setting and just always has a light titlebar:
 
![image](https://user-images.githubusercontent.com/1361714/221089107-c755dc85-2415-4600-8081-caed5b5863b8.png)


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
All screenshots and test cases were done on Windows 10 21H2 (build 19044.2604) on the same build of OBS (except for the movtivation and context screenshot, which was done on release 29.0.1)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
