### PR TITLE
UI: Add volume controls to properties window

### DIFF
--- a/UI/forms/OBSBasicProperties.ui
+++ b/UI/forms/OBSBasicProperties.ui
@@ -44,7 +44,7 @@
       <property name="frameShadow">
        <enum>QFrame::Plain</enum>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_7">
+      <layout class="QHBoxLayout" name="previewLayout">
        <property name="spacing">
         <number>0</number>
        </property>

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -280,6 +280,8 @@ class MuteCheckBox;
 class VolControl : public QWidget {
 	Q_OBJECT
 
+	friend class OBSBasicProperties;
+
 private:
 	OBSSource source;
 	QLabel *nameLabel;

--- a/UI/window-basic-properties.hpp
+++ b/UI/window-basic-properties.hpp
@@ -26,6 +26,7 @@
 
 class OBSPropertiesView;
 class OBSBasic;
+class VolControl;
 
 #include "ui_OBSBasicProperties.h"
 
@@ -42,10 +43,13 @@ private:
 	OBSSignal removedSignal;
 	OBSSignal renamedSignal;
 	OBSSignal updatePropertiesSignal;
+	OBSSignal audioActivated;
+	OBSSignal audioDeactivated;
 	OBSData oldSettings;
 	OBSPropertiesView *view;
 	QDialogButtonBox *buttonBox;
 	QSplitter *windowSplitter;
+	VolControl *vol = nullptr;
 
 	OBSSourceAutoRelease sourceA;
 	OBSSourceAutoRelease sourceB;
@@ -57,6 +61,8 @@ private:
 	static void UpdateProperties(void *data, calldata_t *params);
 	static void DrawPreview(void *data, uint32_t cx, uint32_t cy);
 	static void DrawTransitionPreview(void *data, uint32_t cx, uint32_t cy);
+	static void AudioActivated(void *data, calldata_t *params);
+	static void AudioDeactivated(void *data, calldata_t *params);
 	void UpdateCallback(void *obj, obs_data_t *settings);
 	bool ConfirmQuit();
 	int CheckSettings();
@@ -65,6 +71,8 @@ private:
 private slots:
 	void on_buttonBox_clicked(QAbstractButton *button);
 	void AddPreviewButton();
+	void ShowVolumeControls();
+	void HideVolumeControls();
 
 public:
 	OBSBasicProperties(QWidget *parent, OBSSource source_);


### PR DESCRIPTION
### Description
This makes it easier for users to edit volume controls of a source, without first closing the properties window.

With preview:
![Screenshot from 2023-03-06 07-32-51](https://user-images.githubusercontent.com/19962531/223124871-96d2ca1d-7bb5-4894-aa90-2dd473f8891d.png)

Without preview:
![Screenshot from 2023-03-02 21-06-58](https://user-images.githubusercontent.com/19962531/222622454-0573fe31-79b3-4e32-8a90-f78e6483ed48.png)

### Motivation and Context
Seems like a good idea. It's a small change, so if others don't like it, that's fine to me.

### How Has This Been Tested?
Open properties of sources with audio.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
