### PR TITLE
libobs: Fix Pulseaudio audio monitoring listing sources

### DIFF
--- a/libobs/audio-monitoring/pulse/pulseaudio-enum-devices.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-enum-devices.c
@@ -1,11 +1,11 @@
 #include <obs-internal.h>
 #include "pulseaudio-wrapper.h"
 
-static void pulseaudio_output_info(pa_context *c, const pa_source_info *i,
+static void pulseaudio_output_info(pa_context *c, const pa_sink_info *i,
 				   int eol, void *userdata)
 {
 	UNUSED_PARAMETER(c);
-	if (eol != 0 || i->monitor_of_sink == PA_INVALID_INDEX)
+	if (eol != 0)
 		goto skip;
 
 	struct enum_cb *ecb = (struct enum_cb *)userdata;
@@ -24,8 +24,8 @@ void obs_enum_audio_monitoring_devices(obs_enum_audio_device_cb cb, void *data)
 	ecb->cont = 1;
 
 	pulseaudio_init();
-	pa_source_info_cb_t pa_cb = pulseaudio_output_info;
-	pulseaudio_get_source_info_list(pa_cb, (void *)ecb);
+	pa_sink_info_cb_t pa_cb = pulseaudio_output_info;
+	pulseaudio_get_sink_info_list(pa_cb, (void *)ecb);
 	pulseaudio_unref();
 
 	bfree(ecb);

--- a/libobs/audio-monitoring/pulse/pulseaudio-output.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-output.c
@@ -294,8 +294,8 @@ static void pulseaudio_server_info(pa_context *c, const pa_server_info *i,
 	pulseaudio_signal(0);
 }
 
-static void pulseaudio_source_info(pa_context *c, const pa_source_info *i,
-				   int eol, void *userdata)
+static void pulseaudio_sink_info(pa_context *c, const pa_sink_info *i, int eol,
+				 void *userdata)
 {
 	UNUSED_PARAMETER(c);
 	PULSE_DATA(userdata);
@@ -409,9 +409,9 @@ static bool audio_monitor_init(struct audio_monitor *monitor,
 		return false;
 	}
 
-	if (pulseaudio_get_source_info(pulseaudio_source_info, monitor->device,
-				       (void *)monitor) < 0) {
-		blog(LOG_ERROR, "Unable to get source info !");
+	if (pulseaudio_get_sink_info(pulseaudio_sink_info, monitor->device,
+				     (void *)monitor) < 0) {
+		blog(LOG_ERROR, "Unable to get sink info !");
 		return false;
 	}
 	if (monitor->format == PA_SAMPLE_INVALID) {

--- a/libobs/audio-monitoring/pulse/pulseaudio-wrapper.h
+++ b/libobs/audio-monitoring/pulse/pulseaudio-wrapper.h
@@ -129,6 +129,40 @@ int_fast32_t pulseaudio_get_source_info(pa_source_info_cb_t cb,
 					const char *name, void *userdata);
 
 /**
+ * Request sink information
+ *
+ * The function will block until the operation was executed and the mainloop
+ * called the provided callback function.
+ *
+ * @return negative on error
+ *
+ * @note The function will block until the server context is ready.
+ *
+ * @warning call without active locks
+ */
+int_fast32_t pulseaudio_get_sink_info_list(pa_sink_info_cb_t cb,
+					   void *userdata);
+
+/**
+ * Request sink information from a specific sink
+ *
+ * The function will block until the operation was executed and the mainloop
+ * called the provided callback function.
+ *
+ * @param cb pointer to the callback function
+ * @param name the sink name to get information for
+ * @param userdata pointer to userdata the callback will be called with
+ *
+ * @return negative on error
+ *
+ * @note The function will block until the server context is ready.
+ *
+ * @warning call without active locks
+ */
+int_fast32_t pulseaudio_get_sink_info(pa_sink_info_cb_t cb, const char *name,
+				      void *userdata);
+
+/**
  * Request server information
  *
  * The function will block until the operation was executed and the mainloop


### PR DESCRIPTION
### Description
The Pulseaudio implementation of audio monitoring was actually listing audio sources. This change corrects that, so all possible outputs are available.

### Motivation and Context
While the old code worked for some outputs, not all possible outputs were available. And the actual name displayed, "monitor of x" was wrong.

Closes #4226

### How Has This Been Tested?
Built and tested with an audio source and sink on Fedora Linux. The list of possible monitoring devices is now correct

### Types of changes

Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
