### PR TITLE
media-playback: Fix libavutil version check

### DIFF
--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -446,7 +446,7 @@ bool mp_decode_next(struct mp_decode *d)
 				av_rescale_q(d->in_frame->best_effort_timestamp,
 					     d->stream->time_base,
 					     (AVRational){1, 1000000000});
-#if LIBAVUTIL_VERSION_MAJOR >= 57 && LIBAVUTIL_VERSION_MINOR >= 30
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 30, 100)
 		int64_t duration = d->in_frame->duration;
 #else
 		int64_t duration = d->in_frame->pkt_duration;


### PR DESCRIPTION
### Description

Fixes version check to work correctly with major versions > 57 (current is 58.3).

Should fix #8441

### Motivation and Context

Do I really need to explain this?

### How Has This Been Tested?

CI will tell me if I'm right.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
