### PR TITLE
libobs: Simplify balance float comparison

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -4011,7 +4011,7 @@ static void process_audio(obs_source_t *source,
 	mono_output = audio_output_get_channels(obs->audio.audio) == 1;
 
 	if (!mono_output && source->sample_info.speakers == SPEAKERS_STEREO &&
-	    (source->balance > 0.51f || source->balance < 0.49f)) {
+	    !close_float(source->balance, 0.5f, LARGE_EPSILON)) {
 		process_audio_balancing(source, frames, source->balance,
 					OBS_BALANCE_TYPE_SINE_LAW);
 	}


### PR DESCRIPTION
### Description
This now uses the close_float function, instead of comparing floats manually.

### Motivation and Context
Better and cleaner code

### How Has This Been Tested?
Used balance on sources to make sure nothing broke

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
