### PR TITLE
UI: Fix spacing helpers when rotated and flipped

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -2506,6 +2506,23 @@ void OBSBasicPreview::DrawSpacingHelpers()
 				    groupOti.pos.x, groupOti.pos.y, 0.0f);
 	}
 
+	// Switch top/bottom or right/left if scale is negative
+	if (oti.scale.x < 0.0f) {
+		vec3 l = left;
+		vec3 r = right;
+
+		vec3_copy(&left, &r);
+		vec3_copy(&right, &l);
+	}
+
+	if (oti.scale.y < 0.0f) {
+		vec3 t = top;
+		vec3 b = bottom;
+
+		vec3_copy(&top, &b);
+		vec3_copy(&bottom, &t);
+	}
+
 	if (rot >= HELPER_ROT_BREAKPONT) {
 		for (float i = HELPER_ROT_BREAKPONT; i <= 360.0f; i += 90.0f) {
 			if (rot < i)
@@ -2537,23 +2554,6 @@ void OBSBasicPreview::DrawSpacingHelpers()
 			vec3_copy(&bottom, &l);
 			vec3_copy(&left, &t);
 		}
-	}
-
-	// Switch top/bottom or right/left if scale is negative
-	if (oti.scale.x < 0.0f) {
-		vec3 l = left;
-		vec3 r = right;
-
-		vec3_copy(&left, &r);
-		vec3_copy(&right, &l);
-	}
-
-	if (oti.scale.y < 0.0f) {
-		vec3 t = top;
-		vec3 b = bottom;
-
-		vec3_copy(&top, &b);
-		vec3_copy(&bottom, &t);
 	}
 
 	// Get sides of box transform


### PR DESCRIPTION
### Description
If the scene item was rotated greater than 45 degrees, and flipped vertically or horizontally, the spacing helpers would be drawn incorrectly. This fixes the issue by checking the scale before the rotation, instead of after.

Before:
![Screenshot from 2023-03-04 01-05-53](https://user-images.githubusercontent.com/19962531/222881388-804f3cf3-2147-4fc6-80df-5decef4dd2ee.png)

After:
![Screenshot from 2023-03-04 01-05-28](https://user-images.githubusercontent.com/19962531/222881397-ddbfc6a6-90dd-446f-b435-3698b0062a4c.png)

### Motivation and Context
Fixes bug

### How Has This Been Tested?
Rotated and flipped scene item

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
