### PR TITLE
Hold async mutex when calling set_async_texture_size

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1225,11 +1225,11 @@ static void async_tick(obs_source_t *source)
 		filter_frame(source, &source->prev_async_frame);
 	filter_frame(source, &source->cur_async_frame);
 
-	pthread_mutex_unlock(&source->async_mutex);
-
 	if (source->cur_async_frame)
 		source->async_update_texture =
 			set_async_texture_size(source, source->cur_async_frame);
+
+	pthread_mutex_unlock(&source->async_mutex);
 }
 
 void obs_source_video_tick(obs_source_t *source, float seconds)


### PR DESCRIPTION
### Description
Hold the async mutex when calling `set_async_texture_size`.

### Motivation and Context
Calling `set_async_texture_size` without holding `async_mutex` is dangerous as `cur_async_frame` could be changed / freed by another thread. When running OBS under cuzz (race condition exploiter) I experienced a crash in this code.

### How Has This Been Tested?
Ran OBS and it didn't deadlock.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
