### PR TITLE
obs-vst: Fix memory leaks on macOS when VST's fail to load

### DIFF
--- a/plugins/obs-vst/mac/VSTPlugin-osx.mm
+++ b/plugins/obs-vst/mac/VSTPlugin-osx.mm
@@ -30,6 +30,7 @@ AEffect *VSTPlugin::loadEffect()
 							   true);
 
 	if (bundleUrl == NULL) {
+		CFRelease(pluginPathStringRef);
 		blog(LOG_WARNING,
 		     "Couldn't make URL reference for VST plug-in");
 		return NULL;
@@ -58,6 +59,8 @@ AEffect *VSTPlugin::loadEffect()
 
 	if (mainEntryPoint == NULL) {
 		blog(LOG_WARNING, "Couldn't get a pointer to plug-in's main()");
+		CFRelease(pluginPathStringRef);
+		CFRelease(bundleUrl);
 		CFRelease(bundle);
 		bundle = NULL;
 		return NULL;
@@ -66,6 +69,8 @@ AEffect *VSTPlugin::loadEffect()
 	newEffect = mainEntryPoint(hostCallback_static);
 	if (newEffect == NULL) {
 		blog(LOG_WARNING, "VST Plug-in's main() returns null.");
+		CFRelease(pluginPathStringRef);
+		CFRelease(bundleUrl);
 		CFRelease(bundle);
 		bundle = NULL;
 		return NULL;


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes leaks detected by clang-analyzer.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Ran clang-analyzer to double-check another PR I'm working on and got annoyed by these findings.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiles successfully and no more complaints about obs-vst.
Didn't run with broken VST's as I don't know how I would get them, but the changes are pretty straightforward. We're creating the objects, and we need to release them (see [The Create Rule](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-103029)).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
