### PR TITLE
rtmp-services: Add Joystick.TV

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v4",
-    "version": 220,
+    "version": 221,
     "files": [
         {
             "name": "services.json",
-            "version": 220
+            "version": 221
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2524,6 +2524,25 @@
                 "max video bitrate": 9000,
                 "max audio bitrate": 192
             }
+        },
+        {
+            "name": "Joystick.TV",
+            "more_info_link": "https://support.joystick.tv/support/creator-support/setting-up-your-stream/",
+            "stream_key_link": "https://joystick.tv/stream-settings",
+            "servers": [
+                {
+                    "name": "RTMP",
+                    "url": "rtmp://live.joystick.tv/live/"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 7500,
+                "max audio bitrate": 192,
+                "profile": "main",
+                "bframes": 0,
+                "x264opts": "tune=zerolatency"
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
[JoystickTV](https://joystick.tv/) (NSFW) is an adult live streaming service with a focus on gaming. This PR adds JoystickTV as an official service. The site has been live since January 2022.

### Motivation and Context
Currently our users are just streaming to our site using a custom RTMP setup. We often have to help support with the OBS setup to fine-tune their connection. This PR will allow new users that are less savvy in custom setups to start streaming right away.

### How Has This Been Tested?
These settings are what we have our users go by as a default recommendation. They have been using these settings successfully since we have been live.

### Types of changes
New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.