### PR TITLE
UI: Don't hardcode properties label colors

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -1294,8 +1294,7 @@ static void UpdateFPSLabels(OBSFrameRatePropertyWidget *w)
 		w->currentFPS->setHidden(true);
 		w->timePerFrame->setHidden(true);
 		if (!option)
-			w->warningLabel->setStyleSheet(
-				"QLabel { color: red; }");
+			w->warningLabel->setObjectName("errorLabel");
 
 		return;
 	}
@@ -1305,9 +1304,9 @@ static void UpdateFPSLabels(OBSFrameRatePropertyWidget *w)
 
 	media_frames_per_second match{};
 	if (!option && !matches_ranges(match, *valid_fps, w->fps_ranges, true))
-		w->warningLabel->setStyleSheet("QLabel { color: red; }");
+		w->warningLabel->setObjectName("errorLabel");
 	else
-		w->warningLabel->setStyleSheet("");
+		w->warningLabel->setObjectName("");
 
 	auto convert_to_fps = media_frames_per_second_to_fps;
 	auto convert_to_frame_interval =
@@ -1520,8 +1519,8 @@ void OBSPropertiesView::AddProperty(obs_property_t *property,
 		label = new QLabel(QT_UTF8(obs_property_description(property)));
 
 	if (label) {
-		if (warning) //TODO: select color based on background color
-			label->setStyleSheet("QLabel { color: red; }");
+		if (warning)
+			label->setObjectName("errorLabel");
 
 		if (minSize) {
 			label->setMinimumWidth(minSize);


### PR DESCRIPTION
### Description
Makes the label have colors based on themes, instead of hard coding.

### Motivation and Context
Looked through some TODOs in the code, and noticed some old code where the label colors were still hardcoded. This code was before themes were a thing.

### How Has This Been Tested?
Looked at properties to make sure labels looked correct

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
