### PR TITLE
libobs: Fix device functions not marked as EXPORT

### DIFF
--- a/libobs/graphics/device-exports.h
+++ b/libobs/graphics/device-exports.h
@@ -177,6 +177,15 @@ EXPORT void device_debug_marker_begin(gs_device_t *device,
 				      const char *markername,
 				      const float color[4]);
 EXPORT void device_debug_marker_end(gs_device_t *device);
+EXPORT bool device_is_monitor_hdr(gs_device_t *device, void *monitor);
+EXPORT bool device_shared_texture_available(void);
+
+#ifdef __APPLE__
+EXPORT gs_texture_t *device_texture_create_from_iosurface(gs_device_t *device,
+							  void *iosurf);
+EXPORT gs_texture_t *device_texture_open_shared(gs_device_t *device,
+						uint32_t handle);
+#endif
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
 
@@ -196,6 +205,9 @@ EXPORT bool device_query_dmabuf_modifiers_for_format(gs_device_t *device,
 						     uint64_t **modifiers,
 						     size_t *n_modifiers);
 
+EXPORT gs_texture_t *device_texture_create_from_pixmap(
+	gs_device_t *device, uint32_t width, uint32_t height,
+	enum gs_color_format color_format, uint32_t target, void *pixmap);
 #endif
 
 #ifdef __cplusplus

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -204,9 +204,9 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	/* OSX/Cocoa specific functions */
 #ifdef __APPLE__
 	GRAPHICS_IMPORT(device_shared_texture_available);
-	GRAPHICS_IMPORT_OPTIONAL(device_texture_open_shared);
-	GRAPHICS_IMPORT_OPTIONAL(device_texture_create_from_iosurface);
-	GRAPHICS_IMPORT_OPTIONAL(gs_texture_rebind_iosurface);
+	GRAPHICS_IMPORT(device_texture_open_shared);
+	GRAPHICS_IMPORT(device_texture_create_from_iosurface);
+	GRAPHICS_IMPORT(gs_texture_rebind_iosurface);
 
 	/* win32 specific functions */
 #elif _WIN32


### PR DESCRIPTION
### Description
Marks function symbols intended to be exported to _actually_ be exported even with visibility set to "hidden".

### Motivation and Context
As clang and gcc use "default" visibility (as in "not hidden") when no visibility is specified, all functions are implicitly exported.

When changing default visibility to "hidden", the corresponding symbols are not exposed anymore and linking fails. This PR updates all functions signatures that were added in recent commits but not set to be EXPORTed.

Also makes required OpenGL imports for texture sharing on macOS mandatory.

### How Has This Been Tested?
Tested on macOS and Linux with clang and gcc.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
