### PR TITLE
UI: Add ability to re-color icons

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -135,6 +135,8 @@ target_sources(
           auth-base.cpp
           auth-base.hpp
           display-helpers.hpp
+          icons.cpp
+          icons.hpp
           platform.hpp
           qt-display.cpp
           qt-display.hpp
@@ -157,6 +159,8 @@ target_sources(
           audio-encoders.cpp
           audio-encoders.hpp
           balance-slider.hpp
+          checkbox.cpp
+          checkbox.hpp
           clickable-label.hpp
           double-slider.cpp
           double-slider.hpp
@@ -183,6 +187,7 @@ target_sources(
           media-slider.hpp
           menu-button.cpp
           menu-button.hpp
+          mute-checkbox.cpp
           mute-checkbox.hpp
           plain-text-edit.cpp
           plain-text-edit.hpp

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -684,6 +684,15 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 			undo_data, redo_data, repeatable);
 	}
 
+	void obs_frontend_set_icon(void *obj, const char *path,
+				   const char *theme_id) override
+	{
+		QMetaObject::invokeMethod(main, "UpdateIcon",
+					  Q_ARG(void *, obj),
+					  Q_ARG(const char *, path),
+					  Q_ARG(const char *, theme_id));
+	}
+
 	void on_load(obs_data_t *settings) override
 	{
 		for (size_t i = saveCallbacks.size(); i > 0; i--) {

--- a/UI/checkbox.cpp
+++ b/UI/checkbox.cpp
@@ -1,0 +1,27 @@
+#include "checkbox.hpp"
+#include <QPainter>
+
+OBSCheckBox::OBSCheckBox(QWidget *parent) : QCheckBox(parent) {}
+
+void OBSCheckBox::SetCheckedIcon(QIcon icon)
+{
+	checkedIcon = icon;
+}
+
+void OBSCheckBox::SetUncheckedIcon(QIcon icon)
+{
+	uncheckedIcon = icon;
+}
+
+void OBSCheckBox::paintEvent(QPaintEvent *event)
+{
+	QIcon icon = isChecked() ? checkedIcon : uncheckedIcon;
+
+	if (icon.isNull()) {
+		QCheckBox::paintEvent(event);
+		return;
+	}
+
+	QPainter painter(this);
+	icon.paint(&painter, 0, 0, size().width(), size().height());
+}

--- a/UI/checkbox.hpp
+++ b/UI/checkbox.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QCheckBox>
+
+class QIcon;
+
+class OBSCheckBox : public QCheckBox {
+	Q_OBJECT
+
+	QIcon checkedIcon;
+	QIcon uncheckedIcon;
+
+public:
+	OBSCheckBox(QWidget *parent = nullptr);
+	void SetCheckedIcon(QIcon icon);
+	void SetUncheckedIcon(QIcon icon);
+
+protected:
+	virtual void paintEvent(QPaintEvent *event) override;
+};

--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -1311,6 +1311,8 @@ OBSBasic {
     qproperty-sceneIcon: url(./Dark/sources/scene.svg);
     qproperty-defaultIcon: url(./Dark/sources/default.svg);
     qproperty-audioProcessOutputIcon: url(./Dark/sources/windowaudio.svg);
+    qproperty-iconColor: #fefefe;
+    qproperty-iconColorDisabled: #9a9996;
 }
 
 /* Scene Tree Grid Mode */

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -844,6 +844,8 @@ OBSBasic {
     qproperty-sceneIcon: url(./Dark/sources/scene.svg);
     qproperty-defaultIcon: url(./Dark/sources/default.svg);
     qproperty-audioProcessOutputIcon: url(./Dark/sources/windowaudio.svg);
+    qproperty-iconColor: #fefefe;
+    qproperty-iconColorDisabled: #9a9996;
 }
 
 /* Scene Tree */

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -1299,6 +1299,8 @@ OBSBasic {
     qproperty-sceneIcon: url(./Dark/sources/scene.svg);
     qproperty-defaultIcon: url(./Dark/sources/default.svg);
     qproperty-audioProcessOutputIcon: url(./Dark/sources/windowaudio.svg);
+    qproperty-iconColor: #fefefe;
+    qproperty-iconColorDisabled: #9a9996;
 }
 
 /* Scene Tree Grid Mode */

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -1299,6 +1299,8 @@ OBSBasic {
     qproperty-sceneIcon: url(./Light/sources/scene.svg);
     qproperty-defaultIcon: url(./Light/sources/default.svg);
     qproperty-audioProcessOutputIcon: url(./Light/sources/windowaudio.svg);
+    qproperty-iconColor: #222222;
+    qproperty-iconColorDisabled: #9a9996;
 }
 
 /* Scene Tree Grid Mode */

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -1303,6 +1303,8 @@ OBSBasic {
     qproperty-sceneIcon: url(./Dark/sources/scene.svg);
     qproperty-defaultIcon: url(./Dark/sources/default.svg);
     qproperty-audioProcessOutputIcon: url(./Dark/sources/windowaudio.svg);
+    qproperty-iconColor: #fefefe;
+    qproperty-iconColorDisabled: #9a9996;
 }
 
 /* Scene Tree Grid Mode */

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -1303,6 +1303,8 @@ OBSBasic {
     qproperty-sceneIcon: url(./Dark/sources/scene.svg);
     qproperty-defaultIcon: url(./Dark/sources/default.svg);
     qproperty-audioProcessOutputIcon: url(./Dark/sources/windowaudio.svg);
+    qproperty-iconColor: #fefefe;
+    qproperty-iconColorDisabled: #9a9996;
 }
 
 /* Scene Tree Grid Mode */

--- a/UI/expand-checkbox.hpp
+++ b/UI/expand-checkbox.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <QCheckBox>
+#include "checkbox.hpp"
 
-class ExpandCheckBox : public QCheckBox {
+class ExpandCheckBox : public OBSCheckBox {
 	Q_OBJECT
 };

--- a/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(LibAJANTV2 REQUIRED)
 add_library(aja-output-ui MODULE)
 add_library(OBS::aja-output-ui ALIAS aja-output-ui)
 
-find_qt(COMPONENTS Widgets COMPONENTS_LINUX Gui)
+find_qt(COMPONENTS Widgets Svg Xml COMPONENTS_LINUX Gui)
 
 set_target_properties(
   aja-output-ui
@@ -44,6 +44,8 @@ target_sources(
           ${CMAKE_SOURCE_DIR}/plugins/aja/aja-widget-io.hpp
           ${CMAKE_SOURCE_DIR}/UI/double-slider.cpp
           ${CMAKE_SOURCE_DIR}/UI/double-slider.hpp
+          ${CMAKE_SOURCE_DIR}/UI/icons.cpp
+          ${CMAKE_SOURCE_DIR}/UI/icons.hpp
           ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.hpp
           ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.cpp
           ${CMAKE_SOURCE_DIR}/UI/properties-view.hpp
@@ -58,8 +60,9 @@ target_sources(
           ${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.cpp
           ${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.hpp)
 
-target_link_libraries(aja-output-ui PRIVATE OBS::libobs OBS::frontend-api
-                                            Qt::Widgets AJA::LibAJANTV2)
+target_link_libraries(
+  aja-output-ui PRIVATE OBS::libobs OBS::frontend-api Qt::Widgets Qt::Svg
+                        Qt::Xml AJA::LibAJANTV2)
 
 if(OS_MACOS)
   find_library(IOKIT_FRAMEWORK Iokit)

--- a/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 add_library(decklink-output-ui MODULE)
 add_library(OBS::decklink-output-ui ALIAS decklink-output-ui)
 
-find_qt(COMPONENTS Widgets COMPONENTS_LINUX Gui)
+find_qt(COMPONENTS Widgets Svg Xml COMPONENTS_LINUX Gui)
 
 set_target_properties(
   decklink-output-ui
@@ -26,6 +26,8 @@ target_sources(
           decklink-ui-main.h
           ${CMAKE_SOURCE_DIR}/UI/double-slider.cpp
           ${CMAKE_SOURCE_DIR}/UI/double-slider.hpp
+          ${CMAKE_SOURCE_DIR}/UI/icons.cpp
+          ${CMAKE_SOURCE_DIR}/UI/icons.hpp
           ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.hpp
           ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.cpp
           ${CMAKE_SOURCE_DIR}/UI/properties-view.hpp
@@ -41,7 +43,7 @@ target_sources(
           ${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.cpp)
 
 target_link_libraries(decklink-output-ui PRIVATE OBS::libobs OBS::frontend-api
-                                                 Qt::Widgets)
+                                                 Qt::Widgets Qt::Svg Qt::Xml)
 
 target_compile_features(decklink-output-ui PRIVATE cxx_std_17)
 

--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -3,7 +3,7 @@ project(frontend-tools)
 add_library(frontend-tools MODULE)
 add_library(OBS::frontend-tools ALIAS frontend-tools)
 
-find_qt(COMPONENTS Widgets COMPONENTS_LINUX Gui)
+find_qt(COMPONENTS Widgets Svg Xml COMPONENTS_LINUX Gui)
 
 set_target_properties(
   frontend-tools
@@ -28,6 +28,8 @@ target_sources(
           ${CMAKE_SOURCE_DIR}/UI/double-slider.hpp
           ${CMAKE_SOURCE_DIR}/UI/horizontal-scroll-area.cpp
           ${CMAKE_SOURCE_DIR}/UI/horizontal-scroll-area.hpp
+          ${CMAKE_SOURCE_DIR}/UI/icons.cpp
+          ${CMAKE_SOURCE_DIR}/UI/icons.hpp
           ${CMAKE_SOURCE_DIR}/UI/properties-view.cpp
           ${CMAKE_SOURCE_DIR}/UI/properties-view.hpp
           ${CMAKE_SOURCE_DIR}/UI/properties-view.moc.hpp
@@ -45,7 +47,7 @@ target_sources(
 target_compile_features(frontend-tools PRIVATE cxx_std_17)
 
 target_link_libraries(frontend-tools PRIVATE OBS::frontend-api OBS::libobs
-                                             Qt::Widgets)
+                                             Qt::Widgets Qt::Svg Qt::Xml)
 
 if(OS_POSIX AND NOT OS_MACOS)
   target_link_libraries(frontend-tools PRIVATE Qt::GuiPrivate)

--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher.cpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher.cpp
@@ -333,6 +333,14 @@ void SceneSwitcher::on_toggleStartButton_clicked()
 	}
 }
 
+void SceneSwitcher::showEvent(QShowEvent *event)
+{
+	QDialog::showEvent(event);
+	obs_frontend_set_icon(ui->add, ":/res/images/plus.svg", "addIconSmall");
+	obs_frontend_set_icon(ui->remove, ":/res/images/minus.svg",
+			      "removeIconSmall");
+}
+
 static void SaveSceneSwitcher(obs_data_t *save_data, bool saving, void *)
 {
 	if (saving) {

--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher.hpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher.hpp
@@ -41,6 +41,9 @@ public slots:
 	void on_noMatchSwitchScene_currentTextChanged(const QString &text);
 	void on_checkInterval_valueChanged(int value);
 	void on_toggleStartButton_clicked();
+
+protected:
+	virtual void showEvent(QShowEvent *event) override;
 };
 
 void GetWindowList(std::vector<std::string> &windows);

--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -234,6 +234,16 @@ void ScriptsTool::updatePythonVersionLabel()
 	ui->pythonVersionLabel->setText(label);
 }
 
+void ScriptsTool::ResetIcons()
+{
+	obs_frontend_set_icon(ui->addScripts, ":/res/images/plus.svg",
+			      "addIconSmall");
+	obs_frontend_set_icon(ui->removeScripts, ":/res/images/minus.svg",
+			      "removeIconSmall");
+	obs_frontend_set_icon(ui->reloadScripts, ":/res/images/refresh.svg",
+			      "refreshIconSmall");
+}
+
 void ScriptsTool::RemoveScript(const char *path)
 {
 	for (size_t i = 0; i < scriptData->scripts.size(); i++) {
@@ -607,6 +617,9 @@ static void obs_event(enum obs_frontend_event event, void *)
 
 		delete scriptData;
 		scriptData = new ScriptData;
+	} else if (event == OBS_FRONTEND_EVENT_THEME_CHANGED) {
+		if (scriptsWindow)
+			scriptsWindow->ResetIcons();
 	}
 }
 
@@ -712,6 +725,7 @@ extern "C" void InitScripts()
 
 		if (!scriptsWindow) {
 			scriptsWindow = new ScriptsTool();
+			scriptsWindow->ResetIcons();
 			scriptsWindow->show();
 		} else {
 			scriptsWindow->show();

--- a/UI/frontend-plugins/frontend-tools/scripts.hpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.hpp
@@ -41,6 +41,7 @@ public:
 	void ReloadScript(const char *path);
 	void RefreshLists();
 	void SetScriptDefaults(const char *path);
+	void ResetIcons();
 
 public slots:
 	void on_close_clicked();

--- a/UI/hotkey-edit.cpp
+++ b/UI/hotkey-edit.cpp
@@ -25,6 +25,7 @@
 
 #include "obs-app.hpp"
 #include "qt-wrappers.hpp"
+#include "icons.hpp"
 
 void OBSHotkeyEdit::keyPressEvent(QKeyEvent *event)
 {
@@ -292,13 +293,11 @@ void OBSHotkeyWidget::AddEdit(obs_key_combination combo, int idx)
 	auto edit = new OBSHotkeyEdit(parentWidget(), combo, settings);
 	edit->setToolTip(toolTip);
 
-	auto revert = new QPushButton;
-	revert->setProperty("themeID", "revertIcon");
+	revert = new QPushButton(this);
 	revert->setToolTip(QTStr("Revert"));
 	revert->setEnabled(false);
 
-	auto clear = new QPushButton;
-	clear->setProperty("themeID", "clearIconSmall");
+	clear = new QPushButton(this);
 	clear->setToolTip(QTStr("Clear"));
 	clear->setEnabled(!obs_key_combination_is_empty(combo));
 
@@ -310,16 +309,14 @@ void OBSHotkeyWidget::AddEdit(obs_key_combination combo, int idx)
 			revert->setEnabled(edit->original != new_combo);
 		});
 
-	auto add = new QPushButton;
-	add->setProperty("themeID", "addIconSmall");
+	add = new QPushButton(this);
 	add->setToolTip(QTStr("Add"));
 
-	auto remove = new QPushButton;
-	remove->setProperty("themeID", "removeIconSmall");
+	remove = new QPushButton(this);
 	remove->setToolTip(QTStr("Remove"));
 	remove->setEnabled(removeButtons.size() > 0);
 
-	auto CurrentIndex = [&, remove] {
+	auto CurrentIndex = [this] {
 		auto res = std::find(begin(removeButtons), end(removeButtons),
 				     remove);
 		return std::distance(begin(removeButtons), res);
@@ -366,6 +363,19 @@ void OBSHotkeyWidget::AddEdit(obs_key_combination combo, int idx)
 			 [=](obs_key_combination combo) {
 				 emit SearchKey(combo);
 			 });
+
+	connect(App(), &OBSApp::StyleChanged, this,
+		&OBSHotkeyWidget::ResetIcons);
+
+	ResetIcons();
+}
+
+void OBSHotkeyWidget::ResetIcons()
+{
+	SetIcon(revert, ":/res/images/revert.svg", "revertIcon");
+	SetIcon(clear, ":/res/images/entry-clear.svg", "clearIconSmall");
+	SetIcon(add, ":/res/images/plus.svg", "addIconSmall");
+	SetIcon(remove, ":/res/images/minus.svg", "removeIconSmall");
 }
 
 void OBSHotkeyWidget::RemoveEdit(size_t idx, bool signal)

--- a/UI/hotkey-edit.hpp
+++ b/UI/hotkey-edit.hpp
@@ -179,6 +179,11 @@ public:
 #endif
 	void leaveEvent(QEvent *event) override;
 
+	QPointer<QPushButton> revert;
+	QPointer<QPushButton> clear;
+	QPointer<QPushButton> add;
+	QPointer<QPushButton> remove;
+
 private:
 	void AddEdit(obs_key_combination combo, int idx = -1);
 	void RemoveEdit(size_t idx, bool signal = true);
@@ -198,6 +203,7 @@ private:
 
 private slots:
 	void HandleChangedBindings(obs_hotkey_id id_);
+	void ResetIcons();
 
 signals:
 	void KeyChanged();

--- a/UI/icons.cpp
+++ b/UI/icons.cpp
@@ -1,0 +1,193 @@
+#include "icons.hpp"
+#include "obs-frontend-api.h"
+
+#include <QAction>
+#include <QAbstractButton>
+#include <QDomDocument>
+#include <QSvgRenderer>
+#include <QBitmap>
+#include <QFile>
+#include <QPainter>
+#include <QDirIterator>
+#include <QStyle>
+#include <vector>
+
+#define ICON_COLOR_DARK "#fefefe"
+#define ICON_COLOR_LIGHT "#222222"
+#define ICON_COLOR_DISABLED "#9a9996"
+
+bool iconColorStyled = false;
+bool iconColorDisabledStyled = false;
+QString iconColor;
+QString iconColorDisabled;
+std::vector<IconData *> icons;
+
+static void SetAttrRecur(QDomElement elem, const QString &tag,
+			 const QString &attr, const QString &val)
+{
+	if (elem.tagName().compare(tag) == 0)
+		elem.setAttribute(attr, val);
+
+	for (int i = 0; i < elem.childNodes().count(); i++) {
+		if (!elem.childNodes().at(i).isElement())
+			continue;
+
+		SetAttrRecur(elem.childNodes().at(i).toElement(), tag, attr,
+			     val);
+	}
+}
+
+static QPixmap CreatePixmap(QByteArray data, const QString &color)
+{
+	QDomDocument doc;
+	doc.setContent(data);
+	SetAttrRecur(doc.documentElement(), "path", "fill", color);
+	SetAttrRecur(doc.documentElement(), "svg", "fill", color);
+
+	QSvgRenderer svgRenderer(doc.toByteArray());
+
+	QPixmap pix(svgRenderer.defaultSize());
+	pix.fill(Qt::transparent);
+
+	QPainter pixPainter(&pix);
+	svgRenderer.render(&pixPainter);
+
+	return pix;
+}
+
+static void CreateIcon(const QString &path)
+{
+	bool colored = IconColorStyled();
+
+	QString color;
+
+	if (colored)
+		color = iconColor;
+	else
+		color = obs_frontend_is_theme_dark() ? ICON_COLOR_DARK
+						     : ICON_COLOR_LIGHT;
+
+	QString disabledColor = colored ? iconColorDisabled
+					: ICON_COLOR_DISABLED;
+
+	QFile file(path);
+	file.open(QIODevice::ReadOnly);
+	QByteArray baData = file.readAll();
+
+	QPixmap pix = CreatePixmap(baData, color);
+	QPixmap pixDisabled = CreatePixmap(baData, disabledColor);
+
+	QIcon icon(pix);
+	icon.addPixmap(pixDisabled, QIcon::Disabled);
+
+	IconData *data = new IconData();
+	data->icon = icon;
+	data->path = path;
+
+	icons.emplace_back(data);
+}
+
+void SetIconColorStyled(bool style)
+{
+	iconColorStyled = style;
+}
+
+void SetIconDisabledColorStyled(bool style)
+{
+	iconColorDisabledStyled = style;
+}
+
+void SetIconColorInternal(const QString &color)
+{
+	iconColor = color;
+}
+
+void SetIconDisabledColorInternal(const QString &color)
+{
+	iconColorDisabled = color;
+}
+
+bool IconColorStyled()
+{
+	return iconColorStyled && iconColorDisabledStyled;
+}
+
+QIcon GetIcon(const QString &path, enum IconType type)
+{
+	if (!IconColorStyled())
+		return QIcon();
+
+	QIcon icon;
+
+	if (type != IconType::Original) {
+		for (IconData *data : icons) {
+			if (data->path == path) {
+				icon = data->icon;
+				break;
+			}
+		}
+	} else {
+		icon = QIcon(path);
+	}
+
+	if (icon.isNull())
+		return QIcon();
+
+	if (type != IconType::Disabled)
+		return icon;
+
+	QPixmap pixmap = icon.pixmap(256, QIcon::Disabled);
+	return QIcon(pixmap);
+}
+
+void ClearIcons()
+{
+	for (IconData *data : icons) {
+		delete data;
+	}
+
+	icons.clear();
+}
+
+void LoadIcons()
+{
+	ClearIcons();
+
+	if (!IconColorStyled())
+		return;
+
+	QDirIterator it(":", QDirIterator::Subdirectories);
+
+	while (it.hasNext()) {
+		QString path = it.next();
+
+		if (path.contains(".svg"))
+			CreateIcon(path);
+	}
+}
+
+void SetIcon(QAbstractButton *button, const QString &iconPath,
+	     const QString &themeID)
+{
+	if (!button)
+		return;
+
+	if (IconColorStyled()) {
+		button->setIcon(GetIcon(iconPath));
+	} else {
+		if (!themeID.isEmpty())
+			button->setProperty("themeID", themeID);
+
+		button->style()->unpolish(button);
+		button->style()->polish(button);
+	}
+}
+
+void SetIcon(QAction *action, const QString &iconPath)
+{
+	if (!action)
+		return;
+
+	if (IconColorStyled())
+		action->setIcon(GetIcon(iconPath));
+}

--- a/UI/icons.hpp
+++ b/UI/icons.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <QIcon>
+#include <QString>
+
+class QAction;
+class QAbstractButton;
+
+struct IconData {
+	QIcon icon;
+	QString path;
+};
+
+enum class IconType {
+	Normal,
+	Disabled,
+	Original,
+};
+
+void SetIconColorStyled(bool style);
+void SetIconDisabledColorStyled(bool style);
+bool IconColorStyled();
+
+void SetIconColorInternal(const QString &color);
+void SetIconDisabledColorInternal(const QString &color);
+
+QIcon GetIcon(const QString &path, enum IconType type = IconType::Normal);
+
+void ClearIcons();
+void LoadIcons();
+
+void SetIcon(QAbstractButton *button, const QString &iconPath,
+	     const QString &themeID = "");
+void SetIcon(QAction *action, const QString &iconPath);

--- a/UI/locked-checkbox.cpp
+++ b/UI/locked-checkbox.cpp
@@ -1,5 +1,9 @@
 #include "locked-checkbox.hpp"
+#include "icons.hpp"
 
-LockedCheckBox::LockedCheckBox() {}
-
-LockedCheckBox::LockedCheckBox(QWidget *parent) : QCheckBox(parent) {}
+LockedCheckBox::LockedCheckBox(QWidget *parent) : OBSCheckBox(parent)
+{
+	SetCheckedIcon(GetIcon(":/res/images/locked.svg"));
+	SetUncheckedIcon(
+		GetIcon(":/res/images/unlocked.svg", IconType::Disabled));
+}

--- a/UI/locked-checkbox.hpp
+++ b/UI/locked-checkbox.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <QCheckBox>
+#include "checkbox.hpp"
 
-class LockedCheckBox : public QCheckBox {
+class LockedCheckBox : public OBSCheckBox {
 	Q_OBJECT
 
 public:
-	LockedCheckBox();
-	explicit LockedCheckBox(QWidget *parent);
+	LockedCheckBox(QWidget *parent = nullptr);
 };

--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -1,6 +1,7 @@
 #include "window-basic-main.hpp"
 #include "media-controls.hpp"
 #include "obs-app.hpp"
+#include "icons.hpp"
 #include <QToolTip>
 #include <QStyle>
 #include <QMenu>
@@ -47,10 +48,15 @@ MediaControls::MediaControls(QWidget *parent)
 	: QWidget(parent), ui(new Ui::MediaControls)
 {
 	ui->setupUi(this);
-	ui->playPauseButton->setProperty("themeID", "playIcon");
-	ui->previousButton->setProperty("themeID", "previousIcon");
-	ui->nextButton->setProperty("themeID", "nextIcon");
-	ui->stopButton->setProperty("themeID", "stopIcon");
+	SetIcon(ui->playPauseButton, ":/res/images/media/media_play.svg",
+		"playIcon");
+	SetIcon(ui->previousButton, ":/res/images/media/media_previous.svg",
+		"previousIcon");
+	SetIcon(ui->nextButton, ":/res/images/media/media_next.svg",
+		"nextIcon");
+	SetIcon(ui->stopButton, ":/res/images/media/media_stop.svg",
+		"stopIcon");
+
 	setFocusPolicy(Qt::StrongFocus);
 
 	connect(&mediaTimer, SIGNAL(timeout()), this,
@@ -200,9 +206,8 @@ void MediaControls::StopMediaTimer()
 void MediaControls::SetPlayingState()
 {
 	ui->slider->setEnabled(true);
-	ui->playPauseButton->setProperty("themeID", "pauseIcon");
-	ui->playPauseButton->style()->unpolish(ui->playPauseButton);
-	ui->playPauseButton->style()->polish(ui->playPauseButton);
+	SetIcon(ui->playPauseButton, ":/res/images/media/media_pause.svg",
+		"pauseIcon");
 	ui->playPauseButton->setToolTip(
 		QTStr("ContextBar.MediaControls.PauseMedia"));
 
@@ -214,9 +219,8 @@ void MediaControls::SetPlayingState()
 
 void MediaControls::SetPausedState()
 {
-	ui->playPauseButton->setProperty("themeID", "playIcon");
-	ui->playPauseButton->style()->unpolish(ui->playPauseButton);
-	ui->playPauseButton->style()->polish(ui->playPauseButton);
+	SetIcon(ui->playPauseButton, ":/res/images/media/media_play.svg",
+		"playIcon");
 	ui->playPauseButton->setToolTip(
 		QTStr("ContextBar.MediaControls.PlayMedia"));
 
@@ -225,9 +229,8 @@ void MediaControls::SetPausedState()
 
 void MediaControls::SetRestartState()
 {
-	ui->playPauseButton->setProperty("themeID", "restartIcon");
-	ui->playPauseButton->style()->unpolish(ui->playPauseButton);
-	ui->playPauseButton->style()->polish(ui->playPauseButton);
+	SetIcon(ui->playPauseButton, ":/res/images/media/media_restart.svg",
+		"restartIcon");
 	ui->playPauseButton->setToolTip(
 		QTStr("ContextBar.MediaControls.RestartMedia"));
 

--- a/UI/mute-checkbox.cpp
+++ b/UI/mute-checkbox.cpp
@@ -1,0 +1,8 @@
+#include "mute-checkbox.hpp"
+#include "icons.hpp"
+
+MuteCheckBox::MuteCheckBox(QWidget *parent) : OBSCheckBox(parent)
+{
+	SetCheckedIcon(GetIcon(":/res/images/mute.svg", IconType::Original));
+	SetUncheckedIcon(GetIcon(":/settings/images/settings/audio.svg"));
+}

--- a/UI/mute-checkbox.hpp
+++ b/UI/mute-checkbox.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include <QCheckBox>
+#include "checkbox.hpp"
 
-class MuteCheckBox : public QCheckBox {
+class MuteCheckBox : public OBSCheckBox {
 	Q_OBJECT
+
+public:
+	MuteCheckBox(QWidget *parent = nullptr);
 };

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -48,6 +48,7 @@
 #endif
 #include "window-basic-settings.hpp"
 #include "platform.hpp"
+#include "icons.hpp"
 
 #include <fstream>
 
@@ -1217,6 +1218,9 @@ bool OBSApp::SetTheme(std::string name, std::string path)
 	path = GetTheme(name, path);
 	if (path.empty())
 		return false;
+
+	SetIconColorStyled(false);
+	SetIconDisabledColorStyled(false);
 
 	setStyleSheet("");
 	unique_ptr<OBSThemeMeta> themeMeta;

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -611,3 +611,9 @@ void obs_frontend_add_undo_redo_action(const char *name,
 		c->obs_frontend_add_undo_redo_action(
 			name, undo, redo, undo_data, redo_data, repeatable);
 }
+
+void obs_frontend_set_icon(void *obj, const char *path, const char *theme_id)
+{
+	if (callbacks_valid())
+		c->obs_frontend_set_icon(obj, path, theme_id);
+}

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -242,6 +242,9 @@ EXPORT void obs_frontend_add_undo_redo_action(
 	const char *name, const undo_redo_cb undo, const undo_redo_cb redo,
 	const char *undo_data, const char *redo_data, bool repeatable);
 
+EXPORT void obs_frontend_set_icon(void *obj, const char *path,
+				  const char *theme_id);
+
 /* ------------------------------------------------------------------------- */
 
 #ifdef __cplusplus

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -160,6 +160,9 @@ struct obs_frontend_callbacks {
 						       const char *undo_data,
 						       const char *redo_data,
 						       bool repeatable) = 0;
+
+	virtual void obs_frontend_set_icon(void *obj, const char *path,
+					   const char *theme_id) = 0;
 };
 
 EXPORT void

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -30,6 +30,7 @@
 #include "properties-view.moc.hpp"
 #include "plain-text-edit.hpp"
 #include "obs-app.hpp"
+#include "icons.hpp"
 
 #include <cstdlib>
 #include <initializer_list>
@@ -631,11 +632,12 @@ QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 	return combo;
 }
 
-static void NewButton(QLayout *layout, WidgetInfo *info, const char *themeIcon,
+static void NewButton(QLayout *layout, WidgetInfo *info,
+		      const QString &iconPath, const QString &themeIcon,
 		      void (WidgetInfo::*method)())
 {
 	QPushButton *button = new QPushButton();
-	button->setProperty("themeID", themeIcon);
+	SetIcon(button, iconPath, themeIcon);
 	button->setFlat(true);
 	button->setProperty("toolButton", true);
 
@@ -678,15 +680,16 @@ void OBSPropertiesView::AddEditableList(obs_property_t *prop,
 				       const QModelIndex &, int)));
 
 	QVBoxLayout *sideLayout = new QVBoxLayout();
-	NewButton(sideLayout, info, "addIconSmall", &WidgetInfo::EditListAdd);
-	NewButton(sideLayout, info, "removeIconSmall",
+	NewButton(sideLayout, info, ":/res/images/plus.svg", "addIconSmall",
+		  &WidgetInfo::EditListAdd);
+	NewButton(sideLayout, info, ":/res/images/minus.svg", "removeIconSmall",
 		  &WidgetInfo::EditListRemove);
-	NewButton(sideLayout, info, "configIconSmall",
-		  &WidgetInfo::EditListEdit);
-	NewButton(sideLayout, info, "upArrowIconSmall",
+	NewButton(sideLayout, info, ":/settings/images/settings/general.svg",
+		  "configIconSmall", &WidgetInfo::EditListEdit);
+	NewButton(sideLayout, info, ":/res/images/up.svg", "upArrowIconSmall",
 		  &WidgetInfo::EditListUp);
-	NewButton(sideLayout, info, "downArrowIconSmall",
-		  &WidgetInfo::EditListDown);
+	NewButton(sideLayout, info, ":/res/images/down.svg",
+		  "downArrowIconSmall", &WidgetInfo::EditListDown);
 	sideLayout->addStretch(0);
 
 	QHBoxLayout *subLayout = new QHBoxLayout();

--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -407,16 +407,3 @@ void TruncateLabel(QLabel *label, QString newText, int length)
 
 	SetLabelText(label, newText);
 }
-
-void RefreshToolBarStyling(QToolBar *toolBar)
-{
-	for (QAction *action : toolBar->actions()) {
-		QWidget *widget = toolBar->widgetForAction(action);
-
-		if (!widget)
-			continue;
-
-		widget->style()->unpolish(widget);
-		widget->style()->polish(widget);
-	}
-}

--- a/UI/qt-wrappers.hpp
+++ b/UI/qt-wrappers.hpp
@@ -123,5 +123,3 @@ QStringList OpenFiles(QWidget *parent, QString title, QString path,
 
 void TruncateLabel(QLabel *label, QString newText,
 		   int length = MAX_LABEL_LENGTH);
-
-void RefreshToolBarStyling(QToolBar *toolBar);

--- a/UI/record-button.cpp
+++ b/UI/record-button.cpp
@@ -1,5 +1,6 @@
 #include "record-button.hpp"
 #include "window-basic-main.hpp"
+#include "icons.hpp"
 
 void RecordButton::resizeEvent(QResizeEvent *event)
 {
@@ -65,7 +66,7 @@ static QWidget *getNextWidget(QBoxLayout *container, QLayoutItem *item)
 }
 
 ControlsSplitButton::ControlsSplitButton(const QString &text,
-					 const QVariant &themeID,
+					 const QString &themeID,
 					 void (OBSBasic::*clicked)())
 	: QHBoxLayout(OBSBasic::Get())
 {
@@ -82,14 +83,15 @@ ControlsSplitButton::ControlsSplitButton(const QString &text,
 	addWidget(button.data());
 }
 
-void ControlsSplitButton::addIcon(const QString &name, const QVariant &themeID,
+void ControlsSplitButton::addIcon(const QString &name, const QString &path,
+				  const QString &themeID,
 				  void (OBSBasic::*clicked)())
 {
 	icon.reset(new QPushButton());
 	icon->setAccessibleName(name);
 	icon->setToolTip(name);
 	icon->setChecked(false);
-	icon->setProperty("themeID", themeID);
+	SetIcon(icon.data(), path, themeID);
 
 	QSizePolicy sp;
 	sp.setHeightForWidth(true);

--- a/UI/record-button.hpp
+++ b/UI/record-button.hpp
@@ -19,11 +19,11 @@ class ControlsSplitButton : public QHBoxLayout {
 	Q_OBJECT
 
 public:
-	ControlsSplitButton(const QString &text, const QVariant &themeID,
+	ControlsSplitButton(const QString &text, const QString &themeID,
 			    void (OBSBasic::*clicked)());
 
-	void addIcon(const QString &name, const QVariant &themeID,
-		     void (OBSBasic::*clicked)());
+	void addIcon(const QString &name, const QString &path,
+		     const QString &themeID, void (OBSBasic::*clicked)());
 	void removeIcon();
 	void insert(int index);
 

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -6,6 +6,7 @@
 #include "locked-checkbox.hpp"
 #include "expand-checkbox.hpp"
 #include "platform.hpp"
+#include "icons.hpp"
 
 #include <obs-frontend-api.h>
 #include <obs.h>
@@ -23,6 +24,13 @@
 
 #include <QStylePainter>
 #include <QStyleOptionFocusRect>
+
+SourceTreeSubItemCheckBox::SourceTreeSubItemCheckBox(QWidget *parent)
+	: OBSCheckBox(parent)
+{
+	SetCheckedIcon(GetIcon(":/res/images/expand.svg"));
+	SetUncheckedIcon(GetIcon(":/res/images/collapse.svg"));
+}
 
 static inline OBSScene GetCurrentScene()
 {
@@ -63,15 +71,7 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_)
 	bool sourceVisible = obs_sceneitem_visible(sceneitem);
 
 	if (tree->iconsVisible) {
-		QIcon icon;
-
-		if (strcmp(id, "scene") == 0)
-			icon = main->GetSceneIcon();
-		else if (strcmp(id, "group") == 0)
-			icon = main->GetGroupIcon();
-		else
-			icon = main->GetSourceIcon(id);
-
+		QIcon icon = main->GetSourceIcon(id);
 		QPixmap pixmap = icon.pixmap(QSize(16, 16));
 
 		iconLabel = new QLabel();
@@ -1087,7 +1087,6 @@ SourceTree::SourceTree(QWidget *parent_) : QListView(parent_)
 	UpdateNoSourcesMessage();
 	connect(App(), &OBSApp::StyleChanged, this,
 		&SourceTree::UpdateNoSourcesMessage);
-	connect(App(), &OBSApp::StyleChanged, this, &SourceTree::UpdateIcons);
 
 	setItemDelegate(new SourceTreeDelegate(this));
 }

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -11,6 +11,7 @@
 #include <QStyledItemDelegate>
 #include <obs.hpp>
 #include <obs-frontend-api.h>
+#include <checkbox.hpp>
 
 class QLabel;
 class QCheckBox;
@@ -22,8 +23,11 @@ class LockedCheckBox;
 class VisibilityCheckBox;
 class VisibilityItemWidget;
 
-class SourceTreeSubItemCheckBox : public QCheckBox {
+class SourceTreeSubItemCheckBox : public OBSCheckBox {
 	Q_OBJECT
+
+public:
+	SourceTreeSubItemCheckBox(QWidget *parent = nullptr);
 };
 
 class SourceTreeItem : public QFrame {
@@ -62,7 +66,7 @@ public:
 
 private:
 	QSpacerItem *spacer = nullptr;
-	QCheckBox *expand = nullptr;
+	SourceTreeSubItemCheckBox *expand = nullptr;
 	QLabel *iconLabel = nullptr;
 	VisibilityCheckBox *vis = nullptr;
 	LockedCheckBox *lock = nullptr;

--- a/UI/visibility-checkbox.cpp
+++ b/UI/visibility-checkbox.cpp
@@ -1,5 +1,9 @@
 #include "visibility-checkbox.hpp"
+#include "icons.hpp"
 
-VisibilityCheckBox::VisibilityCheckBox() {}
-
-VisibilityCheckBox::VisibilityCheckBox(QWidget *parent) : QCheckBox(parent) {}
+VisibilityCheckBox::VisibilityCheckBox(QWidget *parent) : OBSCheckBox(parent)
+{
+	SetCheckedIcon(GetIcon(":/res/images/visible.svg"));
+	SetUncheckedIcon(
+		GetIcon(":/res/images/invisible.svg", IconType::Disabled));
+}

--- a/UI/visibility-checkbox.hpp
+++ b/UI/visibility-checkbox.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <QCheckBox>
+#include "checkbox.hpp"
 
-class VisibilityCheckBox : public QCheckBox {
+class VisibilityCheckBox : public OBSCheckBox {
 	Q_OBJECT
 
 public:
-	VisibilityCheckBox();
-	explicit VisibilityCheckBox(QWidget *parent);
+	VisibilityCheckBox(QWidget *parent = nullptr);
 };

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -5,6 +5,7 @@
 #include "mute-checkbox.hpp"
 #include "slider-ignorewheel.hpp"
 #include "slider-absoluteset-style.hpp"
+#include "icons.hpp"
 #include <QFontDatabase>
 #include <QHBoxLayout>
 #include <QPushButton>
@@ -179,7 +180,8 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 
 	if (showConfig) {
 		config = new QPushButton(this);
-		config->setProperty("themeID", "menuIconSmall");
+		SetIcon(config, ":/res/images/dots-vert.svg", "menuIconSmall");
+
 		config->setSizePolicy(QSizePolicy::Maximum,
 				      QSizePolicy::Maximum);
 		config->setMaximumSize(22, 22);

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -25,6 +25,7 @@
 #include "item-widget-helpers.hpp"
 #include "obs-app.hpp"
 #include "undo-stack-obs.hpp"
+#include "icons.hpp"
 
 #include <QMessageBox>
 #include <QCloseEvent>
@@ -180,7 +181,8 @@ OBSBasicFilters::OBSBasicFilters(QWidget *parent, OBSSource source_)
 	renameEffect->setShortcut({Qt::Key_F2});
 #endif
 
-	UpdateFilters();
+	connect(App(), &OBSApp::StyleChanged, this,
+		&OBSBasicFilters::ResetIcons);
 }
 
 OBSBasicFilters::~OBSBasicFilters()
@@ -188,6 +190,21 @@ OBSBasicFilters::~OBSBasicFilters()
 	obs_source_dec_showing(source);
 	ClearListItems(ui->asyncFilters);
 	ClearListItems(ui->effectFilters);
+}
+
+void OBSBasicFilters::ResetIcons()
+{
+	SetIcon(ui->addAsyncFilter, ":/res/images/plus.svg");
+	SetIcon(ui->removeAsyncFilter, ":/res/images/minus.svg");
+	SetIcon(ui->moveAsyncFilterUp, ":/res/images/up.svg");
+	SetIcon(ui->moveAsyncFilterDown, ":/res/images/down.svg");
+
+	SetIcon(ui->addEffectFilter, ":/res/images/plus.svg");
+	SetIcon(ui->removeEffectFilter, ":/res/images/minus.svg");
+	SetIcon(ui->moveEffectFilterUp, ":/res/images/up.svg");
+	SetIcon(ui->moveEffectFilterDown, ":/res/images/down.svg");
+
+	UpdateFilters();
 }
 
 void OBSBasicFilters::Init()

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -121,6 +121,9 @@ private slots:
 	void CopyFilter();
 	void PasteFilter();
 
+public slots:
+	void ResetIcons();
+
 public:
 	OBSBasicFilters(QWidget *parent, OBSSource source_);
 	~OBSBasicFilters();

--- a/UI/window-basic-main-icons.cpp
+++ b/UI/window-basic-main-icons.cpp
@@ -1,41 +1,66 @@
-#include <window-basic-main.hpp>
+#include "window-basic-main.hpp"
+#include "icons.hpp"
 
-QIcon OBSBasic::GetSourceIcon(const char *id) const
+QIcon OBSBasic::GetSourceIcon(const char *id)
 {
+	bool colored = IconColorStyled();
+
+	if (strcmp(id, "scene") == 0)
+		return colored ? GetIcon(":/res/images/sources/scene.svg")
+			       : GetSceneIcon();
+	else if (strcmp(id, "group") == 0)
+		return colored ? GetIcon(":/res/images/sources/group.svg")
+			       : GetGroupIcon();
+
 	obs_icon_type type = obs_source_get_icon_type(id);
 
 	switch (type) {
 	case OBS_ICON_TYPE_IMAGE:
-		return GetImageIcon();
+		return colored ? GetIcon(":/res/images/sources/image.svg")
+			       : GetImageIcon();
 	case OBS_ICON_TYPE_COLOR:
-		return GetColorIcon();
+		return colored ? GetIcon(":/res/images/sources/brush.svg")
+			       : GetColorIcon();
 	case OBS_ICON_TYPE_SLIDESHOW:
-		return GetSlideshowIcon();
+		return colored ? GetIcon(":/res/images/sources/slideshow.svg")
+			       : GetSlideshowIcon();
 	case OBS_ICON_TYPE_AUDIO_INPUT:
-		return GetAudioInputIcon();
+		return colored ? GetIcon(":/res/images/sources/microphone.svg")
+			       : GetAudioInputIcon();
 	case OBS_ICON_TYPE_AUDIO_OUTPUT:
-		return GetAudioOutputIcon();
+		return colored ? GetIcon(":/settings/images/settings/audio.svg")
+			       : GetAudioOutputIcon();
 	case OBS_ICON_TYPE_DESKTOP_CAPTURE:
-		return GetDesktopCapIcon();
+		return colored ? GetIcon(":/settings/images/settings/video.svg")
+			       : GetDesktopCapIcon();
 	case OBS_ICON_TYPE_WINDOW_CAPTURE:
-		return GetWindowCapIcon();
+		return colored ? GetIcon(":/res/images/sources/window.svg")
+			       : GetWindowCapIcon();
 	case OBS_ICON_TYPE_GAME_CAPTURE:
-		return GetGameCapIcon();
+		return colored ? GetIcon(":/res/images/sources/gamepad.svg")
+			       : GetGameCapIcon();
 	case OBS_ICON_TYPE_CAMERA:
-		return GetCameraIcon();
+		return colored ? GetIcon(":/res/images/sources/camera.svg")
+			       : GetCameraIcon();
 	case OBS_ICON_TYPE_TEXT:
-		return GetTextIcon();
+		return colored ? GetIcon(":/res/images/sources/text.svg")
+			       : GetTextIcon();
 	case OBS_ICON_TYPE_MEDIA:
-		return GetMediaIcon();
+		return colored ? GetIcon(":/res/images/sources/media.svg")
+			       : GetMediaIcon();
 	case OBS_ICON_TYPE_BROWSER:
-		return GetBrowserIcon();
+		return colored ? GetIcon(":/res/images/sources/globe.svg")
+			       : GetBrowserIcon();
 	case OBS_ICON_TYPE_CUSTOM:
 		//TODO: Add ability for sources to define custom icons
-		return GetDefaultIcon();
+		return colored ? GetIcon(":/res/images/sources/default.svg")
+			       : GetDefaultIcon();
 	case OBS_ICON_TYPE_PROCESS_AUDIO_OUTPUT:
-		return GetAudioProcessOutputIcon();
+		return colored ? GetIcon(":/res/images/sources/windowaudio.svg")
+			       : GetAudioProcessOutputIcon();
 	default:
-		return GetDefaultIcon();
+		return colored ? GetIcon(":/res/images/sources/default.svg")
+			       : GetDefaultIcon();
 	}
 }
 
@@ -119,6 +144,20 @@ void OBSBasic::SetAudioProcessOutputIcon(const QIcon &icon)
 	audioProcessOutputIcon = icon;
 }
 
+void OBSBasic::SetIconColor(const QColor &color)
+{
+	iconColor = color;
+	SetIconColorStyled(true);
+	SetIconColorInternal(color.name());
+}
+
+void OBSBasic::SetIconDisabledColor(const QColor &color)
+{
+	iconColorDisabled = color;
+	SetIconDisabledColorStyled(true);
+	SetIconDisabledColorInternal(color.name());
+}
+
 QIcon OBSBasic::GetImageIcon() const
 {
 	return imageIcon;
@@ -197,4 +236,59 @@ QIcon OBSBasic::GetDefaultIcon() const
 QIcon OBSBasic::GetAudioProcessOutputIcon() const
 {
 	return audioProcessOutputIcon;
+}
+
+QColor OBSBasic::GetIconColor() const
+{
+	return iconColor;
+}
+
+QColor OBSBasic::GetIconDisabledColor() const
+{
+	return iconColorDisabled;
+}
+
+void OBSBasic::ResetIcons()
+{
+	LoadIcons();
+
+	SetIcon(ui->sourceFiltersButton, ":/res/images/filter.svg");
+	SetIcon(ui->sourcePropertiesButton,
+		":/settings/images/settings/general.svg");
+	SetIcon(ui->sourceInteractButton, ":/res/images/interact.svg");
+
+	SetIcon(ui->actionAddScene, ":/res/images/plus.svg");
+	SetIcon(ui->actionRemoveScene, ":/res/images/minus.svg");
+	SetIcon(ui->actionSceneUp, ":/res/images/up.svg");
+	SetIcon(ui->actionSceneDown, ":/res/images/down.svg");
+	SetIcon(ui->actionSceneFilters, ":/res/images/filter.svg");
+
+	SetIcon(ui->actionAddSource, ":/res/images/plus.svg");
+	SetIcon(ui->actionRemoveSource, ":/res/images/minus.svg");
+	SetIcon(ui->actionSourceProperties,
+		":/settings/images/settings/general.svg");
+	SetIcon(ui->actionSourceUp, ":/res/images/up.svg");
+	SetIcon(ui->actionSourceDown, ":/res/images/down.svg");
+
+	SetIcon(ui->actionMixerToolbarAdvAudio, ":/res/images/cogs.svg");
+	SetIcon(ui->actionMixerToolbarMenu, ":/res/images/dots-vert.svg");
+
+	SetIcon(ui->transitionAdd, ":/res/images/plus.svg");
+	SetIcon(ui->transitionRemove, ":/res/images/minus.svg");
+	SetIcon(ui->transitionProps, ":/settings/images/settings/general.svg");
+
+	if (pause)
+		SetIcon(pause.data(), ":/res/images/media/media_pause.svg",
+			"pauseIconSmall");
+
+	if (vcamButton)
+		SetIcon(vcamButton.data()->second(),
+			":/settings/images/settings/general.svg",
+			"configIconSmall");
+
+	if (replayBufferButton)
+		SetIcon(replayBufferButton.data()->second(),
+			":/res/images/save.svg", "replayIconSmall");
+
+	ui->sources->UpdateIcons();
 }

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -28,6 +28,7 @@
 #include "menu-button.hpp"
 #include "slider-ignorewheel.hpp"
 #include "qt-wrappers.hpp"
+#include "icons.hpp"
 
 #include "obs-hotkey.h"
 
@@ -774,7 +775,8 @@ void OBSBasic::CreateProgramOptions()
 	layout->setSpacing(4);
 
 	QPushButton *configTransitions = new QPushButton();
-	configTransitions->setProperty("themeID", "menuIconSmall");
+	SetIcon(configTransitions, ":/res/images/dots-vert.svg",
+		"menuIconSmall");
 
 	QHBoxLayout *mainButtonLayout = new QHBoxLayout();
 	mainButtonLayout->setSpacing(2);
@@ -787,7 +789,7 @@ void OBSBasic::CreateProgramOptions()
 	quickTransitions->setSpacing(2);
 
 	QPushButton *addQuickTransition = new QPushButton();
-	addQuickTransition->setProperty("themeID", "addIconSmall");
+	SetIcon(addQuickTransition, ":/res/images/plus.svg", "addIconSmall");
 
 	QLabel *quickTransitionsLabel = new QLabel(QTStr("QuickTransitions"));
 	quickTransitionsLabel->setSizePolicy(QSizePolicy::Expanding,

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -173,6 +173,10 @@ class OBSBasic : public OBSMainWindow {
 			   DESIGNABLE true)
 	Q_PROPERTY(QIcon audioProcessOutputIcon READ GetAudioProcessOutputIcon
 			   WRITE SetAudioProcessOutputIcon DESIGNABLE true)
+	Q_PROPERTY(QColor iconColor READ GetIconColor WRITE SetIconColor
+			   DESIGNABLE true)
+	Q_PROPERTY(QColor iconColorDisabled READ GetIconDisabledColor WRITE
+			   SetIconDisabledColor DESIGNABLE true)
 
 	friend class OBSAbout;
 	friend class OBSBasicPreview;
@@ -579,6 +583,8 @@ private:
 	QIcon sceneIcon;
 	QIcon defaultIcon;
 	QIcon audioProcessOutputIcon;
+	QColor iconColor;
+	QColor iconColorDisabled;
 
 	QIcon GetImageIcon() const;
 	QIcon GetColorIcon() const;
@@ -614,6 +620,7 @@ private:
 	bool autoStopBroadcast = true;
 	bool broadcastActive = false;
 	bool broadcastReady = false;
+
 	QPointer<QThread> youtubeStreamCheckThread;
 #if YOUTUBE_ENABLED
 	void YoutubeStreamCheck(const std::string &key);
@@ -815,12 +822,14 @@ private slots:
 	void SetSceneIcon(const QIcon &icon);
 	void SetDefaultIcon(const QIcon &icon);
 	void SetAudioProcessOutputIcon(const QIcon &icon);
+	void SetIconColor(const QColor &color);
+	void SetIconDisabledColor(const QColor &color);
 
 	void TBarChanged(int value);
 	void TBarReleased();
 
 	void LockVolumeControl(bool lock);
-	void ResetProxyStyleSliders();
+	void ThemeChanged();
 
 	void UpdateVirtualCamConfig(const VCamConfig &config);
 
@@ -857,6 +866,7 @@ private:
 
 	bool LowDiskSpace();
 	void DiskSpaceMessage();
+	void ResetIcons();
 
 	OBSSource prevFTBSource = nullptr;
 
@@ -965,9 +975,11 @@ public:
 	void AddProjectorMenuMonitors(QMenu *parent, QObject *target,
 				      const char *slot);
 
-	QIcon GetSourceIcon(const char *id) const;
+	QIcon GetSourceIcon(const char *id);
 	QIcon GetGroupIcon() const;
 	QIcon GetSceneIcon() const;
+	QColor GetIconColor() const;
+	QColor GetIconDisabledColor() const;
 
 	OBSWeakSource copyFilter;
 
@@ -1197,6 +1209,8 @@ public slots:
 	void UpdateContextBar(bool force = false);
 	void UpdateContextBarDeferred(bool force = false);
 	void UpdateContextBarVisibility();
+
+	void UpdateIcon(void *obj, const char *path, const char *themeID);
 
 private:
 	std::unique_ptr<Ui::OBSBasic> ui;

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -2002,8 +2002,6 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *scene,
 		{{{1.f, 1.f, 0.f}}},
 	};
 
-	main->GetCameraIcon();
-
 	QColor selColor = main->GetSelectionColor();
 	QColor cropColor = main->GetCropColor();
 	QColor hoverColor = main->GetHoverColor();

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -46,6 +46,7 @@
 #include "window-basic-settings.hpp"
 #include "window-basic-main-outputs.hpp"
 #include "window-projector.hpp"
+#include "icons.hpp"
 
 #include <util/platform.h>
 #include <util/dstr.hpp>
@@ -920,6 +921,9 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 
 	UpdateAudioWarnings();
 	UpdateAdvNetworkGroup();
+
+	connect(App(), &OBSApp::StyleChanged, this,
+		&OBSBasicSettings::ResetIcons);
 }
 
 OBSBasicSettings::~OBSBasicSettings()
@@ -3977,6 +3981,12 @@ bool OBSBasicSettings::QueryChanges()
 	return true;
 }
 
+void OBSBasicSettings::showEvent(QShowEvent *event)
+{
+	QDialog::showEvent(event);
+	ResetIcons();
+}
+
 void OBSBasicSettings::closeEvent(QCloseEvent *event)
 {
 	if (!AskIfCanCloseSettings())
@@ -5517,42 +5527,74 @@ QIcon OBSBasicSettings::GetAdvancedIcon() const
 
 void OBSBasicSettings::SetGeneralIcon(const QIcon &icon)
 {
-	ui->listWidget->item(0)->setIcon(icon);
+	generalIcon = icon;
 }
 
 void OBSBasicSettings::SetStreamIcon(const QIcon &icon)
 {
-	ui->listWidget->item(1)->setIcon(icon);
+	streamIcon = icon;
 }
 
 void OBSBasicSettings::SetOutputIcon(const QIcon &icon)
 {
-	ui->listWidget->item(2)->setIcon(icon);
+	outputIcon = icon;
 }
 
 void OBSBasicSettings::SetAudioIcon(const QIcon &icon)
 {
-	ui->listWidget->item(3)->setIcon(icon);
+	audioIcon = icon;
 }
 
 void OBSBasicSettings::SetVideoIcon(const QIcon &icon)
 {
-	ui->listWidget->item(4)->setIcon(icon);
+	videoIcon = icon;
 }
 
 void OBSBasicSettings::SetHotkeysIcon(const QIcon &icon)
 {
-	ui->listWidget->item(5)->setIcon(icon);
+	hotkeysIcon = icon;
 }
 
 void OBSBasicSettings::SetAccessibilityIcon(const QIcon &icon)
 {
-	ui->listWidget->item(6)->setIcon(icon);
+	accessibilityIcon = icon;
 }
 
 void OBSBasicSettings::SetAdvancedIcon(const QIcon &icon)
 {
-	ui->listWidget->item(7)->setIcon(icon);
+	advancedIcon = icon;
+}
+
+void OBSBasicSettings::ResetIcons()
+{
+	bool colored = IconColorStyled();
+
+	ui->listWidget->item(0)->setIcon(
+		colored ? GetIcon(":/settings/images/settings/general.svg")
+			: generalIcon);
+	ui->listWidget->item(1)->setIcon(
+		colored ? GetIcon(":/settings/images/settings/stream.svg")
+			: streamIcon);
+	ui->listWidget->item(2)->setIcon(
+		colored ? GetIcon(":/settings/images/settings/output.svg")
+			: outputIcon);
+	ui->listWidget->item(3)->setIcon(
+		colored ? GetIcon(":/settings/images/settings/audio.svg")
+			: audioIcon);
+	ui->listWidget->item(4)->setIcon(
+		colored ? GetIcon(":/settings/images/settings/video.svg")
+			: videoIcon);
+	ui->listWidget->item(5)->setIcon(
+		colored ? GetIcon(":/settings/images/settings/hotkeys.svg")
+			: hotkeysIcon);
+	ui->listWidget->item(6)->setIcon(
+		colored ? GetIcon(":/settings/images/settings/accessibility.svg")
+			: accessibilityIcon);
+	ui->listWidget->item(7)->setIcon(
+		colored ? GetIcon(":/settings/images/settings/advanced.svg")
+			: advancedIcon);
+
+	SetIcon(ui->hotkeyFilterReset, ":/res/images/revert.svg");
 }
 
 int OBSBasicSettings::CurrentFLVTrack()

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -283,6 +283,8 @@ private slots:
 	void on_hotkeyFilterSearch_textChanged(const QString text);
 	void on_hotkeyFilterInput_KeyChanged(obs_key_combination_t combo);
 
+	void ResetIcons();
+
 private:
 	/* output */
 	void LoadSimpleOutputSettings();
@@ -465,6 +467,7 @@ private slots:
 	void UseStreamKeyAdvClicked();
 
 protected:
+	virtual void showEvent(QShowEvent *event) override;
 	virtual void closeEvent(QCloseEvent *event) override;
 	void reject() override;
 

--- a/UI/window-extra-browsers.hpp
+++ b/UI/window-extra-browsers.hpp
@@ -1,10 +1,19 @@
 #pragma once
 
+#include <QPushButton>
+#include <QPointer>
 #include <QDialog>
 #include <QScopedPointer>
 #include <QAbstractTableModel>
 #include <QStyledItemDelegate>
 #include <memory>
+
+class DelButton : public QPushButton {
+public:
+	inline DelButton(QModelIndex index_) : QPushButton(), index(index_) {}
+
+	QPersistentModelIndex index;
+};
 
 class Ui_OBSExtraBrowsers;
 class ExtraBrowsersModel;
@@ -66,6 +75,11 @@ public:
 
 	QString newTitle;
 	QString newURL;
+
+	QPointer<DelButton> del;
+
+private slots:
+	void ResetIcons();
 
 public slots:
 	void Init();


### PR DESCRIPTION
### Description
This adds the ability to change icon colors by qss.

### Motivation and Context
@Warchamp7 really wants this feature because it prevents having to maintain several different sets of icons. It currently doesn't work with combobox or spinbox up/down icons.

### How Has This Been Tested?
Changed icon color in qss and made sure they were the correct color.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
