### PR TITLE
UI: Fix leak with empty path in stats

### DIFF
--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -1469,7 +1469,8 @@ uint64_t os_get_proc_virtual_size(void)
 uint64_t os_get_free_disk_space(const char *dir)
 {
 	wchar_t *wdir = NULL;
-	if (!os_utf8_to_wcs_ptr(dir, 0, &wdir))
+	os_utf8_to_wcs_ptr(dir, 0, &wdir);
+	if (!wdir)
 		return 0;
 
 	ULARGE_INTEGER free;


### PR DESCRIPTION
### Description
If the recording path is left empty in Settings, a leak can occur in window-basic-stats.cpp because a bmalloc is called for a size 1. This fixes the leak by checking against the path.

### Motivation and Context
Leaks are bad.
The leak was found by having an empty path in Settings/output/recording.
OBS then logs 5 leaks.
Admittedly this path should not be empty.
But it's better to be on the safe side even for stuff which we think users won't do.

### How Has This Been Tested?
OBS does not log any leak after the fix.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
