### PR TITLE
UI: Fix tabstops on settings dialog

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -7550,9 +7550,10 @@
   <tabstop>scrollArea_2</tabstop>
   <tabstop>language</tabstop>
   <tabstop>theme</tabstop>
+  <tabstop>openStatsOnStartup</tabstop>
+  <tabstop>hideOBSFromCapture</tabstop>
   <tabstop>updateChannelBox</tabstop>
   <tabstop>enableAutoUpdates</tabstop>
-  <tabstop>openStatsOnStartup</tabstop>
   <tabstop>warnBeforeStreamStart</tabstop>
   <tabstop>warnBeforeStreamStop</tabstop>
   <tabstop>warnBeforeRecordStop</tabstop>
@@ -7713,7 +7714,6 @@
   <tabstop>enableLowLatencyMode</tabstop>
   <tabstop>browserHWAccel</tabstop>
   <tabstop>hotkeyFocusType</tabstop>
-  <tabstop>hideOBSFromCapture</tabstop>
   <tabstop>ignoreRecommended</tabstop>
   <tabstop>useStreamKeyAdv</tabstop>
   <tabstop>hotkeyFilterSearch</tabstop>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Revise tab stop order of updater (`updateChannelBox` and `enableAutoUpdates`) and `hideOBSFromCapture`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The tab stop order should be well aligned at least inside a layout.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

- Checked on Linux, Fedora 36 with a modification to not remove the updater settings.
- Checked the tab stop on qtcreator by eyes.
Without this PR:
  ![qtcreator-tabstop-master](https://user-images.githubusercontent.com/780600/222167093-127d21cd-1287-4baf-83f1-9a753d82601c.png)
  With this PR:
  ![qtcreator-tabstop-fix](https://user-images.githubusercontent.com/780600/222167116-67272a91-4b78-4fde-a834-e28163f5da24.png)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
  I didn't test with Windows.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
