### PR TITLE
UI: Fix media controls shortcuts being global

### DIFF
--- a/UI/forms/source-toolbar/media-controls.ui
+++ b/UI/forms/source-toolbar/media-controls.ui
@@ -71,9 +71,6 @@
        <height>20</height>
       </size>
      </property>
-     <property name="shortcut">
-      <string>Space</string>
-     </property>
      <property name="flat">
       <bool>true</bool>
      </property>

--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -69,6 +69,7 @@ MediaControls::MediaControls(QWidget *parent)
 					 "MediaControlsCountdownTimer");
 
 	QAction *restartAction = new QAction(this);
+	restartAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
 	restartAction->setShortcut({Qt::Key_R});
 	connect(restartAction, SIGNAL(triggered()), this, SLOT(RestartMedia()));
 	addAction(restartAction);
@@ -86,6 +87,13 @@ MediaControls::MediaControls(QWidget *parent)
 		SLOT(MoveSliderBackwards()));
 	sliderBack->setShortcut({Qt::Key_Left});
 	addAction(sliderBack);
+
+	QAction *playPause = new QAction(this);
+	playPause->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+	connect(playPause, SIGNAL(triggered()), this,
+		SLOT(on_playPauseButton_clicked()));
+	playPause->setShortcut({Qt::Key_Space});
+	addAction(playPause);
 }
 
 MediaControls::~MediaControls() {}


### PR DESCRIPTION
### Description
The play, pause and restart shortcuts were being called as global shortcuts, being triggered no matter what. This fixes this by calling the shortcut actions only when the media controls widget has focus.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/7199

### How Has This Been Tested?
Made sure shortcuts only triggered when the media controls were clicked

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
