### PR TITLE
libobs/media-io: Add color range and colorspace data to conversion

### DIFF
--- a/libobs/media-io/video-io.c
+++ b/libobs/media-io/video-io.c
@@ -392,6 +392,8 @@ bool video_output_connect(
 			input.conversion.format = video->info.format;
 			input.conversion.width = video->info.width;
 			input.conversion.height = video->info.height;
+			input.conversion.range = video->info.range;
+			input.conversion.colorspace = video->info.colorspace;
 		}
 
 		if (input.conversion.width == 0)


### PR DESCRIPTION
### Description
By adding the range data we can get successful handling of full range color via custom ffmpeg output. Previously, it would always default to 0 which would would yield partial/limited output.

Adds colorspace info. Currently the the output file is correctly tagged, but not undergone the actual conversion.

Big thank you to @RytoEX who helped me work out some of this libobs stuff, and to @mia-is-baka for their code submission.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/7602
Fixes https://github.com/obsproject/obs-studio/issues/8199
Fixes https://github.com/obsproject/obs-studio/issues/5363

https://github.com/obsproject/obs-studio/pull/8202 was closed.

### How Has This Been Tested?
On Win10 22H2 I ran thru a battery of codecs and containers to test and observe said change, and compare with expected behavior from FFmpeg commandline.


I used ffprobe to check for tagging, as well as ffplay and mpv to confirm output was valid, by recording a black screen with this image ![0-16-doubleBar](https://user-images.githubusercontent.com/50419942/221853467-5e14c5de-dae8-44e0-94b2-e2c548fc5cb5.png)

The background will be 0,0,0 and 0-16 and 235-255 is visible (the bars are not the same). Background is 0,0,0, not 16,16,16.

There are several codec and container variations that do *not* work with full range, and they do not work in FFmpeg CLI either. This is expected behavior, and users would be expected to be mindful of these combinations.

#### Crashes

In #8202 I noted several crashes. I've investigated both of these thoroughly, and it is two distinct crashes that turned out to be unrelated to the color range change (not sure about the other changes).

Crash in swscale happens when you go from yuv to RGB24, which happens by default with qtrle, both on release, master and with this change.

Crash in avcodec happens specifically with ffv1, on release, current master and with this change. Happens regardless of partial/full prior to this change, and does not seem to worsen in any way by this change.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
