### PR TITLE
Revert "obs-ffmpeg: Use FFmpeg's "fast" AAC encoder by default"

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
@@ -22,7 +22,6 @@
 #include <obs-module.h>
 
 #include <libavutil/channel_layout.h>
-#include <libavutil/opt.h>
 #include <libavformat/avformat.h>
 
 #include "obs-ffmpeg-formats.h"
@@ -265,7 +264,6 @@ static void *enc_create(obs_data_t *settings, obs_encoder_t *encoder,
 	}
 
 	if (strcmp(enc->codec->name, "aac") == 0) {
-		av_opt_set(enc->context->priv_data, "aac_coder", "fast", 0);
 	}
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Remove the AAC coder option passing to ffmpeg in `ffmpeg_aac`.
This reverts commit aa58b9cf5f3e030958d23b6d147439e09e49d485.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

FFmpeg has reverted their default AAC encoder from fast to twoloop at the commit [660d1d8e3b](https://github.com/FFmpeg/FFmpeg/commit/660d1d8e3b).
They claimed that `twoloop` has much better rate control management, making it closer to CBR, and it sounds much better.

The `twoloop` as the default is included in n5.0 and later. And, obs-deps is now pointing to n5.1. Hence, just removing the option will choose `twoloop`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 36

Waveforms below show a comparison among `libfdk_aac`, current `ffmpeg_aac`, and this PR's `ffmpeg_aac` for 440 Hz sine wave.
![Screenshot_2023-03-13_01-06-13a](https://user-images.githubusercontent.com/780600/224557330-6926157b-4d2d-42a4-a578-510651718fb3.png)

I guess sine wave with loud volume is a corner case for FFmpeg fast coder so that the difference is significantly observed.

I tested `ffmpeg_aac` by temporarily removing `obs-libfdk.so`.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
  The encoder `ffmpeg_aac` is the default for Windows. This PR will affect OBS Studio on Windows.
  For Linux and macOS, `ffmpeg_aac` is just a fallback because `libfdk_aac` and `CoreAudio_AAC` have priority, respectively.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
