### PR TITLE
UI: Sort and pretty-print exported collections

### DIFF
--- a/libobs/obs-data.c
+++ b/libobs/obs-data.c
@@ -742,6 +742,22 @@ const char *obs_data_get_json(obs_data_t *data)
 	return data->json;
 }
 
+const char *obs_data_get_json_pretty(obs_data_t *data)
+{
+	if (!data)
+		return NULL;
+
+	/* NOTE: don't use libobs bfree for json text */
+	free(data->json);
+	data->json = NULL;
+
+	json_t *root = obs_data_to_json(data);
+	data->json = json_dumps(root, JSON_PRESERVE_ORDER | JSON_INDENT(4));
+	json_decref(root);
+
+	return data->json;
+}
+
 const char *obs_data_get_last_json(obs_data_t *data)
 {
 	return data ? data->json : NULL;
@@ -763,6 +779,20 @@ bool obs_data_save_json_safe(obs_data_t *data, const char *file,
 			     const char *temp_ext, const char *backup_ext)
 {
 	const char *json = obs_data_get_json(data);
+
+	if (json && *json) {
+		return os_quick_write_utf8_file_safe(
+			file, json, strlen(json), false, temp_ext, backup_ext);
+	}
+
+	return false;
+}
+
+bool obs_data_save_json_pretty_safe(obs_data_t *data, const char *file,
+				    const char *temp_ext,
+				    const char *backup_ext)
+{
+	const char *json = obs_data_get_json_pretty(data);
 
 	if (json && *json) {
 		return os_quick_write_utf8_file_safe(

--- a/libobs/obs-data.h
+++ b/libobs/obs-data.h
@@ -70,11 +70,15 @@ EXPORT void obs_data_addref(obs_data_t *data);
 EXPORT void obs_data_release(obs_data_t *data);
 
 EXPORT const char *obs_data_get_json(obs_data_t *data);
+EXPORT const char *obs_data_get_json_pretty(obs_data_t *data);
 EXPORT const char *obs_data_get_last_json(obs_data_t *data);
 EXPORT bool obs_data_save_json(obs_data_t *data, const char *file);
 EXPORT bool obs_data_save_json_safe(obs_data_t *data, const char *file,
 				    const char *temp_ext,
 				    const char *backup_ext);
+EXPORT bool obs_data_save_json_pretty_safe(obs_data_t *data, const char *file,
+					   const char *temp_ext,
+					   const char *backup_ext);
 
 EXPORT void obs_data_apply(obs_data_t *target, obs_data_t *apply_data);
 


### PR DESCRIPTION
### Description

When a scene collection is exported, sort sources by name and pretty-print the output.

This also adds new functions to `obs_data` to get/write JSON in a prettified format.

### Motivation and Context

As of 0dc1e01b5bed35f1514ad32ed4beb5155ca53eb4 the JSON has been saved in minified/"compact" form meaning that it's just one long line.

Opening those files in editors can perform extremely poorly, and tracking changes between them is additionally made difficult due to the order of sources being unreliable.

Some users use git to store and version their scene collection, or work on them collaboratively (e.g. GDQ), and have complained about the instability of the exported collections resulting in large diffs.

### How Has This Been Tested?

Exported some collections, verified they're now pretty-printed and sorted by name.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
