### PR TITLE
UI: Don't try to make OBSBasic parent of ControlsSplitButton

### DIFF
--- a/UI/record-button.cpp
+++ b/UI/record-button.cpp
@@ -67,7 +67,7 @@ static QWidget *getNextWidget(QBoxLayout *container, QLayoutItem *item)
 ControlsSplitButton::ControlsSplitButton(const QString &text,
 					 const QVariant &themeID,
 					 void (OBSBasic::*clicked)())
-	: QHBoxLayout(OBSBasic::Get())
+	: QHBoxLayout()
 {
 	button.reset(new QPushButton(text));
 	button->setCheckable(true);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Passing the parent of a QLayout sets it directly as the top-level layout (as per the [QLayout docs](https://doc.qt.io/qt-6/qlayout.html#QLayout)). This is obviously not what is intended here. Luckily it doesn't even work since the main window of course already has a layout which would need to be explicitly removed before, but it makes Qt yell at us for trying.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
```
QLayout: Attempting to add QLayout "" to OBSBasic "OBSBasic", which already has a layout
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.2.1
Button and everything still works.
Confirmed with a debugger and an explicate destructor that the layout still gets destroyed at the same time as before, which is with the dock (ownership was likely the original intent of passing the parent in the first place, and with QWidgets is correct thing to do, but not with QLayouts).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
