### PR TITLE
UI: Set min/max zoom levels for preview

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -2255,6 +2255,8 @@ void OBSBasicPreview::ResetScrollingOffset()
 
 void OBSBasicPreview::SetScalingLevel(int32_t newScalingLevelVal)
 {
+	newScalingLevelVal = std::clamp(newScalingLevelVal, -MAX_SCALING_LEVEL,
+					MAX_SCALING_LEVEL);
 	float newScalingAmountVal =
 		pow(ZOOM_SENSITIVITY, float(newScalingLevelVal));
 	scalingLevel = newScalingLevelVal;

--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -18,7 +18,9 @@ class QMouseEvent;
 #define ITEM_BOTTOM (1 << 3)
 #define ITEM_ROT (1 << 4)
 
-#define ZOOM_SENSITIVITY 1.125f
+#define MAX_SCALING_LEVEL 20
+#define MAX_SCALING_AMOUNT 10.0f
+#define ZOOM_SENSITIVITY pow(MAX_SCALING_AMOUNT, 1.0f / MAX_SCALING_LEVEL)
 
 #define SPACER_LABEL_MARGIN 6.0f
 


### PR DESCRIPTION
### Description
Prevents the preview from zooming in or out too far.
Min zoom: 10%
Max zoom: 1000%

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/4115

### How Has This Been Tested?
Zoomed preview

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
