### PR TITLE
UI: Fix wrong program scene if tbar is aborted

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -309,8 +309,6 @@ void OBSBasic::TransitionToScene(OBSSource source, bool force,
 	if (!scene)
 		return;
 
-	OBSWeakSource lastProgramScene;
-
 	if (usingPreviewProgram) {
 		if (!tBarActive)
 			lastProgramScene = programScene;
@@ -906,6 +904,7 @@ void OBSBasic::TBarReleased()
 		tBar->blockSignals(false);
 		tBarActive = false;
 		EnableTransitionWidgets(true);
+		programScene = lastProgramScene;
 	}
 
 	tBar->clearFocus();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -497,6 +497,7 @@ private:
 	OBSWeakSource lastScene;
 	OBSWeakSource swapScene;
 	OBSWeakSource programScene;
+	OBSWeakSource lastProgramScene;
 	bool editPropertiesMode = false;
 	bool sceneDuplicationMode = true;
 	bool swapScenesMode = true;


### PR DESCRIPTION
### Description
The program scene would be incorrect if the tbar was released at its original position.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/6586

### How Has This Been Tested?
Checked to see if scene was correct when releasing tbar and ran other studio mode function to make sure nothing broke.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
