### PR TITLE
Fix failures in reading public key file

### DIFF
--- a/UI/update/shared-update.cpp
+++ b/UI/update/shared-update.cpp
@@ -176,12 +176,15 @@ static void LoadPublicKey(std::string &pubkey)
 static bool CheckDataSignature(const char *name, const std::string &data,
 			       const std::string &hexSig)
 try {
+	static std::mutex pubkey_mutex;
+	static std::string obsPubKey;
+
 	if (hexSig.empty() || hexSig.length() > 0xFFFF ||
 	    (hexSig.length() & 1) != 0)
 		throw strprintf("Missing or invalid signature for %s: %s", name,
 				hexSig.c_str());
 
-	static std::string obsPubKey;
+	std::scoped_lock lock(pubkey_mutex);
 	if (obsPubKey.empty())
 		LoadPublicKey(obsPubKey);
 

--- a/UI/update/shared-update.cpp
+++ b/UI/update/shared-update.cpp
@@ -68,7 +68,7 @@ try {
 
 static bool QuickReadFile(const char *file, std::string &data)
 try {
-	std::ifstream fileStream(file);
+	std::ifstream fileStream(file, std::ifstream::binary);
 	if (!fileStream.is_open() || fileStream.fail())
 		throw strprintf("Failed to open file '%s': %s", file,
 				strerror(errno));


### PR DESCRIPTION
### Description

Switched `QuickReadFile` to use binary mode when reading files as text mode converts `\r\n` to just `\n` which caused a premature `EOF` as the size determined by seeking to the end would no longer match the amount of data that is actually read into the buffer.

Also throws in a mutex for good measure since on Windows it can theoretically try to read the public key file from multiple threads at the same time.

### Motivation and Context

Reading the public key could fail if the file was in CRLF format. 

### How Has This Been Tested?

Started OBS, no longer saw read failures.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
