### PR TITLE
UI: Fix preview disabled in studio mode

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1941,6 +1941,10 @@ void OBSBasic::OBSInit()
 		QMetaObject::invokeMethod(this, "EnablePreviewDisplay",
 					  Qt::QueuedConnection,
 					  Q_ARG(bool, previewEnabled));
+	else if (!previewEnabled && IsPreviewProgramMode())
+		QMetaObject::invokeMethod(this, "EnablePreviewDisplay",
+					  Qt::QueuedConnection,
+					  Q_ARG(bool, true));
 
 	RefreshSceneCollections();
 	RefreshProfiles();


### PR DESCRIPTION
### Description
If OBS is set to minimize to system tray on startup and studio mode is enabled, the preview would be disabled when showing OBS, if the preview in non studio mode was disabled.

### Motivation and Context
Fixes bug I've found

### How Has This Been Tested?
Made sure preview was enabled in studio mode when click show from system tray, when set to minimized on start.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
