### PR TITLE
UI, libobs: Fix not handled in switch warnings

### DIFF
--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -135,14 +135,18 @@ bool QTToGSWindow(QWindow *window, gs_window &gswindow)
 		gswindow.display = obs_get_nix_platform_display();
 		break;
 #ifdef ENABLE_WAYLAND
-	case OBS_NIX_PLATFORM_WAYLAND:
+	case OBS_NIX_PLATFORM_WAYLAND: {
 		QPlatformNativeInterface *native =
 			QGuiApplication::platformNativeInterface();
 		gswindow.display =
 			native->nativeResourceForWindow("surface", window);
 		success = gswindow.display != nullptr;
 		break;
+	}
 #endif
+	default:
+		success = false;
+		break;
 	}
 #endif
 	return success;

--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -416,6 +416,8 @@ bool obs_hotkeys_platform_init(struct obs_core_hotkeys *hotkeys)
 		hotkeys_vtable = obs_nix_wayland_get_hotkeys_vtable();
 		break;
 #endif
+	default:
+		break;
 	}
 
 	return hotkeys_vtable->init(hotkeys);

--- a/plugins/linux-v4l2/v4l2-decoder.c
+++ b/plugins/linux-v4l2/v4l2-decoder.c
@@ -116,6 +116,8 @@ int v4l2_decode_frame(struct obs_source_frame *out, uint8_t *data,
 	case AV_PIX_FMT_YUV444P:
 		out->format = VIDEO_FORMAT_I444;
 		break;
+	default:
+		break;
 	}
 
 	return 0;


### PR DESCRIPTION
### Description
These warnings were being spit out by GCC on Linux.

### Motivation and Context
Less spammy compiling

### How Has This Been Tested?
Compiled OBS

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
