### PR TITLE
UI: Add name edit to properties dialog

### DIFF
--- a/UI/forms/OBSBasicProperties.ui
+++ b/UI/forms/OBSBasicProperties.ui
@@ -18,6 +18,49 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="nameLabel">
+       <property name="text">
+        <string>Name</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="nameEdit"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="revertNameButton">
+       <property name="toolTip">
+        <string>Revert</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="obs.qrc">
+         <normaloff>:/res/images/revert.svg</normaloff>:/res/images/revert.svg</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="toolButton" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="themeID" stdset="0">
+        <string>revertIcon</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QSplitter" name="windowSplitter">
      <property name="minimumSize">
       <size>

--- a/UI/window-basic-properties.hpp
+++ b/UI/window-basic-properties.hpp
@@ -46,6 +46,7 @@ private:
 	OBSPropertiesView *view;
 	QDialogButtonBox *buttonBox;
 	QSplitter *windowSplitter;
+	QString origName;
 
 	OBSSourceAutoRelease sourceA;
 	OBSSourceAutoRelease sourceB;
@@ -61,9 +62,11 @@ private:
 	bool ConfirmQuit();
 	int CheckSettings();
 	void Cleanup();
+	bool CheckSourceName();
 
 private slots:
 	void on_buttonBox_clicked(QAbstractButton *button);
+	void on_revertNameButton_clicked();
 	void AddPreviewButton();
 
 public:


### PR DESCRIPTION
### Description
This adds a name edit to the properties dialog, so users can easily set the name of the source, without closing the properties window.

![Screenshot from 2023-03-02 23-03-53](https://user-images.githubusercontent.com/19962531/222636710-89bb3e18-78cd-4082-9b95-215902974211.png)

### Motivation and Context
Make things all in one place.

### How Has This Been Tested?
Set source name in properties dialog

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
