### PR TITLE
UI: Add apply button to properties dialog

### DIFF
--- a/UI/forms/OBSBasicProperties.ui
+++ b/UI/forms/OBSBasicProperties.ui
@@ -111,7 +111,7 @@
    <item alignment="Qt::AlignBottom">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
      </property>
     </widget>
    </item>

--- a/UI/window-basic-properties.hpp
+++ b/UI/window-basic-properties.hpp
@@ -38,7 +38,8 @@ private:
 	std::unique_ptr<Ui::OBSBasicProperties> ui;
 	bool acceptClicked;
 
-	OBSSource source;
+	OBSSource origSource;
+	OBSSourceAutoRelease source;
 	OBSSignal removedSignal;
 	OBSSignal renamedSignal;
 	OBSSignal updatePropertiesSignal;
@@ -51,6 +52,7 @@ private:
 	OBSSourceAutoRelease sourceB;
 	OBSSourceAutoRelease sourceClone;
 	bool direction = true;
+	bool isDefaults = false;
 
 	static void SourceRemoved(void *data, calldata_t *params);
 	static void SourceRenamed(void *data, calldata_t *params);
@@ -61,10 +63,12 @@ private:
 	bool ConfirmQuit();
 	int CheckSettings();
 	void Cleanup();
+	void UpdateOriginalSource(bool reject = false);
 
 private slots:
 	void on_buttonBox_clicked(QAbstractButton *button);
 	void AddPreviewButton();
+	void EnableApplyButton(bool enable = true);
 
 public:
 	OBSBasicProperties(QWidget *parent, OBSSource source_);


### PR DESCRIPTION
### Description
This duplicates the source that is in the properties, so that updating it doesn't update in the preview. To update it in the preview, the user would click the Apply or Ok button.

### Motivation and Context
Idea from @Warchamp7 

### How Has This Been Tested?
Updated the source properties and made sure it didn't update until hit the Apply button.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
