### PR TITLE
Disable encoder scaling if scaled resolution matches output resolution

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -694,6 +694,18 @@ void obs_encoder_set_scaled_size(obs_encoder_t *encoder, uint32_t width,
 		return;
 	}
 
+	const struct video_output_info *voi;
+	voi = video_output_get_info(encoder->media);
+	if (voi && voi->width == width && voi->height == height) {
+		blog(LOG_WARNING,
+		     "encoder '%s': Scaled resolution "
+		     "matches output resolution, scaling "
+		     "disabled",
+		     obs_encoder_get_name(encoder));
+		encoder->scaled_width = encoder->scaled_height = 0;
+		return;
+	}
+
 	encoder->scaled_width = width;
 	encoder->scaled_height = height;
 }


### PR DESCRIPTION
### Description
Adds an additional check to `obs_encoder_set_scaled_size` that disables scaling if the requested scale resolution matches the output resolution.

DRAFT: Is this the correct place to do this? Should the logic also / instead be in the UI to not request the scaling in the first place?

### Motivation and Context
Users would often tick "Enable scaling" in Advanced Output mode and then leave the resolution the same as their main resolution. OBS would dutifully call `obs_encoder_set_scaled_size` with the same resolution as the output, causing an unnecessary pass through swscale and skipping hardware  encoders like jim-nvenc that don't handle rescaled output.

### How Has This Been Tested?
Ran OBS, tried to "rescale" 1080p to 1080p, scaling was disabled and jim-nvenc worked.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
