### PR TITLE
libobs: Add obs_view_get_video_info

### DIFF
--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -797,3 +797,66 @@ Displays
 .. function:: void obs_display_set_background_color(obs_display_t *display, uint32_t color)
 
    Sets the background (clear) color for the display context.
+
+.. _view_reference:
+
+Views
+----------------
+
+.. function:: obs_view_t *obs_view_create(void)
+
+   :return: A view context
+
+---------------------
+
+.. function:: void obs_view_destroy(obs_view_t *view)
+
+   Destroys a view context.
+
+---------------------
+
+.. function:: void obs_view_render(obs_view_t *view)
+
+   Renders the sources of this view context.
+
+---------------------
+
+.. function:: video_t *obs_view_add(obs_view_t *view)
+
+   Renders the sources of this view context.
+
+   :return: The main video output handler for the view context
+
+---------------------
+
+.. function:: video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi)
+
+   Adds a view to the main render loop, with custom video settings.
+
+   :return: The main video output handler for the view context
+
+---------------------
+
+.. function:: void obs_view_remove(obs_view_t *view)
+
+   Removes a view from the main render loop.
+
+---------------------
+
+.. function:: void obs_view_set_source(obs_view_t *view, uint32_t channel, obs_source_t *source)
+
+   Sets the source to be used for this view context.
+
+---------------------
+
+.. function:: obs_source_t *obs_view_get_source(obs_view_t *view, uint32_t channel)
+
+   :return: The source currently in use for this view context
+
+---------------------
+
+.. function:: bool obs_view_get_video_info(obs_view_t *view, struct obs_video_info *ovi)
+
+   Gets the video settings currently in use for this view context.
+
+   :return: *false* if no video

--- a/libobs/obs-view.c
+++ b/libobs/obs-view.c
@@ -198,3 +198,22 @@ void obs_view_remove(obs_view_t *view)
 	set_main_mix();
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 }
+
+bool obs_view_get_video_info(obs_view_t *view, struct obs_video_info *ovi)
+{
+	if (!view)
+		return false;
+
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+
+	size_t idx = find_mix_for_view(view);
+	if (idx != DARRAY_INVALID) {
+		*ovi = obs->video.mixes.array[idx]->ovi;
+		pthread_mutex_unlock(&obs->video.mixes_mutex);
+		return true;
+	}
+
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	return false;
+}

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -918,6 +918,10 @@ EXPORT video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi);
 /** Removes a view from the main render loop */
 EXPORT void obs_view_remove(obs_view_t *view);
 
+/** Gets the video settings currently in use for this view context, returns false if no video */
+EXPORT bool obs_view_get_video_info(obs_view_t *view,
+				    struct obs_video_info *ovi);
+
 /* ------------------------------------------------------------------------- */
 /* Display context */
 


### PR DESCRIPTION
### Description
Add `bool obs_view_get_video_info(obs_view_t *view, struct obs_video_info *ovi)`
Gets the video settings currently in use for this view context, returns false if no video

### Motivation and Context
Allow to get video info from a view, for example to get the size of a view
Useful for future code to create a projector or virtual camera from the view.

### How Has This Been Tested?
On windows 64 bit with test code in the vertical plugin

### Types of changes
- New feature (non-breaking change which adds functionality) 
- Documentation (a change to documentation pages) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
