### PR TITLE
Add unique identifier (UUID) to sources

### DIFF
--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -157,9 +157,13 @@ bool OBSBasic::AddSceneCollection(bool create_new, const QString &qname)
 				  "SceneCollection", name.c_str());
 		config_set_string(App()->GlobalConfig(), "Basic",
 				  "SceneCollectionFile", file.c_str());
+
 		if (create_new) {
 			CreateDefaultScene(false);
+		} else {
+			obs_reset_source_uuids();
 		}
+
 		SaveProjectNow();
 		RefreshSceneCollections();
 	};

--- a/cmake/Modules/FindLibUUID.cmake
+++ b/cmake/Modules/FindLibUUID.cmake
@@ -1,0 +1,34 @@
+# Stripped down version of
+# https://gitlab.kitware.com/cmake/cmake/blob/e1409101c99f7a3487990e9927e8bd0e275f564f/Source/Modules/FindLibUUID.cmake
+#
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+#
+# Once done these will be defined:
+#
+# LibUUID_FOUND LibUUID_INCLUDE_DIRS LibUUID_LIBRARIES
+
+find_library(LibUUID_LIBRARY NAMES uuid)
+mark_as_advanced(LibUUID_LIBRARY)
+
+find_path(LibUUID_INCLUDE_DIR NAMES uuid/uuid.h)
+mark_as_advanced(LibUUID_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  LibUUID
+  FOUND_VAR LibUUID_FOUND
+  REQUIRED_VARS LibUUID_LIBRARY LibUUID_INCLUDE_DIR)
+set(LIBUUID_FOUND ${LibUUID_FOUND})
+
+if(LibUUID_FOUND)
+  set(LibUUID_INCLUDE_DIRS ${LibUUID_INCLUDE_DIR})
+  set(LibUUID_LIBRARIES ${LibUUID_LIBRARY})
+  if(NOT TARGET LibUUID::LibUUID)
+    add_library(LibUUID::LibUUID UNKNOWN IMPORTED)
+    set_target_properties(
+      LibUUID::LibUUID
+      PROPERTIES IMPORTED_LOCATION "${LibUUID_LIBRARY}"
+                 INTERFACE_INCLUDE_DIRECTORIES "${LibUUID_INCLUDE_DIRS}")
+  endif()
+endif()

--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -333,6 +333,15 @@ Libobs Objects
 
 ---------------------
 
+.. function:: obs_source_t *obs_get_source_by_uuid(const char *uuid)
+
+   Gets a source by its UUID.
+  
+   Increments the source reference counter, use
+   :c:func:`obs_source_release()` to release it when complete.
+
+---------------------
+
 .. function:: obs_source_t *obs_get_transition_by_name(const char *name)
 
    Gets a transition by its name.

--- a/docs/sphinx/reference-libobs-util-platform.rst
+++ b/docs/sphinx/reference-libobs-util-platform.rst
@@ -496,3 +496,10 @@ Other Functions
    being translated by Rosetta and running on Apple Silicon Macs. On Windows, it 
    returns true when an x64 binary is being emulated on Windows ARM64 PCs. On all other 
    platforms, it will always returns false.
+
+----------------------
+
+.. function:: char *os_generate_uuid(void)
+
+   Creates a version 4 UUID and returns a NULL-terminated 36-character string.
+   Must be freed with :c:func:`bfree()`.

--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -941,6 +941,12 @@ General Source Functions
 
 ---------------------
 
+.. function:: const char *obs_source_get_uuid(const obs_source_t *source)
+
+   :return: The UUID of the source
+
+---------------------
+
 .. function:: void obs_source_set_name(obs_source_t *source, const char *name)
 
    Sets the name of a source.  If the source is not private and the name

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -307,7 +307,7 @@ if(OS_WINDOWS)
     libobs PRIVATE UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS
                    _CRT_NONSTDC_NO_WARNINGS)
 
-  target_link_libraries(libobs PRIVATE dxgi Avrt Dwmapi winmm)
+  target_link_libraries(libobs PRIVATE dxgi Avrt Dwmapi winmm Rpcrt4)
 
   if(MSVC)
     target_link_libraries(libobs PUBLIC OBS::w32-pthreads)
@@ -374,6 +374,7 @@ elseif(OS_POSIX)
     target_compile_definitions(libobs PRIVATE ENABLE_DARRAY_TYPE_TEST)
   endif()
 
+  find_package(LibUUID REQUIRED)
   find_package(X11 REQUIRED)
   find_package(
     XCB
@@ -393,7 +394,7 @@ elseif(OS_POSIX)
             util/pipe-posix.c
             util/platform-nix.c)
 
-  target_link_libraries(libobs PRIVATE X11::X11_xcb XCB::XCB)
+  target_link_libraries(libobs PRIVATE X11::X11_xcb XCB::XCB LibUUID::LibUUID)
 
   if(USE_XDG)
     target_compile_definitions(libobs PRIVATE USE_XDG)

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -52,7 +52,7 @@ static bool init_encoder(struct obs_encoder *encoder, const char *name,
 	pthread_mutex_init_value(&encoder->pause.mutex);
 
 	if (!obs_context_data_init(&encoder->context, OBS_OBJ_TYPE_ENCODER,
-				   settings, name, hotkey_data, false))
+				   settings, name, NULL, hotkey_data, false))
 		return false;
 	if (pthread_mutex_init_recursive(&encoder->init_mutex) != 0)
 		return false;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -520,6 +520,7 @@ typedef void (*obs_destroy_cb)(void *obj);
 
 struct obs_context_data {
 	char *name;
+	const char *uuid;
 	void *data;
 	obs_data_t *settings;
 	signal_handler_t *signals;
@@ -545,8 +546,8 @@ struct obs_context_data {
 
 extern bool obs_context_data_init(struct obs_context_data *context,
 				  enum obs_obj_type type, obs_data_t *settings,
-				  const char *name, obs_data_t *hotkey_data,
-				  bool private);
+				  const char *name, const char *uuid,
+				  obs_data_t *hotkey_data, bool private);
 extern void obs_context_init_control(struct obs_context_data *context,
 				     void *object, obs_destroy_cb destroy);
 extern void obs_context_data_free(struct obs_context_data *context);
@@ -834,7 +835,8 @@ extern struct obs_source_info *get_source_info2(const char *unversioned_id,
 						uint32_t ver);
 extern bool obs_source_init_context(struct obs_source *source,
 				    obs_data_t *settings, const char *name,
-				    obs_data_t *hotkey_data, bool private);
+				    const char *uuid, obs_data_t *hotkey_data,
+				    bool private);
 
 extern bool obs_transition_init(obs_source_t *transition);
 extern void obs_transition_free(obs_source_t *transition);
@@ -851,8 +853,9 @@ extern void audio_monitor_destroy(struct audio_monitor *monitor);
 
 extern obs_source_t *
 obs_source_create_set_last_ver(const char *id, const char *name,
-			       obs_data_t *settings, obs_data_t *hotkey_data,
-			       uint32_t last_obs_ver, bool is_private);
+			       const char *uuid, obs_data_t *settings,
+			       obs_data_t *hotkey_data, uint32_t last_obs_ver,
+			       bool is_private);
 extern void obs_source_destroy(struct obs_source *source);
 
 enum view_type {

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -94,7 +94,7 @@ static bool init_output_handlers(struct obs_output *output, const char *name,
 				 obs_data_t *settings, obs_data_t *hotkey_data)
 {
 	if (!obs_context_data_init(&output->context, OBS_OBJ_TYPE_OUTPUT,
-				   settings, name, hotkey_data, false))
+				   settings, name, NULL, hotkey_data, false))
 		return false;
 
 	signal_handler_add_array(output->context.signals, output_signals);

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -959,6 +959,7 @@ static void scene_load(void *data, obs_data_t *settings);
 static void scene_load_item(struct obs_scene *scene, obs_data_t *item_data)
 {
 	const char *name = obs_data_get_string(item_data, "name");
+	const char *src_uuid = obs_data_get_string(item_data, "source_uuid");
 	obs_source_t *source;
 	const char *scale_filter_str;
 	const char *blend_method_str;
@@ -970,7 +971,11 @@ static void scene_load_item(struct obs_scene *scene, obs_data_t *item_data)
 	if (obs_data_get_bool(item_data, "group_item_backup"))
 		return;
 
-	source = obs_get_source_by_name(name);
+	if (src_uuid && strlen(src_uuid) == UUID_STR_LENGTH)
+		source = obs_get_source_by_uuid(src_uuid);
+	else
+		source = obs_get_source_by_name(name);
+
 	if (!source) {
 		blog(LOG_WARNING,
 		     "[scene_load_item] Source %s not "
@@ -1124,6 +1129,7 @@ static void scene_save_item(obs_data_array_t *array,
 {
 	obs_data_t *item_data = obs_data_create();
 	const char *name = obs_source_get_name(item->source);
+	const char *src_uuid = obs_source_get_uuid(item->source);
 	const char *scale_filter;
 	const char *blend_method;
 	const char *blend_type;
@@ -1136,6 +1142,7 @@ static void scene_save_item(obs_data_array_t *array,
 	}
 
 	obs_data_set_string(item_data, "name", name);
+	obs_data_set_string(item_data, "source_uuid", src_uuid);
 	obs_data_set_bool(item_data, "visible", item->user_visible);
 	obs_data_set_bool(item_data, "locked", item->locked);
 	obs_data_set_double(item_data, "rot", rot);

--- a/libobs/obs-service.c
+++ b/libobs/obs-service.c
@@ -52,7 +52,8 @@ static obs_service_t *obs_service_create_internal(const char *id,
 	service = bzalloc(sizeof(struct obs_service));
 
 	if (!obs_context_data_init(&service->context, OBS_OBJ_TYPE_SERVICE,
-				   settings, name, hotkey_data, private)) {
+				   settings, name, NULL, hotkey_data,
+				   private)) {
 		bfree(service);
 		return NULL;
 	}

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -118,11 +118,11 @@ static const char *source_signals[] = {
 };
 
 bool obs_source_init_context(struct obs_source *source, obs_data_t *settings,
-			     const char *name, obs_data_t *hotkey_data,
-			     bool private)
+			     const char *name, const char *uuid,
+			     obs_data_t *hotkey_data, bool private)
 {
 	if (!obs_context_data_init(&source->context, OBS_OBJ_TYPE_SOURCE,
-				   settings, name, hotkey_data, private))
+				   settings, name, uuid, hotkey_data, private))
 		return false;
 
 	return signal_handler_add_array(source->context.signals,
@@ -340,7 +340,7 @@ static void obs_source_init_audio_hotkeys(struct obs_source *source)
 }
 
 static obs_source_t *
-obs_source_create_internal(const char *id, const char *name,
+obs_source_create_internal(const char *id, const char *name, const char *uuid,
 			   obs_data_t *settings, obs_data_t *hotkey_data,
 			   bool private, uint32_t last_obs_ver)
 {
@@ -370,7 +370,7 @@ obs_source_create_internal(const char *id, const char *name,
 	source->push_to_talk_key = OBS_INVALID_HOTKEY_ID;
 	source->last_obs_ver = last_obs_ver;
 
-	if (!obs_source_init_context(source, settings, name, hotkey_data,
+	if (!obs_source_init_context(source, settings, name, uuid, hotkey_data,
 				     private))
 		goto fail;
 
@@ -420,24 +420,25 @@ fail:
 obs_source_t *obs_source_create(const char *id, const char *name,
 				obs_data_t *settings, obs_data_t *hotkey_data)
 {
-	return obs_source_create_internal(id, name, settings, hotkey_data,
+	return obs_source_create_internal(id, name, NULL, settings, hotkey_data,
 					  false, LIBOBS_API_VER);
 }
 
 obs_source_t *obs_source_create_private(const char *id, const char *name,
 					obs_data_t *settings)
 {
-	return obs_source_create_internal(id, name, settings, NULL, true,
+	return obs_source_create_internal(id, name, NULL, settings, NULL, true,
 					  LIBOBS_API_VER);
 }
 
 obs_source_t *obs_source_create_set_last_ver(const char *id, const char *name,
+					     const char *uuid,
 					     obs_data_t *settings,
 					     obs_data_t *hotkey_data,
 					     uint32_t last_obs_ver,
 					     bool is_private)
 {
-	return obs_source_create_internal(id, name, settings, hotkey_data,
+	return obs_source_create_internal(id, name, uuid, settings, hotkey_data,
 					  is_private, last_obs_ver);
 }
 
@@ -4239,6 +4240,13 @@ const char *obs_source_get_name(const obs_source_t *source)
 {
 	return obs_source_valid(source, "obs_source_get_name")
 		       ? source->context.name
+		       : NULL;
+}
+
+const char *obs_source_get_uuid(const obs_source_t *source)
+{
+	return obs_source_valid(source, "obs_source_get_uuid")
+		       ? source->context.uuid
 		       : NULL;
 }
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2535,6 +2535,21 @@ obs_data_array_t *obs_save_sources(void)
 	return obs_save_sources_filtered(save_source_filter, NULL);
 }
 
+void obs_reset_source_uuids()
+{
+	pthread_mutex_lock(&obs->data.sources_mutex);
+
+	struct obs_source *source = obs->data.first_source;
+	while (source) {
+		bfree((void *)source->context.uuid);
+		source->context.uuid = os_generate_uuid();
+
+		source = (struct obs_source *)source->context.next;
+	}
+
+	pthread_mutex_unlock(&obs->data.sources_mutex);
+}
+
 /* ensures that names are never blank */
 static inline char *dup_name(const char *name, bool private)
 {

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -798,6 +798,10 @@ typedef bool (*obs_save_source_filter_cb)(void *data, obs_source_t *source);
 EXPORT obs_data_array_t *obs_save_sources_filtered(obs_save_source_filter_cb cb,
 						   void *data);
 
+/** Reset source UUIDs. NOTE: this function is only to be used by the UI and
+ *  will be removed in a future version! */
+EXPORT void obs_reset_source_uuids(void);
+
 enum obs_obj_type {
 	OBS_OBJ_TYPE_INVALID,
 	OBS_OBJ_TYPE_SOURCE,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -697,6 +697,14 @@ EXPORT void obs_enum_services(bool (*enum_proc)(void *, obs_service_t *),
  */
 EXPORT obs_source_t *obs_get_source_by_name(const char *name);
 
+/**
+ * Gets a source by its UUID.
+ *
+ *   Increments the source reference counter, use obs_source_release to
+ * release it when complete.
+ */
+EXPORT obs_source_t *obs_get_source_by_uuid(const char *uuid);
+
 /** Get a transition source by its name. */
 EXPORT obs_source_t *obs_get_transition_by_name(const char *name);
 
@@ -1114,6 +1122,9 @@ EXPORT const char *obs_source_get_name(const obs_source_t *source);
 
 /** Sets the name of a source */
 EXPORT void obs_source_set_name(obs_source_t *source, const char *name);
+
+/** Gets the UUID of a source */
+EXPORT const char *obs_source_get_uuid(const obs_source_t *source);
 
 /** Gets the source type */
 EXPORT enum obs_source_type obs_source_get_type(const obs_source_t *source);

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -35,6 +35,7 @@
 #include <glob.h>
 #include <time.h>
 #include <signal.h>
+#include <uuid/uuid.h>
 
 #if !defined(__APPLE__)
 #include <sys/times.h>
@@ -1136,4 +1137,14 @@ uint64_t os_get_free_disk_space(const char *dir)
 		return 0;
 
 	return (uint64_t)info.f_frsize * (uint64_t)info.f_bavail;
+}
+
+char *os_generate_uuid(void)
+{
+	uuid_t uuid;
+	// 36 char UUID + NULL
+	char *out = bmalloc(37);
+	uuid_generate(uuid);
+	uuid_unparse_lower(uuid, out);
+	return out;
 }

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -21,6 +21,7 @@
 #include <intrin.h>
 #include <psapi.h>
 #include <math.h>
+#include <rpc.h>
 
 #include "base.h"
 #include "platform.h"
@@ -1478,4 +1479,22 @@ uint64_t os_get_free_disk_space(const char *dir)
 	bfree(wdir);
 
 	return success ? free.QuadPart : 0;
+}
+
+char *os_generate_uuid(void)
+{
+	UUID uuid;
+
+	RPC_STATUS res = UuidCreate(&uuid);
+	if (res != RPC_S_OK && res != RPC_S_UUID_LOCAL_ONLY)
+		bcrash("Failed to get UUID, RPC_STATUS: %l", res);
+
+	struct dstr uuid_str = {0};
+	dstr_printf(&uuid_str,
+		    "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+		    uuid.Data1, uuid.Data2, uuid.Data3, uuid.Data4[0],
+		    uuid.Data4[1], uuid.Data4[2], uuid.Data4[3], uuid.Data4[4],
+		    uuid.Data4[5], uuid.Data4[6], uuid.Data4[7]);
+
+	return uuid_str.array;
 }

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -201,6 +201,10 @@ EXPORT bool os_get_proc_memory_usage(os_proc_memory_usage_t *usage);
 EXPORT uint64_t os_get_proc_resident_size(void);
 EXPORT uint64_t os_get_proc_virtual_size(void);
 
+#define UUID_STR_LENGTH 36
+
+EXPORT char *os_generate_uuid(void);
+
 /* clang-format off */
 #ifdef __APPLE__
 # define ARCH_BITS 64


### PR DESCRIPTION
### Description

- Adds libobs platform util for creating UUIDs
- Adds `uuid` to `obs_context_data`
  + Only saves/restores UUIDs for sources
- Adds `obs_get_source_by_uuid()` to retrieve a source by it's UUID

If #8229 gets merged this PR will be updated to use a separate hash table for GUID based lookups.

### Motivation and Context

Developers of plugins and third-party integrations have asked for UUIDs for a long time so that, for example, name changes done via the UI do not result in a desynchronisation between their app's and OBS's state.

#### Why UUIDs/strings?

UUIDv4 is a standardised format that is supported and understood by various frameworks, databases, and standard libraries. They can be serialised/deserialised for storing without any extra work, and can be used in databases with better performance than a generic string type. Additionally, most software engineers should recognise one when they see it, due to their recognisable standard formatting.

While UUIDs in OBS could be stored in a binary representation, this would require us to provide various extra utility functions to convert from/to string representations, as well as potentially having to provide additional functions that do so for the caller (e.g. `obs_get_source_by_uuid_str()`).
Additionally, many API users such as `obs-websocket` would have to convert UUIDs form/to a string format anyway for their use, and even OBS itself would have to convert back and forth when storing/loading scene collections since we use JSON.

In general, I do believe that using a standardised format is beneficial and that storing them in strings is simpler while not being meaningfully slower or memory intensive.

### How Has This Been Tested?

Ran on macOS and Windows, seemed to work fine. UUIDs are saved and restored to scene collection.

Nothing on Linux yet, but any good distro should come with `libuuid`, right?

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
