### PR TITLE
UI: Remove unused variable in PopulateBitrateMap

### DIFF
--- a/UI/audio-encoders.cpp
+++ b/UI/audio-encoders.cpp
@@ -147,7 +147,6 @@ static void PopulateBitrateMap()
 
 		struct obs_audio_info aoi;
 		obs_get_audio_info(&aoi);
-		uint32_t output_channels = get_audio_channels(aoi.speakers);
 
 		HandleEncoderProperties(fallbackEncoder.c_str());
 


### PR DESCRIPTION
### Description
Removes an unused variable triggering compiler errors in CMake 3.0 rework.

### Motivation and Context
Commit 2a2d8fc1bb2943d798aab3747b262b158aa9add2 removed the only usage of the `output_channels` variable, but didn't remove it. This PR fixes the issue.

### How Has This Been Tested?
Tested on macOS 13 with Xcode and extended warnings enabled.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
