### PR TITLE
obs-vst: Fix incorrect VST window size on HiDPI display

### DIFF
--- a/plugins/obs-vst/win/EditorWidget-win.cpp
+++ b/plugins/obs-vst/win/EditorWidget-win.cpp
@@ -49,10 +49,16 @@ void EditorWidget::buildEffectContainer(AEffect *effect)
 	VstRect *vstRect = nullptr;
 	effect->dispatcher(effect, effEditGetRect, 0, 0, &vstRect, 0);
 	if (vstRect) {
-		widget->resize(vstRect->right - vstRect->left,
-			       vstRect->bottom - vstRect->top);
-		resize(vstRect->right - vstRect->left,
-		       vstRect->bottom - vstRect->top);
+		// on Windows, the size reported by 'effect' is larger than
+		// its actuall size by a factor of the monitor's ui scale,
+		// so the window size should be divided by the factor
+		qreal scale_factor = devicePixelRatioF();
+		int width = vstRect->right - vstRect->left;
+		int height = vstRect->bottom - vstRect->top;
+		width = static_cast<int>(width / scale_factor);
+		height = static_cast<int>(height / scale_factor);
+		widget->resize(width, height);
+		resize(width, height);
 	} else {
 		widget->resize(300, 300);
 	}
@@ -72,6 +78,14 @@ void EditorWidget::handleResizeRequest(int, int)
 	effect->dispatcher(effect, effEditGetRect, 0, 0, &rec, 0);
 
 	if (rec) {
-		resize(rec->right - rec->left, rec->bottom - rec->top);
+		// on Windows, the size reported by 'effect' is larger than
+		// its actuall size by a factor of the monitor's ui scale,
+		// so the window size should be divided by the factor
+		qreal scale_factor = devicePixelRatioF();
+		int width = rec->right - rec->left;
+		int height = rec->bottom - rec->top;
+		width = static_cast<int>(width / scale_factor);
+		height = static_cast<int>(height / scale_factor);
+		resize(width, height);
 	}
 }


### PR DESCRIPTION
### Description
On Windows, the VST plugins' window sizes are rendered larger than the actual content on displays that have UI scale factor. The sizes are larger by the scale factor, for example, 100x100 content will have a 200x200 window on a 200% scaled screen, and 150x150 on a 150% scaled screen. This change adjust the window size to fit the content size. The screenshot is a loaded VST plugin with an extremely big window.
![screenshot-1](https://user-images.githubusercontent.com/4050147/222588598-4220cdb8-076b-425f-9f1b-1d20a030648c.png)

### Motivation and Context
The problem described in the description above makes VST plugins difficult to use on HiDPI screen. This change makes the window as big as its content.
Issue #8092 talked about this problem. This change should fix it.

### How Has This Been Tested?
I tested the change with VST2 plugins from MeldaProduction's MFreeFXBundle, and Youlean Loudness Meter 2. The MeldaProduction plugins are HiDPI aware plugins that adjust UI size according to OS setting, and the Youlean one is a HiDPI unaware plugin that provides a custom UI scale option. I loaded those plugins to see if they are created correctly, and I resized them, moved them from one display to another, and also changed the OS's UI scale factor while they are opened.

On a single display environment, the plugins are created and resized correctly under different UI scale factor settings. On a dual display environment, the plugins are created incorrectly if the main window of obs is on a sub-display with an UI scale different from the main display, that the window could be bigger or smaller than the content depending on the UI scale difference, but resizing, if applicable, works correctly and fixes the incorrect initial creation, and for HiDPI aware VST plugins, moving the window between the two displays fixes it too and the window adjusts to the different UI scale correctly.

The type of VST plugins that adjust its content to the window size (which is mentioned in #8092) is not tested due to my lack of access.

The test is done on a 2560x1600 laptop connecting to a 3840x2160 display on Windows 11 22h2.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

Maintainer edit: Fixes #8092