### PR TITLE
Add Safe Mode

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -108,6 +108,10 @@ foreach(graphics_library IN ITEMS opengl metal d3d11)
   endif()
 endforeach()
 
+get_property(obs_module_list GLOBAL PROPERTY OBS_MODULES_ENABLED)
+list(JOIN obs_module_list "|" SAFE_MODULES)
+target_compile_definitions(obs-studio PRIVATE "SAFE_MODULES=\"${SAFE_MODULES}\"")
+
 # cmake-format: off
 set_target_properties_obs(obs-studio PROPERTIES FOLDER frontend OUTPUT_NAME "$<IF:$<PLATFORM_ID:Windows>,obs64,obs>")
 # cmake-format: on

--- a/UI/cmake/legacy.cmake
+++ b/UI/cmake/legacy.cmake
@@ -486,6 +486,10 @@ source_group(
 unset(_SOURCES)
 unset(_UI)
 
+get_property(OBS_MODULE_LIST GLOBAL PROPERTY OBS_MODULE_LIST)
+list(JOIN OBS_MODULE_LIST "|" SAFE_MODULES)
+target_compile_definitions(obs PRIVATE "SAFE_MODULES=\"${SAFE_MODULES}\"")
+
 define_graphic_modules(obs)
 setup_obs_app(obs)
 setup_target_resources(obs obs-studio)

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -125,6 +125,15 @@ AlreadyRunning.Title="OBS is already running"
 AlreadyRunning.Text="OBS is already running! Unless you meant to do this, please shut down any existing instances of OBS before trying to run a new instance. If you have OBS set to minimize to the system tray, please check to see if it's still running there."
 AlreadyRunning.LaunchAnyway="Launch Anyway"
 
+# warning if auto Safe Mode has engaged
+AutoSafeMode.Title="Safe Mode"
+AutoSafeMode.Text="OBS did not shut down properly during your last session.\n\nWould you like to start in Safe Mode (third-party plugins, scripting, and websockets disabled)?"
+AutoSafeMode.LaunchSafe="Run in Safe Mode"
+AutoSafeMode.LaunchNormal="Run Normally"
+## Restart Option
+SafeMode.Restart="Do you want to restart OBS in Safe Mode (third-party plugins, scripting, and websockets disabled)?"
+SafeMode.RestartNormal="Do you want to restart OBS in Normal Mode?"
+
 ChromeOS.Title="Unsupported Platform"
 ChromeOS.Text="OBS appears to be running inside a ChromeOS container. This platform is unsupported."
 
@@ -834,6 +843,8 @@ Basic.MainMenu.Help.Logs.UploadLastLog="Upload &Previous Log File"
 Basic.MainMenu.Help.Logs.ViewCurrentLog="&View Current Log"
 Basic.MainMenu.Help.CheckForUpdates="Check For Updates"
 Basic.MainMenu.Help.Repair="Check File Integrity"
+Basic.MainMenu.Help.RestartSafeMode="Restart in Safe Mode"
+Basic.MainMenu.Help.RestartNormal="Restart in Normal Mode"
 Basic.MainMenu.Help.CrashLogs="Crash &Reports"
 Basic.MainMenu.Help.CrashLogs.ShowLogs="&Show Crash Reports"
 Basic.MainMenu.Help.CrashLogs.UploadLastLog="Upload &Previous Crash Report"

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -532,9 +532,11 @@
     <addaction name="separator"/>
     <addaction name="actionRepair"/>
     <addaction name="actionCheckForUpdates"/>
+    <addaction name="actionRestartSafe"/>
+    <addaction name="actionShowMacPermissions"/>
+    <addaction name="separator"/>
     <addaction name="actionShowWhatsNew"/>
     <addaction name="actionShowAbout"/>
-    <addaction name="actionShowMacPermissions"/>
     <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="menuBasic_MainMenu_Edit">
@@ -2002,6 +2004,11 @@
   <action name="actionRepair">
    <property name="text">
     <string>Basic.MainMenu.Help.Repair</string>
+   </property>
+  </action>
+  <action name="actionRestartSafe">
+   <property name="text">
+    <string>Basic.MainMenu.Help.RestartSafeMode</string>
    </property>
   </action>
   <action name="actionInteract">

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -267,6 +267,8 @@ static inline int GetProfilePath(char *path, size_t size, const char *file)
 
 extern bool portable_mode;
 extern bool steam;
+extern bool safe_mode;
+extern bool disable_3p_plugins;
 
 extern bool opt_start_streaming;
 extern bool opt_start_recording;
@@ -278,6 +280,7 @@ extern bool opt_allow_opengl;
 extern bool opt_always_on_top;
 extern std::string opt_starting_scene;
 extern bool restart;
+extern bool restart_safe;
 
 #ifdef _WIN32
 extern "C" void install_dll_blocklist_hook(void);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -231,6 +231,8 @@ private:
 	QList<QPointer<QDockWidget>> oldExtraDocks;
 	QStringList oldExtraDockNames;
 
+	OBSDataAutoRelease safeModeModuleData;
+
 	bool loaded = false;
 	long disableSaving = 1;
 	bool projectChanged = false;
@@ -1044,6 +1046,7 @@ private slots:
 	void on_actionCheckForUpdates_triggered();
 	void on_actionRepair_triggered();
 	void on_actionShowWhatsNew_triggered();
+	void on_actionRestartSafe_triggered();
 
 	void on_actionShowCrashLogs_triggered();
 	void on_actionUploadLastCrashLog_triggered();

--- a/docs/sphinx/reference-modules.rst
+++ b/docs/sphinx/reference-modules.rst
@@ -271,6 +271,15 @@ plugin modules.
 
 ---------------------
 
+.. function:: void *obs_add_safe_module(const char *name)
+
+   Adds a *name* to the list of modules allowed to load in Safe Mode.
+   If the list is empty, all modules are allowed.
+
+   :param  name: The name of the module (filename sans extension).
+
+---------------------
+
 .. function:: void obs_module_failure_info_free(struct obs_module_failure_info *mfi)
 
    Frees data allocated data used in the *mfi* parameter (calls

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -466,6 +466,7 @@ typedef DARRAY(struct obs_source_info) obs_source_info_array_t;
 struct obs_core {
 	struct obs_module *first_module;
 	DARRAY(struct obs_module_path) module_paths;
+	DARRAY(char *) safe_modules;
 
 	obs_source_info_array_t source_types;
 	obs_source_info_array_t input_types;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1441,6 +1441,10 @@ void obs_shutdown(void)
 		free_module_path(obs->module_paths.array + i);
 	da_free(obs->module_paths);
 
+	for (size_t i = 0; i < obs->safe_modules.num; i++)
+		bfree(obs->safe_modules.array[i]);
+	da_free(obs->safe_modules);
+
 	if (obs->name_store_owned)
 		profiler_name_store_free(obs->name_store);
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -517,6 +517,14 @@ EXPORT const char *obs_get_module_data_path(obs_module_t *module);
  */
 EXPORT void obs_add_module_path(const char *bin, const char *data);
 
+/**
+ * Adds a module to the list of modules allowed to load in Safe Mode.
+ * If the list is empty, all modules are allowed.
+ *
+ * @param  name  Specifies the module's name (filename sans extension).
+ */
+EXPORT void obs_add_safe_module(const char *name);
+
 /** Automatically loads all modules from module paths (convenience function) */
 EXPORT void obs_load_all_modules(void);
 


### PR DESCRIPTION
### Description

This PR adds several things:
- `obs_add_safe_module(name)` to allow specifying a list of safe modules, if the list is not empty, only the specified modules are allowed to load
- Automatic detection of unclean shutdowns (disabled in `Debug` builds)
- Prompt to ask user if they want to run OBS in safe or normal mode when an unclean shutdown has been detected
- `--safe-mode` flag to run OBS in safe mode
- `--only-bundled-plugins` flag to run OBS without third-party plugins
- `--disable-shutdown-check` flag to disable unclean shutdown detection

"Safe Mode" currently disables third-party plugins as well as `frontend-tools` and `obs-websocket` to prevent scripts from running or external applications from making changes to OBS's state.

**Screenshot:**
![2023-03-14_06-32-37_iCsf5G](https://user-images.githubusercontent.com/3123295/224905557-02bf3b7d-e2b9-46df-a809-2fdb0bef2598.png)

The automatic crash/improper shutdown detection works via a sentinel file in the configuration directory that gets created on startup and deleted on shutdown.

### Motivation and Context

Make it possible to run OBS without third-party plugins for debugging or troubleshooting purposes without having to uninstall them.

Additionally, if OBS crashes or is otherwise shut down improperly allow the user to disable third-party plugins on next startup.

### How Has This Been Tested?

- Removed `win-capture` from the list, launched OBS, no window capture sources.
- Killed OBS via VS debugger and verified that the prompt appears on next launch

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
