### PR TITLE
cmake: Check if Sparkle options are non-empty

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -446,7 +446,7 @@ elseif(OS_MACOS)
               update/shared-update.cpp update/shared-update.hpp
               update/update-helpers.cpp update/update-helpers.hpp)
 
-    if(DEFINED SPARKLE_APPCAST_URL AND DEFINED SPARKLE_PUBLIC_KEY)
+    if(SPARKLE_APPCAST_URL AND SPARKLE_PUBLIC_KEY)
       find_library(SPARKLE Sparkle)
       mark_as_advanced(SPARKLE)
 

--- a/cmake/Modules/ObsHelpers_macOS.cmake
+++ b/cmake/Modules/ObsHelpers_macOS.cmake
@@ -354,7 +354,7 @@ function(setup_obs_bundle target)
     set(_CODESIGN_ENTITLEMENTS \"${CMAKE_SOURCE_DIR}/cmake/bundle/macOS\")"
     COMPONENT obs_resources)
 
-  if(DEFINED SPARKLE_APPCAST_URL AND DEFINED SPARKLE_PUBLIC_KEY)
+  if(SPARKLE_APPCAST_URL AND SPARKLE_PUBLIC_KEY)
     add_custom_command(
       TARGET ${target}
       POST_BUILD


### PR DESCRIPTION
### Description

Applies change requested in #7869 to master.

### Motivation and Context

We should check that these variables are non-empty rather than just that they exist.

### How Has This Been Tested?

Has not, but according to the documentation this should work.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
