### PR TITLE
obs-transitions: Add long description for full decode option

### DIFF
--- a/plugins/obs-transitions/data/locale/en-US.ini
+++ b/plugins/obs-transitions/data/locale/en-US.ini
@@ -29,6 +29,7 @@ TrackMatteLayoutVertical="Same file, stacked (stinger on top, track matte at the
 TrackMatteLayoutSeparateFile="Separate file (warning: matte can get out of sync)"
 TrackMatteLayoutMask="Mask only"
 PreloadVideoToRam="Preload Video to RAM"
+PreloadVideoToRam.Description="Load the entire Stinger to RAM, avoiding real-time decoding during playback.\nRequires a lot of RAM (a typical 5 second 1080p60 video takes ~1 GB)."
 AudioFadeStyle="Audio Fade Style"
 AudioFadeStyle.FadeOutFadeIn="Fade out to transition point then fade in"
 AudioFadeStyle.CrossFade="Crossfade"

--- a/plugins/obs-transitions/transition-stinger.c
+++ b/plugins/obs-transitions/transition-stinger.c
@@ -748,16 +748,19 @@ static obs_properties_t *stinger_properties(void *data)
 	obs_property_t *p = obs_properties_add_list(
 		ppts, "tp_type", obs_module_text("TransitionPointType"),
 		OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
-	obs_properties_add_bool(ppts, "hw_decode",
-				obs_module_text("HardwareDecode"));
-	obs_properties_add_bool(ppts, "preload",
-				obs_module_text("PreloadVideoToRam"));
 	obs_property_list_add_int(p, obs_module_text("TransitionPointTypeTime"),
 				  TIMING_TIME);
 	obs_property_list_add_int(
 		p, obs_module_text("TransitionPointTypeFrame"), TIMING_FRAME);
 
 	obs_property_set_modified_callback(p, transition_point_type_modified);
+
+	obs_properties_add_bool(ppts, "hw_decode",
+				obs_module_text("HardwareDecode"));
+	p = obs_properties_add_bool(ppts, "preload",
+				    obs_module_text("PreloadVideoToRam"));
+	obs_property_set_long_description(
+		p, obs_module_text("PreloadVideoToRam.Description"));
 
 	obs_properties_add_int(ppts, "transition_point",
 			       obs_module_text("TransitionPoint"), 0, 120000,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a long description for the "Preload Video to RAM" outlining RAM usage.
Uses the formula `(1920 * 1080 * 1.5 * 60 + 48000 * 4) * 5 = 934.080.000` (1920*10180 pixels, NV12, 60 FPS, 48kHz Audio, 5 seconds) for the "~1 GB" number.

<img width="624" alt="image" src="https://user-images.githubusercontent.com/59806498/221695197-14570afe-952e-4f5f-b066-6b1f93b30d0c.png">

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I'm scared of users (and potentially bad tutorials).
This should point out that the option may not be suitable on some lower-end systems (when doing something besides OBS, like playing games).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.2
See screenshot above (the position of the `(?)` is an existing bug at least on macOS that's not caused by this PR).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
