### PR TITLE
docs: Add clarifications

### DIFF
--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -284,7 +284,8 @@ Libobs Objects
 
 .. function:: void obs_enum_scenes(bool (*enum_proc)(void*, obs_source_t*), void *param)
 
-   Enumerates all scenes.
+   Enumerates all scenes. Use :c:func:`obs_scene_from_source()` if the scene is
+   needed as an :c:type:`obs_scene_t`.
   
    Callback function returns true to continue enumeration, or false to end
    enumeration.

--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -285,7 +285,9 @@ Libobs Objects
 .. function:: void obs_enum_scenes(bool (*enum_proc)(void*, obs_source_t*), void *param)
 
    Enumerates all scenes. Use :c:func:`obs_scene_from_source()` if the scene is
-   needed as an :c:type:`obs_scene_t`.
+   needed as an :c:type:`obs_scene_t`. The order that they are enumerated should
+   not be relied on. If one intends to enumerate the scenes in the order
+   presented by the OBS Studio Frontend, use :c:func:`obs_frontend_get_scenes()`.
   
    Callback function returns true to continue enumeration, or false to end
    enumeration.

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -259,7 +259,8 @@ Functions
    :return: The scene name list, ending with NULL.  The list is stored
             within one contiguous segment of memory, so freeing the
             returned pointer with :c:func:`bfree()` will free the entire
-            list.
+            list. The order is same as the way the frontend displays it in
+            the Scenes dock.
 
 ---------------------------------------
 
@@ -268,7 +269,8 @@ Functions
    :param sources: Pointer to a :c:type:`obs_frontend_source_list`
                    structure to receive the list of
                    reference-incremented scenes.  Release with
-                   :c:func:`obs_frontend_source_list_free`
+                   :c:func:`obs_frontend_source_list_free`. The order is same as
+                   the way the frontend displays it in the Scenes dock.
 
 ---------------------------------------
 

--- a/docs/sphinx/reference-scenes.rst
+++ b/docs/sphinx/reference-scenes.rst
@@ -265,7 +265,8 @@ General Scene Functions
 
 .. function:: void obs_scene_enum_items(obs_scene_t *scene, bool (*callback)(obs_scene_t*, obs_sceneitem_t*, void*), void *param)
 
-   Enumerates scene items within a scene.
+   Enumerates scene items within a scene in order of the bottommost scene item
+   to the topmost scene item.
 
    Callback function returns true to continue enumeration, or false to end
    enumeration.

--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -789,10 +789,11 @@ General Source Functions
 .. function:: obs_weak_source_t *obs_source_get_weak_source(obs_source_t *source)
               obs_source_t *obs_weak_source_get_source(obs_weak_source_t *weak)
 
-   These functions are used to get a weak reference from a strong source
-   reference, or a strong source reference from a weak reference.  If
+   These functions are used to get an incremented weak reference from a strong source
+   reference, or an incremented strong source reference from a weak reference. If
    the source is destroyed, *obs_weak_source_get_source* will return
-   *NULL*.
+   *NULL*. Release with :c:func:`obs_weak_source_release()` or
+   :c:func:`obs_source_release()`, respectively.
 
 ---------------------
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Added more info on some functions

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
It is not immediately clear how to get `obs_scene_t` objects from `obs_enum_scenes`, since it just `obs_source_t` just like `obs_enum_sources`. Developers may also find `obs_enum_scenes` to enumerate in an unexpected order, especially as plugins need to enumerate scenes to show them as options, in which case it has to be in order. Adding a link to the frontend function reduces a lot of development time. The same way, some developers would not expect `obs_scene_enum_items` to start at the bottom, I've seen a few plugins list scene items in a reversed order because this info is not in the docs. Also added the info that `obs_source_get_weak_source` and `obs_weak_source_get_source` returns an incremented reference, which was not clear, especially since we have functions like `obs_scene_get_source` and `obs_sceneitem_get_source` don't increment the reference. The clearer the docs, the less development time for us, especially considering that we'd have to search for code using the functions, along with getting unexpected behavior the first time.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built and viewed locally, tested the enum functions myself, the unreliable order of `obs_enum_scenes` was confirmed by Rodney (my testing showed that it went either most recent to first created or the reverse).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
