### PR TITLE
Support MSVC standard conforming mode

### DIFF
--- a/UI/frontend-plugins/frontend-tools/captions-handler.hpp
+++ b/UI/frontend-plugins/frontend-tools/captions-handler.hpp
@@ -25,8 +25,8 @@ public:
 
 typedef std::function<void(const std::string &)> captions_cb;
 
-#define captions_error(s) std::string(obs_module_text("Captions.Error."##s))
-#define CAPTIONS_ERROR_GENERIC_FAIL captions_error("GenericFail")
+#define CAPTIONS_ERROR_GENERIC_FAIL \
+	std::string(obs_module_text("Captions.Error.GenericFail"))
 
 /* ------------------------------------------------------------------------- */
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -603,20 +603,21 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 		ui->hideOBSFromCapture = nullptr;
 	}
 
-#define PROCESS_PRIORITY(val)                                                \
-	{                                                                    \
-		"Basic.Settings.Advanced.General.ProcessPriority."##val, val \
-	}
-
 	static struct ProcessPriority {
 		const char *name;
 		const char *val;
-	} processPriorities[] = {PROCESS_PRIORITY("High"),
-				 PROCESS_PRIORITY("AboveNormal"),
-				 PROCESS_PRIORITY("Normal"),
-				 PROCESS_PRIORITY("BelowNormal"),
-				 PROCESS_PRIORITY("Idle")};
-#undef PROCESS_PRIORITY
+	} processPriorities[] = {
+		{"Basic.Settings.Advanced.General.ProcessPriority.High",
+		 "High"},
+		{"Basic.Settings.Advanced.General.ProcessPriority.AboveNormal",
+		 "AboveNormal"},
+		{"Basic.Settings.Advanced.General.ProcessPriority.Normal",
+		 "Normal"},
+		{"Basic.Settings.Advanced.General.ProcessPriority.BelowNormal",
+		 "BelowNormal"},
+		{"Basic.Settings.Advanced.General.ProcessPriority.Idle",
+		 "Idle"},
+	};
 
 	for (ProcessPriority pri : processPriorities)
 		ui->processPriority->addItem(QTStr(pri.name), pri.val);

--- a/cmake/Modules/CompilerConfig.cmake
+++ b/cmake/Modules/CompilerConfig.cmake
@@ -68,7 +68,11 @@ if(OS_WINDOWS AND MSVC)
     /D_UNICODE
     /D_CRT_SECURE_NO_WARNINGS
     /D_CRT_NONSTDC_NO_WARNINGS
-    /utf-8)
+    /utf-8
+    /permissive-
+    /Zc:__cplusplus
+    /Zc:preprocessor
+    /std:c17)
 
   add_link_options(
     "LINKER:/OPT:REF"

--- a/libobs/util/windows/ComPtr.hpp
+++ b/libobs/util/windows/ComPtr.hpp
@@ -165,6 +165,12 @@ public:
 		unk->QueryInterface(__uuidof(T), (void **)&this->ptr);
 	}
 
+	template<class U> inline ComQIPtr(const ComPtr<U> &c)
+	{
+		this->ptr = nullptr;
+		c->QueryInterface(__uuidof(T), (void **)&this->ptr);
+	}
+
 	inline ComPtr<T> &operator=(IUnknown *unk)
 	{
 		ComPtr<T>::Clear();

--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -131,7 +131,7 @@ struct nv_bitstream {
 	void *ptr;
 };
 
-#define NV_FAIL(format, ...) nv_fail(enc->encoder, format, __VA_ARGS__)
+#define NV_FAIL(format, ...) nv_fail(enc->encoder, format, ##__VA_ARGS__)
 #define NV_FAILED(x) nv_failed(enc->encoder, x, __FUNCTION__, #x)
 
 static bool nv_bitstream_init(struct nvenc_data *enc, struct nv_bitstream *bs)

--- a/plugins/win-capture/graphics-hook-ver.h
+++ b/plugins/win-capture/graphics-hook-ver.h
@@ -15,7 +15,10 @@
 #define HOOK_VER_MINOR 8
 #define HOOK_VER_PATCH 0
 
+#ifndef STRINGIFY
 #define STRINGIFY(s) #s
+#endif
+
 #define MAKE_VERSION_NAME(major, minor, patch) \
 	STRINGIFY(major) "." STRINGIFY(minor) "." STRINGIFY(patch) ".0"
 #define HOOK_VERSION_NAME \

--- a/plugins/win-dshow/virtualcam-module/virtualcam-module.cpp
+++ b/plugins/win-dshow/virtualcam-module/virtualcam-module.cpp
@@ -6,9 +6,9 @@
 static const REGPINTYPES AMSMediaTypesV = {&MEDIATYPE_Video,
 					   &MEDIASUBTYPE_NV12};
 
-static const REGFILTERPINS AMSPinVideo = {L"Output", false, true,
-					  false,     false, &CLSID_NULL,
-					  nullptr,   1,     &AMSMediaTypesV};
+static const REGFILTERPINS AMSPinVideo = {nullptr, false, true,
+					  false,   false, &CLSID_NULL,
+					  nullptr, 1,     &AMSMediaTypesV};
 
 HINSTANCE dll_inst = nullptr;
 volatile long locks = 0;


### PR DESCRIPTION
### Description

Enable compiling OBS with `/permissive- /Zc:__cplusplus /Zc:preprocessor /std:c17`.

This is the bare-minimum to get OBS (minus `enc-amf`) to compile and run with these options.

See: https://learn.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview

Draft because I'm not 100% happy/sure about some of these. 

### Motivation and Context

Want to not use `/permissive-` anymore and use more consistent build options with *nix.

### How Has This Been Tested?

Build and ran OBS.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
