### PR TITLE
More PipeWire cleanups

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -581,7 +581,7 @@ static void on_process_cb(void *user_data)
 			    obs_pw->format.info.raw.format, NULL, &gs_format,
 			    &swap_red_blue)) {
 			blog(LOG_ERROR,
-			     "[pipewire] unsupported DMA buffer format: %d",
+			     "[pipewire] unsupported buffer format: %d",
 			     obs_pw->format.info.raw.format);
 			goto read_metadata;
 		}

--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -1071,7 +1071,6 @@ uint32_t obs_pipewire_get_height(obs_pipewire *obs_pw)
 void obs_pipewire_video_render(obs_pipewire *obs_pw, gs_effect_t *effect)
 {
 	bool rotated;
-	bool has_crop;
 	int flip = 0;
 
 	gs_eparam_t *image;
@@ -1082,12 +1081,10 @@ void obs_pipewire_video_render(obs_pipewire *obs_pw, gs_effect_t *effect)
 	image = gs_effect_get_param_by_name(effect, "image");
 	gs_effect_set_texture(image, obs_pw->texture);
 
-	has_crop = has_effective_crop(obs_pw);
-
 	rotated = push_rotation(obs_pw);
 
 	flip = get_buffer_flip(obs_pw);
-	if (has_crop) {
+	if (has_effective_crop(obs_pw)) {
 		gs_draw_sprite_subregion(obs_pw->texture, flip, obs_pw->crop.x,
 					 obs_pw->crop.y, obs_pw->crop.width,
 					 obs_pw->crop.height);

--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -1020,43 +1020,51 @@ void obs_pipewire_hide(obs_pipewire *obs_pw)
 
 uint32_t obs_pipewire_get_width(obs_pipewire *obs_pw)
 {
+	bool has_crop;
+
 	if (!obs_pw->negotiated)
 		return 0;
+
+	has_crop = has_effective_crop(obs_pw);
 
 	switch (obs_pw->transform) {
 	case SPA_META_TRANSFORMATION_Flipped:
 	case SPA_META_TRANSFORMATION_None:
 	case SPA_META_TRANSFORMATION_Flipped180:
 	case SPA_META_TRANSFORMATION_180:
-		return obs_pw->crop.valid ? obs_pw->crop.width
-					  : obs_pw->format.info.raw.size.width;
+		return has_crop ? obs_pw->crop.width
+				: obs_pw->format.info.raw.size.width;
 	case SPA_META_TRANSFORMATION_Flipped90:
 	case SPA_META_TRANSFORMATION_90:
 	case SPA_META_TRANSFORMATION_Flipped270:
 	case SPA_META_TRANSFORMATION_270:
-		return obs_pw->crop.valid ? obs_pw->crop.height
-					  : obs_pw->format.info.raw.size.height;
+		return has_crop ? obs_pw->crop.height
+				: obs_pw->format.info.raw.size.height;
 	}
 }
 
 uint32_t obs_pipewire_get_height(obs_pipewire *obs_pw)
 {
+	bool has_crop;
+
 	if (!obs_pw->negotiated)
 		return 0;
+
+	has_crop = has_effective_crop(obs_pw);
 
 	switch (obs_pw->transform) {
 	case SPA_META_TRANSFORMATION_Flipped:
 	case SPA_META_TRANSFORMATION_None:
 	case SPA_META_TRANSFORMATION_Flipped180:
 	case SPA_META_TRANSFORMATION_180:
-		return obs_pw->crop.valid ? obs_pw->crop.height
-					  : obs_pw->format.info.raw.size.height;
+		return has_crop ? obs_pw->crop.height
+				: obs_pw->format.info.raw.size.height;
 	case SPA_META_TRANSFORMATION_Flipped90:
 	case SPA_META_TRANSFORMATION_90:
 	case SPA_META_TRANSFORMATION_Flipped270:
 	case SPA_META_TRANSFORMATION_270:
-		return obs_pw->crop.valid ? obs_pw->crop.width
-					  : obs_pw->format.info.raw.size.width;
+		return has_crop ? obs_pw->crop.width
+				: obs_pw->format.info.raw.size.width;
 	}
 }
 

--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -550,7 +550,7 @@ static void on_process_cb(void *user_data)
 		}
 
 		if (corrupt) {
-			blog(LOG_ERROR,
+			blog(LOG_DEBUG,
 			     "[pipewire] buffer contains corrupted data");
 			goto read_metadata;
 		}


### PR DESCRIPTION
### Description

Various legibility and quality related cleanups.

### Motivation and Context

I dislike code that confuses me, and try to make it less confusing when I see it.

### How Has This Been Tested?

 - Run OBS in Linux / Wayland
 - Check that everything still works

### Types of changes

 - Code cleanup (non-breaking change which makes code smaller or more readable) 

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
